### PR TITLE
Put Regex behind a box in order to save memory

### DIFF
--- a/src/repr/scalar/mod.rs
+++ b/src/repr/scalar/mod.rs
@@ -409,7 +409,7 @@ impl fmt::Display for Datum {
             Datum::Regex(b) => {
                 let Regex(rex) = b.as_ref();
                 write!(f, "/{}/", rex)
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
Since its size is much bigger than every other datum variant