### PR TITLE
lint: check for and fix whitespace errors

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -121,7 +121,7 @@ disabled_lints=(
     clippy::needless_range_loop
 
     # Upstream description: https://rust-lang.github.io/rust-clippy/master/index.html#cognitive_complexity
-    # 
+    #
     # Clippy's cognitive complexity is too easily reached.
     clippy::cognitive-complexity
 

--- a/bin/lint
+++ b/bin/lint
@@ -71,6 +71,7 @@ shell_files=$(sort -u <(git ls-files '*.sh' '*.bash') <(git grep -l '#!.*bash' -
 
 try xargs -n1 awk -f misc/lint/copyright.awk <<< "$copyright_files"
 try xargs misc/lint/trailing-newline.sh <<< "$newline_files"
+try xargs git --no-pager diff --check "$empty_tree" <<< "$newline_files"
 
 if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
     try xargs shellcheck -P SCRIPTDIR <<< "$shell_files"

--- a/doc/user/_index.md
+++ b/doc/user/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Materialize Docs" 
+title: "Materialize Docs"
 disable_toc: true
 disable_list: true
 ---

--- a/doc/user/get-started.md
+++ b/doc/user/get-started.md
@@ -35,7 +35,7 @@ overview and doesn't contain any actual instruction.
 1. Materialize needs to understand your Kafka topics' schemas, so you'll need to
    have your topics reports their schema to a Confluent Schema Registry, or know
    the topics' Avro schemas.
-   
+
     Note that if you are using Debezium (and you should be), all of this happens automatically.
 
 ### Using Materialize

--- a/doc/user/sql/create-sources.md
+++ b/doc/user/sql/create-sources.md
@@ -81,12 +81,12 @@ After creating the source and connecting to Kafka, Materialize receives all of t
 Materialize requires that the data it receives from Kafka have a structure that
 contains both the old and new values for any fields within a record (a "diff
 envelope"), which lets Differential dataflow process arbitrary changes to the
-underlying data, e.g. expressing a record's deletion. 
+underlying data, e.g. expressing a record's deletion.
 
 The only tool that we're aware of that provide data to Kafka in this form is
 Debezium through its envelope structure that contains a `before` and `after`
 field (although CockroachDB's change data capture feature is close to
-operational, as well). 
+operational, as well).
 
 Ultimately, this means that the only sources that you can create must originate
 from Debezium, which must be published through Kafka.
@@ -96,7 +96,7 @@ from Debezium, which must be published through Kafka.
 When creating a source, Materialize looks up stream's structure using a
 Confluent Schema Registry or with the Avro schema you define. The stream's
 schema is then used to create the source within Materialize, which is
-essentially equivalent to a table in the language of RDBMSes. 
+essentially equivalent to a table in the language of RDBMSes.
 
 Once Materialize has determined the structure of the stream, it connects the
 underlying Kafka stream directly to its Differential dataflow engine.
@@ -120,16 +120,16 @@ from their sources that are available from the arrangements within Differential.
 ### Using a Confluent schema registry
 
 ```sql
-CREATE SOURCES 
-LIKE 'mysql.simple.%' 
-FROM 'kafka://kafka:9092' 
+CREATE SOURCES
+LIKE 'mysql.simple.%'
+FROM 'kafka://kafka:9092'
 USING SCHEMA REGISTRY 'http://schema-registry:8081';
 ```
 
 ### Manually defining Avro schema
 
 ```sql
-CREATE SOURCE 'mysql.simple.user' 
+CREATE SOURCE 'mysql.simple.user'
 FROM 'kafka://kafka:9092'
 USING SCHEMA '{
   "type": "record",

--- a/doc/user/sql/create-view.md
+++ b/doc/user/sql/create-view.md
@@ -59,7 +59,7 @@ For more detail about how different clauses impact memory usage, check out our
 ```sql
 CREATE VIEW purchase_sum_by_region
 AS
-    SELECT  sum(purchase.amount) AS region_sum, 
+    SELECT  sum(purchase.amount) AS region_sum,
             region.id AS region_id
     FROM mysql_simple_region AS region
     INNER JOIN mysql_simple_user AS user

--- a/doc/user/sql/functions/length.md
+++ b/doc/user/sql/functions/length.md
@@ -41,8 +41,8 @@ You can find any updates on this behavior in [this GitHub issue](https://github.
 ### Encoding details
 
 - Materialize uses the [`encoding`](https://crates.io/crates/encoding) crate. See the [list of supported encodings](https://lifthrasiir.github.io/rust-encoding/encoding/index.html#supported-encodings), as well as their names [within the API](https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs).
-- Materialize attempts to convert [PostgreSQL-style encoding names](https://www.postgresql.org/docs/9.5/multibyte.html) into the [WHATWG-style encoding names](https://encoding.spec.whatwg.org/) used by the API. 
-    
+- Materialize attempts to convert [PostgreSQL-style encoding names](https://www.postgresql.org/docs/9.5/multibyte.html) into the [WHATWG-style encoding names](https://encoding.spec.whatwg.org/) used by the API.
+
     For example, you can refer to `iso-8859-5` (WHATWG-style) as `ISO_8859_5` (PostrgreSQL-style).
 
     However, there are some differences in the names of the same encodings that we do not convert. For example, the [windows-874](https://encoding.spec.whatwg.org/#windows-1252) encoding is referred to as `WIN874` in PostgreSQL; Materialize does not perform a conversion for these names.

--- a/ex/chbench/packer/fmtdisks.sh
+++ b/ex/chbench/packer/fmtdisks.sh
@@ -9,4 +9,3 @@ set -euxo pipefail
 
 mkswap /dev/nvme0n1
 mkfs.ext4 /dev/nvme1n1
-

--- a/ex/chbench/terraform/docker-credentials.sh
+++ b/ex/chbench/terraform/docker-credentials.sh
@@ -21,4 +21,3 @@ elif ! echo "https://index.docker.io/v1/" | docker-credential-desktop get; then
     echo "try: \`terraform apply -var=docker_username=USERNAME -var=docker_password=PASSWORD\`" >&2
     exit 1
 fi
-

--- a/ex/simple-demo/docker-compose.yml
+++ b/ex/simple-demo/docker-compose.yml
@@ -98,4 +98,3 @@ services:
   inspect:
     image: ubuntu:bionic
     command: "true"
-

--- a/ex/simple-demo/simple-loadgen/main.go
+++ b/ex/simple-demo/simple-loadgen/main.go
@@ -50,7 +50,7 @@ func main() {
 	// simple.region.time is a workaround for the fact that Materialize requires
 	// some activity on row after source is created to ingest it. Will be
 	// removed in future version.
-	doExec(db, `CREATE TABLE IF NOT EXISTS simple.region 
+	doExec(db, `CREATE TABLE IF NOT EXISTS simple.region
 		(
 			id SERIAL PRIMARY KEY,
 			time TIMESTAMP
@@ -59,14 +59,14 @@ func main() {
 	// simple.user.time is a workaround for the fact that Materialize requires
 	// some activity on row after source is created to ingest it. Will be
 	// removed in future version.
-	doExec(db, `CREATE TABLE IF NOT EXISTS simple.user 
+	doExec(db, `CREATE TABLE IF NOT EXISTS simple.user
 		(
-			id SERIAL PRIMARY KEY, 
-			region_id BIGINT UNSIGNED REFERENCES region(id), 
+			id SERIAL PRIMARY KEY,
+			region_id BIGINT UNSIGNED REFERENCES region(id),
 			time TIMESTAMP
 		);`)
 
-	doExec(db, `CREATE TABLE IF NOT EXISTS simple.purchase 
+	doExec(db, `CREATE TABLE IF NOT EXISTS simple.purchase
 		(
 			user_id BIGINT UNSIGNED REFERENCES user(id),
 			amount DECIMAL(12,2)

--- a/misc/editor/vscode/.vscodeignore
+++ b/misc/editor/vscode/.vscodeignore
@@ -1,4 +1,3 @@
 .vscode/**
 .vscode-test/**
 .gitignore
-

--- a/test/order_by.slt
+++ b/test/order_by.slt
@@ -102,7 +102,7 @@ statement ok
 create table baz (val1 int, val2 int);
 
 statement ok
-insert into baz values (12345, 1735), (12345, 1735), (12345, 1735), (1735, 24223), 
+insert into baz values (12345, 1735), (12345, 1735), (12345, 1735), (1735, 24223),
 (12345, 12345), (2079, 24223), (1735, 2079), (1735, 2079), (1735, 2079);
 
 #offset
@@ -248,7 +248,7 @@ CREATE VIEW fizzoffsetview2 as SELECT b, a from fizz ORDER BY b desc, a OFFSET 3
 query TI rowsort
 PEEK fizzoffsetview2
 ----
-four     21243 
+four     21243
 four     24223
 five     6745
 one      12345
@@ -304,10 +304,10 @@ query TI rowsort
 PEEK fizzoffsetview2
 ----
 five     6745
-four     21243 
+four     21243
 four     24223
 one      12345
-three    12345 
+three    12345
 
 query RT rowsort
 PEEK fizzlimitoffsetview2;
@@ -364,7 +364,7 @@ SELECT count(b), count(a) FROM fizzoffsetview;
 query TI rowsort
 PEEK fizzoffsetview2
 ----
-four     21243 
+four     21243
 four     24223
 fourteen 21758
 one      12345

--- a/test/sort.td
+++ b/test/sort.td
@@ -94,7 +94,7 @@ val    quote
 ----------------------------------------------------------------------------
 25040  "New York is real.  The rest is done with mirrors."
 1735   "Ring around the collar."
-21243  "Yes, but every time I try to see things your way, I get a headache." 
+21243  "Yes, but every time I try to see things your way, I get a headache."
 24223  "You are magnetic in your bearing."
 
 > SELECT val, quote FROM foobar ORDER BY quote LIMIT 4 OFFSET 0 ROWS

--- a/test/string.slt
+++ b/test/string.slt
@@ -46,7 +46,7 @@ CREATE TABLE substrtest (strcol CHAR(15), vccol VARCHAR(15), smicol SMALLINT, in
 statement ok
 INSERT INTO substrtest VALUES ('Mg', 'Mn', 1, 1), ('magnesium', 'manganese', 3, null),
     (null, null, 0, 0), ('24.31', '54.94', 2, 3), ('长久不见', '爱不释手', null, 2),
-    ('', '', -1, 2) 
+    ('', '', -1, 2)
 
 #invalid input
 statement error

--- a/www/layouts/partials/sql-grammar/bnf/create-source.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source.bnf
@@ -1,2 +1,2 @@
 create_source ::=
-  'CREATE SOURCE' src_name 'FROM' kafka_src 'USING SCHEMA' ( 'REGISTRY' registry_src | avro_schema ) 
+  'CREATE SOURCE' src_name 'FROM' kafka_src 'USING SCHEMA' ( 'REGISTRY' registry_src | avro_schema )

--- a/www/layouts/partials/sql-grammar/bnf/create-sources.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-sources.bnf
@@ -1,2 +1,2 @@
 create_sources ::=
-  'CREATE SOURCES' ('LIKE' schema_expr)? 'FROM' kafka_src 'USING SCHEMA' ( 'REGISTRY' registry_src | avro_schema ) 
+  'CREATE SOURCES' ('LIKE' schema_expr)? 'FROM' kafka_src 'USING SCHEMA' ( 'REGISTRY' registry_src | avro_schema )

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source.html
@@ -1,16 +1,31 @@
 <svg width="613" height="147">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="132" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="132" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CREATE SOURCE</text><rect x="183" y="3" width="82" height="32"></rect><rect x="181" y="1" width="82" height="32" class="nonterminal"></rect><text class="nonterminal" x="191" y="21">src_name</text><rect x="285" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="283" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="293" y="21">FROM</text><rect x="365" y="3" width="80" height="32"></rect><rect x="363" y="1" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="373" y="21">kafka_src</text><rect x="465" y="3" width="126" height="32" rx="10"></rect>
-         <rect x="463" y="1" width="126" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="473" y="21">USING SCHEMA</text>
-         <rect x="363" y="69" width="88" height="32" rx="10"></rect>
-         <rect x="361" y="67" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="371" y="87">REGISTRY</text><rect x="471" y="69" width="94" height="32"></rect><rect x="469" y="67" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="479" y="87">registry_src</text><rect x="363" y="113" width="104" height="32"></rect><rect x="361" y="111" width="104" height="32" class="nonterminal"></rect><text class="nonterminal" x="371" y="131">avro_schema</text><path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3"></path>
-         <polygon points="603 83 611 79 611 87"></polygon>
-         <polygon points="603 83 595 79 595 87"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="132" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="132" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">CREATE SOURCE</text>
+  <rect x="183" y="3" width="82" height="32"></rect>
+  <rect x="181" y="1" width="82" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="191" y="21">src_name</text>
+  <rect x="285" y="3" width="60" height="32" rx="10"></rect>
+  <rect x="283" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="293" y="21">FROM</text>
+  <rect x="365" y="3" width="80" height="32"></rect>
+  <rect x="363" y="1" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="373" y="21">kafka_src</text>
+  <rect x="465" y="3" width="126" height="32" rx="10"></rect>
+  <rect x="463" y="1" width="126" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="473" y="21">USING SCHEMA</text>
+  <rect x="363" y="69" width="88" height="32" rx="10"></rect>
+  <rect x="361" y="67" width="88" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="371" y="87">REGISTRY</text>
+  <rect x="471" y="69" width="94" height="32"></rect>
+  <rect x="469" y="67" width="94" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="479" y="87">registry_src</text>
+  <rect x="363" y="113" width="104" height="32"></rect>
+  <rect x="361" y="111" width="104" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="371" y="131">avro_schema</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m80 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-292 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3"></path>
+  <polygon points="603 83 611 79 611 87"></polygon>
+  <polygon points="603 83 595 79 595 87"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-sources.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-sources.html
@@ -1,19 +1,34 @@
 <svg width="611" height="179">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="142" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="142" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CREATE SOURCES</text>
-         <rect x="213" y="35" width="52" height="32" rx="10"></rect>
-         <rect x="211" y="33" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="221" y="53">LIKE</text><rect x="285" y="35" width="104" height="32"></rect><rect x="283" y="33" width="104" height="32" class="nonterminal"></rect><text class="nonterminal" x="293" y="53">schema_expr</text><rect x="429" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="427" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="437" y="21">FROM</text><rect x="509" y="3" width="80" height="32"></rect><rect x="507" y="1" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="517" y="21">kafka_src</text><rect x="195" y="101" width="126" height="32" rx="10"></rect>
-         <rect x="193" y="99" width="126" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="203" y="119">USING SCHEMA</text>
-         <rect x="361" y="101" width="88" height="32" rx="10"></rect>
-         <rect x="359" y="99" width="88" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="369" y="119">REGISTRY</text><rect x="469" y="101" width="94" height="32"></rect><rect x="467" y="99" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="477" y="119">registry_src</text><rect x="361" y="145" width="104" height="32"></rect><rect x="359" y="143" width="104" height="32" class="nonterminal"></rect><text class="nonterminal" x="369" y="163">avro_schema</text><path class="line" d="m17 17 h2 m0 0 h10 m142 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m52 0 h10 m0 0 h10 m104 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-438 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m20 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3"></path>
-         <polygon points="601 115 609 111 609 119"></polygon>
-         <polygon points="601 115 593 111 593 119"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="142" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="142" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">CREATE SOURCES</text>
+  <rect x="213" y="35" width="52" height="32" rx="10"></rect>
+  <rect x="211" y="33" width="52" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="221" y="53">LIKE</text>
+  <rect x="285" y="35" width="104" height="32"></rect>
+  <rect x="283" y="33" width="104" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="293" y="53">schema_expr</text>
+  <rect x="429" y="3" width="60" height="32" rx="10"></rect>
+  <rect x="427" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="437" y="21">FROM</text>
+  <rect x="509" y="3" width="80" height="32"></rect>
+  <rect x="507" y="1" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="517" y="21">kafka_src</text>
+  <rect x="195" y="101" width="126" height="32" rx="10"></rect>
+  <rect x="193" y="99" width="126" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="203" y="119">USING SCHEMA</text>
+  <rect x="361" y="101" width="88" height="32" rx="10"></rect>
+  <rect x="359" y="99" width="88" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="369" y="119">REGISTRY</text>
+  <rect x="469" y="101" width="94" height="32"></rect>
+  <rect x="467" y="99" width="94" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="477" y="119">registry_src</text>
+  <rect x="361" y="145" width="104" height="32"></rect>
+  <rect x="359" y="143" width="104" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="369" y="163">avro_schema</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m142 0 h10 m20 0 h10 m0 0 h186 m-216 0 h20 m196 0 h20 m-236 0 q10 0 10 10 m216 0 q0 -10 10 -10 m-226 10 v12 m216 0 v-12 m-216 12 q0 10 10 10 m196 0 q10 0 10 -10 m-206 10 h10 m52 0 h10 m0 0 h10 m104 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m80 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-438 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m126 0 h10 m20 0 h10 m88 0 h10 m0 0 h10 m94 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m104 0 h10 m0 0 h98 m23 -44 h-3"></path>
+  <polygon points="601 115 609 111 609 119"></polygon>
+  <polygon points="601 115 593 111 593 119"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-view.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-view.html
@@ -1,17 +1,25 @@
 <svg width="555" height="135">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="72" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CREATE</text>
-         <rect x="143" y="35" width="122" height="32" rx="10"></rect>
-         <rect x="141" y="33" width="122" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="151" y="53">MATERIALIZED</text>
-         <rect x="305" y="3" width="58" height="32" rx="10"></rect>
-         <rect x="303" y="1" width="58" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="313" y="21">VIEW</text><rect x="383" y="3" width="92" height="32"></rect><rect x="381" y="1" width="92" height="32" class="nonterminal"></rect><text class="nonterminal" x="391" y="21">view_name</text><rect x="495" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="493" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="503" y="21">AS</text><rect x="433" y="101" width="94" height="32"></rect><rect x="431" y="99" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="441" y="119">select_stmt</text><path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m58 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
-         <polygon points="545 115 553 111 553 119"></polygon>
-         <polygon points="545 115 537 111 537 119"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="72" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="72" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">CREATE</text>
+  <rect x="143" y="35" width="122" height="32" rx="10"></rect>
+  <rect x="141" y="33" width="122" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="151" y="53">MATERIALIZED</text>
+  <rect x="305" y="3" width="58" height="32" rx="10"></rect>
+  <rect x="303" y="1" width="58" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="313" y="21">VIEW</text>
+  <rect x="383" y="3" width="92" height="32"></rect>
+  <rect x="381" y="1" width="92" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="391" y="21">view_name</text>
+  <rect x="495" y="3" width="38" height="32" rx="10"></rect>
+  <rect x="493" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="503" y="21">AS</text>
+  <rect x="433" y="101" width="94" height="32"></rect>
+  <rect x="431" y="99" width="94" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="441" y="119">select_stmt</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m58 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m38 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
+  <polygon points="545 115 553 111 553 119"></polygon>
+  <polygon points="545 115 537 111 537 119"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-cast.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-cast.html
@@ -1,17 +1,25 @@
 <svg width="391" height="37">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">CAST</text>
-         <rect x="107" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="105" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="115" y="21">(</text><rect x="153" y="3" width="38" height="32"></rect><rect x="151" y="1" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="161" y="21">val</text><rect x="211" y="3" width="38" height="32" rx="10"></rect>
-         <rect x="209" y="1" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="219" y="21">AS</text><rect x="269" y="3" width="48" height="32"></rect><rect x="267" y="1" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="277" y="21">type</text><rect x="337" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="335" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="345" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="381 17 389 13 389 21"></polygon>
-         <polygon points="381 17 373 13 373 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="56" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">CAST</text>
+  <rect x="107" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="105" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="115" y="21">(</text>
+  <rect x="153" y="3" width="38" height="32"></rect>
+  <rect x="151" y="1" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="161" y="21">val</text>
+  <rect x="211" y="3" width="38" height="32" rx="10"></rect>
+  <rect x="209" y="1" width="38" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="219" y="21">AS</text>
+  <rect x="269" y="3" width="48" height="32"></rect>
+  <rect x="267" y="1" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="277" y="21">type</text>
+  <rect x="337" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="335" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="345" y="21">)</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+  <polygon points="381 17 389 13 389 21"></polygon>
+  <polygon points="381 17 373 13 373 21"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-coalesce.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-coalesce.html
@@ -1,18 +1,22 @@
 <svg width="341" height="81">
-         
-         <polygon points="9 61 1 57 1 65"></polygon>
-         <polygon points="17 61 9 57 9 65"></polygon>
-         <rect x="31" y="47" width="92" height="32" rx="10"></rect>
-         <rect x="29" y="45" width="92" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="65">COALESCE</text>
-         <rect x="143" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="141" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="151" y="65">(</text><rect x="209" y="47" width="38" height="32"></rect><rect x="207" y="45" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="217" y="65">val</text><rect x="209" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="207" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="217" y="21">,</text>
-         <rect x="287" y="47" width="26" height="32" rx="10"></rect>
-         <rect x="285" y="45" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="295" y="65">)</text>
-         <path class="line" d="m17 61 h2 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m38 0 h10 m-78 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m58 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-58 0 h10 m24 0 h10 m0 0 h14 m20 44 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="331 61 339 57 339 65"></polygon>
-         <polygon points="331 61 323 57 323 65"></polygon></svg>
+  <polygon points="9 61 1 57 1 65"></polygon>
+  <polygon points="17 61 9 57 9 65"></polygon>
+  <rect x="31" y="47" width="92" height="32" rx="10"></rect>
+  <rect x="29" y="45" width="92" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="65">COALESCE</text>
+  <rect x="143" y="47" width="26" height="32" rx="10"></rect>
+  <rect x="141" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="151" y="65">(</text>
+  <rect x="209" y="47" width="38" height="32"></rect>
+  <rect x="207" y="45" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="217" y="65">val</text>
+  <rect x="209" y="3" width="24" height="32" rx="10"></rect>
+  <rect x="207" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="217" y="21">,</text>
+  <rect x="287" y="47" width="26" height="32" rx="10"></rect>
+  <rect x="285" y="45" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="295" y="65">)</text>
+  <path class="line" d="m17 61 h2 m0 0 h10 m92 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m38 0 h10 m-78 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m58 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-58 0 h10 m24 0 h10 m0 0 h14 m20 44 h10 m26 0 h10 m3 0 h-3"></path>
+  <polygon points="331 61 339 57 339 65"></polygon>
+  <polygon points="331 61 323 57 323 65"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-extract.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-extract.html
@@ -1,17 +1,25 @@
 <svg width="515" height="37">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="80" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="80" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">EXTRACT</text>
-         <rect x="131" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="129" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="139" y="21">(</text><rect x="177" y="3" width="126" height="32"></rect><rect x="175" y="1" width="126" height="32" class="nonterminal"></rect><text class="nonterminal" x="185" y="21">time_component</text><rect x="323" y="3" width="60" height="32" rx="10"></rect>
-         <rect x="321" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="331" y="21">FROM</text><rect x="403" y="3" width="38" height="32"></rect><rect x="401" y="1" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="411" y="21">val</text><rect x="461" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="459" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="469" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="505 17 513 13 513 21"></polygon>
-         <polygon points="505 17 497 13 497 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="80" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="80" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">EXTRACT</text>
+  <rect x="131" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="129" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="139" y="21">(</text>
+  <rect x="177" y="3" width="126" height="32"></rect>
+  <rect x="175" y="1" width="126" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="185" y="21">time_component</text>
+  <rect x="323" y="3" width="60" height="32" rx="10"></rect>
+  <rect x="321" y="1" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="331" y="21">FROM</text>
+  <rect x="403" y="3" width="38" height="32"></rect>
+  <rect x="401" y="1" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="411" y="21">val</text>
+  <rect x="461" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="459" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="469" y="21">)</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m80 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m26 0 h10 m3 0 h-3"></path>
+  <polygon points="505 17 513 13 513 21"></polygon>
+  <polygon points="505 17 497 13 497 21"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-length.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-length.html
@@ -1,17 +1,25 @@
 <svg width="505" height="69">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="74" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">LENGTH</text>
-         <rect x="125" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="123" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="133" y="21">(</text><rect x="171" y="3" width="36" height="32"></rect><rect x="169" y="1" width="36" height="32" class="nonterminal"></rect><text class="nonterminal" x="179" y="21">str</text><rect x="247" y="35" width="24" height="32" rx="10"></rect>
-         <rect x="245" y="33" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="255" y="53">,</text><rect x="291" y="35" width="120" height="32"></rect><rect x="289" y="33" width="120" height="32" class="nonterminal"></rect><text class="nonterminal" x="299" y="53">encoding_name</text><rect x="451" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="449" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="459" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m24 0 h10 m0 0 h10 m120 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="495 17 503 13 503 21"></polygon>
-         <polygon points="495 17 487 13 487 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="74" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="74" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">LENGTH</text>
+  <rect x="125" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="123" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="133" y="21">(</text>
+  <rect x="171" y="3" width="36" height="32"></rect>
+  <rect x="169" y="1" width="36" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="179" y="21">str</text>
+  <rect x="247" y="35" width="24" height="32" rx="10"></rect>
+  <rect x="245" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="255" y="53">,</text>
+  <rect x="291" y="35" width="120" height="32"></rect>
+  <rect x="289" y="33" width="120" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="299" y="53">encoding_name</text>
+  <rect x="451" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="449" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="459" y="21">)</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m24 0 h10 m0 0 h10 m120 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
+  <polygon points="495 17 503 13 503 21"></polygon>
+  <polygon points="495 17 487 13 487 21"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/func-substring.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/func-substring.html
@@ -1,19 +1,31 @@
 <svg width="593" height="69">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="100" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="100" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">SUBSTRING</text>
-         <rect x="151" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="149" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="159" y="21">(</text><rect x="197" y="3" width="36" height="32"></rect><rect x="195" y="1" width="36" height="32" class="nonterminal"></rect><text class="nonterminal" x="205" y="21">str</text><rect x="253" y="3" width="24" height="32" rx="10"></rect>
-         <rect x="251" y="1" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="261" y="21">,</text><rect x="297" y="3" width="80" height="32"></rect><rect x="295" y="1" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="305" y="21">start_pos</text><rect x="417" y="35" width="24" height="32" rx="10"></rect>
-         <rect x="415" y="33" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="425" y="53">,</text><rect x="461" y="35" width="38" height="32"></rect><rect x="459" y="33" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="469" y="53">len</text><rect x="539" y="3" width="26" height="32" rx="10"></rect>
-         <rect x="537" y="1" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="547" y="21">)</text>
-         <path class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m24 0 h10 m0 0 h10 m38 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
-         <polygon points="583 17 591 13 591 21"></polygon>
-         <polygon points="583 17 575 13 575 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="100" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="100" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">SUBSTRING</text>
+  <rect x="151" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="149" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="159" y="21">(</text>
+  <rect x="197" y="3" width="36" height="32"></rect>
+  <rect x="195" y="1" width="36" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="205" y="21">str</text>
+  <rect x="253" y="3" width="24" height="32" rx="10"></rect>
+  <rect x="251" y="1" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="261" y="21">,</text>
+  <rect x="297" y="3" width="80" height="32"></rect>
+  <rect x="295" y="1" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="305" y="21">start_pos</text>
+  <rect x="417" y="35" width="24" height="32" rx="10"></rect>
+  <rect x="415" y="33" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="425" y="53">,</text>
+  <rect x="461" y="35" width="38" height="32"></rect>
+  <rect x="459" y="33" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="469" y="53">len</text>
+  <rect x="539" y="3" width="26" height="32" rx="10"></rect>
+  <rect x="537" y="1" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="547" y="21">)</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m100 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h92 m-122 0 h20 m102 0 h20 m-142 0 q10 0 10 10 m122 0 q0 -10 10 -10 m-132 10 v12 m122 0 v-12 m-122 12 q0 10 10 10 m102 0 q10 0 10 -10 m-112 10 h10 m24 0 h10 m0 0 h10 m38 0 h10 m20 -32 h10 m26 0 h10 m3 0 h-3"></path>
+  <polygon points="583 17 591 13 591 21"></polygon>
+  <polygon points="583 17 575 13 575 21"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/join-expr.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/join-expr.html
@@ -1,28 +1,58 @@
 <svg width="717" height="377">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon><rect x="31" y="3" width="94" height="32"></rect><rect x="29" y="1" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="39" y="21">select_pred</text><rect x="65" y="69" width="66" height="32" rx="10"></rect>
-         <rect x="63" y="67" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="73" y="87">CROSS</text>
-         <rect x="65" y="113" width="84" height="32" rx="10"></rect>
-         <rect x="63" y="111" width="84" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="73" y="131">NATURAL</text><rect x="189" y="145" width="80" height="32"></rect><rect x="187" y="143" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="197" y="163">join_type</text><rect x="329" y="69" width="54" height="32" rx="10"></rect>
-         <rect x="327" y="67" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="337" y="87">JOIN</text><rect x="403" y="69" width="78" height="32"></rect><rect x="401" y="67" width="78" height="32" class="nonterminal"></rect><text class="nonterminal" x="411" y="87">table_ref</text><rect x="65" y="265" width="80" height="32"></rect><rect x="63" y="263" width="80" height="32" class="nonterminal"></rect><text class="nonterminal" x="73" y="283">join_type</text><rect x="185" y="233" width="54" height="32" rx="10"></rect>
-         <rect x="183" y="231" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="193" y="251">JOIN</text><rect x="259" y="233" width="78" height="32"></rect><rect x="257" y="231" width="78" height="32" class="nonterminal"></rect><text class="nonterminal" x="267" y="251">table_ref</text><rect x="377" y="233" width="64" height="32" rx="10"></rect>
-         <rect x="375" y="231" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="385" y="251">USING</text>
-         <rect x="461" y="233" width="26" height="32" rx="10"></rect>
-         <rect x="459" y="231" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="469" y="251">(</text><rect x="527" y="233" width="62" height="32"></rect><rect x="525" y="231" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="535" y="251">col_ref</text><rect x="527" y="189" width="24" height="32" rx="10"></rect>
-         <rect x="525" y="187" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="535" y="207">,</text>
-         <rect x="629" y="233" width="26" height="32" rx="10"></rect>
-         <rect x="627" y="231" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="637" y="251">)</text>
-         <rect x="377" y="277" width="40" height="32" rx="10"></rect>
-         <rect x="375" y="275" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="385" y="295">ON</text><rect x="437" y="277" width="90" height="32"></rect><rect x="435" y="275" width="90" height="32" class="nonterminal"></rect><text class="nonterminal" x="445" y="295">expression</text><rect x="595" y="343" width="94" height="32"></rect><rect x="593" y="341" width="94" height="32" class="nonterminal"></rect><text class="nonterminal" x="603" y="361">select_post</text><path class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m66 0 h10 m0 0 h158 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m84 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -76 h10 m54 0 h10 m0 0 h10 m78 0 h10 m0 0 h194 m-670 0 h20 m650 0 h20 m-690 0 q10 0 10 10 m670 0 q0 -10 10 -10 m-680 10 v144 m670 0 v-144 m-670 144 q0 10 10 10 m650 0 q10 0 10 -10 m-640 10 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -32 h10 m54 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m40 0 h10 m0 0 h10 m90 0 h10 m0 0 h128 m42 -208 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 274 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
-         <polygon points="707 357 715 353 715 361"></polygon>
-         <polygon points="707 357 699 353 699 361"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="94" height="32"></rect>
+  <rect x="29" y="1" width="94" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="39" y="21">select_pred</text>
+  <rect x="65" y="69" width="66" height="32" rx="10"></rect>
+  <rect x="63" y="67" width="66" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="73" y="87">CROSS</text>
+  <rect x="65" y="113" width="84" height="32" rx="10"></rect>
+  <rect x="63" y="111" width="84" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="73" y="131">NATURAL</text>
+  <rect x="189" y="145" width="80" height="32"></rect>
+  <rect x="187" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="197" y="163">join_type</text>
+  <rect x="329" y="69" width="54" height="32" rx="10"></rect>
+  <rect x="327" y="67" width="54" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="337" y="87">JOIN</text>
+  <rect x="403" y="69" width="78" height="32"></rect>
+  <rect x="401" y="67" width="78" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="411" y="87">table_ref</text>
+  <rect x="65" y="265" width="80" height="32"></rect>
+  <rect x="63" y="263" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="73" y="283">join_type</text>
+  <rect x="185" y="233" width="54" height="32" rx="10"></rect>
+  <rect x="183" y="231" width="54" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="193" y="251">JOIN</text>
+  <rect x="259" y="233" width="78" height="32"></rect>
+  <rect x="257" y="231" width="78" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="267" y="251">table_ref</text>
+  <rect x="377" y="233" width="64" height="32" rx="10"></rect>
+  <rect x="375" y="231" width="64" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="385" y="251">USING</text>
+  <rect x="461" y="233" width="26" height="32" rx="10"></rect>
+  <rect x="459" y="231" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="469" y="251">(</text>
+  <rect x="527" y="233" width="62" height="32"></rect>
+  <rect x="525" y="231" width="62" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="535" y="251">col_ref</text>
+  <rect x="527" y="189" width="24" height="32" rx="10"></rect>
+  <rect x="525" y="187" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="535" y="207">,</text>
+  <rect x="629" y="233" width="26" height="32" rx="10"></rect>
+  <rect x="627" y="231" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="637" y="251">)</text>
+  <rect x="377" y="277" width="40" height="32" rx="10"></rect>
+  <rect x="375" y="275" width="40" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="385" y="295">ON</text>
+  <rect x="437" y="277" width="90" height="32"></rect>
+  <rect x="435" y="275" width="90" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="445" y="295">expression</text>
+  <rect x="595" y="343" width="94" height="32"></rect>
+  <rect x="593" y="341" width="94" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="603" y="361">select_post</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m94 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m66 0 h10 m0 0 h158 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v24 m264 0 v-24 m-264 24 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m84 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -76 h10 m54 0 h10 m0 0 h10 m78 0 h10 m0 0 h194 m-670 0 h20 m650 0 h20 m-690 0 q10 0 10 10 m670 0 q0 -10 10 -10 m-680 10 v144 m670 0 v-144 m-670 144 q0 10 10 10 m650 0 q10 0 10 -10 m-640 10 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m20 -32 h10 m54 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m40 0 h10 m0 0 h10 m90 0 h10 m0 0 h128 m42 -208 l2 0 m2 0 l2 0 m2 0 l2 0 m-144 274 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m94 0 h10 m3 0 h-3"></path>
+  <polygon points="707 357 715 353 715 361"></polygon>
+  <polygon points="707 357 699 353 699 361"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/join-type.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/join-type.html
@@ -1,22 +1,22 @@
 <svg width="329" height="169">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="71" y="3" width="54" height="32" rx="10"></rect>
-         <rect x="69" y="1" width="54" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="21">FULL</text>
-         <rect x="71" y="47" width="52" height="32" rx="10"></rect>
-         <rect x="69" y="45" width="52" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="65">LEFT</text>
-         <rect x="71" y="91" width="64" height="32" rx="10"></rect>
-         <rect x="69" y="89" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="79" y="109">RIGHT</text>
-         <rect x="195" y="35" width="66" height="32" rx="10"></rect>
-         <rect x="193" y="33" width="66" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="203" y="53">OUTER</text>
-         <rect x="51" y="135" width="64" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="64" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">INNER</text>
-         <path class="line" d="m17 17 h2 m40 0 h10 m54 0 h10 m0 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m52 0 h10 m0 0 h12 m-94 -10 v20 m104 0 v-20 m-104 20 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -88 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-250 -32 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v112 m270 0 v-112 m-270 112 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m64 0 h10 m0 0 h166 m23 -132 h-3"></path>
-         <polygon points="319 17 327 13 327 21"></polygon>
-         <polygon points="319 17 311 13 311 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="71" y="3" width="54" height="32" rx="10"></rect>
+  <rect x="69" y="1" width="54" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="79" y="21">FULL</text>
+  <rect x="71" y="47" width="52" height="32" rx="10"></rect>
+  <rect x="69" y="45" width="52" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="79" y="65">LEFT</text>
+  <rect x="71" y="91" width="64" height="32" rx="10"></rect>
+  <rect x="69" y="89" width="64" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="79" y="109">RIGHT</text>
+  <rect x="195" y="35" width="66" height="32" rx="10"></rect>
+  <rect x="193" y="33" width="66" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="203" y="53">OUTER</text>
+  <rect x="51" y="135" width="64" height="32" rx="10"></rect>
+  <rect x="49" y="133" width="64" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="153">INNER</text>
+  <path class="line" d="m17 17 h2 m40 0 h10 m54 0 h10 m0 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m52 0 h10 m0 0 h12 m-94 -10 v20 m104 0 v-20 m-104 20 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -88 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-250 -32 h20 m250 0 h20 m-290 0 q10 0 10 10 m270 0 q0 -10 10 -10 m-280 10 v112 m270 0 v-112 m-270 112 q0 10 10 10 m250 0 q10 0 10 -10 m-260 10 h10 m64 0 h10 m0 0 h166 m23 -132 h-3"></path>
+  <polygon points="319 17 327 13 327 21"></polygon>
+  <polygon points="319 17 311 13 311 21"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/op-cast.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/op-cast.html
@@ -1,8 +1,16 @@
 <svg width="215" height="37">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon><rect x="31" y="3" width="38" height="32"></rect><rect x="29" y="1" width="38" height="32" class="nonterminal"></rect><text class="nonterminal" x="39" y="21">val</text><rect x="89" y="3" width="30" height="32" rx="10"></rect>
-         <rect x="87" y="1" width="30" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="97" y="21">::</text><rect x="139" y="3" width="48" height="32"></rect><rect x="137" y="1" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="147" y="21">type</text><path class="line" d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></path>
-         <polygon points="205 17 213 13 213 21"></polygon>
-         <polygon points="205 17 197 13 197 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="38" height="32"></rect>
+  <rect x="29" y="1" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="39" y="21">val</text>
+  <rect x="89" y="3" width="30" height="32" rx="10"></rect>
+  <rect x="87" y="1" width="30" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="97" y="21">::</text>
+  <rect x="139" y="3" width="48" height="32"></rect>
+  <rect x="137" y="1" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="147" y="21">type</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m38 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"></path>
+  <polygon points="205 17 213 13 213 21"></polygon>
+  <polygon points="205 17 197 13 197 21"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/select_stmt.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/select_stmt.html
@@ -1,64 +1,100 @@
 <svg width="583" height="811">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="31" y="3" width="70" height="32" rx="10"></rect>
-         <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="39" y="21">SELECT</text>
-         <rect x="141" y="35" width="44" height="32" rx="10"></rect>
-         <rect x="139" y="33" width="44" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="149" y="53">ALL</text>
-         <rect x="141" y="123" width="86" height="32" rx="10"></rect>
-         <rect x="139" y="121" width="86" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="149" y="141">DISTINCT</text>
-         <rect x="267" y="123" width="40" height="32" rx="10"></rect>
-         <rect x="265" y="121" width="40" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="275" y="141">ON</text>
-         <rect x="327" y="123" width="26" height="32" rx="10"></rect>
-         <rect x="325" y="121" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="335" y="141">(</text><rect x="393" y="123" width="62" height="32"></rect><rect x="391" y="121" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="401" y="141">col_ref</text><rect x="393" y="79" width="24" height="32" rx="10"></rect>
-         <rect x="391" y="77" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="401" y="97">,</text>
-         <rect x="495" y="123" width="26" height="32" rx="10"></rect>
-         <rect x="493" y="121" width="26" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="503" y="141">)</text><rect x="110" y="249" width="98" height="32"></rect><rect x="108" y="247" width="98" height="32" class="nonterminal"></rect><text class="nonterminal" x="118" y="267">target_elem</text><rect x="110" y="205" width="24" height="32" rx="10"></rect>
-         <rect x="108" y="203" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="118" y="223">,</text>
-         <rect x="268" y="249" width="60" height="32" rx="10"></rect>
-         <rect x="266" y="247" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="276" y="267">FROM</text><rect x="368" y="249" width="88" height="32"></rect><rect x="366" y="247" width="88" height="32" class="nonterminal"></rect><text class="nonterminal" x="376" y="267">table_expr</text><rect x="368" y="205" width="24" height="32" rx="10"></rect>
-         <rect x="366" y="203" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="376" y="223">,</text>
-         <rect x="70" y="407" width="70" height="32" rx="10"></rect>
-         <rect x="68" y="405" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="78" y="425">WHERE</text><rect x="160" y="407" width="48" height="32"></rect><rect x="158" y="405" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="168" y="425">expr</text><rect x="268" y="375" width="68" height="32" rx="10"></rect>
-         <rect x="266" y="373" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="276" y="393">GROUP</text>
-         <rect x="356" y="375" width="38" height="32" rx="10"></rect>
-         <rect x="354" y="373" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="364" y="393">BY</text><rect x="434" y="375" width="62" height="32"></rect><rect x="432" y="373" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="442" y="393">col_ref</text><rect x="434" y="331" width="24" height="32" rx="10"></rect>
-         <rect x="432" y="329" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="442" y="349">,</text>
-         <rect x="222" y="489" width="74" height="32" rx="10"></rect>
-         <rect x="220" y="487" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="230" y="507">HAVING</text><rect x="316" y="489" width="48" height="32"></rect><rect x="314" y="487" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="324" y="507">expr</text><rect x="111" y="599" width="68" height="32" rx="10"></rect>
-         <rect x="109" y="597" width="68" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="119" y="617">ORDER</text>
-         <rect x="199" y="599" width="38" height="32" rx="10"></rect>
-         <rect x="197" y="597" width="38" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="207" y="617">BY</text><rect x="277" y="599" width="62" height="32"></rect><rect x="275" y="597" width="62" height="32" class="nonterminal"></rect><text class="nonterminal" x="285" y="617">col_ref</text><rect x="379" y="631" width="46" height="32" rx="10"></rect>
-         <rect x="377" y="629" width="46" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="387" y="649">ASC</text>
-         <rect x="379" y="675" width="56" height="32" rx="10"></rect>
-         <rect x="377" y="673" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="387" y="693">DESC</text>
-         <rect x="277" y="555" width="24" height="32" rx="10"></rect>
-         <rect x="275" y="553" width="24" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="285" y="573">,</text>
-         <rect x="207" y="777" width="60" height="32" rx="10"></rect>
-         <rect x="205" y="775" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="215" y="795">LIMIT</text><rect x="287" y="777" width="48" height="32"></rect><rect x="285" y="775" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="295" y="795">expr</text><rect x="395" y="777" width="72" height="32" rx="10"></rect>
-         <rect x="393" y="775" width="72" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="403" y="795">OFFSET</text><rect x="487" y="777" width="48" height="32"></rect><rect x="485" y="775" width="48" height="32" class="nonterminal"></rect><text class="nonterminal" x="495" y="795">expr</text><path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h410 m-440 0 h20 m420 0 h20 m-460 0 q10 0 10 10 m440 0 q0 -10 10 -10 m-450 10 v12 m440 0 v-12 m-440 12 q0 10 10 10 m420 0 q10 0 10 -10 m-430 10 h10 m44 0 h10 m0 0 h356 m-430 -10 v20 m440 0 v-20 m-440 20 v68 m440 0 v-68 m-440 68 q0 10 10 10 m420 0 q10 0 10 -10 m-430 10 h10 m86 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-294 0 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m42 -154 l2 0 m2 0 l2 0 m2 0 l2 0 m-515 246 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m40 44 h10 m60 0 h10 m20 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m-228 44 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-490 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m40 -32 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m-268 44 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v14 m288 0 v-14 m-288 14 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m0 0 h258 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-378 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m74 0 h10 m0 0 h10 m48 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-337 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-198 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m198 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-198 0 h10 m24 0 h10 m0 0 h154 m-384 44 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v90 m404 0 v-90 m-404 90 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-352 146 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m60 0 h10 m0 0 h10 m48 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m72 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"></path>
-         <polygon points="573 759 581 755 581 763"></polygon>
-         <polygon points="573 759 565 755 565 763"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="31" y="3" width="70" height="32" rx="10"></rect>
+  <rect x="29" y="1" width="70" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="39" y="21">SELECT</text>
+  <rect x="141" y="35" width="44" height="32" rx="10"></rect>
+  <rect x="139" y="33" width="44" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="149" y="53">ALL</text>
+  <rect x="141" y="123" width="86" height="32" rx="10"></rect>
+  <rect x="139" y="121" width="86" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="149" y="141">DISTINCT</text>
+  <rect x="267" y="123" width="40" height="32" rx="10"></rect>
+  <rect x="265" y="121" width="40" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="275" y="141">ON</text>
+  <rect x="327" y="123" width="26" height="32" rx="10"></rect>
+  <rect x="325" y="121" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="335" y="141">(</text>
+  <rect x="393" y="123" width="62" height="32"></rect>
+  <rect x="391" y="121" width="62" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="401" y="141">col_ref</text>
+  <rect x="393" y="79" width="24" height="32" rx="10"></rect>
+  <rect x="391" y="77" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="401" y="97">,</text>
+  <rect x="495" y="123" width="26" height="32" rx="10"></rect>
+  <rect x="493" y="121" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="503" y="141">)</text>
+  <rect x="110" y="249" width="98" height="32"></rect>
+  <rect x="108" y="247" width="98" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="118" y="267">target_elem</text>
+  <rect x="110" y="205" width="24" height="32" rx="10"></rect>
+  <rect x="108" y="203" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="118" y="223">,</text>
+  <rect x="268" y="249" width="60" height="32" rx="10"></rect>
+  <rect x="266" y="247" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="276" y="267">FROM</text>
+  <rect x="368" y="249" width="88" height="32"></rect>
+  <rect x="366" y="247" width="88" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="376" y="267">table_expr</text>
+  <rect x="368" y="205" width="24" height="32" rx="10"></rect>
+  <rect x="366" y="203" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="376" y="223">,</text>
+  <rect x="70" y="407" width="70" height="32" rx="10"></rect>
+  <rect x="68" y="405" width="70" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="78" y="425">WHERE</text>
+  <rect x="160" y="407" width="48" height="32"></rect>
+  <rect x="158" y="405" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="168" y="425">expr</text>
+  <rect x="268" y="375" width="68" height="32" rx="10"></rect>
+  <rect x="266" y="373" width="68" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="276" y="393">GROUP</text>
+  <rect x="356" y="375" width="38" height="32" rx="10"></rect>
+  <rect x="354" y="373" width="38" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="364" y="393">BY</text>
+  <rect x="434" y="375" width="62" height="32"></rect>
+  <rect x="432" y="373" width="62" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="442" y="393">col_ref</text>
+  <rect x="434" y="331" width="24" height="32" rx="10"></rect>
+  <rect x="432" y="329" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="442" y="349">,</text>
+  <rect x="222" y="489" width="74" height="32" rx="10"></rect>
+  <rect x="220" y="487" width="74" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="230" y="507">HAVING</text>
+  <rect x="316" y="489" width="48" height="32"></rect>
+  <rect x="314" y="487" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="324" y="507">expr</text>
+  <rect x="111" y="599" width="68" height="32" rx="10"></rect>
+  <rect x="109" y="597" width="68" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="119" y="617">ORDER</text>
+  <rect x="199" y="599" width="38" height="32" rx="10"></rect>
+  <rect x="197" y="597" width="38" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="207" y="617">BY</text>
+  <rect x="277" y="599" width="62" height="32"></rect>
+  <rect x="275" y="597" width="62" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="285" y="617">col_ref</text>
+  <rect x="379" y="631" width="46" height="32" rx="10"></rect>
+  <rect x="377" y="629" width="46" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="387" y="649">ASC</text>
+  <rect x="379" y="675" width="56" height="32" rx="10"></rect>
+  <rect x="377" y="673" width="56" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="387" y="693">DESC</text>
+  <rect x="277" y="555" width="24" height="32" rx="10"></rect>
+  <rect x="275" y="553" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="285" y="573">,</text>
+  <rect x="207" y="777" width="60" height="32" rx="10"></rect>
+  <rect x="205" y="775" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="215" y="795">LIMIT</text>
+  <rect x="287" y="777" width="48" height="32"></rect>
+  <rect x="285" y="775" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="295" y="795">expr</text>
+  <rect x="395" y="777" width="72" height="32" rx="10"></rect>
+  <rect x="393" y="775" width="72" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="403" y="795">OFFSET</text>
+  <rect x="487" y="777" width="48" height="32"></rect>
+  <rect x="485" y="775" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="495" y="795">expr</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m70 0 h10 m20 0 h10 m0 0 h410 m-440 0 h20 m420 0 h20 m-460 0 q10 0 10 10 m440 0 q0 -10 10 -10 m-450 10 v12 m440 0 v-12 m-440 12 q0 10 10 10 m420 0 q10 0 10 -10 m-430 10 h10 m44 0 h10 m0 0 h356 m-430 -10 v20 m440 0 v-20 m-440 20 v68 m440 0 v-68 m-440 68 q0 10 10 10 m420 0 q10 0 10 -10 m-430 10 h10 m86 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m26 0 h10 m-294 0 h20 m274 0 h20 m-314 0 q10 0 10 10 m294 0 q0 -10 10 -10 m-304 10 v14 m294 0 v-14 m-294 14 q0 10 10 10 m274 0 q10 0 10 -10 m-284 10 h10 m0 0 h264 m42 -154 l2 0 m2 0 l2 0 m2 0 l2 0 m-515 246 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m98 0 h10 m-138 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m118 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-118 0 h10 m24 0 h10 m0 0 h74 m40 44 h10 m60 0 h10 m20 0 h10 m88 0 h10 m-128 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m108 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-108 0 h10 m24 0 h10 m0 0 h64 m-228 44 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-490 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m40 -32 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m-268 44 h20 m268 0 h20 m-308 0 q10 0 10 10 m288 0 q0 -10 10 -10 m-298 10 v14 m288 0 v-14 m-288 14 q0 10 10 10 m268 0 q10 0 10 -10 m-278 10 h10 m0 0 h258 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-378 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h152 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v12 m182 0 v-12 m-182 12 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m74 0 h10 m0 0 h10 m48 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-337 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m46 0 h10 m0 0 h10 m-86 -10 v20 m96 0 v-20 m-96 20 v24 m96 0 v-24 m-96 24 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m-198 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m198 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-198 0 h10 m24 0 h10 m0 0 h154 m-384 44 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v90 m404 0 v-90 m-404 90 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-352 146 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h138 m-168 0 h20 m148 0 h20 m-188 0 q10 0 10 10 m168 0 q0 -10 10 -10 m-178 10 v12 m168 0 v-12 m-168 12 q0 10 10 10 m148 0 q10 0 10 -10 m-158 10 h10 m60 0 h10 m0 0 h10 m48 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m72 0 h10 m0 0 h10 m48 0 h10 m23 -32 h-3"></path>
+  <polygon points="573 759 581 755 581 763"></polygon>
+  <polygon points="573 759 565 755 565 763"></polygon>
+</svg>

--- a/www/layouts/partials/sql-grammar/rr-diagrams/time-component.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/time-component.html
@@ -1,25 +1,25 @@
 <svg width="175" height="257">
-         
-         <polygon points="9 17 1 13 1 21"></polygon>
-         <polygon points="17 17 9 13 9 21"></polygon>
-         <rect x="51" y="3" width="56" height="32" rx="10"></rect>
-         <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="21">YEAR</text>
-         <rect x="51" y="47" width="70" height="32" rx="10"></rect>
-         <rect x="49" y="45" width="70" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="65">MONTH</text>
-         <rect x="51" y="91" width="48" height="32" rx="10"></rect>
-         <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="109">DAY</text>
-         <rect x="51" y="135" width="60" height="32" rx="10"></rect>
-         <rect x="49" y="133" width="60" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="153">HOUR</text>
-         <rect x="51" y="179" width="74" height="32" rx="10"></rect>
-         <rect x="49" y="177" width="74" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="197">MINUTE</text>
-         <rect x="51" y="223" width="76" height="32" rx="10"></rect>
-         <rect x="49" y="221" width="76" height="32" class="terminal" rx="10"></rect>
-         <text class="terminal" x="59" y="241">SECOND</text>
-         <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h20 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m70 0 h10 m0 0 h6 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m48 0 h10 m0 0 h28 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m60 0 h10 m0 0 h16 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m74 0 h10 m0 0 h2 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -220 h-3"></path>
-         <polygon points="165 17 173 13 173 21"></polygon>
-         <polygon points="165 17 157 13 157 21"></polygon></svg>
+  <polygon points="9 17 1 13 1 21"></polygon>
+  <polygon points="17 17 9 13 9 21"></polygon>
+  <rect x="51" y="3" width="56" height="32" rx="10"></rect>
+  <rect x="49" y="1" width="56" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="21">YEAR</text>
+  <rect x="51" y="47" width="70" height="32" rx="10"></rect>
+  <rect x="49" y="45" width="70" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="65">MONTH</text>
+  <rect x="51" y="91" width="48" height="32" rx="10"></rect>
+  <rect x="49" y="89" width="48" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="109">DAY</text>
+  <rect x="51" y="135" width="60" height="32" rx="10"></rect>
+  <rect x="49" y="133" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="153">HOUR</text>
+  <rect x="51" y="179" width="74" height="32" rx="10"></rect>
+  <rect x="49" y="177" width="74" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="197">MINUTE</text>
+  <rect x="51" y="223" width="76" height="32" rx="10"></rect>
+  <rect x="49" y="221" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="59" y="241">SECOND</text>
+  <path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h20 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m70 0 h10 m0 0 h6 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m48 0 h10 m0 0 h28 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m60 0 h10 m0 0 h16 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m74 0 h10 m0 0 h2 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -220 h-3"></path>
+  <polygon points="165 17 173 13 173 21"></polygon>
+  <polygon points="165 17 157 13 157 21"></polygon>
+</svg>

--- a/www/util/rr-diagram-gen/Makefile
+++ b/www/util/rr-diagram-gen/Makefile
@@ -19,4 +19,3 @@ rr-diagram-gen: *.go
 clean:
 	$(GO) clean $(GOFLAGS)
 	rm -f rr-diagram-gen
-

--- a/www/util/rr-diagram-gen/go.mod
+++ b/www/util/rr-diagram-gen/go.mod
@@ -10,6 +10,7 @@ go 1.13
 require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/cockroachdb/cockroach v19.1.5+incompatible
+	github.com/yosssi/gohtml v0.0.0-20190915184251-7ff6f235ecaf
 	golang.org/x/net v0.0.0-20191109021931-daa7c04131f5
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 )

--- a/www/util/rr-diagram-gen/go.sum
+++ b/www/util/rr-diagram-gen/go.sum
@@ -2,11 +2,15 @@ github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/cockroachdb/cockroach v19.1.5+incompatible/go.mod h1:xeT/CQ0qZHangbYbWShlCGAx31aV4AjGswDUjhKS6HQ=
+github.com/yosssi/gohtml v0.0.0-20190915184251-7ff6f235ecaf h1:VA200mPTYh9FWY8zKX5ctXCtNk78HUez8ecTdsQGhoo=
+github.com/yosssi/gohtml v0.0.0-20190915184251-7ff6f235ecaf/go.mod h1:+ccdNT0xMY1dtc5XBxumbYfOUhmduiGudqaDgD2rVRE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20191109021931-daa7c04131f5 h1:bHNaocaoJxYBo5cw41UyTMLjYlb8wPY7+WFrnklbHOM=
 golang.org/x/net v0.0.0-20191109021931-daa7c04131f5/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 h1:e6HwijUxhDe+hPNjZQQn9bA5PW3vNmnN64U2ZW759Lk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
A number of trailing spaces have slipped into our codebase lately. These
cause annoying diff noise, so add a lint to prevent them, and remove the
whitespace errors that presently exist.