### PR TITLE
testdrive: don't reuse kafka topic names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "ore 0.1.0",
  "postgres 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdkafka 0.20.0 (git+ssh://git@github.com/MaterializeInc/rust-rdkafka.git)",
  "regex 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -26,6 +26,7 @@ ore = { path = "../ore" }
 postgres = "0.16.0-rc.2"  # pre-release for simple_query support
 serde_json = { version = "1.0.40", features = ["preserve_order"] }
 sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }
+rand = "0.7.0"
 rdkafka = "0.20"
 regex = "1"
 reqwest = "0.9.19"

--- a/test/basic.td
+++ b/test/basic.td
@@ -59,7 +59,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=42
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=43
 {"before": null, "after": null}
 
-> CREATE SOURCE data FROM 'kafka://${testdrive.kafka-addr}/data' USING SCHEMA '${schema}'
+> CREATE SOURCE data FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${schema}'
 
 > PEEK data
 a b

--- a/test/decimal.td
+++ b/test/decimal.td
@@ -72,7 +72,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE data FROM 'kafka://${testdrive.kafka-addr}/data' USING SCHEMA '${schema}'
+> CREATE SOURCE data FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${schema}'
 
 > PEEK data
 17.94

--- a/test/joins.td
+++ b/test/joins.td
@@ -89,9 +89,9 @@ $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
 $ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE names FROM 'kafka://${testdrive.kafka-addr}/names' USING SCHEMA '${names-schema}'
+> CREATE SOURCE names FROM 'kafka://${testdrive.kafka-addr}/testdrive-names-${testdrive.seed}' USING SCHEMA '${names-schema}'
 
-> CREATE SOURCE mods FROM 'kafka://${testdrive.kafka-addr}/mods' USING SCHEMA '${mods-schema}'
+> CREATE SOURCE mods FROM 'kafka://${testdrive.kafka-addr}/testdrive-mods-${testdrive.seed}' USING SCHEMA '${mods-schema}'
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT * FROM names JOIN mods USING (num);

--- a/test/multijoins.td
+++ b/test/multijoins.td
@@ -133,11 +133,11 @@ $ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=2
 $ kafka-ingest format=avro topic=plurals schema=${plurals-schema} timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE names FROM 'kafka://${testdrive.kafka-addr}/names' USING SCHEMA '${names-schema}'
+> CREATE SOURCE names FROM 'kafka://${testdrive.kafka-addr}/testdrive-names-${testdrive.seed}' USING SCHEMA '${names-schema}'
 
-> CREATE SOURCE mods FROM 'kafka://${testdrive.kafka-addr}/mods' USING SCHEMA '${mods-schema}'
+> CREATE SOURCE mods FROM 'kafka://${testdrive.kafka-addr}/testdrive-mods-${testdrive.seed}' USING SCHEMA '${mods-schema}'
 
-> CREATE SOURCE plurals FROM 'kafka://${testdrive.kafka-addr}/plurals' USING SCHEMA '${plurals-schema}'
+> CREATE SOURCE plurals FROM 'kafka://${testdrive.kafka-addr}/testdrive-plurals-${testdrive.seed}' USING SCHEMA '${plurals-schema}'
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT * FROM names, mods, plurals WHERE names.num = mods.num AND names.name = plurals.num;

--- a/test/nulls.td
+++ b/test/nulls.td
@@ -44,7 +44,7 @@ $ kafka-ingest format=avro topic=foo schema=${foo-schema} timestamp=1
 $ kafka-ingest format=avro topic=foo schema=${foo-schema} timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE foo FROM 'kafka://${testdrive.kafka-addr}/foo' USING SCHEMA '${foo-schema}'
+> CREATE SOURCE foo FROM 'kafka://${testdrive.kafka-addr}/testdrive-foo-${testdrive.seed}' USING SCHEMA '${foo-schema}'
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT * FROM foo JOIN foo as foo2 USING (a);

--- a/test/registry.td
+++ b/test/registry.td
@@ -77,7 +77,7 @@ $ kafka-ingest format=avro topic=data schema=${schema_v1} publish=true timestamp
 $ kafka-ingest format=avro topic=data schema=${schema_v1} publish=true timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE data_v1 FROM 'kafka://${testdrive.kafka-addr}/data'
+> CREATE SOURCE data_v1 FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}'
   USING SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > PEEK data_v1
@@ -91,7 +91,7 @@ $ kafka-ingest format=avro topic=data schema=${schema_v2} publish=true timestamp
 $ kafka-ingest format=avro topic=data schema=${schema_v2} publish=true timestamp=4
 {"before": null, "after": null}
 
-> CREATE SOURCE data_v2 FROM 'kafka://${testdrive.kafka-addr}/data'
+> CREATE SOURCE data_v2 FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}'
   USING SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > PEEK data_v1


### PR DESCRIPTION
Reusing Kafka topics is fraught with peril. (See the enclosed removed
comments for details; basically, Kafka deletion is asynchronous, and can
impact a topic created with the same name in the future.)

Instead, randomly generate a name for each testdrive invocation, like
testdrive-TOPICNAME-123456789. We still clean up after ourselves by
deleting any topics that start with testdrive-TOPICNAME on the next
testdrive invocation, but those topics are abandoned at that point and
so can't impact the current testdrive run.

This fixes the races we've been seeing in CI lately (hopefully!).