### PR TITLE
bin/lint: better error messages about shellcheck

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -11,6 +11,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+. misc/shlib/shlib.bash
+
 failed=false
 
 try() {
@@ -18,6 +20,22 @@ try() {
         failed=true
     fi
 }
+
+if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
+    if ! command_exists shellcheck; then
+        printf "lint: fatal: unable to find \`shellcheck\` command on your system\n" >&2
+        printf "hint: https://github.com/koalaman/shellcheck#installing\n" >&2
+        printf "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1\n" >&2
+        exit 1
+    fi
+    version=$(shellcheck --version | grep version: | grep -oE "[0-9]\.[0-9]\.[0-9]" || echo "0.0.0+unknown")
+    if ! version_compat "0.7.0" "$version"; then
+        printf "lint: fatal: shellcheck v0.7.0+ is required\n" >&2
+        printf "hint: detected version %q\n" "$version" >&2
+        printf "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1\n" >&2
+        exit 1
+    fi
+fi
 
 # This Git incantation lists the source files in this repository. If you change
 # it, please preserve the following properties:
@@ -55,7 +73,10 @@ shell_files=$(sort -u <(git ls-files '*.sh' '*.bash') <(git grep -l '#!.*bash' -
 
 try xargs -n1 awk -f misc/lint/copyright.awk <<< "$copyright_files"
 try xargs misc/lint/trailing-newline.sh <<< "$newline_files"
-try xargs shellcheck -P SCRIPTDIR <<< "$shell_files"
+
+if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
+    try xargs shellcheck -P SCRIPTDIR <<< "$shell_files"
+fi
 
 if $failed; then
     exit 1

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -7,19 +7,48 @@
 #
 # shlib.bash — A shell utility library.
 
+# die [ARGS...]
+#
+# Outputs ARGS to stderr, then exits the script with a failing exit status.
 die() {
     echo "$@" >&2
     exit 1
 }
 
+# run PROGRAM [ARGS...]
+#
+# Runs PROGRAM, but informs the user first. Specifically, run outputs "PROGRAM
+# ARGS..." to stderr, then executes PROGRAM with the specified ARGS.
+run() {
+   echo "$*" >&2
+   "$@"
+}
+
+# runv PROGRAM [ARGS...]
+#
+# Like run, but prints a more verbose informational message to stderr of the
+# form ">run PROGRAM ARGS...".
 runv() {
     echo "run> $*" >&2
     "$@"
 }
 
-run() {
-   echo "$*" >&2
-   "$@"
+# command_exists PROGRAM
+#
+# Returns successfully if PROGRAM exists in $PATH, or unsuccessfully otherwise.
+# Outputs nothing.
+command_exists() {
+    hash "$1" 2>/dev/null
+}
+
+# version_compat MINIMUM ACTUAL
+# version_compat [VERSIONS...]
+#
+# Checks whether VERSIONS is in sorted order according to version comparison
+# rules. Typical usage is to provide exactly two versions, in which case the
+# function checks that ACTUAL is greater than or equal to MINIMUM.
+version_compat() {
+    printf "%s\n" "$@" | sort --check=silent --version-sort
 }
 
 ci_init() {


### PR DESCRIPTION
Complain more verbosely when shellcheck is missing, or is a version that
is too old. Also allow folks to skip it by setting MZDEV_NO_SHELLCHECK
in their environment.

Improves on the situation described in MaterializeInc/database-issues#230.