### PR TITLE
sql: support extract function-like operator

### DIFF
--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -76,6 +76,7 @@ tests=(
     # test/cockroach/exec_hash_join.slt
     # test/cockroach/exec_merge_join.slt
     test/cockroach/exec_window.slt
+    test/cockroach/extract.slt
     # test/cockroach/float.slt
     test/cockroach/inet.slt
     test/cockroach/information_schema.slt

--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -7,7 +7,7 @@ use std::cmp;
 use std::convert::TryFrom;
 use std::fmt;
 
-use chrono::NaiveDateTime;
+use chrono::{Datelike, NaiveDateTime, Timelike};
 use pretty::{BoxDoc, Doc};
 use serde::{Deserialize, Serialize};
 
@@ -261,7 +261,6 @@ pub fn sub_timestamp_interval(a: Datum, b: Datum) -> Datum {
 }
 
 fn add_timestamp_months(dt: NaiveDateTime, months: i64) -> NaiveDateTime {
-    use chrono::{Datelike, Timelike};
     use std::convert::TryInto;
 
     if months == 0 {
@@ -622,6 +621,93 @@ pub fn ascii(a: Datum) -> Datum {
     }
 }
 
+pub fn extract_interval_year(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_interval().years())
+}
+
+pub fn extract_interval_month(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_interval().months())
+}
+
+pub fn extract_interval_day(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_interval().days())
+}
+
+pub fn extract_interval_hour(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_interval().hours())
+}
+
+pub fn extract_interval_minute(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_interval().minutes())
+}
+
+pub fn extract_interval_second(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(a.unwrap_interval().seconds())
+}
+
+pub fn extract_timestamp_year(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(f64::from(a.unwrap_timestamp().year()))
+}
+
+pub fn extract_timestamp_month(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(f64::from(a.unwrap_timestamp().month()))
+}
+
+pub fn extract_timestamp_day(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(f64::from(a.unwrap_timestamp().day()))
+}
+
+pub fn extract_timestamp_hour(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(f64::from(a.unwrap_timestamp().hour()))
+}
+
+pub fn extract_timestamp_minute(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    Datum::from(f64::from(a.unwrap_timestamp().minute()))
+}
+
+pub fn extract_timestamp_second(a: Datum) -> Datum {
+    if a.is_null() {
+        return Datum::Null;
+    }
+    let a = a.unwrap_timestamp();
+    let s = f64::from(a.second());
+    let ns = f64::from(a.nanosecond()) / 1e9;
+    Datum::from(s + ns)
+}
+
 #[derive(Ord, PartialOrd, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum BinaryFunc {
     And,
@@ -789,6 +875,18 @@ pub enum UnaryFunc {
     CastDateToTimestamp,
     BuildLikeRegex,
     Ascii,
+    ExtractIntervalYear,
+    ExtractIntervalMonth,
+    ExtractIntervalDay,
+    ExtractIntervalHour,
+    ExtractIntervalMinute,
+    ExtractIntervalSecond,
+    ExtractTimestampYear,
+    ExtractTimestampMonth,
+    ExtractTimestampDay,
+    ExtractTimestampHour,
+    ExtractTimestampMinute,
+    ExtractTimestampSecond,
 }
 
 impl UnaryFunc {
@@ -823,6 +921,18 @@ impl UnaryFunc {
             UnaryFunc::CastDateToTimestamp => cast_date_to_timestamp,
             UnaryFunc::BuildLikeRegex => build_like_regex,
             UnaryFunc::Ascii => ascii,
+            UnaryFunc::ExtractIntervalYear => extract_interval_year,
+            UnaryFunc::ExtractIntervalMonth => extract_interval_month,
+            UnaryFunc::ExtractIntervalDay => extract_interval_day,
+            UnaryFunc::ExtractIntervalHour => extract_interval_hour,
+            UnaryFunc::ExtractIntervalMinute => extract_interval_minute,
+            UnaryFunc::ExtractIntervalSecond => extract_interval_second,
+            UnaryFunc::ExtractTimestampYear => extract_timestamp_year,
+            UnaryFunc::ExtractTimestampMonth => extract_timestamp_month,
+            UnaryFunc::ExtractTimestampDay => extract_timestamp_day,
+            UnaryFunc::ExtractTimestampHour => extract_timestamp_hour,
+            UnaryFunc::ExtractTimestampMinute => extract_timestamp_minute,
+            UnaryFunc::ExtractTimestampSecond => extract_timestamp_second,
         }
     }
 
@@ -873,9 +983,21 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::CastDecimalToInt64 => f.write_str("dectoi64"),
             UnaryFunc::CastDecimalToFloat32 => f.write_str("dectof32"),
             UnaryFunc::CastDecimalToFloat64 => f.write_str("dectof64"),
-            UnaryFunc::CastDateToTimestamp => f.write_str("datetotimestamp"),
+            UnaryFunc::CastDateToTimestamp => f.write_str("datetots"),
             UnaryFunc::BuildLikeRegex => f.write_str("compilelike"),
             UnaryFunc::Ascii => f.write_str("ascii"),
+            UnaryFunc::ExtractIntervalYear => f.write_str("ivextractyear"),
+            UnaryFunc::ExtractIntervalMonth => f.write_str("ivextractmonth"),
+            UnaryFunc::ExtractIntervalDay => f.write_str("ivextractday"),
+            UnaryFunc::ExtractIntervalHour => f.write_str("ivextracthour"),
+            UnaryFunc::ExtractIntervalMinute => f.write_str("ivextractminute"),
+            UnaryFunc::ExtractIntervalSecond => f.write_str("ivextractsecond"),
+            UnaryFunc::ExtractTimestampYear => f.write_str("tsextractyear"),
+            UnaryFunc::ExtractTimestampMonth => f.write_str("tsextractmonth"),
+            UnaryFunc::ExtractTimestampDay => f.write_str("tsextractday"),
+            UnaryFunc::ExtractTimestampHour => f.write_str("tsextracthour"),
+            UnaryFunc::ExtractTimestampMinute => f.write_str("tsextractminute"),
+            UnaryFunc::ExtractTimestampSecond => f.write_str("tsextractsecond"),
         }
     }
 }

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -231,7 +231,7 @@ Project {
       Project {
         outputs: [0 .. 9, 3],
         Filter {
-          predicates: [datetotimestamp #6 > 2007-01-02 00:00:00],
+          predicates: [datetots #6 > 2007-01-02 00:00:00],
           Get { orderline }
         }
       }
@@ -351,10 +351,7 @@ Project {
         ],
         Get { orderline },
         Filter {
-          predicates: [
-            !isnull #3,
-            datetotimestamp #4 > 2007-01-02 00:00:00
-          ],
+          predicates: [!isnull #3, datetots #4 > 2007-01-02 00:00:00],
           Get { "order" }
         },
         Filter { predicates: [#9 ~ /^A.*$/], Get { customer } },
@@ -402,8 +399,8 @@ Project {
         ],
         Filter {
           predicates: [
-            datetotimestamp #4 < 2012-01-02 00:00:00,
-            datetotimestamp #4 >= 2007-01-02 00:00:00
+            datetots #4 < 2012-01-02 00:00:00,
+            datetots #4 >= 2007-01-02 00:00:00
           ],
           Get { "order" }
         },
@@ -481,7 +478,7 @@ Project {
             Filter {
               predicates: [
                 !isnull #3,
-                datetotimestamp #4 >= 2007-01-02 00:00:00
+                datetots #4 >= 2007-01-02 00:00:00
               ],
               Get { "order" }
             },
@@ -512,10 +509,10 @@ Let {
     aggregates: [sum(#8)],
     Filter {
       predicates: [
-        datetotimestamp #6 < 2020-01-01 00:00:00,
+        datetots #6 < 2020-01-01 00:00:00,
         i32toi64 #7 <= 100000,
         i32toi64 #7 >= 1,
-        datetotimestamp #6 >= 1999-01-01 00:00:00
+        datetots #6 >= 1999-01-01 00:00:00
       ],
       Get { orderline }
     }
@@ -534,7 +531,6 @@ Union {
 }
 
 # Query 07
-skipif postgresql # TODO(benesch): Unsupported: complicated expressions are not yet supported: EXTRACT(YEAR FROM o_entry_d) (ErrorMessage { msg: "complicated expressions are not yet supported: EXTRACT(YEAR FROM o_entry_d)" })
 query T multiline
 EXPLAIN PLAN FOR
 SELECT
@@ -563,9 +559,59 @@ AND ol_delivery_d BETWEEN TIMESTAMP '2007-01-02 00:00:00.000000' AND TIMESTAMP '
 GROUP BY su_nationkey, substr(c_state, 1, 1), extract(year FROM o_entry_d)
 ORDER BY su_nationkey, cust_nation, l_year
 ----
+Project {
+  outputs: [0 .. 3, 0 .. 2],
+  Reduce {
+    group_key: [73 .. 75],
+    aggregates: [sum(#33)],
+    Project {
+      outputs: [0 .. 72, 3, 73, 74],
+      Map {
+        scalars: [substr(#52, 1, 1), tsextractyear datetots #39],
+        Filter {
+          predicates: [
+            ((#66 = "GERMANY") && (#70 = "CAMBODIA"))
+            ||
+            ((#66 = "CAMBODIA") && (#70 = "GERMANY")),
+            #64 = i32toi64 #69
+          ],
+          Join {
+            variables: [
+              [(0, 7), (1, 4)],
+              [(0, 8), (1, 5)],
+              [(1, 0), (2, 0)],
+              [(1, 1), (2, 1)],
+              [(1, 2), (2, 2)],
+              [(2, 3), (3, 0)],
+              [(2, 1), (3, 1)],
+              [(2, 2), (3, 2)],
+              [(0, 3), (4, 0)]
+            ],
+            Filter {
+              predicates: [#24 = i32toi64 #0],
+              Join { variables: [], Get { supplier }, Get { stock } }
+            },
+            Filter {
+              predicates: [
+                !isnull #4,
+                !isnull #5,
+                datetots #6 <= 2012-01-02 00:00:00,
+                datetots #6 >= 2007-01-02 00:00:00
+              ],
+              Get { orderline }
+            },
+            Filter { predicates: [!isnull #3], Get { "order" } },
+            Get { customer },
+            Get { nation },
+            Get { nation }
+          }
+        }
+      }
+    }
+  }
+}
 
 # Query 08
-skipif postgresql # TODO(benesch): Unsupported: complicated expressions are not yet supported: EXTRACT(YEAR FROM o_entry_d) (ErrorMessage { msg: "complicated expressions are not yet supported: EXTRACT(YEAR FROM o_entry_d)" })
 query T multiline
 EXPLAIN PLAN FOR
 SELECT
@@ -593,9 +639,73 @@ AND i_id = ol_i_id
 GROUP BY extract(year FROM o_entry_d)
 ORDER BY l_year
 ----
+Project {
+  outputs: [0, 3, 0],
+  Map {
+    scalars: [((#1 * 10000000dec) / #2) * 10dec],
+    Reduce {
+      group_key: [81],
+      aggregates: [
+        sum(if #75 = "GERMANY" then #38 else i64todec 0 * 100dec),
+        sum(#38)
+      ],
+      Map {
+        scalars: [tsextractyear datetots #44],
+        Join {
+          variables: [[(0, 8), (1, 0)], [(0, 72), (2, 0)]],
+          Filter {
+            predicates: [i32toi64 #70 = #69],
+            Join {
+              variables: [
+                [(0, 0), (1, 4)],
+                [(0, 13), (1, 5)],
+                [(1, 0), (2, 0)],
+                [(1, 1), (2, 1)],
+                [(1, 2), (2, 2)],
+                [(2, 3), (3, 0)],
+                [(2, 1), (3, 1)],
+                [(2, 2), (3, 2)]
+              ],
+              Filter {
+                predicates: [#29 = i32toi64 #5],
+                Project {
+                  outputs: [0 .. 4, 23 .. 29, 5 .. 22],
+                  Join {
+                    variables: [[(0, 0), (1, 0)]],
+                    Filter {
+                      predicates: [#4 ~ /^.*b$/],
+                      Get { item }
+                    },
+                    Get { stock },
+                    Get { supplier }
+                  }
+                }
+              },
+              Filter {
+                predicates: [!isnull #4, !isnull #5, #4 < 1000],
+                Get { orderline }
+              },
+              Filter {
+                predicates: [
+                  !isnull #3,
+                  datetots #4 <= 2012-01-02 00:00:00,
+                  datetots #4 >= 2007-01-02 00:00:00
+                ],
+                Get { "order" }
+              },
+              Get { customer },
+              Get { nation }
+            }
+          },
+          Get { nation },
+          Filter { predicates: [#1 = "EUROPE"], Get { region } }
+        }
+      }
+    }
+  }
+}
 
 # Query 09
-skipif postgresql # TODO(benesch): Unsupported: complicated expressions are not yet supported: EXTRACT(YEAR FROM o_entry_d) (ErrorMessage { msg: "complicated expressions are not yet supported: EXTRACT(YEAR FROM o_entry_d)" })
 query T multiline
 EXPLAIN PLAN FOR
 SELECT
@@ -614,6 +724,44 @@ AND i_data like '%BB'
 GROUP BY n_name, extract(year FROM o_entry_d)
 ORDER BY n_name, l_year DESC
 ----
+Project {
+  outputs: [0 .. 2, 0, 1],
+  Reduce {
+    group_key: [52, 53],
+    aggregates: [sum(#38)],
+    Project {
+      outputs: [0 .. 51, 49, 52],
+      Map {
+        scalars: [tsextractyear datetots #44],
+        Join {
+          variables: [
+            [(0, 0), (1, 4)],
+            [(0, 6), (1, 5)],
+            [(1, 0), (2, 0)],
+            [(1, 1), (2, 1)],
+            [(1, 2), (2, 2)],
+            [(0, 26), (3, 0)]
+          ],
+          Filter {
+            predicates: [#22 = i32toi64 #23],
+            Join {
+              variables: [[(0, 0), (1, 0)]],
+              Filter { predicates: [#4 ~ /^.*BB$/], Get { item } },
+              Get { stock },
+              Get { supplier }
+            }
+          },
+          Filter {
+            predicates: [!isnull #4, !isnull #5],
+            Get { orderline }
+          },
+          Get { "order" },
+          Get { nation }
+        }
+      }
+    }
+  }
+}
 
 # Query 10
 query T multiline
@@ -661,7 +809,7 @@ Project {
                 Filter {
                   predicates: [
                     !isnull #3,
-                    datetotimestamp #4 >= 2007-01-02 00:00:00
+                    datetots #4 >= 2007-01-02 00:00:00
                   ],
                   Get { "order" }
                 },
@@ -942,7 +1090,7 @@ Project {
               [(1, 2), (0, 2)]
             ],
             Filter {
-              predicates: [datetotimestamp #6 < 2020-01-01 00:00:00],
+              predicates: [datetots #6 < 2020-01-01 00:00:00],
               Get { orderline }
             },
             Get { "order" }
@@ -1043,8 +1191,8 @@ Let {
       Filter {
         predicates: [
           !isnull #4,
-          datetotimestamp #6 < 2020-01-02 00:00:00,
-          datetotimestamp #6 >= 2007-01-02 00:00:00
+          datetots #6 < 2020-01-02 00:00:00,
+          datetots #6 >= 2007-01-02 00:00:00
         ],
         Get { orderline }
       },
@@ -1119,7 +1267,7 @@ Let {
             predicates: [
               !isnull #4,
               !isnull #5,
-              datetotimestamp #6 >= 2007-01-02 00:00:00
+              datetots #6 >= 2007-01-02 00:00:00
             ],
             Get { orderline }
           },
@@ -1179,7 +1327,7 @@ Project {
                 predicates: [
                   !isnull #4,
                   !isnull #5,
-                  datetotimestamp #6 >= 2007-01-02 00:00:00
+                  datetots #6 >= 2007-01-02 00:00:00
                 ],
                 Get { orderline }
               }
@@ -1613,7 +1761,7 @@ Project {
                       Filter {
                         predicates: [
                           #33 = #11,
-                          datetotimestamp #35 > 2010-05-23 12:00:00
+                          datetots #35 > 2010-05-23 12:00:00
                         ],
                         Get { id-3 }
                       },

--- a/test/cockroach/extract.slt
+++ b/test/cockroach/extract.slt
@@ -1,0 +1,203 @@
+# Copyright 2015 - 2019 The Cockroach Authors. All rights reserved.
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+#
+# This file is derived from the evaluation test suite in CockroachDB.
+# The original file was retrieved on October 7, 2019 from:
+#
+#     https://github.com/cockroachdb/cockroach/blob/d2f7fbf5dd1fc1a099bbad790a2e1f7c60a66cc3/pkg/sql/sem/tree/testdata/eval/extract
+#
+# The original source code is subject to the terms of the Apache
+# 2.0 license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+# Extract from dates.
+
+skipif postgresql # literal coercion for dates is not supported
+query I
+SELECT extract(year FROM '2010-09-28')
+----
+2010
+
+query I
+SELECT extract(year FROM DATE '2010-09-28')
+----
+2010
+
+query I
+SELECT extract(month FROM DATE '2010-09-28')
+----
+9
+
+query I
+SELECT extract(day FROM DATE '2010-09-28')
+----
+28
+
+skipif postgresql # dayofyear is not supported
+query I
+SELECT extract(dayofyear FROM DATE '2010-09-28')
+----
+271
+
+skipif postgresql # week is not supported
+query I
+SELECT extract(week FROM DATE '2010-01-14')
+----
+2
+
+skipif postgresql # dayofweek is not supported
+query I
+SELECT extract(dayofweek FROM DATE '2010-09-28')
+----
+2
+
+skipif postgresql # quarter is not supported
+query I
+SELECT extract(quarter FROM DATE '2010-09-28')
+----
+3
+
+# Extract from times. These don't currently work, because we don't support the
+# TIME data type, which is distinct from TIMESTAMP and DATE.
+
+skipif postgresql
+query I
+SELECT extract(hour FROM TIME '12:00:00')
+----
+12
+
+skipif postgresql
+query I
+SELECT extract(minute FROM TIME '12:30:00')
+----
+30
+
+skipif postgresql
+query I
+SELECT extract(second FROM TIME '12:00:30')
+----
+30
+
+skipif postgresql
+query I
+SELECT extract(millisecond FROM TIME '12:00:00.123456')
+----
+123
+
+skipif postgresql
+query I
+SELECT extract(microsecond FROM TIME '12:00:00.123456')
+----
+123456
+
+# Extract from timestamps.
+
+skipif postgresql # literal coercion for timestamps is not supported
+query I
+SELECT extract(year FROM '2010-09-28 12:13:14.1')
+----
+2010
+
+query I
+SELECT extract(year FROM TIMESTAMP '2010-09-28 12:13:14.1')
+----
+2010
+
+query I
+SELECT extract(month FROM TIMESTAMP '2010-09-28 12:13:14.1')
+----
+9
+
+query I
+SELECT extract(day FROM TIMESTAMP '2010-09-28 12:13:14.1')
+----
+28
+
+skipif postgresql # dayofyear is not supported
+query I
+SELECT extract(dayofyear FROM TIMESTAMP '2010-09-28 12:13:14.1')
+----
+271
+
+skipif postgresql # week is not supported
+query I
+SELECT extract(week FROM TIMESTAMP '2010-01-14 12:13:14.1')
+----
+2
+
+skipif postgresql # dayofweek is not supported
+query I
+SELECT extract(dayofweek FROM TIMESTAMP '2010-09-28 12:13:14.1')
+----
+2
+
+skipif postgresql # quarter is not supported
+query I
+SELECT extract(quarter FROM TIMESTAMP '2010-09-28 12:13:14.1')
+----
+3
+
+query I
+SELECT extract(hour FROM TIMESTAMP '2010-01-10 12:13:14.1')
+----
+12
+
+query I
+SELECT extract(minute FROM TIMESTAMP '2010-01-10 12:13:14.1')
+----
+13
+
+query R
+SELECT extract(second FROM TIMESTAMP '2010-01-10 12:13:14.1')
+----
+14.100
+
+skipif postgresql # millisecond is not supported
+query R
+SELECT extract(millisecond FROM TIMESTAMP '2010-01-10 12:13:14.123456')
+----
+14123.456
+
+skipif postgresql # microsecond is not supported
+query I
+SELECT extract(microsecond FROM TIMESTAMP '2010-01-10 12:13:14.123456')
+----
+123456
+
+skipif postgresql # epoch is not supported
+query I
+SELECT extract(epoch FROM TIMESTAMP '2010-01-10 12:13:14.1')
+----
+1263125594
+
+# Extract from intervals.
+
+skipif postgresql # literal coercion for intervals is not supported
+query I
+SELECT extract(hour FROM '123m')
+----
+2
+
+query I
+SELECT extract(hour FROM INTERVAL '123' MINUTE)
+----
+2
+
+query I
+SELECT extract(minute FROM INTERVAL '123:10' MINUTE TO SECOND)
+----
+3
+
+query R
+SELECT extract(second FROM INTERVAL '10:20.30' MINUTE TO SECOND)
+----
+20.300
+
+skipif postgresql # millisecond is not supported
+query R
+SELECT extract(millisecond FROM INTERVAL '20.3040' SECOND)
+----
+20304


### PR DESCRIPTION
Support the basic features of the EXTRACT function-like operator, which
extracts date/time fields from date/time-like objects.

Fix MaterializeInc/database-issues#150.

---

Also, @frankmcsherry is likely to be excited about this, and perhaps he will be excited about this enough to review it!