### PR TITLE
Fully implement UNION, EXCEPT, and INTERSECT

### DIFF
--- a/src/materialize/sql/mod.rs
+++ b/src/materialize/sql/mod.rs
@@ -574,14 +574,17 @@ impl Planner {
                         } else {
                             left_expr.union(right_expr).distinct()
                         }
-                    },
+                    }
                     SetOperator::Except => {
                         if *all {
                             left_expr.union(right_expr.negate()).threshold()
                         } else {
-                            left_expr.distinct().union(right_expr.distinct().negate()).threshold()
+                            left_expr
+                                .distinct()
+                                .union(right_expr.distinct().negate())
+                                .threshold()
                         }
-                    },
+                    }
                     SetOperator::Intersect => {
                         // TODO: Let's not duplicate the left-hand expression into TWO dataflows!
                         // Though we believe that render() does The Right Thing (TM)
@@ -590,11 +593,14 @@ impl Planner {
                         // i.e., the record counts for differential data flow definitely remain non-negative.
                         let left_clone = left_expr.clone();
                         if *all {
-                            left_expr.union(left_clone.union(right_expr.negate()).threshold().negate())
+                            left_expr
+                                .union(left_clone.union(right_expr.negate()).threshold().negate())
                         } else {
-                            left_expr.union(left_clone.union(right_expr.negate()).threshold().negate()).distinct()
+                            left_expr
+                                .union(left_clone.union(right_expr.negate()).threshold().negate())
+                                .distinct()
                         }
-                    },
+                    }
                 };
                 Ok(relation_expr)
             }


### PR DESCRIPTION
`UNION`, `EXCEPT`, and `INTERSECT` are implemented as follows, with each operator gaining in complexity:

  * `UNION ALL` still uses the same implementation as before, i.e., maps down to the differential data flow operator `RelationExpr::Union` — though the source code has been restructured a bit to accommodate the divergent placement of the `RelationExpr::Distinct` operator.
  * `EXCEPT ALL` uses the new `RelationExpr::Threshold` introduced with MaterializeInc/materialize#345:

    ```
    a EXCEPT ALL b = Threshold(a - b)
                   = Threshold(Union(a, Negate(b)))
    ```

  * `INTERSECT ALL`, in turn, builds on `EXCEPT ALL` as follows:

    ```
    a INTERSECT ALL b = a - (a EXCEPT ALL b)
                      = Union(a, Negate(a EXCEPT ALL b))
                      = Union(a, Threshold(Union(a, Negate(b))))
    ```

  * `UNION` must apply `Distinct` on the *output* of `UNION ALL`.
  * `EXCEPT` must apply `Distinct` on the *inputs* of `EXCEPT ALL`.
  * `INTERSECT` may apply `Distinct` on either the inputs or the output. For now, we do so on the output because there are far fewer records to track.

With this change in place, all tests in `sqllogictest`'s `select4.test` pass:

```
==> sqllogictest/test/select4.test
unsupported=0 parse-failure=0 plan-failure=0 unexpected-plan-success=0 wrong-number-of-rows-inserted=0 inference-failure=0 wrong-column-names=0 output-failure=0 bail=0 success=3857 total=3857
```

This should suffice as a compelling test for `Threshold` as well and thereby this pull request completes MaterializeInc/database-issues#104.