### PR TITLE
coord: merge thread and coordinator

### DIFF
--- a/src/coord/lib.rs
+++ b/src/coord/lib.rs
@@ -20,4 +20,4 @@ mod command;
 mod coord;
 
 pub use command::{Command, ExecuteResponse, Response, RowsFuture};
-pub use coord::{serve, Config};
+pub use coord::{Config, Coordinator};


### PR DESCRIPTION
The responsibilities of the coordinator were previously arbitrarily
split between the serve function and the Coordinator object, a
consequence of the crate evolving organically. These are really meant to
be one object. Start down that road by folding the serve function into
Coordinator::new and Coordinator::serve, the latter of which is a new
method.

Clients are now responsible for calling `Coordinator::serve` in its own
thread, which makes the API a bit cleaner.

Note that this commit is an MVP. Additional cleanup work needs to
happen, as the Coordinator object calls some free functions that should
really be methods on the Coordinator. (This change is a bit hard to make
due to the borrow checker, which is why it'll be follow-on work.)