### PR TITLE
sql: eagerly incorporate predicates when decorrelating

### DIFF
--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -368,6 +368,15 @@ AND EXISTS (
 GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt
 ----
+Let {
+  id-1 = Filter {
+    predicates: [
+      datetots #4 < 2012-01-02 00:00:00,
+      datetots #4 >= 2007-01-02 00:00:00
+    ],
+    Get { "order" }
+  }
+} in
 Project {
   outputs: [0, 1, 0],
   Reduce {
@@ -384,13 +393,7 @@ Project {
             [(0, 2), (1, 2)],
             [(0, 4), (1, 3)]
           ],
-          Filter {
-            predicates: [
-              datetots #4 < 2012-01-02 00:00:00,
-              datetots #4 >= 2007-01-02 00:00:00
-            ],
-            Get { "order" }
-          },
+          Get { id-1 },
           Distinct {
             group_key: [0 .. 3],
             Project {
@@ -404,16 +407,7 @@ Project {
                     [(0, 2), (1, 2)]
                   ],
                   Get { orderline },
-                  Project {
-                    outputs: [0 .. 2, 4],
-                    Filter {
-                      predicates: [
-                        datetots #4 < 2012-01-02 00:00:00,
-                        datetots #4 >= 2007-01-02 00:00:00
-                      ],
-                      Get { "order" }
-                    }
-                  }
+                  Project { outputs: [0 .. 2, 4], Get { id-1 } }
                 }
               }
             }
@@ -780,6 +774,63 @@ Project {
   }
 }
 
+
+# Query 11
+query T multiline
+EXPLAIN PLAN FOR
+SELECT s_i_id, sum(s_order_cnt) AS ordercount
+FROM stock, supplier, nation
+WHERE s_su_suppkey = su_suppkey
+AND su_nationkey = n_nationkey
+AND n_name = 'GERMANY'
+GROUP BY s_i_id
+HAVING sum(s_order_cnt) > (
+    SELECT sum(s_order_cnt) * 0.005
+    FROM stock, supplier, nation
+    WHERE s_su_suppkey = su_suppkey
+    AND su_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+)
+ORDER BY ordercount DESC
+----
+Let {
+  id-1 = Project {
+    outputs: [0 .. 24, 26 .. 29],
+    Join {
+      variables: [[(0, 17), (1, 7)], [(1, 3), (2, 0)]],
+      Get { stock },
+      Map { scalars: [i32toi64 #0], Get { supplier } },
+      Filter { predicates: [#1 = "GERMANY"], Get { nation } }
+    }
+  }
+} in
+Project {
+  outputs: [0, 1, 1],
+  Filter {
+    predicates: [(i32todec #1 * 1000000dec) > #2],
+    Join {
+      variables: [],
+      Reduce {
+        group_key: [29],
+        aggregates: [sum(#14)],
+        Project { outputs: [0 .. 28, 0], Get { id-1 } }
+      },
+      Project {
+        outputs: [1],
+        Map {
+          scalars: [(i32todec #0 * 1000dec) * 5dec],
+          Reduce {
+            group_key: [],
+            aggregates: [sum(#14)],
+            Get { id-1 }
+          }
+        }
+      }
+    }
+  }
+}
+
+
 # Query 11
 query T multiline
 EXPLAIN PLAN FOR
@@ -1051,11 +1102,17 @@ Let {
   }
 } in
 Project {
-  outputs: [0 .. 2, 4, 9, 0],
+  outputs: [0 .. 2, 4, 8, 0],
   Join {
-    variables: [[(0, 7), (1, 0)], [(1, 1), (2, 0)]],
-    Map { scalars: [i32toi64 #0], Get { supplier } },
-    Filter { predicates: [!isnull #1], Get { id-1 } },
+    variables: [[(0, 8), (1, 0)]],
+    Project {
+      outputs: [0 .. 6, 8, 9],
+      Join {
+        variables: [[(0, 7), (1, 0)]],
+        Map { scalars: [i32toi64 #0], Get { supplier } },
+        Filter { predicates: [!isnull #1], Get { id-1 } }
+      }
+    },
     Filter {
       predicates: [!isnull #0],
       Reduce { group_key: [], aggregates: [max(#1)], Get { id-1 } }
@@ -1080,7 +1137,13 @@ AND (
 GROUP BY i_name, substr(i_data, 1, 3), i_price
 ORDER BY supplier_cnt DESC
 ----
-Let { id-1 = Join { variables: [], Get { stock }, Get { item } } } in
+Let {
+  id-1 = Join {
+    variables: [[(0, 0), (1, 0)]],
+    Get { stock },
+    Filter { predicates: [!(#4 ~ /^zz.*$/)], Get { item } }
+  }
+} in
 Let { id-2 = Distinct { group_key: [17], Get { id-1 } } } in
 Let {
   id-3 = Reduce {
@@ -1109,10 +1172,7 @@ Project {
           outputs: [0 .. 22],
           Join {
             variables: [[(0, 17), (1, 0)]],
-            Filter {
-              predicates: [!(#22 ~ /^zz.*$/), #0 = #18],
-              Get { id-1 }
-            },
+            Get { id-1 },
             Union {
               Filter { predicates: [#1], Get { id-3 } },
               Map {
@@ -1337,7 +1397,11 @@ AND n_name = 'GERMANY'
 ORDER BY su_name
 ----
 Let {
-  id-1 = Join { variables: [], Get { supplier }, Get { nation } }
+  id-1 = Join {
+    variables: [[(0, 3), (1, 0)]],
+    Get { supplier },
+    Filter { predicates: [#1 = "GERMANY"], Get { nation } }
+  }
 } in
 Let { id-2 = Distinct { group_key: [0], Get { id-1 } } } in
 Let {
@@ -1356,7 +1420,7 @@ Project {
   outputs: [1, 2, 1],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Filter { predicates: [#3 = #7, #8 = "GERMANY"], Get { id-1 } },
+    Get { id-1 },
     Reduce {
       group_key: [0],
       aggregates: [any(true)],
@@ -1437,14 +1501,24 @@ ORDER BY numwait DESC, su_name
 ----
 Let {
   id-1 = Project {
-    outputs: [0 .. 6, 37 .. 46, 29 .. 36, 11 .. 28, 7 .. 10],
-    Join {
-      variables: [],
-      Get { supplier },
-      Get { nation },
-      Get { stock },
-      Get { "order" },
-      Get { orderline }
+    outputs: [0 .. 6, 30 .. 47, 12 .. 29, 8 .. 11],
+    Filter {
+      predicates: [#36 > #44],
+      Join {
+        variables: [
+          [(0, 3), (1, 0)],
+          [(0, 7), (2, 17)],
+          [(2, 0), (3, 4)],
+          [(2, 1), (3, 2), (4, 2)],
+          [(3, 0), (4, 0)],
+          [(3, 1), (4, 1)]
+        ],
+        Map { scalars: [i32toi64 #0], Get { supplier } },
+        Filter { predicates: [#1 = "GERMANY"], Get { nation } },
+        Get { stock },
+        Get { orderline },
+        Get { "order" }
+      }
     }
   }
 } in
@@ -1483,20 +1557,7 @@ Project {
           [(0, 9), (1, 2)],
           [(0, 13), (1, 3)]
         ],
-        Filter {
-          predicates: [
-            #3 = #43,
-            #7 = #17,
-            #8 = #18,
-            #9 = #19,
-            #9 = #26,
-            #11 = #25,
-            #42 = i32toi64 #0,
-            #44 = "GERMANY",
-            #13 > #21
-          ],
-          Get { id-1 }
-        },
+        Get { id-1 },
         Union {
           Filter { predicates: [!#4], Get { id-3 } },
           Map {
@@ -1536,79 +1597,88 @@ GROUP BY substr(c_state, 1, 1)
 ORDER BY substr(c_state, 1, 1)
 ----
 Let {
-  id-1 = Reduce {
-    group_key: [],
-    aggregates: [sum(#16), count(#16)],
+  id-1 = Project {
+    outputs: [0 .. 21],
     Filter {
-      predicates: [
-        (
-          (
+      predicates: [(#16 * 1000000dec) > #22],
+      Join {
+        variables: [],
+        Filter {
+          predicates: [
             (
               (
                 (
-                  (false || (substr(#11, 1, 1) = "1"))
+                  (
+                    (
+                      (false || (substr(#11, 1, 1) = "1"))
+                      ||
+                      (substr(#11, 1, 1) = "2")
+                    )
+                    ||
+                    (substr(#11, 1, 1) = "3")
+                  )
                   ||
-                  (substr(#11, 1, 1) = "2")
+                  (substr(#11, 1, 1) = "4")
                 )
                 ||
-                (substr(#11, 1, 1) = "3")
+                (substr(#11, 1, 1) = "5")
               )
               ||
-              (substr(#11, 1, 1) = "4")
+              (substr(#11, 1, 1) = "6")
             )
             ||
-            (substr(#11, 1, 1) = "5")
-          )
-          ||
-          (substr(#11, 1, 1) = "6")
-        )
-        ||
-        (substr(#11, 1, 1) = "7"),
-        #16 > 0dec
-      ],
-      Get { customer }
-    }
-  }
-} in
-Let {
-  id-2 = Project {
-    outputs: [2],
-    Map {
-      scalars: [
-        ((#0 * 10000000dec) / (i64todec #1 * 100dec)) * 10dec
-      ],
-      Union {
-        Get { id-1 },
-        Map {
-          scalars: [null, 0],
-          Union {
-            Negate { Project { outputs: [], Get { id-1 } } },
-            Constant [[]]
+            (substr(#11, 1, 1) = "7")
+          ],
+          Get { customer }
+        },
+        Project {
+          outputs: [2],
+          Map {
+            scalars: [
+              ((#0 * 10000000dec) / (i64todec #1 * 100dec)) * 10dec
+            ],
+            Reduce {
+              group_key: [],
+              aggregates: [sum(#16), count(#16)],
+              Filter {
+                predicates: [
+                  (
+                    (
+                      (
+                        (
+                          (
+                            (false || (substr(#11, 1, 1) = "1"))
+                            ||
+                            (substr(#11, 1, 1) = "2")
+                          )
+                          ||
+                          (substr(#11, 1, 1) = "3")
+                        )
+                        ||
+                        (substr(#11, 1, 1) = "4")
+                      )
+                      ||
+                      (substr(#11, 1, 1) = "5")
+                    )
+                    ||
+                    (substr(#11, 1, 1) = "6")
+                  )
+                  ||
+                  (substr(#11, 1, 1) = "7"),
+                  #16 > 0dec
+                ],
+                Get { customer }
+              }
+            }
           }
         }
       }
     }
   }
 } in
+Let { id-2 = Distinct { group_key: [0 .. 2], Get { id-1 } } } in
 Let {
-  id-3 = Join {
-    variables: [],
-    Get { customer },
-    Union {
-      Get { id-2 },
-      Map {
-        scalars: [null],
-        Union {
-          Negate { Distinct { group_key: [], Get { id-2 } } },
-          Constant [[]]
-        }
-      }
-    }
-  }
-} in
-Let { id-4 = Distinct { group_key: [0 .. 2], Get { id-3 } } } in
-Let {
-  id-5 = Map {
+  id-3 = Map {
     scalars: [true],
     Distinct {
       group_key: [0 .. 2],
@@ -1621,7 +1691,7 @@ Let {
             [(0, 3), (1, 0)]
           ],
           Get { "order" },
-          Get { id-4 }
+          Get { id-2 }
         }
       }
     }
@@ -1642,44 +1712,16 @@ Project {
             [(0, 1), (1, 1)],
             [(0, 2), (1, 2)]
           ],
-          Filter {
-            predicates: [
-              (
-                (
-                  (
-                    (
-                      (
-                        (false || (substr(#11, 1, 1) = "1"))
-                        ||
-                        (substr(#11, 1, 1) = "2")
-                      )
-                      ||
-                      (substr(#11, 1, 1) = "3")
-                    )
-                    ||
-                    (substr(#11, 1, 1) = "4")
-                  )
-                  ||
-                  (substr(#11, 1, 1) = "5")
-                )
-                ||
-                (substr(#11, 1, 1) = "6")
-              )
-              ||
-              (substr(#11, 1, 1) = "7"),
-              (#16 * 1000000dec) > #22
-            ],
-            Get { id-3 }
-          },
+          Get { id-1 },
           Union {
-            Filter { predicates: [!#3], Get { id-5 } },
+            Filter { predicates: [!#3], Get { id-3 } },
             Map {
               scalars: [false],
               Union {
                 Negate {
-                  Project { outputs: [0 .. 2], Get { id-5 } }
+                  Project { outputs: [0 .. 2], Get { id-3 } }
                 },
-                Get { id-4 }
+                Get { id-2 }
               }
             }
           }

--- a/test/subquery.slt
+++ b/test/subquery.slt
@@ -215,3 +215,35 @@ Project {
     Distinct { group_key: [], Get { t2 } }
   }
 }
+
+query T multiline
+EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2 WHERE t3.b = t2.b)
+----
+Let {
+  id-1 = Join {
+    variables: [[(0, 0), (1, 0)]],
+    Get { t1 },
+    Get { t3 }
+  }
+} in
+Project {
+  outputs: [0 .. 2],
+  Map {
+    scalars: [true],
+    Join {
+      variables: [[(0, 2), (1, 0)]],
+      Get { id-1 },
+      Distinct {
+        group_key: [0],
+        Project {
+          outputs: [1, 0],
+          Join {
+            variables: [[(0, 0), (1, 0)]],
+            Get { t2 },
+            Distinct { group_key: [2], Get { id-1 } }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The branch key tightening introduced in MaterializeInc/materialize#719 had the defect that it was
interfering with the assertive predicate pushdown introduced in MaterializeInc/materialize#715.
As a result, correlated subqueries could wind up planning large cross
joins, even though a join key was technically available.

This commit not only restores the assertive predicate pushdown behavior,
it enhances to never before seen power: even the five-way cross join in
q21 is finally optimized.

The trick is to take a query that looks like

    SELECT * FROM a, b, c
    WHERE a.a = b.a AND b.c = c.c AND EXISTS (<subquery>)

and rewrite it to look like, essentially:

    SELECT * FROM (
        SELECT * FROM a, b, c WHERE a.a = b.a AND b.c = c.c
    ) WHERE EXISTS (<subquery>)

In the old example, <subquery> is evaluated in the context of `FROM
a, b, c` (i.e., the three-way cross join), and we needed serious
optimization smarts to push down the join key (`a.a = b.a AND ...`) to
both sides of the join.

In the rewritten example, <subquery> is evaluated in the context of
`FROM a, b, c WHERE a.a = b.a AND b.c = c.c` (i.e., the predicates are
applied first), and the branch naturally applies to the post-selection
relation without any kind of complicated optimizations required.

Things get tricky when multiple subqueries are in play, and this patch
doesn't attempt to make optimal decisions. A query like

    SELECT * FROM a, b, c
    WHERE a.a = b.a AND b.c = c.c
    AND EXISTS (<subquery>)
    AND EXISTS (<subquery 2>)

may very well be more efficient if <subquery 2> is evaluated before
<subquery>, but at the moment we simply plan in the order that
subqueries appear.

Fix MaterializeInc/database-issues#248.