### PR TITLE
Always print PEEK latencies, don't stop on Err

### DIFF
--- a/src/metrics/bin/metrics.rs
+++ b/src/metrics/bin/metrics.rs
@@ -30,12 +30,12 @@ fn measure_peek_times() {
             Ok(latency) => {
                 println!("\nLatency: {:#?}", latency);
                 latencies.push(latency)
-            },
+            }
             Err(error) => {
                 println!("\nHit error: {:#?}", error);
-//                running = false;
+                //                running = false;
             }
         }
     }
-//    println!("Latencies are: {:#?}", latencies);
+    //    println!("Latencies are: {:#?}", latencies);
 }


### PR DESCRIPTION
I'm not sure of the best way to iterate on this! Ideally I could change a crate locally and push a test version to Docker Hub, but I'm not sure how to do that now that the build information has been pulled out of the /metrics directory.