### PR TITLE
mtrlz/queue: fix EXPLAIN PLAN

### DIFF
--- a/src/materialize/queue/coordinator.rs
+++ b/src/materialize/queue/coordinator.rs
@@ -225,7 +225,7 @@ where
             Plan::ExplainPlan { typ, relation_expr } => SqlResponse::SendRows {
                 typ,
                 rows: vec![vec![Datum::from(relation_expr.pretty())]],
-                wait_for: WaitFor::Optimizer,
+                wait_for: WaitFor::NoOne,
                 transform: Default::default(),
             },
         }


### PR DESCRIPTION
I appear to have broken this in the coordinator refactor. EXPLAIN PLAN
no longer needs to wait for the optimizer, as the optimizer and the
queue are now the same module and so the results can be returned
directly.