### PR TITLE
Batch logging messages

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -217,13 +217,16 @@ where
             use crate::logging::BatchLogger;
             use timely::dataflow::operators::capture::event::link::EventLink;
 
+            let granularity_ms =
+                std::cmp::max(1, logging.granularity_ns() / 1_000_000) as Timestamp;
+
             // Establish loggers first, so we can either log the logging or not, as we like.
             let t_linked = std::rc::Rc::new(EventLink::new());
-            let mut t_logger = BatchLogger::new(t_linked.clone());
+            let mut t_logger = BatchLogger::new(t_linked.clone(), granularity_ms);
             let d_linked = std::rc::Rc::new(EventLink::new());
-            let mut d_logger = BatchLogger::new(d_linked.clone());
+            let mut d_logger = BatchLogger::new(d_linked.clone(), granularity_ms);
             let m_linked = std::rc::Rc::new(EventLink::new());
-            let mut m_logger = BatchLogger::new(m_linked.clone());
+            let mut m_logger = BatchLogger::new(m_linked.clone(), granularity_ms);
 
             // Construct logging dataflows and endpoints before registering any.
             let t_traces = logging::timely::construct(&mut self.inner, logging, t_linked);


### PR DESCRIPTION
Logging messages can be batched based on the timestamp used, until the point that the timestamp will no longer be used. Based on our logging granularity, we can batch more aggressively, because this timestamp changes relatively less frequently.

This PR relies on the assumption that all log analysis will advance their timestamps by the same logic, and things will go off the rails if this is not true. This may not be detected if violated, because the log machinery is minting their own progress traffic. We could be more conservative with capabilities (e.g. rounding down rather than up, to the nearest `granularity_ms`) but rounding up is *supposed* to work.