### PR TITLE
sqllogictest: hack in support for multiline output

### DIFF
--- a/test/tpch.slt
+++ b/test/tpch.slt
@@ -122,6 +122,98 @@ ORDER BY
 	l_returnflag,
 	l_linestatus
 
+query T multiline
+EXPLAIN PLAN FOR SELECT
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) as sum_qty,
+	sum(l_extendedprice) as sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+	avg(l_quantity) as avg_qty,
+	avg(l_extendedprice) as avg_price,
+	avg(l_discount) as avg_disc,
+	count(*) as count_order
+FROM
+	lineitem
+WHERE
+	l_shipdate <= date '1998-12-01' -- - interval '60' day (fails with an error)
+GROUP BY
+	l_returnflag,
+	l_linestatus
+----
+Project {
+  outputs: [0, 1, 13, 14, 15, 16, 17, 18, 19, 20],
+  Map {
+    scalars: [#12],
+    Map {
+      scalars: [
+        (
+            (#10 * Significand(10000000))
+            /
+            (i64todec #11 * Significand(100))
+          )
+          *
+          Significand(10)
+      ],
+      Map {
+        scalars: [
+          (
+              (#8 * Significand(10000000))
+              /
+              (i64todec #9 * Significand(100))
+            )
+            *
+            Significand(10)
+        ],
+        Map {
+          scalars: [
+            (
+                (#6 * Significand(10000000))
+                /
+                (i64todec #7 * Significand(100))
+              )
+              *
+              Significand(10)
+          ],
+          Map {
+            scalars: [#5],
+            Map {
+              scalars: [#4],
+              Map {
+                scalars: [#8],
+                Map {
+                  scalars: [#6],
+                  Reduce {
+                    group_key: [8, 9],
+                    aggregates: [
+                      SumDecimal,
+                        SumDecimal,
+                        SumDecimal,
+                        SumDecimal,
+                        SumDecimal,
+                        Count,
+                        SumDecimal,
+                        Count,
+                        SumDecimal,
+                        Count,
+                        CountAll
+                    ],
+                    Filter {
+                      predicates: [#10 <= 1998-12-01],
+                      Get { lineitem }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 
 query IITI valuesort
 -- Query 03


### PR DESCRIPTION
It turns out trying to match Cockroach's behavior here is an exercise in
insanity. Instead just introduce a new query option called "multiline",
which causes the expected output to be assumed to be a single row with
multiple lines, rather than each line being its own row.