### PR TITLE
dataflow,expr: introduce proper id type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ name = "catalog"
 version = "0.1.0"
 dependencies = [
  "dataflow-types",
+ "expr",
  "failure",
  "repr",
 ]
@@ -3119,6 +3120,7 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 name = "symbiosis"
 version = "0.1.0"
 dependencies = [
+ "catalog",
  "chrono",
  "dataflow-types",
  "failure",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -10,5 +10,6 @@ path = "lib.rs"
 
 [dependencies]
 dataflow-types = { path = "../dataflow-types" }
+expr = { path = "../expr" }
 failure = "0.1.6"
 repr = { path = "../repr" }

--- a/src/catalog/lib.rs
+++ b/src/catalog/lib.rs
@@ -3,13 +3,13 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-use failure::bail;
-use repr::QualName;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use dataflow_types::{Index, Sink, Source, View};
-use repr::{RelationDesc, RelationType};
+use expr::{GlobalId, Id, IdHumanizer};
+use failure::bail;
+use repr::QualName;
+use repr::RelationDesc;
 
 /// A `Catalog` keeps track of the SQL objects known to the planner.
 ///
@@ -20,7 +20,17 @@ use repr::{RelationDesc, RelationType};
 /// It also enforces uniqueness of names.
 #[derive(Debug)]
 pub struct Catalog {
-    inner: HashMap<QualName, CatalogItemAndMetadata>,
+    id: usize,
+    by_name: HashMap<QualName, GlobalId>,
+    by_id: HashMap<GlobalId, CatalogEntry>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CatalogEntry {
+    inner: CatalogItem,
+    used_by: Vec<GlobalId>,
+    id: GlobalId,
+    name: QualName,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -31,150 +41,133 @@ pub enum CatalogItem {
     Index(Index),
 }
 
-impl CatalogItem {
-    /// Reports the name of this calatog item.
-    pub fn name(&self) -> &QualName {
-        match self {
-            CatalogItem::Source(src) => &src.name,
-            CatalogItem::Sink(sink) => &sink.name,
-            CatalogItem::View(view) => &view.name,
-            CatalogItem::Index(idx) => &idx.name,
-        }
-    }
-
+impl CatalogEntry {
     /// Reports the description of the datums produced by this catalog item.
-    pub fn desc(&self) -> &RelationDesc {
-        match self {
-            CatalogItem::Source(src) => &src.desc,
-            CatalogItem::Sink(_) => panic!(
-                "programming error: CatalogItem.typ called on Sink variant, \
-                 but sinks don't have a type"
+    pub fn desc(&self) -> Result<&RelationDesc, failure::Error> {
+        match &self.inner {
+            CatalogItem::Source(src) => Ok(&src.desc),
+            CatalogItem::Sink(_) => bail!(
+                "catalog item '{}' is a sink and so cannot be depended upon",
+                self.name
             ),
-            CatalogItem::View(view) => &view.desc,
-            CatalogItem::Index(_) => panic!(
-                "programming error: CatalogItem.typ called on Index variant, \
-                 but indexes don't have a type"
+            CatalogItem::View(view) => Ok(&view.desc),
+            CatalogItem::Index(_) => bail!(
+                "catalog item '{}' is an index and so cannot be depended upon",
+                self.name
             ),
         }
     }
 
-    /// Reports the type of the datums produced by this catalog item.
-    pub fn typ(&self) -> &RelationType {
-        match self {
-            CatalogItem::Source(src) => src.desc.typ(),
-            CatalogItem::Sink(_) => panic!(
-                "programming error: CatalogItem.typ called on Sink variant, \
-                 but sinks don't have a type"
-            ),
-            CatalogItem::View(view) => view.desc.typ(),
-            CatalogItem::Index(_) => panic!(
-                "programming error: CatalogItem.typ called on Index variant, \
-                 but indexes don't have a type"
-            ),
-        }
-    }
-    /// Collects the names of the dataflows that this dataflow depends upon.
-    pub fn uses(&self) -> Vec<&QualName> {
-        match self {
+    /// Collects the identifiers of the dataflows that this dataflow depends
+    /// upon.
+    pub fn uses(&self) -> Vec<GlobalId> {
+        match &self.inner {
             CatalogItem::Source(_src) => Vec::new(),
-            CatalogItem::Sink(sink) => vec![&sink.from.0],
+            CatalogItem::Sink(sink) => vec![sink.from.0],
             CatalogItem::View(view) => {
                 let mut out = Vec::new();
-                view.relation_expr.unbound_uses(&mut out);
+                view.relation_expr.global_uses(&mut out);
                 out
             }
             CatalogItem::Index(idx) => {
                 let mut out = Vec::new();
-                out.push(&idx.on_name);
+                out.push(idx.on_id);
                 out
             }
         }
     }
-}
 
-#[derive(Debug)]
-struct CatalogItemAndMetadata {
-    inner: CatalogItem,
-    used_by: Vec<QualName>,
+    /// Returns the `CatalogItem` associated with this catalog entry.
+    pub fn item(&self) -> &CatalogItem {
+        &self.inner
+    }
+
+    /// Returns the global ID of this catalog entry.
+    pub fn id(&self) -> GlobalId {
+        self.id
+    }
+
+    /// Returns the name of this catalog entry.
+    pub fn name(&self) -> &QualName {
+        &self.name
+    }
 }
 
 impl Default for Catalog {
     fn default() -> Catalog {
         Catalog {
-            inner: HashMap::new(),
+            id: 0,
+            by_name: HashMap::new(),
+            by_id: HashMap::new(),
         }
     }
 }
 
 impl Catalog {
+    pub fn allocate_id(&mut self) -> GlobalId {
+        self.id += 1;
+        GlobalId::user(self.id)
+    }
+
     /// Returns the named catalog item, if it exists.
     ///
     /// See also [`Catalog::get`].
-    pub fn try_get(&self, name: &QualName) -> Option<&CatalogItem> {
-        self.inner.get(name).map(|dm| &dm.inner)
+    pub fn try_get(&self, name: &QualName) -> Option<&CatalogEntry> {
+        self.by_name.get(name).map(|id| &self.by_id[id])
     }
 
     /// Returns the named catalog item, or an error if it does not exist.
     ///
     /// See also [`Catalog::try_get`].
-    pub fn get(&self, name: &QualName) -> Result<&CatalogItem, failure::Error> {
+    pub fn get(&self, name: &QualName) -> Result<&CatalogEntry, failure::Error> {
         self.try_get(name)
             .ok_or_else(|| failure::err_msg(format!("catalog item '{}' does not exist", name)))
     }
 
-    /// Returns the descriptor for the named catalog item, or an error if the named
-    /// catalog item does not exist.
-    pub fn get_desc(&self, name: &QualName) -> Result<&RelationDesc, failure::Error> {
-        match self.get(name)? {
-            CatalogItem::Sink { .. } => bail!(
-                "catalog item {} is a sink and cannot be depended upon",
-                name
-            ),
-            CatalogItem::Index { .. } => bail!(
-                "catalog item {} is an index and cannot be depended upon",
-                name
-            ),
-            item => Ok(item.desc()),
-        }
-    }
-
-    /// Returns the type for the named catalog item, or an error if the named
-    /// catalog item does not exist.
-    pub fn get_type(&self, name: &QualName) -> Result<&RelationType, failure::Error> {
-        match self.get(name)? {
-            CatalogItem::Sink { .. } => bail!(
-                "catalog item {} is a sink and cannot be depended upon",
-                name
-            ),
-            item => Ok(item.typ()),
-        }
-    }
-
-    /// Inserts a new catalog item, returning an error if a catalog item with the same
-    /// name already exists.
+    /// Inserts a new catalog item, returning an error if a catalog item with
+    /// the same name already exists.
     ///
     /// The internal dependency graph is updated accordingly. The function will
     /// panic if any of `item`'s dependencies are not present in the store.
-    pub fn insert(&mut self, item: CatalogItem) -> Result<(), failure::Error> {
-        let name = item.name();
-        match self.inner.entry(name.clone()) {
-            Entry::Occupied(_) => bail!("catalog item {} already exists", name),
-            Entry::Vacant(vacancy) => {
-                vacancy.insert(CatalogItemAndMetadata {
-                    inner: item.clone(),
-                    used_by: Vec::new(),
-                });
-            }
+    pub fn insert(
+        &mut self,
+        name: QualName,
+        item: CatalogItem,
+    ) -> Result<GlobalId, failure::Error> {
+        let id = self.allocate_id();
+        self.insert_id(name, id, item)?;
+        Ok(id)
+    }
+
+    pub fn insert_id(
+        &mut self,
+        name: QualName,
+        id: GlobalId,
+        item: CatalogItem,
+    ) -> Result<(), failure::Error> {
+        let item = CatalogEntry {
+            inner: item,
+            name,
+            id,
+            used_by: Vec::new(),
+        };
+        if self.by_name.contains_key(&item.name) {
+            bail!("catalog item '{}' already exists", item.name)
+        }
+        if self.by_id.contains_key(&item.id) {
+            bail!("catalog item with id {} already exists", item.id)
         }
         for u in item.uses() {
-            match self.inner.get_mut(u) {
-                Some(entry) => entry.used_by.push(name.clone()),
+            match self.by_id.get_mut(&u) {
+                Some(metadata) => metadata.used_by.push(item.id),
                 None => panic!(
                     "Catalog: missing dependent catalog item {} while installing {}",
-                    u, name
+                    u, item.name
                 ),
             }
         }
+        self.by_name.insert(item.name.clone(), item.id);
+        self.by_id.insert(item.id, item);
         Ok(())
     }
 
@@ -183,8 +176,8 @@ impl Catalog {
     /// an error will be returned if any existing views depend upon the view
     /// specified for removal. If `mode` is [`RemoveMode::Cascade`], then the
     /// views that transitively depend upon the view specified for removal will
-    /// be collected into the `to_remove` vector. In either mode, `name` is
-    /// included in `to_remove`.
+    /// be collected into the `to_remove` vector. In either mode, the identifier
+    /// that corresponds to `name` is included in `to_remove`.
     ///
     /// To actually remove the views, call [`Catalog::remove`] on each
     /// name in `to_remove`.
@@ -192,13 +185,12 @@ impl Catalog {
         &self,
         name: &QualName,
         mode: RemoveMode,
-        to_remove: &mut Vec<QualName>,
+        to_remove: &mut Vec<GlobalId>,
     ) -> Result<(), failure::Error> {
-        let metadata = match self.inner.get(name) {
+        let metadata = match self.try_get(name) {
             Some(metadata) => metadata,
             None => return Ok(()),
         };
-
         match mode {
             RemoveMode::Restrict => {
                 if !metadata
@@ -209,38 +201,54 @@ impl Catalog {
                     bail!(
                         "cannot delete {}: still depended upon by catalog item '{}'",
                         name,
-                        metadata.used_by[0]
+                        self.by_id[&metadata.used_by[0]].name()
                     )
                 }
+                to_remove.push(metadata.id);
+                Ok(())
             }
             RemoveMode::Cascade => {
-                let used_by = metadata.used_by.clone();
-                for u in used_by {
-                    self.plan_remove(&u, RemoveMode::Cascade, to_remove)?;
-                }
+                self.plan_remove_cascade(metadata, to_remove);
+                Ok(())
             }
         }
-
-        to_remove.push(name.to_owned());
-
-        Ok(())
     }
 
-    /// Unconditionally removes the named view. It is required that `name`
+    fn plan_remove_cascade(&self, metadata: &CatalogEntry, to_remove: &mut Vec<GlobalId>) {
+        let used_by = metadata.used_by.clone();
+        for u in used_by {
+            self.plan_remove_cascade(&self.by_id[&u], to_remove);
+        }
+        to_remove.push(metadata.id);
+    }
+
+    /// Unconditionally removes the named view. It is required that `id`
     /// come from the output of `plan_remove`; otherwise consistency rules may
     /// be violated.
-    pub fn remove(&mut self, name: &QualName) {
-        if let Some(metadata) = self.inner.remove(name) {
-            for u in metadata.inner.uses() {
-                if let Some(entry) = self.inner.get_mut(u) {
-                    entry.used_by.retain(|u| u != name)
+    pub fn remove(&mut self, id: GlobalId) {
+        if let Some(metadata) = self.by_id.remove(&id) {
+            for u in metadata.uses() {
+                if let Some(dep_metadata) = self.by_id.get_mut(&u) {
+                    dep_metadata.used_by.retain(|u| *u != metadata.id)
                 }
             }
+            self.by_name
+                .remove(&metadata.name)
+                .expect("catalog out of sync");
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&QualName, &CatalogItem)> {
-        self.inner.iter().map(|(k, v)| (k, &v.inner))
+    pub fn iter(&self) -> impl Iterator<Item = (&CatalogEntry)> {
+        self.by_id.iter().map(|(_id, entry)| entry)
+    }
+}
+
+impl IdHumanizer for Catalog {
+    fn humanize_id(&self, id: Id) -> Option<String> {
+        match id {
+            Id::Global(id) => self.by_id.get(&id).map(|entry| entry.name.to_string()),
+            Id::Local(_) => None,
+        }
     }
 }
 

--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -3,9 +3,11 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-use repr::{LiteralName, QualName, RelationDesc, ScalarType};
 use std::collections::HashSet;
 use std::time::Duration;
+
+use expr::GlobalId;
+use repr::{LiteralName, QualName, RelationDesc, ScalarType};
 
 /// Logging configuration.
 #[derive(Debug, Clone)]
@@ -103,6 +105,25 @@ impl LogVariant {
         }
     }
 
+    pub fn id(&self) -> GlobalId {
+        // Bind all identifiers in one place to avoid accidental clashes.
+        match self {
+            LogVariant::Timely(TimelyLog::Operates) => GlobalId::system(1),
+            LogVariant::Timely(TimelyLog::Channels) => GlobalId::system(2),
+            LogVariant::Timely(TimelyLog::Elapsed) => GlobalId::system(3),
+            LogVariant::Timely(TimelyLog::Histogram) => GlobalId::system(4),
+            LogVariant::Timely(TimelyLog::Addresses) => GlobalId::system(5),
+            LogVariant::Timely(TimelyLog::Parks) => GlobalId::system(6),
+            LogVariant::Differential(DifferentialLog::Arrangement) => GlobalId::system(7),
+            LogVariant::Differential(DifferentialLog::Sharing) => GlobalId::system(8),
+            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => GlobalId::system(9),
+            LogVariant::Materialized(MaterializedLog::DataflowDependency) => GlobalId::system(10),
+            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => GlobalId::system(11),
+            LogVariant::Materialized(MaterializedLog::PeekCurrent) => GlobalId::system(12),
+            LogVariant::Materialized(MaterializedLog::PeekDuration) => GlobalId::system(13),
+        }
+    }
+
     /// By which columns should the logs be indexed.
     ///
     /// This is distinct from the `keys` property of the type, which indicates uniqueness.
@@ -188,7 +209,7 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
                 .add_column("uuid", ScalarType::String)
                 .add_column("worker", ScalarType::Int64)
-                .add_column("name", ScalarType::String)
+                .add_column("id", ScalarType::String)
                 .add_column("time", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 

--- a/src/dataflow/logging/materialized.rs
+++ b/src/dataflow/logging/materialized.rs
@@ -17,7 +17,8 @@ use timely::logging::WorkerIdentifier;
 use super::{LogVariant, MaterializedLog};
 use crate::arrangement::KeysValsHandle;
 use dataflow_types::Timestamp;
-use repr::{Datum, QualName, RowPacker, RowUnpacker};
+use expr::GlobalId;
+use repr::{Datum, RowPacker, RowUnpacker};
 
 /// Type alias for logging of materialized events.
 pub type Logger = timely::logging_core::Logger<MaterializedEvent, WorkerIdentifier>;
@@ -28,16 +29,16 @@ pub type Logger = timely::logging_core::Logger<MaterializedEvent, WorkerIdentifi
 )]
 pub enum MaterializedEvent {
     /// Dataflow command, true for create and false for drop.
-    Dataflow(QualName, bool),
+    Dataflow(GlobalId, bool),
     /// Dataflow depends on a named source of data.
     DataflowDependency {
-        dataflow: QualName,
-        source: QualName,
+        dataflow: GlobalId,
+        source: GlobalId,
     },
     /// Peek command, true for install and false for retire.
     Peek(Peek, bool),
     /// Available frontier information for views.
-    Frontier(QualName, Timestamp, i64),
+    Frontier(GlobalId, Timestamp, i64),
 }
 
 /// A logged peek event.
@@ -45,8 +46,8 @@ pub enum MaterializedEvent {
     Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct Peek {
-    /// The name of the view the peek targets.
-    name: QualName,
+    /// The identifier of the view the peek targets.
+    id: GlobalId,
     /// The logical timestamp requested.
     time: Timestamp,
     /// The connection ID of the peek.
@@ -54,12 +55,8 @@ pub struct Peek {
 }
 
 impl Peek {
-    pub fn new(name: QualName, time: Timestamp, conn_id: u32) -> Self {
-        Self {
-            name,
-            time,
-            conn_id,
-        }
+    pub fn new(id: GlobalId, time: Timestamp, conn_id: u32) -> Self {
+        Self { id, time, conn_id }
     }
 }
 
@@ -112,8 +109,8 @@ pub fn construct<A: Allocate>(
                         let time_ns = time.as_nanos() as Timestamp;
 
                         match datum {
-                            MaterializedEvent::Dataflow(name, is_create) => {
-                                dataflow_session.give((name.clone(), worker, is_create, time_ns));
+                            MaterializedEvent::Dataflow(id, is_create) => {
+                                dataflow_session.give((id, worker, is_create, time_ns));
 
                                 // For now we know that these always happen in
                                 // the correct order, but it may be necessary
@@ -121,13 +118,13 @@ pub fn construct<A: Allocate>(
                                 // reference to their own sources and a logger
                                 // that is called on them in a `with_drop` handler
                                 if is_create {
-                                    active_dataflows.insert((name, worker), vec![]);
+                                    active_dataflows.insert((id, worker), vec![]);
                                 } else {
-                                    let key = &(name, worker);
+                                    let key = &(id, worker);
                                     match active_dataflows.remove(key) {
                                         Some(sources) => {
                                             for (source, worker) in sources {
-                                                let n = key.0.clone();
+                                                let n = key.0;
                                                 dependency_session
                                                     .give((n, source, worker, false, time_ns));
                                             }
@@ -141,9 +138,7 @@ pub fn construct<A: Allocate>(
                                 }
                             }
                             MaterializedEvent::DataflowDependency { dataflow, source } => {
-                                let df = dataflow.clone();
-                                let s = source.clone();
-                                dependency_session.give((df, s, worker, true, time_ns));
+                                dependency_session.give((dataflow, source, worker, true, time_ns));
                                 let key = (dataflow, worker);
                                 match active_dataflows.get_mut(&key) {
                                     Some(existing_sources) => {
@@ -218,7 +213,7 @@ pub fn construct<A: Allocate>(
                     packer.pack(&[
                         Datum::String(&*format!("{}", peek.conn_id)),
                         Datum::Int64(worker as i64),
-                        Datum::String(&*peek.name.to_string()),
+                        Datum::String(&peek.id.to_string()),
                         Datum::Int64(peek.time as i64),
                     ])
                 }

--- a/src/dataflow/sink/kafka.rs
+++ b/src/dataflow/sink/kafka.rs
@@ -13,15 +13,15 @@ use timely::dataflow::{Scope, Stream};
 use timely::Data;
 
 use dataflow_types::{Diff, KafkaSinkConnector, Timestamp};
-use repr::QualName;
+use expr::GlobalId;
 
-pub fn kafka<G, B, K, V>(stream: &Stream<G, B>, name: &QualName, _connector: KafkaSinkConnector)
+pub fn kafka<G, B, K, V>(stream: &Stream<G, B>, id: GlobalId, _connector: KafkaSinkConnector)
 where
     G: Scope<Timestamp = Timestamp>,
     B: Data + BatchReader<K, V, Timestamp, Diff>,
     K: fmt::Debug,
 {
-    stream.sink(Pipeline, &*name.to_string(), move |input| {
+    stream.sink(Pipeline, &format!("kafka-{}", id), move |input| {
         input.for_each(|_, batches| {
             for batch in batches.iter() {
                 let mut cur = batch.cursor();

--- a/src/dataflow/sink/tail.rs
+++ b/src/dataflow/sink/tail.rs
@@ -13,16 +13,16 @@ use timely::order::PartialOrder;
 use timely::Data;
 
 use dataflow_types::{Diff, TailSinkConnector, Timestamp, Update};
-use repr::{QualName, Row};
+use expr::GlobalId;
+use repr::Row;
 
-pub fn tail<G, B>(stream: &Stream<G, B>, name: &QualName, connector: TailSinkConnector)
+pub fn tail<G, B>(stream: &Stream<G, B>, id: GlobalId, connector: TailSinkConnector)
 where
     G: Scope<Timestamp = Timestamp>,
     B: Data + BatchReader<Row, Row, Timestamp, Diff>,
 {
     let mut tx = connector.tx.connect().wait().unwrap();
-    // TODO: should this preserve the QualName part of it?
-    stream.sink(Pipeline, &name.to_string(), move |input| {
+    stream.sink(Pipeline, &format!("tail-{}", id), move |input| {
         input.for_each(|_, batches| {
             let mut results: Vec<Update> = Vec::new();
             for batch in batches.iter() {

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -16,7 +16,7 @@ use super::util::source;
 use super::SharedCapability;
 use dataflow_types::{Diff, KafkaSourceConnector, Timestamp};
 use interchange::avro;
-use repr::{QualName, Row};
+use repr::Row;
 
 use lazy_static::lazy_static;
 use prometheus::{IntCounter, IntCounterVec};
@@ -46,7 +46,7 @@ lazy_static! {
 
 pub fn kafka<G>(
     scope: &G,
-    name: &QualName,
+    name: String,
     connector: KafkaSourceConnector,
     read_kafka: bool,
 ) -> (Stream<G, (Row, Timestamp, Diff)>, Option<SharedCapability>)
@@ -59,8 +59,7 @@ where
         raw_schema,
         schema_registry_url,
     } = connector;
-    let (stream, capability) = source(scope, name, move |info| {
-        let name = name.clone();
+    let (stream, capability) = source(scope, &name.clone(), move |info| {
         let activator = scope.activator_for(&info.address[..]);
 
         let mut config = ClientConfig::new();

--- a/src/dataflow/source/util.rs
+++ b/src/dataflow/source/util.rs
@@ -14,13 +14,8 @@ use timely::Data;
 
 use super::SharedCapability;
 use dataflow_types::Timestamp;
-use repr::QualName;
 
-pub fn source<G, D, B, L>(
-    scope: &G,
-    name: &QualName,
-    construct: B,
-) -> (Stream<G, D>, SharedCapability)
+pub fn source<G, D, B, L>(scope: &G, name: &str, construct: B) -> (Stream<G, D>, SharedCapability)
 where
     G: Scope<Timestamp = Timestamp>,
     D: Data,
@@ -29,7 +24,7 @@ where
         + 'static,
 {
     let mut cap_out = None;
-    let stream = timely_source(scope, &*name.to_string(), |cap, info| {
+    let stream = timely_source(scope, name, |cap, info| {
         // Share ownership of the source's capability with the outside world.
         let cap = Rc::new(RefCell::new(cap));
         cap_out = Some(cap.clone());

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -1,0 +1,102 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// An opaque identifier for a dataflow component. In other words, identifies
+/// the target of a [`RelationExpr::Get`](crate::RelationExpr::Get).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum Id {
+    /// An identifier that refers to a local component of a dataflow.
+    Local(LocalId),
+    /// An identifier that returns to a global dataflow.
+    Global(GlobalId),
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Id::Local(id) => id.fmt(f),
+            Id::Global(id) => id.fmt(f),
+        }
+    }
+}
+
+/// A trait for turning [`Id`]s into human-readable strings.
+pub trait IdHumanizer {
+    /// Attempts to return the a human-readable string for `id`.
+    fn humanize_id(&self, id: Id) -> Option<String>;
+}
+
+/// The identifier for a local component of a dataflow.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub struct LocalId(usize);
+
+impl LocalId {
+    /// Constructs a new local identifier. It is the caller's responsibility
+    /// to provide a unique `v`.
+    pub fn new(v: usize) -> LocalId {
+        LocalId(v)
+    }
+}
+
+impl fmt::Display for LocalId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "l{}", self.0)
+    }
+}
+
+/// The identifier for a global dataflow.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum GlobalId {
+    /// System namespace.
+    System(usize),
+    /// User namespace.
+    User(usize),
+}
+
+impl GlobalId {
+    /// Constructs a new global identifier in the system namespace. It is the
+    /// caller's responsibility to provide a unique `v`.
+    pub fn system(v: usize) -> GlobalId {
+        GlobalId::System(v)
+    }
+
+    /// Constructs a new global identifier in the user namespace. It is the
+    /// caller's responsiblity to provide a unique `v`.
+    pub fn user(v: usize) -> GlobalId {
+        GlobalId::User(v)
+    }
+}
+
+impl fmt::Display for GlobalId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GlobalId::System(id) => write!(f, "s{}", id),
+            GlobalId::User(id) => write!(f, "u{}", id),
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test_utils {
+    use super::*;
+
+    pub struct DummyHumanizer;
+
+    impl IdHumanizer for DummyHumanizer {
+        fn humanize_id(&self, _: Id) -> Option<String> {
+            None
+        }
+    }
+
+    impl From<&LocalId> for char {
+        fn from(id: &LocalId) -> char {
+            id.0 as u8 as char
+        }
+    }
+}

--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -12,10 +12,12 @@ pub mod like;
 #[macro_use]
 pub mod pretty_pretty;
 
+mod id;
 mod relation;
 mod scalar;
 pub mod transform;
 
+pub use id::{GlobalId, Id, IdHumanizer, LocalId};
 pub use relation::func::AggregateFunc;
 pub use relation::{AggregateExpr, ColumnOrder, IdGen, RelationExpr};
 pub use scalar::func::{BinaryFunc, UnaryFunc, VariadicFunc};

--- a/src/expr/pretty_pretty.rs
+++ b/src/expr/pretty_pretty.rs
@@ -13,7 +13,6 @@
 
 //! Making [`pretty`] Pretty Again
 
-use crate::RelationExpr;
 use ore::collections::CollectionExt;
 use pretty::Doc::Space;
 use pretty::{BoxDoc, Doc};
@@ -40,15 +39,6 @@ macro_rules! to_doc {
         )*
         doc
     }}
-}
-
-impl<'a> From<&'a Box<RelationExpr>> for Doc<'a, BoxDoc<'a, ()>, ()> {
-    /// Turn [`RelationExpr`] into [`pretty::Doc`] by invoking
-    /// [`RelationExpr::to_doc`]. Without this trait, `to_doc!` would
-    /// be far less convenient.
-    fn from(s: &'a Box<RelationExpr>) -> Doc<'a, BoxDoc<'a, ()>, ()> {
-        s.to_doc()
-    }
 }
 
 /// Embrace `doc` as the sequence `left`, `doc`, `right`. The resulting document has one

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -128,7 +128,6 @@ impl Default for Optimizer {
             Box::new(crate::transform::predicate_pushdown::PredicatePushdown),
             Box::new(crate::transform::projection_lifting::ProjectionLifting),
             Box::new(crate::transform::fusion::project::Project),
-            Box::new(crate::transform::binding::Normalize),
             Box::new(crate::transform::constant_join::ConstantJoin),
         ];
         Self { transforms }

--- a/src/sql/expr.rs
+++ b/src/sql/expr.rs
@@ -21,7 +21,7 @@ pub enum RelationExpr {
         typ: RelationType,
     },
     Get {
-        name: QualName,
+        id: dataflow_expr::Id,
         typ: RelationType,
     },
     // only needed for CTEs
@@ -251,7 +251,7 @@ impl RelationExpr {
                 rows: rows.into_iter().map(|row| (row, 1)).collect(),
                 typ,
             })),
-            Get { name, typ } => Ok(get_outer.product(SR::Get { name, typ })),
+            Get { id, typ } => Ok(get_outer.product(SR::Get { id, typ })),
             Project { input, outputs } => {
                 let input = input.applied_to(id_gen, get_outer.clone())?;
                 let outputs = (0..get_outer.arity())

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+catalog = { path = "../catalog" }
 chrono = { version = "0.4", features = ["serde"] }
 dataflow-types = { path = "../dataflow-types" }
 failure = "0.1.6"

--- a/test/basic.td
+++ b/test/basic.td
@@ -145,4 +145,4 @@ b  c
 > CREATE INDEX idx1 ON test5(c)
 
 ! PEEK idx1
-unsupported SQL statement: PEEK index
+catalog item 'idx1' is an index and so cannot be depended upon

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -230,7 +230,7 @@ Project {
       ],
       Filter {
         predicates: [datetots #6 > 2007-01-02 00:00:00],
-        Get { orderline }
+        Get { orderline (u13) }
       }
     }
   }
@@ -273,7 +273,7 @@ Project {
       [(3, 3), (4, 0)],
       [(4, 2), (5, 0)]
     ],
-    Filter { predicates: [#4 ~ ^.*b$], Get { item } },
+    Filter { predicates: [#4 ~ ^.*b$], Get { item (u15) } },
     Filter {
       predicates: [!isnull #1],
       Reduce {
@@ -285,17 +285,20 @@ Project {
             [(1, 3), (2, 0)],
             [(2, 2), (3, 0)]
           ],
-          Get { stock },
-          Map { scalars: [i32toi64 #0], Get { supplier } },
-          Get { nation },
-          Filter { predicates: [#1 ~ ^EUROP.*$], Get { region } }
+          Get { stock (u17) },
+          Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+          Get { nation (u19) },
+          Filter {
+            predicates: [#1 ~ ^EUROP.*$],
+            Get { region (u23) }
+          }
         }
       }
     },
-    Filter { predicates: [!isnull #2], Get { stock } },
-    Map { scalars: [i32toi64 #0], Get { supplier } },
-    Get { nation },
-    Filter { predicates: [#1 ~ ^EUROP.*$], Get { region } }
+    Filter { predicates: [!isnull #2], Get { stock (u17) } },
+    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    Get { nation (u19) },
+    Filter { predicates: [#1 ~ ^EUROP.*$], Get { region (u23) } }
   }
 }
 
@@ -330,13 +333,13 @@ Project {
         [(0, 2), (1, 2), (2, 2), (3, 2)],
         [(2, 3), (3, 0)]
       ],
-      Get { orderline },
-      Get { neworder },
+      Get { orderline (u13) },
+      Get { neworder (u9) },
       Filter {
         predicates: [datetots #4 > 2007-01-02 00:00:00],
-        Get { "order" }
+        Get { "order" (u11) }
       },
-      Filter { predicates: [#9 ~ ^A.*$], Get { customer } }
+      Filter { predicates: [#9 ~ ^A.*$], Get { customer (u5) } }
     }
   }
 }
@@ -360,12 +363,12 @@ GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt
 ----
 Let {
-  id-1 = Filter {
+  l0 = Filter {
     predicates: [
       datetots #4 < 2012-01-02 00:00:00,
       datetots #4 >= 2007-01-02 00:00:00
     ],
-    Get { "order" }
+    Get { "order" (u11) }
   }
 } in
 Reduce {
@@ -380,7 +383,7 @@ Reduce {
         [(0, 2), (1, 2)],
         [(0, 4), (1, 3)]
       ],
-      Get { id-1 },
+      Get { l0 },
       Distinct {
         group_key: [10 .. 12, 14],
         Filter {
@@ -391,8 +394,8 @@ Reduce {
               [(0, 1), (1, 1)],
               [(0, 2), (1, 2)]
             ],
-            Get { orderline },
-            Get { id-1 }
+            Get { orderline (u13) },
+            Get { l0 }
           }
         }
       }
@@ -439,16 +442,19 @@ Reduce {
       [(4, 3), (5, 0)],
       [(5, 2), (6, 0)]
     ],
-    Get { customer },
+    Get { customer (u5) },
     Filter {
       predicates: [datetots #4 >= 2007-01-02 00:00:00],
-      Get { "order" }
+      Get { "order" (u11) }
     },
-    Get { orderline },
-    Get { stock },
-    Map { scalars: [i32toi64 #0, i32toi64 #3], Get { supplier } },
-    Get { nation },
-    Filter { predicates: [#1 = "EUROPE"], Get { region } }
+    Get { orderline (u13) },
+    Get { stock (u17) },
+    Map {
+      scalars: [i32toi64 #0, i32toi64 #3],
+      Get { supplier (u21) }
+    },
+    Get { nation (u19) },
+    Filter { predicates: [#1 = "EUROPE"], Get { region (u23) } }
   }
 }
 
@@ -462,7 +468,7 @@ AND ol_delivery_d < TIMESTAMP '2020-01-01 00:00:00.000000'
 AND ol_quantity BETWEEN 1 AND 100000
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#8)],
     Filter {
@@ -472,16 +478,16 @@ Let {
         i32toi64 #7 >= 1,
         datetots #6 >= 1999-01-01 00:00:00
       ],
-      Get { orderline }
+      Get { orderline (u13) }
     }
   }
 } in
 Union {
-  Get { id-1 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { id-1 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -539,19 +545,19 @@ Reduce {
           [(4, 3), (5, 0)],
           [(5, 21), (6, 4)]
         ],
-        Map { scalars: [i32toi64 #0], Get { supplier } },
-        Get { nation },
-        Get { stock },
+        Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+        Get { nation (u19) },
+        Get { stock (u17) },
         Filter {
           predicates: [
             datetots #6 <= 2012-01-02 00:00:00,
             datetots #6 >= 2007-01-02 00:00:00
           ],
-          Get { orderline }
+          Get { orderline (u13) }
         },
-        Get { "order" },
-        Get { customer },
-        Map { scalars: [i32toi64 #0], Get { nation } }
+        Get { "order" (u11) },
+        Get { customer (u5) },
+        Map { scalars: [i32toi64 #0], Get { nation (u19) } }
       }
     }
   }
@@ -610,24 +616,27 @@ Project {
             [(5, 2), (6, 0)],
             [(7, 3), (8, 0)]
           ],
-          Filter { predicates: [#4 ~ ^.*b$], Get { item } },
+          Filter { predicates: [#4 ~ ^.*b$], Get { item (u15) } },
           Filter {
             predicates: [!isnull #4, #4 < 1000],
-            Get { orderline }
+            Get { orderline (u13) }
           },
           Filter {
             predicates: [
               datetots #4 <= 2012-01-02 00:00:00,
               datetots #4 >= 2007-01-02 00:00:00
             ],
-            Get { "order" }
+            Get { "order" (u11) }
           },
-          Get { customer },
-          Get { stock },
-          Map { scalars: [i32toi64 #0], Get { nation } },
-          Filter { predicates: [#1 = "EUROPE"], Get { region } },
-          Map { scalars: [i32toi64 #0], Get { supplier } },
-          Get { nation }
+          Get { customer (u5) },
+          Get { stock (u17) },
+          Map { scalars: [i32toi64 #0], Get { nation (u19) } },
+          Filter {
+            predicates: [#1 = "EUROPE"],
+            Get { region (u23) }
+          },
+          Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+          Get { nation (u19) }
         }
       }
     }
@@ -668,12 +677,12 @@ Reduce {
         [(3, 17), (4, 7)],
         [(4, 3), (5, 0)]
       ],
-      Filter { predicates: [#4 ~ ^.*BB$], Get { item } },
-      Get { orderline },
-      Get { "order" },
-      Get { stock },
-      Map { scalars: [i32toi64 #0], Get { supplier } },
-      Get { nation }
+      Filter { predicates: [#4 ~ ^.*BB$], Get { item (u15) } },
+      Get { orderline (u13) },
+      Get { "order" (u11) },
+      Get { stock (u17) },
+      Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+      Get { nation (u19) }
     }
   }
 }
@@ -711,13 +720,13 @@ Project {
           [(0, 21), (3, 4)],
           [(1, 0), (2, 0)]
         ],
-        Get { customer },
+        Get { customer (u5) },
         Filter {
           predicates: [datetots #4 >= 2007-01-02 00:00:00],
-          Get { "order" }
+          Get { "order" (u11) }
         },
-        Get { orderline },
-        Map { scalars: [i32toi64 #0], Get { nation } }
+        Get { orderline (u13) },
+        Map { scalars: [i32toi64 #0], Get { nation (u19) } }
       }
     }
   }
@@ -742,11 +751,11 @@ HAVING sum(s_order_cnt) > (
 ORDER BY ordercount DESC
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 17), (1, 7)], [(1, 3), (2, 0)]],
-    Get { stock },
-    Map { scalars: [i32toi64 #0], Get { supplier } },
-    Filter { predicates: [#1 = "GERMANY"], Get { nation } }
+    Get { stock (u17) },
+    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    Filter { predicates: [#1 = "GERMANY"], Get { nation (u19) } }
   }
 } in
 Project {
@@ -755,10 +764,10 @@ Project {
     predicates: [(i32todec #1 * 1000000dec) > #3],
     Join {
       variables: [],
-      Reduce { group_key: [0], aggregates: [sum(#14)], Get { id-1 } },
+      Reduce { group_key: [0], aggregates: [sum(#14)], Get { l0 } },
       Map {
         scalars: [(i32todec #0 * 1000dec) * 5dec],
-        Reduce { group_key: [], aggregates: [sum(#14)], Get { id-1 } }
+        Reduce { group_key: [], aggregates: [sum(#14)], Get { l0 } }
       }
     }
   }
@@ -797,9 +806,9 @@ Reduce {
       ],
       Filter {
         predicates: [datetots #6 < 2020-01-01 00:00:00],
-        Get { orderline }
+        Get { orderline (u13) }
       },
-      Get { "order" }
+      Get { "order" (u11) }
     }
   }
 }
@@ -821,10 +830,10 @@ GROUP BY c_count
 ORDER BY custdist DESC, c_count DESC
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 1), (1, 1)], [(0, 2), (1, 2)], [(0, 3), (1, 0)]],
-    Filter { predicates: [i32toi64 #5 > 8], Get { "order" } },
-    Get { customer }
+    Filter { predicates: [i32toi64 #5 > 8], Get { "order" (u11) } },
+    Get { customer (u5) }
   }
 } in
 Reduce {
@@ -834,15 +843,12 @@ Reduce {
     group_key: [0],
     aggregates: [count(#22)],
     Union {
-      Project {
-        outputs: [8 .. 29, 0, 9, 10, 8, 4 .. 7],
-        Get { id-1 }
-      },
+      Project { outputs: [8 .. 29, 0, 9, 10, 8, 4 .. 7], Get { l0 } },
       Map {
         scalars: [null, null, null, null, null, null, null, null],
         Union {
-          Negate { Distinct { group_key: [8 .. 29], Get { id-1 } } },
-          Get { customer }
+          Negate { Distinct { group_key: [8 .. 29], Get { l0 } } },
+          Get { customer (u5) }
         }
       }
     }
@@ -860,7 +866,7 @@ AND ol_delivery_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
 AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(if #14 ~ ^PR.*$ then #8 else 0dec), sum(#8)],
     Join {
@@ -870,9 +876,9 @@ Let {
           datetots #6 < 2020-01-02 00:00:00,
           datetots #6 >= 2007-01-02 00:00:00
         ],
-        Get { orderline }
+        Get { orderline (u13) }
       },
-      Get { item }
+      Get { item (u15) }
     }
   }
 } in
@@ -883,11 +889,11 @@ Project {
       (((10000dec * #0) * 10000000dec) / (100dec + #1)) * 10dec
     ],
     Union {
-      Get { id-1 },
+      Get { l0 },
       Map {
         scalars: [null, null],
         Union {
-          Project { outputs: [], Negate { Get { id-1 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -928,16 +934,16 @@ AND total_revenue = (
 ORDER BY su_suppkey
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [27],
     aggregates: [sum(#8)],
     Join {
       variables: [[(0, 4), (1, 0)], [(0, 5), (1, 1)]],
       Filter {
         predicates: [datetots #6 >= 2007-01-02 00:00:00],
-        Get { orderline }
+        Get { orderline (u13) }
       },
-      Get { stock }
+      Get { stock (u17) }
     }
   }
 } in
@@ -945,11 +951,11 @@ Project {
   outputs: [0 .. 2, 4, 9],
   Join {
     variables: [[(0, 7), (1, 0)], [(1, 1), (2, 0)]],
-    Map { scalars: [i32toi64 #0], Get { supplier } },
-    Filter { predicates: [!isnull #1], Get { id-1 } },
+    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    Filter { predicates: [!isnull #1], Get { l0 } },
     Filter {
       predicates: [!isnull #0],
-      Reduce { group_key: [], aggregates: [max(#1)], Get { id-1 } }
+      Reduce { group_key: [], aggregates: [max(#1)], Get { l0 } }
     }
   }
 }
@@ -972,21 +978,21 @@ GROUP BY i_name, substr(i_data, 1, 3), i_price
 ORDER BY supplier_cnt DESC
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { stock },
-    Filter { predicates: [!(#4 ~ ^zz.*$)], Get { item } }
+    Get { stock (u17) },
+    Filter { predicates: [!(#4 ~ ^zz.*$)], Get { item (u15) } }
   }
 } in
-Let { id-2 = Distinct { group_key: [17], Get { id-1 } } } in
+Let { l3 = Distinct { group_key: [17], Get { l0 } } } in
 Let {
-  id-3 = Reduce {
+  l2 = Reduce {
     group_key: [0],
     aggregates: [all(#0 != i32toi64 #1)],
     Join {
       variables: [],
-      Get { id-2 },
-      Filter { predicates: [#6 ~ ^.*bad.*$], Get { supplier } }
+      Get { l3 },
+      Filter { predicates: [#6 ~ ^.*bad.*$], Get { supplier (u21) } }
     }
   }
 } in
@@ -997,14 +1003,14 @@ Reduce {
     scalars: [substr(#22, 1, 3)],
     Join {
       variables: [[(0, 17), (1, 0)]],
-      Get { id-1 },
+      Get { l0 },
       Union {
-        Filter { predicates: [#1], Get { id-3 } },
+        Filter { predicates: [#1], Get { l2 } },
         Map {
           scalars: [true],
           Union {
-            Project { outputs: [0], Negate { Get { id-3 } } },
-            Get { id-2 }
+            Project { outputs: [0], Negate { Get { l2 } } },
+            Get { l3 }
           }
         }
       }
@@ -1029,14 +1035,14 @@ WHERE ol_i_id = t.i_id
 AND ol_quantity < t.a
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#8)],
     Filter {
       predicates: [(i32todec #7 * 1000000dec) < #13],
       Join {
         variables: [[(0, 4), (1, 0)]],
-        Get { orderline },
+        Get { orderline (u13) },
         Map {
           scalars: [
             ((i32todec #1 * 10000000dec) / i64todec #2) / 10dec
@@ -1046,8 +1052,8 @@ Let {
             aggregates: [sum(#7), count(#7)],
             Join {
               variables: [[(0, 4), (1, 0)]],
-              Get { orderline },
-              Filter { predicates: [#4 ~ ^.*b$], Get { item } }
+              Get { orderline (u13) },
+              Filter { predicates: [#4 ~ ^.*b$], Get { item (u15) } }
             }
           }
         }
@@ -1060,11 +1066,11 @@ Project {
   Map {
     scalars: [(#0 * 10000000dec) / 20dec],
     Union {
-      Get { id-1 },
+      Get { l0 },
       Map {
         scalars: [null],
         Union {
-          Project { outputs: [], Negate { Get { id-1 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -1101,9 +1107,9 @@ Project {
           [(0, 2), (1, 2), (2, 2)],
           [(1, 3), (2, 0)]
         ],
-        Get { orderline },
-        Get { "order" },
-        Get { customer }
+        Get { orderline (u13) },
+        Get { "order" (u11) },
+        Get { customer (u5) }
       }
     }
   }
@@ -1138,7 +1144,7 @@ WHERE (
 )
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#8)],
     Filter {
@@ -1155,22 +1161,22 @@ Let {
         variables: [[(0, 4), (1, 0)]],
         Filter {
           predicates: [i32toi64 #7 <= 10, i32toi64 #7 >= 1],
-          Get { orderline }
+          Get { orderline (u13) }
         },
         Filter {
           predicates: [#3 <= 40000000dec, #3 >= 100dec],
-          Get { item }
+          Get { item (u15) }
         }
       }
     }
   }
 } in
 Union {
-  Get { id-1 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { id-1 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -1196,29 +1202,29 @@ AND n_name = 'GERMANY'
 ORDER BY su_name
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 3), (1, 0)]],
-    Get { supplier },
-    Filter { predicates: [#1 = "GERMANY"], Get { nation } }
+    Get { supplier (u21) },
+    Filter { predicates: [#1 = "GERMANY"], Get { nation (u19) } }
   }
 } in
 Let {
-  id-2 = Join {
+  l3 = Join {
     variables: [[(0, 0), (1, 0)], [(2, 4), (3, 0)]],
-    Get { id-1 },
-    Get { id-1 },
+    Get { l0 },
+    Get { l0 },
     Filter {
       predicates: [datetots #6 > 2010-05-23 12:00:00],
-      Get { orderline }
+      Get { orderline (u13) }
     },
-    Get { stock }
+    Get { stock (u17) }
   }
 } in
 Project {
   outputs: [1, 2],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { id-1 },
+    Get { l0 },
     Reduce {
       group_key: [0],
       aggregates: [any(true)],
@@ -1233,13 +1239,16 @@ Project {
               aggregates: [sum(#29)],
               Join {
                 variables: [[(0, 32), (1, 0)]],
-                Get { id-2 },
+                Get { l3 },
                 Map {
                   scalars: [true],
                   Join {
                     variables: [[(0, 0), (1, 0)]],
-                    Distinct { group_key: [32], Get { id-2 } },
-                    Filter { predicates: [#4 ~ ^co.*$], Get { item } }
+                    Distinct { group_key: [32], Get { l3 } },
+                    Filter {
+                      predicates: [#4 ~ ^co.*$],
+                      Get { item (u15) }
+                    }
                   }
                 }
               }
@@ -1279,7 +1288,7 @@ GROUP BY su_name
 ORDER BY numwait DESC, su_name
 ----
 Let {
-  id-1 = Filter {
+  l0 = Filter {
     predicates: [#36 > #44],
     Join {
       variables: [
@@ -1290,17 +1299,17 @@ Let {
         [(3, 0), (4, 0)],
         [(3, 1), (4, 1)]
       ],
-      Map { scalars: [i32toi64 #0], Get { supplier } },
-      Filter { predicates: [#1 = "GERMANY"], Get { nation } },
-      Get { stock },
-      Get { orderline },
-      Get { "order" }
+      Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+      Filter { predicates: [#1 = "GERMANY"], Get { nation (u19) } },
+      Get { stock (u17) },
+      Get { orderline (u13) },
+      Get { "order" (u11) }
     }
   }
 } in
-Let { id-2 = Distinct { group_key: [30 .. 32, 36], Get { id-1 } } } in
+Let { l2 = Distinct { group_key: [30 .. 32, 36], Get { l0 } } } in
 Let {
-  id-3 = Map {
+  l1 = Map {
     scalars: [true],
     Distinct {
       group_key: [0 .. 3],
@@ -1312,8 +1321,8 @@ Let {
             [(0, 1), (1, 1)],
             [(0, 2), (1, 2)]
           ],
-          Get { id-2 },
-          Get { orderline }
+          Get { l2 },
+          Get { orderline (u13) }
         }
       }
     }
@@ -1329,14 +1338,14 @@ Reduce {
       [(0, 32), (1, 2)],
       [(0, 36), (1, 3)]
     ],
-    Get { id-1 },
+    Get { l0 },
     Union {
-      Filter { predicates: [!#4], Get { id-3 } },
+      Filter { predicates: [!#4], Get { l1 } },
       Map {
         scalars: [false],
         Union {
-          Project { outputs: [0 .. 3], Negate { Get { id-3 } } },
-          Get { id-2 }
+          Project { outputs: [0 .. 3], Negate { Get { l1 } } },
+          Get { l2 }
         }
       }
     }
@@ -1367,7 +1376,7 @@ GROUP BY substr(c_state, 1, 1)
 ORDER BY substr(c_state, 1, 1)
 ----
 Let {
-  id-1 = Filter {
+  l0 = Filter {
     predicates: [(#16 * 1000000dec) > #24],
     Join {
       variables: [],
@@ -1397,7 +1406,7 @@ Let {
           ||
           (substr(#11, 1, 1) = "7")
         ],
-        Get { customer }
+        Get { customer (u5) }
       },
       Map {
         scalars: [
@@ -1433,7 +1442,7 @@ Let {
               (substr(#11, 1, 1) = "7"),
               #16 > 0dec
             ],
-            Get { customer }
+            Get { customer (u5) }
           }
         }
       }
@@ -1441,7 +1450,7 @@ Let {
   }
 } in
 Let {
-  id-2 = Map {
+  l3 = Map {
     scalars: [true],
     Distinct {
       group_key: [8 .. 10],
@@ -1451,8 +1460,8 @@ Let {
           [(0, 2), (1, 2)],
           [(0, 3), (1, 0)]
         ],
-        Get { "order" },
-        Get { id-1 }
+        Get { "order" (u11) },
+        Get { l0 }
       }
     }
   }
@@ -1469,16 +1478,16 @@ Reduce {
         [(0, 2), (1, 2)]
       ],
       Union {
-        Filter { predicates: [!#3], Get { id-2 } },
+        Filter { predicates: [!#3], Get { l3 } },
         Map {
           scalars: [false],
           Union {
-            Project { outputs: [0 .. 2], Negate { Get { id-2 } } },
-            Project { outputs: [0 .. 2], Get { id-1 } }
+            Project { outputs: [0 .. 2], Negate { Get { l3 } } },
+            Project { outputs: [0 .. 2], Get { l0 } }
           }
         }
       },
-      Get { id-1 }
+      Get { l0 }
     }
   }
 }

--- a/test/createdrop.td
+++ b/test/createdrop.td
@@ -49,10 +49,10 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=34
 # Test that creating objects of the same name does not work
 
 ! CREATE MATERIALIZED VIEW i AS SELECT 1.5 AS c
-catalog item i already exists
+catalog item 'i' already exists
 
 ! CREATE INDEX v ON v2(x)
-catalog item v already exists
+catalog item 'v' already exists
 
 $ set dummy={
     "type": "record",
@@ -65,7 +65,7 @@ $ set dummy={
             "name": "row",
             "type": "record",
             "fields": [
-              {"name": "X", 
+              {"name": "X",
                "type": {
                   "type": "bytes",
                   "scale": 3,
@@ -82,16 +82,16 @@ $ set dummy={
   }
 
 ! CREATE SOURCE v2 FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${dummy}'
-catalog item v2 already exists
+catalog item 'v2' already exists
 
 ! CREATE SOURCE i2 FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${dummy}'
-catalog item i2 already exists
+catalog item 'i2' already exists
 
 ! CREATE INDEX s ON v2(x)
-catalog item s already exists
+catalog item 's' already exists
 
 ! CREATE MATERIALIZED VIEW s AS SELECT 'bloop' AS d
-catalog item s already exists
+catalog item 's' already exists
 
 # Test that objects do not get dropped if the drop command does not specify the correct type
 ! DROP SOURCE v

--- a/test/dependencies.td
+++ b/test/dependencies.td
@@ -110,7 +110,7 @@ catalog item 'test4' does not exist
 > CREATE SINK s1 FROM v1 INTO 'kafka://${testdrive.kafka-addr}/v'
 
 ! CREATE MATERIALIZED VIEW v2 AS SELECT * FROM s1;
-catalog item s1 is a sink and cannot be depended upon
+catalog item 's1' is a sink and so cannot be depended upon
 
 # Test that dependent indexes prevent view deletion when restrict is specified
 
@@ -133,7 +133,7 @@ cannot delete s: still depended upon by catalog item 'i2'
 # Test that indexes cannot be depended upon
 
 ! CREATE MATERIALIZED VIEW v3 as SELECT * FROM i1;
-catalog item i1 is an index and cannot be depended upon
+catalog item 'i1' is an index and so cannot be depended upon
 
 # Test cascade delete associated indexes
 > DROP VIEW v2 CASCADE;

--- a/test/subquery.slt
+++ b/test/subquery.slt
@@ -198,8 +198,8 @@ Project {
     scalars: [true],
     Join {
       variables: [],
-      Get { t1 },
-      Distinct { group_key: [], Get { t2 } }
+      Get { t1 (u26) },
+      Distinct { group_key: [], Get { t2 (u28) } }
     }
   }
 }
@@ -211,10 +211,10 @@ Project {
   outputs: [0, 0, 2],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { t1 },
-    Get { t3 },
+    Get { t1 (u26) },
+    Get { t3 (u30) },
     Constant [[true]],
-    Distinct { group_key: [], Get { t2 } }
+    Distinct { group_key: [], Get { t2 (u28) } }
   }
 }
 
@@ -222,10 +222,10 @@ query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2 WHERE t3.b = t2.b)
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { t1 },
-    Get { t3 }
+    Get { t1 (u26) },
+    Get { t3 (u30) }
   }
 } in
 Project {
@@ -234,13 +234,13 @@ Project {
     scalars: [true],
     Join {
       variables: [[(0, 2), (1, 0)]],
-      Get { id-1 },
+      Get { l0 },
       Distinct {
         group_key: [1],
         Join {
           variables: [[(0, 0), (1, 0)]],
-          Get { t2 },
-          Distinct { group_key: [2], Get { id-1 } }
+          Get { t2 (u28) },
+          Distinct { group_key: [2], Get { l0 } }
         }
       }
     }

--- a/test/tpch.slt
+++ b/test/tpch.slt
@@ -143,7 +143,10 @@ Project {
         countall(null),
         countall(null)
       ],
-      Filter { predicates: [#10 <= 1998-12-01], Get { lineitem } }
+      Filter {
+        predicates: [#10 <= 1998-12-01],
+        Get { lineitem (u15) }
+      }
     }
   }
 }
@@ -187,26 +190,29 @@ ORDER BY
     s_acctbal DESC, n_name, s_name, p_partkey;
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [
       [(0, 0), (1, 0)],
       [(1, 1), (2, 0)],
       [(2, 3), (3, 0)],
       [(3, 2), (4, 0)]
     ],
-    Filter { predicates: [#5 = 15, #4 ~ ^.*BRASS$], Get { part } },
-    Get { partsupp },
-    Get { supplier },
-    Get { nation },
-    Filter { predicates: [#1 = "EUROPE"], Get { region } }
+    Filter {
+      predicates: [#5 = 15, #4 ~ ^.*BRASS$],
+      Get { part (u5) }
+    },
+    Get { partsupp (u9) },
+    Get { supplier (u7) },
+    Get { nation (u1) },
+    Filter { predicates: [#1 = "EUROPE"], Get { region (u3) } }
   }
 } in
-Let { id-2 = Distinct { group_key: [0], Get { id-1 } } } in
+Let { l3 = Distinct { group_key: [0], Get { l0 } } } in
 Project {
   outputs: [19, 15, 22, 0, 2, 16, 18, 20],
   Join {
     variables: [[(0, 0), (1, 0)], [(0, 12), (1, 1)]],
-    Get { id-1 },
+    Get { l0 },
     Reduce {
       group_key: [0],
       aggregates: [min(#7)],
@@ -217,14 +223,14 @@ Project {
           [(5, 3), (6, 0)],
           [(6, 2), (7, 0)]
         ],
-        Get { id-2 },
-        Get { id-2 },
-        Get { id-2 },
-        Get { id-2 },
-        Get { partsupp },
-        Get { supplier },
-        Get { nation },
-        Filter { predicates: [#1 = "EUROPE"], Get { region } }
+        Get { l3 },
+        Get { l3 },
+        Get { l3 },
+        Get { l3 },
+        Get { partsupp (u9) },
+        Get { supplier (u7) },
+        Get { nation (u1) },
+        Filter { predicates: [#1 = "EUROPE"], Get { region (u3) } }
       }
     }
   }
@@ -263,9 +269,15 @@ Project {
     aggregates: [sum(#22 * (100dec - #23))],
     Join {
       variables: [[(0, 0), (1, 1)], [(1, 0), (2, 0)]],
-      Filter { predicates: [#6 = "BUILDING"], Get { customer } },
-      Filter { predicates: [#4 < 1995-03-15], Get { orders } },
-      Filter { predicates: [#10 > 1995-03-15], Get { lineitem } }
+      Filter {
+        predicates: [#6 = "BUILDING"],
+        Get { customer (u11) }
+      },
+      Filter { predicates: [#4 < 1995-03-15], Get { orders (u13) } },
+      Filter {
+        predicates: [#10 > 1995-03-15],
+        Get { lineitem (u15) }
+      }
     }
   }
 }
@@ -296,9 +308,9 @@ order by
     o_orderpriority;
 ----
 Let {
-  id-1 = Filter {
+  l0 = Filter {
     predicates: [datetots #4 < 1993-10-01 00:00:00, #4 >= 1993-07-01],
-    Get { orders }
+    Get { orders (u13) }
   }
 } in
 Reduce {
@@ -308,13 +320,13 @@ Reduce {
     scalars: [true],
     Join {
       variables: [[(0, 0), (1, 0)]],
-      Get { id-1 },
+      Get { l0 },
       Distinct {
         group_key: [16],
         Join {
           variables: [[(0, 0), (1, 0)]],
-          Filter { predicates: [#11 < #12], Get { lineitem } },
-          Distinct { group_key: [0], Get { id-1 } }
+          Filter { predicates: [#11 < #12], Get { lineitem (u15) } },
+          Distinct { group_key: [0], Get { l0 } }
         }
       }
     }
@@ -360,14 +372,14 @@ Reduce {
       [(3, 0), (4, 2)],
       [(4, 0), (5, 0)]
     ],
-    Get { customer },
-    Get { nation },
-    Filter { predicates: [#1 = "ASIA"], Get { region } },
-    Get { supplier },
-    Get { lineitem },
+    Get { customer (u11) },
+    Get { nation (u1) },
+    Filter { predicates: [#1 = "ASIA"], Get { region (u3) } },
+    Get { supplier (u7) },
+    Get { lineitem (u15) },
     Filter {
       predicates: [#4 < 1995-01-01, #4 >= 1994-01-01],
-      Get { orders }
+      Get { orders (u13) }
     }
   }
 }
@@ -387,7 +399,7 @@ where
     ;
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#5 * #6)],
     Filter {
@@ -398,16 +410,16 @@ Let {
         #6 >= 5dec,
         #10 >= 1994-01-01
       ],
-      Get { lineitem }
+      Get { lineitem (u15) }
     }
   }
 } in
 Union {
-  Get { id-1 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { id-1 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -475,15 +487,15 @@ Reduce {
           [(3, 1), (4, 0)],
           [(4, 3), (5, 0)]
         ],
-        Get { supplier },
-        Get { nation },
+        Get { supplier (u7) },
+        Get { nation (u1) },
         Filter {
           predicates: [#10 <= 1996-12-31, #10 >= 1995-01-01],
-          Get { lineitem }
+          Get { lineitem (u15) }
         },
-        Get { orders },
-        Get { customer },
-        Get { nation }
+        Get { orders (u13) },
+        Get { customer (u11) },
+        Get { nation (u1) }
       }
     }
   }
@@ -554,18 +566,21 @@ Project {
           ],
           Filter {
             predicates: [#4 = "ECONOMY ANODIZED STEEL"],
-            Get { part }
+            Get { part (u5) }
           },
-          Get { lineitem },
+          Get { lineitem (u15) },
           Filter {
             predicates: [#4 <= 1996-12-31, #4 >= 1995-01-01],
-            Get { orders }
+            Get { orders (u13) }
           },
-          Get { customer },
-          Get { nation },
-          Filter { predicates: [#1 = "AMERICA"], Get { region } },
-          Get { supplier },
-          Get { nation }
+          Get { customer (u11) },
+          Get { nation (u1) },
+          Filter {
+            predicates: [#1 = "AMERICA"],
+            Get { region (u3) }
+          },
+          Get { supplier (u7) },
+          Get { nation (u1) }
         }
       }
     }
@@ -623,12 +638,12 @@ Reduce {
         [(2, 0), (3, 0)],
         [(4, 3), (5, 0)]
       ],
-      Filter { predicates: [#1 ~ ^green$], Get { part } },
-      Get { partsupp },
-      Get { lineitem },
-      Get { orders },
-      Get { supplier },
-      Get { nation }
+      Filter { predicates: [#1 ~ ^green$], Get { part (u5) } },
+      Get { partsupp (u9) },
+      Get { lineitem (u15) },
+      Get { orders (u13) },
+      Get { supplier (u7) },
+      Get { nation (u1) }
     }
   }
 }
@@ -680,17 +695,17 @@ Project {
         [(0, 3), (1, 0)],
         [(2, 0), (3, 0)]
       ],
-      Get { customer },
-      Get { nation },
+      Get { customer (u11) },
+      Get { nation (u1) },
       Filter {
         predicates: [
           #4 < 1994-01-01,
           datetots #4 < 1994-01-01 00:00:00,
           #4 >= 1993-10-01
         ],
-        Get { orders }
+        Get { orders (u13) }
       },
-      Filter { predicates: [#8 = "R"], Get { lineitem } }
+      Filter { predicates: [#8 = "R"], Get { lineitem (u15) } }
     }
   }
 }
@@ -727,11 +742,11 @@ order by
     value desc;
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 1), (1, 0)], [(1, 3), (2, 0)]],
-    Get { partsupp },
-    Get { supplier },
-    Filter { predicates: [#1 = "GERMANY"], Get { nation } }
+    Get { partsupp (u9) },
+    Get { supplier (u7) },
+    Filter { predicates: [#1 = "GERMANY"], Get { nation (u1) } }
   }
 } in
 Project {
@@ -743,14 +758,14 @@ Project {
       Reduce {
         group_key: [0],
         aggregates: [sum(#3 * (i64todec #2 * 100dec))],
-        Get { id-1 }
+        Get { l0 }
       },
       Map {
         scalars: [#0 * 1dec],
         Reduce {
           group_key: [],
           aggregates: [sum(#3 * (i64todec #2 * 100dec))],
-          Get { id-1 }
+          Get { l0 }
         }
       }
     }
@@ -797,7 +812,7 @@ Reduce {
   ],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { orders },
+    Get { orders (u13) },
     Filter {
       predicates: [
         (#14 = "MAIL") || (#14 = "SHIP"),
@@ -806,7 +821,7 @@ Reduce {
         datetots #12 < 1995-01-01 00:00:00,
         #12 >= 1994-01-01
       ],
-      Get { lineitem }
+      Get { lineitem (u15) }
     }
   }
 }
@@ -836,12 +851,12 @@ order by
     c_count desc;
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 1)]],
-    Get { customer },
+    Get { customer (u11) },
     Filter {
       predicates: [!(#8 ~ ^.*special.*requests.*$)],
-      Get { orders }
+      Get { orders (u13) }
     }
   }
 } in
@@ -852,7 +867,7 @@ Reduce {
     group_key: [0],
     aggregates: [count(#8)],
     Union {
-      Project { outputs: [0 .. 8, 0, 10 .. 16], Get { id-1 } },
+      Project { outputs: [0 .. 8, 0, 10 .. 16], Get { l0 } },
       Map {
         scalars: [
           null,
@@ -866,8 +881,8 @@ Reduce {
           null
         ],
         Union {
-          Negate { Distinct { group_key: [0 .. 7], Get { id-1 } } },
-          Get { customer }
+          Negate { Distinct { group_key: [0 .. 7], Get { l0 } } },
+          Get { customer (u11) }
         }
       }
     }
@@ -892,7 +907,7 @@ where
     and l_shipdate < date '1996-01-01' + interval '1' month
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [
       sum(if #20 ~ ^PROMO.*$ then #5 * (100dec - #6) else 0dec),
@@ -905,9 +920,9 @@ Let {
           datetots #10 < 1996-02-01 00:00:00,
           #10 >= 1996-01-01
         ],
-        Get { lineitem }
+        Get { lineitem (u15) }
       },
-      Get { part }
+      Get { part (u5) }
     }
   }
 } in
@@ -916,11 +931,11 @@ Project {
   Map {
     scalars: [(((10000dec * #0) * 10000000dec) / #1) * 1000dec],
     Union {
-      Get { id-1 },
+      Get { l0 },
       Map {
         scalars: [null, null],
         Union {
-          Project { outputs: [], Negate { Get { id-1 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -969,11 +984,15 @@ Project {
   outputs: [0 .. 2, 4, 8],
   Join {
     variables: [[(0, 0), (1, 0)], [(1, 1), (2, 0)]],
-    Get { supplier },
-    Filter { predicates: [!isnull #1], Get { revenue } },
+    Get { supplier (u7) },
+    Filter { predicates: [!isnull #1], Get { revenue (u17) } },
     Filter {
       predicates: [!isnull #0],
-      Reduce { group_key: [], aggregates: [max(#1)], Get { revenue } }
+      Reduce {
+        group_key: [],
+        aggregates: [max(#1)],
+        Get { revenue (u17) }
+      }
     }
   }
 }
@@ -1016,9 +1035,9 @@ order by
     p_size;
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { partsupp },
+    Get { partsupp (u9) },
     Filter {
       predicates: [
         !(#4 ~ ^MEDIUM POLISHED.*$),
@@ -1039,21 +1058,21 @@ Let {
         (#5 = 9),
         #3 != "Brand#45"
       ],
-      Get { part }
+      Get { part (u5) }
     }
   }
 } in
-Let { id-2 = Distinct { group_key: [1], Get { id-1 } } } in
+Let { l3 = Distinct { group_key: [1], Get { l0 } } } in
 Let {
-  id-3 = Reduce {
+  l2 = Reduce {
     group_key: [0],
     aggregates: [all(#0 != #1)],
     Join {
       variables: [],
-      Get { id-2 },
+      Get { l3 },
       Filter {
         predicates: [#6 ~ ^.*Customer.*Complaints.*$],
-        Get { supplier }
+        Get { supplier (u7) }
       }
     }
   }
@@ -1063,14 +1082,14 @@ Reduce {
   aggregates: [count(distinct #1)],
   Join {
     variables: [[(0, 1), (1, 0)]],
-    Get { id-1 },
+    Get { l0 },
     Union {
-      Filter { predicates: [#1], Get { id-3 } },
+      Filter { predicates: [#1], Get { l2 } },
       Map {
         scalars: [true],
         Union {
-          Project { outputs: [0], Negate { Get { id-3 } } },
-          Get { id-2 }
+          Project { outputs: [0], Negate { Get { l2 } } },
+          Get { l3 }
         }
       }
     }
@@ -1099,24 +1118,24 @@ where
   );
 ----
 Let {
-  id-1 = Join {
+  l1 = Join {
     variables: [[(0, 1), (1, 0)]],
-    Get { lineitem },
+    Get { lineitem (u15) },
     Filter {
       predicates: [#3 = "Brand#23", #6 = "MED BOX"],
-      Get { part }
+      Get { part (u5) }
     }
   }
 } in
 Let {
-  id-2 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#5)],
     Filter {
       predicates: [(#4 * 10000000dec) < #28],
       Join {
         variables: [[(0, 1), (1, 0)]],
-        Get { id-1 },
+        Get { l1 },
         Map {
           scalars: [
             2dec
@@ -1128,8 +1147,8 @@ Let {
             aggregates: [sum(#4), countall(null)],
             Join {
               variables: [[(0, 1), (1, 0)]],
-              Get { lineitem },
-              Distinct { group_key: [1], Get { id-1 } }
+              Get { lineitem (u15) },
+              Distinct { group_key: [1], Get { l1 } }
             }
           }
         }
@@ -1142,11 +1161,11 @@ Project {
   Map {
     scalars: [(#0 * 10000000dec) / 70dec],
     Union {
-      Get { id-2 },
+      Get { l0 },
       Map {
         scalars: [null],
         Union {
-          Project { outputs: [], Negate { Get { id-2 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -1191,11 +1210,11 @@ order by
     o_orderdate;
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 1)], [(1, 0), (2, 0)]],
-    Get { customer },
-    Get { orders },
-    Get { lineitem }
+    Get { customer (u11) },
+    Get { orders (u13) },
+    Get { lineitem (u15) }
   }
 } in
 Reduce {
@@ -1203,7 +1222,7 @@ Reduce {
   aggregates: [sum(#21)],
   Join {
     variables: [[(0, 8), (1, 0)]],
-    Get { id-1 },
+    Get { l0 },
     Reduce {
       group_key: [0],
       aggregates: [any(true)],
@@ -1214,8 +1233,8 @@ Reduce {
           aggregates: [sum(#4)],
           Join {
             variables: [[(0, 0), (1, 0)]],
-            Get { lineitem },
-            Distinct { group_key: [8], Get { id-1 } }
+            Get { lineitem (u15) },
+            Distinct { group_key: [8], Get { l0 } }
           }
         }
       }
@@ -1263,7 +1282,7 @@ where
     );
 ----
 Let {
-  id-1 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#5 * (100dec - #6))],
     Filter {
@@ -1355,19 +1374,19 @@ Let {
             (#14 = "AIR") || (#14 = "AIR REG"),
             #13 = "DELIVER IN PERSON"
           ],
-          Get { lineitem }
+          Get { lineitem (u15) }
         },
-        Filter { predicates: [#5 >= 1], Get { part } }
+        Filter { predicates: [#5 >= 1], Get { part (u5) } }
       }
     }
   }
 } in
 Union {
-  Get { id-1 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { id-1 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -1415,30 +1434,30 @@ order by
     s_name;
 ----
 Let {
-  id-1 = Join {
+  l0 = Join {
     variables: [[(0, 3), (1, 0)]],
-    Get { supplier },
-    Filter { predicates: [#1 = "CANADA"], Get { nation } }
+    Get { supplier (u7) },
+    Filter { predicates: [#1 = "CANADA"], Get { nation (u1) } }
   }
 } in
 Let {
-  id-2 = Join {
+  l4 = Join {
     variables: [],
-    Distinct { group_key: [0], Get { id-1 } },
-    Get { partsupp }
+    Distinct { group_key: [0], Get { l0 } },
+    Get { partsupp (u9) }
   }
 } in
 Let {
-  id-3 = Join {
+  l3 = Join {
     variables: [[(0, 1), (1, 0)]],
-    Get { id-2 },
+    Get { l4 },
     Reduce {
       group_key: [9],
       aggregates: [any(true)],
       Join {
         variables: [[(0, 0), (1, 0)]],
-        Filter { predicates: [#1 ~ ^forest.*$], Get { part } },
-        Distinct { group_key: [1], Get { id-2 } }
+        Filter { predicates: [#1 ~ ^forest.*$], Get { part (u5) } },
+        Distinct { group_key: [1], Get { l4 } }
       }
     }
   }
@@ -1447,7 +1466,7 @@ Project {
   outputs: [1, 2],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { id-1 },
+    Get { l0 },
     Reduce {
       group_key: [0],
       aggregates: [any(true)],
@@ -1455,7 +1474,7 @@ Project {
         predicates: [(i64todec #3 * 1000dec) > #11],
         Join {
           variables: [[(0, 1), (1, 0)], [(0, 2), (1, 1)]],
-          Filter { predicates: [#0 = #2], Get { id-3 } },
+          Filter { predicates: [#0 = #2], Get { l3 } },
           Map {
             scalars: [5dec * #2],
             Reduce {
@@ -1468,9 +1487,9 @@ Project {
                     datetots #10 < 1996-01-01 00:00:00,
                     #10 >= 1995-01-01
                   ],
-                  Get { lineitem }
+                  Get { lineitem (u15) }
                 },
-                Distinct { group_key: [1, 2], Get { id-3 } }
+                Distinct { group_key: [1, 2], Get { l3 } }
               }
             }
           }
@@ -1524,37 +1543,37 @@ order by
     s_name;
 ----
 Let {
-  id-1 = Join {
+  l1 = Join {
     variables: [[(0, 0), (2, 2)], [(0, 3), (1, 0)], [(2, 0), (3, 0)]],
-    Get { supplier },
-    Filter { predicates: [#1 = "SAUDI ARABIA"], Get { nation } },
-    Filter { predicates: [#12 > #11], Get { lineitem } },
-    Filter { predicates: [#2 = "F"], Get { orders } }
+    Get { supplier (u7) },
+    Filter { predicates: [#1 = "SAUDI ARABIA"], Get { nation (u1) } },
+    Filter { predicates: [#12 > #11], Get { lineitem (u15) } },
+    Filter { predicates: [#2 = "F"], Get { orders (u13) } }
   }
 } in
 Let {
-  id-2 = Map {
+  l0 = Map {
     scalars: [true],
     Join {
       variables: [[(0, 11), (1, 0)], [(0, 0), (1, 1)]],
-      Get { id-1 },
+      Get { l1 },
       Distinct {
         group_key: [0, 1],
         Filter {
           predicates: [#4 != #1],
           Join {
             variables: [[(0, 0), (1, 0)]],
-            Distinct { group_key: [11, 0], Get { id-1 } },
-            Get { lineitem }
+            Distinct { group_key: [11, 0], Get { l1 } },
+            Get { lineitem (u15) }
           }
         }
       }
     }
   }
 } in
-Let { id-3 = Distinct { group_key: [11, 0], Get { id-2 } } } in
+Let { l5 = Distinct { group_key: [11, 0], Get { l0 } } } in
 Let {
-  id-4 = Map {
+  l4 = Map {
     scalars: [true],
     Distinct {
       group_key: [0, 1],
@@ -1562,8 +1581,8 @@ Let {
         predicates: [#4 != #1],
         Join {
           variables: [[(0, 0), (1, 0)]],
-          Get { id-3 },
-          Filter { predicates: [#12 > #11], Get { lineitem } }
+          Get { l5 },
+          Filter { predicates: [#12 > #11], Get { lineitem (u15) } }
         }
       }
     }
@@ -1574,14 +1593,14 @@ Reduce {
   aggregates: [countall(null)],
   Join {
     variables: [[(0, 11), (1, 0)], [(0, 0), (1, 1)]],
-    Get { id-2 },
+    Get { l0 },
     Union {
-      Filter { predicates: [!#2], Get { id-4 } },
+      Filter { predicates: [!#2], Get { l4 } },
       Map {
         scalars: [false],
         Union {
-          Project { outputs: [0, 1], Negate { Get { id-4 } } },
-          Get { id-3 }
+          Project { outputs: [0, 1], Negate { Get { l4 } } },
+          Get { l5 }
         }
       }
     }
@@ -1640,7 +1659,7 @@ ORDER BY
     cntrycode;
 ----
 Let {
-  id-1 = Filter {
+  l0 = Filter {
     predicates: [(#5 * 1000000dec) > #10],
     Join {
       variables: [],
@@ -1670,7 +1689,7 @@ Let {
           ||
           (substr(#4, 1, 2) = ":7")
         ],
-        Get { customer }
+        Get { customer (u11) }
       },
       Map {
         scalars: [
@@ -1706,23 +1725,23 @@ Let {
               (substr(#4, 1, 2) = "17"),
               #5 > 0dec
             ],
-            Get { customer }
+            Get { customer (u11) }
           }
         }
       }
     }
   }
 } in
-Let { id-2 = Distinct { group_key: [0], Get { id-1 } } } in
+Let { l4 = Distinct { group_key: [0], Get { l0 } } } in
 Let {
-  id-3 = Map {
+  l3 = Map {
     scalars: [true],
     Distinct {
       group_key: [9],
       Join {
         variables: [[(0, 1), (1, 0)]],
-        Get { orders },
-        Get { id-2 }
+        Get { orders (u13) },
+        Get { l4 }
       }
     }
   }
@@ -1734,14 +1753,14 @@ Reduce {
     scalars: [substr(#4, 1, 2)],
     Join {
       variables: [[(0, 0), (1, 0)]],
-      Get { id-1 },
+      Get { l0 },
       Union {
-        Filter { predicates: [!#1], Get { id-3 } },
+        Filter { predicates: [!#1], Get { l3 } },
         Map {
           scalars: [false],
           Union {
-            Project { outputs: [0], Negate { Get { id-3 } } },
-            Get { id-2 }
+            Project { outputs: [0], Negate { Get { l3 } } },
+            Get { l4 }
           }
         }
       }


### PR DESCRIPTION
Apologies in advance for the size of this commit. I'm not sure there's any way to make it smaller. ~I'm still shaking out some bugs in the coordinator, but SLT is passing, so things are mostly working and I wanted to get feedback on the approach before going too much deeper.~

~@frankmcsherry tomorrow I may try to rope you into helping me track down this coordinator bug. It's something with the view/source mirroring.~

This is passing tests locally, so I guess this is no longer WIP.

----

This commit works towards a longstanding goal of a proper ID type for
"dataflow components", where a "dataflow component" is roughly anything
that can be the target of a RelationExpr::Get expression.

Previously, we were using simple string names (or, more recently,
QualNames) across the entire system. But names are a SQL concept, doubly
so when qualified, and the dataflow layer really wants to deal with
something simpler and cheaper. Enter expr::Id.

An expr::Id is either in the local or global namespace; the global
namespace is further subdivided into system and user namespaces. Within
each namespace, identifiers are simply a usize. This makes it dead
simple to allocate IDs, as each layer can use its own ID allocator.
(System global IDs are hardcoded into the binary; user global IDs are
allocated by the catalog; and local IDs are allocated whenever a
RelationExpr is built.)

Fix MaterializeInc/database-issues#323.