### PR TITLE
quiesce maintenance

### DIFF
--- a/src/dataflow/coordinator.rs
+++ b/src/dataflow/coordinator.rs
@@ -168,10 +168,12 @@ impl CommandCoordinator {
     /// receive, and so cannot be owned only by the coordinator.
     pub fn maintenance(&mut self, sequencer: &mut Sequencer<SequencedCommand>) {
         // Take this opportunity to drain `since_update` commands.
-        sequencer.push(SequencedCommand::AllowCompaction(std::mem::replace(
-            &mut self.since_updates,
-            Vec::new(),
-        )));
+        if !self.since_updates.is_empty() {
+            sequencer.push(SequencedCommand::AllowCompaction(std::mem::replace(
+                &mut self.since_updates,
+                Vec::new(),
+            )));
+        }
     }
 
     /// A policy for determining the timestamp for a peek.


### PR DESCRIPTION
This PR suppresses the transmission of empty compaction methods, which would do nothing other than keep the sequencer busy and prevent timely parking.