### PR TITLE
ci: standard on HOST vs. ADDR vs. URL

### DIFF
--- a/ci/test/docker-compose.yml
+++ b/ci/test/docker-compose.yml
@@ -17,11 +17,10 @@ services:
     - SSH_AUTH_SOCK=/tmp/ssh-agent.sock
     - SCCACHE_MEMCACHED=tcp://buildcache.internal.mtrlz.dev:11211
     - CARGO_HOME=/cargo
-    - ZOOKEEPER_URL=zookeeper:2181
-    - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     - RUSTC_WRAPPER=sccache
-    - KAFKA_HOST=kafka
-    - ZOOKEEPER_HOST=zookeeper
+    - ZOOKEEPER_ADDR=zookeeper:2181
+    - KAFKA_ADDR=kafka:9092
+    - SCHEMA_REGISTRY_URL=http://schema-registry:8081
     user: $BUILDKITE_AGENT_UID:$BUILDKITE_AGENT_GID
     depends_on: [kafka, zookeeper, schema-registry]
   zookeeper:

--- a/ci/test/test.sh
+++ b/ci/test/test.sh
@@ -65,7 +65,10 @@ if [[ ! "$fast" ]]; then
     # TODO(benesch): we need proper synchronization here.
     sleep 0.1
 
-    target/debug/testdrive --kafka-addr "${KAFKA_HOST:-localhost}:9092" test/*
+    args=()
+    [[ "$KAFKA_ADDR" ]] && args+=("--kafka-addr" "$KAFKA_ADDR")
+    [[ "$SCHEMA_REGISTRY_URL" ]] && args+=("--schema-registry-url" "$SCHEMA_REGISTRY_URL")
+    try target/debug/testdrive "${args[@]}" test/*
 fi
 
 cd fuzz

--- a/src/metastore/tests/util.rs
+++ b/src/metastore/tests/util.rs
@@ -15,8 +15,8 @@ use tokio_zookeeper::ZooKeeper;
 use ore::closure;
 
 lazy_static! {
-    pub static ref ZOOKEEPER_ADDR: SocketAddr = match env::var("ZOOKEEPER_URL") {
-        Ok(addr) => parse_addr(&addr).expect("unable to parse ZOOKEEPER_URL"),
+    pub static ref ZOOKEEPER_ADDR: SocketAddr = match env::var("ZOOKEEPER_ADDR") {
+        Ok(addr) => parse_addr(&addr).expect("unable to parse ZOOKEEPER_ADDR"),
         _ => "127.0.0.1:2181".parse().unwrap(),
     };
 }


### PR DESCRIPTION
A "URL" now means something with a scheme, like http://foo.bar,
where as an "ADDR" means just a host and port. Use that language
consistently throughout the CI scripts, command line arguments, and
variable names. Then fix CI, now that everything is less confusing.