### PR TITLE
docs: csv source docs, and source explanation changes

### DIFF
--- a/doc/user/sql/create-view.md
+++ b/doc/user/sql/create-view.md
@@ -7,7 +7,8 @@ menu:
 ---
 
 `CREATE VIEW` creates a materialized view, which lets you retrieve incrementally
-updated results of a `SELECT` query very quickly. Despite the simplicity of creating a view, it's Materialize's most powerful feature.
+updated results of a `SELECT` query very quickly. Despite the simplicity of
+creating a view, it's Materialize's most powerful feature.
 
 ## Conceptual framework
 
@@ -44,12 +45,15 @@ As data continues to stream in from Kafka, Differential passes the data to the
 appropriate dataflows, which are then responsible for making any necessary
 updates to maintain the views you've defined.
 
-When reading from a view (e.g. `SELECT * FROM some_view`), Materialize simply returns the current result set for the persisted dataflow.
+When reading from a view (e.g. `SELECT * FROM some_view`), Materialize simply
+returns the current result set for the persisted dataflow.
 
 ### Memory
 
-Views are maintained in memory. Because of this, one must be sure that all intermediate stages of the query, as well as its result set can fit in the memory of a single machine, while also understanding
-the rate at which the query's result set will grow.
+Views are maintained in memory. Because of this, one must be sure that all
+intermediate stages of the query, as well as its result set can fit in the
+memory of a single machine, while also understanding the rate at which the
+query's result set will grow.
 
 For more detail about how different clauses impact memory usage, check out our
 [`SELECT`](../select) documentation.

--- a/www/assets/sass/_docs_body.scss
+++ b/www/assets/sass/_docs_body.scss
@@ -13,12 +13,26 @@ main {
   }
 
   h2 {
+    font-size: 1.3rem;
     margin-top: 3rem;
+    a {
+      color: black !important;
+    }
   }
 
   h3 {
-    font-size: 0.85rem;
+    font-size: 1.2rem;
     margin-top: 2rem;
+    a {
+      color: #666666 !important;
+    }
+  }
+
+  h4 {
+    font-size: 1rem;
+    a {
+      color: black !important;
+    }
   }
 
   a {
@@ -39,7 +53,6 @@ main {
   }
 
   .headline-hash {
-    color: black;
     &:hover {
       opacity: 0.75;
     }

--- a/www/layouts/partials/sql-grammar/bnf/create-source.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source.bnf
@@ -1,2 +1,6 @@
 create_source ::=
-  'CREATE SOURCE' src_name 'FROM' kafka_src 'USING SCHEMA' ( 'REGISTRY' registry_src | avro_schema )
+  'CREATE SOURCE' src_name 'FROM'
+  (
+      kafka_src 'USING SCHEMA' ( 'REGISTRY' registry_src | avro_schema ) |
+      local_file 'WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')'
+  )


### PR DESCRIPTION
Details creating CSV sources and mentions requirement that > 0 streaming sources are used in each view.

Also includes some minor CSS changes that make the complexity of the `CREATE SOURCE` doc a little more manageable.

@umanwizard PTAL for technical review and let me know if there are any dimensions I'm missing here.