### PR TITLE
Length function and encoding package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +980,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "differential-dataflow",
+ "encoding",
  "failure",
  "indexmap",
  "ordered-float",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 [dependencies]
 chrono = "0.4"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+encoding = "0.2"
 failure = "0.1.6"
 indexmap = "1.2.0"
 ordered-float = { version = "1.0.2", features = ["serde"] }

--- a/test/string.slt
+++ b/test/string.slt
@@ -39,10 +39,10 @@ select ascii(substr('inside literal', 3, 4));
 ----
 115
 
+### substr ###
 statement ok
 CREATE TABLE substrtest (strcol CHAR(15), vccol VARCHAR(15), smicol SMALLINT, intcol INT)
 
-### substr ###
 statement ok
 INSERT INTO substrtest VALUES ('Mg', 'Mn', 1, 1), ('magnesium', 'manganese', 3, null),
     (null, null, 0, 0), ('24.31', '54.94', 2, 3), ('长久不见', '爱不释手', null, 2),
@@ -338,3 +338,75 @@ select substr('subexpression test', ascii(''), 3);
 su
 
 #TODO: materialize#606 Add tests for the alternate syntax if it is enabled
+
+### length ###
+statement ok
+create table lengthtest(strcol CHAR(15), vccol VARCHAR(15));
+
+statement ok
+insert into lengthtest values ('str', 'str'), (' str', ' str'), ('str ', 'str '), ('你好', '你好'), ('今日は', '今日は'), ('हेलो', 'हेलो'), (null, null), ('','');
+
+#invalid input
+statement error
+select length(99)
+
+statement error
+select length('str', 99)
+
+#standard tests
+query I rowsort
+select length(strcol) from lengthtest;
+----
+15
+15
+15
+15
+15
+15
+15
+NULL
+
+query I rowsort
+select length(vccol) from lengthtest;
+----
+0
+2
+3
+3
+4
+4
+4
+NULL
+
+query I
+select length('你好', 'big5');
+----
+3
+
+query I
+select length('你好', 'iso-8859-5');
+----
+6
+
+#encoding name conversion from pg to WHATWG
+query I
+select length('你好', 'ISO_8859_5');
+----
+6
+
+#invalid encoding name
+query I
+select length('你好', 'iso-123');
+----
+NULL
+
+#null inputs
+query I
+select length(null);
+----
+NULL
+
+query I
+select length('str', null);
+----
+NULL


### PR DESCRIPTION
Implements Postgres-similar:

- `length(str)`
- `length(str, encoding_name)`

Includes a new dependency for [`encoding`](https://crates.io/crates/encoding) for non-UTF-8 lengths. I think this is viable because we can re-use this for all other functions that require encoding.

Closes MaterializeInc/database-issues#229