### PR TITLE
deps: switch back to mainline timely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
  "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "timely 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -648,7 +648,7 @@ name = "dataflow-bin"
 version = "0.1.0"
 dependencies = [
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "timely 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "timely 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
  "timely_sort 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1333,7 +1333,7 @@ dependencies = [
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql 0.1.0",
  "state_machine_future 0.2.0 (git+https://github.com/benesch/state_machine_future.git?branch=context-generic-bounds)",
- "timely 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2488,7 +2488,7 @@ dependencies = [
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql 0.1.0",
  "sqlparser 0.4.1-alpha.0 (git+ssh://git@github.com/MaterializeInc/sqlparser.git)",
- "timely 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "whoami 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2706,26 +2706,26 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.10.0"
-source = "git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup#7fca2c94a4ac98100794b8c183c38768c717d18b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d5dfae1853ffd454795a84255525d4494a909a6"
 dependencies = [
  "abomonation 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "abomonation_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "timely_bytes 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
- "timely_communication 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
- "timely_logging 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely_bytes 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
+ "timely_communication 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
+ "timely_logging 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
 ]
 
 [[package]]
 name = "timely_bytes"
 version = "0.10.0"
-source = "git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup#7fca2c94a4ac98100794b8c183c38768c717d18b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d5dfae1853ffd454795a84255525d4494a909a6"
 
 [[package]]
 name = "timely_communication"
 version = "0.10.0"
-source = "git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup#7fca2c94a4ac98100794b8c183c38768c717d18b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d5dfae1853ffd454795a84255525d4494a909a6"
 dependencies = [
  "abomonation 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "abomonation_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2733,14 +2733,14 @@ dependencies = [
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "timely_bytes 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
- "timely_logging 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)",
+ "timely_bytes 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
+ "timely_logging 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)",
 ]
 
 [[package]]
 name = "timely_logging"
 version = "0.10.0"
-source = "git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup#7fca2c94a4ac98100794b8c183c38768c717d18b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d5dfae1853ffd454795a84255525d4494a909a6"
 
 [[package]]
 name = "timely_sort"
@@ -3548,10 +3548,10 @@ dependencies = [
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum timely 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)" = "<none>"
-"checksum timely_bytes 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)" = "<none>"
-"checksum timely_communication 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)" = "<none>"
-"checksum timely_logging 0.10.0 (git+https://github.com/frankmcsherry/timely-dataflow?branch=tpc_openup)" = "<none>"
+"checksum timely 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)" = "<none>"
+"checksum timely_bytes 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)" = "<none>"
+"checksum timely_communication 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)" = "<none>"
+"checksum timely_logging 0.10.0 (git+https://github.com/TimelyDataflow/timely-dataflow)" = "<none>"
 "checksum timely_sort 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f6e4b497ab85f6e09ea309d696342d198e444e93a4a55500bf3b0c3c53bdd4b3"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,3 @@ futures = { git = "ssh://git@github.com/MaterializeInc/futures-rs.git", branch =
 #
 # [patch."ssh://git@github.com/MaterializeInc/sqlparser.git"]
 # sqlparser = { path = "../sqlparser" }
-
-[patch."https://github.com/TimelyDataflow/timely-dataflow"]
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow", branch = "tpc_openup"}

--- a/src/comm/util.rs
+++ b/src/comm/util.rs
@@ -131,7 +131,7 @@ mod tests {
         let listener = TcpListener::bind(&addr)?;
         let addr = listener.local_addr()?;
         drop(listener);
-        // Hope tthat no one else will be listening on this port now.
+        // Hope that no one else will be listening on this port now.
         let mut runtime = Runtime::new()?;
         match runtime.block_on(TryConnectFuture::<TcpStream>::new(
             addr,


### PR DESCRIPTION
PR #424 switched us to a Timely branch that exposed more of the
networking guts, but that PR has been merged
(TimelyDataflow/timely-dataflow#292), so we're cleared to switch back to
master.