### PR TITLE
docs: add util for generating SVGs for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 .envrc
 doc/user/public
 doc/user/resources
+doc/user/util/rr-diagram-gen/rr-diagram-gen

--- a/doc/user/layouts/partials/sql-grammar/rr-diagrams/create-source.html
+++ b/doc/user/layouts/partials/sql-grammar/rr-diagrams/create-source.html
@@ -1,35 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="467" height="147">
-    <polygon points="9 17 1 13 1 21" />
-    <polygon points="17 17 9 13 9 21" />
-    <rect x="31" y="3" width="132" height="32" rx="10" />
-    <rect x="29" y="1" width="132" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="39" y="21">CREATE SOURCE</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#src_name" xlink:title="src_name">
-        <rect x="183" y="3" width="82" height="32" />
-        <rect x="181" y="1" width="82" height="32" class="nonterminal" />
-        <text class="nonterminal" x="191" y="21">src_name</text></a>
-    <rect x="285" y="3" width="60" height="32" rx="10" />
-    <rect x="283" y="1" width="60" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="293" y="21">FROM</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#kafka_src" xlink:title="kafka_src">
-        <rect x="365" y="3" width="80" height="32" />
-        <rect x="363" y="1" width="80" height="32" class="nonterminal" />
-        <text class="nonterminal" x="373" y="21">kafka_src</text></a>
-    <rect x="51" y="69" width="126" height="32" rx="10" />
-    <rect x="49" y="67" width="126" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="59" y="87">USING SCHEMA</text>
-    <rect x="217" y="69" width="88" height="32" rx="10" />
-    <rect x="215" y="67" width="88" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="225" y="87">REGISTRY</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#registry_src" xlink:title="registry_src">
-        <rect x="325" y="69" width="94" height="32" />
-        <rect x="323" y="67" width="94" height="32" class="nonterminal" />
-        <text class="nonterminal" x="333" y="87">registry_src</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#avro_schema" xlink:title="avro_schema">
-        <rect x="217" y="113" width="104" height="32" />
-        <rect x="215" y="111" width="104" height="32" class="nonterminal" />
-        <text class="nonterminal" x="225" y="131">avro_schema</text></a>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line"
-        d="m17 17 h2 m0 0 h10 m132 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-438 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m20 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3" />
-    <polygon points="457 83 465 79 465 87" />
-    <polygon points="457 83 449 79 449 87" /></svg>
+<svg width="613" height="147">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="132" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="132" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE SOURCE</text><rect x="183" y="3" width="82" height="32"></rect><rect x="181" y="1" width="82" height="32" class="nonterminal"></rect><text class="nonterminal" x="191" y="21">src_name</text><rect x="285" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="283" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="293" y="21">FROM</text><rect x="365" y="3" width="80" height="32"></rect><rect x="363" y="1" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="373" y="21">kafka_src</text><rect x="465" y="3" width="126" height="32" rx="10"></rect>
+         <rect x="463" y="1" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="473" y="21">USING SCHEMA</text>
+         <rect x="363" y="69" width="88" height="32" rx="10"></rect>
+         <rect x="361" y="67" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="371" y="87">REGISTRY</text><rect x="471" y="69" width="94" height="32"></rect><rect x="469" y="67" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="479" y="87">registry_src</text><rect x="363" y="113" width="104" height="32"></rect><rect x="361" y="111" width="104" height="32" class="nonterminal"></rect><text class="nonterminal" x="371" y="131">avro_schema</text><path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3"></path>
+         <polygon points="603 83 611 79 611 87"></polygon>
+         <polygon points="603 83 595 79 595 87"></polygon></svg>

--- a/doc/user/layouts/partials/sql-grammar/rr-diagrams/create-sources.html
+++ b/doc/user/layouts/partials/sql-grammar/rr-diagrams/create-sources.html
@@ -1,38 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="541" height="179">
-    <polygon points="11 17 3 13 3 21" />
-    <polygon points="19 17 11 13 11 21" />
-    <rect x="33" y="3" width="142" height="32" rx="10" />
-    <rect x="31" y="1" width="142" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="41" y="21">CREATE SOURCES</text>
-    <rect x="215" y="35" width="52" height="32" rx="10" />
-    <rect x="213" y="33" width="52" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="223" y="53">LIKE</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#schema_expr" xlink:title="schema_expr">
-        <rect x="287" y="35" width="104" height="32" />
-        <rect x="285" y="33" width="104" height="32" class="nonterminal" />
-        <text class="nonterminal" x="295" y="53">schema_expr</text></a>
-    <rect x="431" y="3" width="60" height="32" rx="10" />
-    <rect x="429" y="1" width="60" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="439" y="21">FROM</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#kafka_src" xlink:title="kafka_src">
-        <rect x="25" y="101" width="80" height="32" />
-        <rect x="23" y="99" width="80" height="32" class="nonterminal" />
-        <text class="nonterminal" x="33" y="119">kafka_src</text></a>
-    <rect x="125" y="101" width="126" height="32" rx="10" />
-    <rect x="123" y="99" width="126" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="133" y="119">USING SCHEMA</text>
-    <rect x="291" y="101" width="88" height="32" rx="10" />
-    <rect x="289" y="99" width="88" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="299" y="119">REGISTRY</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#registry_src" xlink:title="registry_src">
-        <rect x="399" y="101" width="94" height="32" />
-        <rect x="397" y="99" width="94" height="32" class="nonterminal" />
-        <text class="nonterminal" x="407" y="119">registry_src</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#avro_schema" xlink:title="avro_schema">
-        <rect x="291" y="145" width="104" height="32" />
-        <rect x="289" y="143" width="104" height="32" class="nonterminal" />
-        <text class="nonterminal" x="299" y="163">avro_schema</text></a>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line"
-        d="m19 17 h2 m0 0 h10 m142 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m52 0 h10 m0 0 h10 m104 0 h10 m20 -32 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-510 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3" />
-    <polygon points="531 115 539 111 539 119" />
-    <polygon points="531 115 523 111 523 119" /></svg>
+<svg width="611" height="179">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="142" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="142" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE SOURCES</text>
+         <rect x="213" y="35" width="52" height="32" rx="10"></rect>
+         <rect x="211" y="33" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="221" y="53">LIKE</text><rect x="285" y="35" width="104" height="32"></rect><rect x="283" y="33" width="104" height="32" class="nonterminal"></rect><text class="nonterminal" x="293" y="53">schema_expr</text><rect x="429" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="427" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="437" y="21">FROM</text><rect x="509" y="3" width="80" height="32"></rect><rect x="507" y="1" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="517" y="21">kafka_src</text><rect x="195" y="101" width="126" height="32" rx="10"></rect>
+         <rect x="193" y="99" width="126" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="203" y="119">USING SCHEMA</text>
+         <rect x="361" y="101" width="88" height="32" rx="10"></rect>
+         <rect x="359" y="99" width="88" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="369" y="119">REGISTRY</text><rect x="469" y="101" width="94" height="32"></rect><rect x="467" y="99" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="477" y="119">registry_src</text><rect x="361" y="145" width="104" height="32"></rect><rect x="359" y="143" width="104" height="32" class="nonterminal"></rect><text class="nonterminal" x="369" y="163">avro_schema</text><path class="line" d="m17 17 h2 m0 0 h10 m142 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m52 0 h10 m0 0 h10 m104 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-438 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m20 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3"></path>
+         <polygon points="601 115 609 111 609 119"></polygon>
+         <polygon points="601 115 593 111 593 119"></polygon></svg>

--- a/doc/user/layouts/partials/sql-grammar/rr-diagrams/create-view.html
+++ b/doc/user/layouts/partials/sql-grammar/rr-diagrams/create-view.html
@@ -1,27 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="555" height="135">
-    <polygon points="9 17 1 13 1 21" />
-    <polygon points="17 17 9 13 9 21" />
-    <rect x="31" y="3" width="72" height="32" rx="10" />
-    <rect x="29" y="1" width="72" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="39" y="21">CREATE</text>
-    <rect x="143" y="35" width="122" height="32" rx="10" />
-    <rect x="141" y="33" width="122" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="151" y="53">MATERIALIZED</text>
-    <rect x="305" y="3" width="58" height="32" rx="10" />
-    <rect x="303" y="1" width="58" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="313" y="21">VIEW</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#view_name" xlink:title="view_name">
-        <rect x="383" y="3" width="92" height="32" />
-        <rect x="381" y="1" width="92" height="32" class="nonterminal" />
-        <text class="nonterminal" x="391" y="21">view_name</text></a>
-    <rect x="495" y="3" width="38" height="32" rx="10" />
-    <rect x="493" y="1" width="38" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="503" y="21">AS</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#select_stmt" xlink:title="select_stmt">
-        <rect x="433" y="101" width="94" height="32" />
-        <rect x="431" y="99" width="94" height="32" class="nonterminal" />
-        <text class="nonterminal" x="441" y="119">select_stmt</text></a>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line"
-        d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m58 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3" />
-    <polygon points="545 115 553 111 553 119" />
-    <polygon points="545 115 537 111 537 119" /></svg>
+<svg width="555" height="135">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="72" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CREATE</text>
+         <rect x="143" y="35" width="122" height="32" rx="10"></rect>
+         <rect x="141" y="33" width="122" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="151" y="53">MATERIALIZED</text>
+         <rect x="305" y="3" width="58" height="32" rx="10"></rect>
+         <rect x="303" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="313" y="21">VIEW</text><rect x="383" y="3" width="92" height="32"></rect><rect x="381" y="1" width="92" height="32" class="nonterminal"></rect><text class="nonterminal" x="391" y="21">view_name</text><rect x="495" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="493" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="503" y="21">AS</text><rect x="433" y="101" width="94" height="32"></rect><rect x="431" y="99" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="441" y="119">select_stmt</text><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m58 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
+         <polygon points="545 115 553 111 553 119"></polygon>
+         <polygon points="545 115 537 111 537 119"></polygon></svg>

--- a/doc/user/layouts/partials/sql-grammar/rr-diagrams/join-expr.html
+++ b/doc/user/layouts/partials/sql-grammar/rr-diagrams/join-expr.html
@@ -1,66 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="717" height="377">
-    <polygon points="9 17 1 13 1 21" />
-    <polygon points="17 17 9 13 9 21" /><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#select_pred"
-        xlink:title="select_pred">
-        <rect x="31" y="3" width="94" height="32" />
-        <rect x="29" y="1" width="94" height="32" class="nonterminal" />
-        <text class="nonterminal" x="39" y="21">select_pred</text></a>
-    <rect x="65" y="69" width="66" height="32" rx="10" />
-    <rect x="63" y="67" width="66" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="73" y="87">CROSS</text>
-    <rect x="65" y="113" width="84" height="32" rx="10" />
-    <rect x="63" y="111" width="84" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="73" y="131">NATURAL</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#join_type" xlink:title="join_type">
-        <rect x="189" y="145" width="80" height="32" />
-        <rect x="187" y="143" width="80" height="32" class="nonterminal" />
-        <text class="nonterminal" x="197" y="163">join_type</text></a>
-    <rect x="329" y="69" width="54" height="32" rx="10" />
-    <rect x="327" y="67" width="54" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="337" y="87">JOIN</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#table_ref" xlink:title="table_ref">
-        <rect x="403" y="69" width="78" height="32" />
-        <rect x="401" y="67" width="78" height="32" class="nonterminal" />
-        <text class="nonterminal" x="411" y="87">table_ref</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#join_type" xlink:title="join_type">
-        <rect x="65" y="265" width="80" height="32" />
-        <rect x="63" y="263" width="80" height="32" class="nonterminal" />
-        <text class="nonterminal" x="73" y="283">join_type</text></a>
-    <rect x="185" y="233" width="54" height="32" rx="10" />
-    <rect x="183" y="231" width="54" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="193" y="251">JOIN</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#table_ref" xlink:title="table_ref">
-        <rect x="259" y="233" width="78" height="32" />
-        <rect x="257" y="231" width="78" height="32" class="nonterminal" />
-        <text class="nonterminal" x="267" y="251">table_ref</text></a>
-    <rect x="377" y="233" width="64" height="32" rx="10" />
-    <rect x="375" y="231" width="64" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="385" y="251">USING</text>
-    <rect x="461" y="233" width="26" height="32" rx="10" />
-    <rect x="459" y="231" width="26" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="469" y="251">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#col_ref"
-        xlink:title="col_ref">
-        <rect x="527" y="233" width="62" height="32" />
-        <rect x="525" y="231" width="62" height="32" class="nonterminal" />
-        <text class="nonterminal" x="535" y="251">col_ref</text></a>
-    <rect x="527" y="189" width="24" height="32" rx="10" />
-    <rect x="525" y="187" width="24" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="535" y="207">,</text>
-    <rect x="629" y="233" width="26" height="32" rx="10" />
-    <rect x="627" y="231" width="26" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="637" y="251">)</text>
-    <rect x="377" y="277" width="40" height="32" rx="10" />
-    <rect x="375" y="275" width="40" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="385" y="295">ON</text><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#expression" xlink:title="expression">
-        <rect x="437" y="277" width="90" height="32" />
-        <rect x="435" y="275" width="90" height="32" class="nonterminal" />
-        <text class="nonterminal" x="445" y="295">expression</text></a><a xmlns:xlink="http://www.w3.org/1999/xlink"
-        xlink:href="#select_post" xlink:title="select_post">
-        <rect x="595" y="343" width="94" height="32" />
-        <rect x="593" y="341" width="94" height="32" class="nonterminal" />
-        <text class="nonterminal" x="603" y="361">select_post</text></a>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line"
-        d="m17 17 h2 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m66 0 h10 m0 0 h158 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m84 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -76 h10 m54 0 h10 m0 0 h10 m78 0 h10 m0 0 h194 m-670 0 h20 m650 0 h20 m-690 0 q10 0 10 10 m670 0 q0 -10 10 -10 m-680 10 v144 m670 0 v-144 m-670 144 q0 10 10 10 m650 0 q10 0 10 -10 m-640 10 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -32 h10 m54 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m40 0 h10 m0 0 h10 m90 0 h10 m0 0 h128 m42 -208 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 274 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3" />
-    <polygon points="707 357 715 353 715 361" />
-    <polygon points="707 357 699 353 699 361" /></svg>
+<svg width="717" height="377">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><rect x="31" y="3" width="94" height="32"></rect><rect x="29" y="1" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="39" y="21">select_pred</text><rect x="65" y="69" width="66" height="32" rx="10"></rect>
+         <rect x="63" y="67" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="87">CROSS</text>
+         <rect x="65" y="113" width="84" height="32" rx="10"></rect>
+         <rect x="63" y="111" width="84" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="73" y="131">NATURAL</text><rect x="189" y="145" width="80" height="32"></rect><rect x="187" y="143" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="197" y="163">join_type</text><rect x="329" y="69" width="54" height="32" rx="10"></rect>
+         <rect x="327" y="67" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="337" y="87">JOIN</text><rect x="403" y="69" width="78" height="32"></rect><rect x="401" y="67" width="78" height="32" class="nonterminal"></rect><text class="nonterminal" x="411" y="87">table_ref</text><rect x="65" y="265" width="80" height="32"></rect><rect x="63" y="263" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="73" y="283">join_type</text><rect x="185" y="233" width="54" height="32" rx="10"></rect>
+         <rect x="183" y="231" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="193" y="251">JOIN</text><rect x="259" y="233" width="78" height="32"></rect><rect x="257" y="231" width="78" height="32" class="nonterminal"></rect><text class="nonterminal" x="267" y="251">table_ref</text><rect x="377" y="233" width="64" height="32" rx="10"></rect>
+         <rect x="375" y="231" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="385" y="251">USING</text>
+         <rect x="461" y="233" width="26" height="32" rx="10"></rect>
+         <rect x="459" y="231" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="469" y="251">(</text><rect x="527" y="233" width="62" height="32"></rect><rect x="525" y="231" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="535" y="251">col_ref</text><rect x="527" y="189" width="24" height="32" rx="10"></rect>
+         <rect x="525" y="187" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="535" y="207">,</text>
+         <rect x="629" y="233" width="26" height="32" rx="10"></rect>
+         <rect x="627" y="231" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="637" y="251">)</text>
+         <rect x="377" y="277" width="40" height="32" rx="10"></rect>
+         <rect x="375" y="275" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="385" y="295">ON</text><rect x="437" y="277" width="90" height="32"></rect><rect x="435" y="275" width="90" height="32" class="nonterminal"></rect><text class="nonterminal" x="445" y="295">expression</text><rect x="595" y="343" width="94" height="32"></rect><rect x="593" y="341" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="603" y="361">select_post</text><path class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m66 0 h10 m0 0 h158 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m84 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -76 h10 m54 0 h10 m0 0 h10 m78 0 h10 m0 0 h194 m-670 0 h20 m650 0 h20 m-690 0 q10 0 10 10 m670 0 q0 -10 10 -10 m-680 10 v144 m670 0 v-144 m-670 144 q0 10 10 10 m650 0 q10 0 10 -10 m-640 10 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -32 h10 m54 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m40 0 h10 m0 0 h10 m90 0 h10 m0 0 h128 m42 -208 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 274 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
+         <polygon points="707 357 715 353 715 361"></polygon>
+         <polygon points="707 357 699 353 699 361"></polygon></svg>

--- a/doc/user/layouts/partials/sql-grammar/rr-diagrams/join-type.html
+++ b/doc/user/layouts/partials/sql-grammar/rr-diagrams/join-type.html
@@ -1,22 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="329" height="169">
-    <polygon points="9 17 1 13 1 21" />
-    <polygon points="17 17 9 13 9 21" />
-    <rect x="71" y="3" width="54" height="32" rx="10" />
-    <rect x="69" y="1" width="54" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="79" y="21">FULL</text>
-    <rect x="71" y="47" width="52" height="32" rx="10" />
-    <rect x="69" y="45" width="52" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="79" y="65">LEFT</text>
-    <rect x="71" y="91" width="64" height="32" rx="10" />
-    <rect x="69" y="89" width="64" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="79" y="109">RIGHT</text>
-    <rect x="195" y="35" width="66" height="32" rx="10" />
-    <rect x="193" y="33" width="66" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="203" y="53">OUTER</text>
-    <rect x="51" y="135" width="64" height="32" rx="10" />
-    <rect x="49" y="133" width="64" height="32" class="terminal" rx="10" />
-    <text class="terminal" x="59" y="153">INNER</text>
-    <path xmlns:svg="http://www.w3.org/2000/svg" class="line"
-        d="m17 17 h2 m40 0 h10 m54 0 h10 m0 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m52 0 h10 m0 0 h12 m-94 -10 v20 m104 0 v-20 m-104 20 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -88 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-250 -32 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v112 m270 0 v-112 m-270 112 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m64 0 h10 m0 0 h166 m23 -132 h-3" />
-    <polygon points="319 17 327 13 327 21" />
-    <polygon points="319 17 311 13 311 21" /></svg>
+<svg width="329" height="169">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="71" y="3" width="54" height="32" rx="10"></rect>
+         <rect x="69" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="21">FULL</text>
+         <rect x="71" y="47" width="52" height="32" rx="10"></rect>
+         <rect x="69" y="45" width="52" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="65">LEFT</text>
+         <rect x="71" y="91" width="64" height="32" rx="10"></rect>
+         <rect x="69" y="89" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="79" y="109">RIGHT</text>
+         <rect x="195" y="35" width="66" height="32" rx="10"></rect>
+         <rect x="193" y="33" width="66" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="203" y="53">OUTER</text>
+         <rect x="51" y="135" width="64" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="64" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">INNER</text>
+         <path class="line" d="m17 17 h2 m40 0 h10 m54 0 h10 m0 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m52 0 h10 m0 0 h12 m-94 -10 v20 m104 0 v-20 m-104 20 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -88 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-250 -32 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v112 m270 0 v-112 m-270 112 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m64 0 h10 m0 0 h166 m23 -132 h-3"></path>
+         <polygon points="319 17 327 13 327 21"></polygon>
+         <polygon points="319 17 311 13 311 21"></polygon></svg>

--- a/doc/user/layouts/partials/sql-grammar/rr-diagrams/select_stmt.html
+++ b/doc/user/layouts/partials/sql-grammar/rr-diagrams/select_stmt.html
@@ -1,0 +1,64 @@
+<svg width="583" height="811">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SELECT</text>
+         <rect x="141" y="35" width="44" height="32" rx="10"></rect>
+         <rect x="139" y="33" width="44" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="53">ALL</text>
+         <rect x="141" y="123" width="86" height="32" rx="10"></rect>
+         <rect x="139" y="121" width="86" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="149" y="141">DISTINCT</text>
+         <rect x="267" y="123" width="40" height="32" rx="10"></rect>
+         <rect x="265" y="121" width="40" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="275" y="141">ON</text>
+         <rect x="327" y="123" width="26" height="32" rx="10"></rect>
+         <rect x="325" y="121" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="335" y="141">(</text><rect x="393" y="123" width="62" height="32"></rect><rect x="391" y="121" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="401" y="141">col_ref</text><rect x="393" y="79" width="24" height="32" rx="10"></rect>
+         <rect x="391" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="401" y="97">,</text>
+         <rect x="495" y="123" width="26" height="32" rx="10"></rect>
+         <rect x="493" y="121" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="503" y="141">)</text><rect x="110" y="249" width="98" height="32"></rect><rect x="108" y="247" width="98" height="32" class="nonterminal"></rect><text class="nonterminal" x="118" y="267">target_elem</text><rect x="110" y="205" width="24" height="32" rx="10"></rect>
+         <rect x="108" y="203" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="118" y="223">,</text>
+         <rect x="268" y="249" width="60" height="32" rx="10"></rect>
+         <rect x="266" y="247" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="276" y="267">FROM</text><rect x="368" y="249" width="88" height="32"></rect><rect x="366" y="247" width="88" height="32" class="nonterminal"></rect><text class="nonterminal" x="376" y="267">table_expr</text><rect x="368" y="205" width="24" height="32" rx="10"></rect>
+         <rect x="366" y="203" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="376" y="223">,</text>
+         <rect x="70" y="407" width="70" height="32" rx="10"></rect>
+         <rect x="68" y="405" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="78" y="425">WHERE</text><rect x="160" y="407" width="48" height="32"></rect><rect x="158" y="405" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="168" y="425">expr</text><rect x="268" y="375" width="68" height="32" rx="10"></rect>
+         <rect x="266" y="373" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="276" y="393">GROUP</text>
+         <rect x="356" y="375" width="38" height="32" rx="10"></rect>
+         <rect x="354" y="373" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="364" y="393">BY</text><rect x="434" y="375" width="62" height="32"></rect><rect x="432" y="373" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="442" y="393">col_ref</text><rect x="434" y="331" width="24" height="32" rx="10"></rect>
+         <rect x="432" y="329" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="442" y="349">,</text>
+         <rect x="222" y="489" width="74" height="32" rx="10"></rect>
+         <rect x="220" y="487" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="230" y="507">HAVING</text><rect x="316" y="489" width="48" height="32"></rect><rect x="314" y="487" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="324" y="507">expr</text><rect x="111" y="599" width="68" height="32" rx="10"></rect>
+         <rect x="109" y="597" width="68" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="119" y="617">ORDER</text>
+         <rect x="199" y="599" width="38" height="32" rx="10"></rect>
+         <rect x="197" y="597" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="207" y="617">BY</text><rect x="277" y="599" width="62" height="32"></rect><rect x="275" y="597" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="285" y="617">col_ref</text><rect x="379" y="631" width="46" height="32" rx="10"></rect>
+         <rect x="377" y="629" width="46" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="387" y="649">ASC</text>
+         <rect x="379" y="675" width="56" height="32" rx="10"></rect>
+         <rect x="377" y="673" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="387" y="693">DESC</text>
+         <rect x="277" y="555" width="24" height="32" rx="10"></rect>
+         <rect x="275" y="553" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="285" y="573">,</text>
+         <rect x="207" y="777" width="60" height="32" rx="10"></rect>
+         <rect x="205" y="775" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="215" y="795">LIMIT</text><rect x="287" y="777" width="48" height="32"></rect><rect x="285" y="775" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="295" y="795">expr</text><rect x="395" y="777" width="72" height="32" rx="10"></rect>
+         <rect x="393" y="775" width="72" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="403" y="795">OFFSET</text><rect x="487" y="777" width="48" height="32"></rect><rect x="485" y="775" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="495" y="795">expr</text><path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h410 m-440 0 h20 m420 0 h20 m-460 0 q10 0 10 10 m440 0 q0 -10 10 -10 m-450 10 v12 m440 0 v-12 m-440 12 q0 10 10 10 m420 0 q10 0 10 -10 m-430 10 h10 m44 0 h10 m0 0 h356 m-430 -10 v20 m440 0 v-20 m-440 20 v68 m440 0 v-68 m-440 68 q0 10 10 10 m420 0 q10 0 10 -10 m-430 10 h10 m86 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-294 0 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m42 -154 l2 0 m2 0 l2 0 m2 0 l2 0 m-515 246 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m40 44 h10 m60 0 h10 m20 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m-228 44 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-490 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m40 -32 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m-268 44 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v14 m288 0 v-14 m-288 14 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m0 0 h258 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-378 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m74 0 h10 m0 0 h10 m48 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-337 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-198 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m198 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-198 0 h10 m24 0 h10 m0 0 h154 m-384 44 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v90 m404 0 v-90 m-404 90 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-352 146 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m60 0 h10 m0 0 h10 m48 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m72 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"></path>
+         <polygon points="573 759 581 755 581 763"></polygon>
+         <polygon points="573 759 565 755 565 763"></polygon></svg>

--- a/doc/user/util/rr-diagram-gen/Makefile
+++ b/doc/user/util/rr-diagram-gen/Makefile
@@ -1,0 +1,22 @@
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+BINARY_NAME=rr-diagram-gen
+BINARY_UNIX=$(BINARY_NAME)_unix
+
+src_default=../../layouts/partials/sql-grammar/bnf/
+dst_default=../../layouts/partials/sql-grammar/rr-diagrams/
+
+all: clean build run
+
+build :
+	$(GOBUILD) -o $(BINARY_NAME) -v
+
+clean :
+	$(GOCLEAN)
+	rm -f $(BINARY_NAME)
+	rm -f $(BINARY_UNIX)
+
+run :
+	./$(BINARY_NAME) $(src_default) $(dst_default)

--- a/doc/user/util/rr-diagram-gen/README.md
+++ b/doc/user/util/rr-diagram-gen/README.md
@@ -1,0 +1,13 @@
+# Automatic Railroad Diagram Generator
+
+Materialize's SQL API documentation relies on a "railroad diagram" to express a statement's syntax. These diagrams are obtained from <https://www.bottlecaps.de/rr/ui>, which is a service that converts EBNF files (used to express a grammar) into SVGs (the aforementioned railroad diagrams). Those SVGs are then appropriate to include in the Materialize docs once they've been tidied up a bit.
+
+## Usage
+
+With Golang installed, run:
+
+```shell
+make run
+```
+
+which will build the binary in this directory, and convert all BNF files in the appropriate directory into SVGs.

--- a/doc/user/util/rr-diagram-gen/go.mod
+++ b/doc/user/util/rr-diagram-gen/go.mod
@@ -1,0 +1,10 @@
+module github.com/materializeinc/materialize/doc/user/util/rr-diagram-gen
+
+go 1.13
+
+require (
+	github.com/PuerkitoBio/goquery v1.5.0
+	github.com/cockroachdb/cockroach v19.1.5+incompatible
+	golang.org/x/net v0.0.0-20191109021931-daa7c04131f5
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+)

--- a/doc/user/util/rr-diagram-gen/go.sum
+++ b/doc/user/util/rr-diagram-gen/go.sum
@@ -1,0 +1,12 @@
+github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP7EJk=
+github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
+github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20191109021931-daa7c04131f5 h1:bHNaocaoJxYBo5cw41UyTMLjYlb8wPY7+WFrnklbHOM=
+golang.org/x/net v0.0.0-20191109021931-daa7c04131f5/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/doc/user/util/rr-diagram-gen/main.go
+++ b/doc/user/util/rr-diagram-gen/main.go
@@ -1,0 +1,224 @@
+// Copyright 2015 - 2019 The Cockroach Authors. All rights reserved.
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+//
+// This file is derived from the docgen tool in CockroachDB. The
+// original files were retrieved on Nov 12, 2019 from:
+//
+//     https://github.com/cockroachdb/cockroach/tree/d2f7fbf5dd1fc1a099bbad790a2e1f7c60a66cc3/pkg/cmd/docgen
+//
+// The original source code is subject to the terms of the Apache
+// 2.0 license, a copy of which can be found in the LICENSE file at the
+// root of this repository.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/html"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	rrAddr = "http://bottlecaps.de/rr/ui"
+)
+
+// EBNFtoXHTML generates the railroad XHTML from a EBNF file.
+func EBNFtoXHTML(bnf []byte) ([]byte, error) {
+
+	v := url.Values{}
+	v.Add("frame", "diagram")
+	v.Add("text", string(bnf))
+	v.Add("width", "620")
+	v.Add("options", "eliminaterecursion")
+	v.Add("options", "factoring")
+	v.Add("options", "inline")
+
+	resp, err := http.Post(rrAddr, "application/x-www-form-urlencoded", strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%s: %s", resp.Status, string(body))
+	}
+	return body, nil
+}
+
+// XHTMLtoHTML converts the XHTML railroad diagrams to HTML.
+func XHTMLtoHTML(xhtml []byte) (string, error) {
+	r := bytes.NewReader(xhtml)
+	b := new(bytes.Buffer)
+	z := html.NewTokenizer(r)
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			err := z.Err()
+			if err == io.EOF {
+				break
+			}
+			return "", z.Err()
+		}
+		t := z.Token()
+		switch t.Type {
+		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
+			idx := strings.IndexByte(t.Data, ':')
+			t.Data = t.Data[idx+1:]
+		}
+		var na []html.Attribute
+		for _, a := range t.Attr {
+			if strings.HasPrefix(a.Key, "xmlns") {
+				continue
+			}
+			na = append(na, a)
+		}
+		t.Attr = na
+		b.WriteString(t.String())
+	}
+
+	doc, err := goquery.NewDocumentFromReader(b)
+	if err != nil {
+		return "", err
+	}
+	defs := doc.Find("defs")
+	dhtml, err := defs.First().Html()
+	if err != nil {
+		return "", err
+	}
+	doc.Find("head").AppendHtml(dhtml)
+	defs.Remove()
+	doc.Find("svg").First().Remove()
+	doc.Find("meta[http-equiv]").Remove()
+	doc.Find("head").PrependHtml(`<meta charset="UTF-8">`)
+	doc.Find("a[name]:not([href])").Each(func(_ int, s *goquery.Selection) {
+		name, exists := s.Attr("name")
+		if !exists {
+			return
+		}
+		s.SetAttr("href", "#"+name)
+	})
+	s, err := doc.Find("html").Html()
+	s = "<!DOCTYPE html><html>" + s + "</html>"
+	return s, err
+}
+
+// ExtractSVGDiagram extracts the embedded SVG diagram.
+func ExtractSVGDiagram(html string) (string, error) {
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		return "", err
+	}
+
+	// The railroad diagram page we received has two SVGs;
+	// we want the first one.
+	svgSelection := doc.Find("body svg").Eq(0)
+
+	svgSelection.Children().Each(func(i int, s *goquery.Selection) {
+		// Remove all anchor tags, which Materialize
+		// doesn't use.
+		if s.Is("a") {
+			s.ReplaceWithSelection(s.Children())
+		}
+	})
+
+	svgString, err := goquery.OuterHtml(svgSelection)
+
+	if err != nil {
+		return "", err
+	}
+
+	svgString += "\n"
+
+	return svgString, nil
+}
+
+// ConvertBNFtoSVG finds all .bnf files in srcDir,
+// converts them to SVG files, and writes those SVG
+// files to dstDir as .html files appropriate for
+// being included in Hugo.
+func ConvertBNFtoSVG(srcDir string, dstDir string) {
+	bnfFilename := regexp.MustCompile(`(.+?)\.bnf$`)
+	files, err := ioutil.ReadDir(srcDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Writing converted BNF files to...")
+
+	// Find all BNF files.
+	for _, f := range files {
+
+		if bnfFilename.Match([]byte(f.Name())) {
+
+			bnf, err := ioutil.ReadFile(srcDir + f.Name())
+			if err != nil {
+				log.Fatalf(fmt.Sprintf("Cannot read %s\n", f.Name()))
+			}
+
+			xhtml, err := EBNFtoXHTML(bnf)
+			if err != nil {
+				panic(fmt.Sprintf("EBNF to XHTML conversion failed for %s: %v\n", f.Name(), err))
+			}
+
+			html, err := XHTMLtoHTML(xhtml)
+			if err != nil {
+				panic(fmt.Sprintf("XHTML to HTML conversion failed for %s: %v", f.Name(), err))
+			}
+
+			svg, err := ExtractSVGDiagram(html)
+			if err != nil {
+				panic(fmt.Sprintf("Extracting SVG from HTML failed for %s: %v", f.Name(), err))
+			}
+
+			dstFilename := bnfFilename.ReplaceAllString(f.Name(), dstDir+"$1.html")
+			err = ioutil.WriteFile(dstFilename, []byte(svg), 0644)
+			if err != nil {
+				panic(fmt.Sprintf("Failed to write %s: %v", dstFilename, err))
+			}
+			fmt.Println("\t", dstFilename)
+		}
+	}
+}
+
+func main() {
+
+	if len(os.Args) != 3 {
+		log.Fatalf("USAGE: rr-diagram-gen <srcDir> <dstDir>\n")
+	}
+
+	srcDir := os.Args[1]
+	dstDir := os.Args[2]
+
+	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+		log.Fatalf("srcDir (%s) does not exist.\n", srcDir)
+	}
+
+	if _, err := os.Stat(dstDir); os.IsNotExist(err) {
+		log.Fatalf("dstDir (%s) does not exist.\n", srcDir)
+	}
+
+	if unix.Access(dstDir, unix.W_OK) != nil {
+		log.Fatalf("dstDir (%s) is not writable\n", dstDir)
+	}
+
+	ConvertBNFtoSVG(srcDir, dstDir)
+
+}


### PR DESCRIPTION
Automatically generate railroad SVGs from BNFs. Recreates all of them every time because there are so few, but this could be improved in the future by only generating those that have been updated.