### PR TITLE
docs: initial function and operator docs

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -39,3 +39,11 @@ You can now include the diagram on a page using:
 Because our diagrams rely on Hugo's `partials` features, the diagram files are
 maintained in the `/www` dir (the actual Hugo site), but referenced as if they
 were local (through the magic of symlinks).
+
+## Function + Operator docs
+
+The **Functions** you see at `www/docs/sql/functions/` are populated from `www/data/sql_funcs.json`. Unfortunately this means that they're ad hoc and are not actually generated from the Materialize source code.
+
+As new functions get added, this file must be manually updated. The idea here is to structure functions by their input type (whereas operators are grouped by their output type), largely influenced by the way that Postgres structures their function docs.
+
+If you see the need to add or change the grouping here, don't be shy.

--- a/doc/user/_index.md
+++ b/doc/user/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Materialize Docs" 
 disable_toc: true
+disable_list: true
 ---
 
 Materialize is a streaming SQL materialized view engine.

--- a/doc/user/sql/_index.md
+++ b/doc/user/sql/_index.md
@@ -1,0 +1,5 @@
+---
+title: "SQL"
+description: "Find all of the great SQL statements you know and love..."
+disable_toc: true
+---

--- a/doc/user/sql/functions/_index.md
+++ b/doc/user/sql/functions/_index.md
@@ -1,0 +1,50 @@
+---
+title: "Functions + Operators"
+description: "Find all of the great SQL functions you know and love..."
+disable_list: true
+disable_toc: true
+weight: 1
+---
+
+This page details Materialize's supported SQL [functions](#functions) and [operators](#operators).
+
+## Functions
+
+{{< fnlist >}}
+
+## Operators
+
+### Generic
+
+Operator | Computes
+---------|---------
+`val::type` | Cast of `val` as `type` ([docs](cast))
+
+### Boolean
+
+Operator | Computes
+---------|---------
+`AND` | Boolean "and"
+`OR` | Boolean "or"
+`=` | Equality
+`<>` | Inequality
+`!=` | Inequality
+`<` | Less than
+`>` | Greater than
+`<=` | Less than or equal to
+`>=` | Greater than or equal to
+`a BETWEEN x AND y` | `a >= x AND a <= y`
+`a NOT BETWEEN x AND y` | `a < x OR a > y`
+`a IS NULL` | `a = NULL`
+`a IS NOT NULL` | `a != NULL`
+`a LIKE match_expr` | `a` matches `match_expr`, using [SQL LIKE matching](https://www.w3schools.com/sql/sql_like.asp)
+
+### Numbers
+
+Operator | Computes
+---------|---------
+ `+` | Addition
+ `-` | Subtraction
+ `*` | Multiplication
+ `/` | Division
+ `%` | Modulo

--- a/doc/user/sql/functions/cast.md
+++ b/doc/user/sql/functions/cast.md
@@ -1,0 +1,62 @@
+---
+title: "CAST Function and Operator"
+description: "Returns the value converted to the specified type"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+The `cast` function and operator return a value converted to the specified type.
+
+## Parameters
+
+{{< diagram "func-cast.html" >}}
+
+{{< diagram "op-cast.html" >}}
+
+Parameter | Type | Description
+----------|------|------------
+_val_ | Any | The value you want to convert.
+_type_ | Typename | The return value's type.
+
+## Return value
+
+`cast` returns the value with the type specified by the _type_ parameter.
+
+## Details
+
+### Valid casts
+
+Source type | Return type
+------------|------------
+Int | Int
+Int | Float
+Int | Decimal
+Float | Float
+Float | Int
+Decimal | Decimal
+Decimal | Int
+Decimal | Float
+Date | Timestamp
+Date | TimestampTZ
+
+## Examples
+
+```sql
+SELECT CAST(CAST(100.21 AS DECIMAL(10,2)) AS FLOAT) AS dec_to_float;
+```
+```bash
+ dec_to_float
+--------------
+       100.21
+```
+<hr/>
+
+```sql
+SELECT 100.21::DECIMAL(10,2)::FLOAT AS dec_to_float;
+```
+```bash
+ dec_to_float
+--------------
+       100.21
+```

--- a/doc/user/sql/functions/coalesce.md
+++ b/doc/user/sql/functions/coalesce.md
@@ -1,0 +1,30 @@
+---
+title: "COALESCE Function"
+description: "Returns the first non-NULL element provided."
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`COALESCE` returns the first non-`NULL` element provided.
+
+## Parameters
+
+Parameter | Type | Description
+----------|------|------------
+val | Any | The values you want to check.
+
+## Return value
+
+All elements of the parameters for `coalesce` must be of the same type; `coalesce` returns that type, or _NULL_.
+
+## Examples
+
+```sql
+SELECT coalesce (NULL, 3, 2, 1) AS coalesce_res;
+```
+```bash
+ res
+-----
+   3
+```

--- a/doc/user/sql/functions/extract.md
+++ b/doc/user/sql/functions/extract.md
@@ -1,0 +1,38 @@
+---
+title: "EXTRACT Function"
+description: "Returns a specified time component from a time-based value"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`EXTRACT` returns some time component from a time-based value, such as the year from a Timestamp.
+
+## Parameters
+
+### func_extract
+
+{{< diagram "func-extract.html" >}}
+
+### time_component
+
+{{< diagram "time-component.html" >}}
+
+Parameter | Type | Description
+----------|------|------------
+_val_ | Time | The value from which you want to extract a component.
+
+## Return value
+
+`extract` returns a Float value.
+
+## Examples
+
+```sql
+SELECT EXTRACT(SECOND FROM TIMESTAMP '2006-01-02 15:04:05.06') AS sec_extr;
+```
+```bash
+ sec_extr
+----------
+     5.06
+```

--- a/doc/user/sql/functions/length.md
+++ b/doc/user/sql/functions/length.md
@@ -1,0 +1,70 @@
+---
+title: "LENGTH Function"
+description: "Returns the number of characters in a string."
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`LENGTH` returns the graphemes (which is roughly equivalent to printed characters) in a string.
+
+## Parameters
+
+{{< diagram "func-length.html" >}}
+
+Parameter | Type | Description
+----------|------|------------
+_str_ | String | The string whose length you want.
+_encoding&lowbar;name_ | String | The [encoding](#encoding-details) you want to use for calculating the string's length. _Defaults to UTF-8_.
+
+## Return value
+
+`length` returns an Int.
+
+## Details
+
+### Errors
+
+`length` operations might return `NULL` values indicating errors in the following cases:
+
+- The _encoding&lowbar;name_ provided is not available in our encoding package.
+- Some byte sequence in _str_ was not compatible with the selected encoding.
+
+### Fixed-width strings
+
+Materialize returns the length of fixed-width strings as the maximum width of the string. For example `length` on a `CHAR(15)` column returns `15` as each string's length.
+
+Materialize receives strings from your database in the same format they are emitted. In the case of fixed-width strings, e.g. `CHAR` columns in PostgreSQL, we receive the value padded by empty spaces. Because we cannot determine whether those spaces were intentional or an artifact of a fixed-width string, we provide the length of the string as we received it.
+
+You can find any updates on this behavior in [this GitHub issue](https://github.com/MaterializeInc/materialize/issues/589).
+
+### Encoding details
+
+- Materialize uses the [`encoding`](https://crates.io/crates/encoding) crate. See the [list of supported encodings](https://lifthrasiir.github.io/rust-encoding/encoding/index.html#supported-encodings), as well as their names [within the API](https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs).
+- Materialize attempts to convert [PostgreSQL-style encoding names](https://www.postgresql.org/docs/9.5/multibyte.html) into the [WHATWG-style encoding names](https://encoding.spec.whatwg.org/) used by the API. 
+    
+    For example, you can refer to `iso-8859-5` (WHATWG-style) as `ISO_8859_5` (PostrgreSQL-style).
+
+    However, there are some differences in the names of the same encodings that we do not convert. For example, the [windows-874](https://encoding.spec.whatwg.org/#windows-1252) encoding is referred to as `WIN874` in PostgreSQL; Materialize does not perform a conversion for these names.
+
+## Examples
+
+```sql
+SELECT LENGTH('你好') AS len;
+```
+```bash
+ len
+-----
+   2
+```
+
+<hr/>
+
+```sql
+SELECT LENGTH('你好', 'big5') AS len;
+```
+```bash
+ len
+-----
+   3
+```

--- a/doc/user/sql/functions/substring.md
+++ b/doc/user/sql/functions/substring.md
@@ -1,0 +1,45 @@
+---
+title: "SUBSTRING Function"
+description: "Returns substring at specified positions"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+`SUBSTRING` returns a specified substring of a string.
+
+## Parameters
+
+{{< diagram "func-substring.html" >}}
+
+Parameter | Type | Description
+----------|------|------------
+_str_ | String | The base string.
+_start&lowbar;pos_ | Int | The starting position for the substring; counting starts at 1.
+_len_ | Int | The length of the substring you want to return.
+
+## Return value
+
+`substring` returns a String.
+
+## Examples
+
+```sql
+SELECT SUBSTRING('abcdefg', 3) AS substr;
+```
+```bash
+ substr
+--------
+ cdefg
+```
+
+ <hr/>
+
+```sql
+SELECT SUBSTRING('abcdefg', 3, 3) AS substr;
+```
+```bash
+ substr
+--------
+ cde
+```

--- a/www/assets/sass/_docs_table.scss
+++ b/www/assets/sass/_docs_table.scss
@@ -15,4 +15,13 @@ th {
 td {
   padding: 10px;
   min-width: 160px;
+
+  .highlight {
+    background-color: #fff;
+    margin-bottom: 0px;
+    padding: 0px;
+    pre {
+      background-color: #fff !important;
+    }
+  }
 }

--- a/www/config.toml
+++ b/www/config.toml
@@ -14,3 +14,10 @@ pygmentsStyle = "xcode"
     identifier = "sql"
     name = "SQL"
     weight = 2
+
+    [[menu.main]]
+    identifier = "sql-functions"
+    name = "Functions + Operators"
+    url = "/docs/sql/functions/"
+    weight = 1
+    parent = "sql"

--- a/www/data/sql_funcs.json
+++ b/www/data/sql_funcs.json
@@ -1,0 +1,106 @@
+[
+    {
+        "type": "Generic",
+        "functions": [
+            {
+                "signature": "CAST(cast_expr) -> T",
+                "description": "Value as type `T`",
+                "url": "cast"
+            },
+            {
+                "signature": "COALESCE(x: T...) -> T?",
+                "description": "First non-_NULL_ arg, or _NULL_ if all are _NULL_"
+            },
+            {
+                "signature": "NULLIF(x: T, y: T) -> T?",
+                "description": "_NULL_ if `x == y`, else `x`"
+            }
+        ]
+    },
+    {
+        "type": "Aggregate",
+        "functions": [
+            {
+                "signature": "COUNT(x: T) -> Int",
+                "description": "Number on non-_NULL_ inputs"
+            },
+            {
+                "signature": "MAX(x: T) -> T",
+                "description": "Maximum value among `T`"
+            },
+            {
+                "signature": "MIN(x: T) -> T",
+                "description": "Minimum value among `T`"
+            },
+            {
+                "signature": "SUM(x: T) -> T",
+                "description": "Sum of `T`'s values"
+            }
+        ]
+    },
+    {
+        "type": "Column",
+        "functions": [
+            {
+                "signature": "lhs bool_op ALL(c: C) -> Bool",
+                "description": "`true` if applying [bool_op](#boolean) to `lhs` and every value of `C` evaluates to `true`"
+            },
+            {
+                "signature": "lhs bool_op ANY(c: C) -> Bool",
+                "description": "`true` if applying [bool_op](#boolean) to `lhs` and any value of `C` evaluates to `true`"
+            }
+        ]
+    },
+    {
+        "type": "Numbers",
+        "functions": [
+            {
+                "signature": "ABS(x: N) -> N",
+                "description": "The absolute value of `x`"
+            },
+            {
+                "signature": "MOD(x: N, y: N) -> N",
+                "description": "`x % y`"
+            }
+        ]
+    },
+    {
+        "type": "String",
+        "functions": [
+            {
+                "signature": "ASCII(s: Str) -> Int",
+                "description": "The ASCII value of `s`'s left-most character"
+            },
+            {
+                "signature": "LENGTH(s: Str) -> Int",
+                "description": "Number of graphemes in `s`",
+                "url": "length"
+            },
+            {
+                "signature": "LENGTH(s: Str, encoding_name: Str) -> Int",
+                "description": "Number of graphemes in `s` using `encoding_name`",
+                "url": "length"
+            },
+            {
+                "signature": "SUBSTRING(s: Str, start_pos: Int) -> Str",
+                "description": "Substring of `s` starting at `start_pos`",
+                "url": "substring"
+            },
+            {
+                "signature": "SUBSTRING(s: Str, start_pos: Int, l: Int) -> Str",
+                "description": "Substring starting at `start_pos` of length `l`",
+                "url": "substring"
+            }
+        ]
+    },
+    {
+        "type": "Time",
+        "functions": [
+            {
+                "signature": "EXTRACT(extract_expr) -> Float",
+                "description": "Specified time component from value",
+                "url": "extract"
+            }
+        ]
+    }
+]

--- a/www/layouts/_default/list.html
+++ b/www/layouts/_default/list.html
@@ -4,4 +4,12 @@
 
 {{ partial "content-parser.html" .Content }}
 
-{{end}}
+{{ if not (.Params.disable_list) }}
+{{ range .Pages.ByWeight }}
+<li>
+  <a href="{{.Permalink}}">{{.Title}}</a>
+</li>
+{{ end }}{{/*  {{ range .Pages.ByWeight }} */}}
+{{ end }}{{/*  {{ if not (.Params.disable_list) }} */}}
+
+{{ end }}{{/*  {{ define "main"}} */}}

--- a/www/layouts/partials/sql-grammar/bnf/func-cast.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/func-cast.bnf
@@ -1,0 +1,2 @@
+func_cast ::=
+  'CAST' '(' val 'AS' type ')'

--- a/www/layouts/partials/sql-grammar/bnf/func-coalesce.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/func-coalesce.bnf
@@ -1,0 +1,2 @@
+func_coalesce ::=
+  'COALESCE' '(' val ( ',' val )* ')'

--- a/www/layouts/partials/sql-grammar/bnf/func-extract.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/func-extract.bnf
@@ -1,0 +1,2 @@
+func_extract ::=
+  'EXTRACT' '(' time_component 'FROM' val ')'

--- a/www/layouts/partials/sql-grammar/bnf/func-length.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/func-length.bnf
@@ -1,0 +1,2 @@
+func_length ::=
+  'LENGTH' '(' str (',' encoding_name)? ')'

--- a/www/layouts/partials/sql-grammar/bnf/func-substring.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/func-substring.bnf
@@ -1,0 +1,2 @@
+func_substr ::=
+  'SUBSTRING' '(' str ',' start_pos (',' len)? ')'

--- a/www/layouts/partials/sql-grammar/bnf/op-cast.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/op-cast.bnf
@@ -1,0 +1,2 @@
+op_cast ::=
+  val '::' type

--- a/www/layouts/partials/sql-grammar/bnf/time-component.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/time-component.bnf
@@ -1,0 +1,2 @@
+time_component ::=
+  ( 'YEAR' | 'MONTH' | 'DAY' | 'HOUR' | 'MINUTE' | 'SECOND' )

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-cast.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-cast.html
@@ -1,0 +1,17 @@
+<svg width="391" height="37">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">CAST</text>
+         <rect x="107" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="105" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="115" y="21">(</text><rect x="153" y="3" width="38" height="32"></rect><rect x="151" y="1" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="161" y="21">val</text><rect x="211" y="3" width="38" height="32" rx="10"></rect>
+         <rect x="209" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="219" y="21">AS</text><rect x="269" y="3" width="48" height="32"></rect><rect x="267" y="1" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="277" y="21">type</text><rect x="337" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="335" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="345" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="381 17 389 13 389 21"></polygon>
+         <polygon points="381 17 373 13 373 21"></polygon></svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-coalesce.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-coalesce.html
@@ -1,0 +1,18 @@
+<svg width="341" height="81">
+         
+         <polygon points="9 61 1 57 1 65"></polygon>
+         <polygon points="17 61 9 57 9 65"></polygon>
+         <rect x="31" y="47" width="92" height="32" rx="10"></rect>
+         <rect x="29" y="45" width="92" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="65">COALESCE</text>
+         <rect x="143" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="141" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="151" y="65">(</text><rect x="209" y="47" width="38" height="32"></rect><rect x="207" y="45" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="217" y="65">val</text><rect x="209" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="207" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="217" y="21">,</text>
+         <rect x="287" y="47" width="26" height="32" rx="10"></rect>
+         <rect x="285" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="295" y="65">)</text>
+         <path class="line" d="m17 61 h2 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m38 0 h10 m-78 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m58 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-58 0 h10 m24 0 h10 m0 0 h14 m20 44 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="331 61 339 57 339 65"></polygon>
+         <polygon points="331 61 323 57 323 65"></polygon></svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-extract.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-extract.html
@@ -1,0 +1,17 @@
+<svg width="515" height="37">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="80" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">EXTRACT</text>
+         <rect x="131" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="129" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="139" y="21">(</text><rect x="177" y="3" width="126" height="32"></rect><rect x="175" y="1" width="126" height="32" class="nonterminal"></rect><text class="nonterminal" x="185" y="21">time_component</text><rect x="323" y="3" width="60" height="32" rx="10"></rect>
+         <rect x="321" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="331" y="21">FROM</text><rect x="403" y="3" width="38" height="32"></rect><rect x="401" y="1" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="411" y="21">val</text><rect x="461" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="459" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="469" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="505 17 513 13 513 21"></polygon>
+         <polygon points="505 17 497 13 497 21"></polygon></svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-length.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-length.html
@@ -1,0 +1,17 @@
+<svg width="505" height="69">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">LENGTH</text>
+         <rect x="125" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="123" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="133" y="21">(</text><rect x="171" y="3" width="36" height="32"></rect><rect x="169" y="1" width="36" height="32" class="nonterminal"></rect><text class="nonterminal" x="179" y="21">str</text><rect x="247" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="245" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="255" y="53">,</text><rect x="291" y="35" width="120" height="32"></rect><rect x="289" y="33" width="120" height="32" class="nonterminal"></rect><text class="nonterminal" x="299" y="53">encoding_name</text><rect x="451" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="449" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="459" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m24 0 h10 m0 0 h10 m120 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="495 17 503 13 503 21"></polygon>
+         <polygon points="495 17 487 13 487 21"></polygon></svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-substring.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-substring.html
@@ -1,0 +1,19 @@
+<svg width="593" height="69">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="31" y="3" width="100" height="32" rx="10"></rect>
+         <rect x="29" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="39" y="21">SUBSTRING</text>
+         <rect x="151" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="149" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="159" y="21">(</text><rect x="197" y="3" width="36" height="32"></rect><rect x="195" y="1" width="36" height="32" class="nonterminal"></rect><text class="nonterminal" x="205" y="21">str</text><rect x="253" y="3" width="24" height="32" rx="10"></rect>
+         <rect x="251" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="261" y="21">,</text><rect x="297" y="3" width="80" height="32"></rect><rect x="295" y="1" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="305" y="21">start_pos</text><rect x="417" y="35" width="24" height="32" rx="10"></rect>
+         <rect x="415" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="425" y="53">,</text><rect x="461" y="35" width="38" height="32"></rect><rect x="459" y="33" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="469" y="53">len</text><rect x="539" y="3" width="26" height="32" rx="10"></rect>
+         <rect x="537" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="547" y="21">)</text>
+         <path class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m24 0 h10 m0 0 h10 m38 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
+         <polygon points="583 17 591 13 591 21"></polygon>
+         <polygon points="583 17 575 13 575 21"></polygon></svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/op-cast.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/op-cast.html
@@ -1,0 +1,8 @@
+<svg width="215" height="37">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon><rect x="31" y="3" width="38" height="32"></rect><rect x="29" y="1" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="39" y="21">val</text><rect x="89" y="3" width="30" height="32" rx="10"></rect>
+         <rect x="87" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="97" y="21">::</text><rect x="139" y="3" width="48" height="32"></rect><rect x="137" y="1" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="147" y="21">type</text><path class="line" d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></path>
+         <polygon points="205 17 213 13 213 21"></polygon>
+         <polygon points="205 17 197 13 197 21"></polygon></svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/time-component.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/time-component.html
@@ -1,0 +1,25 @@
+<svg width="175" height="257">
+         
+         <polygon points="9 17 1 13 1 21"></polygon>
+         <polygon points="17 17 9 13 9 21"></polygon>
+         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="21">YEAR</text>
+         <rect x="51" y="47" width="70" height="32" rx="10"></rect>
+         <rect x="49" y="45" width="70" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="65">MONTH</text>
+         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
+         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="109">DAY</text>
+         <rect x="51" y="135" width="60" height="32" rx="10"></rect>
+         <rect x="49" y="133" width="60" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="153">HOUR</text>
+         <rect x="51" y="179" width="74" height="32" rx="10"></rect>
+         <rect x="49" y="177" width="74" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="197">MINUTE</text>
+         <rect x="51" y="223" width="76" height="32" rx="10"></rect>
+         <rect x="49" y="221" width="76" height="32" class="terminal" rx="10"></rect>
+         <text class="terminal" x="59" y="241">SECOND</text>
+         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h20 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m70 0 h10 m0 0 h6 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m48 0 h10 m0 0 h28 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m60 0 h10 m0 0 h16 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m74 0 h10 m0 0 h2 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -220 h-3"></path>
+         <polygon points="165 17 173 13 173 21"></polygon>
+         <polygon points="165 17 157 13 157 21"></polygon></svg>

--- a/www/layouts/shortcodes/fnlist.html
+++ b/www/layouts/shortcodes/fnlist.html
@@ -1,0 +1,35 @@
+{{/*  Converts www/data/sql_funcs.json into table. */}}
+{{ range $.Site.Data.sql_funcs }}
+<h3>
+  <a class="headline-hash" href="#{{ lower .type }}-func">
+    {{.type}}
+  </a>
+  <a name="{{ lower .type }}-func"></a>
+</h3>
+
+<table>
+  <tr>
+    <th>
+      Function
+    </th>
+    <th>
+      Computes
+    </th>
+  </tr>
+  {{ range .functions }}
+  <tr>
+    <td>
+      {{ highlight .signature "rust" "" }}
+    </td>
+    <td>
+
+      {{ .description | markdownify }}
+
+      {{ if .url}}(<a href="{{ .url}}">docs</a>){{ end }}
+
+    </td>
+  </tr>
+  {{ end }} {{/*  {{ range .functions }} */}}
+</table>
+
+{{ end }}{{/*  {{ range $.Site.Data.sql_funcs }} */}}


### PR DESCRIPTION
Initial design of function and operators. I think I found most of them in the code, but we can always add anything I'm missing later.

Will do technical reviews of content with appropriate engineers after merging (reversing typical order here simply because these docs are meant more for a structured exploration of what this needed to look like, so you can imagine them as placeholders rather than finalized documentation).

Note: the page at `/docs/sql/functions` does not work with Hugo's TOC module because the content comes from the `data` dir and is rendered after the step where the TOC gets generated. This could theoretically be generated in some other way (i.e. another shortcode?) but at some later date.