### PR TITLE
Complete the plumbing for EXPLAIN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pretty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "repr 0.1.0",
@@ -1757,6 +1758,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typed-arena 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.4.1-alpha.0"
-source = "git+ssh://git@github.com/MaterializeInc/sqlparser.git#402d430599e6ed4e446bfe34ef306763391bfddb"
+source = "git+ssh://git@github.com/MaterializeInc/sqlparser.git#342f4ecb37857cf1a08185f707f790e951f8646e"
 dependencies = [
  "bigdecimal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2969,6 +2978,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +3378,7 @@ dependencies = [
 "checksum predicates 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "53e09015b0d3f5a0ec2d4428f7559bb7b3fff341b4e159fedd1d57fac8b939ff"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
 "checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+"checksum pretty 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f60c0d9f6fc88ecdd245d90c1920ff76a430ab34303fc778d33b1d0a4c3bf6d3"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
@@ -3481,6 +3496,7 @@ dependencies = [
 "checksum trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9992e58dba365798803c0b91018ff6c8d3fc77e06977c4539af2a6bfe0a039"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
+"checksum typed-arena 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f70f5c346cc11bc044ae427ab2feae213350dca9e2d637047797d5ff316a646"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -100,13 +100,14 @@ where
         logging_config: Option<logging::LoggingConfiguration>,
     ) -> Worker<'w, A> {
         let sequencer = Sequencer::new(w, Instant::now());
-        let command_coordinator =
-            dataflow_command_receiver.map(|dcr| coordinator::CommandCoordinator::new(dcr));
+        let exfiltrator = Rc::new(exfiltrator_config.into());
+        let command_coordinator = dataflow_command_receiver
+            .map(|dcr| coordinator::CommandCoordinator::new(dcr, Rc::clone(&exfiltrator)));
 
         Worker {
             inner: w,
             local_input_mux,
-            exfiltrator: Rc::new(exfiltrator_config.into()),
+            exfiltrator,
             pending_peeks: Vec::new(),
             traces: TraceManager::default(),
             inputs: HashMap::new(),

--- a/src/dataflow/types.rs
+++ b/src/dataflow/types.rs
@@ -26,6 +26,10 @@ pub enum DataflowCommand {
         source: RelationExpr,
         when: PeekWhen,
     },
+    Explain {
+        relation_expr: RelationExpr,
+        connection_uuid: Uuid,
+    },
     Shutdown,
 }
 

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -15,3 +15,4 @@ regex = "1.2.1"
 regex-syntax = "0.6.8"
 repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
+pretty = "0.5.2"

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use self::func::AggregateFunc;
 use crate::ScalarExpr;
+use pretty::{BoxDoc, Doc};
 
 #[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -423,6 +424,11 @@ impl RelationExpr {
     {
         f(self);
         self.visit1_mut(|e| e.visit_mut_pre(f));
+    }
+
+    pub fn pretty(&mut self) -> String {
+        let doc = Doc::<BoxDoc<()>>::text("Hello, world!");
+        format!("{}", doc.pretty(120),)
     }
 }
 


### PR DESCRIPTION
* Onboard pretty 0.5.2, a pretty-printer based on Wadler's formatting combinators. Create a first, trivial invocation.
* Add support for forwarding Explain to the coordinator, which does the planning and uses exfiltrator to directly communicate with the client.
* Add the corresponding control plane logic, notably in the client-facing pgwire component.

This pull request largely completes the implementation of the control plane for MaterializeInc/database-issues#116.