### PR TITLE
sqllogictest,testdrive: downgrade to stable release of postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 dependencies = [
- "memchr",
+ "memchr 2.2.1",
 ]
 
 [[package]]
@@ -54,16 +54,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "antidote"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-
-[[package]]
 name = "arbitrary"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c7d1523aa3a127adf8b27af2404c03c12825b4c4d0698f01648d63fa9df62ee"
+
+[[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 
 [[package]]
 name = "arrayvec"
@@ -108,7 +108,7 @@ version = "0.6.5"
 source = "git+ssh://git@github.com/MaterializeInc/avro-rs.git#dd965e4560ae0c600a52acc2e250ffad891355fc"
 dependencies = [
  "chrono",
- "digest",
+ "digest 0.8.0",
  "failure",
  "libflate",
  "log 0.4.8",
@@ -146,6 +146,16 @@ checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "base64"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+dependencies = [
+ "byteorder 1.3.2",
+ "safemem",
 ]
 
 [[package]]
@@ -199,14 +209,24 @@ checksum = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 
 [[package]]
 name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+dependencies = [
+ "arrayref",
+ "byte-tools 0.2.0",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
- "byte-tools",
+ "byte-tools 0.3.1",
  "byteorder 1.3.2",
- "generic-array",
+ "generic-array 0.12.0",
 ]
 
 [[package]]
@@ -215,7 +235,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 dependencies = [
- "byte-tools",
+ "byte-tools 0.3.1",
 ]
 
 [[package]]
@@ -225,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94cdf78eb7e94c566c1f5dbe2abf8fc70a548fc902942a48c4b3a98b48ca9ade"
 dependencies = [
  "lazy_static",
- "memchr",
+ "memchr 2.2.1",
  "regex-automata",
  "serde",
 ]
@@ -235,6 +255,12 @@ name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-tools"
@@ -393,6 +419,12 @@ dependencies = [
  "tokio-serde-bincode",
  "uuid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 
 [[package]]
 name = "cookie"
@@ -607,12 +639,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 dependencies = [
- "generic-array",
- "subtle",
+ "constant_time_eq",
+ "generic-array 0.9.0",
 ]
 
 [[package]]
@@ -634,7 +666,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 dependencies = [
- "memchr",
+ "memchr 2.2.1",
 ]
 
 [[package]]
@@ -758,20 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_state_machine_future"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1220ad071cb8996454c20adf547a34ba3ac793759dab793d9dc04996a373ac83"
-dependencies = [
- "darling",
- "heck",
- "petgraph",
- "proc-macro2 0.4.30",
- "quote 0.6.12",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,11 +811,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
+dependencies = [
+ "generic-array 0.9.0",
+]
+
+[[package]]
+name = "digest"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.0",
 ]
 
 [[package]]
@@ -917,6 +944,12 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
@@ -1024,6 +1057,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
@@ -1086,13 +1128,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.7.0"
+name = "hex"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"
+checksum = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
+
+[[package]]
+name = "hmac"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.7.6",
 ]
 
 [[package]]
@@ -1213,7 +1261,7 @@ dependencies = [
  "repr",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.8.0",
  "url",
 ]
 
@@ -1395,9 +1443,24 @@ dependencies = [
 
 [[package]]
 name = "md5"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
+
+[[package]]
+name = "md5"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
+
+[[package]]
+name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -1571,7 +1634,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
- "memchr",
+ "memchr 2.2.1",
  "version_check",
 ]
 
@@ -1760,7 +1823,7 @@ dependencies = [
  "crossbeam",
  "env_logger 0.7.1",
  "failure",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures",
  "lazy_static",
  "libc",
@@ -1851,6 +1914,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg_interval"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e445870a4b4c91a285b863e90ec5b3190f31f263a5f68e3e81b3987021e45802"
+dependencies = [
+ "byteorder 1.3.2",
+ "chrono",
+ "postgres",
+]
+
+[[package]]
 name = "pgwire"
 version = "0.1.0"
 dependencies = [
@@ -1871,7 +1945,7 @@ dependencies = [
  "rand 0.7.2",
  "repr",
  "sql",
- "state_machine_future 0.2.0 (git+https://github.com/benesch/state_machine_future.git?branch=context-generic-bounds)",
+ "state_machine_future",
  "tokio",
 ]
 
@@ -1901,36 +1975,48 @@ checksum = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 
 [[package]]
 name = "postgres"
-version = "0.16.0-rc.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756f20b5014f54be24b127f7bee61c296712a8ab7a2cfb649c89ef43d45665c7"
+checksum = "115dde90ef51af573580c035857badbece2aa5cde3de1dfb3c932969ca92a6c5"
 dependencies = [
  "bytes",
- "fallible-iterator",
- "futures",
- "lazy_static",
+ "fallible-iterator 0.1.6",
  "log 0.4.8",
- "tokio",
- "tokio-postgres",
+ "postgres-protocol",
+ "postgres-shared",
+ "socket2",
 ]
 
 [[package]]
 name = "postgres-protocol"
-version = "0.4.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a770315d137ca2f88813cf707ec50f3da13293c7d42516ac2735d185c035795"
+checksum = "2487e66455bf88a1b247bf08a3ce7fe5197ac6d67228d920b0ee6a0e97fd7312"
 dependencies = [
- "base64",
+ "base64 0.6.0",
  "byteorder 1.3.2",
  "bytes",
- "fallible-iterator",
- "generic-array",
+ "fallible-iterator 0.1.6",
+ "generic-array 0.9.0",
  "hmac",
- "md5",
- "memchr",
- "rand 0.6.5",
- "sha2",
+ "md5 0.3.8",
+ "memchr 1.0.2",
+ "rand 0.3.23",
+ "sha2 0.7.1",
  "stringprep",
+]
+
+[[package]]
+name = "postgres-shared"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffac35b3e0029b404c24a3b82149b4e904f293e8ca4a327eefa24d3ca50df36f"
+dependencies = [
+ "chrono",
+ "fallible-iterator 0.1.6",
+ "hex",
+ "phf",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -2121,6 +2207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
  "proc-macro2 1.0.1",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
 ]
 
 [[package]]
@@ -2386,7 +2482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 dependencies = [
  "aho-corasick",
- "memchr",
+ "memchr 2.2.1",
  "regex-syntax",
  "thread_local",
 ]
@@ -2442,7 +2538,7 @@ version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 dependencies = [
- "base64",
+ "base64 0.10.1",
  "bytes",
  "cookie",
  "cookie_store",
@@ -2479,13 +2575,13 @@ checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 [[package]]
 name = "rust_decimal"
 version = "1.0.3"
-source = "git+https://github.com/MaterializeInc/rust-decimal.git#73f3b5bb0f018d7531e8b1d2baff138b08d7a41d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a28ded8f10361cefb69a8d8e1d195acf59344150534c165c401d6611cf013d"
 dependencies = [
  "byteorder 1.3.2",
  "num",
  "postgres",
  "serde",
- "tokio-postgres",
 ]
 
 [[package]]
@@ -2526,6 +2622,12 @@ name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+
+[[package]]
+name = "safemem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 
 [[package]]
 name = "same-file"
@@ -2656,12 +2758,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+dependencies = [
+ "block-buffer 0.3.3",
+ "byte-tools 0.2.0",
+ "digest 0.7.6",
+ "fake-simd",
+]
+
+[[package]]
+name = "sha2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.0",
  "fake-simd",
  "opaque-debug",
 ]
@@ -2695,6 +2809,18 @@ name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+
+[[package]]
+name = "socket2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.7",
+]
 
 [[package]]
 name = "spin"
@@ -2735,12 +2861,14 @@ dependencies = [
  "getopts",
  "itertools",
  "lazy_static",
- "md5",
+ "md5 0.6.1",
  "ordered-float",
  "ore",
+ "pg_interval",
  "postgres",
  "regex",
  "repr",
+ "rust_decimal",
  "serde_json",
  "sql",
  "sqlparser",
@@ -2770,18 +2898,7 @@ name = "state_machine_future"
 version = "0.2.0"
 source = "git+https://github.com/benesch/state_machine_future.git?branch=context-generic-bounds#8830f127c297930d8c107fc8668fb1af6dc3e9e4"
 dependencies = [
- "derive_state_machine_future 0.2.0 (git+https://github.com/benesch/state_machine_future.git?branch=context-generic-bounds)",
- "futures",
- "rent_to_own",
-]
-
-[[package]]
-name = "state_machine_future"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "530e1d624baae485bce12e6647acb76aafa253346ee8a16751974eed5a24b13d"
-dependencies = [
- "derive_state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_state_machine_future",
  "futures",
  "rent_to_own",
 ]
@@ -2810,12 +2927,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "syn"
@@ -3132,31 +3243,6 @@ dependencies = [
  "bytes",
  "futures",
  "log 0.4.8",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.4.0-rc.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fa9e11d40ede655e8e40294bfd16058d466768a633eb01b5af298cd92a6e1f"
-dependencies = [
- "antidote",
- "bytes",
- "chrono",
- "fallible-iterator",
- "futures",
- "futures-cpupool",
- "lazy_static",
- "log 0.4.8",
- "percent-encoding",
- "phf",
- "postgres-protocol",
- "state_machine_future 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-codec",
- "tokio-io",
- "tokio-tcp",
- "tokio-timer",
- "tokio-uds",
 ]
 
 [[package]]

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -26,9 +26,11 @@ lazy_static = "1"
 md5 = "*"
 ordered-float = "*"
 ore = { path = "../ore" }
-postgres = { version = "0.16.0-rc.2", features = ["with-chrono-0_4"] }
+postgres = { version = "0.15", features = ["with-chrono"] }
+pg_interval = "0.3"
 regex = "1"
 repr = { path = "../repr" }
+rust_decimal = "1.0"
 serde_json = "1"
 sql = { path = "../sql" }
 sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -25,14 +25,14 @@ getopts = "0.2"
 interchange = { path = "../interchange" }
 lazy_static = "1.4.0"
 ore = { path = "../ore" }
-postgres = "0.16.0-rc.2"  # pre-release for simple_query support
+postgres = "0.15"
 serde_json = { version = "1.0.41", features = ["preserve_order"] }
 sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }
 rand = "0.7.2"
 rdkafka = { version = "0.21", features = ["cmake_build"] }
 regex = "1"
 reqwest = "0.9.22"
-rust_decimal = { git = "https://github.com/MaterializeInc/rust-decimal.git", features = ["postgres", "tokio-postgres"] }
+rust_decimal = { version = "1.0", features = ["postgres"] }
 termcolor = "1.0.5"
 
 [dev-dependencies]

--- a/src/testdrive/action/mod.rs
+++ b/src/testdrive/action/mod.rs
@@ -25,7 +25,7 @@ pub struct Config {
 
 pub struct State {
     seed: u32,
-    pgconn: postgres::Client,
+    pgconn: postgres::Connection,
     schema_registry_url: String,
     ccsr_client: ccsr::Client,
     kafka_addr: String,
@@ -131,7 +131,7 @@ pub fn create_state(config: &Config) -> Result<State, Error> {
             .materialized_url
             .mz_as_deref()
             .unwrap_or_else(|| "postgres://ignored@localhost:6875");
-        postgres::Client::connect(&url, postgres::NoTls).map_err(|e| Error::General {
+        postgres::Connection::connect(url, postgres::TlsMode::None).map_err(|e| Error::General {
             ctx: "opening SQL connection".into(),
             cause: Box::new(e),
             hints: vec![


### PR DESCRIPTION
Using a stable release of the postgres driver means we can use
off-the-shelf packages for interval and decimal decoding, rather than
rolling our own.