### PR TITLE
SHOW OBJECTS should show all objects by default

### DIFF
--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -233,7 +233,7 @@ fn handle_show_objects(
     object_type: ObjectType,
     like: Option<String>,
 ) -> Result<Plan, failure::Error> {
-    let like_regex = build_like_regex_from_string(like.as_ref().unwrap_or(&String::from(".")))?;
+    let like_regex = build_like_regex_from_string(like.as_ref().unwrap_or(&String::from("%")))?;
     let mut rows: Vec<Row> = catalog
         .iter()
         .filter(|(name, ci)| object_type_matches(object_type, ci) && like_regex.is_match(name))

--- a/test/basic.td
+++ b/test/basic.td
@@ -72,6 +72,22 @@ Field Nullable Type
 b     NO       int8
 sum   YES      int8
 
+> SHOW TABLES;
+data
+logs_addresses
+logs_arrangement
+logs_channels
+logs_dataflow_dependency
+logs_dataflows
+logs_elapsed
+logs_frontiers
+logs_histogram
+logs_operates
+logs_parks
+logs_peek_durations
+logs_peeks
+logs_sharing
+
 > SHOW TABLES LIKE '%peeks%';
 logs_peeks
 


### PR DESCRIPTION
Seeing if there's a way to count tables instead of listing them...