### PR TITLE
Create arrangement by primary key when creating dataflows

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -72,7 +72,12 @@ pub fn build_dataflow<A: Allocate>(
             let pkey_indices_clone = src.pkey_indices.clone();
             let arrangement_by_key = stream
                 .as_collection()
-                .map(move |x| (pkey_indices_clone.iter().map(|i| x[i].clone()).collect(), x))
+                .map(move |x| {
+                    (
+                        pkey_indices_clone.iter().map(|i| x[*i].clone()).collect(),
+                        x,
+                    )
+                })
                 .arrange_named::<KeysValsSpine>(&format!("Arrange: {}", src.name));
 
             manager.set_by_keys(


### PR DESCRIPTION
So far, we've only created arrangements `by_self`, which means key, value pairs like: (all the data, ()). We can do better! This PR introduces the first arrangement by primary key, like: (keyed data, all the data). 

For now, we will only create `by_key` arrangements when creating a new dataflow source. (This is because primary key information is currently only tied to the `Source` struct). In the future, we will likely want to expand creation of `by_key` arrangements to other instances, like creating views.

This PR introduces arrangements by key, but does not use them. Using `by_key` arrangements will come in following PRs.