### PR TITLE
*: remove the exfiltrator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,6 +608,7 @@ dependencies = [
 name = "dataflow-types"
 version = "0.1.0"
 dependencies = [
+ "comm 0.1.0",
  "expr 0.1.0",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "repr 0.1.0",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+comm = { path = "../comm" }
 expr = { path = "../expr" }
 repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -70,15 +70,6 @@ pub struct RowSetFinishing {
     pub limit: Option<usize>,
 }
 
-/// A batch of data exfiltrated from the dataflow layer.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Exfiltration {
-    /// The complete result of a `DataflowCommand::Peek` from one worker.
-    Peek(Vec<Vec<Datum>>),
-    /// A chunk of updates from a tail sink.
-    Tail(Vec<Update>),
-}
-
 #[derive(Debug, Clone)]
 pub enum LocalInput {
     /// Send a batch of updates to the input
@@ -184,7 +175,7 @@ pub struct KafkaSinkConnector {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TailSinkConnector {
-    pub conn_id: u32,
+    pub tx: comm::mpsc::Sender<Vec<Update>>,
 }
 
 /// A view transforms one dataflow into another.

--- a/src/dataflow/lib.rs
+++ b/src/dataflow/lib.rs
@@ -10,9 +10,7 @@ mod render;
 mod sink;
 mod source;
 
-pub mod exfiltrate;
 pub mod logging;
 pub mod server;
 
-pub use exfiltrate::ExfiltratorConfig;
 pub use server::{serve, BroadcastToken, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -24,7 +24,6 @@ use repr::Datum;
 use super::sink;
 use super::source;
 use crate::arrangement::{manager::WithDrop, TraceManager};
-use crate::exfiltrate::Exfiltrator;
 use crate::logging::materialized::{Logger, MaterializedEvent};
 
 mod context;
@@ -35,7 +34,6 @@ pub fn build_dataflow<A: Allocate>(
     manager: &mut TraceManager,
     worker: &mut TimelyWorker<A>,
     local_input_mux: &mut Mux<Uuid, LocalInput>,
-    exfiltrator: Rc<Exfiltrator>,
     logger: &mut Option<Logger>,
 ) {
     let worker_timer = worker.timer();
@@ -102,9 +100,7 @@ pub fn build_dataflow<A: Allocate>(
                     let done = Rc::new(Cell::new(false));
                     sink::kafka(&arrangement.stream, &sink.name, c, done, worker_timer)
                 }
-                SinkConnector::Tail(c) => {
-                    sink::tail(&arrangement.stream, &sink.name, c, exfiltrator)
-                }
+                SinkConnector::Tail(c) => sink::tail(&arrangement.stream, &sink.name, c),
             }
         }
         Dataflow::View(view) => {

--- a/src/dataflow/sink/tail.rs
+++ b/src/dataflow/sink/tail.rs
@@ -3,34 +3,31 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-use crate::exfiltrate::Exfiltrator;
 use dataflow_types::{Diff, TailSinkConnector, Timestamp, Update};
 use differential_dataflow::trace::cursor::Cursor;
 use differential_dataflow::trace::BatchReader;
+use futures::{Future, Sink};
 use repr::Datum;
-use std::rc::Rc;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 use timely::Data;
 
-pub fn tail<G, B>(
-    stream: &Stream<G, B>,
-    name: &str,
-    connector: TailSinkConnector,
-    exfiltrator: Rc<Exfiltrator>,
-) where
+pub fn tail<G, B>(stream: &Stream<G, B>, name: &str, connector: TailSinkConnector)
+where
     G: Scope<Timestamp = Timestamp>,
     B: Data + BatchReader<Vec<Datum>, (), Timestamp, Diff>,
 {
     stream.sink(Pipeline, &name, move |input| {
+        let mut tx = connector.tx.connect().wait().unwrap();
+
         input.for_each(|_, batches| {
-            let mut result: Vec<Update> = Vec::new();
+            let mut results: Vec<Update> = Vec::new();
             for batch in batches.iter() {
                 let mut cur = batch.cursor();
                 while let Some(key) = cur.get_key(&batch) {
                     cur.map_times(&batch, |time, diff| {
-                        result.push(Update {
+                        results.push(Update {
                             row: key.clone(),
                             timestamp: *time,
                             diff: *diff,
@@ -39,7 +36,12 @@ pub fn tail<G, B>(
                     cur.step_key(&batch);
                 }
             }
-            exfiltrator.send_tail(connector.conn_id, result);
+
+            // TODO(benesch): this blocks the Timely thread until the send
+            // completes. Hopefully it's just a quick write to a kernel buffer,
+            // but perhaps not if the batch gets too large? We may need to do
+            // something smarter, like offloading to a networking thread.
+            (&mut tx).send(results).wait().unwrap();
         });
     })
 }

--- a/src/materialize/queue/transient.rs
+++ b/src/materialize/queue/transient.rs
@@ -20,12 +20,14 @@ enum Message {
 
 pub fn serve<C>(
     switchboard: comm::Switchboard<C>,
+    num_timely_workers: usize,
     logging_config: Option<&LoggingConfig>,
     cmd_rx: UnboundedReceiver<Command>,
 ) where
     C: comm::Connection,
 {
-    let mut coord = coordinator::Coordinator::new(switchboard.clone(), logging_config);
+    let mut coord =
+        coordinator::Coordinator::new(switchboard.clone(), num_timely_workers, logging_config);
     let feedback_rx = coord.enable_feedback();
 
     let mut planner = sql::Planner::new(logging_config);


### PR DESCRIPTION
Now that we have cross-process channels with the `comm` crate, we no
longer need a goofy RPC layer that uses HTTP. Hook everything up with
channels instead.

One other nice side effect of this change is it's easy to make the
coordinator reponsible for sorting peek results. The pgwire module now
expects any rows to be provided in one shot via a channel, rather than
expecting N results, one from each of the Timely workers.