### PR TITLE
Fix materialize#1158.

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -63,6 +63,8 @@ pub enum RelationExpr {
         /// The source collection.
         input: Box<RelationExpr>,
         /// Expressions which determine values to append to each row.
+        /// An expression may refer to columns in `input` or
+        /// expressions defined earlier in the vector
         scalars: Vec<ScalarExpr>,
     },
     /// Keep rows from a dataflow where all the predicates are true

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -1208,11 +1208,12 @@ Let {
     Filter { predicates: [#1 = "GERMANY"], Get { nation (u19) } }
   }
 } in
+Let { l4 = Distinct { group_key: [0], Get { l0 } } } in
 Let {
   l3 = Join {
     variables: [[(0, 0), (1, 0)], [(2, 4), (3, 0)]],
-    Get { l0 },
-    Get { l0 },
+    Get { l4 },
+    Get { l4 },
     Filter {
       predicates: [datetots #6 > 2010-05-23 12:00:00],
       Get { orderline (u13) }
@@ -1235,16 +1236,16 @@ Project {
           Filter {
             predicates: [(2 * i32toi64 #3) > i32toi64 #4],
             Reduce {
-              group_key: [0, 32 .. 34],
-              aggregates: [sum(#29)],
+              group_key: [0, 12 .. 14],
+              aggregates: [sum(#9)],
               Join {
-                variables: [[(0, 32), (1, 0)]],
+                variables: [[(0, 12), (1, 0)]],
                 Get { l3 },
                 Map {
                   scalars: [true],
                   Join {
                     variables: [[(0, 0), (1, 0)]],
-                    Distinct { group_key: [32], Get { l3 } },
+                    Distinct { group_key: [12], Get { l3 } },
                     Filter {
                       predicates: [#4 ~ ^co.*$],
                       Get { item (u15) }
@@ -1449,6 +1450,7 @@ Let {
     }
   }
 } in
+Let { l4 = Distinct { group_key: [0 .. 2], Get { l0 } } } in
 Let {
   l3 = Map {
     scalars: [true],
@@ -1461,33 +1463,33 @@ Let {
           [(0, 3), (1, 0)]
         ],
         Get { "order" (u11) },
-        Get { l0 }
+        Get { l4 }
       }
     }
   }
 } in
 Reduce {
   group_key: [29],
-  aggregates: [countall(null), sum(#20)],
+  aggregates: [countall(null), sum(#16)],
   Map {
-    scalars: [substr(#13, 1, 1)],
+    scalars: [substr(#9, 1, 1)],
     Join {
       variables: [
         [(0, 0), (1, 0)],
         [(0, 1), (1, 1)],
         [(0, 2), (1, 2)]
       ],
+      Get { l0 },
       Union {
         Filter { predicates: [!#3], Get { l3 } },
         Map {
           scalars: [false],
           Union {
             Project { outputs: [0 .. 2], Negate { Get { l3 } } },
-            Project { outputs: [0 .. 2], Get { l0 } }
+            Get { l4 }
           }
         }
-      },
-      Get { l0 }
+      }
     }
   }
 }

--- a/test/subquery.slt
+++ b/test/subquery.slt
@@ -246,3 +246,52 @@ Project {
     }
   }
 }
+
+mode cockroach
+# Regression test for materialize#1158
+# The following subquery currently generates a plan with a map with
+# 4 scalars that refer to other scalars in the map. If query planning optimizes away
+# this particular case, replace with another query that generates such a plan
+query T
+EXPLAIN PLAN FOR
+SELECT age, ascii_num * 2 as result FROM (
+  SELECT age, ascii(letter) AS ascii_num FROM (
+    SELECT age, substr(replaced, 2, 1) AS letter FROM (
+      SELECT age, replace(likee, 'o', 'i') AS replaced FROM (
+        SELECT likee, age FROM likes, age WHERE liker=peep
+      )
+    )
+  )
+)
+----
+Project {
+  outputs: [3, 7],
+  Map {
+    scalars: [
+      replace(#1, "o", "i"),
+      substr(#4, 2, 1),
+      ascii #5,
+      i32toi64 #6 * 2
+    ],
+    Join {
+      variables: [[(0, 0), (1, 0)]],
+      Filter { predicates: [!isnull #0], Get { likes (u3) } },
+      Filter { predicates: [!isnull #0], Get { age (u14) } }
+    }
+  }
+}
+
+query II rowsort
+SELECT age, ascii_num * 2 as result FROM (
+  SELECT age, ascii(letter) AS ascii_num FROM (
+    SELECT age, substr(replaced, 2, 1) AS letter FROM (
+      SELECT age, replace(likee, 'o', 'i') AS replaced FROM (
+        SELECT likee, age FROM likes, age WHERE liker=peep
+      )
+    )
+  )
+)
+----
+100  236
+103  210
+103  236


### PR DESCRIPTION
Resolves MaterializeInc/database-issues#396 

Will update the issue with the explanation of the panic, but essentially it is that sometimes a scalar in a RelationExpr::Map will refer to a different scalar in the same map instead of a column of the input. 

Testing the fix resulted in finding a second, related panic in projection lifting, which has also been fixed.