### PR TITLE
pgwire: fix simple query protocol

### DIFF
--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -427,7 +427,7 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
                     conn,
                     rx,
                     field_formats: None,
-                    extended: true,
+                    extended: false,
                 })
             }
             FrontendMessage::Parse { name, sql, .. } => {


### PR DESCRIPTION
I accidentally broke the simple query protocol in #784; the protocol
state machine was accidentally falling into the extended query flow even
when the simple flow was active due to a simple typo.

Fix that. It's clear that we need some tests for the simple flow, but
I'm going to defer that for the moment, since the incoming JDBC work
will provide hundreds and hundreds of tests for the protocol.