### PR TITLE
ex/chbench/grafana: Dashboard visualization improvements

### DIFF
--- a/ex/chbench/grafana/conf/dashboards/materialize.json
+++ b/ex/chbench/grafana/conf/dashboards/materialize.json
@@ -1217,7 +1217,7 @@
       "yBucketSize": null
     }
   ],
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [],

--- a/src/metrics/bin/metrics.rs
+++ b/src/metrics/bin/metrics.rs
@@ -145,7 +145,10 @@ fn create_histogram(query: &str) -> Histogram {
         "mz_client_peek_seconds",
         "how long peeks took",
         &["query"],
-        vec![0.000_500, 0.001, 0.002, 0.004, 0.008, 0.016, 0.034, 0.067, 0.120, 0.250, 0.500, 1.0]
+        vec![
+            0.000_250, 0.000_500, 0.001, 0.002, 0.004, 0.008, 0.016, 0.034, 0.067, 0.120, 0.250,
+            0.500, 1.0
+        ]
     )
     .expect("can create histogram");
     hist_vec.with_label_values(&[query])


### PR DESCRIPTION
* Set explicit colors for the Peek latencies charts, so that the max/various p-vals
  always match between then
* Make frontier lags log2 to match the latench charts
* Give the mysql tables chart a different name that hopefully makes it more clear that
  it's row counts and not just table counts "MySQL TPCCH Table Row Counts"
* Change the default refresh rate to once every 30s -- the default view can take over 5s
  to load if you're looking at many hours of data, so having a 5s refresh was really
  annoying