### PR TITLE
Return pkey indices, not new vec

### DIFF
--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -47,7 +47,7 @@ pub fn validate_key_schema(
                     if key_column.scalar_type == value_column.scalar_type
                         && key_column.nullable == value_column.nullable
                     {
-                        indices.push(index.clone());
+                        indices.push(*index);
                     } else {
                         bail!(
                             "key and value column types do not match: key {:?} vs. value {:?}",


### PR DESCRIPTION
This is a bug fix! I found it tracking down why arrangements weren't being sharing between dataflows as expected.