### PR TITLE
Alter peek results

### DIFF
--- a/src/materialize/pgwire/protocol.rs
+++ b/src/materialize/pgwire/protocol.rs
@@ -342,7 +342,8 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
                 state.peek_results.extend(results.unwrap_peeked());
                 state.remaining_results -= 1;
                 if state.remaining_results == 0 {
-                    let peek_results = state.peek_results;
+                    let mut peek_results = state.peek_results;
+                    peek_results.sort();
                     let row_type = state.row_type;
                     let stream: MessageStream = Box::new(futures::stream::iter_ok(
                         peek_results.into_iter().map(move |row| {


### PR DESCRIPTION
A quick 1.5 liner that sorts results before they are returned through pgwire, so that the user gets a deterministic and sane set of results, independent of the number of workers used.