### PR TITLE
gitignore: don't include editor-specific entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
+# Editor or environment-specific entries should not be committed to the
+# repository but can be kept in Git's global configuration:
+#
+# https://help.github.com/articles/ignoring-files/#create-a-global-gitignore
+#
+# For advice on what entries to include in your global gitignore, please see
+# GitHub's gitignore repository, which contains an excellent set of entries for
+# many different editing tools:
+#
+# https://github.com/github/gitignore/tree/master/Global
+
 target
 /.cargo
 .mtrlz.log
-**/*.rs.bk
-.idea
-.envrc
-doc/user/public
-doc/user/resources
-doc/user/util/rr-diagram-gen/rr-diagram-gen
+*.rs.bk

--- a/doc/user/.gitignore
+++ b/doc/user/.gitignore
@@ -1,0 +1,2 @@
+/public
+/resources

--- a/doc/user/util/rr-diagram-gen/.gitignore
+++ b/doc/user/util/rr-diagram-gen/.gitignore
@@ -1,0 +1,1 @@
+rr-diagram-gen

--- a/misc/docker/ci-materialized/.gitignore
+++ b/misc/docker/ci-materialized/.gitignore
@@ -1,1 +1,1 @@
-materialized
+/materialized

--- a/misc/docker/ci-metrics/.gitignore
+++ b/misc/docker/ci-metrics/.gitignore
@@ -1,1 +1,1 @@
-metrics
+/metrics


### PR DESCRIPTION
Don't include editor-specific entries. We don't want to be in the
business of ignoring every user's editor's mess. That's what the global
gitignore file is for.

Also move some doc/user specific entries to doc/user/.gitignore, to
limit the entries in the global gitignore to those that apply globally.

Finally, standardize on glob syntax. Entries that start with a slash
apply to entries at the level of the gitignore; other entries match at
any level beneath the level of the gitignore.

@jamii does this impact you unduly? Is there some (Nix-related?) reason that you can't ignore `.envrc` in ~/.config/git/ignore or .git/info/exclude?