### PR TITLE
expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,43 @@
 # Materialize
 
-Materialize provides streaming SQL materialized views on top of
-[differential dataflow].
+Materialize provides streaming SQL materialized views on top of [Differential
+dataflow].
 
 ⚠️  Materialize is a work in progress. Expect things to break frequently. ⚠️
 
 [differential dataflow]: https://github.com/TimelyDataflow/differential-dataflow
 
+## Features
+
+- Real-time analysis of your streaming data, capable handling of millions of
+  updates per second.
+- ANSI Standard SQL (and more), including joins.
+- Distributed. Replicated. Highly Available.
+- Flexible deployments can scale up and down.
+
+## Get started
+
+Check out [our getting started guide](doc/user/content/get-started.md).
+
 ## Documentation
 
-High level documentation is stored in the [doc](doc) folder of this
-repository. Table of contents:
+This repo contains Materialize's user documentation and documentation site at
+[doc/user/](doc/user), including:
 
-  * [Architecture overview](doc/user/content/overview/what-is-materialize.md)
-  * [Architecture overview](doc/user/content/overview/architecture.md)
-  * [Developer guide](doc/deverloper/develop.md)
-  * [Demo instructions](doc/developer/demo.md)
+- [What is Materialize?](doc/user/content/overview/what-is-materialize.md)
+- [Architecture overview](doc/user/content/overview/architecture.md)
+
+### Developer docs
+
+Materialize's developers can find docs at [doc/developer](doc/developer),
+including:
+
+- [Developer guide](doc/deverloper/develop.md)
+- [Demo instructions](doc/developer/demo.md)
 
 API documentation is hosted at <https://mtrlz.dev/api/>.
+
+## Roadmap
+
+Follow our roadmap [on
+GitHub](https://github.com/MaterializeInc/materialize/issues/31).


### PR DESCRIPTION
Adds some more detail to the main `README`.

@rjnn Is this the kind of thing you were looking for from MaterializeInc/database-issues#65 ? This is a pretty lean interpretation of that issue, but think `README`s are best as something akin to skimmable landing pages.

Closes MaterializeInc/database-issues#65 