### PR TITLE
pre-push: rearrange so fast things happen first

### DIFF
--- a/bin/pre-push
+++ b/bin/pre-push
@@ -15,7 +15,7 @@ SHLIB_NOT_IN_CI=1
 
 ci_try bin/lint
 ci_try cargo fmt -- --check
-ci_try cargo test
 ci_try bin/check
+ci_try cargo test
 
 ci_status_report


### PR DESCRIPTION
Most notably, do bin/check before cargo test, so that clippy errors are
surfaced as early as possible to reduce frustration.

Touches MaterializeInc/database-issues#130.