### PR TITLE
repr: remove ScalarType::Time variant

### DIFF
--- a/src/pgwire/types.rs
+++ b/src/pgwire/types.rs
@@ -113,7 +113,6 @@ impl From<&ScalarType> for PgType {
             ScalarType::Timestamp => TIMESTAMP,
             ScalarType::TimestampTz => TIMESTAMPTZ,
             ScalarType::Interval => INTERVAL,
-            ScalarType::Time => unimplemented!("TIME is not implemented"),
             ScalarType::Bytes => BYTEA,
             ScalarType::String => TEXT,
         }

--- a/src/repr/scalar/mod.rs
+++ b/src/repr/scalar/mod.rs
@@ -472,7 +472,6 @@ pub enum ScalarType {
     /// be less than or equal to the precision.
     Decimal(u8, u8),
     Date,
-    Time,
     Timestamp,
     TimestampTz,
     /// A possibly-negative time span
@@ -501,7 +500,6 @@ impl<'a> ScalarType {
             ScalarType::Float64 => Datum::Float64(OrderedFloat(0.0)),
             ScalarType::Decimal(_, _) => Datum::Decimal(Significand::new(0)),
             ScalarType::Date => Datum::Date(NaiveDate::from_ymd(1, 1, 1)),
-            ScalarType::Time => unimplemented!("TIME is not implemented"),
             ScalarType::Timestamp => Datum::Timestamp(NaiveDateTime::from_timestamp(0, 0)),
             ScalarType::TimestampTz => {
                 Datum::TimestampTz(DateTime::from_utc(NaiveDateTime::from_timestamp(0, 0), Utc))
@@ -529,7 +527,6 @@ impl PartialEq for ScalarType {
             | (Float32, Float32)
             | (Float64, Float64)
             | (Date, Date)
-            | (Time, Time)
             | (Timestamp, Timestamp)
             | (TimestampTz, TimestampTz)
             | (Interval, Interval)
@@ -544,7 +541,6 @@ impl PartialEq for ScalarType {
             | (Float64, _)
             | (Decimal(_, _), _)
             | (Date, _)
-            | (Time, _)
             | (Timestamp, _)
             | (TimestampTz, _)
             | (Interval, _)
@@ -571,12 +567,11 @@ impl Hash for ScalarType {
                 state.write_u8(*s);
             }
             Date => state.write_u8(7),
-            Time => state.write_u8(8),
-            Timestamp => state.write_u8(9),
-            TimestampTz => state.write_u8(10),
-            Interval => state.write_u8(11),
-            Bytes => state.write_u8(12),
-            String => state.write_u8(13),
+            Timestamp => state.write_u8(8),
+            TimestampTz => state.write_u8(9),
+            Interval => state.write_u8(10),
+            Bytes => state.write_u8(11),
+            String => state.write_u8(12),
         }
     }
 }
@@ -598,7 +593,6 @@ impl fmt::Display for ScalarType {
             Float64 => f.write_str("f64"),
             Decimal(p, s) => write!(f, "decimal({}, {})", p, s),
             Date => f.write_str("date"),
-            Time => f.write_str("time"),
             Timestamp => f.write_str("timestamp"),
             TimestampTz => f.write_str("timestamptz"),
             Interval => f.write_str("interval"),

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -2465,7 +2465,6 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, failure:
         DataType::Timestamp => ScalarType::Timestamp,
         DataType::TimestampTz => ScalarType::TimestampTz,
         DataType::Interval => ScalarType::Interval,
-        DataType::Time => ScalarType::Time,
         DataType::Bytea => ScalarType::Bytes,
         other @ DataType::Array(_)
         | other @ DataType::Binary(..)
@@ -2473,6 +2472,7 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, failure:
         | other @ DataType::Clob(_)
         | other @ DataType::Custom(_)
         | other @ DataType::Regclass
+        | other @ DataType::Time
         | other @ DataType::TimeTz
         | other @ DataType::Uuid
         | other @ DataType::Varbinary(_) => bail!("Unexpected SQL type: {:?}", other),

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -853,7 +853,6 @@ fn postgres_type_name(typ: ScalarType) -> &'static str {
         ScalarType::Float64 => "float8",
         ScalarType::Decimal(_, _) => "numeric",
         ScalarType::Date => "date",
-        ScalarType::Time => "time",
         ScalarType::Timestamp => "timestamp",
         ScalarType::TimestampTz => "timestamptz",
         ScalarType::Interval => "interval",


### PR DESCRIPTION
ScalarType::Time is an ancient ScalarType variant (added in 2f2e334cf)
that cannot be constructed, as there is no Datum::Time variant and never
has been. We're not planning on supporting the SQL time type for quite a
while (it has insane semantics around timezones that make it virtually
useless), so just remove ScalarType::Time so that everyone doesn't need
to invent their own way to ignore the variant.