### PR TITLE
Support floor(int)

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1435,6 +1435,15 @@ fn plan_function<'a>(
                             ColumnType::new(ScalarType::Null), // ignored
                         )),
                     },
+                    // Postgres converts these to doubles when floor is called
+                    ScalarType::Int32 => ScalarExpr::CallUnary {
+                        func: UnaryFunc::CastInt32ToFloat64,
+                        expr: Box::new(expr),
+                    },
+                    ScalarType::Int64 => ScalarExpr::CallUnary {
+                        func: UnaryFunc::CastInt64ToFloat64,
+                        expr: Box::new(expr),
+                    },
                     _ => bail!("ceil only accepts decimals and floats, not type {:?}", typ),
                 };
                 Ok(expr)
@@ -1485,7 +1494,16 @@ fn plan_function<'a>(
                             ColumnType::new(ScalarType::Null), // ignored
                         )),
                     },
-                    _ => bail!("floor only accepts decimals and floats, not type {:?}", typ),
+                    // Postgres converts these to doubles when floor is called
+                    ScalarType::Int32 => ScalarExpr::CallUnary {
+                        func: UnaryFunc::CastInt32ToFloat64,
+                        expr: Box::new(expr),
+                    },
+                    ScalarType::Int64 => ScalarExpr::CallUnary {
+                        func: UnaryFunc::CastInt64ToFloat64,
+                        expr: Box::new(expr),
+                    },
+                    _ => bail!("floor only accepts numbers, not type {:?}", typ),
                 };
                 Ok(expr)
             }

--- a/test/funcs.slt
+++ b/test/funcs.slt
@@ -106,3 +106,24 @@ query RRRRR
 SELECT ceil(1.1), ceil(1.111), ceil(100.1), ceil(100.11), ceil(-4.1)
 ----
 2.0 2.000 101.0 101.00 -4.0
+
+# postgres converts ints to floats on floor/ceil
+query R
+SELECT floor(1)
+----
+1
+
+query R
+SELECT floor(1)
+----
+1
+
+query R
+SELECT floor(cast(1 AS bigint))
+----
+1
+
+query R
+SELECT ceil(cast(1 AS bigint))
+----
+1


### PR DESCRIPTION
Because why not. No seriously I guess people want to be able to call `floor` on any
numeric type, because we're running into this.

Postgres converts both i32 and i64 types to f64, so that's what we do.