### PR TITLE
Reduce dataflows created for peeks.

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -12,7 +12,7 @@
 // Clippy doesn't understand `as_of` and complains.
 #![allow(clippy::wrong_self_convention)]
 
-use expr::{ColumnOrder, RelationExpr, ScalarExpr};
+use expr::{ColumnOrder, RelationExpr};
 use repr::{Datum, RelationDesc, Row};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -87,8 +87,6 @@ pub fn compare_columns(order: &[ColumnOrder], left: &[Datum], right: &[Datum]) -
 /// trivial peeks.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RowSetFinishing {
-    /// Include only rows matching all predicates.
-    pub filter: Vec<ScalarExpr>,
     /// Order rows by the given columns.
     pub order_by: Vec<ColumnOrder>,
     /// Include only as many rows (after offset).

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -165,7 +165,6 @@ fn plan_query(
     }
 
     let finishing = RowSetFinishing {
-        filter: vec![],
         order_by,
         limit,
         project: (0..output_typ.column_types.len()).collect(),

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -515,7 +515,6 @@ fn handle_peek(
             PeekWhen::EarliestSource
         },
         finishing: RowSetFinishing {
-            filter: vec![],
             offset: 0,
             limit: None,
             order_by: (0..typ.column_types.len())


### PR DESCRIPTION
This PR reduces the number of dataflows created for peeks by handling both projections and filters in the peek processsing pipeline, so that if the query is an optional projection around an optional filter around a get, we can process the query without dataflow construction. This should ease the load on the system, and reduce the amount of random nonsense the system has to do in response to relatively easy peek and select queries.

Fixes MaterializeInc/database-issues#232