### PR TITLE
*: remove some unnecessary clippy allow directives

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -303,7 +303,6 @@ impl RelationExpr {
     }
 
     /// Collects the names of the dataflows that this relation_expr depends upon.
-    #[allow(clippy::unneeded_field_pattern)]
     pub fn uses_inner<'a, 'b>(&'a self, out: &'b mut Vec<&'a str>) {
         self.visit(&mut |e| match e {
             RelationExpr::Get { name, .. } => {

--- a/src/materialize/pgwire/protocol.rs
+++ b/src/materialize/pgwire/protocol.rs
@@ -3,10 +3,6 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-// Ignore disparity between the sizes of the variants in the generated state
-// machine.
-#![allow(clippy::large_enum_variant)]
-
 use byteorder::{ByteOrder, NetworkEndian};
 use futures::sink::Send as SinkSend;
 use futures::stream;


### PR DESCRIPTION
These lints are now globally allowed in bin/check, so the specific
overrides are no longer necessary.