### PR TITLE
ci/deploy: use a less crashy nightly

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       queue: builder
     plugins:
       - docker#v3.1.0:
-          image: materialize/ci-builder:nightly-20191111-162438
+          image: materialize/ci-builder:nightly-20191128-235400
           propagate-uid-gid: true
           mount-ssh-agent: true
           volumes:


### PR DESCRIPTION
The old nightly was crashing when it tried to build our docs. Hopefully
this one crashes less.