### PR TITLE
Serialize text timestamps according to rfc3339/is8601

### DIFF
--- a/src/pgwire/message.rs
+++ b/src/pgwire/message.rs
@@ -428,11 +428,15 @@ impl FieldValue {
             FieldValue::Bytea(b) => b.into(),
             FieldValue::Date(d) => d.to_string().into_bytes().into(),
             FieldValue::Timestamp(ts) => ts
-                .format("%Y-%m-%dT%H:%M:%S.%f")
+                .format("%Y-%m-%d %H:%M:%S.%f")
                 .to_string()
                 .into_bytes()
                 .into(),
-            FieldValue::TimestampTz(ts) => ts.to_rfc3339().into_bytes().into(),
+            FieldValue::TimestampTz(ts) => ts
+                .format("%Y-%m-%d %H:%M:%S.%f%:z")
+                .to_string()
+                .into_bytes()
+                .into(),
             FieldValue::Interval(i) => match i {
                 repr::Interval::Months(count) => format!("{} months", count).into_bytes().into(),
                 repr::Interval::Duration {


### PR DESCRIPTION
RFC3339 requires a timezone[1], so the naive date time cannot use that shorthand.

This fixes timestamp parsing in metabase, and probably everywhere else.

[1]: https://tools.ietf.org/html/rfc3339#section-4.4