### PR TITLE
Script to flush changes to tables

### DIFF
--- a/ex/chbench/README.md
+++ b/ex/chbench/README.md
@@ -109,6 +109,13 @@ For maximum style points, use `watch-sql` for some live query monitoring:
 $ docker-compose run cli watch-sql "PEEK q01"
 ```
 
+To ensure that materialized reflects all changes to the source data, you can
+run:
+
+```bash session
+$ docker-compose run schema-registry flush-tables
+```
+
 [CH-benCHmark]: https://db.in.tum.de/research/projects/CHbenCHmark/index.shtml?lang=en
 [docker-compose]: https://docs.docker.com/compose/
 

--- a/ex/chbench/docker-compose.yml
+++ b/ex/chbench/docker-compose.yml
@@ -59,11 +59,11 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka]
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    build: schema-registry
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
-     - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081
+     - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081,http://localhost:8081
     depends_on: [zookeeper, kafka]
   connector:
     build: connector

--- a/ex/chbench/schema-registry/Dockerfile
+++ b/ex/chbench/schema-registry/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+FROM confluentinc/cp-schema-registry
+
+RUN apt-get update -q && apt-get install -qy jq
+
+COPY flush-tables /usr/local/bin/flush-tables

--- a/ex/chbench/schema-registry/flush-tables
+++ b/ex/chbench/schema-registry/flush-tables
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+set -exo pipefail
+
+TABLES="customer district history item nation neworder order orderline region stock supplier warehouse"
+for table in ${TABLES}; do
+  # shellcheck disable=SC2086
+  kafka-avro-console-producer --broker-list kafka:9092 --topic tpch.tpch.$table \
+    --property value.schema="$(curl schema-registry:8081/subjects/mysql.tpcch.${table}-value/versions/1 | jq -r .schema | jq .)" <<<'{"before":null,"after":null,"source":{"version":{"string":"0.9.5.Final"},"connector":{"string":"mysql"},"name":"tpch","server_id":0,"ts_sec":0,"gtid":null,"file":"binlog.000004","pos":951896181,"row":0,"snapshot":{"boolean":true},"thread":null,"db":{"string":"tpch"},"table":{"string":"lineitem"},"query":null},"op":"c","ts_ms":{"long":1560886948093}}'
+done


### PR DESCRIPTION
Inserts an empty event into all chbenchmark Kafka topics, to advance the
timestamps for the corresponding materialized sources