### PR TITLE
Enable order by in subqueries.

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -9,7 +9,7 @@
 //! on the interface of the dataflow crate, and not its implementation, can
 //! avoid the dependency, as the dataflow crate is very slow to compile.
 
-use expr::{RelationExpr, ScalarExpr};
+use expr::{ColumnOrder, RelationExpr, ScalarExpr};
 use repr::{Datum, RelationDesc, RelationType};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -41,12 +41,6 @@ pub struct Update {
     pub row: Vec<Datum>,
     pub timestamp: u64,
     pub diff: isize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ColumnOrder {
-    pub column: usize,
-    pub desc: bool,
 }
 
 pub fn compare_columns(order: &[ColumnOrder], left: &[Datum], right: &[Datum]) -> Ordering {
@@ -87,7 +81,7 @@ pub struct RowSetFinishing {
 
 impl RowSetFinishing {
     pub fn is_trivial(&self) -> bool {
-        (self.limit == None) && self.order_by.is_empty()
+        (self.limit == None) && self.order_by.is_empty() && self.offset == 0
     }
 }
 

--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -17,6 +17,6 @@ mod scalar;
 pub mod transform;
 
 pub use relation::func::AggregateFunc;
-pub use relation::{AggregateExpr, IdGen, RelationExpr};
+pub use relation::{AggregateExpr, ColumnOrder, IdGen, RelationExpr};
 pub use scalar::func::{BinaryFunc, UnaryFunc, VariadicFunc};
 pub use scalar::ScalarExpr;

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -16,12 +16,12 @@
 //! To deal with this, whenever we see a SQL GROUP BY we look ahead for aggregates and precompute them in the `RelationExpr::Reduce`. When we reach the same aggregates during normal planning later on, we look them up in an `ExprContext` to find the precomputed versions.
 
 use super::expr::{
-    AggregateExpr, AggregateFunc, BinaryFunc, ColumnRef, JoinKind, RelationExpr, ScalarExpr,
-    UnaryFunc, VariadicFunc, LITERAL_NULL, LITERAL_TRUE,
+    AggregateExpr, AggregateFunc, BinaryFunc, ColumnOrder, ColumnRef, JoinKind, RelationExpr,
+    ScalarExpr, UnaryFunc, VariadicFunc, LITERAL_NULL, LITERAL_TRUE,
 };
 use super::scope::{Scope, ScopeItem, ScopeItemName};
 use super::{extract_sql_object_name, Planner};
-use dataflow_types::{ColumnOrder, RowSetFinishing};
+use dataflow_types::RowSetFinishing;
 use failure::{bail, ensure, format_err, ResultExt};
 use ore::iter::{FallibleIteratorExt, IteratorExt};
 use repr::decimal::MAX_DECIMAL_PRECISION;
@@ -64,6 +64,7 @@ impl Planner {
         let output_typ = expr.typ(outer_relation_type);
         let mut order_by = vec![];
         let mut map_exprs = vec![];
+
         for obe in &q.order_by {
             match &obe.expr {
                 Expr::Value(Value::Number(n)) => {
@@ -111,6 +112,7 @@ impl Planner {
                 }
             }
         }
+
         let finishing = RowSetFinishing {
             filter: vec![],
             order_by,
@@ -119,6 +121,31 @@ impl Planner {
             offset,
         };
         Ok((expr.map(map_exprs), scope, finishing))
+    }
+
+    pub fn plan_subquery(
+        &self,
+        q: &Query,
+        outer_scope: &Scope,
+        outer_relation_type: &RelationType,
+    ) -> Result<(RelationExpr, Scope), failure::Error> {
+        let (mut expr, scope, finishing) = self.plan_query(q, outer_scope, outer_relation_type)?;
+        if finishing.limit.is_some() || finishing.offset > 0 {
+            expr = RelationExpr::TopK {
+                input: Box::new(expr),
+                group_key: vec![],
+                order_key: finishing.order_by,
+                limit: finishing.limit,
+                offset: finishing.offset,
+            };
+        }
+        Ok((
+            RelationExpr::Project {
+                input: Box::new(expr),
+                outputs: finishing.project,
+            },
+            scope,
+        ))
     }
 
     fn plan_set_expr(
@@ -261,11 +288,7 @@ impl Planner {
                 Ok((expr.unwrap(), scope))
             }
             SetExpr::Query(query) => {
-                let (expr, scope, finishing) =
-                    self.plan_query(query, outer_scope, outer_relation_type)?;
-                if !finishing.is_trivial() {
-                    bail!("ORDER BY and LIMIT are not yet supported in subqueries");
-                }
+                let (expr, scope) = self.plan_subquery(query, outer_scope, outer_relation_type)?;
                 Ok((expr, scope))
             }
         }
@@ -532,11 +555,8 @@ impl Planner {
                 if *lateral {
                     bail!("LATERAL derived tables are not yet supported");
                 }
-                let (expr, scope, finishing) =
-                    self.plan_query(&subquery, &Scope::empty(None), &RelationType::empty())?;
-                if !finishing.is_trivial() {
-                    bail!("ORDER BY and LIMIT are not yet supported in subqueries");
-                }
+                let (expr, scope) =
+                    self.plan_subquery(&subquery, &Scope::empty(None), &RelationType::empty())?;
                 let alias = if let Some(TableAlias { name, columns }) = alias {
                     if !columns.is_empty() {
                         bail!("aliasing columns is not yet supported");
@@ -904,10 +924,7 @@ impl Planner {
                             .chain(ctx.inner_relation_type.column_types.iter().cloned())
                             .collect(),
                     );
-                    let (expr, _scope, finishing) = self.plan_query(query, &ctx.scope, &typ)?;
-                    if !finishing.is_trivial() {
-                        bail!("ORDER BY and LIMIT are not yet supported in subqueries");
-                    }
+                    let (expr, _scope) = self.plan_subquery(query, &ctx.scope, &typ)?;
                     Ok(expr.exists())
                 }
                 Expr::Subquery(query) => {
@@ -919,10 +936,7 @@ impl Planner {
                             .chain(ctx.inner_relation_type.column_types.iter().cloned())
                             .collect(),
                     );
-                    let (expr, _scope, finishing) = self.plan_query(query, &ctx.scope, &typ)?;
-                    if !finishing.is_trivial() {
-                        bail!("ORDER BY and LIMIT are not yet supported in subqueries");
-                    }
+                    let (expr, _scope) = self.plan_subquery(query, &ctx.scope, &typ)?;
                     let column_types = expr.typ(&typ).column_types;
                     if column_types.len() != 1 {
                         bail!(
@@ -1013,10 +1027,8 @@ impl Planner {
                 .collect(),
         );
         // plan right
-        let (right, _scope, finishing) = self.plan_query(right, &ctx.scope, &typ)?;
-        if !finishing.is_trivial() {
-            bail!("ORDER BY and LIMIT are not yet supported in subqueries");
-        }
+
+        let (right, _scope) = self.plan_subquery(right, &ctx.scope, &typ)?;
         let column_types = right.typ(&typ).column_types;
         if column_types.len() != 1 {
             bail!(

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -26,10 +26,10 @@ use crate::store::{DataflowStore, RemoveMode};
 use crate::{extract_sql_object_name, Plan, Planner};
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    ColumnOrder, Dataflow, KafkaSinkConnector, KafkaSourceConnector, PeekWhen, RowSetFinishing,
-    Sink, SinkConnector, Source, SourceConnector, View,
+    Dataflow, KafkaSinkConnector, KafkaSourceConnector, PeekWhen, RowSetFinishing, Sink,
+    SinkConnector, Source, SourceConnector, View,
 };
-use expr::RelationExpr;
+use expr::{ColumnOrder, RelationExpr};
 use interchange::avro;
 use ore::collections::CollectionExt;
 use ore::option::OptionExt;

--- a/test/order_by.slt
+++ b/test/order_by.slt
@@ -3,6 +3,8 @@
 # This file is part of Materialize. Materialize may not be used or
 # distributed without the express permission of Materialize, Inc.
 
+mode cockroach
+
 statement ok
 create table foo(a int, b text);
 
@@ -54,3 +56,141 @@ select a from foo order by exists (select * from bar where bar.a = foo.a), a;
 0
 2
 1
+
+###sorts, limits, and offsets in subqueries ###
+
+#these tests have been designed to cover a wide range of situations where there
+#may be a subquery. be sure when modifying these tests to maintain a representation
+#for each situation.
+
+statement ok
+create table fizz(a int, b text);
+
+statement ok
+insert into fizz(a,b) values (2079, 'thirteen'), (12345, 'one'), (12345, 'two'), (12345, 'three'),
+(6745, 'five'), (24223, 'four'), (21243, 'four'), (1735, 'two'), (25040, 'two');
+
+#the order by's inside the subquery are technically meaningless because they do not
+#propagate to the outer query, but we should still return correct results.
+#TODO: materialize#696 replace the current query with the one below
+#SELECT b FROM (SELECT min(b) as b FROM fizz GROUP BY a ORDER BY a DESC)
+query T rowsort
+SELECT b FROM (SELECT a, min(b) as b FROM fizz GROUP BY a ORDER BY a DESC)
+----
+five
+four
+four
+one
+thirteen
+two
+two
+
+query I rowsort
+SELECT ascii(b) FROM (SELECT a, b FROM fizz ORDER BY a ASC, b DESC)
+----
+102
+102
+102
+111
+116
+116
+116
+116
+116
+
+statement ok
+create table baz (val1 int, val2 int);
+
+statement ok
+insert into baz values (12345, 1735), (12345, 1735), (12345, 1735), (1735, 24223), 
+(12345, 12345), (2079, 24223), (1735, 2079), (1735, 2079), (1735, 2079);
+
+#offset
+query I rowsort
+SELECT a FROM fizz where a > ANY(SELECT val1 from baz order by val1 offset 3 ROWS)
+----
+12345
+12345
+12345
+2079
+21243
+24223
+25040
+6745
+
+query I rowsort
+SELECT a from fizz where a in (SELECT val1 from baz order by val1 offset 0 rows)
+----
+12345
+12345
+12345
+1735
+2079
+
+#limit
+query I
+SELECT a FROM fizz WHERE a < ALL(SELECT val1 from baz order by val1 desc limit 5)
+----
+1735
+
+query I
+SELECT count(*) from fizz where exists(SELECT val1 from baz order by val1 limit 0)
+----
+0
+
+#offset + limit
+query TI
+SELECT b, (SELECT val1 from baz where val2 = a order by val1 limit 1 offset 1 rows) c from fizz order by b, c desc
+----
+five      NULL
+four      2079
+four      NULL
+one       NULL
+thirteen  1735
+three     NULL
+two       12345
+two       NULL
+two       NULL
+
+#limit + offset return correct results when there are identical rows
+query I
+SELECT val1 FROM (SELECT val1, val2 FROM baz ORDER BY val2 LIMIT 2)
+----
+12345
+12345
+
+query I
+SELECT val1 FROM (SELECT val1, val2 FROM baz ORDER BY val2 DESC OFFSET 7 ROWS)
+----
+12345
+12345
+
+query I rowsort
+SELECT val1 FROM (SELECT val1, val2 FROM baz ORDER BY val2 LIMIT 2 OFFSET 2 ROWS)
+----
+1735
+12345
+
+query I
+SELECT val1 FROM (SELECT val1, val2 FROM baz ORDER BY val2 DESC LIMIT 1 OFFSET 7 ROWS)
+----
+12345
+
+#order by/limit/offset still works after deleting some entries
+statement ok
+CREATE view bazv AS (SELECT val1, val2 FROM baz ORDER BY val2 DESC, val1 LIMIT 2 OFFSET 1 ROW);
+
+query II rowsort
+PEEK bazv
+----
+2079   24223
+12345  12345
+
+statement ok
+DELETE FROM baz WHERE val1=12345;
+
+query II rowsort
+PEEK bazv
+----
+1735   2079
+2079   24223


### PR DESCRIPTION
Part of the task involved in MaterializeInc/database-issues#62

Support order by in subqueries using TopK. Currently, sorting is naively implemented by just using Vec::sort_by on the results for each grouping key. Have we made an issue for making this more performant? If not, do we want to make a issue for that?

Order by still does not work in views because I assume that work is outside the scope of this PR and belongs to MaterializeInc/database-issues#236 instead.

I toss out any order by commands if it is in a subquery, and there is no order by or limit since the order by commands are meaningless in that case.