### PR TITLE
sql: ensure avg outputs a fractional type

### DIFF
--- a/src/sql/transform.rs
+++ b/src/sql/transform.rs
@@ -34,6 +34,12 @@ impl<'ast> VisitMut<'ast> for AvgFuncRewriter {
                     over: None,
                     distinct: func.distinct,
                 });
+                let sum = Expr::Function(Function {
+                    name: ObjectName(vec!["internal".into(), "avg_promotion".into()]),
+                    args: vec![sum],
+                    over: None,
+                    distinct: false,
+                });
                 let count = Expr::Function(Function {
                     name: ObjectName(vec!["count".into()]),
                     args: args.clone(),

--- a/src/sqllogictest/lib.rs
+++ b/src/sqllogictest/lib.rs
@@ -710,6 +710,11 @@ fn format_row(
             (Type::Bool, Datum::True) => "true".to_owned(),
 
             // weird type coercions that sqllogictest doesn't document
+            (Type::Integer, Datum::Decimal(d)) => {
+                let (_precision, scale) = col_typ.scalar_type.unwrap_decimal_parts();
+                let d = d.with_scale(scale);
+                format!("{:.0}", d)
+            }
             (Type::Integer, Datum::Float64(f)) => format!("{:.0}", f.trunc()),
             (Type::Integer, Datum::String(_)) => "0".to_owned(),
             (Type::Integer, Datum::False) => "0".to_owned(),

--- a/test/aggregates.slt
+++ b/test/aggregates.slt
@@ -32,3 +32,31 @@ SHOW COLUMNS FROM t
  Field Nullable Type
  a     YES      i64
  b     YES      i64
+
+# avg on an integer column should return a decimal with the default decimal
+# division scale increase.
+
+query R
+SELECT avg(a) FROM t
+----
+1.750000
+
+# But avg on a float column should return a float.
+
+statement ok
+CREATE TABLE t2 (a float)
+
+statement ok
+INSERT INTO t2 VALUES (1.0), (1.0), (2.0), (3.0)
+
+query R
+SELECT avg(a) FROM t2
+----
+1.75
+
+# avg of an explicit NULL should return NULL.
+
+query R
+SELECT avg(NULL)
+----
+NULL


### PR DESCRIPTION
avg was previously using its input type as its output type, so taking
the avg of an integral column would return an integral result, with the
fractional component truncated. That behavior was technically in
compliance with the SQL spec, but is not what PostgreSQL and MySQL do,
and surprising to boot. Instead, choose the smallest fractional type
that can represent the input, and use that as the output type.

Fix MaterializeInc/database-issues#180.