### PR TITLE
Normalize logging

### DIFF
--- a/etc/materialized/startup.sql
+++ b/etc/materialized/startup.sql
@@ -4,10 +4,15 @@
 -- distributed without the express permission of Materialize, Inc.
 
 CREATE VIEW logs_records_per_dataflow AS
-SELECT address_value AS dataflow, SUM(records) AS records
-FROM logs_operates AS lo
-JOIN logs_arrangement AS la
-ON lo.id = la.operator
-AND lo.worker = la.worker
-AND lo.address_slot = 0
-GROUP BY address_value;
+SELECT logs_addresses.value AS dataflow, SUM(records) AS records
+FROM
+    logs_operates,
+    logs_addresses,
+    logs_arrangement
+WHERE
+    logs_operates.id = logs_arrangement.operator AND
+    logs_operates.worker = logs_arrangement.worker AND
+    logs_addresses.id = logs_operates.id AND
+    logs_addresses.worker = logs_addresses.worker AND
+    logs_addresses.slot = 0
+GROUP BY logs_addresses.value;

--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -144,8 +144,8 @@ impl LogVariant {
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
                 .add_column("id", ScalarType::Int64)
                 .add_column("worker", ScalarType::Int64)
-                .add_column("address_slot", ScalarType::Int64)
-                .add_column("address_value", ScalarType::Int64)
+                .add_column("slot", ScalarType::Int64)
+                .add_column("value", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()

--- a/src/dataflow/logging/timely.rs
+++ b/src/dataflow/logging/timely.rs
@@ -142,9 +142,7 @@ pub fn construct<A: Allocate>(
                                 // Dropped operators should result in a negative record for
                                 // the `operates` collection, cancelling out the initial
                                 // operator announcement.
-                                if let Some(event) =
-                                    operates_data.remove(&(event.id, worker))
-                                {
+                                if let Some(event) = operates_data.remove(&(event.id, worker)) {
                                     operates_session.give((
                                         vec![
                                             Datum::Int64(event.id as i64),
@@ -171,7 +169,9 @@ pub fn construct<A: Allocate>(
                                     // issue a deletion for channels in the dataflow.
                                     if event.addr.len() == 1 {
                                         let dataflow_id = event.addr[0];
-                                        if let Some(events) = channels_data.remove(&(dataflow_id, worker)) {
+                                        if let Some(events) =
+                                            channels_data.remove(&(dataflow_id, worker))
+                                        {
                                             for event in events {
                                                 // Retract channel description.
                                                 channels_session.give((
@@ -188,7 +188,9 @@ pub fn construct<A: Allocate>(
                                                 ));
 
                                                 // Enumerate the address of the scope containing the channel.
-                                                for (addr_slot, addr_value) in event.scope_addr.iter().enumerate() {
+                                                for (addr_slot, addr_value) in
+                                                    event.scope_addr.iter().enumerate()
+                                                {
                                                     addresses_session.give((
                                                         vec![
                                                             Datum::Int64(event.id as i64),


### PR DESCRIPTION
This PR adds a new logging collection, `logs_addresses`, which contains the normalized representation of the "addresses" for operators and channels. An address is a vector of integers, and the normalized representation is the key (id and worker), and then the index and value of the associated vector.

This breaks some of the queries we were using that relied on the denormalized representation. Get in touch if they seem hard to reproduce!