### PR TITLE
Add substr func

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -29,7 +29,7 @@ use repr::decimal::MAX_DECIMAL_PRECISION;
 use repr::{ColumnType, Datum, RelationType, ScalarType};
 use sqlparser::ast::visit::{self, Visit};
 use sqlparser::ast::{
-    BinaryOperator, DataType, Expr, Function, JoinConstraint, JoinOperator, ParsedDate,
+    BinaryOperator, DataType, Expr, Function, JoinConstraint, JoinOperator, ObjectName, ParsedDate,
     ParsedTimestamp, Query, Select, SelectItem, SetExpr, SetOperator, TableAlias, TableFactor,
     TableWithJoins, UnaryOperator, Value, Values,
 };
@@ -1100,6 +1100,49 @@ impl Planner {
                     Ok((expr, typ))
                 }
 
+                "substr" => {
+                    let func = Function {
+                        name: ObjectName(vec![String::from("substring")]),
+                        args: sql_func.args.clone(),
+                        over: sql_func.over.clone(),
+                        distinct: sql_func.distinct,
+                    };
+                    self.plan_function(ctx, &func)
+                }
+
+                "substring" => {
+                    if sql_func.args.len() < 2 || sql_func.args.len() > 3 {
+                        bail!(
+                            "substring expects two or three arguments, got {:?}",
+                            sql_func.args.len()
+                        );
+                    }
+                    let mut exprs = Vec::new();
+                    let (expr1, typ1) = self.plan_expr(ctx, &sql_func.args[0])?;
+                    if typ1.scalar_type != ScalarType::String
+                        && typ1.scalar_type != ScalarType::Null
+                    {
+                        bail!("substring first argument has non-string type {:?}", typ1);
+                    }
+                    exprs.push(expr1);
+
+                    let (expr2, typ2) = self.plan_expr(ctx, &sql_func.args[1])?;
+                    let (verified_expr2, _) =
+                        plan_promote_int_int64("substring", expr2, typ2, "start")?;
+                    exprs.push(verified_expr2);
+                    if sql_func.args.len() == 3 {
+                        let (expr3, typ3) = self.plan_expr(ctx, &sql_func.args[2])?;
+                        let (verified_expr3, _) =
+                            plan_promote_int_int64("substring", expr3, typ3, "length")?;
+                        exprs.push(verified_expr3);
+                    }
+                    let expr = ScalarExpr::CallVariadic {
+                        func: VariadicFunc::Substr,
+                        exprs,
+                    };
+                    Ok((expr, ColumnType::new(typ1.scalar_type).nullable(true)))
+                }
+
                 // Promotes a numeric type to the smallest fractional type that
                 // can represent it. This is primarily useful for the avg
                 // aggregate function, so that the avg of an integer column does
@@ -1921,6 +1964,30 @@ where
         }
     };
     Ok((expr, to_type))
+}
+
+fn plan_promote_int_int64<C>(
+    context: C,
+    e: ScalarExpr,
+    typ: ColumnType,
+    argname: &str,
+) -> Result<(ScalarExpr, ColumnType), failure::Error>
+where
+    C: fmt::Display + Copy,
+{
+    let (caste, casttyp) = match typ.scalar_type {
+        ScalarType::Int32 => plan_cast_internal(context, e, &typ, ScalarType::Int64)?,
+        _ => (e, typ),
+    };
+    if casttyp.scalar_type != ScalarType::Int64 && casttyp.scalar_type != ScalarType::Null {
+        bail!(
+            "{} {:?} argument has non-integer type {:?}",
+            context,
+            argname,
+            casttyp
+        );
+    }
+    Ok((caste, casttyp))
 }
 
 fn rescale_decimal(expr: ScalarExpr, s1: u8, s2: u8) -> ScalarExpr {

--- a/test/string.slt
+++ b/test/string.slt
@@ -34,4 +34,307 @@ select ascii(null);
 ----
 NULL
 
-#TODO: test that ascii works with string expressions inside
+query I
+select ascii(substr('inside literal', 3, 4));
+----
+115
+
+statement ok
+CREATE TABLE substrtest (strcol CHAR(15), vccol VARCHAR(15), smicol SMALLINT, intcol INT)
+
+### substr ###
+statement ok
+INSERT INTO substrtest VALUES ('Mg', 'Mn', 1, 1), ('magnesium', 'manganese', 3, null),
+    (null, null, 0, 0), ('24.31', '54.94', 2, 3), ('长久不见', '爱不释手', null, 2),
+    ('', '', -1, 2) 
+
+#invalid input
+statement error
+select substr(192, 1, 1)
+
+statement error
+select substr('from wrong type', 1.5, 2)
+
+statement error
+select substr('for wrong type', 2, 1.5)
+
+query I
+select substr('for cannot be negative', 1, -3)
+----
+NULL
+
+query I
+select substr('for still cannot be negative', 30, -2)
+----
+NULL
+
+#standard tests
+
+#TODO: materialize#589 select strcol from substrtest
+query T colnames
+select substr(vccol, 1, 3) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.
+Mn
+man
+爱不释
+
+query T colnames
+select substr(vccol, 1, 5) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.94
+Mn
+manga
+爱不释手
+
+query T colnames
+select substr(vccol, 1) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.94
+Mn
+manganese
+爱不释手
+
+query T colnames
+select substr(vccol, 3) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+(empty)
+.94
+nganese
+释手
+
+query T colnames
+select substr(vccol, 3, 1) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+(empty)
+.
+n
+释
+
+#negative start position
+query T colnames
+select substr(vccol, -1) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.94
+Mn
+manganese
+爱不释手
+
+query T colnames
+select substr(vccol, -2, 6) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.
+Mn
+man
+爱不释
+
+query T colnames
+select substr(vccol, -3, 5) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+5
+M
+m
+爱
+
+query TT colnames
+select substr(strcol, -4, 5) as strres, substr(vccol, -4, 5) as vcres from substrtest order by vcres;
+----
+strres  vcres
+NULL    NULL
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+
+query TT colnames
+select substr(strcol, -6, 6) as strres, substr(vccol, -6, 6) as vcres from substrtest order by vcres;
+----
+strres  vcres
+NULL    NULL
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+
+query TT colnames
+select substr(strcol, -5, 4) as strres, substr(vccol, -5, 4) as vcres from substrtest order by vcres;
+----
+strres  vcres
+NULL    NULL
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+
+#for or start is zero
+query T colnames
+select substr(vccol, 0) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.94
+Mn
+manganese
+爱不释手
+
+query T colnames
+select substr(vccol, 0, 3) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54
+Mn
+ma
+爱不
+
+query TT colnames
+select substr(strcol, 0, 0) as strres, substr(vccol, 0, 0) as vcres from substrtest order by vcres;
+----
+strres  vcres
+NULL    NULL
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+
+query TT colnames
+select substr(strcol, 3, 0) as strres, substr(vccol, 3, 0) as vcres from substrtest order by vcres;
+----
+strres  vcres
+NULL    NULL
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+(empty) (empty)
+
+#null inputs
+query T
+select substr(null, 1);
+----
+NULL
+
+query T
+select substr(null, 1, 3);
+----
+NULL
+
+query T
+select substr('text string', null);
+----
+NULL
+
+query T
+select substr(null, null);
+----
+NULL
+
+query T
+select substr('foo', null, 3);
+----
+NULL
+
+query T
+select substr('bar', null, null);
+----
+NULL
+
+query T
+select substr('baz', 2, null);
+----
+NULL
+
+query T
+select substr(null, null, null);
+----
+NULL
+
+#alternative syntax
+query T colnames
+select substring(vccol, 1, 3) as vcres from substrtest order by vcres;
+----
+vcres
+NULL
+(empty)
+54.
+Mn
+man
+爱不释
+
+#testing different kinds of int columns and null content in columns
+query T
+select substr(vccol, smicol, smicol) as vcres from substrtest order by vcres;
+----
+NULL
+NULL
+NULL
+4.
+M
+nga
+
+query T
+select substr(vccol, intcol, intcol) as vcres from substrtest order by vcres;
+----
+NULL
+NULL
+(empty)
+.94
+M
+不释
+
+query T
+select substr(vccol, smicol, intcol) as vcres from substrtest order by vcres;
+----
+NULL
+NULL
+NULL
+(empty)
+4.9
+M
+
+query T
+select substr(vccol, intcol, smicol) as vcres from substrtest order by vcres;
+----
+NULL
+NULL
+NULL
+NULL
+.9
+M
+
+query T
+select substr('subexpression test', ascii(''), 3);
+----
+su
+
+#TODO: materialize#606 Add tests for the alternate syntax if it is enabled


### PR DESCRIPTION
Resolves MaterializeInc/database-issues#148

I considered structuring this in a way to minimize work if we decide to take up MaterializeInc/database-issues#198, but I decided against it because
1. There are just too many ways that database systems are handling MaterializeInc/database-issues#198 (or not handling it at all).
2. It’s not that much work to adjust the code to work with MaterializeInc/database-issues#198 however we decide to handle it.

I followed the example of MaterializeInc/materialize#582 and am returning NULL for now if the third argument, i.e. the length, is a negative value.