### PR TITLE
docs: automatically create links to headers

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -86,3 +86,7 @@ Note that this process will be more automated in the near future.
 - Headers are not linkable.
 - Pages have no TOC feature.
 - Is not "responsive" and makes naive decisions about breakpoints. If someone would like to volunteer their web development expertise to make this more sane, I would be really happy to help them out.
+
+# Miscellany, Trivia, & Footguns
+
+- Headers are automatically hyperlinked using `/doc/user/layouts/partials/content-parser.html`, inspired by [this Hugo thread](https://discourse.gohugo.io/t/adding-anchor-next-to-headers/1726/8), and more specifically [kaushalmodi/hugo-onyx-theme](https://github.com/kaushalmodi/hugo-onyx-theme/blob/cd232177f1af37f5371d252f8401ce049dc52db8/layouts/partials/headline-hash.html).

--- a/doc/user/assets/sass/_docs_body.scss
+++ b/doc/user/assets/sass/_docs_body.scss
@@ -37,4 +37,11 @@ main {
   .list-page {
     min-height: 60vh;
   }
+
+  .headline-hash {
+    color: black;
+    &:hover {
+      opacity: 0.75;
+    }
+  }
 }

--- a/doc/user/layouts/_default/single.html
+++ b/doc/user/layouts/_default/single.html
@@ -2,6 +2,6 @@
 
 <h1>{{.Title}}</h1>
 
-{{.Content}}
+{{ partial "content-parser.html" .Content }}
 
 {{end}}

--- a/doc/user/layouts/index.html
+++ b/doc/user/layouts/index.html
@@ -7,6 +7,6 @@
 </div>
 <div class="homepage-content">
     <!-- Note that the content for index.html, as a sort of list page, will pull from content/_index.md -->
-    {{.Content}}
+    {{ partial "content-parser.html" .Content }}
 </div>
 {{ end }}

--- a/doc/user/layouts/partials/content-parser.html
+++ b/doc/user/layouts/partials/content-parser.html
@@ -1,0 +1,2 @@
+<!-- headline hasher -->
+{{ . | replaceRE "(<h[2-9] id=\"([^\"]+)\".+)(</h[2-9]+>)" `<a class="headline-hash" href="#${2}">${1}&nbsp;</a> ${3}` | safeHTML }}


### PR DESCRIPTION
Add self-referencing anchor links to all headers; i.e. click a header to get a link to it.

Let me know if this genre of review can also be fielded by anyone else, @benesch.