### PR TITLE
Allow configuring urls used by metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,8 @@ name = "metrics"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "failure",
+ "getopts",
  "postgres",
  "prometheus",
  "regex",

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -10,8 +10,9 @@ name = "metrics"
 path = "bin/metrics.rs"
 
 [dependencies]
+getopts = "0.2"
+failure = "0.1.6"
 regex = "1.3.1"
 prometheus = { version = "0.7", features = ["push", "process"] }
 chrono = "0.4.10"
 postgres = { version = "0.15", features = ["with-chrono"] }
-


### PR DESCRIPTION
For running stuff without docker, we need to be able to pass localhost urls for everything.