### PR TITLE
ex/chbench: always pass -d --build to docker-compose up

### DIFF
--- a/ex/chbench/README.md
+++ b/ex/chbench/README.md
@@ -29,7 +29,7 @@ want to increase memory available to Docker Engine using the following steps:
 To get started, bring up the Docker Compose containers in the background. To do this, open up a new shell, and from the Materialize repository, change to the `ex/chbench` directory and type the following three commands after each other:
 
 ```shell session
-$ docker-compose up -d
+$ docker-compose up -d --build
 Creating network "chbench_default" with the default driver
 Creating chbench_inspect_1      ... done
 Creating chbench_chbench_1      ... done

--- a/ex/chbench/dc.sh
+++ b/ex/chbench/dc.sh
@@ -16,18 +16,22 @@ main() {
     esac
 }
 
+dc_up() {
+    docker-compose up -d --build "$@"
+}
+
 bring_up() {
-    docker-compose up -d materialized mysql
+    dc_up materialized mysql
     docker-compose logs materialized | tail -n 5
     echo "Waiting for mysql to come up"
     sleep 5
     docker-compose logs mysql | tail -n 5
-    docker-compose up -d connector
+    dc_up connector
     echo "Waiting for schema registry to be fully up"
     sleep 5
     docker-compose logs schema-registry | tail -n 5
     echo "Materialize and all chbench should be running fine, bringing up metrics"
-    docker-compose up -d grafana
+    dc_up grafana
 }
 
 shut_down() {


### PR DESCRIPTION
Failing to pass `-d` results in interminable log spam to the console.
Failing to pass `--build` results in potentially stale images; since
`--build` won't actually rebuild if there's nothing to do, it's not
really any slower than not passing it.

`docker-compose up` really has the defaults wrong here. Update
all references to `docker-compose up` to `docker-compose up -d --build`
to nudge people in the correct direction.