### PR TITLE
Return "BEGIN" for PgJDBC

### DIFF
--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -692,7 +692,9 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
                         }
                     }
                     ExecuteResponse::StartTransaction => {
-                        command_complete!("START TRANSACTION", "transaction_start")
+                        // PgJDBC expects "BEGIN", not "START TRANSACTION".
+                        // The two actions are equivalent in PostgreSQL.
+                        command_complete!("BEGIN", "transaction_start")
                     }
                     ExecuteResponse::Commit => {
                         command_complete!("COMMIT TRANSACTION", "transaction_commit")


### PR DESCRIPTION
Return the message "BEGIN" instead of "START TRANSACTION" to PgJDBC. 

I briefly considered refactoring all the "StartTransaction" Materialize objects to be "Begin" instead, but didn't because: 1) they are functionally the same 2) it feels like "StartTransaction" is more descriptive? But happy to add that change, too.