### PR TITLE
sql: support identifier functions like CURRENT_TIMESTAMP

### DIFF
--- a/test/dates-times.slt
+++ b/test/dates-times.slt
@@ -617,3 +617,8 @@ query B
 SELECT current_timestamp() > timestamp '2016-06-13 00:00:00'
 ----
 true
+
+query B
+SELECT current_timestamp > timestamp '2016-06-13 00:00:00'
+----
+true


### PR DESCRIPTION
Support what I'm calling "identifier functions", which are magic
identifiers that are actually function calls. To kick things off,
support CURRENT_TIMESTAMP. There a bunch more magic identifiers, like
CURRENT_USER, but we can get to those when we have support for the
underlying functions.