### PR TITLE
dataflow: ask Kafka to use sparse connections

### DIFF
--- a/src/materialize/dataflow/source/kafka.rs
+++ b/src/materialize/dataflow/source/kafka.rs
@@ -42,6 +42,7 @@ where
             .set("auto.offset.reset", "earliest")
             .set("session.timeout.ms", "6000")
             .set("fetch.message.max.bytes", "134217728")
+            .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &connector.addr.to_string());
 
         let mut consumer: Option<BaseConsumer<DefaultConsumerContext>> = if read_kafka {


### PR DESCRIPTION
Ask the Kafka library not to eagerly connect to multiple brokers to save
on threads . This doesn't actually make the situation better in our
tests, where we use just one broker, but will prevent the situation from
getting worse in production where multiple brokers are used.

Informs MaterializeInc/database-issues#68.