### PR TITLE
allow images to pass linter by not linting them

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -40,13 +40,21 @@ copyright_files=$(grep -vE \
     -e '\.json$' \
     -e '^misc/docker/ci-builder/ssh_known_hosts$' \
     -e '\.asc$' \
+    -e '\.png$' \
+    -e '\.jpe?g$' \
+    <<< "$files"
+)
+
+newline_files=$(grep -vE \
+    -e '\.png$' \
+    -e '\.jpe?g$' \
     <<< "$files"
 )
 
 shell_files=$(sort -u <(git ls-files '*.sh' '*.bash') <(git grep -l '#!.*bash' -- ':!*.md'))
 
 try xargs -n1 awk -f misc/lint/copyright.awk <<< "$copyright_files"
-try xargs misc/lint/trailing-newline.sh <<< "$files"
+try xargs misc/lint/trailing-newline.sh <<< "$newline_files"
 try xargs shellcheck <<< "$shell_files"
 
 if $failed; then


### PR DESCRIPTION
The linter was unhappy with images (#653, #673), so I'm trying to ensure they don't get linted. Anything I need to do once this is merged to "deploy" these changes to Buildkite?