### PR TITLE
expr: remove RelationExpr::OrDefault

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -294,30 +294,6 @@ where
                     self.render_topk(relation_expr, scope, worker_index);
                 }
 
-                RelationExpr::OrDefault { input, default } => {
-                    use differential_dataflow::operators::reduce::Threshold;
-                    use differential_dataflow::operators::Join;
-                    use timely::dataflow::operators::to_stream::ToStream;
-
-                    self.ensure_rendered(input, scope, worker_index);
-                    let input = self.collection(input).unwrap();
-
-                    let present = input.map(|_| ()).distinct();
-                    let value = if worker_index == 0 {
-                        vec![(((), default.clone()), Default::default(), 1isize)]
-                    } else {
-                        vec![]
-                    };
-                    let default = value
-                        .to_stream(scope)
-                        .as_collection()
-                        .antijoin(&present)
-                        .map(|((), default)| default);
-
-                    self.collections
-                        .insert(relation_expr.clone(), input.concat(&default));
-                }
-
                 RelationExpr::Negate { input } => {
                     self.ensure_rendered(input, scope, worker_index);
                     let collection = self.collection(input).unwrap().negate();

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -32,7 +32,6 @@ impl FoldConstants {
             RelationExpr::Let { .. } => { /*constant prop done in InlineLet*/ }
             RelationExpr::Reduce { .. } => { /*too complicated*/ }
             RelationExpr::TopK { .. } => { /*too complicated*/ }
-            RelationExpr::OrDefault { .. } => { /*too complicated*/ }
             RelationExpr::Negate { .. } => { /*cannot currently negate constants*/ }
             RelationExpr::Distinct { input } => {
                 if let RelationExpr::Constant { rows, typ } = &**input {


### PR DESCRIPTION
This node is no longer used. When its behavior is needed, an equivalent
dataflow can be built by expr::RelationExpr::lookup, which is the
codepath that the new decorrelator uses.