### PR TITLE
catalog: persist catalog items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,9 @@ dependencies = [
  "expr",
  "failure",
  "repr",
+ "rusqlite",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1047,6 +1050,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fixedbitset"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1523,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1561,7 @@ dependencies = [
  "postgres",
  "pretty_assertions",
  "prometheus",
+ "tempfile",
  "tokio",
 ]
 
@@ -2685,6 +2715,21 @@ name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "rusqlite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
+dependencies = [
+ "bitflags",
+ "fallible-iterator 0.2.0",
+ "fallible-streaming-iterator",
+ "libsqlite3-sys",
+ "lru-cache",
+ "memchr 2.2.1",
+ "time",
+]
 
 [[package]]
 name = "rust_decimal"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -13,3 +13,6 @@ dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.6"
 repr = { path = "../repr" }
+rusqlite = { version = "0.20", features = ["bundled"] }
+serde = "1.0"
+serde_json = "1.0.41"

--- a/src/catalog/sql.rs
+++ b/src/catalog/sql.rs
@@ -1,0 +1,35 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput, Value, ValueRef};
+use serde::{Deserialize, Serialize};
+
+pub struct SqlVal<T>(pub T);
+
+impl<T> ToSql for SqlVal<T>
+where
+    T: Serialize,
+{
+    fn to_sql(&self) -> Result<ToSqlOutput, rusqlite::Error> {
+        let bytes = serde_json::to_vec(&self.0)
+            .map_err(|err| rusqlite::Error::ToSqlConversionFailure(Box::new(err)))?;
+        Ok(ToSqlOutput::Owned(Value::Blob(bytes)))
+    }
+}
+
+impl<T> FromSql for SqlVal<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    fn column_result(val: ValueRef) -> Result<Self, FromSqlError> {
+        let bytes = match val {
+            ValueRef::Blob(bytes) => bytes,
+            _ => return Err(FromSqlError::InvalidType),
+        };
+        Ok(SqlVal(
+            serde_json::from_slice(bytes).map_err(|err| FromSqlError::Other(Box::new(err)))?,
+        ))
+    }
+}

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 pub enum Id {
     /// An identifier that refers to a local component of a dataflow.
     Local(LocalId),
-    /// An identifier that returns to a global dataflow.
+    /// An identifier that refers to a global dataflow.
     Global(GlobalId),
 }
 

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -30,6 +30,7 @@ ore = { path = "../ore" }
 parse_duration = "2.0.1"
 pgwire = { path = "../pgwire" }
 prometheus = { version = "0.7.0", default-features = false, features = ["process"] }
+tempfile = "3.1"
 tokio = "0.1"
 
 [dev-dependencies]

--- a/src/materialized/tests/now.rs
+++ b/src/materialized/tests/now.rs
@@ -12,7 +12,8 @@ mod util;
 fn test_now() -> Result<(), Box<dyn Error>> {
     ore::log::init();
 
-    let (_server, conn) = util::start_server()?;
+    let data_dir = None;
+    let (_server, conn) = util::start_server(data_dir)?;
 
     let rows = &conn.query("SELECT now()", &[])?;
     assert_eq!(1, rows.len());

--- a/src/materialized/tests/persistence.rs
+++ b/src/materialized/tests/persistence.rs
@@ -1,0 +1,35 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+use std::error::Error;
+
+mod util;
+
+#[test]
+fn test_persistence() -> Result<(), Box<dyn Error>> {
+    ore::log::init();
+
+    let data_dir = tempfile::tempdir()?;
+    let data_dir = Some(data_dir.path().to_owned());
+
+    {
+        let (_server, conn) = util::start_server(data_dir.clone())?;
+        // TODO(benesch): when file sources land, use them here. Creating a
+        // populated Kafka source here is too annoying.
+        conn.execute("CREATE VIEW persistme AS SELECT 1", &[])?;
+    }
+
+    {
+        let (_server, conn) = util::start_server(data_dir)?;
+        let rows: Vec<String> = conn
+            .query("SHOW VIEWS", &[])?
+            .into_iter()
+            .map(|row| row.get(0))
+            .collect();
+        assert_eq!(rows, &["persistme"]);
+    }
+
+    Ok(())
+}

--- a/src/materialized/tests/prepared.rs
+++ b/src/materialized/tests/prepared.rs
@@ -11,7 +11,8 @@ mod util;
 fn test_prepared_statements() -> Result<(), Box<dyn Error>> {
     ore::log::init();
 
-    let (_server, conn) = util::start_server()?;
+    let data_dir = None;
+    let (_server, conn) = util::start_server(data_dir)?;
 
     let rows: Vec<String> = conn
         .query("SELECT $1", &[&String::from("42")])?

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -5,18 +5,21 @@
 
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::PathBuf;
 
 use postgres::params::{ConnectParams, Host};
 use postgres::{Connection, TlsMode};
 
-pub fn start_server() -> Result<(materialized::Server, Connection), Box<dyn Error>> {
+pub fn start_server(
+    data_directory: Option<PathBuf>,
+) -> Result<(materialized::Server, Connection), Box<dyn Error>> {
     let server = materialized::serve(materialized::Config {
         logging_granularity: None,
         threads: 1,
         process: 0,
         addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],
         bootstrap_sql: "".into(),
-        data_directory: None,
+        data_directory,
         symbiosis_url: None,
         gather_metrics: false,
     })?;

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -11,7 +11,7 @@ use repr::ScalarType;
 
 #[test]
 fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
-    let catalog = Catalog::default();
+    let catalog = Catalog::open(None)?;
     let test_cases = vec![
         (
             "SELECT $1, $2, $3",


### PR DESCRIPTION
Add single-node persistence for the catalog. Restarting a materialized
server will automatically install the same sources and views that were
present when the server was shutdown.

The catalog is stored on disk using SQLite. The default location is
"mzdata/catalog", relative to the CWD of materialized, but can be
configured with the --data-directory command line flag.