### PR TITLE
add "dyn" to a few bare trait objects

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -123,6 +123,13 @@ disabled_lints=(
     clippy::unneeded_field_pattern
 )
 
+extra_lints=(
+    # Upstream description: https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#bare-trait-object
+    #
+    # Omitting `dyn` on a trait object will become deprecated in the near future
+    bare_trait_objects
+)
+
 # NOTE(benesch): we ignore some ShellCheck complaints about sloppy word
 # splitting below. It's substantially clearer than doing things "properly,"
 # and the inputs to this script are trusted.
@@ -131,4 +138,4 @@ pkgspec=$(sed -nE 's,.*"src/([^"]+)".*,-p \1,p' Cargo.toml)
 # shellcheck disable=SC2086
 run cargo clean $pkgspec
 # shellcheck disable=SC2046
-run cargo clippy -- -D warnings $(printf -- "-A %s " "${disabled_lints[@]}")
+run cargo clippy -- -D warnings $(printf -- "-D %s " "${extra_lints[@]}") $(printf -- "-A %s " "${disabled_lints[@]}")

--- a/src/materialize/dataflow/arrangement/manager.rs
+++ b/src/materialize/dataflow/arrangement/manager.rs
@@ -18,7 +18,7 @@ pub type TraceValHandle<K, V, T, R> = TraceAgent<OrdValSpine<K, V, T, R>>;
 pub type KeysOnlyHandle = TraceKeyHandle<Vec<Datum>, Timestamp, Diff>;
 pub type KeysValsHandle = TraceValHandle<Vec<Datum>, Vec<Datum>, Timestamp, Diff>;
 
-pub type DeleteCallback = Box<FnOnce()>;
+pub type DeleteCallback = Box<dyn FnOnce()>;
 
 /// A map from collection names to cached arrangements.
 ///

--- a/src/materialize/server/http.rs
+++ b/src/materialize/server/http.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use crate::glue::*;
 use ore::future::FutureExt;
 
-struct FutureResponse(Box<Future<Item = Response<Body>, Error = failure::Error> + Send>);
+struct FutureResponse(Box<dyn Future<Item = Response<Body>, Error = failure::Error> + Send>);
 
 impl From<Response<Body>> for FutureResponse {
     fn from(res: Response<Body>) -> FutureResponse {

--- a/src/sqllogictest/lib.rs
+++ b/src/sqllogictest/lib.rs
@@ -533,7 +533,7 @@ struct FullState {
     dataflow_command_sender: UnboundedSender<(DataflowCommand, CommandMeta)>,
     worker0_thread: std::thread::Thread,
     // this is only here to avoid dropping it too early
-    _dataflow_workers: Box<Drop>,
+    _dataflow_workers: Box<dyn Drop>,
     current_timestamp: u64,
     local_input_uuids: HashMap<String, Uuid>,
     local_input_mux: LocalInputMux,
@@ -1072,7 +1072,7 @@ impl RecordRunner for OnlyParseState {
 
 pub fn run_string(source: &str, input: &str, verbosity: usize, only_parse: bool) -> Outcomes {
     let mut outcomes = Outcomes::default();
-    let mut state: Box<RecordRunner> = if only_parse {
+    let mut state: Box<dyn RecordRunner> = if only_parse {
         Box::new(OnlyParseState::start())
     } else {
         Box::new(FullState::start().unwrap())

--- a/src/sqllogictest/postgres.rs
+++ b/src/sqllogictest/postgres.rs
@@ -265,7 +265,7 @@ impl FromSql<'_> for DecimalWrapper {
     fn from_sql(
         _ty: &PostgresType,
         raw: &[u8],
-    ) -> Result<Self, Box<std::error::Error + 'static + Send + Sync>> {
+    ) -> Result<Self, Box<dyn std::error::Error + 'static + Send + Sync>> {
         // TODO(jamii) how do we attribute this?
         // based on:
         //   https://docs.diesel.rs/src/diesel/pg/types/floats/mod.rs.html#55-82

--- a/src/testdrive/action/mod.rs
+++ b/src/testdrive/action/mod.rs
@@ -37,7 +37,7 @@ pub struct State {
 
 pub struct PosAction {
     pub pos: usize,
-    pub action: Box<Action>,
+    pub action: Box<dyn Action>,
 }
 
 pub trait Action {
@@ -58,7 +58,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Inp
         let pos = cmd.pos;
         let wrap_err = |e| InputError { msg: e, pos };
         let subst = |msg: &str| substitute_vars(msg, &vars).map_err(wrap_err);
-        let action: Box<Action> = match cmd.command {
+        let action: Box<dyn Action> = match cmd.command {
             Command::Builtin(mut builtin) => {
                 for val in builtin.args.values_mut() {
                     *val = subst(val)?;

--- a/src/testdrive/error.rs
+++ b/src/testdrive/error.rs
@@ -96,7 +96,7 @@ impl Error {
         self,
         filename: &str,
         contents: &str,
-        positioner: &Positioner,
+        positioner: &dyn Positioner,
     ) -> Self {
         match self {
             Error::Input { err, .. } => {


### PR DESCRIPTION
This was causing a bunch of warning spew on nightly, and I think the deprecation warning is supposed to get turned on in 1.37 or 1.38 or something, so might as well deal with it now.