### PR TITLE
bin/ci-image: clean up docker image naming

### DIFF
--- a/bin/ci-image
+++ b/bin/ci-image
@@ -30,12 +30,12 @@ esac
 do_build() {
     run bin/xcompile build --bin "$image" "$@"
     run cp target/x86_64-unknown-linux-gnu/debug/"$image" misc/docker/ci-"$image"
-    local tag=materialize/ci-"$image"
+    local tag=materialize/"$image"
     run docker build --pull --tag "$tag:latest" --tag "$tag:local" misc/docker/ci-"$image"
 }
 
 do_run() {
-    run docker run -it --rm --init materialize/ci-"$image" "$@"
+    run docker run -it --rm --init materialize/"$image":local "$@"
 }
 
 do_bnr() {


### PR DESCRIPTION
The built images should not use the "ci-" prefix, because we're not
actually in CI; the ci- prefix is just used to stage the actual images
before they're published. Also teach the run subcommand to use the
`local` tag, just to increase the probability that the right image gets
selected. Previously it was possible to accidentally run an image from
the registry, rather than one that was locally built.