### PR TITLE
repr: remove ColumnType::name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,6 +2230,7 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ore 0.1.0",
  "pretty 0.5.3-alpha.0 (git+https://github.com/Marwes/pretty.rs.git?rev=7fb895eff160b8bfd6d28efb19bf24f0b9326109)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/coord/coordinator.rs
+++ b/src/coord/coordinator.rs
@@ -31,7 +31,7 @@ use dataflow_types::{
 };
 use expr::RelationExpr;
 use ore::future::FutureExt;
-use repr::{ColumnType, Datum, RelationType, ScalarType};
+use repr::{Datum, RelationDesc, ScalarType};
 use sql::Plan;
 
 /// Glues the external world to the Timely workers.
@@ -103,7 +103,7 @@ where
                         .collect(),
                 );
                 send_immediate_rows(
-                    RelationType::new(vec![ColumnType::new(ScalarType::String).name("Topic")]),
+                    RelationDesc::empty().add_column("Topic", ScalarType::String),
                     sources
                         .iter()
                         .map(|s| vec![Datum::from(s.name.to_owned())])
@@ -145,6 +145,7 @@ where
 
             Plan::Peek {
                 mut source,
+                desc,
                 when,
                 finishing,
             } => {
@@ -154,7 +155,6 @@ where
                 // also to ensure that there is a view in place to query, if the source of data
                 // for the peek is not a base relation.
 
-                let typ = source.typ();
                 self.optimizer.optimize(&mut source);
 
                 let (rows_tx, rows_rx) = self.switchboard.mpsc();
@@ -183,12 +183,11 @@ where
                     // a new transient dataflow that will be dropped after the
                     // peek completes.
                     let name = format!("<peek_{}>", Uuid::new_v4());
-                    let typ = source.typ();
 
                     self.create_dataflows(vec![Dataflow::View(View {
                         name: name.clone(),
                         relation_expr: source,
-                        typ,
+                        desc: desc.clone(),
                         as_of: Some(vec![timestamp.clone()]),
                     })]);
                     broadcast(
@@ -207,13 +206,6 @@ where
                     );
                 }
 
-                let typ = RelationType::new(
-                    finishing
-                        .project
-                        .iter()
-                        .map(|i| typ.column_types[*i].clone())
-                        .collect(),
-                );
                 let rows_rx = rows_rx
                     .take(self.num_timely_workers as u64)
                     .concat2()
@@ -246,7 +238,7 @@ where
                     .from_err()
                     .boxed();
 
-                SqlResponse::SendRows { typ, rx: rows_rx }
+                SqlResponse::SendRows { desc, rx: rows_rx }
             }
 
             Plan::Tail(source) => {
@@ -255,22 +247,22 @@ where
                     &mut self.broadcast_tx,
                     SequencedCommand::CreateDataflows(vec![Dataflow::Sink(Sink {
                         name: format!("<tail_{}>", Uuid::new_v4()),
-                        from: (source.name().to_owned(), source.typ().clone()),
+                        from: (source.name().to_owned(), source.desc().clone()),
                         connector: SinkConnector::Tail(TailSinkConnector { tx }),
                     })]),
                 );
                 SqlResponse::Tailing { rx }
             }
 
-            Plan::SendRows { typ, rows } => send_immediate_rows(typ, rows),
+            Plan::SendRows { desc, rows } => send_immediate_rows(desc, rows),
 
             Plan::ExplainPlan {
-                typ,
+                desc,
                 mut relation_expr,
             } => {
                 self.optimizer.optimize(&mut relation_expr);
                 let rows = vec![vec![Datum::from(relation_expr.pretty())]];
-                send_immediate_rows(typ, rows)
+                send_immediate_rows(desc, rows)
             }
 
             Plan::Parsed { name } => SqlResponse::Parsed { name },
@@ -539,11 +531,11 @@ fn broadcast(
 /// Constructs a [`SqlResponse`] that that will send some rows to the client
 /// immediately, as opposed to asking the dataflow layer to send along the rows
 /// after some computation.
-fn send_immediate_rows(typ: RelationType, rows: Vec<Vec<Datum>>) -> SqlResponse {
+fn send_immediate_rows(desc: RelationDesc, rows: Vec<Vec<Datum>>) -> SqlResponse {
     let (tx, rx) = futures::sync::oneshot::channel();
     tx.send(rows).unwrap();
     SqlResponse::SendRows {
-        typ,
+        desc,
         rx: Box::new(rx.from_err()),
     }
 }

--- a/src/coord/lib.rs
+++ b/src/coord/lib.rs
@@ -11,7 +11,7 @@
 
 use dataflow_types::Update;
 use futures::Future;
-use repr::{Datum, RelationType};
+use repr::{Datum, RelationDesc};
 use sql::Session;
 use std::fmt;
 
@@ -77,7 +77,7 @@ pub enum SqlResponse {
     DroppedView,
     EmptyQuery,
     SendRows {
-        typ: RelationType,
+        desc: RelationDesc,
         rx: RowsFuture,
     },
     /// We have successfully parsed the query and stashed it in the [`Session`]
@@ -100,7 +100,7 @@ impl fmt::Debug for SqlResponse {
             SqlResponse::DroppedView => f.write_str("SqlResposne::DroppedView"),
             SqlResponse::EmptyQuery => f.write_str("SqlResponse::EmptyQuery"),
             SqlResponse::Parsed { name } => write!(f, "SqlResponse::Parsed(name: {})", name),
-            SqlResponse::SendRows { typ, rx: _ } => write!(f, "SqlResponse::SendRows({:?})", typ),
+            SqlResponse::SendRows { desc, rx: _ } => write!(f, "SqlResponse::SendRows({:?})", desc),
             SqlResponse::SetVariable => f.write_str("SqlResponse::SetVariable"),
             SqlResponse::Tailing { rx: _ } => f.write_str("SqlResponse::Tailing"),
         }

--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -3,7 +3,7 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-use repr::{ColumnType, RelationType, ScalarType};
+use repr::{RelationDesc, ScalarType};
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -105,93 +105,91 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PeekDuration) => "logs_peek_durations",
         }
     }
-    pub fn schema(&self) -> RelationType {
+
+    pub fn schema(&self) -> RelationDesc {
         match self {
-            LogVariant::Timely(TimelyLog::Operates) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("id"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-                ColumnType::new(ScalarType::Int64).name("address_slot"),
-                ColumnType::new(ScalarType::Int64).name("address_value"),
-                ColumnType::new(ScalarType::String).name("name"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Timely(TimelyLog::Channels) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("id"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-                ColumnType::new(ScalarType::String).name("scope"),
-                ColumnType::new(ScalarType::Int64).name("source_node"),
-                ColumnType::new(ScalarType::Int64).name("source_port"),
-                ColumnType::new(ScalarType::Int64).name("target_node"),
-                ColumnType::new(ScalarType::Int64).name("target_port"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Timely(TimelyLog::Messages) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("channel"),
-                ColumnType::new(ScalarType::Int64).name("count"),
-            ])
-            .add_keys(vec![0]),
-            LogVariant::Timely(TimelyLog::Shutdown) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("id"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Timely(TimelyLog::Text) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("text"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-            ]),
-            LogVariant::Timely(TimelyLog::Elapsed) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("id"),
-                ColumnType::new(ScalarType::Int64).name("elapsed_ns"),
-            ])
-            .add_keys(vec![0]),
-            LogVariant::Timely(TimelyLog::Histogram) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("id"),
-                ColumnType::new(ScalarType::Int64).name("duration_ns"),
-                ColumnType::new(ScalarType::Int64).name("count"),
-            ])
-            .add_keys(vec![0]),
-            LogVariant::Differential(DifferentialLog::Arrangement) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("operator"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-                ColumnType::new(ScalarType::Int64).name("records"),
-                ColumnType::new(ScalarType::Int64).name("batches"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Differential(DifferentialLog::Sharing) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("operator"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-                ColumnType::new(ScalarType::Int64).name("count"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationType::new(vec![
-                ColumnType::new(ScalarType::String).name("name"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Materialized(MaterializedLog::DataflowDependency) => {
-                RelationType::new(vec![
-                    ColumnType::new(ScalarType::String).name("dataflow"),
-                    ColumnType::new(ScalarType::String).name("source"),
-                    ColumnType::new(ScalarType::Int64).name("worker"),
-                ])
-            }
-            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationType::new(vec![
-                ColumnType::new(ScalarType::String).name("name"),
-                ColumnType::new(ScalarType::Int64).name("time"),
-            ]),
-            LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationType::new(vec![
-                ColumnType::new(ScalarType::String).name("uuid"),
-                ColumnType::new(ScalarType::Int64).name("worker"),
-                ColumnType::new(ScalarType::String).name("name"),
-                ColumnType::new(ScalarType::Int64).name("time"),
-            ])
-            .add_keys(vec![0, 1]),
-            LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationType::new(vec![
-                ColumnType::new(ScalarType::Int64).name("worker"),
-                ColumnType::new(ScalarType::Int64).name("duration_ns"),
-                ColumnType::new(ScalarType::Int64).name("count"),
-            ])
-            .add_keys(vec![0, 1]),
+            LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
+                .add_column("id", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("address_slot", ScalarType::Int64)
+                .add_column("address_value", ScalarType::Int64)
+                .add_column("name", ScalarType::String)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
+                .add_column("id", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("scope", ScalarType::String)
+                .add_column("source_node", ScalarType::Int64)
+                .add_column("source_port", ScalarType::Int64)
+                .add_column("target_node", ScalarType::Int64)
+                .add_column("target_port", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Timely(TimelyLog::Messages) => RelationDesc::empty()
+                .add_column("channel", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
+                .add_keys(vec![0]),
+
+            LogVariant::Timely(TimelyLog::Shutdown) => RelationDesc::empty()
+                .add_column("id", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Timely(TimelyLog::Text) => RelationDesc::empty()
+                .add_column("text", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64),
+
+            LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
+                .add_column("id", ScalarType::Int64)
+                .add_column("elapsed_ns", ScalarType::Int64)
+                .add_keys(vec![0]),
+
+            LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
+                .add_column("id", ScalarType::Int64)
+                .add_column("duration_ns", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
+                .add_keys(vec![0]),
+
+            LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
+                .add_column("operator", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("records", ScalarType::Int64)
+                .add_column("batches", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
+                .add_column("operator", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
+                .add_column("name", ScalarType::String)
+                .add_column("worker", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
+                .add_column("dataflow", ScalarType::String)
+                .add_column("source", ScalarType::String)
+                .add_column("worker", ScalarType::Int64),
+
+            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
+                .add_column("name", ScalarType::String)
+                .add_column("time", ScalarType::Int64),
+
+            LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
+                .add_column("uuid", ScalarType::String)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("name", ScalarType::String)
+                .add_column("time", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
+
+            LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
+                .add_column("worker", ScalarType::Int64)
+                .add_column("duration_ns", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
+                .add_keys(vec![0, 1]),
         }
     }
 }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -10,7 +10,7 @@
 //! avoid the dependency, as the dataflow crate is very slow to compile.
 
 use expr::RelationExpr;
-use repr::{Datum, RelationType};
+use repr::{Datum, RelationDesc, RelationType};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use url::Url;
@@ -105,15 +105,27 @@ impl Dataflow {
         }
     }
 
-    /// Reports the type of the datums produced by this dataflow.
-    pub fn typ(&self) -> &RelationType {
+    /// Reports the description of the datums produced by this dataflow.
+    pub fn desc(&self) -> &RelationDesc {
         match self {
-            Dataflow::Source(src) => &src.typ,
+            Dataflow::Source(src) => &src.desc,
             Dataflow::Sink(_) => panic!(
                 "programming error: Dataflow.typ called on Sink variant, \
                  but sinks don't have a type"
             ),
-            Dataflow::View(view) => &view.typ,
+            Dataflow::View(view) => &view.desc,
+        }
+    }
+
+    /// Reports the type of the datums produced by this dataflow.
+    pub fn typ(&self) -> &RelationType {
+        match self {
+            Dataflow::Source(src) => src.desc.typ(),
+            Dataflow::Sink(_) => panic!(
+                "programming error: Dataflow.typ called on Sink variant, \
+                 but sinks don't have a type"
+            ),
+            Dataflow::View(view) => view.desc.typ(),
         }
     }
 
@@ -136,14 +148,14 @@ impl Dataflow {
 pub struct Source {
     pub name: String,
     pub connector: SourceConnector,
-    pub typ: RelationType,
+    pub desc: RelationDesc,
 }
 
 #[serde(rename_all = "snake_case")]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Sink {
     pub name: String,
-    pub from: (String, RelationType),
+    pub from: (String, RelationDesc),
     pub connector: SinkConnector,
 }
 
@@ -191,7 +203,7 @@ pub struct TailSinkConnector {
 pub struct View {
     pub name: String,
     pub relation_expr: RelationExpr,
-    pub typ: RelationType,
+    pub desc: RelationDesc,
     /// Indicates if sources can be advanced to a supplied frontier.
     /// Outputs will only be correct from this frontier onward.
     pub as_of: Option<Vec<Timestamp>>,
@@ -216,22 +228,16 @@ mod tests {
                     inputs: vec![
                         RelationExpr::Get {
                             name: "orders".into(),
-                            typ: RelationType::new(vec![
-                                ColumnType::new(ScalarType::Int64).name("id")
-                            ]),
+                            typ: RelationType::new(vec![ColumnType::new(ScalarType::Int64)]),
                         },
                         Box::new(RelationExpr::Union {
                             left: Box::new(RelationExpr::Get {
                                 name: "customers2018".into(),
-                                typ: RelationType::new(vec![
-                                    ColumnType::new(ScalarType::Int64).name("id")
-                                ]),
+                                typ: RelationType::new(vec![ColumnType::new(ScalarType::Int64)]),
                             }),
                             right: Box::new(RelationExpr::Get {
                                 name: "customers2019".into(),
-                                typ: RelationType::new(vec![
-                                    ColumnType::new(ScalarType::Int64).name("id")
-                                ]),
+                                typ: RelationType::new(vec![ColumnType::new(ScalarType::Int64)]),
                             }),
                         })
                         .distinct(),
@@ -239,10 +245,9 @@ mod tests {
                     variables: vec![vec![(0, 0), (1, 0)]],
                 }),
             },
-            typ: RelationType::new(vec![
-                ColumnType::new(ScalarType::String).name("name"),
-                ColumnType::new(ScalarType::Int32).name("quantity"),
-            ]),
+            desc: RelationDesc::empty()
+                .add_column("name", ScalarType::String)
+                .add_column("quantity", ScalarType::String),
             as_of: None,
         });
 

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -69,7 +69,7 @@ pub fn build_dataflow<A: Allocate>(
                 WithDrop::new(arrangement_by_self.trace, capability.clone()),
             );
 
-            for keys in src.typ.keys.iter() {
+            for keys in src.desc.typ().keys.iter() {
                 let keys_clone = keys.clone();
                 let arrangement_by_key = stream
                     .as_collection()

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 use ore::collections::CollectionExt;
 use repr::decimal::{Significand, MAX_DECIMAL_PRECISION};
-use repr::{ColumnType, Datum, RelationType, ScalarType};
+use repr::{ColumnType, Datum, RelationDesc, RelationType, ScalarType};
 
 /// Validates an Avro key schema for use as a source.
 ///
@@ -27,45 +27,31 @@ use repr::{ColumnType, Datum, RelationType, ScalarType};
 /// columns.
 pub fn validate_key_schema(
     key_schema: &str,
-    validated_value_schema: &RelationType,
+    value_desc: &RelationDesc,
 ) -> Result<Vec<usize>, Error> {
-    let mut vname_to_value_column = HashMap::new();
-    for (i, column) in validated_value_schema.column_types.iter().enumerate() {
-        if let Some(name) = &column.name {
-            vname_to_value_column.insert(name, (i, column));
-        }
-    }
-
     let key_schema = parse_schema(key_schema)?;
+    let key_desc = validate_schema_1(&key_schema)?;
     let mut indices = Vec::new();
-    for key_column in validate_schema_1(&key_schema)?.column_types.iter() {
-        if let Some(name) = &key_column.name {
-            // The code around ColumnTypes
-            let value = vname_to_value_column.get(name);
-            match value {
-                Some((index, value_column)) => {
-                    if key_column.scalar_type == value_column.scalar_type
-                        && key_column.nullable == value_column.nullable
-                    {
-                        indices.push(*index);
-                    } else {
-                        bail!(
-                            "key and value column types do not match: key {:?} vs. value {:?}",
-                            key_column,
-                            value_column,
-                        )
-                    }
+    for (name, key_type) in key_desc.iter() {
+        if let Some(name) = name {
+            match value_desc.get_by_name(name) {
+                Some((index, value_type)) if key_type == value_type => {
+                    indices.push(index);
                 }
+                Some((_, value_type)) => bail!(
+                    "key and value column types do not match: key {:?} vs. value {:?}",
+                    key_type,
+                    value_type,
+                ),
                 None => bail!("Value schema missing primary key column: {}", name),
             }
         }
     }
-
     Ok(indices)
 }
 
-/// Converts an Apache Avro schema into a [`repr::RelationType`].
-pub fn validate_value_schema(schema: &str) -> Result<RelationType, Error> {
+/// Converts an Apache Avro schema into a [`repr::RelationDesc`].
+pub fn validate_value_schema(schema: &str) -> Result<RelationDesc, Error> {
     let schema = parse_schema(schema)?;
 
     // The top-level record needs to be a diff "envelope" that contains
@@ -122,21 +108,23 @@ pub fn validate_value_schema(schema: &str) -> Result<RelationType, Error> {
     validate_schema_1(row_schema)
 }
 
-fn validate_schema_1(schema: &Schema) -> Result<RelationType, Error> {
+fn validate_schema_1(schema: &Schema) -> Result<RelationDesc, Error> {
     match schema {
         Schema::Record { fields, .. } => {
             let column_types = fields
                 .iter()
                 .map(|f| {
                     Ok(ColumnType {
-                        name: Some(f.name.clone()),
                         nullable: is_nullable(&f.schema),
                         scalar_type: validate_schema_2(&f.schema)?,
                     })
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
-
-            Ok(RelationType::new(column_types))
+            let column_names = fields.iter().map(|f| Some(f.name.clone()));
+            Ok(RelationDesc::new(
+                RelationType::new(column_types),
+                column_names,
+            ))
         }
         _ => bail!("row schemas must be records, got: {:?}", schema),
     }
@@ -177,7 +165,6 @@ fn validate_schema_2(schema: &Schema) -> Result<ScalarType, Error> {
                 .filter(|s| !is_null(s))
                 .map(|s| {
                     Ok(ColumnType {
-                        name: None,
                         nullable: is_nullable(s),
                         scalar_type: validate_schema_2(s)?,
                     })
@@ -534,13 +521,13 @@ mod tests {
     use serde::Deserialize;
     use std::fs::File;
 
-    use repr::RelationType;
+    use repr::RelationDesc;
 
     #[derive(Deserialize)]
     struct TestCase {
         name: String,
         input: serde_json::Value,
-        expected: RelationType,
+        expected: RelationDesc,
     }
 
     #[test]

--- a/src/pgwire/message.rs
+++ b/src/pgwire/message.rs
@@ -11,7 +11,7 @@ use chrono::{Datelike, NaiveDate, NaiveDateTime};
 
 use super::types::PgType;
 use repr::decimal::Decimal;
-use repr::{ColumnType, Datum, Interval, RelationType, ScalarType};
+use repr::{ColumnType, Datum, Interval, RelationDesc, RelationType, ScalarType};
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -369,13 +369,12 @@ pub fn field_values_from_row(row: Vec<Datum>, typ: &RelationType) -> Vec<Option<
         .collect()
 }
 
-pub fn row_description_from_type(typ: &RelationType) -> Vec<FieldDescription> {
-    typ.column_types
-        .iter()
-        .map(|typ| {
+pub fn row_description_from_desc(desc: &RelationDesc) -> Vec<FieldDescription> {
+    desc.iter()
+        .map(|(name, typ)| {
             let pg_type: PgType = (&typ.scalar_type).into();
             FieldDescription {
-                name: typ.name.as_ref().unwrap_or(&"?column?".into()).to_owned(),
+                name: name.unwrap_or("?column?").to_owned(),
                 table_id: 0,
                 column_id: 0,
                 type_oid: pg_type.oid,

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -27,7 +27,7 @@ use crate::message::{
 use coord::{self, SqlResponse};
 use dataflow_types::Update;
 use ore::future::{Recv, StreamExt};
-use repr::{Datum, RelationType};
+use repr::{Datum, RelationDesc};
 use sql::Session;
 
 use prometheus::IntCounterVec;
@@ -219,7 +219,7 @@ pub enum StateMachine<A: Conn + 'static> {
     SendRowDescription {
         send: SinkSend<A>,
         session: Session,
-        row_type: RelationType,
+        row_desc: RelationDesc,
         rows_rx: coord::RowsFuture,
     },
 
@@ -228,7 +228,7 @@ pub enum StateMachine<A: Conn + 'static> {
     WaitForRows {
         conn: A,
         session: Session,
-        row_type: RelationType,
+        row_desc: RelationDesc,
         rows_rx: coord::RowsFuture,
         field_formats: Option<Vec<FieldFormat>>,
         currently_extended: bool,
@@ -546,12 +546,12 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
                         currently_extended: false,
                         label: "empty",
                     }),
-                    SqlResponse::SendRows { typ, rx } => transition!(SendRowDescription {
+                    SqlResponse::SendRows { desc, rx } => transition!(SendRowDescription {
                         send: state.conn.send(BackendMessage::RowDescription(
-                            super::message::row_description_from_type(&typ)
+                            super::message::row_description_from_desc(&desc)
                         )),
                         session,
-                        row_type: typ,
+                        row_desc: desc,
                         rows_rx: rx,
                     }),
                     SqlResponse::SetVariable => command_complete!("SET", "set"),
@@ -665,14 +665,14 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
                         send: state.conn.send(BackendMessage::ParseComplete),
                         session,
                     }),
-                    SqlResponse::SendRows { typ, rx } => {
+                    SqlResponse::SendRows { desc, rx } => {
                         trace!("handle extended: send rows");
                         let ff = state.field_formats;
                         debug_assert!(ff.is_some(), "field formats must be set for execute");
                         transition!(WaitForRows {
                             session,
                             conn: state.conn,
-                            row_type: typ,
+                            row_desc: desc,
                             rows_rx: rx,
                             field_formats: ff,
                             currently_extended: true
@@ -722,8 +722,8 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
         };
         match statement {
             Some(ps) => {
-                let typ = ps.source().typ();
-                let desc = super::message::row_description_from_type(&typ);
+                let desc = ps.desc();
+                let desc = super::message::row_description_from_desc(&desc);
                 transition!(SendDescribeResponseRowdesc {
                     send: conn.send(BackendMessage::RowDescription(desc)),
                     session: state.session,
@@ -756,7 +756,7 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
         transition!(WaitForRows {
             conn,
             session: state.session,
-            row_type: state.row_type,
+            row_desc: state.row_desc,
             rows_rx: state.rows_rx,
             field_formats: None,
             currently_extended: false
@@ -802,7 +802,7 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
             state.conn,
             state.session,
             peek_results,
-            state.row_type,
+            state.row_desc,
             state.field_formats.clone(),
             state.currently_extended,
         ))
@@ -916,7 +916,7 @@ fn send_rows<A, R>(
     conn: A,
     session: Session,
     rows: R,
-    row_type: RelationType,
+    row_desc: RelationDesc,
     field_formats: Option<Vec<FieldFormat>>,
     currently_extended: bool,
 ) -> SendCommandComplete<A>
@@ -932,7 +932,7 @@ where
         .into_iter()
         .map(move |row| {
             BackendMessage::DataRow(
-                message::field_values_from_row(row, &row_type),
+                message::field_values_from_row(row, row_desc.typ()),
                 formats.fresh(),
             )
         })

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1.5"
 ordered-float = { version = "1.0.2", features = ["serde"] }
+ore = { path = "../ore" }
 # TODO(grimmr): upgrade to 0.5.3 after release, when `space_()` becomes officially available.
 pretty = { git = "https://github.com/Marwes/pretty.rs.git", rev = "7fb895eff160b8bfd6d28efb19bf24f0b9326109" }
 regex = "1.3.1"

--- a/src/repr/lib.rs
+++ b/src/repr/lib.rs
@@ -25,7 +25,7 @@
 mod relation;
 mod scalar;
 
-pub use relation::{ColumnType, RelationType};
+pub use relation::{ColumnType, RelationDesc, RelationType};
 pub use scalar::decimal;
 pub use scalar::regex;
 pub use scalar::{Datum, Interval, ScalarType};

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -10,7 +10,7 @@
 use dataflow_types::{Dataflow, PeekWhen, RowSetFinishing, Sink, Source, View};
 use failure::bail;
 
-use repr::{Datum, RelationType};
+use repr::{Datum, RelationDesc};
 pub use session::Session;
 use sqlparser::ast::ObjectName;
 
@@ -43,16 +43,17 @@ pub enum Plan {
     },
     Peek {
         source: ::expr::RelationExpr,
+        desc: RelationDesc,
         when: PeekWhen,
         finishing: RowSetFinishing,
     },
     Tail(Dataflow),
     SendRows {
-        typ: RelationType,
+        desc: RelationDesc,
         rows: Vec<Vec<Datum>>,
     },
     ExplainPlan {
-        typ: RelationType,
+        desc: RelationDesc,
         relation_expr: ::expr::RelationExpr,
     },
 }

--- a/src/sql/session.rs
+++ b/src/sql/session.rs
@@ -32,6 +32,7 @@ use std::collections::HashMap;
 use failure::bail;
 
 use dataflow_types::RowSetFinishing;
+use repr::RelationDesc;
 
 // NOTE(benesch): there is a lot of duplicative code in this file in order to
 // avoid runtime type casting. If the approach gets hard to maintain, we can
@@ -356,6 +357,7 @@ impl Var for SessionVar<bool> {
 pub struct PreparedStatement {
     pub raw_sql: String,
     source: ::expr::RelationExpr,
+    desc: RelationDesc,
     finishing: RowSetFinishing,
 }
 
@@ -363,17 +365,23 @@ impl PreparedStatement {
     pub fn new(
         raw_sql: String,
         source: ::expr::RelationExpr,
+        desc: RelationDesc,
         finishing: RowSetFinishing,
     ) -> PreparedStatement {
         PreparedStatement {
             raw_sql,
             source,
+            desc,
             finishing,
         }
     }
 
     pub fn source(&self) -> &::expr::RelationExpr {
         &self.source
+    }
+
+    pub fn desc(&self) -> &RelationDesc {
+        &self.desc
     }
 
     pub fn finishing(&self) -> &RowSetFinishing {

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -33,7 +33,7 @@ use expr::RelationExpr;
 use interchange::avro;
 use ore::collections::CollectionExt;
 use ore::option::OptionExt;
-use repr::{ColumnType, Datum, RelationType, ScalarType};
+use repr::{Datum, RelationDesc, RelationType, ScalarType};
 
 impl Planner {
     pub fn new(logging_config: Option<&LoggingConfig>) -> Planner {
@@ -103,6 +103,7 @@ impl Planner {
             })?;
         Ok(Plan::Peek {
             source: prepared.source().clone(),
+            desc: prepared.desc().clone(),
             when: PeekWhen::Immediately,
             finishing: prepared.finishing().clone(),
         })
@@ -171,11 +172,10 @@ impl Planner {
     ) -> Result<Plan, failure::Error> {
         if variable == unicase::Ascii::new("ALL") {
             Ok(Plan::SendRows {
-                typ: RelationType::new(vec![
-                    ColumnType::new(ScalarType::String).name("name"),
-                    ColumnType::new(ScalarType::String).name("setting"),
-                    ColumnType::new(ScalarType::String).name("description"),
-                ]),
+                desc: RelationDesc::empty()
+                    .add_column("name", ScalarType::String)
+                    .add_column("setting", ScalarType::String)
+                    .add_column("description", ScalarType::String),
                 rows: session
                     .vars()
                     .iter()
@@ -185,9 +185,7 @@ impl Planner {
         } else {
             let variable = session.get(&variable)?;
             Ok(Plan::SendRows {
-                typ: RelationType::new(vec![
-                    ColumnType::new(ScalarType::String).name(variable.name())
-                ]),
+                desc: RelationDesc::empty().add_column(variable.name(), ScalarType::String),
                 rows: vec![vec![variable.value().into()]],
             })
         }
@@ -208,8 +206,8 @@ impl Planner {
             .collect();
         rows.sort_unstable();
         Ok(Plan::SendRows {
-            typ: RelationType::new(vec![ColumnType::new(ScalarType::String)
-                .name(object_type_as_plural_str(object_type).to_owned())]),
+            desc: RelationDesc::empty()
+                .add_column(object_type_as_plural_str(object_type), ScalarType::String),
             rows,
         })
     }
@@ -234,25 +232,22 @@ impl Planner {
 
         let column_descriptions: Vec<_> = self
             .dataflows
-            .get_type(&table_name.to_string())?
-            .column_types
+            .get_desc(&table_name.to_string())?
             .iter()
-            .map(|colty| {
+            .map(|(name, typ)| {
                 vec![
-                    colty.name.mz_as_deref().unwrap_or("?").into(),
-                    if colty.nullable { "YES" } else { "NO" }.into(),
-                    colty.scalar_type.to_string().into(),
+                    name.mz_as_deref().unwrap_or("?").into(),
+                    if typ.nullable { "YES" } else { "NO" }.into(),
+                    typ.scalar_type.to_string().into(),
                 ]
             })
             .collect();
 
-        let col_name = |s: &str| ColumnType::new(ScalarType::String).name(s.to_string());
         Ok(Plan::SendRows {
-            typ: RelationType::new(vec![
-                col_name("Field"),
-                col_name("Nullable"),
-                col_name("Type"),
-            ]),
+            desc: RelationDesc::empty()
+                .add_column("Field", ScalarType::String)
+                .add_column("Nullable", ScalarType::String)
+                .add_column("Type", ScalarType::String),
             rows: column_descriptions,
         })
     }
@@ -269,11 +264,11 @@ impl Planner {
                 if !with_options.is_empty() {
                     bail!("WITH options are not yet supported");
                 }
-                let (relation_expr, finishing) = self.plan_toplevel_query(&query)?;
+                let (relation_expr, mut desc, finishing) = self.plan_toplevel_query(&query)?;
                 if !finishing.is_trivial() {
                     bail!("ORDER BY and LIMIT are not yet supported in view definitions.");
                 }
-                let mut typ = relation_expr.typ();
+                let typ = desc.typ();
                 if !columns.is_empty() {
                     if columns.len() != typ.column_types.len() {
                         bail!(
@@ -282,14 +277,14 @@ impl Planner {
                             typ.column_types.len()
                         )
                     }
-                    for (typ, name) in typ.column_types.iter_mut().zip(columns) {
-                        typ.name = Some(name.clone());
+                    for (i, name) in columns.iter().enumerate() {
+                        desc.set_name(i, Some(name.into()));
                     }
                 }
                 let view = View {
                     name: extract_sql_object_name(name)?,
                     relation_expr,
-                    typ,
+                    desc,
                     as_of: None,
                 };
                 self.dataflows.insert(Dataflow::View(view.clone()))?;
@@ -379,7 +374,7 @@ impl Planner {
                 let (addr, topic) = parse_kafka_topic_url(url)?;
                 let sink = Sink {
                     name,
-                    from: (from, dataflow.typ().clone()),
+                    from: (from, dataflow.desc().clone()),
                     connector: SinkConnector::Kafka(KafkaSinkConnector {
                         addr,
                         topic,
@@ -440,6 +435,7 @@ impl Planner {
                 name: dataflow.name().to_owned(),
                 typ: typ.clone(),
             },
+            desc: dataflow.desc().clone(),
             when: if immediate {
                 PeekWhen::Immediately
             } else {
@@ -460,9 +456,10 @@ impl Planner {
     }
 
     pub fn handle_select(&mut self, query: Query) -> Result<Plan, failure::Error> {
-        let (relation_expr, finishing) = self.plan_toplevel_query(&query)?;
+        let (relation_expr, desc, finishing) = self.plan_toplevel_query(&query)?;
         Ok(Plan::Peek {
             source: relation_expr,
+            desc,
             when: PeekWhen::Immediately,
             finishing,
         })
@@ -479,10 +476,10 @@ impl Planner {
         super::transform::transform(&mut stmt);
         match stmt {
             Statement::Query(query) => {
-                let (relation_expr, finishing) = self.plan_toplevel_query(&query)?;
+                let (relation_expr, desc, finishing) = self.plan_toplevel_query(&query)?;
                 session.set_prepared_statement(
                     name.clone(),
-                    PreparedStatement::new(sql, relation_expr, finishing),
+                    PreparedStatement::new(sql, relation_expr, desc, finishing),
                 );
                 Ok(Plan::Parsed { name })
             }
@@ -491,17 +488,17 @@ impl Planner {
     }
 
     pub fn handle_explain(&mut self, stage: Stage, query: Query) -> Result<Plan, failure::Error> {
-        let (relation_expr, _finishing) = self.plan_toplevel_query(&query)?;
+        let (relation_expr, _desc, _finishing) = self.plan_toplevel_query(&query)?;
         // Previouly we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
         // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
         if stage == Stage::Dataflow {
             Ok(Plan::SendRows {
-                typ: RelationType::new(vec![ColumnType::new(ScalarType::String).name("Dataflow")]),
+                desc: RelationDesc::empty().add_column("Dataflow", ScalarType::String),
                 rows: vec![vec![Datum::from(relation_expr.pretty())]],
             })
         } else {
             Ok(Plan::ExplainPlan {
-                typ: RelationType::new(vec![ColumnType::new(ScalarType::String).name("Dataflow")]),
+                desc: RelationDesc::empty().add_column("Dataflow", ScalarType::String),
                 relation_expr,
             })
         }
@@ -510,12 +507,25 @@ impl Planner {
     /// Plans and decorrelates a query once we've planned all nested RelationExprs.
     /// Decorrelation converts a sql::RelationExpr (which can include correlations)
     /// to an expr::RelationExpr (which cannot include correlations).
+    ///
+    /// Note that the returned `RelationDesc` describes the expression after
+    /// applying the returned `RowSetFinishing`.
     fn plan_toplevel_query(
         &mut self,
         query: &Query,
-    ) -> Result<(RelationExpr, RowSetFinishing), failure::Error> {
-        let (relation_expr, _scope, finishing) = self.plan_query(query, &Scope::empty(None))?;
-        Ok((relation_expr.decorrelate()?, finishing))
+    ) -> Result<(RelationExpr, RelationDesc, RowSetFinishing), failure::Error> {
+        let (expr, scope, finishing) = self.plan_query(query, &Scope::empty(None))?;
+        let expr = expr.decorrelate()?;
+        let typ = expr.typ();
+        let typ = RelationType::new(
+            finishing
+                .project
+                .iter()
+                .map(|i| typ.column_types[*i].clone())
+                .collect(),
+        );
+        let desc = RelationDesc::new(typ, scope.column_names());
+        Ok((expr, desc, finishing))
     }
 }
 
@@ -552,13 +562,13 @@ fn build_source(
         }
     };
 
-    let typ = avro::validate_value_schema(&value_schema)?;
+    let desc = avro::validate_value_schema(&value_schema)?;
     let pkey_indices = match key_schema {
-        Some(key_schema) => avro::validate_key_schema(&key_schema, &typ)?,
+        Some(key_schema) => avro::validate_key_schema(&key_schema, &desc)?,
         None => Vec::new(),
     };
 
-    let typ = typ.add_keys(pkey_indices);
+    let desc = desc.add_keys(pkey_indices);
 
     Ok(Source {
         name,
@@ -568,7 +578,7 @@ fn build_source(
             raw_schema: value_schema,
             schema_registry_url,
         }),
-        typ,
+        desc,
     })
 }
 

--- a/src/sql/store.rs
+++ b/src/sql/store.rs
@@ -10,7 +10,7 @@ use std::iter::{self, FromIterator};
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{Dataflow, LocalSourceConnector, Source, SourceConnector};
-use repr::RelationType;
+use repr::{RelationDesc, RelationType};
 
 #[derive(Debug)]
 pub struct DataflowStore {
@@ -33,7 +33,7 @@ impl DataflowStore {
                         connector: SourceConnector::Local(LocalSourceConnector {
                             uuid: uuid::Uuid::new_v4(),
                         }),
-                        typ: log.schema(),
+                        desc: log.schema(),
                     })
                 }))
             }
@@ -48,6 +48,15 @@ impl DataflowStore {
     pub fn get(&self, name: &str) -> Result<&Dataflow, failure::Error> {
         self.try_get(name)
             .ok_or_else(|| failure::err_msg(format!("dataflow {} does not exist", name)))
+    }
+
+    pub fn get_desc(&self, name: &str) -> Result<&RelationDesc, failure::Error> {
+        match self.get(name)? {
+            Dataflow::Sink { .. } => {
+                bail!("dataflow {} is a sink and cannot be depended upon", name)
+            }
+            dataflow => Ok(dataflow.desc()),
+        }
     }
 
     pub fn get_type(&self, name: &str) -> Result<&RelationType, failure::Error> {

--- a/src/sqllogictest/fuzz.rs
+++ b/src/sqllogictest/fuzz.rs
@@ -14,9 +14,9 @@ pub fn fuzz(sqls: &str) {
     let mut state = State::start().unwrap();
     for sql in sqls.split(';') {
         if let Ok(plan) = state.plan_sql(sql) {
-            if let SqlResponse::SendRows { typ, rx } = state.run_plan(plan) {
+            if let SqlResponse::SendRows { desc, rx } = state.run_plan(plan) {
                 for row in rx.wait().unwrap() {
-                    for (typ, datum) in typ.column_types.iter().zip(row.into_iter()) {
+                    for (typ, datum) in desc.iter_types().zip(row.into_iter()) {
                         assert!(datum.is_instance_of(typ));
                     }
                 }

--- a/src/sqllogictest/postgres.rs
+++ b/src/sqllogictest/postgres.rs
@@ -19,12 +19,12 @@ use sqlparser::ast::ColumnOption;
 use sqlparser::ast::{DataType, ObjectType, Statement};
 
 use repr::decimal::Significand;
-use repr::{ColumnType, Datum, Interval, RelationType, ScalarType};
+use repr::{ColumnType, Datum, Interval, RelationDesc, RelationType, ScalarType};
 use sql::scalar_type_from_sql;
 
 pub struct Postgres {
     client: Client,
-    table_types: HashMap<String, (Vec<DataType>, RelationType)>,
+    table_types: HashMap<String, (Vec<DataType>, RelationDesc)>,
 }
 
 pub type Row = Vec<Datum>;
@@ -32,7 +32,7 @@ pub type Diff = Vec<(Row, isize)>;
 
 #[derive(Debug, Clone)]
 pub enum Outcome {
-    Created(String, RelationType),
+    Created(String, RelationDesc),
     Dropped(Vec<String>),
     Changed {
         table_name: String,
@@ -100,7 +100,6 @@ END $$;
                         .iter()
                         .map(|column| {
                             Ok(ColumnType {
-                                name: Some(column.name.clone()),
                                 scalar_type: scalar_type_from_sql(&column.data_type)?,
                                 nullable: !column
                                     .options
@@ -110,6 +109,7 @@ END $$;
                         })
                         .collect::<Result<Vec<_>, failure::Error>>()?,
                 );
+                let names = columns.iter().map(|column| Some(column.name.clone()));
 
                 for constraint in constraints {
                     use sqlparser::ast::TableConstraint;
@@ -138,9 +138,10 @@ END $$;
                     }
                 }
 
+                let desc = RelationDesc::new(typ, names);
                 self.table_types
-                    .insert(name.to_string(), (sql_types, typ.clone()));
-                Outcome::Created(name.to_string(), typ)
+                    .insert(name.to_string(), (sql_types, desc.clone()));
+                Outcome::Created(name.to_string(), desc)
             }
             Statement::Drop {
                 names,
@@ -209,7 +210,7 @@ END $$;
     }
 
     fn run_query(&mut self, table_name: &str, query: String) -> Result<Vec<Row>, failure::Error> {
-        let (sql_types, typ) = self
+        let (sql_types, desc) = self
             .table_types
             .get(table_name)
             .ok_or_else(|| format_err!("Unknown table: {:?}", table_name))?
@@ -223,12 +224,12 @@ END $$;
                         &postgres_row,
                         c,
                         &sql_types[c],
-                        typ.column_types[c].nullable,
+                        desc.typ().column_types[c].nullable,
                     )?;
                     ensure!(
-                        datum.is_instance_of(&typ.column_types[c]),
+                        datum.is_instance_of(&desc.typ().column_types[c]),
                         "Expected value of type {:?}, got {:?}",
-                        typ.column_types[c],
+                        desc.typ().column_types[c],
                         datum
                     );
                     Ok(datum)

--- a/test/registry.td
+++ b/test/registry.td
@@ -167,7 +167,7 @@ $ kafka-ingest format=avro topic=mismatched-data schema=${schema_v1} key_schema=
 
 ! CREATE SOURCE data_v3 FROM 'kafka://${testdrive.kafka-addr}/testdrive-mismatched-data-${testdrive.seed}'
   USING SCHEMA REGISTRY '${testdrive.schema-registry-url}';
-key and value column types do not match: key ColumnType { name: Some("a"), nullable: false, scalar_type: Int32 } vs. value ColumnType { name: Some("a"), nullable: false, scalar_type: Int64 }
+key and value column types do not match
 
 $ kafka-ingest format=avro topic=data schema=${schema_v1} key_schema=${valid_key_schema}
   publish=true timestamp=5


### PR DESCRIPTION
Most layers of the stack don't care about naming the columns in a
relation type, and they were therefore frequently wrong. The SQL
planner, which cares a lot about column names, has its own scope object
for tracking column names.

So, remove ColumnType::name. A new struct, RelationDesc, is introduced,
which bundles a RelationType with optional column names, for the few
places that we do want relation expressions with column names.

Fix MaterializeInc/database-issues#210.