### PR TITLE
sqllogictest: speed up postgres integration

### DIFF
--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -522,7 +522,7 @@ impl State {
                 self.coord.drop_dataflows(names);
                 rows_inserted = None;
             }
-            postgres::Outcome::Changed(name, _typ, updates) => {
+            postgres::Outcome::Changed(name, updates) => {
                 let updates = updates
                     .into_iter()
                     .map(|(row, diff)| Update {

--- a/test/slt.slt
+++ b/test/slt.slt
@@ -1,0 +1,28 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+# Tests that exist primarily to test our sqllogictest runner,
+# rather than Materialize.
+
+statement ok
+CREATE TABLE t (a int)
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3), (4), (5)
+
+# Computing the diff for UPDATEs with WHERE clauses is a bit involved.
+# Check that we do it right.
+
+statement ok
+UPDATE t SET a = a - 1 WHERE a > 3
+
+query I
+SELECT * FROM t ORDER BY a
+----
+1
+2
+3
+3
+4


### PR DESCRIPTION
It was taking multiple minutes to insert 10000 rows into Postgres. The
issue was that we'd diff the whole table after every
INSERT/UPDATE/DELETE statement. We can be quite a bit smarter than that,
by asking Postgres to tell us only about the rows that were
inserted/updated/deleted via the `RETURNING *` Postgres extension.  Note
that updates are a tad more involved, as we need to run a separate query
to determine the pre-update values.

This makes inserting 10000 rows take a few seconds, which is far more
reasonable.