### PR TITLE
ore,mzd,slt: improve ergonomics of server shutdown

### DIFF
--- a/src/ore/lib.rs
+++ b/src/ore/lib.rs
@@ -21,6 +21,7 @@ pub mod netio;
 pub mod option;
 pub mod panic;
 pub mod sync;
+pub mod thread;
 pub mod tokio;
 
 /// Logs a message to stderr and crashes the process.

--- a/src/ore/thread.rs
+++ b/src/ore/thread.rs
@@ -1,0 +1,32 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+//! Thread utilities.
+
+use std::thread::JoinHandle;
+
+/// Wraps a [`JoinHandle`] so that the child thread is joined when the handle is
+/// dropped, rather than detached. If the child thread panics,
+/// `JoinOnDropHandle` will panic when dropped.
+#[derive(Debug)]
+pub struct JoinOnDropHandle<T>(Option<JoinHandle<T>>);
+
+impl<T> Drop for JoinOnDropHandle<T> {
+    fn drop(&mut self) {
+        self.0.take().unwrap().join().unwrap();
+    }
+}
+
+/// Extension methods for [`JoinHandle`].
+pub trait JoinHandleExt<T> {
+    /// Converts a [`JoinHandle`] into a [`JoinOnDropHandle`].
+    fn join_on_drop(self) -> JoinOnDropHandle<T>;
+}
+
+impl<T> JoinHandleExt<T> for JoinHandle<T> {
+    fn join_on_drop(self) -> JoinOnDropHandle<T> {
+        JoinOnDropHandle(Some(self))
+    }
+}


### PR DESCRIPTION
Shutting down a materialized server must be done carefully. First the
command queue transmitter (cmdq_tx) must be shutdown, to send the
shutdown signal. Then we have to wait for the dataflow workers to
shutdown, in order to make sure messages are not still flowing between
the workers and the coordinator. Then we have to wait for the
coordinator to shut down, to make sure nothing is still using the tokio
runtime. And lastly, the tokio runtime can be shutdown.

This was previously handled with a custom drop implementation for
materialized::Server, and a drop-like shutdown function for
sqllogictest::runner::State. These approaches were both flawed;
materialized::Server was forced to use a bunch of unnecessary options so
that it could move out of some fields in its drop implementation, while
sqllogictest was forgetting to call the shutdown method in some modes.

Solve both issues by providing a JoinOnDropHandle that waits for a
thread to shutdown when the handle is dropped. (std::thread::JoinHandle
*detaches* from the thread when dropped.) Then we don't need to provide
a custom drop implementation, but can rely on the field drop order to
handle everything for us.

This has the nice side effect of solving the hang when passing
--rewrite-results to SLT.