### PR TITLE
Use key information for join order.

### DIFF
--- a/src/coord/coordinator.rs
+++ b/src/coord/coordinator.rs
@@ -268,7 +268,6 @@ where
                 typ,
                 mut relation_expr,
             } => {
-                let timer = std::time::Instant::now();
                 self.optimizer.optimize(&mut relation_expr, &typ);
                 let rows = vec![vec![Datum::from(relation_expr.pretty())]];
                 send_immediate_rows(typ, rows)

--- a/src/expr/transform/join_order.rs
+++ b/src/expr/transform/join_order.rs
@@ -161,7 +161,7 @@ fn order_join(
 /// This method attempts to produce an order on relations so that each join will involve at least a
 /// unique key, which would ensure that the number of records does not increase along the join. The
 /// attempt starts from a specified `start` relation, and greedily adds relations as long as any have
-/// unique keys that must be equal to some bound column.`
+/// unique keys that must be equal to some bound column.
 fn order_on_keys(
     relations: usize,
     start: usize,


### PR DESCRIPTION
We previously (wrongly) used the first field as a proxy for key information. We now extract it from the type.