### PR TITLE
Reduce frontier coordination if stable.

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -334,17 +334,21 @@ where
                         .reported_frontiers
                         .get_mut(&id)
                         .expect("Frontier missing!");
-                    let mut changes = ChangeBatch::new();
-                    for time in lower.elements().iter() {
-                        changes.update(time.clone(), -1);
+                    if lower != &upper {
+                        let mut changes = ChangeBatch::new();
+                        for time in lower.elements().iter() {
+                            changes.update(time.clone(), -1);
+                        }
+                        for time in upper.elements().iter() {
+                            changes.update(time.clone(), 1);
+                        }
+                        let lower = self.reported_frontiers.get_mut(&id).unwrap();
+                        changes.compact();
+                        if !changes.is_empty() {
+                            progress.push((id, changes));
+                        }
+                        lower.clone_from(&upper);
                     }
-                    for time in upper.elements().iter() {
-                        changes.update(time.clone(), 1);
-                    }
-                    let lower = self.reported_frontiers.get_mut(&id).unwrap();
-                    changes.compact();
-                    progress.push((id, changes));
-                    lower.clone_from(&upper);
                 }
             }
             feedback_tx


### PR DESCRIPTION
Each worker tracks for each maintained trace the most recent frontier it has reported to the coordinator. Each time around the loop, it means to report any changes back to the coordinator. Right now it determines the changes and reports all of them, independent of which changes are non-empty. This PR changes the behavior to suppress reporting empty change sets, and further to avoid the work in the first place if the frontiers are stable (avoiding some allocation work).