### PR TITLE
deps: upgrade to uuid v0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-serde-bincode",
- "uuid",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -487,7 +487,7 @@ dependencies = [
  "tokio",
  "tokio-threadpool",
  "url",
- "uuid",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -737,7 +737,7 @@ dependencies = [
  "tokio",
  "url",
  "url_serde",
- "uuid",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -760,7 +760,7 @@ dependencies = [
  "serde_json",
  "url",
  "url_serde",
- "uuid",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -915,7 +915,7 @@ dependencies = [
  "regex-syntax",
  "repr",
  "serde",
- "uuid",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -2560,7 +2560,7 @@ dependencies = [
  "tokio-threadpool",
  "tokio-timer",
  "url",
- "uuid",
+ "uuid 0.7.4",
  "winreg",
 ]
 
@@ -2847,7 +2847,7 @@ dependencies = [
  "sqlparser",
  "unicase",
  "url",
- "uuid",
+ "uuid 0.8.1",
 ]
 
 [[package]]
@@ -2875,7 +2875,7 @@ dependencies = [
  "sqlparser",
  "timely",
  "tokio",
- "uuid",
+ "uuid 0.8.1",
  "walkdir",
 ]
 
@@ -3532,8 +3532,16 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
- "byteorder 1.3.2",
  "rand 0.6.5",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.2",
  "serde",
 ]
 

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -17,7 +17,7 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 tokio = "0.1"
 tokio-serde-bincode = "0.2"
-uuid = { version = "0.7.4", features = ["serde", "v4", "u128"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 ore = { path = "../ore" }
 
 [dev-dependencies]

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -40,7 +40,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features =
 tokio = "0.1"
 tokio-threadpool = "0.1"
 url = "1.7.2"
-uuid = { version = "0.7.4", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -15,7 +15,7 @@ repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
 url = "1.7.2"
 url_serde = "0.2.0"
-uuid = { version = "0.7.4", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -30,7 +30,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features =
 tokio = "0.1"
 url = "1.7.2"
 url_serde = "0.2.0"
-uuid = { version = "0.7.4", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -21,4 +21,4 @@ repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
 # TODO(grimmr): upgrade to 0.5.3 after release, when `space_()` becomes officially available.
 pretty = { git = "https://github.com/Marwes/pretty.rs.git", rev = "7fb895eff160b8bfd6d28efb19bf24f0b9326109" }
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"] }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -19,7 +19,7 @@ repr = { path = "../repr" }
 sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }
 unicase = "2.5.1"
 url = "1.7.2"
-uuid = { version = "0.7.4", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -33,5 +33,5 @@ sql = { path = "../sql" }
 sqlparser = { git = "ssh://git@github.com/MaterializeInc/sqlparser.git" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 tokio = "0.1"
-uuid = "*"
+uuid = "0.8"
 walkdir = "2"


### PR DESCRIPTION
Dependabot wasn't able to do this automatically, because the comm crate
was depending on a u128 feature that was removed in v0.8. Luckily, we're
no longer in need of that feature, so we can drop it from comm's
Cargo.toml.