### PR TITLE
Add `mysqlcli` to chbench Dockerfile

### DIFF
--- a/ex/chbench/README.md
+++ b/ex/chbench/README.md
@@ -112,6 +112,18 @@ $ docker-compose run cli watch-sql "PEEK q01"
 [CH-benCHmark]: https://db.in.tum.de/research/projects/CHbenCHmark/index.shtml?lang=en
 [docker-compose]: https://docs.docker.com/compose/
 
+## Using the MySQL CLI
+
+If you want to access a MySQL shell, run the following in the
+`ex/chbench` directory:
+
+```
+docker-compose run mysqlcli
+```
+
+If you've just run `docker-compose up`, you might need to wait a few seconds
+before running this.
+
 ## Using Docker for Mac
 
 You should run this demo on an EC2 VM or Linux machine. Should you want to run

--- a/ex/chbench/docker-compose.yml
+++ b/ex/chbench/docker-compose.yml
@@ -22,6 +22,12 @@ services:
         source: chbench-gen
         target: /var/lib/mysql-files
         read_only: true
+  mysqlcli:
+    image: debezium/example-mysql:0.9
+    command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=debezium"]
+    init: true
+    depends_on:
+      - mysql
   zookeeper:
     image: confluentinc/cp-zookeeper:5.3.0
     environment:


### PR DESCRIPTION
Add the ability to run the MySQL CLI against the MySQL that's part of
the chbenchmark setup