### PR TITLE
ci/test: skip rust steps when no rust changed

### DIFF
--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -5,7 +5,7 @@
 # This file is part of Materialize. Materialize may not be used or
 # distributed without the express permission of Materialize, Inc.
 #
-# build.host.sh — packages test binaries into Docker images in CI.
+# build.sh — packages test binaries into Docker images in CI.
 
 set -euo pipefail
 

--- a/ci/test/mkpipeline.sh
+++ b/ci/test/mkpipeline.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+#
+# mkpipeline.sh — dynamically renders a pipeline.yml for Buildkite.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+. misc/shlib/shlib.bash
+
+# changes_matching GLOB
+#
+# Reports whether there were any changes on this branch in a file whose name
+# matches GLOB. Note that this function always returns true if there were any
+# changes to the build configuration itself.
+changes_matching() {
+    if git diff --no-patch --quiet origin/master... -- "bin/*" "ci/*" "$@"; then
+        echo false
+    else
+        echo true
+    fi
+}
+
+CHANGED_DOC_USER=$(changes_matching "doc/user/*")
+CHANGED_RUST=$(changes_matching "src/*" Cargo.lock)
+CHANGED_SLT=$(changes_matching "test/*.slt" "test/**/*.slt")
+CHANGED_TESTDRIVE=$(changes_matching "test/*.td" "test/**/*.td")
+export CHANGED_DOC_USER CHANGED_RUST CHANGED_SLT CHANGED_TESTDRIVE
+
+run git diff --stat origin/master...
+env | grep CHANGED
+
+buildkite-agent pipeline upload ci/test/pipeline.yml

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -9,12 +9,13 @@ steps:
   - id: build
     label: ":docker: build"
     command: ci/test/build.sh
+    if: $CHANGED_RUST || $CHANGED_SLT || $CHANGED_TESTDRIVE || build.branch == "master"
     timeout_in_minutes: 30
     agents:
       queue: builder
 
   - id: lint-fast
-    label: ":bath: lint and rustfmt"
+    label: Fast linters
     command: ci/test/lint-fast.sh
     timeout_in_minutes: 10
     plugins:
@@ -28,8 +29,9 @@ steps:
           - CARGO_HOME=/cargo
 
   - id: lint-slow
-    label: ":paperclip: clippy and doctests"
+    label: ":japanese_ogre: Lint and Format"
     command: ci/test/lint-slow.sh
+    if: $CHANGED_RUST
     timeout_in_minutes: 30
     plugins:
       - docker#v3.1.0:
@@ -52,6 +54,7 @@ steps:
       - docker-compose#v3.0.3:
           config: ci/test/cargo-test.compose.yml
           run: app
+    if: $CHANGED_RUST
 
   - id: testdrive
     label: ":racing_car: testdrive"
@@ -62,6 +65,7 @@ steps:
       - docker-compose#v3.0.3:
           config: ci/test/testdrive.compose.yml
           run: testdrive
+    if: $CHANGED_RUST || $CHANGED_TESTDRIVE
 
   - id: short-sqllogictest
     label: ":bulb: Short SQL logic tests"
@@ -75,6 +79,7 @@ steps:
       - docker-compose#v3.0.3:
           config: ci/slt/docker-compose.yml
           run: sqllogictest
+    if: $CHANGED_RUST || $CHANGED_SLT
 
   - id: full-sqllogictest
     label: ":bulb: :bulb: Full SQL logic tests"


### PR DESCRIPTION
This will make landing docs PRs way more pleasant.

Addresses half of MaterializeInc/database-issues#299.