### PR TITLE
Fix backtrace symbolication in panic handling on macOS

### DIFF
--- a/src/materialize/Cargo.toml
+++ b/src/materialize/Cargo.toml
@@ -13,7 +13,7 @@ path = "bin/materialized.rs"
 path = "lib.rs"
 
 [dependencies]
-backtrace = "0.3.37"
+backtrace = { version = "0.3.37", features = ["coresymbolication"] }
 bincode = "1.1.4"
 byteorder = "1.3"
 bytes = "0.4"


### PR DESCRIPTION
Apparently the "coresymbolication" feature is necessary to get
backtraces on macOS to have proper file/line information.