### PR TITLE
Allow coordinator to return constant results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,7 @@ version = "0.1.0"
 dependencies = [
  "comm",
  "expr",
+ "pdqselect",
  "pretty_assertions",
  "repr",
  "serde",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 [dependencies]
 comm = { path = "../comm" }
 expr = { path = "../expr" }
+pdqselect = "0.1.0"
 repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
 url = "1.7.2"


### PR DESCRIPTION
This PR allows the coordinator to immediately return constant results post-optimization. This seems like a smart thing to do, and only reduces the test surface of "can we build dataflows for constant expressions".