### PR TITLE
Re-imagine Unbind and Deduplicate

### DIFF
--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -17,6 +17,7 @@ mod scalar;
 pub mod transform;
 
 pub use relation::func::AggregateFunc;
-pub use relation::{AggregateExpr, ColumnOrder, IdGen, RelationExpr};
+pub use relation::{AggregateExpr, ColumnOrder, RelationExpr};
 pub use scalar::func::{BinaryFunc, UnaryFunc, VariadicFunc};
 pub use scalar::ScalarExpr;
+pub use transform::binding::IdGen;

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -4,7 +4,6 @@
 // distributed without the express permission of Materialize, Inc.
 
 #![deny(missing_docs)]
-
 // Clippy is wrong.
 #![allow(clippy::op_ref, clippy::len_zero)]
 
@@ -14,6 +13,7 @@ use self::func::AggregateFunc;
 use crate::pretty_pretty::{
     compact_intersperse_doc, tighten_outputs, to_braced_doc, to_tightly_braced_doc,
 };
+use crate::transform::binding::IdGen;
 use crate::ScalarExpr;
 use failure::ResultExt;
 use pretty::Doc::Space;
@@ -793,7 +793,7 @@ impl RelationExpr {
             // already done
             body(id_gen, self)
         } else {
-            let name = format!("tmp_{}", id_gen.allocate_id());
+            let name = id_gen.fresh_id();
             let get = RelationExpr::Get {
                 name: name.clone(),
                 typ: self.typ(),
@@ -865,20 +865,6 @@ pub struct ColumnOrder {
     pub column: usize,
     /// Whether to sort in descending order
     pub desc: bool,
-}
-
-/// Manages the allocation of locally unique IDs when building a [`RelationExpr`].
-#[derive(Debug, Default)]
-pub struct IdGen {
-    id: usize,
-}
-
-impl IdGen {
-    fn allocate_id(&mut self) -> usize {
-        let id = self.id;
-        self.id += 1;
-        id
-    }
 }
 
 /// Describes an aggregation expression.

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -87,7 +87,10 @@ impl Default for Optimizer {
             Box::new(crate::transform::fusion::join::Join),
             Box::new(crate::transform::join_elision::JoinElision),
             Box::new(crate::transform::empty_map::EmptyMap),
-            // Unbinding increases the complexity, but exposes more optimization opportunities.
+            // Yes, Unbind runs twice, since the first run may just create more opportunities.
+            // Though we should move Unbind + Deduplicate into a fixed point, since Deduplicate
+            // may also create more opportunities for Unbind.
+            Box::new(crate::transform::binding::Unbind),
             Box::new(crate::transform::binding::Unbind),
             Box::new(crate::transform::binding::Deduplicate),
             // Early actions include "no-brainer" transformations that reduce complexity in linear passes.
@@ -122,7 +125,6 @@ impl Default for Optimizer {
             Box::new(crate::transform::join_order::JoinOrder),
             Box::new(crate::transform::predicate_pushdown::PredicatePushdown),
             Box::new(crate::transform::fusion::project::Project),
-            Box::new(crate::transform::binding::Normalize),
             Box::new(crate::transform::constant_join::ConstantJoin),
         ];
         Self { transforms }


### PR DESCRIPTION
`Unbind` now only undoes unncessary bindings and `Deduplicate` now correctly handles existing bindings. I got rid of `Normalize` as well, since it only obscures the names of bindings, which makes debugging harder. This pull request closes MaterializeInc/database-issues#238.