### PR TITLE
expr,sql: map via joins

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -804,12 +804,10 @@ impl RelationExpr {
                     .distinct()
                     .negate()
                     .union(keys)
-                    // .map(
-                    //     default
-                    //         .iter()
-                    //         .map(|(datum, typ)| (ScalarExpr::Literal(datum.clone()), typ.clone()))
-                    //         .collect(),
-                    // )
+                    // This join is logically equivalent to
+                    // `.map(<default_expr>)`, but using a join allows for
+                    // potential predicate pushdown and elision in the
+                    // optimizer.
                     .product(RelationExpr::constant(
                         vec![default.iter().map(|(datum, _)| datum.clone()).collect()],
                         RelationType::new(default.iter().map(|(_, typ)| typ.clone()).collect()),


### PR DESCRIPTION
Frank had the insight that mapping via joins with a constant relation
expression allows our optimizer to do more work, including eliding the
map/join entirely if predicates can be pushed down. Use this pattern in
another place in the decorrelation code, to save on a redundant
map/filter, and also leave some comments behind in both places it's
used.