### PR TITLE
ci/slt: fix jq parsing in upload

### DIFF
--- a/ci/slt/parse-summary.jq
+++ b/ci/slt/parse-summary.jq
@@ -7,5 +7,5 @@
 
 {
     "keys": keys_unsorted | join(", "),
-    "values": values | join(", ")
+    "values": values | map(tostring) | join(", ")
 } | "INSERT INTO slt (commit, \(.keys)) VALUES ('\($commit)', \(.values))"


### PR DESCRIPTION
Apparently jq 1.6 allows you to join arrays of numbers, but jq 1.5,
which we use in our CI builder image, requires an explicit call to
tostring first.