### PR TITLE
expr,sql: rework scalar expression typing

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -254,7 +254,7 @@ where
                     let scalars = scalars.clone();
                     let collection = self.collection(input).unwrap().map(move |mut tuple| {
                         for s in scalars.iter() {
-                            let to_push = s.0.eval(&tuple[..]);
+                            let to_push = s.eval(&tuple[..]);
                             tuple.push(to_push);
                         }
                         tuple
@@ -458,7 +458,7 @@ where
 
             // Track whether aggregations are Abelian (and so accumulable) or not.
             let mut abelian = Vec::new();
-            for (aggregate, _type) in aggregates.iter() {
+            for aggregate in aggregates.iter() {
                 let accumulable = match aggregate.func {
                     AggregateFunc::SumInt32 => !aggregate.distinct,
                     AggregateFunc::SumInt64 => !aggregate.distinct,
@@ -491,7 +491,7 @@ where
                     let mut vals = Vec::new();
                     let mut aggs = vec![1i128];
 
-                    for (index, (aggregate, _column_type)) in aggregates_clone.iter().enumerate() {
+                    for (index, aggregate) in aggregates_clone.iter().enumerate() {
                         // Presently, we can accumulate in the difference field only
                         // if the aggregation has a known type and does not require
                         // us to accumulate only distinct elements.
@@ -578,7 +578,7 @@ where
                     let mut abelian_pos = 1; // <- advance past the count
                     let mut non_abelian_pos = 0;
 
-                    for ((agg, _column_type), abl) in aggregates.iter().zip(abelian.iter()) {
+                    for (agg, abl) in aggregates.iter().zip(abelian.iter()) {
                         if *abl {
                             let value = match agg.func {
                                 AggregateFunc::SumInt32 => {

--- a/src/expr/scalar/mod.rs
+++ b/src/expr/scalar/mod.rs
@@ -6,9 +6,10 @@
 pub mod func;
 
 use pretty::{BoxDoc, Doc};
-use repr::Datum;
+use repr::{ColumnType, Datum, RelationType, ScalarType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::mem;
 
 use self::func::{BinaryFunc, UnaryFunc, VariadicFunc};
 use crate::pretty_pretty::to_tightly_braced_doc;
@@ -19,7 +20,7 @@ pub enum ScalarExpr {
     /// A column of the input row
     Column(usize),
     /// A literal value.
-    Literal(Datum),
+    Literal(Datum, ColumnType),
     /// A function call that takes one expression as an argument.
     CallUnary {
         func: UnaryFunc,
@@ -52,8 +53,8 @@ impl ScalarExpr {
         ScalarExpr::Column(column)
     }
 
-    pub fn literal(datum: Datum) -> Self {
-        ScalarExpr::Literal(datum)
+    pub fn literal(datum: Datum, typ: ColumnType) -> Self {
+        ScalarExpr::Literal(datum, typ)
     }
 
     pub fn call_unary(self, func: UnaryFunc) -> Self {
@@ -85,7 +86,7 @@ impl ScalarExpr {
     {
         match self {
             ScalarExpr::Column(_) => (),
-            ScalarExpr::Literal(_) => (),
+            ScalarExpr::Literal(_, _) => (),
             ScalarExpr::CallUnary { expr, .. } => {
                 f(expr);
             }
@@ -120,7 +121,7 @@ impl ScalarExpr {
     {
         match self {
             ScalarExpr::Column(_) => (),
-            ScalarExpr::Literal(_) => (),
+            ScalarExpr::Literal(_, _) => (),
             ScalarExpr::CallUnary { expr, .. } => {
                 f(expr);
             }
@@ -167,8 +168,39 @@ impl ScalarExpr {
         support
     }
 
-    fn is_literal(&self) -> bool {
-        if let ScalarExpr::Literal(_) = self {
+    pub fn take(&mut self) -> Self {
+        mem::replace(
+            self,
+            ScalarExpr::Literal(Datum::Null, ColumnType::new(ScalarType::Null)),
+        )
+    }
+
+    pub fn is_literal(&self) -> bool {
+        if let ScalarExpr::Literal(_, _) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_literal_true(&self) -> bool {
+        if let ScalarExpr::Literal(Datum::True, _) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_literal_false(&self) -> bool {
+        if let ScalarExpr::Literal(Datum::False, _) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_literal_null(&self) -> bool {
+        if let ScalarExpr::Literal(Datum::Null, _) = self {
             true
         } else {
             false
@@ -179,11 +211,11 @@ impl ScalarExpr {
     ///
     /// ```rust
     /// use expr::{BinaryFunc, ScalarExpr};
-    /// use repr::Datum;
+    /// use repr::{ColumnType, Datum, ScalarType};
     ///
     /// let expr_0 = ScalarExpr::Column(0);
-    /// let expr_t = ScalarExpr::Literal(Datum::True);
-    /// let expr_f = ScalarExpr::Literal(Datum::False);
+    /// let expr_t = ScalarExpr::Literal(Datum::True, ColumnType::new(ScalarType::Bool));
+    /// let expr_f = ScalarExpr::Literal(Datum::False, ColumnType::new(ScalarType::Bool));
     ///
     /// let mut test =
     /// expr_t
@@ -195,40 +227,66 @@ impl ScalarExpr {
     /// assert_eq!(test, expr_t);
     /// ```
     pub fn reduce(&mut self) {
-        self.visit_mut(&mut |e| {
-            let should_eval = match e {
-                ScalarExpr::CallUnary { expr, .. } => expr.is_literal(),
-                ScalarExpr::CallBinary { expr1, expr2, .. } => {
-                    expr1.is_literal() && expr2.is_literal()
+        let empty = RelationType::new(vec![]);
+        let eval = |e: &ScalarExpr| ScalarExpr::Literal(e.eval(&[]), e.typ(&empty));
+        self.visit_mut(&mut |e| match e {
+            ScalarExpr::Column(_) | ScalarExpr::Literal(_, _) => (),
+            ScalarExpr::CallUnary { expr, .. } => {
+                if expr.is_literal() {
+                    *e = eval(e);
                 }
-                ScalarExpr::CallVariadic { exprs, .. } => exprs.iter().all(|e| e.is_literal()),
-                ScalarExpr::If { cond, then, els } => {
-                    if cond.is_literal() {
-                        let eval = cond.eval(&[]);
-                        if eval == Datum::True {
-                            then.is_literal()
-                        } else if eval == Datum::False || eval == Datum::Null {
-                            els.is_literal()
-                        } else {
-                            unreachable!()
-                        }
-                    } else {
-                        false
+            }
+            ScalarExpr::CallBinary { expr1, expr2, .. } => {
+                if expr1.is_literal() && expr2.is_literal() {
+                    *e = eval(e);
+                }
+            }
+            ScalarExpr::CallVariadic { exprs, .. } => {
+                if exprs.iter().all(|e| e.is_literal()) {
+                    *e = eval(e);
+                }
+            }
+            ScalarExpr::If { cond, then, els } => {
+                if cond.is_literal() {
+                    match cond.eval(&[]) {
+                        Datum::True if then.is_literal() => *e = eval(then),
+                        Datum::False | Datum::Null if els.is_literal() => *e = eval(els),
+                        Datum::True | Datum::False | Datum::Null => (),
+                        _ => unreachable!(),
                     }
                 }
-                _ => false,
-            };
-
-            if should_eval {
-                *e = ScalarExpr::Literal(e.eval(&[]));
             }
         });
+    }
+
+    pub fn typ(&self, relation_type: &RelationType) -> ColumnType {
+        match self {
+            ScalarExpr::Column(i) => relation_type.column_types[*i],
+            ScalarExpr::Literal(_, typ) => *typ,
+            ScalarExpr::CallUnary { expr, func } => func.output_type(expr.typ(relation_type)),
+            ScalarExpr::CallBinary { expr1, expr2, func } => {
+                func.output_type(expr1.typ(relation_type), expr2.typ(relation_type))
+            }
+            ScalarExpr::CallVariadic { exprs, func } => {
+                func.output_type(exprs.iter().map(|e| e.typ(relation_type)).collect())
+            }
+            ScalarExpr::If { cond: _, then, els } => {
+                let then_type = then.typ(relation_type);
+                let else_type = els.typ(relation_type);
+                let nullable = then_type.nullable || else_type.nullable;
+                if then_type.scalar_type != ScalarType::Null {
+                    then_type.nullable(nullable)
+                } else {
+                    else_type.nullable(nullable)
+                }
+            }
+        }
     }
 
     pub fn eval(&self, data: &[Datum]) -> Datum {
         match self {
             ScalarExpr::Column(index) => data[*index].clone(),
-            ScalarExpr::Literal(datum) => datum.clone(),
+            ScalarExpr::Literal(datum, _) => datum.clone(),
             ScalarExpr::CallUnary { func, expr } => {
                 let eval = expr.eval(data);
                 (func.func())(eval)
@@ -257,7 +315,7 @@ impl ScalarExpr {
 
         fn needs_wrap(expr: &ScalarExpr) -> bool {
             match expr {
-                Column(_) | Literal(_) | CallUnary { .. } | CallVariadic { .. } => false,
+                Column(_) | Literal(_, _) | CallUnary { .. } | CallVariadic { .. } => false,
                 CallBinary { .. } | If { .. } => true,
             }
         }
@@ -272,7 +330,7 @@ impl ScalarExpr {
 
         match self {
             Column(n) => to_doc!("#", n.to_string()),
-            Literal(d) => d.into(),
+            Literal(d, _) => d.into(),
             CallUnary { func, expr } => {
                 let mut doc = Doc::from(func);
                 if !func.display_is_symbolic() && !needs_wrap(expr) {
@@ -328,24 +386,34 @@ mod tests {
 
     #[test]
     fn test_pretty_scalar_expr() {
-        let plus_expr = ScalarExpr::literal(Datum::Int64(1))
-            .call_binary(ScalarExpr::literal(Datum::Int64(2)), BinaryFunc::AddInt64);
+        use ScalarType::*;
+        let col_type = |st| ColumnType::new(st);
+        let int64_lit = |n| ScalarExpr::literal(Datum::Int64(n), col_type(Int64));
+
+        let plus_expr = int64_lit(1).call_binary(int64_lit(2), BinaryFunc::AddInt64);
         assert_eq!(plus_expr.to_doc().pretty(72).to_string(), "1 + 2");
 
-        let regex_expr = ScalarExpr::literal(Datum::String("foo".into())).call_binary(
-            ScalarExpr::literal(Datum::from(regex::Regex::new("f?oo").unwrap())),
-            BinaryFunc::MatchRegex,
-        );
+        let regex_expr = ScalarExpr::literal(Datum::String("foo".into()), col_type(String))
+            .call_binary(
+                ScalarExpr::literal(
+                    Datum::from(regex::Regex::new("f?oo").unwrap()),
+                    col_type(Regex),
+                ),
+                BinaryFunc::MatchRegex,
+            );
         assert_eq!(
             regex_expr.to_doc().pretty(72).to_string(),
             r#""foo" ~ /f?oo/"#
         );
 
-        let neg_expr = ScalarExpr::literal(Datum::Int64(1)).call_unary(UnaryFunc::NegInt64);
+        let neg_expr = int64_lit(1).call_unary(UnaryFunc::NegInt64);
         assert_eq!(neg_expr.to_doc().pretty(72).to_string(), "-1");
 
-        let bool_expr = ScalarExpr::literal(Datum::True)
-            .call_binary(ScalarExpr::literal(Datum::False), BinaryFunc::And)
+        let bool_expr = ScalarExpr::literal(Datum::True, col_type(Bool))
+            .call_binary(
+                ScalarExpr::literal(Datum::False, col_type(Bool)),
+                BinaryFunc::And,
+            )
             .call_unary(UnaryFunc::Not);
         assert_eq!(
             bool_expr.to_doc().pretty(72).to_string(),
@@ -353,7 +421,7 @@ mod tests {
         );
 
         let cond_expr = ScalarExpr::if_then_else(
-            ScalarExpr::literal(Datum::True),
+            ScalarExpr::literal(Datum::True, col_type(Bool)),
             neg_expr.clone(),
             plus_expr.clone(),
         );

--- a/src/expr/transform/predicate_pushdown.rs
+++ b/src/expr/transform/predicate_pushdown.rs
@@ -33,7 +33,7 @@
 //! let predicate0 = ScalarExpr::column(0);
 //! let predicate1 = ScalarExpr::column(1);
 //! let predicate01 = ScalarExpr::column(0).call_binary(ScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = ScalarExpr::literal(Datum::False);
+//! let predicate012 = ScalarExpr::literal(Datum::False, ColumnType::new(ScalarType::Bool));
 //!
 //! let mut expr = join.filter(
 //!    vec![
@@ -45,6 +45,8 @@
 //!
 //! PredicatePushdown.transform(&mut expr);
 //! ```
+
+use repr::{ColumnType, Datum, ScalarType};
 
 use crate::{AggregateFunc, RelationExpr, ScalarExpr};
 
@@ -243,10 +245,13 @@ impl PredicatePushdown {
                         } else if let ScalarExpr::Column(col) = &predicate {
                             if *col == group_key.len()
                                 && aggregates.len() == 1
-                                && aggregates[0].0.func == AggregateFunc::Any
+                                && aggregates[0].func == AggregateFunc::Any
                             {
-                                push_down.push(aggregates[0].0.expr.clone());
-                                aggregates[0].0.expr = ScalarExpr::Literal(repr::Datum::True);
+                                push_down.push(aggregates[0].expr.clone());
+                                aggregates[0].expr = ScalarExpr::Literal(
+                                    Datum::True,
+                                    ColumnType::new(ScalarType::Bool),
+                                );
                             } else {
                                 retain.push(predicate);
                             }

--- a/src/expr/transform/projection_extraction.rs
+++ b/src/expr/transform/projection_extraction.rs
@@ -26,7 +26,7 @@ impl ProjectionExtraction {
     pub fn action(&self, relation: &mut RelationExpr) {
         if let RelationExpr::Map { input, scalars } = relation {
             if scalars.iter().any(|s| {
-                if let ScalarExpr::Column(_) = s.0 {
+                if let ScalarExpr::Column(_) = s {
                     true
                 } else {
                     false
@@ -36,9 +36,9 @@ impl ProjectionExtraction {
                 let mut outputs: Vec<_> = (0..input_arity).collect();
                 let mut dropped = 0;
                 scalars.retain(|scalar| {
-                    if let ScalarExpr::Column(col) = scalar.0 {
+                    if let ScalarExpr::Column(col) = scalar {
                         dropped += 1;
-                        outputs.push(col);
+                        outputs.push(*col);
                         false // don't retain
                     } else {
                         outputs.push(outputs.len() - dropped);
@@ -47,7 +47,7 @@ impl ProjectionExtraction {
                 });
                 if dropped > 0 {
                     for scalar in scalars {
-                        scalar.0.permute(&outputs);
+                        scalar.permute(&outputs);
                     }
                     *relation = relation.take_dangerous().project(outputs);
                 }

--- a/src/pgwire/message.rs
+++ b/src/pgwire/message.rs
@@ -258,7 +258,7 @@ pub enum FieldValue {
 }
 
 impl FieldValue {
-    pub fn from_datum(datum: Datum, typ: &ColumnType) -> Option<FieldValue> {
+    pub fn from_datum(datum: Datum, typ: ColumnType) -> Option<FieldValue> {
         match datum {
             Datum::Null => None,
             Datum::True => Some(FieldValue::Bool(true)),
@@ -365,7 +365,7 @@ impl FieldValue {
 pub fn field_values_from_row(row: Vec<Datum>, typ: &RelationType) -> Vec<Option<FieldValue>> {
     row.into_iter()
         .zip(typ.column_types.iter())
-        .map(|(col, typ)| FieldValue::from_datum(col, typ))
+        .map(|(col, typ)| FieldValue::from_datum(col, *typ))
         .collect()
 }
 

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -514,14 +514,15 @@ impl Planner {
         &mut self,
         query: &Query,
     ) -> Result<(RelationExpr, RelationDesc, RowSetFinishing), failure::Error> {
-        let (expr, scope, finishing) = self.plan_query(query, &Scope::empty(None))?;
+        let (expr, scope, finishing) =
+            self.plan_query(query, &Scope::empty(None), &RelationType::empty())?;
         let expr = expr.decorrelate()?;
         let typ = expr.typ();
         let typ = RelationType::new(
             finishing
                 .project
                 .iter()
-                .map(|i| typ.column_types[*i].clone())
+                .map(|i| typ.column_types[*i])
                 .collect(),
         );
         let desc = RelationDesc::new(typ, scope.column_names());

--- a/src/sqllogictest/fuzz.rs
+++ b/src/sqllogictest/fuzz.rs
@@ -17,7 +17,7 @@ pub fn fuzz(sqls: &str) {
             if let SqlResponse::SendRows { desc, rx } = state.run_plan(plan) {
                 for row in rx.wait().unwrap() {
                     for (typ, datum) in desc.iter_types().zip(row.into_iter()) {
-                        assert!(datum.is_instance_of(typ));
+                        assert!(datum.is_instance_of(*typ));
                     }
                 }
             }

--- a/src/sqllogictest/postgres.rs
+++ b/src/sqllogictest/postgres.rs
@@ -227,7 +227,7 @@ END $$;
                         desc.typ().column_types[c].nullable,
                     )?;
                     ensure!(
-                        datum.is_instance_of(&desc.typ().column_types[c]),
+                        datum.is_instance_of(desc.typ().column_types[c]),
                         "Expected value of type {:?}, got {:?}",
                         desc.typ().column_types[c],
                         datum

--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -680,7 +680,7 @@ impl State {
                 });
             }
             for (inferred_type, datum) in inferred_types.iter().zip(row.iter()) {
-                if !datum.is_instance_of(inferred_type) {
+                if !datum.is_instance_of(*inferred_type) {
                     return Ok(Outcome::InferenceFailure {
                         expected_types,
                         inferred_types: inferred_types.to_vec(),


### PR DESCRIPTION
~~The goal here is to unblock Jessica's work on predicate splitting and pushdown. This series of patches leaves behind a bit of a mess, but is generally moving things in the right direction and is hopefully mergeable.~~

---

~~**sql: remove sql::expr::RelationExpr::typ**~~

~~In every case that sql::expr::RelationExpr::typ is called, it can be
replaced with asking the scope for type information. Remove it. Note
that ::expr::RelationExpr::typ still exists; the idea is to avoid
duplicating all that code at both the SQL and dataflow layer.~~

----

~~**expr,sql: learn to compute ScalarExpr's types**~~

~~This is critical when a ScalarExpr needs to be split into pieces.~~

~~Addresses half of MaterializeInc/database-issues#231.~~

----

~~**pgwire,coord,sql: stop depending on ColumnType::name as much**~~

~~This is a step towards MaterializeInc/database-issues#210. It was also necessary to fix some "wrong
column name" errors introduced by the last commit, because it is no
longer possible to store an expression's alias directly in
expr::RelationExpr.~~

---

**expr,sql: rework scalar expression typing**

Previously, the SQL planner would keep track of a scalar expression's types as it built up the scalar expression, throwing away type information about the leaves of the expression as it worked its way towards the root. This is problematic when a ScalarExpr later needs to be split into pieces, as the type information about the inside of an expression was lost.

Add a new ScalarExpr::typ method that can derive a scalar expression's type on the fly. This requires that ScalarExpr::Literal contain type information, as the full type of decimal and null literals cannot be inferred.

Note that ScalarExpr::typ is added to both ::sql::expr::ScalarExpr and ::expr::ScalarExpr. The ::sql::expr version requires both the outer and inner relation expressions that the scalar expression will be evaluated upon (due to correlation), while the ::expr version requries just the single relation expression (thanks to decorrelation).

Then, teach the planner to use ScalarExpr::typ whenever scalar expression type information is required, rather than passing it upwards along with the expression. Functions that planned scalar expressions previously returned (ScalarExpr, ColumnType), and now return ScalarExpr, as the column type can be computed (via typ) whenever required.

Finally, remove the ColumnTypes from RelationExpr::Reduce and RelationExpr::Map, as they can be derived from the contained ScalarExprs/AggregateExprs as necessary. This prevents them from going stale as optimizations rewrite the tree.

Addresses half of MaterializeInc/database-issues#231.