### PR TITLE
Use shutdown buttons

### DIFF
--- a/src/materialize/dataflow/render.rs
+++ b/src/materialize/dataflow/render.rs
@@ -55,35 +55,48 @@ pub fn build_dataflow<A: Allocate>(
             manager.set_trace(src.name.clone(), &arrangement, on_delete);
         }
         Dataflow::View(view) => {
-            let arrangement = build_plan(&view.plan, manager, scope).arrange_by_self();
-            let on_delete = Box::new(|| ());
+            let mut buttons = Vec::new();
+            let arrangement = build_plan(&view.plan, manager, scope, &mut buttons).arrange_by_self();
+            let on_delete = Box::new(move || for button in buttons.iter_mut() { button.press(); });
             manager.set_trace(view.name.clone(), &arrangement, on_delete);
         }
     })
 }
 
+use timely::dataflow::operators::CapabilitySet;
+use differential_dataflow::operators::arrange::ShutdownButton;
+
 fn build_plan<S: Scope<Timestamp = Timestamp>>(
     plan: &Plan,
     manager: &mut TraceManager,
     scope: &mut S,
+    buttons: &mut Vec<ShutdownButton<CapabilitySet<Timestamp>>>,
 ) -> Collection<S, Datum, Diff> {
     match plan {
-        Plan::Source(name) => manager
-            .get_trace(name.to_owned())
-            .unwrap_or_else(|| panic!(format!("unable to find dataflow {}", name)))
-            .import(scope)
-            .as_collection(|k, ()| k.to_owned()),
+        Plan::Source(name) => {
+            let (arranged, button) =
+            manager
+                .get_trace(name.to_owned())
+                .unwrap_or_else(|| panic!(format!("unable to find dataflow {}", name)))
+                .import_core(scope, &format!("Import ({})", name));
+
+            buttons.push(button);
+
+            arranged
+                .as_collection(|k, ()| k.to_owned())
+        },
+
 
         Plan::Project { outputs, input } => {
             let outputs = outputs.clone();
-            build_plan(&input, manager, scope).map(move |datum| {
+            build_plan(&input, manager, scope, buttons).map(move |datum| {
                 Datum::Tuple(outputs.iter().map(|expr| eval_expr(expr, &datum)).collect())
             })
         }
 
         Plan::Filter { predicate, input } => {
             let predicate = predicate.clone();
-            build_plan(&input, manager, scope).filter(move |datum| {
+            build_plan(&input, manager, scope, buttons).filter(move |datum| {
                 match eval_expr(&predicate, &datum) {
                     Datum::False => false,
                     Datum::True => true,
@@ -96,7 +109,7 @@ fn build_plan<S: Scope<Timestamp = Timestamp>>(
         Plan::Aggregate { key, aggs, input } => {
             let key = key.clone();
             let aggs = aggs.clone();
-            build_plan(&input, manager, scope)
+            build_plan(&input, manager, scope, buttons)
                 .map(move |datum| (eval_expr(&key, &datum), datum))
                 .reduce(move |_key, input, output| {
                     let res: Vec<_> = aggs
@@ -131,9 +144,9 @@ fn build_plan<S: Scope<Timestamp = Timestamp>>(
         } => {
             let left_key = left_key.clone();
             let right_key = right_key.clone();
-            let left = build_plan(&left, manager, scope)
+            let left = build_plan(&left, manager, scope, buttons)
                 .map(move |datum| (eval_expr(&left_key, &datum), datum));
-            let right = build_plan(&right, manager, scope)
+            let right = build_plan(&right, manager, scope, buttons)
                 .map(move |datum| (eval_expr(&right_key, &datum), datum));
 
             let mut flow = left.join(&right).map(|(_key, (left, right))| {
@@ -171,10 +184,10 @@ fn build_plan<S: Scope<Timestamp = Timestamp>>(
             flow
         }
 
-        Plan::Distinct(plan) => build_plan(plan, manager, scope).distinct_total(),
+        Plan::Distinct(plan) => build_plan(plan, manager, scope, buttons).distinct_total(),
         Plan::UnionAll(plans) => {
             assert!(!plans.is_empty());
-            let mut plans = plans.iter().map(|plan| build_plan(plan, manager, scope));
+            let mut plans = plans.iter().map(|plan| build_plan(plan, manager, scope, buttons));
             let plan = plans.next().unwrap();
             plans.fold(plan, |p1, p2| p1.concat(&p2))
         }

--- a/src/materialize/dataflow/trace.rs
+++ b/src/materialize/dataflow/trace.rs
@@ -19,7 +19,7 @@ pub type TraceKeyHandle<K, T, R> = TraceAgent<K, (), T, R, OrdKeySpine<K, T, R>>
 
 pub type KeysOnlyHandle = TraceKeyHandle<Datum, Timestamp, Diff>;
 
-pub type DeleteCallback = Box<Fn()>;
+pub type DeleteCallback = Box<FnMut()>;
 
 pub struct TraceManager {
     traces: HashMap<String, TraceInfo>,
@@ -73,13 +73,13 @@ impl TraceManager {
     }
 
     pub fn del_trace(&mut self, name: &str) {
-        if let Some(ti) = self.traces.remove(name) {
+        if let Some(mut ti) = self.traces.remove(name) {
             (ti.delete_callback)();
         }
     }
 
     pub fn del_all_traces(&mut self) {
-        for (_, ti) in self.traces.drain() {
+        for (_, mut ti) in self.traces.drain() {
             (ti.delete_callback)();
         }
     }


### PR DESCRIPTION
This PR demonstrates the use of `ShutdownButton` to collect buttons to disconnect the inputs to a view. When buttons are pressed, the input capabilities used to supply new batches are just dropped, and the downstream view can complete (whether it does or not is up to the computation).

The code here maintains a `&mut Vec<ShutdownButton<_>>` in `render::build_plan`, and each time we import a new *input* we add a button. 

This PR clashes with the trace re-use, in that we would also want to collect those buttons too, but I thought this might be a better starting point for @jamii to get tests up and running without horrible times due to maintained dataflows.