### PR TITLE
Constant propagation

### DIFF
--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -115,7 +115,6 @@ impl FoldConstants {
                 }
                 _ => {}
             },
-            // _ => {}
         }
     }
 }


### PR DESCRIPTION
This removes the `_ =>` case for constant propagation, which requires us to call out each case. This led to a few additional optimizations, and a few explicitly called out as a bit exhausting at the moment. In principle all of them except `Negate` should be implementable, and most queries based on constant data could plausibly be resolved to a `RelationExpr::Constant`.