### PR TITLE
docs: misc. improvements

### DIFF
--- a/doc/demo.md
+++ b/doc/demo.md
@@ -13,7 +13,8 @@ assume that you are running commands from the root of the materialize repo.
 Each demo involves starting several terminal sessions:
 
 * A materialize daemon -- where the magic happens
-* A materialize shell -- the human interface to the materialze engine
+* A materialize shell -- the human interface to the materialize engine
+    - Requires `psql` (`brew install postgres`)
 * At least one avro producer window -- the channel through which content gets
   into materialize
 
@@ -22,7 +23,7 @@ demos rely upon are running. For now, that means we need `confluent connect`
 and `materialized`.
 
 We have a collection of helpful tools in `doc/demo-utils.sh`, including one
-that makes sure that confluent is running and materialize is up to date and
+that makes sure that `confluent` is running and materialize is up to date and
 running.
 
 So, to get the core services running we just run `mtrlz-start`:
@@ -88,9 +89,12 @@ $ mtrlz-shell
 > CREATE SOURCE quotes FROM 'kafka://localhost/quotes' USING SCHEMA REGISTRY 'http://localhost:8081';
 > SHOW COLUMNS FROM quotes;
 > PEEK quotes;
+> SELECT quote, 42 FROM quotes;
 > CREATE MATERIALIZED VIEW business_insights AS SELECT quote, 42 FROM quotes;
 > PEEK business_insights;
 ```
+
+Though this doesn't really demonstrate the capabilities of Materialize––it's just a toy example––`PEEK` is much faster than the corresponding `SELECT`. However, it is worth noting one can query data in Materialize with arbitrary `SELECT`s; you aren't limited to _only_ creating materialized views.
 
 ## Aggregate demo
 

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -11,11 +11,14 @@ into a single download. Not so conveniently, it bundles many other components as
 well. Strangely, their webpages do not mention ZooKeeper at all, even though version
 5.3.0 most definitely does include the corresponding binaries.
 
+Due to some change in the scope of the Confluent Platform project, you also need to install the [Confluent CLI] independently.
+
 [Rust]: https://www.rust-lang.org
 [Apache ZooKeeper]: https://zookeeper.apache.org
 [Apache Kafka]: https://kafka.apache.org
 [Confluent Schema Registry]: https://www.confluent.io/confluent-schema-registry/
 [Confluent Platform]: https://www.confluent.io/product/confluent-platform/
+[Confluent CLI]: https://docs.confluent.io/current/cli/installing.html#scripted-installation
 
 ## Installing
 
@@ -70,7 +73,17 @@ Reach out to @jamii for more information.
 [confluent-install]: https://docs.confluent.io/current/installation/installing_cp/index.html
 [nix]: https://nixos.org/nix/
 
-## Building
+### Confluent CLI
+
+As of Sep 23, 2019 you can run:
+
+```shell
+curl -L https://cnfl.io/cli | sh -s -- -b /usr/local/bin
+```
+
+However, if this ever stops working, check out these great docs on the [Confluent CLI].
+
+## Building Materialize
 
 Materialize is fully integrated with Cargo, so building it is dead simple:
 
@@ -97,19 +110,30 @@ automatically started upon login, but we leave it to you to sort that out.
 
 [MaterializeInc/sqlparser]: https://github.com/MaterializeInc/sqlparser.git
 
-You can use the included `confluent` CLI command to start and stop individual services. For example:
+## Prepping Confluent
+
+Like we mentioned above, you need to have a few Confluent services running to get Materialize to work. To prep what you need (for the [demo], at least), run the following:
 
 ```shell
-confluent status        # View what services are currently running.
-confluent start kafka   # Start Kafka and any services it depends upon.
-confluent log kafka     # View Kafka log file.
+confluent local start kafka     # Also starts zookeeper
+confluent local start schema-registry
+```
+
+You can also use the included `confluent` CLI command to start and stop individual services. For example:
+
+```shell
+confluent local status        # View what services are currently running.
+confluent local start kafka   # Start Kafka and any services it depends upon.
+confluent local log kafka     # View Kafka log file.
 ```
 
 Beware that the CLI is fairly buggy, especially around service management.
 Putting your computer to sleep often causes the service status to get out of
-sync. In other words, trust the output of `confluent log` and `ps ... | grep`
-over the output of `confluent status`. Still, it's reliable enough to be more
-convenient than managing each service manually.
+sync. In other words, trust the output of `confluent local log` and `ps ... |
+grep` over the output of `confluent local status`. Still, it's reliable enough 
+to be more convenient than managing each service manually.
+
+[demo](demo.md)
 
 ## Testing
 
@@ -158,4 +182,3 @@ This keeps the Git history tidy, since it avoids creating merge commits when you
 `git pull` with unpushed changes. The `rebase.autoStash` option makes this
 workflow particularly ergonomic by stashing any uncommitted changes you have
 when you run `git pull`, then unstashing them after the rebase is complete.
-


### PR DESCRIPTION
- Reflect new reality of `confluent-platform`.
- Add scaffolding to the setup process (e.g. install `psql`)
- Add some `SELECT` queries to the demo to showcase that Materialize also offers regular ol' SQL's prowess to the underlying stream. I thought this was neat so ¯\_(ツ)_/¯...glad to yank those out if they aren't compelling to others.

Also please let me know if there are others who (w/sh)ould review.