### PR TITLE
comm: interleave messages from multiple MPSC senders

### DIFF
--- a/src/comm/mpsc.rs
+++ b/src/comm/mpsc.rs
@@ -32,6 +32,7 @@
 //! [`Send`] and so can be freely sent between threads.
 
 use futures::{Future, Poll, Sink, Stream};
+use ore::future::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::marker::PhantomData;
@@ -103,7 +104,7 @@ impl<D> Receiver<D> {
             conn_rx
                 .map_err(|_| -> bincode::Error { unreachable!() })
                 .map(protocol::decoder)
-                .flatten(),
+                .select_flatten(),
         ))
     }
 }

--- a/src/comm/tests/mpsc.rs
+++ b/src/comm/tests/mpsc.rs
@@ -1,0 +1,37 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+use comm::Switchboard;
+use futures::{Future, Sink, Stream};
+use std::error::Error;
+
+/// Verifies that MPSC channels receive messages from all streams
+/// simultaneously. The original implementation had a bug in which streams were
+/// exhausted in order, i.e., messages from the second stream were only
+/// presented after the first stream was closed.
+#[test]
+fn test_mpsc_select() -> Result<(), Box<dyn Error>> {
+    let (switchboard, _runtime) = Switchboard::local()?;
+
+    let (tx, mut rx) = switchboard.mpsc();
+    let mut tx1 = tx.clone().connect().wait()?;
+    let mut tx2 = tx.connect().wait()?;
+
+    tx1 = tx1.send(1).wait()?;
+    tx2 = tx2.send(2).wait()?;
+    let msgs = rx.by_ref().take(2).collect().wait()?;
+    if msgs != &[1, 2] && msgs != [2, 1] {
+        panic!("received unexpected messages: {:#?}", msgs);
+    }
+
+    tx1.send(3).wait()?;
+    tx2.send(4).wait()?;
+    let msgs = rx.by_ref().take(2).collect().wait()?;
+    if msgs != &[3, 4] && msgs != [4, 3] {
+        panic!("received unexpected messages: {:#?}", msgs);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fix a bug in the implementation of MPSC senders in which messages from
producers were presented in a total order, i.e., messages from the
second producer would only be presented after the first producer was
closed. Now messages from multiple producers are properly interleaved.

This required the addition of a new `SelectFlatten` stream combinator,
since nothing like this exists in the futures library itself.