### PR TITLE
ci/slt: use correct path for sqlite tests

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -21,7 +21,7 @@ mkdir -p target
 
 sqllogictest \
     -v --json-summary-file=target/slt-summary.json "$@" \
-    sqllogictest/test \
     test/*.slt \
     test/cockroach/*.slt \
+    test/sqlite/test \
     | tee target/slt.log


### PR DESCRIPTION
SQLite tests live in test/sqlite/test now, not sqllogictest/test.