### PR TITLE
Logging keys

### DIFF
--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -227,5 +227,4 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PeekDuration) => Some(vec![0, 1]),
         }
     }
-
 }


### PR DESCRIPTION
This PR adds primary key information for logging channels (and breaks should new logging types not specify this information). The expected output is `Option<Vec<usize>>` to indicate the columns that form the primary key, should they exist. If not, `None` is the right output.

cc: @quodlibetor 