### PR TITLE
dataflow,sql: lower avg to sum / count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.4.1-alpha.0"
-source = "git+ssh://git@github.com/MaterializeInc/sqlparser.git#342f4ecb37857cf1a08185f707f790e951f8646e"
+source = "git+ssh://git@github.com/MaterializeInc/sqlparser.git#aa9b649d3fd73c3556d188db9866e937d70774e8"
 dependencies = [
  "bigdecimal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/dataflow/render.rs
+++ b/src/dataflow/render.rs
@@ -337,7 +337,7 @@ where
                 // Reduce has the ability to lift any Abelian, non-distinct aggregations
                 // into the diff field. We also need to maintain the count as well, as we
                 // need to distinguish "things that accumulate to zero" from "the absence
-                // of things". It also gives us a quick and easy story about `Avg`.
+                // of things".
 
                 // We have an additional opportunity to discard any parts of the record
                 // that do not contribute to the non-Abelian or distinct aggregations.
@@ -353,11 +353,6 @@ where
                         AggregateFunc::SumFloat32 => !aggregate.distinct,
                         AggregateFunc::SumFloat64 => !aggregate.distinct,
                         AggregateFunc::SumDecimal => !aggregate.distinct,
-                        AggregateFunc::AvgInt32 => !aggregate.distinct,
-                        AggregateFunc::AvgInt64 => !aggregate.distinct,
-                        AggregateFunc::AvgFloat32 => !aggregate.distinct,
-                        AggregateFunc::AvgFloat64 => !aggregate.distinct,
-                        AggregateFunc::AvgDecimal => !aggregate.distinct,
                         AggregateFunc::Count => !aggregate.distinct,
                         AggregateFunc::CountAll => !aggregate.distinct,
                         _ => false,
@@ -521,68 +516,6 @@ where
                                         abelian_pos += 2;
                                         if non_nulls > 0 {
                                             Datum::from(total)
-                                        } else {
-                                            Datum::Null
-                                        }
-                                    }
-                                    AggregateFunc::AvgInt32 => {
-                                        let total = sums[abelian_pos] as i32;
-                                        let non_nulls = sums[abelian_pos + 1] as i32;
-                                        abelian_pos += 2;
-                                        if non_nulls > 0 {
-                                            Datum::Int32(total / non_nulls)
-                                        } else {
-                                            Datum::Null
-                                        }
-                                    }
-                                    AggregateFunc::AvgInt64 => {
-                                        let total = sums[abelian_pos] as i64;
-                                        let non_nulls = sums[abelian_pos + 1] as i64;
-                                        abelian_pos += 2;
-                                        if non_nulls > 0 {
-                                            Datum::Int64(total / non_nulls)
-                                        } else {
-                                            Datum::Null
-                                        }
-                                    }
-                                    AggregateFunc::AvgFloat32 => {
-                                        let total = sums[abelian_pos];
-                                        let non_nulls = sums[abelian_pos + 1];
-                                        abelian_pos += 2;
-                                        if non_nulls > 0 {
-                                            Datum::Float32(
-                                                ((((total as f64) / float_scale)
-                                                    / (non_nulls as f64))
-                                                    as f32)
-                                                    .into(),
-                                            )
-                                        } else {
-                                            Datum::Null
-                                        }
-                                    }
-                                    AggregateFunc::AvgFloat64 => {
-                                        let total = sums[abelian_pos];
-                                        let non_nulls = sums[abelian_pos + 1];
-                                        abelian_pos += 2;
-                                        if non_nulls > 0 {
-                                            Datum::Float64(
-                                                (((total as f64) / float_scale)
-                                                    / (non_nulls as f64))
-                                                    .into(),
-                                            )
-                                        } else {
-                                            Datum::Null
-                                        }
-                                    }
-                                    AggregateFunc::AvgDecimal => {
-                                        let total = sums[abelian_pos];
-                                        let non_nulls = sums[abelian_pos + 1];
-                                        abelian_pos += 2;
-                                        if non_nulls > 0 {
-                                            // TODO(benesch): This should use the same decimal
-                                            // division path as the planner, rather than
-                                            // hardcoding a 6 digit increase in the scale (#212).
-                                            Datum::from(1_000_000 * total / non_nulls)
                                         } else {
                                             Datum::Null
                                         }

--- a/src/expr/transform/aggregation.rs
+++ b/src/expr/transform/aggregation.rs
@@ -122,7 +122,7 @@ mod tests {
         let data = RelationExpr::constant(vec![], typ1);
 
         let agg0 = AggregateExpr {
-            func: AggregateFunc::AvgInt64,
+            func: AggregateFunc::MaxInt64,
             expr: ScalarExpr::Column(0),
             distinct: false,
         };

--- a/src/sql/transform.rs
+++ b/src/sql/transform.rs
@@ -1,0 +1,52 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+//! Transformations of SQL ASTs.
+//!
+//! Most query optimizations are performed by the dataflow layer, but some
+//! are much easier to perform in SQL. Someday, we'll want our own SQL IR,
+//! but for now we just use the parser's AST directly.
+
+use sqlparser::ast::visit_mut::{self, VisitMut};
+use sqlparser::ast::{BinaryOperator, Expr, Function, ObjectName, Statement};
+
+pub fn transform(stmt: &mut Statement) {
+    AvgFuncRewriter.visit_statement(stmt);
+}
+
+// Rewrites `avg(col)` to `sum(col) / count(col)`, so that we can pretend the
+// `avg` aggregate function doesn't exist from here on out. This also has the
+// nice side effect of reusing the division planning logic, which is not trivial
+// for some types, like decimals.
+struct AvgFuncRewriter;
+
+impl<'ast> VisitMut<'ast> for AvgFuncRewriter {
+    fn visit_expr(&mut self, expr: &'ast mut Expr) {
+        visit_mut::visit_expr(self, expr);
+        if let Expr::Function(func) = expr {
+            if func.name.to_string().to_lowercase() == "avg" {
+                let args = func.args.clone();
+                let sum = Expr::Function(Function {
+                    name: ObjectName(vec!["sum".into()]),
+                    args: args.clone(),
+                    over: None,
+                    distinct: func.distinct,
+                });
+                let count = Expr::Function(Function {
+                    name: ObjectName(vec!["count".into()]),
+                    args: args.clone(),
+                    over: None,
+                    distinct: func.distinct,
+                });
+                let div = Expr::BinaryOp {
+                    left: Box::new(sum),
+                    op: BinaryOperator::Divide,
+                    right: Box::new(count),
+                };
+                *expr = Expr::Nested(Box::new(div));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add our first SQL AST transformer, which rewrites `avg(col)` to
`sum(col) / count(col)`, so that the rest of the codebase doesn't need
to think about averages.

Fix MaterializeInc/database-issues#70.

Note that tests are expected to fail until https://github.com/MaterializeInc/sqlparser/pull/11 lands and this repo bumps the dep. It's ready for review in the meantime, though. I recommend going commit by commit, since I was careful to split the code-movement commits from the logic-changing commits.