### PR TITLE
Shutdown peeks

### DIFF
--- a/src/materialize/dataflow/server.rs
+++ b/src/materialize/dataflow/server.rs
@@ -418,7 +418,7 @@ where
                 match self
                     .inputs
                     .get_mut(&insert.name)
-                    .expect(&format!("Failed to find input: {:?}", insert.name))
+                    .unwrap_or_else(|| panic!("Failed to find input: {:?}", insert.name))
                 {
                     InputCapability::Local { handle, .. } => {
                         let time = *insert.capability.time();


### PR DESCRIPTION
Fixes MaterializeInc/database-issues#85 by guarding the processing of peeks by a test that we are not shutting down.