### PR TITLE
docs: add connection section & CLI docs

### DIFF
--- a/doc/user/_index.md
+++ b/doc/user/_index.md
@@ -2,6 +2,7 @@
 title: "Materialize Docs"
 disable_toc: true
 disable_list: true
+weight: 1
 ---
 
 Materialize is a streaming SQL materialized view engine.

--- a/doc/user/connect/_index.md
+++ b/doc/user/connect/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Connect"
+description: "Find out how to connect to Materialize"
+disable_toc: true
+---

--- a/doc/user/connect/cli.md
+++ b/doc/user/connect/cli.md
@@ -1,0 +1,24 @@
+---
+title: "CLI Connections"
+description: "You can connect to Materialize from your favorite shell using Postgres-compatible tools, like psql or pgcli."
+menu:
+  main:
+    parent: "connections"
+---
+
+You can connect to a running `materialized` process from your favorite shell using Postgres-compatible tools.
+
+### Connection details
+
+Detail | Info
+-------|------
+**Port** | 6875
+**SSL** | Not supported yet; use `sslmode=disable`
+
+### Supported tools
+
+Tool | Description | Install
+-----|-------------|--------
+`mzcli` | Materialize adaptation of `pgcli` | [GitHub](https://github.com/MaterializeInc/mzcli#quick-start)
+`psql` | Vanilla PostgreSQL CLI tool. Useful for executing queries from scripts using `-c`. | `libpq` or `postgresql-client`
+`pgcli` | CLI tool with auto-completion & syntax highlighting | [`pgcli` documentation](https://www.pgcli.com/install)

--- a/www/config.toml
+++ b/www/config.toml
@@ -8,6 +8,11 @@ pygmentsStyle = "xcode"
     [[menu.main]]
     identifier = "overview"
     name = "Overview"
+    weight = 5
+
+    [[menu.main]]
+    identifier = "connections"
+    name = "Connect"
     weight = 10
 
     [[menu.main]]


### PR DESCRIPTION
Provide high-level guidance around connecting to Materialize from a CLI. Given that we don't know the form that our final demos will take, I'm hesitating to provide more detailed guidance around each tool. (This total amount of documentation might also be totally sufficient ¯\_(ツ)_/¯).

Will add more sections for things like drivers (e.g. JDBC) as those details come on line.

@quodlibetor would love your thoughts on this since you've done the work of adapting `pgcli`. Anything you think we need/where I've missed the mark?

Closes MaterializeInc/database-issues#330