### PR TITLE
.github: configure merge-when-green

### DIFF
--- a/.github/merge-when-green.yml
+++ b/.github/merge-when-green.yml
@@ -1,0 +1,2 @@
+requiredChecks:
+- buildkite/tests

--- a/bin/lint
+++ b/bin/lint
@@ -39,6 +39,7 @@ copyright_files=$(grep -vE \
     -e '\.md$' \
     -e '\.json$' \
     -e '^misc/docker/ci-builder/(rust.asc|ssh_known_hosts)$' \
+    -e '^.github/' \
     <<< "$files"
 )
 


### PR DESCRIPTION
Configure merge-when-green so that it knows when status checks have
passed. The idea is that you attach the "merge when green" label to a PR
that you want to be automatically merged when tests pass. Useful when
your PR has been LGTM'd, but you had to push fixes for a few nits and
don't want to sit around staring at GitHub waiting for the build to
pass.