### PR TITLE
Add nice horizontal rules for readability

### DIFF
--- a/src/sqllogictest/lib.rs
+++ b/src/sqllogictest/lib.rs
@@ -1245,7 +1245,9 @@ pub fn run_string(source: &str, input: &str, verbosity: usize, only_parse: bool)
                     println!("{}", HEAVY_HORIZONTAL_RULE);
                     println!("{}", outcome);
                     match &record {
-                        Record::Statement { sql, .. } => println!("{}\n{}", LIGHT_HORIZONTAL_RULE, sql),
+                        Record::Statement { sql, .. } => {
+                            println!("{}\n{}", LIGHT_HORIZONTAL_RULE, sql)
+                        }
                         Record::Query { sql, .. } => println!("{}\n{}", LIGHT_HORIZONTAL_RULE, sql),
                         _ => (),
                     }


### PR DESCRIPTION
Previously, the SQLite barfed out the results, with the association between error message and offending query being unclear. This pull requests adds nice horizontal rules with Unicode box drawing characters to improve readability.