### PR TITLE
simplify dual

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -267,13 +267,13 @@ impl Planner {
                 )
             })
             .unwrap_or_else(|| {
-                let typ = RelationType::new(vec![ColumnType::new(ScalarType::String).name("x")]);
+                let typ = RelationType::new(vec![]);
                 Ok((
                     RelationExpr::Constant {
-                        rows: vec![vec![Datum::String("X".into())]],
+                        rows: vec![vec![]],
                         typ: typ.clone(),
                     },
-                    Scope::from_source(Some("dual"), typ, Some(outer_scope.clone())),
+                    Scope::from_source(None, typ, Some(outer_scope.clone())),
                 ))
             })?;
 


### PR DESCRIPTION
We have had a historical `dual` relation for `SELECT` statements without a `FROM` block. This had a single row with a single string column. This replaces that with a single row with no columns, which causes less anxiety for query optimization (empty relations can be elided from joins easily, whereas constant propagation needs to be invoked to determine that the `"X"` is discarded).