### PR TITLE
add names to reduce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "differential-dataflow"
 version = "0.10.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#c78b860af3f4b6148c8bedbf3f13a5eb1c006b23"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#8a44b24fbe76d42b9bcc2a64ad5f774e060aab30"
 dependencies = [
  "abomonation 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "abomonation_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
This PR upgrades the differential dataflow dependence and introduces names for our `reduce` invocations at the same time. It supersedes #372.