### PR TITLE
pgwire: don't fall out of extended mode upon empty queries

### DIFF
--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -572,7 +572,7 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
                     SqlResponse::EmptyQuery => transition!(SendCommandComplete {
                         send: Box::new(state.conn.send(BackendMessage::EmptyQueryResponse)),
                         session,
-                        currently_extended: false,
+                        currently_extended: state.extended,
                         label: "empty",
                     }),
                     SqlResponse::SendRows { desc, rx } => {


### PR DESCRIPTION
We need to propagate the extended mode bool when we see an
EmptyQueryResponse, because EmptyQueryResponse can be returned in both
the simple and extended query flow.

h/t to @quodlibetor for discovering this. Feel free to merge on green!