### PR TITLE
materialized: add a data-directory flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target
 .mtrlz.log
 **/*.rs.bk
 .netlify
+mzdata

--- a/src/coord/transient.rs
+++ b/src/coord/transient.rs
@@ -15,6 +15,7 @@ use ore::collections::CollectionExt;
 use sql::store::{Catalog, CatalogItem};
 use sql::PreparedStatement;
 use sql::{Plan, Session};
+use std::path::Path;
 use std::thread;
 use std::thread::JoinHandle;
 use symbiosis::Postgres;
@@ -36,6 +37,7 @@ where
     pub symbiosis_url: Option<&'a str>,
     pub logging: Option<&'a LoggingConfig>,
     pub bootstrap_sql: String,
+    pub data_directory: Option<&'a Path>,
     pub cmd_rx: UnboundedReceiver<Command>,
 }
 

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -21,6 +21,7 @@ use std::fs::{read_to_string, File};
 use std::io::{BufRead, BufReader};
 use std::panic;
 use std::panic::PanicInfo;
+use std::path::PathBuf;
 use std::process;
 use std::sync::Mutex;
 use std::thread;
@@ -77,6 +78,12 @@ fn run() -> Result<(), failure::Error> {
         "file with SQL queries to execute when bootstrapping",
         "FILE",
     );
+    opts.optopt(
+        "D",
+        "data-directory",
+        "where materialized will store metadata (default mzdata)",
+        "PATH",
+    );
     opts.optopt("", "symbiosis", "(internal use only)", "URL");
     opts.optflag("", "no-prometheus", "Do not gather prometheus metrics");
 
@@ -121,6 +128,8 @@ fn run() -> Result<(), failure::Error> {
         Some(bootstrap_file) => read_to_string(&bootstrap_file)?,
     };
 
+    let data_directory = popts.opt_get_default("data-directory", PathBuf::from("mzdata"))?;
+
     let _server = materialized::serve(materialized::Config {
         logging_granularity,
         version,
@@ -128,6 +137,7 @@ fn run() -> Result<(), failure::Error> {
         process,
         addresses,
         bootstrap_sql,
+        data_directory: Some(data_directory),
         symbiosis_url: popts.opt_str("symbiosis"),
         gather_metrics,
     })?;

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -18,6 +18,7 @@ use futures::{Future, Stream};
 use log::error;
 use std::any::Any;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{self, AsyncWrite};
@@ -52,6 +53,8 @@ pub struct Config {
     pub addresses: Vec<String>,
     /// SQL to run if bootstrapping a new cluster.
     pub bootstrap_sql: String,
+    /// The directory in which `materialized` should store its own metadata.
+    pub data_directory: Option<PathBuf>,
     /// An optional symbiosis endpoint. See the
     /// [`symbiosis`](../symbiosis/index.html) crate for details.
     pub symbiosis_url: Option<String>,
@@ -210,6 +213,7 @@ pub fn serve(config: Config) -> Result<Server, failure::Error> {
                 symbiosis_url: config.symbiosis_url.mz_as_deref(),
                 logging: logging_config.as_ref(),
                 bootstrap_sql: config.bootstrap_sql,
+                data_directory: config.data_directory.mz_as_deref(),
                 cmd_rx,
             })?
             .join_on_drop(),

--- a/src/materialized/tests/prepared.rs
+++ b/src/materialized/tests/prepared.rs
@@ -23,6 +23,7 @@ fn test_prepared_statements() -> Result<(), Box<dyn Error>> {
         process: 0,
         addresses: vec![format!("127.0.0.1:{}", rand_port).into()],
         bootstrap_sql: "".into(),
+        data_directory: None,
         symbiosis_url: None,
         gather_metrics: false,
     })?;

--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -348,6 +348,7 @@ impl State {
             symbiosis_url: Some("postgres://"),
             logging: logging_config.as_ref(),
             bootstrap_sql: "".into(),
+            data_directory: None,
             cmd_rx,
         })?;
 


### PR DESCRIPTION
This is presently unused, but will soon determine where materialized
persists cluster metadata, and where materialized permits file sources
to read from.