### PR TITLE
Fix EC2 setup script for chbenchmark

### DIFF
--- a/ex/chbench/scripts/ec2-setup.sh
+++ b/ex/chbench/scripts/ec2-setup.sh
@@ -46,8 +46,6 @@ if [[ -z $docker_compose ]]; then
 fi
 groupadd -f docker
 usermod -aG docker ubuntu
-chmod 777 /mnt/docker
-chown -R ubuntu:docker /mnt/docker
 
 # Mount local SSD as swap
 existing_swap=$(grep swap /etc/fstab || true)


### PR DESCRIPTION
We were performing operations on /mnt/docker before it was created