### PR TITLE
dataflow: fix shutdown command processing

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -308,15 +308,10 @@ where
                 if let SequencedCommand::Shutdown = cmd {
                     shutdown = true;
                 }
-                // Avoid non-determinism in post-shutdown commands.
-                if !shutdown {
-                    self.handle_command(cmd);
-                }
+                self.handle_command(cmd);
             }
 
-            if !shutdown {
-                self.process_peeks();
-            }
+            self.process_peeks();
         }
     }
 

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -6,6 +6,7 @@
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use postgres::params::{ConnectParams, Host};
 use postgres::{Connection, TlsMode};
@@ -14,7 +15,7 @@ pub fn start_server(
     data_directory: Option<PathBuf>,
 ) -> Result<(materialized::Server, Connection), Box<dyn Error>> {
     let server = materialized::serve(materialized::Config {
-        logging_granularity: None,
+        logging_granularity: Some(Duration::from_secs(1)),
         threads: 1,
         process: 0,
         addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],


### PR DESCRIPTION
Actually call Worker::handle_command when a SequencedCommand::Shutdown
command arrives. The old implementation was skipping this step, which
was preventing logging from being disabled, which was preventing servers
from cleanly shutting down when logging was enabled.

Fix MaterializeInc/database-issues#336.