### PR TITLE
Avoid multiple recursive calls in join::typ()

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -178,6 +178,8 @@ impl RelationExpr {
             RelationExpr::Join { inputs, variables } => {
                 let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
 
+                // Iterating and cloning types inside the flat_map() avoids allocating Vec<>,
+                // as clones are directly added to column_types Vec<>.
                 let column_types = input_types
                     .iter()
                     .flat_map(|i| i.column_types.iter().cloned())


### PR DESCRIPTION
I was a bad goat and in implementing unique keys called `RelationExpr::typ()` multiple times in the recursive descent, resulting in exponential blow-up. This should fix this, and make the call be linear in the size of the relation expression.