### PR TITLE
Lie and say that we support transactions

### DIFF
--- a/src/coord/coordinator.rs
+++ b/src/coord/coordinator.rs
@@ -193,6 +193,10 @@ where
 
             Plan::SetVariable { name, .. } => ExecuteResponse::SetVariable { name },
 
+            Plan::StartTransaction => ExecuteResponse::StartTransaction,
+            Plan::Commit => ExecuteResponse::Commit,
+            Plan::Rollback => ExecuteResponse::Rollback,
+
             Plan::Peek {
                 mut source,
                 when,

--- a/src/coord/lib.rs
+++ b/src/coord/lib.rs
@@ -72,6 +72,8 @@ pub type RowsFuture = Box<dyn Future<Item = PeekResponse, Error = failure::Error
 
 /// Response from the queue to an `Execute` command.
 pub enum ExecuteResponse {
+    /// The current session has been taken out of transaction mode by COMMIT
+    Commit,
     CreatedSink,
     CreatedSource,
     CreatedTable,
@@ -82,10 +84,14 @@ pub enum ExecuteResponse {
     DroppedView,
     EmptyQuery,
     Inserted(usize),
+    /// The current session has been taken out of transaction mode by ROLLBACK
+    Rollback,
     SendRows(RowsFuture),
     SetVariable {
         name: String,
     },
+    /// The current session has been placed into transaction mode
+    StartTransaction,
     Tailing {
         rx: comm::mpsc::Receiver<Vec<Update>>,
     },
@@ -104,11 +110,14 @@ impl fmt::Debug for ExecuteResponse {
             ExecuteResponse::DroppedTable => f.write_str("ExecuteResponse::DroppedTable"),
             ExecuteResponse::DroppedView => f.write_str("ExecuteResponse::DroppedView"),
             ExecuteResponse::EmptyQuery => f.write_str("ExecuteResponse::EmptyQuery"),
+            ExecuteResponse::Commit => f.write_str("ExecuteResponse::Commit"),
+            ExecuteResponse::Rollback => f.write_str("ExecuteResponse::Rollback"),
             ExecuteResponse::Inserted(n) => write!(f, "ExecuteResponse::Inserted({})", n),
             ExecuteResponse::SendRows(_) => write!(f, "ExecuteResponse::SendRows(<rx>)"),
             ExecuteResponse::SetVariable { name } => {
                 write!(f, "ExecuteResponse::SetVariable({})", name)
             }
+            ExecuteResponse::StartTransaction => f.write_str("ExecuteResponse::StartTransaction"),
             ExecuteResponse::Tailing { rx: _ } => f.write_str("ExecuteResponse::Tailing"),
             ExecuteResponse::Updated(n) => write!(f, "ExecuteResponse::Updated({})", n),
         }

--- a/src/coord/transient.rs
+++ b/src/coord/transient.rs
@@ -170,6 +170,8 @@ fn apply_plan(
             }
         }
         Plan::SetVariable { name, value } => session.set(name, value)?,
+        Plan::StartTransaction => session.start_transaction(),
+        Plan::Commit | Plan::Rollback => session.end_transaction(),
         _ => (),
     }
     Ok(())

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -14,7 +14,7 @@ use sqlparser::dialect::AnsiDialect;
 use sqlparser::parser::Parser as SqlParser;
 use store::{Catalog, CatalogItem};
 
-pub use session::{PreparedStatement, Session};
+pub use session::{PreparedStatement, Session, TransactionStatus};
 pub use sqlparser::ast::{ObjectType, Statement};
 
 mod expr;
@@ -45,6 +45,18 @@ pub enum Plan {
         name: String,
         value: String,
     },
+    /// Nothing needs to happen, but the frontend must be notified
+    StartTransaction,
+    /// Commit a transaction
+    ///
+    /// We don't do anything for transactions, so other than changing the session state
+    /// this is a no-op
+    Commit,
+    /// Rollback a transaction
+    ///
+    /// We don't do anything for transactions, so other than changing the session state
+    /// this is a no-op
+    Rollback,
     Peek {
         source: ::expr::RelationExpr,
         when: PeekWhen,

--- a/src/sql/session.rs
+++ b/src/sql/session.rs
@@ -27,9 +27,12 @@
 
 #![forbid(missing_docs)]
 
+#[allow(clippy::module_inception)]
 mod session;
-mod statements;
-mod vars;
+mod statement;
+mod transaction;
+mod var;
 
 pub use session::Session;
-pub use statements::{Portal, PreparedStatement};
+pub use statement::{Portal, PreparedStatement};
+pub use transaction::TransactionStatus;

--- a/src/sql/session/statement.rs
+++ b/src/sql/session/statement.rs
@@ -1,3 +1,8 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
 //! PreparedStatements maintain in-progress state during a session
 //!
 //! In postgres there are two ways to construct prepared statements:

--- a/src/sql/session/transaction.rs
+++ b/src/sql/session/transaction.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+/// The current transaction status of a Session
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransactionStatus {
+    /// Not currently in a transaction
+    Idle,
+    /// Currently in a transaction
+    InTransaction,
+    /// Currently in a transaction block which is failed
+    Failed,
+}

--- a/src/sql/session/var.rs
+++ b/src/sql/session/var.rs
@@ -1,3 +1,8 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
 //! Variables that can be set by users or the server
 //!
 //! Some of these can be set by the `SET` sql statement, see the top-level `session` docs

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -42,6 +42,9 @@ pub fn describe_statement(
         | Statement::CreateView { .. }
         | Statement::Drop { .. }
         | Statement::SetVariable { .. }
+        | Statement::StartTransaction { .. }
+        | Statement::Rollback { .. }
+        | Statement::Commit { .. }
         | Statement::Tail { .. } => (None, vec![]),
 
         Statement::CreateSources { .. } => (
@@ -134,6 +137,9 @@ pub fn handle_statement(
     match stmt {
         Statement::Peek { name, immediate } => handle_peek(catalog, name, immediate),
         Statement::Tail { name } => handle_tail(catalog, name),
+        Statement::StartTransaction { .. } => handle_start_transaction(),
+        Statement::Commit { .. } => handle_commit_transaction(),
+        Statement::Rollback { .. } => handle_rollback_transaction(),
         Statement::CreateSource { .. }
         | Statement::CreateSink { .. }
         | Statement::CreateView { .. }
@@ -226,6 +232,18 @@ fn handle_tail(catalog: &Catalog, from: ObjectName) -> Result<Plan, failure::Err
     let from = extract_sql_object_name(&from)?;
     let dataflow = catalog.get(&from)?;
     Ok(Plan::Tail(dataflow.clone()))
+}
+
+fn handle_start_transaction() -> Result<Plan, failure::Error> {
+    Ok(Plan::StartTransaction)
+}
+
+fn handle_commit_transaction() -> Result<Plan, failure::Error> {
+    Ok(Plan::Commit)
+}
+
+fn handle_rollback_transaction() -> Result<Plan, failure::Error> {
+    Ok(Plan::Rollback)
 }
 
 fn handle_show_objects(

--- a/test/transactions.slt
+++ b/test/transactions.slt
@@ -1,0 +1,64 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t (a int)
+
+statement ok
+INSERT INTO t (a) VALUES (1)
+
+#### next transaction
+
+statement ok
+BEGIN
+
+query I rowsort
+SELECT * FROM t
+----
+1
+
+statement ok
+COMMIT
+
+#### next transaction
+
+statement ok
+BEGIN
+
+query I rowsort
+SELECT * FROM t
+----
+1
+
+statement ok
+ROLLBACK
+
+#### next transaction
+
+statement ok
+START TRANSACTION
+
+query I rowsort
+SELECT * FROM t
+----
+1
+
+statement ok
+COMMIT
+
+#### next transaction
+
+statement ok
+START TRANSACTION
+
+query I rowsort
+SELECT * FROM t
+----
+1
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
This plumbs the initial support for transactions through materialized -- we don't _do_
anything for transactions, but we can support users requesting them.

While for the most part the fact that we're lying about it should have limited observable
effect, there are two obvious cases where the fact that we don't actually do anything for
transactions could be user visible:

* Since we don't freeze timestamps, it is possible that peeks at views from the same
  source see things at different timestamps. It's unclear what the semantics of PEEKs
  across different sources should be.
* Also when doing `CREATE` various things we could take advantage of transactions to not
  create anything in the case of a rollback, and maybe to take a wholistic view on
  arrangement/view creation inside the transaction.

Part of MaterializeInc/database-issues#295

----

One thing that I'm not sure how I feel about is storing `TransactionStatus` as a
`SessionVar`, it's not really a variable in the same way as the other kinds of vars in
that file, and I think it will eventually grow out to its own semi-complex thing like
statements, but for now it seems kind of okay.