### PR TITLE
Document alternatives for GitHub Authentication

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,27 +1,22 @@
 # GitHub Authentication
 
 Reconciling security and convenience is genuinely difficult. Fortunately, GitHub gives us plenty
-of options.
+of options. Most importantly, if you are a member of the MaterializeInc organization, you already
+have [two-factor authentication on GitHub](https://help.github.com/en/articles/accessing-github-using-two-factor-authentication)
+enabled. Otherwise, you couldn't have joined the GitHub organization.
 
 ## The Limits of SSH
 
 Our [default setup](https://github.com/MaterializeInc/mtrlz-setup) relies on SSH and a newly
-created key registered with GitHub. This works for all user accounts, independent of whether
-they have two-factor authentication enabled or not.
-
-**If you haven't enabled [two-factor authentication on GitHub](https://help.github.com/en/articles/accessing-github-using-two-factor-authentication#using-two-factor-authentication-with-the-command-line),
-go directly to your settings and enable two-factor authentication. Do not read ahead. Do
-not collect lunch.**
-
-SSH, however, won't work for repositories cloned via `https` URLs, which feature prominently
-in GitHub's web interface and are used by [GitHub Desktop](https://desktop.github.com). For
-accounts without two-factor authentication, you still can enter user name and password on the
-command line.
+created key registered with GitHub. This works for most settings, but not when repositories are
+cloned via the `https` URLs featured so prominently in GitHub's web interface and also used by
+[GitHub Desktop](https://desktop.github.com). Since we have two-factor authentication enabled, we
+cannot just enter user name and password on the command line either.
 
 ## The Joys of the Personal Access Token
 
-For accounts with two-factor authentication accessed from macOS, you can make working with
-repositories cloned via `https` as seamless as for those cloned via SSH.
+On macOS, you can use [a personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
+to make the user experience comparably seamless:
 
  1. [Create a personal access token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
     for GitHub. The new access token should have the **repo** scope, no more. Once generated,


### PR DESCRIPTION
I kept running into password prompts and couldn't use command line tools. The documented setup is simple enough and works.