### PR TITLE
coord,dataflow: only produce future updates in TAIL

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -220,6 +220,7 @@ pub struct KafkaSinkConnector {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TailSinkConnector {
     pub tx: comm::mpsc::Sender<Vec<Update>>,
+    pub since: Timestamp,
 }
 
 /// A view transforms one dataflow into another.


### PR DESCRIPTION
This supersedes MaterializeInc/materialize#427. The feedback in that PR was substantially easier
to address after the coordinator refactor. TAIL now only produces
records *after* the TAIL command begins, so that TAILing a large
relation does not require outputting a snapshot of that large relation
first. The biggest difference is that the notion of current time is
derived from the upper frontier of the tailed view, rather than using
the current system time.

Fix MaterializeInc/database-issues#15.