### PR TITLE
Try to make test_partial_read more robust

### DIFF
--- a/src/materialized/tests/prepared.rs
+++ b/src/materialized/tests/prepared.rs
@@ -44,9 +44,6 @@ fn test_partial_read() -> util::TestResult {
         if simpler.len() >= expected_rows {
             break;
         }
-        if i > 8 {
-            println!("WAT: got zero dataflows after 8 tries");
-        }
         std::thread::sleep(std::time::Duration::from_millis(20));
         simpler = conn.query(query, &[])?;
     }


### PR DESCRIPTION
It takes a few milliseconds for log views to be created, apparently, because sometimes we
were getting `1` simple query result instead of the expected 3.