### PR TITLE
Minimize logs

### DIFF
--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -42,9 +42,6 @@ pub enum LogVariant {
 pub enum TimelyLog {
     Operates,
     Channels,
-    Messages,
-    Shutdown,
-    Text,
     Elapsed,
     Histogram,
 }
@@ -69,9 +66,6 @@ impl LogVariant {
         vec![
             LogVariant::Timely(TimelyLog::Operates),
             LogVariant::Timely(TimelyLog::Channels),
-            LogVariant::Timely(TimelyLog::Messages),
-            LogVariant::Timely(TimelyLog::Shutdown),
-            LogVariant::Timely(TimelyLog::Text),
             LogVariant::Timely(TimelyLog::Elapsed),
             LogVariant::Timely(TimelyLog::Histogram),
             LogVariant::Differential(DifferentialLog::Arrangement),
@@ -89,9 +83,6 @@ impl LogVariant {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => "logs_operates",
             LogVariant::Timely(TimelyLog::Channels) => "logs_channels",
-            LogVariant::Timely(TimelyLog::Messages) => "logs_messages",
-            LogVariant::Timely(TimelyLog::Shutdown) => "logs_shutdown",
-            LogVariant::Timely(TimelyLog::Text) => "logs_text",
             LogVariant::Timely(TimelyLog::Elapsed) => "logs_elapsed",
             LogVariant::Timely(TimelyLog::Histogram) => "logs_histogram",
             LogVariant::Differential(DifferentialLog::Arrangement) => "logs_arrangement",
@@ -125,20 +116,6 @@ impl LogVariant {
                 .add_column("target_node", ScalarType::Int64)
                 .add_column("target_port", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
-
-            LogVariant::Timely(TimelyLog::Messages) => RelationDesc::empty()
-                .add_column("channel", ScalarType::Int64)
-                .add_column("count", ScalarType::Int64)
-                .add_keys(vec![0]),
-
-            LogVariant::Timely(TimelyLog::Shutdown) => RelationDesc::empty()
-                .add_column("id", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
-
-            LogVariant::Timely(TimelyLog::Text) => RelationDesc::empty()
-                .add_column("text", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
                 .add_column("id", ScalarType::Int64)

--- a/test/logging.td
+++ b/test/logging.td
@@ -14,14 +14,6 @@
 > SELECT count(*) FROM count_channels;
 1
 
-> CREATE VIEW count_shutdown AS SELECT count(*) FROM logs_shutdown;
-> SELECT count(*) FROM count_shutdown;
-1
-
-> CREATE VIEW count_text AS SELECT count(*) FROM logs_text;
-> SELECT count(*) FROM count_text;
-1
-
 > CREATE VIEW count_elapsed AS SELECT count(*) FROM logs_elapsed;
 > SELECT count(*) FROM count_elapsed;
 1


### PR DESCRIPTION
This PR deletes entries from `logs_operates` and `logs_channels` when the corresponding operator and dataflow are dropped. The intent is to limit the amount of log data maintained as the system runs to avoid resource exhaustion from the logging infrastructure.

cc @cuongdo 