### PR TITLE
repr: introduce ColumnName type

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -38,7 +38,7 @@ use dataflow_types::{
 use expr::RelationExpr;
 use ore::collections::CollectionExt;
 use ore::future::FutureExt;
-use repr::{Datum, LiteralName, QualName, RelationDesc, Row, RowPacker, RowUnpacker};
+use repr::{ColumnName, Datum, LiteralName, QualName, RelationDesc, Row, RowPacker, RowUnpacker};
 use sql::PreparedStatement;
 use sql::{MutationKind, ObjectType, Plan, Session};
 use symbiosis::Postgres;
@@ -510,7 +510,7 @@ where
                     // session.
                     let desc = RelationDesc::new(
                         typ,
-                        iter::repeat::<Option<QualName>>(None).take(ncols).collect(),
+                        iter::repeat::<Option<ColumnName>>(None).take(ncols),
                     );
                     let dataflow = DataflowDesc::from(View {
                         name: name.clone(),

--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -119,83 +119,83 @@ impl LogVariant {
     pub fn schema(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .add_column("id".lit(), ScalarType::Int64)
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("name".lit(), ScalarType::String)
+                .add_column("id", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("name", ScalarType::String)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .add_column("id".lit(), ScalarType::Int64)
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("source_node".lit(), ScalarType::Int64)
-                .add_column("source_port".lit(), ScalarType::Int64)
-                .add_column("target_node".lit(), ScalarType::Int64)
-                .add_column("target_port".lit(), ScalarType::Int64)
+                .add_column("id", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("source_node", ScalarType::Int64)
+                .add_column("source_port", ScalarType::Int64)
+                .add_column("target_node", ScalarType::Int64)
+                .add_column("target_port", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .add_column("id".lit(), ScalarType::Int64)
-                .add_column("elapsed_ns".lit(), ScalarType::Int64)
+                .add_column("id", ScalarType::Int64)
+                .add_column("elapsed_ns", ScalarType::Int64)
                 .add_keys(vec![0]),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .add_column("id".lit(), ScalarType::Int64)
-                .add_column("duration_ns".lit(), ScalarType::Int64)
-                .add_column("count".lit(), ScalarType::Int64)
+                .add_column("id", ScalarType::Int64)
+                .add_column("duration_ns", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
                 .add_keys(vec![0]),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .add_column("id".lit(), ScalarType::Int64)
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("slot".lit(), ScalarType::Int64)
-                .add_column("value".lit(), ScalarType::Int64)
+                .add_column("id", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("slot", ScalarType::Int64)
+                .add_column("value", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("slept_for".lit(), ScalarType::Int64)
-                .add_column("requested".lit(), ScalarType::Int64)
-                .add_column("count".lit(), ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("slept_for", ScalarType::Int64)
+                .add_column("requested", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1, 2]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
-                .add_column("operator".lit(), ScalarType::Int64)
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("records".lit(), ScalarType::Int64)
-                .add_column("batches".lit(), ScalarType::Int64)
+                .add_column("operator", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("records", ScalarType::Int64)
+                .add_column("batches", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .add_column("operator".lit(), ScalarType::Int64)
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("count".lit(), ScalarType::Int64)
+                .add_column("operator", ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .add_column("name".lit(), ScalarType::String)
-                .add_column("worker".lit(), ScalarType::Int64)
+                .add_column("name", ScalarType::String)
+                .add_column("worker", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .add_column("dataflow".lit(), ScalarType::String)
-                .add_column("source".lit(), ScalarType::String)
-                .add_column("worker".lit(), ScalarType::Int64),
+                .add_column("dataflow", ScalarType::String)
+                .add_column("source", ScalarType::String)
+                .add_column("worker", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .add_column("name".lit(), ScalarType::String)
-                .add_column("time".lit(), ScalarType::Int64),
+                .add_column("name", ScalarType::String)
+                .add_column("time", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .add_column("uuid".lit(), ScalarType::String)
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("name".lit(), ScalarType::String)
-                .add_column("time".lit(), ScalarType::Int64)
+                .add_column("uuid", ScalarType::String)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("name", ScalarType::String)
+                .add_column("time", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .add_column("worker".lit(), ScalarType::Int64)
-                .add_column("duration_ns".lit(), ScalarType::Int64)
-                .add_column("count".lit(), ScalarType::Int64)
+                .add_column("worker", ScalarType::Int64)
+                .add_column("duration_ns", ScalarType::Int64)
+                .add_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
         }
     }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -308,8 +308,8 @@ mod tests {
                 )),
             },
             desc: RelationDesc::empty()
-                .add_column("name".lit(), ScalarType::String)
-                .add_column("quantity".lit(), ScalarType::String),
+                .add_column("name", ScalarType::String)
+                .add_column("quantity", ScalarType::String),
         });
 
         let decoded: DataflowDesc =

--- a/src/expr/transform/binding.rs
+++ b/src/expr/transform/binding.rs
@@ -108,7 +108,7 @@ impl Drop for LocalBinding<'_> {
     /// Drop this local binding by restoring the environment to its prior state.
     fn drop(&mut self) {
         if let Some(value) = self.prior.take() {
-            let name = std::mem::replace(&mut self.name, QualName::invalid());
+            let name = std::mem::replace(&mut self.name, QualName::trusted("$INVALID$"));
             self.env.bindings.insert(name, value);
         } else {
             self.env.bindings.pop();

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -120,10 +120,7 @@ fn validate_schema_1(schema: &Schema) -> Result<RelationDesc, Error> {
                     })
                 })
                 .collect::<Result<Vec<_>, Error>>()?;
-            let mut column_names = Vec::with_capacity(fields.len());
-            for field in fields.iter() {
-                column_names.push(Some(field.name.parse()?));
-            }
+            let column_names = fields.iter().map(|f| Some(f.name.clone()));
             Ok(RelationDesc::new(
                 RelationType::new(column_types),
                 column_names,

--- a/src/pgwire/message.rs
+++ b/src/pgwire/message.rs
@@ -14,8 +14,7 @@ use lazy_static::lazy_static;
 use super::types::PgType;
 use crate::codec::RawParameterBytes;
 use repr::decimal::Decimal;
-use repr::{ColumnType, Datum, Interval, RelationDesc, RelationType, Row, ScalarType};
-use repr::{LiteralName, QualName};
+use repr::{ColumnName, ColumnType, Datum, Interval, RelationDesc, RelationType, Row, ScalarType};
 use sql::TransactionStatus as SqlTransactionStatus;
 
 // Pgwire protocol versions are represented as 32-bit integers, where the
@@ -253,7 +252,7 @@ impl From<&ScalarType> for ParameterDescription {
 
 #[derive(Debug)]
 pub struct FieldDescription {
-    pub name: QualName,
+    pub name: ColumnName,
     pub table_id: u32,
     pub column_id: u16,
     pub type_oid: u32,
@@ -570,7 +569,7 @@ pub fn row_description_from_desc(desc: &RelationDesc) -> Vec<FieldDescription> {
         .map(|(name, typ)| {
             let pg_type: PgType = (&typ.scalar_type).into();
             FieldDescription {
-                name: name.cloned().unwrap_or_else(|| "?column?".lit()),
+                name: name.cloned().unwrap_or_else(|| "?column?".into()),
                 table_id: 0,
                 column_id: 0,
                 type_oid: pg_type.oid,

--- a/src/repr/lib.rs
+++ b/src/repr/lib.rs
@@ -21,7 +21,7 @@ mod row;
 mod scalar;
 
 pub use qualname::{LiteralName, QualName};
-pub use relation::{ColumnType, RelationDesc, RelationType};
+pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{PackableRow, Row, RowPacker, RowUnpacker, UnpackedRow};
 pub use scalar::decimal;
 pub use scalar::regex;

--- a/src/repr/qualname.rs
+++ b/src/repr/qualname.rs
@@ -117,20 +117,6 @@ impl QualName {
         }
     }
 
-    //pub fn matches_ident_name(&self, rhs: &str) -> bool {}
-
-    /// Invalid names are currently generated throughout the code base because we were using strings and could be lazy
-    ///
-    /// TODO: get rid of this
-    pub fn invalid() -> QualName {
-        QualName::trusted("$$_INVALID_NAME_$$")
-    }
-
-    /// Extract a QualName from an object, or construct an invalid one
-    pub fn from_or_invalid(name: ObjectName) -> QualName {
-        QualName::new_normalized(name.0).unwrap_or_else(|_| QualName::invalid())
-    }
-
     /// Create a QualName based on a string that is trusted to be correct
     pub fn trusted(ident: &str) -> QualName {
         QualName(vec![Identifier {

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -17,6 +17,8 @@ use sqlparser::parser::Parser as SqlParser;
 pub use session::{PreparedStatement, Session, TransactionStatus};
 pub use sqlparser::ast::{ObjectType, Statement};
 
+pub mod names;
+
 mod expr;
 mod query;
 mod scope;

--- a/src/sql/names.rs
+++ b/src/sql/names.rs
@@ -1,0 +1,15 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+use repr::ColumnName;
+use sqlparser::ast::Ident;
+
+pub fn ident_to_col_name(ident: Ident) -> ColumnName {
+    if ident.quote_style.is_some() {
+        ColumnName::from(ident.value)
+    } else {
+        ColumnName::from(ident.value.to_lowercase())
+    }
+}

--- a/src/sqllogictest/ast.rs
+++ b/src/sqllogictest/ast.rs
@@ -5,8 +5,6 @@
 
 //! Abstract syntax tree nodes for sqllogictest.
 
-use repr::QualName;
-
 /// The declared type of an output column in a query.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
@@ -85,7 +83,7 @@ pub struct QueryOutput<'a> {
     pub types: Vec<Type>,
     pub sort: Sort,
     pub label: Option<&'a str>,
-    pub column_names: Option<Vec<QualName>>,
+    pub column_names: Option<Vec<repr::ColumnName>>,
     pub mode: Mode,
     pub output: Output,
     pub output_str: &'a str,

--- a/src/sqllogictest/parser.rs
+++ b/src/sqllogictest/parser.rs
@@ -10,7 +10,7 @@ use std::borrow::ToOwned;
 use failure::{bail, format_err};
 use lazy_static::lazy_static;
 use regex::Regex;
-use repr::QualName;
+use repr::ColumnName;
 
 use crate::ast::{Mode, Output, QueryOutput, Record, Sort, Type};
 
@@ -218,7 +218,7 @@ fn parse_query<'a>(
             split_at(input, &LINE_REGEX)?
                 .split(' ')
                 .filter(|s| !s.is_empty())
-                .map(|s| QualName::trusted(s))
+                .map(ColumnName::from)
                 .collect(),
         )
     } else {

--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -40,7 +40,7 @@ use coord::ExecuteResponse;
 use dataflow;
 use ore::option::OptionExt;
 use ore::thread::{JoinHandleExt, JoinOnDropHandle};
-use repr::{ColumnType, Datum, LiteralName, QualName, RelationDesc, Row};
+use repr::{ColumnName, ColumnType, Datum, RelationDesc, Row};
 use sql::{Session, Statement};
 use sqlparser::dialect::AnsiDialect;
 use sqlparser::parser::{Parser as SqlParser, ParserError as SqlParserError};
@@ -72,8 +72,8 @@ pub enum Outcome<'a> {
         message: String,
     },
     WrongColumnNames {
-        expected_column_names: &'a Vec<QualName>,
-        inferred_column_names: Vec<QualName>,
+        expected_column_names: &'a Vec<ColumnName>,
+        inferred_column_names: Vec<ColumnName>,
     },
     OutputFailure {
         expected_output: &'a Output,
@@ -580,7 +580,7 @@ impl State {
         if let Some(expected_column_names) = expected_column_names {
             let inferred_column_names = desc
                 .iter_names()
-                .map(|t| t.owned().unwrap_or_else(|| "?column?".lit()))
+                .map(|t| t.owned().unwrap_or_else(|| "?column?".into()))
                 .collect::<Vec<_>>();
             if expected_column_names != &inferred_column_names {
                 return Ok(Outcome::WrongColumnNames {

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -150,6 +150,10 @@ END $$;
                         })
                         .collect::<Result<Vec<_>, failure::Error>>()?,
                 );
+                let names = columns
+                    .iter()
+                    .map(|c| Some(sql::names::ident_to_col_name(c.name.clone())));
+
                 for constraint in constraints {
                     use sqlparser::ast::TableConstraint;
                     if let TableConstraint::Unique {
@@ -176,12 +180,6 @@ END $$;
                         typ = typ.add_keys(keys);
                     }
                 }
-
-                let names = columns
-                    .iter()
-                    .cloned()
-                    .map(|column| QualName::try_from(column.name).map(Some))
-                    .collect::<Result<Vec<_>, _>>()?;
 
                 let desc = RelationDesc::new(typ, names);
                 self.table_types

--- a/test/aggregates.slt
+++ b/test/aggregates.slt
@@ -35,9 +35,9 @@ SELECT a+1 FROM t GROUP BY a+1 HAVING sum(b) = 3;
 query TTT colnames
 SHOW COLUMNS FROM t
 ----
- field nullable type
- a     YES      int8
- b     YES      int8
+Field  Nullable  Type
+ a     YES       int8
+ b     YES       int8
 
 # avg on an integer column should return a decimal with the default decimal
 # division scale increase.

--- a/test/createdrop.td
+++ b/test/createdrop.td
@@ -44,7 +44,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=34
 
 > CREATE INDEX i ON v(a)
 
-> CREATE INDEX i2 ON s(Y)
+> CREATE INDEX i2 ON s("Y")
 
 # Test that creating objects of the same name does not work
 

--- a/test/dependencies.td
+++ b/test/dependencies.td
@@ -125,7 +125,7 @@ cannot delete v2: still depended upon by catalog item 'i1'
 
 > CREATE SOURCE s FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${schema}'
 
-> CREATE INDEX i2 ON s(X);
+> CREATE INDEX i2 ON s("X");
 
 ! DROP SOURCE s;
 cannot delete s: still depended upon by catalog item 'i2'


### PR DESCRIPTION
ColumnNames can't be qualified, so they should have their own dedicated
type, rather than using repr::QualName.

Fix MaterializeInc/database-issues#317.
Fix MaterializeInc/database-issues#318.
Fix MaterializeInc/database-issues#322.
Fix MaterializeInc/database-issues#323.