### PR TITLE
dataflow,sql: use finishing as name for RowSetFinishing consistently

### DIFF
--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -44,7 +44,7 @@ pub enum Plan {
     Peek {
         source: ::expr::RelationExpr,
         when: PeekWhen,
-        transform: RowSetFinishing,
+        finishing: RowSetFinishing,
     },
     Tail(Dataflow),
     SendRows {

--- a/src/sql/session.rs
+++ b/src/sql/session.rs
@@ -350,19 +350,19 @@ impl Var for SessionVar<bool> {
 pub struct PreparedStatement {
     pub raw_sql: String,
     source: ::expr::RelationExpr,
-    transform: RowSetFinishing,
+    finishing: RowSetFinishing,
 }
 
 impl PreparedStatement {
     pub fn new(
         raw_sql: String,
         source: ::expr::RelationExpr,
-        transform: RowSetFinishing,
+        finishing: RowSetFinishing,
     ) -> PreparedStatement {
         PreparedStatement {
             raw_sql,
             source,
-            transform,
+            finishing,
         }
     }
 
@@ -370,8 +370,8 @@ impl PreparedStatement {
         &self.source
     }
 
-    pub fn transform(&self) -> &RowSetFinishing {
-        &self.transform
+    pub fn finishing(&self) -> &RowSetFinishing {
+        &self.finishing
     }
 }
 


### PR DESCRIPTION
RowSetFinishing was renamed from RowSetTransform. Many variables of type
RowSetFinishing, however, were called `transform`, in reference to its
old name. Rename those variables to `finishing` to reduce confusion.