### PR TITLE
Only filter nullable columns

### DIFF
--- a/src/expr/transform/predicate_pushdown.rs
+++ b/src/expr/transform/predicate_pushdown.rs
@@ -84,7 +84,10 @@ impl PredicatePushdown {
                     // to individual elements of `inputs`.
 
                     let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-                    let input_arities = input_types.iter().map(|i| i.column_types.len()).collect::<Vec<_>>();
+                    let input_arities = input_types
+                        .iter()
+                        .map(|i| i.column_types.len())
+                        .collect::<Vec<_>>();
 
                     let mut offset = 0;
                     let mut prior_arities = Vec::new();


### PR DESCRIPTION
This PR reduces the filtering of null columns for join keys to those cases where the column is actually nullable. Columns that are not nullable are not filtered, which is very helpful for arrangement re-use.

This might be the first time we exercise the `nullable` attribute of the type, so errors could result.

cc @jamii 