### PR TITLE
expr,sql: use distinct_by in more places

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -431,8 +431,7 @@ impl RelationExpr {
                     },
                 },
                 right.union(
-                    both.project(((both_arity - right_arity)..both_arity).collect())
-                        .distinct()
+                    both.distinct_by(((both_arity - right_arity)..both_arity).collect())
                         .negate(),
                 ),
             ],
@@ -755,8 +754,7 @@ impl RelationExpr {
             .let_in(id_gen, |_id_gen, get_keys_and_values| {
                 Ok(get_keys_and_values
                     .clone()
-                    .project((0..keys.arity()).collect())
-                    .distinct()
+                    .distinct_by((0..keys.arity()).collect())
                     .negate()
                     .union(keys)
                     // This join is logically equivalent to
@@ -805,7 +803,7 @@ impl RelationExpr {
         self.let_in(id_gen, |id_gen, get_outer| {
             // TODO(jamii) this is a correct but not optimal value of key - optimize this by looking at what columns `branch` actually uses
             let key = (0..get_outer.arity()).collect::<Vec<_>>();
-            let keyed_outer = get_outer.clone().project(key.clone()).distinct();
+            let keyed_outer = get_outer.clone().distinct_by(key.clone());
             keyed_outer.let_in(id_gen, |id_gen, get_keyed_outer| {
                 let branch = branch(id_gen, get_keyed_outer.clone())?;
                 branch.let_in(id_gen, |_id_gen, get_branch| {

--- a/src/sql/expr.rs
+++ b/src/sql/expr.rs
@@ -383,8 +383,7 @@ impl ScalarExpr {
                         // compute for every row in get_inner
                         .applied_to(id_gen, get_inner.clone())?
                         // throw away actual values and just remember whether or not there where __any__ rows
-                        .project((0..get_inner.arity()).collect())
-                        .distinct()
+                        .distinct_by((0..get_inner.arity()).collect())
                         // Append true to anything that returned any rows. This
                         // join is logically equivalent to
                         // `.map(vec![Datum::True])`, but using a join allows

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -501,27 +501,24 @@ Reduce {
       },
       Distinct {
         group_key: [0, 1, 2, 3, 4, 5, 6, 7],
-        Project {
-          outputs: [0, 1, 2, 3, 4, 5, 6, 7],
-          Filter {
-            predicates: [#14 >= #4],
-            Join {
-              variables: [
-                [(0, 1), (1, 1)],
-                [(0, 2), (1, 2)],
-                [(0, 0), (1, 0)]
-              ],
-              Filter {
-                predicates: [!isnull #0, !isnull #1, !isnull #2],
-                Distinct {
-                  group_key: [0, 1, 2, 3, 4, 5, 6, 7],
-                  Get { "order" }
-                }
-              },
-              Filter {
-                predicates: [!isnull #0, !isnull #1, !isnull #2],
-                Get { orderline }
+        Filter {
+          predicates: [#14 >= #4],
+          Join {
+            variables: [
+              [(0, 1), (1, 1)],
+              [(0, 2), (1, 2)],
+              [(0, 0), (1, 0)]
+            ],
+            Filter {
+              predicates: [!isnull #0, !isnull #1, !isnull #2],
+              Distinct {
+                group_key: [0, 1, 2, 3, 4, 5, 6, 7],
+                Get { "order" }
               }
+            },
+            Filter {
+              predicates: [!isnull #0, !isnull #1, !isnull #2],
+              Get { orderline }
             }
           }
         }
@@ -987,10 +984,7 @@ Let {
           variables: [],
           Union {
             Negate {
-              Distinct {
-                group_key: [0, 1, 2],
-                Project { outputs: [0, 1, 2], Get { id-3 } }
-              }
+              Distinct { group_key: [0, 1, 2], Get { id-3 } }
             },
             Get { id-2 }
           },
@@ -1017,10 +1011,7 @@ Project {
           variables: [],
           Union {
             Negate {
-              Distinct {
-                group_key: [0, 1, 2],
-                Project { outputs: [0, 1, 2], Get { id-4 } }
-              }
+              Distinct { group_key: [0, 1, 2], Get { id-4 } }
             },
             Get { id-2 }
           },
@@ -1188,33 +1179,7 @@ Reduce {
                 20,
                 21
               ],
-              Project {
-                outputs: [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7,
-                  8,
-                  9,
-                  10,
-                  11,
-                  12,
-                  13,
-                  14,
-                  15,
-                  16,
-                  17,
-                  18,
-                  19,
-                  20,
-                  21
-                ],
-                Get { id-1 }
-              }
+              Get { id-1 }
             }
           },
           Get { customer }
@@ -1269,12 +1234,7 @@ Project {
       Join {
         variables: [],
         Union {
-          Negate {
-            Distinct {
-              group_key: [],
-              Project { outputs: [], Get { id-1 } }
-            }
-          },
+          Negate { Distinct { group_key: [], Get { id-1 } } },
           Constant [[]]
         },
         Constant [[null, null]]
@@ -1547,12 +1507,7 @@ Project {
       Join {
         variables: [],
         Union {
-          Negate {
-            Distinct {
-              group_key: [],
-              Project { outputs: [], Get { id-1 } }
-            }
-          },
+          Negate { Distinct { group_key: [], Get { id-1 } } },
           Constant [[]]
         },
         Constant [[null]]
@@ -1655,12 +1610,7 @@ Union {
   Join {
     variables: [],
     Union {
-      Negate {
-        Distinct {
-          group_key: [],
-          Project { outputs: [], Get { id-1 } }
-        }
-      },
+      Negate { Distinct { group_key: [], Get { id-1 } } },
       Constant [[]]
     },
     Constant [[null]]
@@ -2250,72 +2200,21 @@ Let {
         45,
         46
       ],
-      Project {
-        outputs: [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          7,
-          8,
-          9,
-          10,
-          11,
-          12,
-          13,
-          14,
-          15,
-          16,
-          17,
-          18,
-          19,
-          20,
-          21,
-          22,
-          23,
-          24,
-          25,
-          26,
-          27,
-          28,
-          29,
-          30,
-          31,
-          32,
-          33,
-          34,
-          35,
-          36,
-          37,
-          38,
-          39,
-          40,
-          41,
-          42,
-          43,
-          44,
-          45,
-          46
-        ],
-        Filter {
-          predicates: [#53 > #13],
-          Join {
-            variables: [
-              [(0, 8), (1, 1)],
-              [(0, 9), (1, 2)],
-              [(0, 7), (1, 0)]
-            ],
-            Filter {
-              predicates: [!isnull #7, !isnull #8, !isnull #9],
-              Get { id-2 }
-            },
-            Filter {
-              predicates: [!isnull #0, !isnull #1, !isnull #2],
-              Get { orderline }
-            }
+      Filter {
+        predicates: [#53 > #13],
+        Join {
+          variables: [
+            [(0, 8), (1, 1)],
+            [(0, 9), (1, 2)],
+            [(0, 7), (1, 0)]
+          ],
+          Filter {
+            predicates: [!isnull #7, !isnull #8, !isnull #9],
+            Get { id-2 }
+          },
+          Filter {
+            predicates: [!isnull #0, !isnull #1, !isnull #2],
+            Get { orderline }
           }
         }
       }
@@ -2496,58 +2395,7 @@ Reduce {
                   45,
                   46
                 ],
-                Project {
-                  outputs: [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9,
-                    10,
-                    11,
-                    12,
-                    13,
-                    14,
-                    15,
-                    16,
-                    17,
-                    18,
-                    19,
-                    20,
-                    21,
-                    22,
-                    23,
-                    24,
-                    25,
-                    26,
-                    27,
-                    28,
-                    29,
-                    30,
-                    31,
-                    32,
-                    33,
-                    34,
-                    35,
-                    36,
-                    37,
-                    38,
-                    39,
-                    40,
-                    41,
-                    42,
-                    43,
-                    44,
-                    45,
-                    46
-                  ],
-                  Get { id-3 }
-                }
+                Get { id-3 }
               }
             },
             Get { id-2 }


### PR DESCRIPTION
Now that we have an explicit `RelationExpr::distinct_by`, the old idiom
of achieving distinct by via `RelationExpr::project` followed by
`RelationExpr::distinct` is deprecated, as it introduces an unnecessary
project node. Update a few call sites to use the new idiom.

One day we'll want to do this via a transformation, too, but it's useful
to just construct the desired plan directly, when it's easily within our
control to do so.