### PR TITLE
Decode bools from bytes

### DIFF
--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -617,6 +617,11 @@ impl RawParameterBytes {
     fn generate_datum_from_bytes(bytes: &[u8], typ: ScalarType) -> Result<Datum, failure::Error> {
         Ok(match typ {
             ScalarType::Null => Datum::Null,
+            ScalarType::Bool => match bytes[0] {
+                // Rust bools are 1 byte in size.
+                0 => Datum::False,
+                _ => Datum::True,
+            },
             ScalarType::Int32 => Datum::Int32(NetworkEndian::read_i32(bytes)),
             ScalarType::Int64 => Datum::Int64(NetworkEndian::read_i64(bytes)),
             ScalarType::Float32 => Datum::Float32(NetworkEndian::read_f32(bytes).into()),


### PR DESCRIPTION
This feels.. weird?

But looking around, I didn't see an obvious way to go from `[u8]` -> `bool`. It seems, through online discussions, that `bool`s are consistently 1 byte in Rust. So I guess we could just compare? But happy to do anything else.