### PR TITLE
comm: remove duplicated rand dependency

### DIFF
--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -22,4 +22,3 @@ ore = { path = "../ore" }
 assert_cmd = "0.11"
 getopts = "0.2"
 predicates = "1.0.1"
-rand = "0.7"


### PR DESCRIPTION
Now that rand is a full-time dependency, it no longer needs to be a dev
dependency.