### PR TITLE
Advance view inputs

### DIFF
--- a/src/dataflow/arrangement/context.rs
+++ b/src/dataflow/arrangement/context.rs
@@ -14,6 +14,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::{Arranged, TraceAgent};
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::trace::wrappers::enter::TraceEnter;
+use differential_dataflow::trace::wrappers::frontier::TraceFrontier;
 use differential_dataflow::Collection;
 use differential_dataflow::Data;
 
@@ -25,8 +26,13 @@ type Diff = isize;
 // Local type definition to avoid the horror in signatures.
 type Arrangement<S, V> =
     Arranged<S, TraceValHandle<Vec<V>, Vec<V>, <S as ScopeParent>::Timestamp, Diff>>;
-type ArrangementImport<S, V, T> =
-    Arranged<S, TraceEnter<TraceValHandle<Vec<V>, Vec<V>, T, Diff>, <S as ScopeParent>::Timestamp>>;
+type ArrangementImport<S, V, T> = Arranged<
+    S,
+    TraceEnter<
+        TraceFrontier<TraceValHandle<Vec<V>, Vec<V>, T, Diff>>,
+        <S as ScopeParent>::Timestamp,
+    >,
+>;
 
 /// Dataflow-local collections and arrangements.
 ///

--- a/src/dataflow/coordinator.rs
+++ b/src/dataflow/coordinator.rs
@@ -148,6 +148,7 @@ impl CommandCoordinator {
                             name: name.clone(),
                             relation_expr: source,
                             typ,
+                            as_of: Some(vec![timestamp.clone()]),
                         })]);
                     sequencer.push(create_command);
                     (name, true)

--- a/src/dataflow/render.rs
+++ b/src/dataflow/render.rs
@@ -95,6 +95,12 @@ pub fn build_dataflow<A: Allocate>(
             }
         }
         Dataflow::View(view) => {
+            let as_of = view
+                .as_of
+                .as_ref()
+                .map(|x| x.to_vec())
+                .unwrap_or_else(|| vec![0]);
+
             // The scope.clone() occurs to allow import in the region.
             // We build a region here to establish a pattern of a scope inside the dataflow,
             // so that other similar uses (e.g. with iterative scopes) do not require weird
@@ -106,7 +112,8 @@ pub fn build_dataflow<A: Allocate>(
                     if let RelationExpr::Get { name, typ: _ } = e {
                         // Import the believed-to-exist base arrangement.
                         if let Some(mut trace) = manager.get_by_self(&name).cloned() {
-                            let (arranged, button) = trace.import_core(scope, name);
+                            let (arranged, button) =
+                                trace.import_frontier_core(scope, name, as_of.clone());
                             let arranged = arranged.enter(region);
                             context
                                 .collections

--- a/src/dataflow/types.rs
+++ b/src/dataflow/types.rs
@@ -168,6 +168,9 @@ pub struct View {
     pub name: String,
     pub relation_expr: RelationExpr,
     pub typ: RelationType,
+    /// Indicates if sources can be advanced to a supplied frontier.
+    /// Outputs will only be correct from this frontier onward.
+    pub as_of: Option<Vec<Timestamp>>,
 }
 
 #[cfg(test)]
@@ -223,6 +226,7 @@ mod tests {
                     ColumnType::new(ScalarType::Int32).name("quantity"),
                 ],
             },
+            as_of: None,
         });
 
         let decoded: Dataflow = serde_json::from_str(&serde_json::to_string_pretty(&dataflow)?)?;

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -502,6 +502,7 @@ impl Planner {
                     name: extract_sql_object_name(name)?,
                     relation_expr,
                     typ,
+                    as_of: None,
                 })])
             }
             Statement::CreateSource {


### PR DESCRIPTION
This PR adds an optional field to each `View` that describes a frontier "as_of" which the view should be constructed. The effect is that imported sources will be advanced to this frontier, and the results of the view will be guaranteed to be correct only as of this frontier.

The purpose is to allow us to forcibly advance updates to this frontier to avoid computation for times we have no interest in. Without this, differential dataflow will happily perform computations for various historical times we may not require. In a sense, while compaction "permits" the advancing of times, it does not "require" that times be advanced. This is what enables that.