### PR TITLE
distinct pushdown

### DIFF
--- a/src/expr/transform/distinct_pushdown.rs
+++ b/src/expr/transform/distinct_pushdown.rs
@@ -1,0 +1,48 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+use crate::RelationExpr;
+use repr::RelationType;
+
+/// Pushes distinct through various operators, towards their sources.
+#[derive(Debug)]
+pub struct DistinctPushdown;
+
+impl super::Transform for DistinctPushdown {
+    fn transform(&self, relation: &mut RelationExpr, metadata: &RelationType) {
+        self.transform(relation, metadata)
+    }
+}
+
+impl DistinctPushdown {
+    pub fn transform(&self, relation: &mut RelationExpr, _metadata: &RelationType) {
+        relation.visit_mut(&mut |e| {
+            self.action(e, &e.typ());
+        });
+    }
+    pub fn action(&self, relation: &mut RelationExpr, _metadata: &RelationType) {
+        if let RelationExpr::Distinct { input } = relation {
+            match &mut **input {
+                RelationExpr::Distinct { .. } => {
+                    // Duplicate distincts can be suppressed.
+                    *relation = input.take();
+                }
+                RelationExpr::Join { inputs, .. } => {
+                    // We distinct the inputs to joins.
+                    // This could cause us to miss on arrangement opportunities.
+                    for input in inputs.iter_mut() {
+                        *input = input.take().distinct();
+                    }
+                    *relation = input.take();
+                }
+                RelationExpr::Reduce { .. } => {
+                    // We believe reduce operators will not output duplicates.
+                    *relation = input.take();
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -10,6 +10,7 @@ use repr::RelationType;
 
 pub mod aggregation;
 pub mod binding;
+pub mod distinct_pushdown;
 pub mod distinct_union;
 pub mod empty_map;
 pub mod fusion;
@@ -79,6 +80,7 @@ impl Default for Optimizer {
             Box::new(crate::transform::Fixpoint {
                 transforms: vec![
                     Box::new(crate::transform::reduction::FoldConstants),
+                    Box::new(crate::transform::distinct_pushdown::DistinctPushdown),
                     Box::new(crate::transform::predicate_pushdown::PredicatePushdown),
                     Box::new(crate::transform::fusion::join::Join),
                     Box::new(crate::transform::fusion::filter::Filter),


### PR DESCRIPTION
This PR pushes distinct downwards, were it is absorbed into other distincts, or into reduce, and is pushed through join and map operators. We believe this is correct.

Many other operators will not tolerate distinct pushdown. It is not clear that distinct pushdown is the right optimization to run always, but it currently appears important for join optimization, and makes some sense with respect to minimizing changes early.