### PR TITLE
Change the unstable-COMMIT docker image to not strip symbols

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -102,6 +102,16 @@ reproduced here. If you need to recreate the SSH key:
 
 If you need the Docker hub password, it's in the company 1Password.
 
+## Docker Images
+
+We produce several docker images as part of CI, all are prefixed with `ci-`
+until they are ready for end-users to use.
+
+The two tradeoffs that we try to balance are CI speed and end-user convenience.
+Right now that mostly manifests as creating stripped binaries for use within CI
+and a `ci-raw-materialized` unstripped docker image for use in all
+interactive/deployed scenarios.
+
 ## Build caching
 
 Rust compilation is slow enough that we use [sccache], a distributed build cache

--- a/ci/deploy/docker.sh
+++ b/ci/deploy/docker.sh
@@ -9,9 +9,9 @@
 
 set -euo pipefail
 
-docker pull "materialize/ci-materialized:$MATERIALIZED_IMAGE_ID"
+docker pull "materialize/ci-raw-materialized:$MATERIALIZED_IMAGE_ID"
 
 for tag in "unstable-$BUILDKITE_COMMIT" latest; do
-    docker tag "materialize/ci-materialized:$MATERIALIZED_IMAGE_ID" "materialize/materialized:$tag"
+    docker tag "materialize/ci-raw-materialized:$MATERIALIZED_IMAGE_ID" "materialize/materialized:$tag"
     docker push "materialize/materialized:$tag"
 done

--- a/misc/docker/ci-raw-materialized/Dockerfile
+++ b/misc/docker/ci-raw-materialized/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+FROM ubuntu:bionic
+
+COPY materialized /usr/local/bin
+
+ENTRYPOINT ["materialized"]


### PR DESCRIPTION
This should allow us to get backtraces if materialized crashes.