### PR TITLE
sql: improve support for modulus

### DIFF
--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -456,6 +456,13 @@ pub fn mod_float64(a: Datum, b: Datum) -> Datum {
     Datum::from(a.unwrap_float64() % b.unwrap_float64())
 }
 
+pub fn mod_decimal(a: Datum, b: Datum) -> Datum {
+    if a.is_null() || b.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_decimal() % b.unwrap_decimal())
+}
+
 pub fn neg_int32(a: Datum) -> Datum {
     if a.is_null() {
         return Datum::Null;
@@ -580,6 +587,7 @@ pub enum BinaryFunc {
     ModInt64,
     ModFloat32,
     ModFloat64,
+    ModDecimal,
     Eq,
     NotEq,
     Lt,
@@ -620,6 +628,7 @@ impl BinaryFunc {
             BinaryFunc::ModInt64 => mod_int64,
             BinaryFunc::ModFloat32 => mod_float32,
             BinaryFunc::ModFloat64 => mod_float64,
+            BinaryFunc::ModDecimal => mod_decimal,
             BinaryFunc::Eq => eq,
             BinaryFunc::NotEq => not_eq,
             BinaryFunc::Lt => lt,

--- a/src/repr/scalar/decimal.rs
+++ b/src/repr/scalar/decimal.rs
@@ -51,7 +51,7 @@ use std::fmt;
 use std::fmt::Write;
 use std::hash::{Hash, Hasher};
 use std::iter::Sum;
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Rem, Sub};
 
 /// The significand of a decimal number with up to 38 digits of precision.
 ///
@@ -219,6 +219,25 @@ where
 
     fn div(self, other: T) -> Self {
         Self(self.0 / other)
+    }
+}
+
+impl Rem<Significand> for Significand {
+    type Output = Self;
+
+    fn rem(self, other: Self) -> Self {
+        Self(self.0 % other.0)
+    }
+}
+
+impl<T> Rem<T> for Significand
+where
+    i128: Rem<T, Output = i128>,
+{
+    type Output = Self;
+
+    fn rem(self, other: T) -> Self {
+        Self(self.0 % other)
     }
 }
 

--- a/test/decimal.slt
+++ b/test/decimal.slt
@@ -68,6 +68,16 @@ SELECT a * 2 FROM basic
 ----
 0.20
 
+query R
+SELECT a / 2 FROM basic
+----
+0.0500000
+
+query R
+SELECT a % 2 FROM basic
+----
+0.1
+
 # Arithmetic that involves simple rescaling.
 
 query RR

--- a/test/type-promotion.slt
+++ b/test/type-promotion.slt
@@ -1,0 +1,42 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+statement ok
+CREATE TABLE t (a float, b int)
+
+statement ok
+INSERT INTO t VALUES (4.7, 2)
+
+# Test that all arithmetic and comparison operators coalesce their arguments.
+# The goal is not to test every possible combination of arguments, but just a
+# basic sanity check. An old version of the code forgot to include modulus in
+# list of operators that should coalesce their inputs.
+
+query RRRRRBBBBBB
+SELECT
+    a + b,
+    a - b,
+    a * b,
+    a / b,
+    a % b,
+    a < b,
+    a <= b,
+    a > b,
+    a >= b,
+    a = b,
+    a <> b
+FROM t
+----
+6.700
+2.700
+9.400
+2.350
+0.700
+false
+false
+true
+true
+false
+true


### PR DESCRIPTION
Add modulus to the list of arithmetic operators that should try to
coalesce its arguments, and also add support for decimal modulus.

Fix MaterializeInc/database-issues#146.