### PR TITLE
sql: cast float to decimal

### DIFF
--- a/doc/user/sql/functions/cast.md
+++ b/doc/user/sql/functions/cast.md
@@ -34,11 +34,14 @@ Int | Float
 Int | Decimal
 Float | Float
 Float | Int
+Float | Decimal<sup>1</sup>
 Decimal | Decimal
 Decimal | Int
 Decimal | Float
 Date | Timestamp
 Date | TimestampTZ
+
+<sup>1</sup> Casting a `FLOAT` to a `DECIMAL` can yield an imprecise result due to the floating point arithmetic involved in the conversion.
 
 ## Examples
 

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -2476,7 +2476,15 @@ where
         (Int64, Int32) => expr.call_unary(CastInt64ToInt32),
         (Float32, Int64) => expr.call_unary(CastFloat32ToInt64),
         (Float32, Float64) => expr.call_unary(CastFloat32ToFloat64),
+        (Float32, Decimal(_, s)) => {
+            let s = ScalarExpr::literal(Datum::from(s as i32), ColumnType::new(to_scalar_type));
+            expr.call_binary(s, BinaryFunc::CastFloat32ToDecimal)
+        }
         (Float64, Int64) => expr.call_unary(CastFloat64ToInt64),
+        (Float64, Decimal(_, s)) => {
+            let s = ScalarExpr::literal(Datum::from(s as i32), ColumnType::new(to_scalar_type));
+            expr.call_binary(s, BinaryFunc::CastFloat64ToDecimal)
+        }
         (String, Float64) => expr.call_unary(CastStringToFloat64),
         (Decimal(_, s), Int32) => rescale_decimal(expr, s, 0).call_unary(CastDecimalToInt32),
         (Decimal(_, s), Int64) => rescale_decimal(expr, s, 0).call_unary(CastDecimalToInt64),

--- a/test/decimal.slt
+++ b/test/decimal.slt
@@ -211,3 +211,41 @@ query R
 SELECT 1.0 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1
 ----
 1.000000000000
+
+### float64 to decimal ###
+
+query R
+select cast(3.141529::float as decimal(38,6));
+----
+3.141529
+
+# Truncation
+query R
+select cast(3.141529::float as decimal(38,5));
+----
+3.14152
+
+# Floating point imprecision
+# Note that this result differs from PostgreSQL
+query R
+select cast(3.141529::float as decimal(38,7));
+----
+3.1415289
+
+# Expansion with 0s
+query R
+select cast(3.141529::float as decimal(38,8));
+----
+3.14152900
+
+# Numeric overflow
+query R
+select cast(100::float as decimal(38,37));
+----
+NULL
+
+# Null input
+query R
+select cast(null::float as decimal(38,7));
+----
+NULL


### PR DESCRIPTION
Adds support for casting floats to decimals with max precision and configurable scale, as well as tests for the casting (will add tests for other casts in a future PR).

I have some basic questions about how to improve this implementation:

- Is it worth doing something more clever to prevent floating point imprecision? e.g. as a strawman, convert to string and do a char-by-char recalculation.
- If not worth doing something more fiddly, is there a way to check for floating point overflow? I found `checked_mul` for int-like types, but maybe I'm being naive in assuming that something like this is possible for floats?
- I have an intentionally ugly [`let s_clone = s.clone()`](#diff-7fc4d65293925a07b27c4fa1a259fbd3R1043); what is the more idiomatic way of getting an owned value there? Sorry for the new question––I realize there are a number of things I could be doing here.

Closes MaterializeInc/database-issues#339 