### PR TITLE
Update timely version, and reduce logging volume.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,7 +2857,7 @@ dependencies = [
 name = "sqllogictest"
 version = "0.0.1"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 0.5.3",
  "chrono",
  "comm",
  "coord",
@@ -3135,7 +3135,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.10.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#78686d7f006db9a8f8cbd76161e44892918828db"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#939b215323e7f01dc85e2f8a9587e647866d9ed2"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -3149,12 +3149,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.10.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#78686d7f006db9a8f8cbd76161e44892918828db"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#939b215323e7f01dc85e2f8a9587e647866d9ed2"
 
 [[package]]
 name = "timely_communication"
 version = "0.10.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#78686d7f006db9a8f8cbd76161e44892918828db"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#939b215323e7f01dc85e2f8a9587e647866d9ed2"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -3169,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.10.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#78686d7f006db9a8f8cbd76161e44892918828db"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#939b215323e7f01dc85e2f8a9587e647866d9ed2"
 
 [[package]]
 name = "timely_sort"


### PR DESCRIPTION
This PR bumps the timely dependence to the new master that reduces logging volume, and performs some reductions of its own (creating log messages only for non-empty buffers, and then only in a vector as large as is required for the number of events).

There are some remaining opportunities, mostly to take advantage of our known logging frequency to increase the amount of batching done in our `BatchLogger`, which should be able to batch until the timestamp moves to the next granularity of time. This needs to be double-checked against our logic in the actual log processing dataflows, to ensure we are treating timestamps there appropriately.

cc @cuongdo @umanwizard 