### PR TITLE
[wip] add a script to cross-compile materialize to linux

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+/test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .mtrlz.log
 **/*.rs.bk
 .idea
+misc/docker/cross/deps

--- a/misc/docker/cross/Dockerfile
+++ b/misc/docker/cross/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1.37-stretch
+
+WORKDIR /usr/src/materialize
+
+RUN apt-get update -o Acquire::Languages=none \
+    && apt-get install -qy --no-install-recommends \
+        libclang-dev \
+        llvm-dev \
+        clang \
+    && apt-get autoremove -qy \
+    && rm -rf \
+        /var/cache/apt/archives \
+        /var/lib/apt/lists/* \
+    ;
+
+
+# TODO: fuzz shouldn't be required for this
+COPY Cargo.lock Cargo.toml ./
+COPY src ./src
+COPY fuzz ./fuzz
+# required for the build script
+COPY .git ./.git
+COPY misc/docker/cross/deps/ /deps/
+
+RUN pwd && ls && \
+    cargo build --release --bin materialized \
+    ;

--- a/misc/docker/cross/build.sh
+++ b/misc/docker/cross/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# I'm sorry
+
+set -e
+
+if [[ ! -f Cargo.tom ]] ; then
+    echo "This must be run from the materialize directory like so:"
+    echo "    bash misc/docker/cross/build.sh"
+    exit 1
+fi
+
+crossdir=misc/docker/cross
+
+mkdir -p $crossdir/deps
+
+# TODO: we should pull the exact version of avro-rs from the lockfile?
+for repo in avro-rs rust-rdkafka futures-rs sqlparser ; do
+    if [[ ! -d $crossdir/deps/$repo ]]; then
+        git clone --recurse-submodules ssh://git@github.com/MaterializeInc/$repo.git $crossdir/deps/$repo
+    fi
+done
+
+(
+    cd $crossdir/deps/futures-rs
+    # the exact commit in Cargo.lock
+    git checkout 29d0d2af30620039b79f77441a82f6dbf8e0cf66
+)
+
+# the Dockerfile COPY's avro into the /deps/ dir, so that's the path we use
+sed -i '' -Ee 's,git.=.*/([^.]+).git.*,path = "/deps/\1" },' Cargo.toml
+
+if ! (grep -E '^\[patch.*sqlparser' Cargo.toml>/dev/null) ; then
+    cat >>Cargo.toml <<EOF
+[patch."ssh://git@github.com/MaterializeInc/sqlparser.git"]
+sqlparser = { path = "/deps/sqlparser" }
+EOF
+fi
+
+docker build -f $crossdir/Dockerfile . -t materialize/local-build

--- a/misc/docker/cross/rebuild.sh
+++ b/misc/docker/cross/rebuild.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+local_dir=/usr/app/
+source_dir=/usr/src/materialize
+
+docker run --user "$(id -u)":"$(id -g)" \
+    -v "$PWD":$local_dir -w $source_dir \
+    materialize/local-build \
+    bash -c "mkdir -p $local_dir ;
+cp -r target $local_dir/target/linux ;
+cd $local_dir;
+cargo build --release --target-dir=target/linux"


### PR DESCRIPTION
The intended eventual flow is to run build.sh from the materialize directory to generate
a cache of the the dependencies:

    bash misc/docker/cross/build.sh

and then to run the rebuild script to create the binary file in
target/linux/release/materialized:

    bash misc/docker/cross/rebuild.sh

or just use `materialize/local-build` as a docker-image or FROM target.

Then... git checkout Cargo.toml to get rid of the hacks in the script.