### PR TITLE
Make address column relational

### DIFF
--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -111,7 +111,8 @@ impl LogVariant {
                 column_types: vec![
                     ColumnType::new(ScalarType::Int64).name("id"),
                     ColumnType::new(ScalarType::Int64).name("worker"),
-                    ColumnType::new(ScalarType::String).name("address"),
+                    ColumnType::new(ScalarType::Int64).name("address slot"),
+                    ColumnType::new(ScalarType::Int64).name("address value"),
                     ColumnType::new(ScalarType::String).name("name"),
                 ],
             },

--- a/src/dataflow/logging/timely.rs
+++ b/src/dataflow/logging/timely.rs
@@ -72,16 +72,19 @@ pub fn construct<A: Allocate>(
 
                         match datum {
                             TimelyEvent::Operates(event) => {
-                                operates_session.give((
-                                    vec![
-                                        Datum::Int64(event.id as i64),
-                                        Datum::Int64(worker as i64),
-                                        Datum::String(format!("{:?}", event.addr)),
-                                        Datum::String(event.name),
-                                    ],
-                                    time_ms,
-                                    1,
-                                ));
+                                for (addr_slot, addr_value) in event.addr.iter().enumerate() {
+                                    operates_session.give((
+                                        vec![
+                                            Datum::Int64(event.id as i64),
+                                            Datum::Int64(worker as i64),
+                                            Datum::Int64(addr_slot as i64),
+                                            Datum::Int64(*addr_value as i64),
+                                            Datum::String(event.name.clone()),
+                                        ],
+                                        time_ms,
+                                        1,
+                                    ));
+                                }
                             }
                             TimelyEvent::Channels(event) => {
                                 channels_session.give((


### PR DESCRIPTION
Previously, it contained the string representation of an array. Now, there are two columns encoding the contents, one for the slot number and one for the value. I did not add another table since the only piece of information that could be separated out is the name.