### PR TITLE
coord,sql: introduce symbiosis mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
  "repr",
  "smallvec",
  "sql",
+ "symbiosis",
  "timely",
  "tokio",
  "tokio-threadpool",
@@ -2885,11 +2886,8 @@ dependencies = [
  "md5 0.6.1",
  "ordered-float",
  "ore",
- "pg_interval",
- "postgres",
  "regex",
  "repr",
- "rust_decimal",
  "serde_json",
  "sql",
  "sqlparser",
@@ -2897,7 +2895,6 @@ dependencies = [
  "tokio",
  "uuid",
  "walkdir",
- "whoami",
 ]
 
 [[package]]
@@ -2999,6 +2996,23 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "symbiosis"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "dataflow-types",
+ "failure",
+ "ore",
+ "pg_interval",
+ "postgres",
+ "repr",
+ "rust_decimal",
+ "sql",
+ "sqlparser",
+ "whoami",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "src/ore",
     "src/repr",
     "src/sql",
+    "src/symbiosis",
     "src/testdrive",
     "src/sqllogictest",
 ]

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -112,14 +112,17 @@ automatically started upon login, but we leave it to you to sort that out.
 
 ## Prepping Confluent
 
-Like we mentioned above, you need to have a few Confluent services running to get Materialize to work. To prep what you need (for the [demo], at least), run the following:
+Like we mentioned above, you need to have a few Confluent services running to
+get Materialize to work. To prep what you need (for the [demo], at least), run
+the following:
 
 ```shell
 confluent local start kafka     # Also starts zookeeper
 confluent local start schema-registry
 ```
 
-You can also use the included `confluent` CLI command to start and stop individual services. For example:
+You can also use the included `confluent` CLI command to start and stop
+individual services. For example:
 
 ```shell
 confluent local status        # View what services are currently running.
@@ -130,10 +133,34 @@ confluent local log kafka     # View Kafka log file.
 Beware that the CLI is fairly buggy, especially around service management.
 Putting your computer to sleep often causes the service status to get out of
 sync. In other words, trust the output of `confluent local log` and `ps ... |
-grep` over the output of `confluent local status`. Still, it's reliable enough 
+grep` over the output of `confluent local status`. Still, it's reliable enough
 to be more convenient than managing each service manually.
 
 [demo](demo.md)
+
+## Symbiosis mode
+
+For the convenience of developers, Materialize has a semi-secret "symbiosis"
+mode that turns Materialize into a full HTAP system, rather than an OLAP system
+that must sit atop a OLTP system via a CDC pipeline. In other words, where
+you would normally need to plug MySQL into Debezium into Kafka into Materialize,
+and run all the Confluent services that that entails, you can instead run:
+
+    $ materialized --symbiosis postgres://localhost:5432
+
+When symbiosis mode is active, all DDL statements and all writes will be routed
+to the specified PostgreSQL server. `CREATE TABLE`, for example, will create
+both a table in PostgreSQL and a source in Materialize that mirrors that table.
+`INSERT`, `UPDATE`, and `DELETE` statements that target that table will be
+reflected in Materialize for the next `SELECT` statement.
+
+Symbiosis mode is not suitable for production use, as its implementation is
+very inefficient. It is, however, excellent for manually taking Materialize
+for a spin without the hassle of setting up various Kafka topics and Avro
+schemas. It also powers our sqllogictest runner.
+
+See the [symbiosis crate documentation](https://mtrlz.dev/api/symbiosis) for
+more details.
 
 ## Testing
 

--- a/src/comm/switchboard.rs
+++ b/src/comm/switchboard.rs
@@ -7,6 +7,7 @@
 
 use futures::stream::FuturesOrdered;
 use futures::{future, Future, Stream};
+use log::error;
 use ore::future::StreamExt;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -90,7 +91,7 @@ impl Switchboard<UnixStream> {
                 .incoming()
                 .map_err(|err| panic!("local switchboard: accept: {}", err))
                 .for_each(move |conn| switchboard.handle_connection(conn))
-                .map_err(|err| panic!("local switchboard: handle connection: {}", err))
+                .map_err(|err| error!("local switchboard: handle connection: {}", err))
         });
         Ok((switchboard, runtime))
     }

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -35,6 +35,7 @@ regex-syntax = "0.6.12"
 repr = { path = "../repr" }
 smallvec = "0.6"
 sql = { path = "../sql" }
+symbiosis = { path = "../symbiosis" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 tokio = "0.1"
 tokio-threadpool = "0.1"

--- a/src/coord/coordinator.rs
+++ b/src/coord/coordinator.rs
@@ -29,12 +29,12 @@ use dataflow::{SequencedCommand, WorkerFeedbackWithMeta};
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
     compare_columns, DataflowDesc, PeekResponse, PeekWhen, RowSetFinishing, Sink, SinkConnector,
-    TailSinkConnector, Timestamp, Update, View,
+    Source, SourceConnector, TailSinkConnector, Timestamp, Update, View,
 };
 use expr::RelationExpr;
 use ore::future::FutureExt;
 use repr::{Datum, RelationDesc, ScalarType};
-use sql::Plan;
+use sql::{MutationKind, ObjectType, Plan};
 
 /// Glues the external world to the Timely workers.
 pub struct Coordinator<C>
@@ -53,7 +53,9 @@ where
     /// that is servicing the TAIL. A connection can only run one TAIL at a
     /// time.
     active_tails: HashMap<u32, String>,
+    local_input_time: Timestamp,
     log: bool,
+    symbiosis: bool,
 }
 
 impl<C> Coordinator<C>
@@ -64,6 +66,7 @@ where
         switchboard: comm::Switchboard<C>,
         num_timely_workers: usize,
         logging_config: Option<&LoggingConfig>,
+        symbiosis: bool,
     ) -> Self {
         let broadcast_tx = switchboard.broadcast_tx(dataflow::BroadcastToken).wait();
 
@@ -76,7 +79,9 @@ where
             sources: HashMap::new(),
             since_updates: Vec::new(),
             active_tails: HashMap::new(),
+            local_input_time: 1,
             log: logging_config.is_some(),
+            symbiosis,
         };
 
         if let Some(logging_config) = logging_config {
@@ -113,29 +118,17 @@ where
         }
     }
 
-    pub fn sequence_insert(&mut self, name: String, updates: Vec<Update>) {
-        broadcast(
-            &mut self.broadcast_tx,
-            SequencedCommand::Insert { name, updates },
-        )
-    }
-
-    pub fn sequence_advance_time(&mut self, name: String, to: Timestamp) {
-        broadcast(
-            &mut self.broadcast_tx,
-            SequencedCommand::AdvanceTime { name, to },
-        )
-    }
-
-    // TODO(benesch): the `ts_override` parameter exists only to support
-    // sqllogictest and is kind of gross. See if we can get rid of it.
-    pub fn sequence_plan(
-        &mut self,
-        plan: Plan,
-        conn_id: u32,
-        ts_override: Option<Timestamp>,
-    ) -> QueryExecuteResponse {
+    pub fn sequence_plan(&mut self, plan: Plan, conn_id: u32) -> QueryExecuteResponse {
         match plan {
+            Plan::CreateTable { name, desc } => {
+                self.create_sources(vec![Source {
+                    name,
+                    connector: SourceConnector::Local,
+                    desc,
+                }]);
+                QueryExecuteResponse::CreatedTable
+            }
+
             Plan::CreateSource(source) => {
                 let sources = vec![source];
                 self.create_sources(sources);
@@ -163,7 +156,7 @@ where
                 QueryExecuteResponse::CreatedView
             }
 
-            Plan::DropItems((names, response)) => {
+            Plan::DropItems(names, item_type) => {
                 let mut sources_to_drop = Vec::new();
                 let mut views_to_drop = Vec::new();
                 for name in names {
@@ -187,10 +180,11 @@ where
                     )
                 }
                 self.drop_views(views_to_drop);
-                if response {
-                    QueryExecuteResponse::DroppedSource
-                } else {
-                    QueryExecuteResponse::DroppedView
+                match item_type {
+                    ObjectType::Source => QueryExecuteResponse::DroppedSource,
+                    ObjectType::View => QueryExecuteResponse::DroppedView,
+                    ObjectType::Table => QueryExecuteResponse::DroppedTable,
+                    ObjectType::Sink | ObjectType::Index => unreachable!(),
                 }
             }
 
@@ -217,12 +211,11 @@ where
                 // Choose a timestamp for all workers to use in the peek.
                 // We minimize over all participating views, to ensure that the query will not
                 // need to block on the arrival of further input data.
-                let timestamp =
-                    ts_override.unwrap_or_else(|| self.determine_timestamp(&source, when));
+                let timestamp = self.determine_timestamp(&source, when);
 
                 // For straight-forward dataflow pipelines, use finishing instructions instead of
                 // dataflow operators.
-                Coordinator::<C>::maybe_use_finishing(&mut source, &mut finishing);
+                Self::maybe_use_finishing(&mut source, &mut finishing);
 
                 // Create a transient view if the peek is not of a base relation.
                 if let RelationExpr::Get { name, typ: _ } = source {
@@ -362,6 +355,53 @@ where
                 let rows = vec![vec![Datum::from(relation_expr.pretty())]];
                 send_immediate_rows(desc, rows)
             }
+
+            Plan::SendDiffs {
+                name,
+                updates,
+                affected_rows,
+                kind,
+            } => {
+                let updates = updates
+                    .into_iter()
+                    .map(|(row, diff)| Update {
+                        row,
+                        diff,
+                        timestamp: self.local_input_time,
+                    })
+                    .collect();
+
+                broadcast(
+                    &mut self.broadcast_tx,
+                    SequencedCommand::Insert { name, updates },
+                );
+
+                self.local_input_time += 1;
+
+                let local_inputs = self
+                    .sources
+                    .iter()
+                    .filter_map(|(name, (src, _view))| match src.connector {
+                        SourceConnector::Local => Some(name.as_str()),
+                        _ => None,
+                    });
+
+                for name in local_inputs {
+                    broadcast(
+                        &mut self.broadcast_tx,
+                        SequencedCommand::AdvanceTime {
+                            name: name.into(),
+                            to: self.local_input_time,
+                        },
+                    );
+                }
+
+                match kind {
+                    MutationKind::Delete => QueryExecuteResponse::Deleted(affected_rows),
+                    MutationKind::Insert => QueryExecuteResponse::Inserted(affected_rows),
+                    MutationKind::Update => QueryExecuteResponse::Updated(affected_rows),
+                }
+            }
         }
     }
 
@@ -379,7 +419,7 @@ where
                 .insert(source.name.clone(), (source.clone(), Some(name)));
         }
         let mut dataflows = Vec::new();
-        for source in sources {
+        for source in sources.iter() {
             if let Some(rename) = &self.sources.get(&source.name).unwrap().1 {
                 dataflows.push(
                     DataflowDesc::new(None)
@@ -392,7 +432,7 @@ where
                             raw_sql: "<created by CREATE SOURCE>".to_string(),
                             desc: source.desc.clone(),
                         })
-                        .add_source(source),
+                        .add_source(source.clone()),
                 );
             }
         }
@@ -402,6 +442,17 @@ where
         );
         for dataflow in dataflows.iter() {
             self.insert_views(dataflow);
+        }
+        for source in sources {
+            if let SourceConnector::Local = source.connector {
+                broadcast(
+                    &mut self.broadcast_tx,
+                    SequencedCommand::AdvanceTime {
+                        name: source.name,
+                        to: self.local_input_time,
+                    },
+                );
+            }
         }
     }
 
@@ -518,7 +569,7 @@ where
     }
 
     pub fn enable_feedback(&mut self) -> comm::mpsc::Receiver<WorkerFeedbackWithMeta> {
-        let (tx, rx) = self.switchboard.mpsc();
+        let (tx, rx) = self.switchboard.mpsc_limited(self.num_timely_workers);
         broadcast(&mut self.broadcast_tx, SequencedCommand::EnableFeedback(tx));
         rx
     }
@@ -546,6 +597,12 @@ where
 
     /// A policy for determining the timestamp for a peek.
     fn determine_timestamp(&mut self, source: &RelationExpr, when: PeekWhen) -> Timestamp {
+        if self.symbiosis {
+            // In symbiosis mode, we enforce serializability by forcing all
+            // PEEKs to peek at the latest input time.
+            return self.local_input_time - 1;
+        }
+
         match when {
             // Explicitly requested timestamps should be respected.
             PeekWhen::AtTimestamp(timestamp) => timestamp,

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -78,8 +78,9 @@ fn run() -> Result<(), failure::Error> {
         "s",
         "startup",
         "file with SQL queries to execute at startup",
-        "STARTUP",
+        "FILE",
     );
+    opts.optopt("", "symbiosis", "(internal use only)", "URL");
     opts.optflag("", "no-prometheus", "Do not gather prometheus metrics");
 
     let popts = opts.parse(&args[1..])?;
@@ -130,6 +131,7 @@ fn run() -> Result<(), failure::Error> {
         process,
         addresses,
         sql,
+        symbiosis_url: popts.opt_str("symbiosis"),
         gather_metrics,
     })
 }

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -15,7 +15,7 @@ use sqlparser::parser::Parser as SqlParser;
 use store::{Catalog, CatalogItem};
 
 pub use session::{PreparedStatement, Session};
-pub use sqlparser::ast::Statement;
+pub use sqlparser::ast::{ObjectType, Statement};
 
 mod expr;
 mod query;
@@ -34,11 +34,12 @@ pub enum Plan {
     CreateSource(Source),
     CreateSources(Vec<Source>),
     CreateSink(Sink),
+    CreateTable {
+        name: String,
+        desc: RelationDesc,
+    },
     CreateView(View),
-    // DropSources(Vec<String>),
-    // DropViews(Vec<String>),
-    /// Items to drop, and true iff a source.
-    DropItems((Vec<String>, bool)),
+    DropItems(Vec<String>, ObjectType),
     EmptyQuery,
     SetVariable {
         name: String,
@@ -59,6 +60,19 @@ pub enum Plan {
         desc: RelationDesc,
         relation_expr: ::expr::RelationExpr,
     },
+    SendDiffs {
+        name: String,
+        updates: Vec<(Vec<Datum>, isize)>,
+        affected_rows: usize,
+        kind: MutationKind,
+    },
+}
+
+#[derive(Debug)]
+pub enum MutationKind {
+    Insert,
+    Update,
+    Delete,
 }
 
 /// Parses a raw SQL string into a [`Statement`].

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -365,8 +365,8 @@ fn handle_drop_dataflow(catalog: &Catalog, stmt: Statement) -> Result<Plan, fail
     to_remove.sort();
     to_remove.dedup();
     Ok(match object_type {
-        ObjectType::Source => Plan::DropItems((to_remove, true)),
-        ObjectType::View => Plan::DropItems((to_remove, false)),
+        ObjectType::Source => Plan::DropItems(to_remove, ObjectType::Source),
+        ObjectType::View => Plan::DropItems(to_remove, ObjectType::View),
         _ => bail!("unsupported SQL statement: DROP {}", object_type),
     })
 }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -26,11 +26,8 @@ lazy_static = "1"
 md5 = "*"
 ordered-float = "*"
 ore = { path = "../ore" }
-postgres = { version = "0.15", features = ["with-chrono"] }
-pg_interval = "0.3"
 regex = "1"
 repr = { path = "../repr" }
-rust_decimal = "1.0"
 serde_json = "1"
 sql = { path = "../sql" }
 sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }
@@ -38,4 +35,3 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features =
 tokio = "0.1"
 uuid = "*"
 walkdir = "2"
-whoami = "0.6.0"

--- a/src/sqllogictest/fuzz.rs
+++ b/src/sqllogictest/fuzz.rs
@@ -13,12 +13,10 @@ use crate::runner::State;
 pub fn fuzz(sqls: &str) {
     let mut state = State::start().unwrap();
     for sql in sqls.split(';') {
-        if let Ok(plan) = state.plan_sql(sql) {
-            if let QueryExecuteResponse::SendRows { desc, rx } = state.run_plan(plan) {
-                for row in rx.wait().unwrap().unwrap_rows() {
-                    for (typ, datum) in desc.iter_types().zip(row.into_iter()) {
-                        assert!(datum.is_instance_of(*typ));
-                    }
+        if let Ok(QueryExecuteResponse::SendRows { desc, rx }) = state.run_sql(sql) {
+            for row in rx.wait().unwrap().unwrap_rows() {
+                for (typ, datum) in desc.iter_types().zip(row.into_iter()) {
+                    assert!(datum.is_instance_of(*typ));
                 }
             }
         }

--- a/src/sqllogictest/lib.rs
+++ b/src/sqllogictest/lib.rs
@@ -17,5 +17,3 @@ pub mod fuzz;
 pub mod parser;
 pub mod runner;
 pub mod util;
-
-mod postgres;

--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -22,12 +22,13 @@
 //!       if wrong, record the error
 
 use std::borrow::ToOwned;
-use std::collections::HashSet;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::mem;
 use std::ops;
 use std::path::Path;
+use std::thread::JoinHandle;
 
 use failure::{bail, ResultExt};
 use futures::Future;
@@ -35,20 +36,15 @@ use itertools::izip;
 use lazy_static::lazy_static;
 use regex::Regex;
 
-use coord::{coordinator::Coordinator, QueryExecuteResponse};
+use coord::QueryExecuteResponse;
 use dataflow;
-use dataflow_types::{self, Source, SourceConnector, Update};
-use ore::collections::CollectionExt;
 use ore::option::OptionExt;
 use repr::{ColumnType, Datum};
-use sql::store::RemoveMode;
-use sql::Session;
-use sqlparser::ast::{ObjectType, Statement};
+use sql::{Session, Statement};
 use sqlparser::dialect::AnsiDialect;
 use sqlparser::parser::{Parser as SqlParser, ParserError as SqlParserError};
 
 use crate::ast::{Mode, Output, QueryOutput, Record, Sort, Type};
-use crate::postgres::{self, Postgres};
 use crate::util;
 
 #[derive(Debug)]
@@ -261,20 +257,12 @@ fn write_err(kind: &str, error: &impl failure::AsFail, f: &mut fmt::Formatter) -
 const NUM_TIMELY_WORKERS: usize = 3;
 
 pub(crate) struct State {
-    // Hold a reference to the dataflow workers threads to avoid dropping them
-    // too early. Order is important here! They must appear before the runtime,
-    // so that the runtime is *dropped* after the workers. We rely on the
-    // runtime to send the shutdown signal to the workers; if the runtime goes
-    // away first, the workers won't ever get the shutdown signal.
-    _dataflow_workers: Box<dyn Drop>,
-    _runtime: tokio::runtime::Runtime,
-    postgres: Postgres,
-    catalog: sql::store::Catalog,
+    dataflow_workers: Box<dyn Drop>,
+    runtime: tokio::runtime::Runtime,
+    coord_thread: JoinHandle<()>,
+    cmd_tx: futures::sync::mpsc::UnboundedSender<coord::Command>,
     session: Session,
-    coord: Coordinator<tokio::net::UnixStream>,
     conn_id: u32,
-    current_timestamp: u64,
-    local_inputs: HashSet<String>,
 }
 
 fn format_row(
@@ -345,38 +333,40 @@ fn format_row(
 
 impl State {
     pub fn start() -> Result<Self, failure::Error> {
-        let postgres = Postgres::open_and_erase()?;
         let logging_config = None;
-        let catalog = sql::store::Catalog::new(logging_config);
-        let session = Session::default();
         let process_id = 0;
+        let symbiosis_url = Some("postgres://");
+        let startup_sql = "";
+
         let (switchboard, runtime) = comm::Switchboard::local()?;
+
+        let (cmd_tx, cmd_rx) = futures::sync::mpsc::unbounded();
+        let coord_thread = coord::transient::serve(
+            switchboard.clone(),
+            NUM_TIMELY_WORKERS,
+            symbiosis_url,
+            logging_config.as_ref(),
+            startup_sql.into(),
+            cmd_rx,
+        )?;
+
         let dataflow_workers = dataflow::serve(
             vec![None],
             NUM_TIMELY_WORKERS,
             process_id,
             switchboard.clone(),
             runtime.executor(),
-            None, // disable logging
+            logging_config.clone(),
         )
         .unwrap();
 
-        let coord = Coordinator::new(
-            switchboard.clone(),
-            NUM_TIMELY_WORKERS,
-            None, // disable logging
-        );
-
         Ok(State {
-            _runtime: runtime,
-            postgres,
-            catalog,
-            session,
-            coord,
+            runtime,
+            dataflow_workers: Box::new(dataflow_workers),
+            coord_thread,
+            cmd_tx,
+            session: Session::default(),
             conn_id: 1,
-            _dataflow_workers: Box::new(dataflow_workers),
-            current_timestamp: 1,
-            local_inputs: HashSet::new(),
         })
     }
 
@@ -420,139 +410,32 @@ impl State {
             return Ok(Outcome::Success);
         }
 
-        // parse statement
-        let statements = match SqlParser::parse_sql(&AnsiDialect {}, sql.to_string()) {
-            Ok(statements) => statements,
-            Err(error) => return Ok(Outcome::ParseFailure { error }),
-        };
-        let statement = match &*statements {
-            [] => bail!("Got zero statements?"),
-            [statement] => statement,
-            _ => bail!("Got multiple statements: {:?}", statements),
-        };
+        match self.run_sql(sql) {
+            Ok(resp) => match expected_rows_affected {
+                None => Ok(Outcome::Success),
+                Some(expected) => match resp {
+                    QueryExecuteResponse::Inserted(actual)
+                    | QueryExecuteResponse::Updated(actual)
+                    | QueryExecuteResponse::Deleted(actual) => {
+                        if expected != actual {
+                            Ok(Outcome::WrongNumberOfRowsInserted {
+                                expected_count: expected,
+                                actual_count: actual,
+                            })
+                        } else {
+                            Ok(Outcome::Success)
+                        }
+                    }
 
-        match statement {
-            // run through postgres and send diffs to materialize
-            Statement::CreateTable { .. }
-            | Statement::Drop {
-                object_type: ObjectType::Table,
-                ..
-            }
-            | Statement::Delete { .. }
-            | Statement::Insert { .. }
-            | Statement::Update { .. }
-            | Statement::SetVariable { .. } => {
-                self.run_statement_postgres(sql, statement, expected_rows_affected)
-            }
-
-            // run through materialize directly
-            Statement::Query { .. }
-            | Statement::CreateView { .. }
-            | Statement::CreateSource { .. }
-            | Statement::CreateSink { .. }
-            | Statement::Drop { .. } => match self.plan_sql(sql) {
-                Ok(plan) => {
-                    let _ = self.run_plan(plan);
-                    Ok(Outcome::Success)
-                }
-                Err(error) => Ok(Outcome::PlanFailure { error }),
+                    _ => Ok(Outcome::PlanFailure {
+                        error: failure::format_err!(
+                            "Query did not insert any rows, expected {}",
+                            expected,
+                        ),
+                    }),
+                },
             },
-
-            _ => bail!("Unsupported statement: {:?}", statement),
-        }
-    }
-
-    fn run_statement_postgres<'a>(
-        &mut self,
-        sql: &'a str,
-        statement: &Statement,
-        expected_rows_affected: Option<usize>,
-    ) -> Result<Outcome<'a>, failure::Error> {
-        let outcome = match self
-            .postgres
-            .run_statement(&sql, statement)
-            .context("Unsupported by postgres")
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                return Ok(Outcome::Unsupported {
-                    error: error.into(),
-                });
-            }
-        };
-        if let Statement::SetVariable { .. } = statement {
-            // `SetVariable` statements don't generate any diffs, so we can
-            // skip the rest.
-            return Ok(Outcome::Success);
-        }
-        let rows_affected;
-        match outcome {
-            postgres::Outcome::Created(name, desc) => {
-                let source = Source {
-                    name: name.clone(),
-                    connector: SourceConnector::Local,
-                    desc,
-                };
-                self.catalog
-                    .insert(sql::store::CatalogItem::Source(source.clone()))?;
-                self.coord
-                    .sequence_plan(sql::Plan::CreateSource(source), self.conn_id, None);
-                self.local_inputs.insert(name.clone());
-                self.coord
-                    .sequence_advance_time(name.clone(), self.current_timestamp);
-                rows_affected = None;
-            }
-            postgres::Outcome::Dropped(names) => {
-                let mut all_names = vec![];
-                // The only reason we would use RemoveMode::Restrict is to test
-                // expected errors, and we currently set should_run=false
-                // whenever errors are expected.
-                for name in &names {
-                    // Close down the input if it exists. (The input might not
-                    // exist if the DROP statement was a DROP IF NOT EXISTS.)
-                    let _ = self.local_inputs.remove(name);
-                    self.catalog
-                        .plan_remove(name, RemoveMode::Cascade, &mut all_names)?;
-                }
-                for name in &all_names {
-                    self.catalog.remove(name)
-                }
-                self.coord.drop_views(all_names);
-                rows_affected = None;
-            }
-            postgres::Outcome::Changed {
-                table_name,
-                updates,
-                affected,
-            } => {
-                let updates = updates
-                    .into_iter()
-                    .map(|(row, diff)| Update {
-                        row,
-                        diff,
-                        timestamp: self.current_timestamp,
-                    })
-                    .collect::<Vec<_>>();
-                self.coord.sequence_insert(table_name.clone(), updates);
-                self.current_timestamp += 1;
-                for name in &self.local_inputs {
-                    self.coord
-                        .sequence_advance_time(name.clone(), self.current_timestamp);
-                }
-                rows_affected = Some(affected);
-            }
-        }
-        match (rows_affected, expected_rows_affected) {
-            (None, Some(expected)) => Ok(Outcome::PlanFailure {
-                error: failure::format_err!("Query did not insert any rows, expected {}", expected,),
-            }),
-            (Some(actual), Some(expected)) if actual != expected => {
-                Ok(Outcome::WrongNumberOfRowsInserted {
-                    expected_count: expected,
-                    actual_count: actual,
-                })
-            }
-            _ => Ok(Outcome::Success),
+            Err(error) => Ok(Outcome::PlanFailure { error }),
         }
     }
 
@@ -587,9 +470,17 @@ impl State {
             }
         }
 
-        // get plan
-        let plan = match self.plan_sql(sql) {
-            Ok(plan) => plan,
+        // send plan, read response
+        let (desc, rows_rx) = match self.run_sql(sql) {
+            Ok(QueryExecuteResponse::SendRows { desc, rx }) => (desc, rx),
+            Ok(other) => {
+                return Ok(Outcome::PlanFailure {
+                    error: failure::format_err!(
+                        "Query did not result in SendRows, instead got {:?}",
+                        other
+                    ),
+                });
+            }
             Err(error) => {
                 // TODO(jamii) check error messages, once ours stabilize
                 if output.is_err() {
@@ -603,19 +494,6 @@ impl State {
                         return Ok(Outcome::PlanFailure { error });
                     }
                 }
-            }
-        };
-
-        // send plan, read response
-        let (desc, rows_rx) = match self.run_plan(plan) {
-            QueryExecuteResponse::SendRows { desc, rx } => (desc, rx),
-            other => {
-                return Ok(Outcome::PlanFailure {
-                    error: failure::format_err!(
-                        "Query did not result in SendRows, instead got {:?}",
-                        other
-                    ),
-                });
             }
         };
 
@@ -754,25 +632,26 @@ impl State {
         Ok(Outcome::Success)
     }
 
-    pub(crate) fn plan_sql(&mut self, sql: &str) -> Result<sql::Plan, failure::Error> {
-        let stmts = sql::parse(sql.into())?;
-        if stmts.len() != 1 {
-            bail!("expected exactly one statement, but got {}", stmts.len());
-        }
-        let plan = sql::plan(&self.catalog, &self.session, stmts.into_element())?;
-        coord::transient::apply_plan(&mut self.catalog, &mut self.session, &plan)?;
-        Ok(plan)
+    pub(crate) fn run_sql(&mut self, sql: &str) -> Result<QueryExecuteResponse, failure::Error> {
+        let (tx, rx) = futures::sync::oneshot::channel();
+        self.cmd_tx
+            .unbounded_send(coord::Command::Query {
+                sql: sql.into(),
+                session: mem::replace(&mut self.session, Session::default()),
+                conn_id: self.conn_id,
+                tx,
+            })
+            .expect("futures channel should not fail");
+        let resp = rx.wait().expect("futures channel should not fail");
+        mem::replace(&mut self.session, resp.session);
+        resp.result
     }
 
-    pub(crate) fn run_plan(&mut self, plan: sql::Plan) -> QueryExecuteResponse {
-        let ts = Some(self.current_timestamp - 1);
-        self.coord.sequence_plan(plan, self.conn_id, ts)
-    }
-}
-
-impl Drop for State {
-    fn drop(&mut self) {
-        self.coord.shutdown();
+    fn shutdown(self) {
+        drop(self.cmd_tx);
+        drop(self.dataflow_workers);
+        self.coord_thread.join().unwrap();
+        drop(self.runtime);
     }
 }
 
@@ -825,6 +704,7 @@ pub fn run_string(source: &str, input: &str, verbosity: usize) -> Outcomes {
             break;
         }
     }
+    state.shutdown();
     outcomes
 }
 

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "symbiosis"
+description = "Built-in OLTP support via symbiosis."
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+dataflow-types = { path = "../dataflow-types" }
+failure = "0.1.6"
+ore = { path = "../ore" }
+postgres = { version = "0.15", features = ["with-chrono"] }
+pg_interval = "0.3"
+repr = { path = "../repr" }
+rust_decimal = "1.0"
+sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }
+sql = { path = "../sql" }
+whoami = "0.6"

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -3,7 +3,22 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-//! Postgres glue for sqllogictest.
+//! Symbiosis mode.
+//!
+//! In symbiosis mode, Materialize will conjoin with an OLTP database to
+//! masquerade as a HTAP system. All DDL statements and writes will be routed to
+//! the OLTP database (like `CREATE TABLE`, `INSERT`, etc.), while reads will be
+//! routed through Materialize. Changes to the tables in the OLTP database are
+//! automatically streamed through Materialize.
+//!
+//! The only supported OLTP database at the moment is PostgreSQL. Supporting
+//! other databases is complicated by the fact that we roughly followe
+//! Postgres's SQL semantics; using, say, MySQL, would be rather confusing,
+//! because `INSERT`, `UPDATE`, and `DELETE` statements would be subject to a
+//! wildly different set of SQL semantics than `SELECT` statements.
+//!
+//! Symbiosis mode is only suitable for development. It is likely to be
+//! extremely slow and inefficient on large data sets.
 
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -13,53 +28,66 @@ use ::postgres::rows::Row as PostgresRow;
 use ::postgres::types::FromSql;
 use ::postgres::{Connection, TlsMode};
 use failure::{bail, ensure, format_err};
+use postgres::params::{ConnectParams, IntoConnectParams};
 use rust_decimal::Decimal;
 use sqlparser::ast::ColumnOption;
 use sqlparser::ast::{DataType, ObjectType, Statement};
 
+use ore::option::OptionExt;
 use repr::decimal::Significand;
 use repr::{ColumnType, Datum, Interval, RelationDesc, RelationType, ScalarType};
-use sql::scalar_type_from_sql;
+use sql::{scalar_type_from_sql, MutationKind, Plan};
 
 pub struct Postgres {
     conn: Connection,
     table_types: HashMap<String, (Vec<DataType>, RelationDesc)>,
 }
 
-pub type Row = Vec<Datum>;
-pub type Diff = Vec<(Row, isize)>;
-
-#[derive(Debug, Clone)]
-pub enum Outcome {
-    Created(String, RelationDesc),
-    Dropped(Vec<String>),
-    Changed {
-        table_name: String,
-        updates: Diff,
-        affected: usize,
-    },
-}
-
 impl Postgres {
-    pub fn open_and_erase() -> Result<Self, failure::Error> {
-        // This roughly matches the environment variables that the official C
-        // library for PostgreSQL, libpq, uses [0]. It would be nice if this
-        // hunk of code lived in the Rust PostgreSQL library.
-        //
-        // [0]: https://www.postgresql.org/docs/current/libpq-envars.html
-        let user = env::var("PGUSER").unwrap_or_else(|_| whoami::username());
-        let password = env::var("PGPASSWORD").unwrap_or_else(|_| "".into());
-        let dbname = env::var("PGDATABASE").unwrap_or_else(|_| user.clone());
-        let port = match env::var("PGPORT") {
-            Ok(port) => port.parse()?,
-            Err(_) => 5432,
+    pub fn open_and_erase(url: &str) -> Result<Self, failure::Error> {
+        let params = url
+            .into_connect_params()
+            .map_err(failure::Error::from_boxed_compat)?;
+
+        // Fill in default values for parameters using the same logic that libpq
+        // uses, which involves reading various environment variables. The
+        // `postgres` crate makes this maximally annoying.
+        let params = {
+            let mut new_params = ConnectParams::builder();
+
+            if let Some(user) = params.user() {
+                let password = user
+                    .password()
+                    .owned()
+                    .or_else(|| env::var("PGPASSWORD").ok());
+                new_params.user(user.name(), password.mz_as_deref());
+            } else {
+                let name = env::var("PGUSER").unwrap_or_else(|_| whoami::username());
+                let password = env::var("PGPASSWORD").ok();
+                new_params.user(&name, password.mz_as_deref());
+            }
+
+            if let Some(database) = params
+                .database()
+                .owned()
+                .or_else(|| env::var("PGDATABASE").ok())
+            {
+                new_params.database(&database);
+            }
+            new_params.port(params.port());
+
+            let mut host = params.host().clone();
+            if let postgres::params::Host::Tcp(hostname) = &host {
+                if hostname == "" {
+                    let host_str = env::var("PGHOST").unwrap_or_else(|_| "localhost".into());
+                    host = postgres::params::Host::Tcp(host_str);
+                }
+            }
+
+            new_params.build(host)
         };
-        let host = env::var("PGHOST").unwrap_or_else(|_| "localhost".into());
-        let url = format!(
-            "postgresql://{}:{}@{}:{}/{}",
-            user, password, host, port, dbname
-        );
-        let conn = Connection::connect(url, TlsMode::None)?;
+
+        let conn = Connection::connect(params, TlsMode::None)?;
         // drop all tables
         conn.execute(
             r#"
@@ -79,19 +107,26 @@ END $$;
         })
     }
 
-    pub fn run_statement(
-        &mut self,
-        sql: &str,
-        parsed: &Statement,
-    ) -> Result<Outcome, failure::Error> {
-        Ok(match parsed {
+    pub fn can_handle(&self, stmt: &Statement) -> bool {
+        match stmt {
+            Statement::CreateTable { .. }
+            | Statement::Drop { .. }
+            | Statement::Delete { .. }
+            | Statement::Insert { .. }
+            | Statement::Update { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub fn execute(&mut self, stmt: &Statement) -> Result<Plan, failure::Error> {
+        Ok(match stmt {
             Statement::CreateTable {
                 name,
                 columns,
                 constraints,
                 ..
             } => {
-                self.conn.execute(sql, &[])?;
+                self.conn.execute(&stmt.to_string(), &[])?;
                 let sql_types = columns
                     .iter()
                     .map(|column| column.data_type.clone())
@@ -142,42 +177,50 @@ END $$;
                 let desc = RelationDesc::new(typ, names);
                 self.table_types
                     .insert(name.to_string(), (sql_types, desc.clone()));
-                Outcome::Created(name.to_string(), desc)
+                Plan::CreateTable {
+                    name: name.to_string(),
+                    desc,
+                }
             }
             Statement::Drop {
                 names,
                 object_type: ObjectType::Table,
                 ..
             } => {
-                self.conn.execute(sql, &[])?;
-                Outcome::Dropped(names.iter().map(|name| name.to_string()).collect())
+                self.conn.execute(&stmt.to_string(), &[])?;
+                Plan::DropItems(
+                    names.iter().map(|name| name.to_string()).collect(),
+                    ObjectType::Table,
+                )
             }
             Statement::Delete { table_name, .. } => {
                 let mut updates = vec![];
                 let table_name = table_name.to_string();
-                let sql = format!("{} RETURNING *", parsed.to_string());
+                let sql = format!("{} RETURNING *", stmt.to_string());
                 for row in self.run_query(&table_name, sql)? {
                     updates.push((row, -1));
                 }
-                let affected = updates.len();
-                Outcome::Changed {
-                    table_name,
+                let affected_rows = updates.len();
+                Plan::SendDiffs {
+                    name: table_name,
                     updates,
-                    affected,
+                    affected_rows,
+                    kind: MutationKind::Delete,
                 }
             }
             Statement::Insert { table_name, .. } => {
                 let mut updates = vec![];
                 let table_name = table_name.to_string();
-                let sql = format!("{} RETURNING *", parsed.to_string());
+                let sql = format!("{} RETURNING *", stmt.to_string());
                 for row in self.run_query(&table_name, sql)? {
                     updates.push((row, 1));
                 }
-                let affected = updates.len();
-                Outcome::Changed {
-                    table_name,
+                let affected_rows = updates.len();
+                Plan::SendDiffs {
+                    name: table_name,
                     updates,
-                    affected,
+                    affected_rows,
+                    kind: MutationKind::Insert,
                 }
             }
             Statement::Update {
@@ -194,23 +237,28 @@ END $$;
                 for row in self.run_query(&table_name, sql)? {
                     updates.push((row, -1))
                 }
-                let affected = updates.len();
-                let sql = format!("{} RETURNING *", parsed.to_string());
+                let affected_rows = updates.len();
+                let sql = format!("{} RETURNING *", stmt.to_string());
                 for row in self.run_query(&table_name, sql)? {
                     updates.push((row, 1));
                 }
-                assert_eq!(affected * 2, updates.len());
-                Outcome::Changed {
-                    table_name,
+                assert_eq!(affected_rows * 2, updates.len());
+                Plan::SendDiffs {
+                    name: table_name,
                     updates,
-                    affected,
+                    affected_rows,
+                    kind: MutationKind::Update,
                 }
             }
-            _ => bail!("Unsupported statement: {:?}", parsed),
+            _ => bail!("Unsupported symbiosis statement: {:?}", stmt),
         })
     }
 
-    fn run_query(&mut self, table_name: &str, query: String) -> Result<Vec<Row>, failure::Error> {
+    fn run_query(
+        &mut self,
+        table_name: &str,
+        query: String,
+    ) -> Result<Vec<Vec<Datum>>, failure::Error> {
         let (sql_types, desc) = self
             .table_types
             .get(table_name)
@@ -323,7 +371,6 @@ fn get_column(
         DataType::Decimal(_, _) => {
             let desired_scale = match scalar_type_from_sql(sql_type).unwrap() {
                 ScalarType::Decimal(_precision, desired_scale) => desired_scale,
-
                 _ => unreachable!(),
             };
             match get_column_inner::<Decimal>(postgres_row, i, nullable)? {


### PR DESCRIPTION
From the comment on the new symbiosis crate:

> In symbiosis mode, Materialize will conjoin with an OLTP database to
> masquerade as a HTAP system. All DDL statements and writes will be routed to
> the OLTP database (like `CREATE TABLE`, `INSERT`, etc.), while reads will be
> routed through Materialize. Changes to the tables in the OLTP database are
> automatically streamed through Materialize.
> 
> The only supported OLTP database at the moment is PostgreSQL. Supporting
> other databases is complicated by the fact that we roughly followe
> Postgres's SQL semantics; using, say, MySQL, would be rather confusing,
> because `INSERT`, `UPDATE`, and `DELETE` statements would be subject to a
> wildly different set of SQL semantics than `SELECT` statements.
> 
> Symbiosis mode is only suitable for development. It is likely to be
> extremely slow and inefficient on large data sets.

The symbiosis implementation is an adapation of the code that used to
live in the sqllogictest runner, which has been ported to use the new
symbiosis system in Materialize proper.

To start materialized in symbiosis mode:

    $ materialized --symbiosis postgres://