### PR TITLE
Make runv stick out more in logs

### DIFF
--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -27,9 +27,9 @@ run() {
 # runv PROGRAM [ARGS...]
 #
 # Like run, but prints a more verbose informational message to stderr of the
-# form ">run PROGRAM ARGS...".
+# form "🚀$ PROGRAM ARGS...".
 runv() {
-    echo "run> $*" >&2
+    echo "🚀$ $*" >&2
     "$@"
 }
 


### PR DESCRIPTION
The `run>` word just looks a lot like the text that it is often interspersed with. I
wanted something that would stick out but not be too distracting, I'm happy to change
this to something less cute or more functional if anyone has ideas (I read this prompt as
"launch shell command") but the plain white text was annoyingly hard to spot when just
glancing.