### PR TITLE
Ignore configuration state for IntelliJ IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .mtrlz.log
 **/*.rs.bk
+.idea


### PR DESCRIPTION
IntelliJ is a great tool, especially for understanding a large codebase. It does, however, save a bunch of configuration files that should *not* be shared.

Make it so!