### PR TITLE
check types of NOT operation

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1618,7 +1618,13 @@ fn plan_unary_op<'a>(
     let expr = plan_expr(catalog, ecx, expr, Some(type_hint))?;
     let typ = ecx.column_type(&expr);
     let func = match op {
-        UnaryOperator::Not => UnaryFunc::Not,
+        UnaryOperator::Not => match typ.scalar_type {
+            ScalarType::Bool => UnaryFunc::Not,
+            _ => bail!(
+                "Cannot apply operator Not to non-boolean type {:?}",
+                typ.scalar_type
+            ),
+        },
         UnaryOperator::Plus => return Ok(expr), // no-op
         UnaryOperator::Minus => match typ.scalar_type {
             ScalarType::Int32 => UnaryFunc::NegInt32,

--- a/test/boolean.slt
+++ b/test/boolean.slt
@@ -1,0 +1,75 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+statement error
+select not 1;
+
+statement error
+select 1 and 1;
+
+statement error
+select 1 or 1;
+
+statement error
+select 1 or false;
+
+statement error
+select false or 1;
+
+statement error
+select 1 and false;
+
+statement error
+select false and 1;
+
+query B
+select not true;
+----
+false
+
+query B
+select not false;
+----
+true
+
+query B
+select true and false;
+----
+false
+
+query B
+select true and true;
+----
+true
+
+query B
+select false and false;
+----
+false
+
+query B
+select true or false;
+----
+true
+
+query B
+select true or true;
+----
+true
+
+query B
+select false or false;
+----
+false
+
+query B
+select true and not true;
+----
+false
+
+query B
+select not false or false;
+----
+true


### PR DESCRIPTION
Add type checking to `NOT`, otherwise unchecked arguments get passed to [`not`](https://github.com/MaterializeInc/materialize/blob/b0bb0d39f19046b8a5a31de31040f63c8f4cedd4/src/expr/scalar/func.rs#L44), which panics, e.g.

```sql
SELECT NOT 1;
```

Also added a trivial set of Boolean tests. Can make this exhaustive if that's worthwhile.