### PR TITLE
Log layout/message changes

### DIFF
--- a/src/ore/log.rs
+++ b/src/ore/log.rs
@@ -123,7 +123,7 @@ pub fn init() {
     LOG_INIT.call_once(|| {
         env_logger::Builder::from_env(env_logger::Env::new().filter_or("MZ_LOG", "info"))
             .format(|buf, record| {
-                let ts = buf.timestamp_nanos();
+                let ts = buf.timestamp_micros();
                 let level = buf.default_styled_level(record.level());
                 write!(buf, "[{} {:>5} ", ts, level)?;
                 match (record.file(), record.line()) {


### PR DESCRIPTION
strip leading `src/` and trailing `.rs` from log lines -- this specifically affects
materialize-internal crates.

Align the log messages as:

    ERROR
     WARN
     INFO
    DEBUG
    TRACE

An example new log message looks like:

    [.. TRACE pgwire/protocol:423] cid=1 recv query: Parse { name: "", sql: "SELECT..
    [.. DEBUG pgwire/protocol:443] parse sql: SELECT DISTINCT t.typname FROM pg_enum..
    [.. TRACE pgwire/protocol:912] cid=1 send error kind=Extended
    [..  WARN pgwire/codec:184] error for client: Error->dataflow pg_enum does not exist
    [.. TRACE pgwire/protocol:875] cid=1 drain until sync..