### PR TITLE
doc,test: enforce a consistent style on SQL queries

### DIFF
--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -1,0 +1,97 @@
+# Style guide
+
+Following are the coding conventions that Materialize developers should strive
+to adhere to.
+
+## SQL style
+
+The PostgreSQL manual adheres to a consistent style for its SQL statements, and
+we strive to do the same.
+
+The basic idea is to capitalize keywords, but lowercase identifiers. What
+counts as a keyword and what counts as an identifier is often surprising,
+especially when the identifier refers to a built-in function or type.
+
+For example, here is a properly formatted `CREATE TABLE statement:
+
+```sql
+CREATE TABLE distributors (
+    id integer PRIMARY KEY,
+    name varchar(40)
+)
+```
+
+`CREATE` and `TABLE` are obviously both keywords, and are capitalized as such.
+Perhaps surprisingly, `integer` is a type name—an identifier—and therefore is
+not capitalized. The same is true for `varchar`. But `PRIMARY` and `KEY` *are*
+identifiers, and are again capitalized.
+
+The formatting of SQL statements is generally straightforward. For example:
+
+```sql
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue,
+    EXTRACT(DAY FROM l_shipdate)
+FROM
+    lineitem
+WHERE
+    l_quantity < 24
+    AND l_shipdate >= DATE '1994-01-01'
+    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' YEAR
+    AND l_discount BETWEEN 0.06 - 0.01 AND 0.07
+```
+
+A few tokens require special attention.
+
+Aggregate functions, like `sum`, are not capitalized. In general, functions are
+never capitalized. `EXTRACT`, however, *is* capitalized, because `EXTRACT` is a
+function-like operator that has special syntax—notice how it its argument is
+`DAY FROM l_shipdate`, where `DAY` and `FROM` are keywords. If it were a
+normal function, it would be formatted as `extract('day', l_shipdate)`.
+
+Type constructors like `DATE '1994-01-01` and `INTERVAL '1' YEAR` *do*
+capitalize the type name, because in this case the type name *is* a keyword.
+These date-time related keywords are strange corner of SQL's syntax. There
+is no `INTEGER '7'` syntax, for example.
+
+The keywords `TRUE`, `FALSE`, and `NULL` are always capitalized, even though
+they are often rendered in output as lowercase.
+
+Function calls, including type constructors that take arguments, should not have
+a space between the name of the function and the open parenthesis, but
+keywords followed by an open parenthesis should have a space in between.
+Symbolic operators, like `=` and `+`, should always be surrounded by spaces,
+and commas should always be followed by a space. Following are several examples
+of queries that obey the spacing rules
+
+```sql
+CREATE TABLE t (a varchar(40));
+CREATE SOURCE test FROM 'file:///test.csv' WITH (format = 'csv', columns = 5);
+SELECT coalesce(1, NULL, 2);
+SELECT (1 + 2) - (7 * 4);
+```
+
+and several queries that don't:
+
+```sql
+CREATE TABLE t (a varchar (40));
+CREATE SOURCE test FROM 'file:///test.csv' WITH(format='csv', columns=5);
+SELECT coalesce (1, NULL,2);
+SELECT 1+2;
+```
+
+There are no rules about how to break a SQL query across multiple lines, and how
+to indent the resulting pieces, so just do whatever you think looks best.
+
+These rules are admittedly somewhat obtuse, and even the PostgreSQL manual is
+not entirely consistent on the finer points, so don't worry about being exact.
+But please at least capitalize the obvious keywords, like `SELECT`, `INSERT`,
+`FROM`, `WHERE`, `AS`, `AND`, etc.
+
+## Rust style
+
+No specific guidelines here yet. [Clippy] and [rustfmt] are enforced via CI,
+and they are opinionated enough for the moment.
+
+[Clippy]: https://github.com/rust-lang/rust-clippy
+[rustfmt]: https://github.com/rust-lang/rustfmt

--- a/doc/user/sql/create-sources.md
+++ b/doc/user/sql/create-sources.md
@@ -209,7 +209,7 @@ USING SCHEMA '{
 ### Creating CSV source
 
 ```sql
-CREATE SOURCE test FROM 'file:///test.csv' WITH ( format='csv', columns=5 );
+CREATE SOURCE test FROM 'file:///test.csv' WITH (format = 'csv', columns = 5);
 ```
 
 - The prefix for the file is `file://`, which is followed by the absolute path

--- a/doc/user/sql/create-view.md
+++ b/doc/user/sql/create-view.md
@@ -63,8 +63,8 @@ For more detail about how different clauses impact memory usage, check out our
 ```sql
 CREATE VIEW purchase_sum_by_region
 AS
-    SELECT  sum(purchase.amount) AS region_sum,
-            region.id AS region_id
+    SELECT sum(purchase.amount) AS region_sum,
+           region.id AS region_id
     FROM mysql_simple_region AS region
     INNER JOIN mysql_simple_user AS user
         ON region.id = user.region_id

--- a/doc/user/sql/functions/cast.md
+++ b/doc/user/sql/functions/cast.md
@@ -46,7 +46,7 @@ Date | TimestampTZ
 ## Examples
 
 ```sql
-SELECT CAST(CAST(100.21 AS DECIMAL(10,2)) AS FLOAT) AS dec_to_float;
+SELECT CAST (CAST (100.21 AS decimal(10, 2)) AS float) AS dec_to_float;
 ```
 ```bash
  dec_to_float
@@ -56,7 +56,7 @@ SELECT CAST(CAST(100.21 AS DECIMAL(10,2)) AS FLOAT) AS dec_to_float;
 <hr/>
 
 ```sql
-SELECT 100.21::DECIMAL(10,2)::FLOAT AS dec_to_float;
+SELECT 100.21::decimal(10, 2)::float AS dec_to_float;
 ```
 ```bash
  dec_to_float

--- a/doc/user/sql/functions/coalesce.md
+++ b/doc/user/sql/functions/coalesce.md
@@ -21,7 +21,7 @@ All elements of the parameters for `coalesce` must be of the same type; `coalesc
 ## Examples
 
 ```sql
-SELECT coalesce (NULL, 3, 2, 1) AS coalesce_res;
+SELECT coalesce(NULL, 3, 2, 1) AS coalesce_res;
 ```
 ```bash
  res

--- a/doc/user/sql/functions/length.md
+++ b/doc/user/sql/functions/length.md
@@ -50,7 +50,7 @@ You can find any updates on this behavior in [this GitHub issue](https://github.
 ## Examples
 
 ```sql
-SELECT LENGTH('你好') AS len;
+SELECT length('你好') AS len;
 ```
 ```bash
  len
@@ -61,7 +61,7 @@ SELECT LENGTH('你好') AS len;
 <hr/>
 
 ```sql
-SELECT LENGTH('你好', 'big5') AS len;
+SELECT length('你好', 'big5') AS len;
 ```
 ```bash
  len

--- a/doc/user/sql/functions/substring.md
+++ b/doc/user/sql/functions/substring.md
@@ -25,7 +25,7 @@ _len_ | Int | The length of the substring you want to return.
 ## Examples
 
 ```sql
-SELECT SUBSTRING('abcdefg', 3) AS substr;
+SELECT substring('abcdefg', 3) AS substr;
 ```
 ```bash
  substr
@@ -36,7 +36,7 @@ SELECT SUBSTRING('abcdefg', 3) AS substr;
  <hr/>
 
 ```sql
-SELECT SUBSTRING('abcdefg', 3, 3) AS substr;
+SELECT substring('abcdefg', 3, 3) AS substr;
 ```
 ```bash
  substr

--- a/doc/user/sql/select.md
+++ b/doc/user/sql/select.md
@@ -85,7 +85,7 @@ The following query creates a materialized view representing the total of all pu
 
 ``` sql
 CREATE VIEW mat_view AS
-    SELECT region.id, SUM(purchase.total)
+    SELECT region.id, sum(purchase.total)
     FROM mysql_simple_purchase AS purchase
     JOIN mysql_simple_user AS user
         ON purchase.user_id = user.id
@@ -109,7 +109,7 @@ In this case, Materialized simply returns the results of the dataflow you create
 ### Reading from sources
 
 ```sql
-SELECT region.id, SUM(purchase.total)
+SELECT region.id, sum(purchase.total)
 FROM mysql_simple_purchase AS purchase
 JOIN mysql_simple_user AS user
     ON purchase.user_id = user.id

--- a/test/aggregates.slt
+++ b/test/aggregates.slt
@@ -12,7 +12,7 @@ statement ok
 INSERT INTO t (a, b) VALUES (1, 1), (1, 2), (2, 3), (3, 1)
 
 statement error aggregate functions are not allowed in WHERE clause
-SELECT a FROM t WHERE sum(b) = 3 GROUP BY a;
+SELECT a FROM t WHERE sum(b) = 3 GROUP BY a
 
 query III colnames
 SELECT 1 AS literal, sum(a) as sum_a, sum(b) FROM t
@@ -21,13 +21,13 @@ literal  sum_a  sum
 1        7      7
 
 query I rowsort
-SELECT a FROM t GROUP BY a HAVING sum(b) = 3;
+SELECT a FROM t GROUP BY a HAVING sum(b) = 3
 ----
 1
 2
 
 query I rowsort
-SELECT a+1 FROM t GROUP BY a+1 HAVING sum(b) = 3;
+SELECT a + 1 FROM t GROUP BY a + 1 HAVING sum(b) = 3
 ----
 2
 3
@@ -68,4 +68,4 @@ SELECT avg(NULL)
 NULL
 
 statement error
-SELECT * ORDER BY SUM(fake_column);
+SELECT * ORDER BY SUM(fake_column)

--- a/test/arithmetic.slt
+++ b/test/arithmetic.slt
@@ -7,293 +7,295 @@ mode cockroach
 
 # TODO: The types supported by mod are SMALLINT, BIGINT, INTEGER, DECIMAL, and NUMERIC.
 # Tests all types?
+
 ### mod ###
 
 # positive dividend and divisor
+
 query I
-select mod(34, 7);
+SELECT mod(34, 7)
 ----
 6
 
 query I
-select mod(35, 7);
+SELECT mod(35, 7)
 ----
 0
 
 query I
-select mod(4,4);
+SELECT mod(4, 4)
 ----
 0
 
 query I
-select mod(7, 11);
+SELECT mod(7, 11)
 ----
 7
 
 query R
-select mod(4.3, 2.1);
+SELECT mod(4.3, 2.1)
 ----
 0.1
 
 query R
-select mod(4, 2.1);
+SELECT mod(4, 2.1)
 ----
 1.9
 
 query R
-select mod(0.34, 1.1);
+SELECT mod(0.34, 1.1)
 ----
 0.34
 
 query R
-select mod(4.2, 2.1);
+SELECT mod(4.2, 2.1)
 ----
 0.0
 
 # negative dividend
 query I
-select mod(-3234, 73);
+SELECT mod(-3234, 73)
 ----
 -22
 
 query I
-select mod(-100, 10);
+SELECT mod(-100, 10)
 ----
 0
 
 query I
-select mod(-5,5);
+SELECT mod(-5, 5)
 ----
 0
 
 query I
-select mod(-237, 1100);
+SELECT mod(-237, 1100)
 ----
 -237
 
 query R
-select mod(-2.254, 2.2);
+SELECT mod(-2.254, 2.2)
 ----
 -0.054
 
 query R
-select mod(-4, 1.75);
+SELECT mod(-4, 1.75)
 ----
 -0.50
 
 query R
-select mod(-0.3234, 200);
+SELECT mod(-0.3234, 200)
 ----
 -0.3234
 
 query R
-select mod(-7.5, 1.5);
+SELECT mod(-7.5, 1.5)
 ----
 0.0
 
 # negative divisor
 
 query I
-select mod(23, -5);
+SELECT mod(23, -5)
 ----
 3
 
 query I
-select mod(20, -2);
+SELECT mod(20, -2)
 ----
 0
 
 query I
-select mod(29,-29);
+SELECT mod(29, -29)
 ----
 0
 
 query I
-select mod(7, -11);
+SELECT mod(7, -11)
 ----
 7
 
 query R
-select mod(8.5, -4.6);
+SELECT mod(8.5, -4.6)
 ----
 3.9
 
 query R
-select mod(30, -11.9);
+SELECT mod(30, -11.9)
 ----
 6.2
 
 query R
-select mod(0.0019, -0.013);
+SELECT mod(0.0019, -0.013)
 ----
 0.0019
 
 query R
-select mod(14.4, -0.002);
+SELECT mod(14.4, -0.002)
 ----
 0.000
 
 # negative dividend and negative divisor
 
 query I
-select mod(-121, -17);
+SELECT mod(-121, -17)
 ----
 -2
 
 query I
-select mod(-64, -8);
+SELECT mod(-64, -8)
 ----
 0
 
 query I
-select mod(-344,-344);
+SELECT mod(-344, -344)
 ----
 0
 
 query I
-select mod(-13, -123);
+SELECT mod(-13, -123)
 ----
 -13
 
 query R
-select mod(-5.6, -2.3);
+SELECT mod(-5.6, -2.3)
 ----
 -1.0
 
 query R
-select mod(-10.4, -2);
+SELECT mod(-10.4, -2)
 ----
 -0.4
 
 query R
-select mod(-2.45, -45.6);
+SELECT mod(-2.45, -45.6)
 ----
 -2.45
 
 query R
-select mod(-12.15, -4.05);
+SELECT mod(-12.15, -4.05)
 ----
 0.00
 
-# special values: 0/null dividend and/or divisor
+# special values: 0/NULL dividend and/or divisor
 
 query I
-select mod(0,4);
+SELECT mod(0, 4)
 ----
 0
 
 query R
-select mod(0.000, 2);
+SELECT mod(0.000, 2)
 ----
 0.000
 
 query R
-select mod(0, 1.23);
+SELECT mod(0, 1.23)
 ----
 0.00
 
 query R
-select mod(4, 0.0);
+SELECT mod(4, 0.0)
 ----
 NULL
 
 query I
-select mod(0, 0);
+SELECT mod(0, 0)
 ----
 NULL
 
 query I
-select mod(0, null);
+SELECT mod(0, NULL)
 ----
 NULL
 
 query I
-select mod(null, 0);
+SELECT mod(NULL, 0)
 ----
 NULL
 
 query I
-select mod(-5, null);
+SELECT mod(-5, NULL)
 ----
 NULL
 
 query I
-select mod(null, 0.45);
+SELECT mod(NULL, 0.45)
 ----
 NULL
 
 query I
-select 1 % 0;
+SELECT 1 % 0
 ----
 NULL
 
 query R
-select 1 % 0.0;
+SELECT 1 % 0.0
 ----
 NULL
 
 query R
-select 1.0 % 0;
+SELECT 1.0 % 0
 ----
 NULL
 
 query R
-select 1.0 % 0.0;
+SELECT 1.0 % 0.0
 ----
 NULL
 
 query R
-select 1 % cast(0.0 AS float);
+SELECT 1 % CAST (0.0 AS float)
 ----
 NULL
 
 query I
-select 1 / 0;
+SELECT 1 / 0
 ----
 NULL
 
 query R
-select 1 / 0.0;
+SELECT 1 / 0.0
 ----
 NULL
 
 query R
-select 1.0 / 0;
+SELECT 1.0 / 0
 ----
 NULL
 
 query R
-select 1.0 / 0.0;
+SELECT 1.0 / 0.0
 ----
 NULL
 
 query R
-select 1 / cast(0.0 AS float);
+SELECT 1 / CAST (0.0 AS float)
 ----
 NULL
 
 query I
-select 1 + cast('5' AS DOUBLE PRECISION);
+SELECT 1 + CAST ('5' AS double precision)
 ----
 6
 
 query II
-select cast('+Inf' AS DOUBLE PRECISION), cast('inf' AS DOUBLE PRECISION);
+SELECT CAST ('+Inf' AS double precision), CAST ('inf' AS double precision)
 ----
 inf inf
 
 query T
-select cast(cast(1.1 AS DOUBLE PRECISION) AS TEXT)
+SELECT CAST (CAST (1.1 AS double precision) AS text)
 ----
 1.1
 
 query T
-select cast(cast(1 as int) AS TEXT)
+SELECT CAST (CAST (1 as int) AS text)
 ----
 1
 
 query TT
-SELECT false::text, true::text
+SELECT FALSE::text, TRUE::text
 ----
 false  true
 

--- a/test/basic.td
+++ b/test/basic.td
@@ -134,7 +134,7 @@ b  max
 2  1
 
 > CREATE MATERIALIZED VIEW test5 AS
-  SELECT b, max(a) as c FROM data GROUP BY b;
+  SELECT b, max(a) AS c FROM data GROUP BY b;
 
 > PEEK test5
 b  c

--- a/test/boolean.slt
+++ b/test/boolean.slt
@@ -4,72 +4,72 @@
 # distributed without the express permission of Materialize, Inc.
 
 statement error
-select not 1;
+SELECT NOT 1
 
 statement error
-select 1 and 1;
+SELECT 1 AND 1
 
 statement error
-select 1 or 1;
+SELECT 1 OR 1
 
 statement error
-select 1 or false;
+SELECT 1 OR FALSE
 
 statement error
-select false or 1;
+SELECT FALSE OR 1
 
 statement error
-select 1 and false;
+SELECT 1 AND FALSE
 
 statement error
-select false and 1;
+SELECT FALSE AND 1
 
 query B
-select not true;
+SELECT NOT TRUE
 ----
 false
 
 query B
-select not false;
+SELECT NOT FALSE
 ----
 true
 
 query B
-select true and false;
+SELECT TRUE AND FALSE
 ----
 false
 
 query B
-select true and true;
+SELECT TRUE AND TRUE
 ----
 true
 
 query B
-select false and false;
+SELECT FALSE AND FALSE
 ----
 false
 
 query B
-select true or false;
+SELECT TRUE OR FALSE
 ----
 true
 
 query B
-select true or true;
+SELECT TRUE OR TRUE
 ----
 true
 
 query B
-select false or false;
+SELECT FALSE OR FALSE
 ----
 false
 
 query B
-select true and not true;
+SELECT TRUE AND NOT TRUE
 ----
 false
 
 query B
-select not false or false;
+SELECT NOT FALSE OR FALSE
 ----
 true

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -12,8 +12,8 @@ CREATE TABLE warehouse (
     w_city char(20),
     w_state char(2),
     w_zip char(9),
-    w_tax decimal(4,4),
-    w_ytd decimal(12,2),
+    w_tax decimal(4, 4),
+    w_ytd decimal(12, 2),
     PRIMARY KEY (w_id)
 )
 
@@ -27,8 +27,8 @@ CREATE TABLE district (
     d_city char(20),
     d_state char(2),
     d_zip char(9),
-    d_tax decimal(4,4),
-    d_ytd decimal(12,2),
+    d_tax decimal(4, 4),
+    d_ytd decimal(12, 2),
     d_next_o_id integer,
     PRIMARY KEY (d_w_id, d_id)
 )
@@ -52,10 +52,10 @@ CREATE TABLE customer (
     c_phone char(16),
     c_since DATE,
     c_credit char(2),
-    c_credit_lim decimal(12,2),
-    c_discount decimal(4,4),
-    c_balance decimal(12,2),
-    c_ytd_payment decimal(12,2),
+    c_credit_lim decimal(12, 2),
+    c_discount decimal(4, 4),
+    c_balance decimal(12, 2),
+    c_ytd_payment decimal(12, 2),
     c_payment_cnt smallint,
     c_delivery_cnt smallint,
     c_data text,
@@ -74,7 +74,7 @@ CREATE TABLE history (
     h_d_id smallint,
     h_w_id integer,
     h_date date,
-    h_amount decimal(6,2),
+    h_amount decimal(6, 2),
     h_data char(24)
 )
 
@@ -118,7 +118,7 @@ CREATE TABLE orderline (
     ol_supply_w_id integer,
     ol_delivery_d date,
     ol_quantity smallint,
-    ol_amount decimal(6,2),
+    ol_amount decimal(6, 2),
     ol_dist_info char(24),
     PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
 )
@@ -134,7 +134,7 @@ CREATE TABLE item (
     i_id integer,
     i_im_id smallint,
     i_name char(24),
-    i_price decimal(5,2),
+    i_price decimal(5, 2),
     i_data char(50),
     PRIMARY KEY (i_id)
 )
@@ -184,7 +184,7 @@ CREATE TABLE supplier (
     su_address char(40) NOT NULL,
     su_nationkey smallint NOT NULL,
     su_phone char(15) NOT NULL,
-    su_acctbal decimal(12,2) NOT NULL,
+    su_acctbal decimal(12, 2) NOT NULL,
     su_comment char(101) NOT NULL,
     PRIMARY KEY (su_suppkey)
 )
@@ -498,7 +498,7 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT
     su_nationkey AS supp_nation,
-    substr(c_state,1,1) AS cust_nation,
+    substr(c_state, 1, 1) AS cust_nation,
     extract(year FROM o_entry_d) AS l_year,
     sum(ol_amount) AS revenue
 FROM supplier, stock, orderline, "order", customer, nation n1, nation n2

--- a/test/dates-times.slt
+++ b/test/dates-times.slt
@@ -20,18 +20,18 @@ SELECT a FROM dateish
 2019-12-31
 
 query T
-SELECT MAX(a) FROM dateish
+SELECT max(a) FROM dateish
 ----
 2019-12-31
 
 query T
-SELECT MIN(a) FROM dateish
+SELECT min(a) FROM dateish
 ----
 2000-01-01
 
 statement ok
 CREATE TABLE timestampish (
-    b TIMESTAMP
+    b timestamp
 )
 
 statement ok
@@ -49,12 +49,12 @@ SELECT b FROM timestampish
 2020-01-01 01:02:03.789
 
 query T
-SELECT MAX(b) FROM timestampish
+SELECT max(b) FROM timestampish
 ----
 2020-01-01 01:02:03.789
 
 query T
-SELECT MIN(b) FROM timestampish
+SELECT min(b) FROM timestampish
 ----
 1969-06-01 10:10:10.410
 
@@ -80,7 +80,7 @@ SELECT INTERVAL '1' MINUTE
 
 statement ok
 CREATE TABLE iv_ish (
-    b INTERVAL
+    b interval
 )
 
 statement ok
@@ -286,7 +286,7 @@ SELECT * FROM dateish WHERE a != DATE '1999-12-31' + INTERVAL '2' DAY
 
 statement ok
 CREATE TABLE timestamp_compares (
-    c TIMESTAMP
+    c timestamp
 )
 
 statement ok
@@ -380,12 +380,12 @@ SELECT * FROM timestamptzish
 2000-01-01 08:00:00 UTC
 
 query T
-SELECT MAX(t) FROM timestamptzish
+SELECT max(t) FROM timestamptzish
 ----
 2000-01-01 08:00:00 UTC
 
 query T
-SELECT MIN(t) FROM timestamptzish
+SELECT min(t) FROM timestamptzish
 ----
 1999-12-31 06:00:00 UTC
 
@@ -614,12 +614,12 @@ SELECT now() + INTERVAL '100' HOUR > now()
 true
 
 query B
-SELECT current_timestamp() > timestamp '2016-06-13 00:00:00'
+SELECT current_timestamp() > TIMESTAMP '2016-06-13 00:00:00'
 ----
 true
 
 query B
-SELECT current_timestamp > timestamp '2016-06-13 00:00:00'
+SELECT current_timestamp > TIMESTAMP '2016-06-13 00:00:00'
 ----
 true
 

--- a/test/decimal.slt
+++ b/test/decimal.slt
@@ -113,7 +113,7 @@ SELECT 10.01 * 1.1
 11.011
 
 query R
-SELECT 10.001 * 0.001;
+SELECT 10.001 * 0.001
 ----
 0.010001
 
@@ -128,7 +128,7 @@ SELECT 1.0 / 3.0
 0.3333333
 
 query R
-SELECT CAST(2 AS decimal(1, 0)) / CAST(7 AS decimal(1, 0))
+SELECT CAST (2 AS decimal(1, 0)) / CAST (7 AS decimal(1, 0))
 ----
 0.285714
 
@@ -199,9 +199,9 @@ CREATE TABLE casts (
 
 query RRR
 SELECT
-    CAST(0.1 as int),
-    CAST(0.1 AS decimal(15, 2)),
-    CAST(0.1 as float)
+    CAST (0.1 AS int),
+    CAST (0.1 AS decimal(15, 2)),
+    CAST (0.1 AS float)
 ----
 0  0.10  0.1
 
@@ -215,37 +215,37 @@ SELECT 1.0 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1
 ### float64 to decimal ###
 
 query R
-select cast(3.141529::float as decimal(38,6));
+SELECT CAST (3.141529::float AS decimal(38, 6))
 ----
 3.141529
 
 # Truncation
 query R
-select cast(3.141529::float as decimal(38,5));
+SELECT CAST (3.141529::float AS decimal(38, 5))
 ----
 3.14152
 
 # Floating point imprecision
 # Note that this result differs from PostgreSQL
 query R
-select cast(3.141529::float as decimal(38,7));
+SELECT CAST (3.141529::float AS decimal(38, 7))
 ----
 3.1415289
 
 # Expansion with 0s
 query R
-select cast(3.141529::float as decimal(38,8));
+SELECT CAST (3.141529::float AS decimal(38, 8))
 ----
 3.14152900
 
 # Numeric overflow
 query R
-select cast(100::float as decimal(38,37));
+SELECT CAST (100::float AS decimal(38, 37))
 ----
 NULL
 
 # Null input
 query R
-select cast(null::float as decimal(38,7));
+SELECT CAST (null::float AS decimal(38, 7))
 ----
 NULL

--- a/test/funcs.slt
+++ b/test/funcs.slt
@@ -77,12 +77,12 @@ SELECT date_trunc('millennium', TIMESTAMP '2019-11-26 15:56:46.241150')
 2001-01-01 00:00:00
 
 query R
-SELECT floor(cast(1.1 AS DOUBLE PRECISION))
+SELECT floor(CAST (1.1 AS double precision))
 ----
 1
 
 query R
-SELECT floor(cast(1.1 AS float))
+SELECT floor(CAST (1.1 AS float))
 ----
 1
 
@@ -93,12 +93,12 @@ SELECT floor(1.1), floor(1.111), floor(100.1), floor(100.11), floor(-4.1)
 
 
 query R
-SELECT ceil(cast(1.1 AS DOUBLE PRECISION))
+SELECT ceil(CAST (1.1 AS double precision))
 ----
 2
 
 query R
-SELECT ceil(cast(1.1 AS float))
+SELECT ceil(CAST (1.1 AS float))
 ----
 2
 

--- a/test/order_by.slt
+++ b/test/order_by.slt
@@ -6,76 +6,83 @@
 mode cockroach
 
 statement ok
-create table foo(a int, b text);
+CREATE TABLE foo (
+    a int,
+    b text
+)
 
 statement ok
-insert into foo(a,b) values (0, 'zero'), (1, 'one'), (2, 'two');
+INSERT INTO foo (a, b) VALUES (0, 'zero'), (1, 'one'), (2, 'two')
 
 query I nosort
-select a from foo order by a
+SELECT a FROM foo ORDER BY a
 ----
 0
 1
 2
 
 query I nosort
-select a from foo order by a desc
+SELECT a FROM foo ORDER BY a DESC
 ----
 2
 1
 0
 
 query I nosort
-select a+1 from foo order by a+1
+SELECT a + 1 FROM foo ORDER BY a + 1
 ----
 1
 2
 3
 
 query I nosort
-select sum(a) from foo order by sum(a)
+SELECT sum(a) FROM foo ORDER BY sum(a)
 ----
 3
 
 query I nosort
-select a from foo order by (0-a)
+SELECT a FROM foo ORDER BY (0-a)
 ----
 2
 1
 0
 
 statement ok
-create table bar(a int);
+CREATE TABLE bar (a int)
 
 statement ok
-insert into bar(a) values (1);
+INSERT INTO bar (a) VALUES (1)
 
 query I nosort
-select a from foo order by exists (select * from bar where bar.a = foo.a), a;
+SELECT a FROM foo ORDER BY exists (SELECT * FROM bar WHERE bar.a = foo.a), a
 ----
 0
 2
 1
 
-###sorts, limits, and offsets in subqueries ###
+### sorts, limits, and offsets in subqueries ###
 
-#these tests have been designed to cover a wide range of situations where there
-#may be a subquery. be sure when modifying these tests to maintain a representation
-#for each situation.
-
-statement ok
-create table fizz(a int, b text);
+# These tests have been designed to cover a wide range of situations where there
+# may be a subquery. Be sure when modifying these tests to maintain a
+# representation for each situation.
 
 statement ok
-insert into fizz(a,b) values (2079, 'thirteen'), (12345, 'one'), (12345, 'two'), (12345, 'three'),
-(6745, 'five'), (24223, 'four'), (21243, 'four'), (1735, 'two'), (25040, 'two');
+CREATE TABLE fizz(a int, b text)
 
-#the order by's inside the subquery are technically meaningless because they do not
-#propagate to the outer query, but we should still return correct results.
-#TODO: materialize#696 replace the current query with the one below
-#SELECT b FROM (SELECT min(b) as b FROM fizz GROUP BY a ORDER BY a DESC)
+statement ok
+INSERT INTO fizz(a, b) VALUES
+    (2079, 'thirteen'), (12345, 'one'),
+    (12345, 'two'), (12345, 'three'),
+    (6745, 'five'), (24223, 'four'),
+    (21243, 'four'), (1735, 'two'),
+    (25040, 'two')
+
+# the ORDER BY's inside the subquery are technically meaningless because they do not
+# propagate to the outer query, but we should still return correct results.
+# TODO: materialize#696 replace the current query with the one below
+# SELECT b FROM (SELECT min(b) AS b FROM fizz GROUP BY a ORDER BY a DESC)
 query T rowsort
-SELECT b FROM (SELECT a, min(b) as b FROM fizz GROUP BY a ORDER BY a DESC)
+SELECT b FROM (SELECT a, min(b) AS b FROM fizz GROUP BY a ORDER BY a DESC)
 ----
 five
 four
@@ -99,15 +106,21 @@ SELECT ascii(b) FROM (SELECT a, b FROM fizz ORDER BY a ASC, b DESC)
 116
 
 statement ok
-create table baz (val1 int, val2 int);
+CREATE TABLE baz (
+    val1 int,
+    val2 int
+)
 
 statement ok
-insert into baz values (12345, 1735), (12345, 1735), (12345, 1735), (1735, 24223),
-(12345, 12345), (2079, 24223), (1735, 2079), (1735, 2079), (1735, 2079);
+INSERT INTO baz VALUES
+    (12345, 1735), (12345, 1735), (12345, 1735),
+    (1735, 24223), (12345, 12345), (2079, 24223),
+    (1735, 2079), (1735, 2079), (1735, 2079)
 
-#offset
+# offset
+
 query I rowsort
-SELECT a FROM fizz where a > ANY(SELECT val1 from baz order by val1 offset 3 ROWS)
+SELECT a FROM fizz WHERE a > ANY(SELECT val1 FROM baz ORDER BY val1 offset 3 ROWS)
 ----
 12345
 12345
@@ -119,7 +132,7 @@ SELECT a FROM fizz where a > ANY(SELECT val1 from baz order by val1 offset 3 ROW
 6745
 
 query I rowsort
-SELECT a from fizz where a in (SELECT val1 from baz order by val1 offset 0 rows)
+SELECT a FROM fizz WHERE a IN (SELECT val1 FROM baz ORDER BY val1 offset 0 rows)
 ----
 12345
 12345
@@ -127,20 +140,21 @@ SELECT a from fizz where a in (SELECT val1 from baz order by val1 offset 0 rows)
 1735
 2079
 
-#limit
+# limit
 query I
-SELECT a FROM fizz WHERE a < ALL(SELECT val1 from baz order by val1 desc limit 5)
+SELECT a FROM fizz WHERE a < ALL(SELECT val1 FROM baz ORDER BY val1 DESC limit 5)
 ----
 1735
 
 query I
-SELECT count(*) from fizz where exists(SELECT val1 from baz order by val1 limit 0)
+SELECT count(*) FROM fizz WHERE exists(SELECT val1 FROM baz ORDER BY val1 limit 0)
 ----
 0
 
-#offset + limit
+# offset + limit
 query TI
-SELECT b, (SELECT val1 from baz where val2 = a order by val1 limit 1 offset 1 rows) c from fizz order by b, c desc
+SELECT b, (SELECT val1 FROM baz WHERE val2 = a ORDER BY val1 limit 1 offset 1 rows) c
+FROM fizz ORDER BY b, c DESC
 ----
 five      NULL
 four      2079
@@ -152,7 +166,7 @@ two       12345
 two       NULL
 two       NULL
 
-#limit + offset return correct results when there are identical rows
+# limit + offset return correct results when there are identical rows
 query I
 SELECT val1 FROM (SELECT val1, val2 FROM baz ORDER BY val2 LIMIT 2)
 ----
@@ -176,11 +190,12 @@ SELECT val1 FROM (SELECT val1, val2 FROM baz ORDER BY val2 DESC LIMIT 1 OFFSET 7
 ----
 12345
 
-#order by/limit/offset in subqueries still works after deleting some entries
-#note: the parentheses around the select statement currently makes it a subquery test.
-#change the test if we optimize so that the select is no longer treated as a subquery
+# ORDER BY/limit/offset in subqueries still works after deleting some entries
+# Note: the parentheses around the SELECT statement currently makes it a subquery
+# test. Change the test if we optimize so that the SELECT is no longer treated
+# as a subquery.
 statement ok
-CREATE view bazv AS (SELECT val1, val2 FROM baz ORDER BY val2 DESC, val1 LIMIT 2 OFFSET 1 ROW);
+CREATE VIEW bazv AS (SELECT val1, val2 FROM baz ORDER BY val2 DESC, val1 LIMIT 2 OFFSET 1 ROW)
 
 query II rowsort
 PEEK bazv
@@ -189,7 +204,7 @@ PEEK bazv
 12345  12345
 
 statement ok
-DELETE FROM baz WHERE val1=12345;
+DELETE FROM baz WHERE val1=12345
 
 query II rowsort
 PEEK bazv
@@ -197,13 +212,13 @@ PEEK bazv
 1735   2079
 2079   24223
 
-### order by/offset/limit in toplevel select query in view creation ###
+### ORDER BY/offset/limit in toplevel select query in view creation ###
 
 statement ok
-CREATE VIEW fizzorderview as SELECT a, b FROM fizz ORDER BY a desc, b;
+CREATE VIEW fizzorderview AS SELECT a, b FROM fizz ORDER BY a DESC, b
 
-#TODO: materialize#724 take out the rowsort and rearrange results
-#when order by's persist past the view creation
+# TODO: materialize#724 take out the rowsort and rearrange results
+# when ORDER BY's persist past the view creation
 query IT rowsort
 PEEK fizzorderview
 ----
@@ -218,15 +233,15 @@ PEEK fizzorderview
 25040 two
 
 statement ok
-CREATE VIEW fizzlimitview as SELECT a, b FROM fizz LIMIT 4;
+CREATE VIEW fizzlimitview AS SELECT a, b FROM fizz LIMIT 4
 
 query II
-SELECT count(a), count(b) FROM fizzlimitview;
+SELECT count(a), count(b) FROM fizzlimitview
 ----
 4 4
 
 statement ok
-CREATE VIEW fizzlimitview2 as SELECT b, a from fizz ORDER BY a asc LIMIT 2;
+CREATE VIEW fizzlimitview2 AS SELECT b, a FROM fizz ORDER BY a ASC LIMIT 2
 
 query TI rowsort
 PEEK fizzlimitview2
@@ -235,15 +250,15 @@ thirteen 2079
 two      1735
 
 statement ok
-CREATE VIEW fizzoffsetview as SELECT a, b FROM fizz OFFSET 6 ROWS;
+CREATE VIEW fizzoffsetview AS SELECT a, b FROM fizz OFFSET 6 ROWS
 
 query II
-SELECT count(b), count(a) FROM fizzoffsetview;
+SELECT count(b), count(a) FROM fizzoffsetview
 ----
 3 3
 
 statement ok
-CREATE VIEW fizzoffsetview2 as SELECT b, a from fizz ORDER BY b desc, a OFFSET 3 ROWS
+CREATE VIEW fizzoffsetview2 AS SELECT b, a FROM fizz ORDER BY b DESC, a OFFSET 3 ROWS
 
 query TI rowsort
 PEEK fizzoffsetview2
@@ -256,26 +271,28 @@ thirteen 2079
 three    12345
 
 statement ok
-CREATE VIEW fizzlimitoffsetview as SELECT sum(a) as tot, b FROM fizz GROUP BY b ORDER BY tot LIMIT 1 OFFSET 4 ROWS;
+CREATE VIEW fizzlimitoffsetview AS SELECT sum(a) AS tot, b FROM fizz GROUP BY b
+ORDER BY tot LIMIT 1 OFFSET 4 ROWS
 
 query I
-SELECT count(tot) from fizzlimitoffsetview;
+SELECT count(tot) FROM fizzlimitoffsetview
 ----
 1
 
 statement ok
-CREATE VIEW fizzlimitoffsetview2 as SELECT avg(a), b FROM fizz GROUP BY b ORDER BY b desc LIMIT 3 OFFSET 2 ROWS;
+CREATE VIEW fizzlimitoffsetview2 AS SELECT avg(a), b FROM fizz GROUP BY b
+ORDER BY b DESC LIMIT 3 OFFSET 2 ROWS
 
 query RT rowsort
-PEEK fizzlimitoffsetview2;
+PEEK fizzlimitoffsetview2
 ----
 12345.000000 one
 2079.000000  thirteen
 22733.000000 four
 
-# delete and add an entry; see how views update
+# delete and add an entry see how views update
 statement ok
-DELETE FROM fizz WHERE b='thirteen';
+DELETE FROM fizz WHERE b = 'thirteen'
 
 query IT rowsort
 PEEK fizzorderview
@@ -296,7 +313,7 @@ five     6745
 two      1735
 
 query II
-SELECT count(b), count(a) FROM fizzoffsetview;
+SELECT count(b), count(a) FROM fizzoffsetview
 ----
 2 2
 
@@ -310,22 +327,22 @@ one      12345
 three    12345
 
 query RT rowsort
-PEEK fizzlimitoffsetview2;
+PEEK fizzlimitoffsetview2
 ----
 12345.000000 one
 22733.000000 four
 6745.000000  five
 
 statement ok
-DELETE FROM fizz WHERE b='five';
+DELETE FROM fizz WHERE b = 'five'
 
 query II
-SELECT count(a), count(b) FROM fizzlimitview;
+SELECT count(a), count(b) FROM fizzlimitview
 ----
 4 4
 
 query I
-SELECT count(tot) from fizzlimitoffsetview;
+SELECT count(tot) FROM fizzlimitoffsetview
 ----
 0
 
@@ -346,7 +363,7 @@ PEEK fizzorderview
 7584  twelve
 
 query II
-SELECT count(a), count(b) FROM fizzlimitview;
+SELECT count(a), count(b) FROM fizzlimitview
 ----
 4 4
 
@@ -357,7 +374,7 @@ twelve   7584
 two      1735
 
 query II
-SELECT count(b), count(a) FROM fizzoffsetview;
+SELECT count(b), count(a) FROM fizzoffsetview
 ----
 3 3
 
@@ -372,12 +389,12 @@ three    12345
 twelve   7584
 
 query I
-SELECT count(tot) from fizzlimitoffsetview;
+SELECT count(tot) FROM fizzlimitoffsetview
 ----
 1
 
 query RT rowsort
-PEEK fizzlimitoffsetview2;
+PEEK fizzlimitoffsetview2
 ----
 12345.000000 one
 21758.000000 fourteen

--- a/test/scoping.slt
+++ b/test/scoping.slt
@@ -6,10 +6,10 @@
 mode cockroach
 
 statement ok
-CREATE TABLE t1 (a int);
+CREATE TABLE t1 (a int)
 
 statement ok
-CREATE TABLE t2 (a int);
+CREATE TABLE t2 (a int)
 
 # This works in MySQL, but not PostgreSQL.
 query I

--- a/test/select_all_group_by.slt
+++ b/test/select_all_group_by.slt
@@ -15,7 +15,7 @@ statement ok
 CREATE TABLE bar (a integer, b integer)
 
 statement ok
-INSERT INTO bar VALUES (37, 42), (37, 42);
+INSERT INTO bar VALUES (37, 42), (37, 42)
 
 query II
 SELECT *, count(*) FROM foo GROUP BY a
@@ -23,7 +23,7 @@ SELECT *, count(*) FROM foo GROUP BY a
 37 1
 
 query II
-SELECT *, count(*) FROM foo GROUP BY a, a, a+1
+SELECT *, count(*) FROM foo GROUP BY a, a, a + 1
 ----
 37 1
 
@@ -33,28 +33,28 @@ SELECT a FROM foo GROUP BY a, foo.a
 37
 
 statement error internal error: unable to resolve scope item
-SELECT *, count(*) FROM bar GROUP BY a;
+SELECT *, count(*) FROM bar GROUP BY a
 
 query II
-SELECT a, count(*) FROM bar GROUP BY a;
+SELECT a, count(*) FROM bar GROUP BY a
 ----
 37 2
 
 query II
-SELECT * FROM bar GROUP BY a, b;
+SELECT * FROM bar GROUP BY a, b
 ----
 37 42
 
 statement ok
-CREATE TABLE quux (a integer);
+CREATE TABLE quux (a integer)
 
 query I
-SELECT count(a) FROM quux WHERE a < 0;
+SELECT count(a) FROM quux WHERE a < 0
 ----
 0
 
 query I
-SELECT count(*) FROM quux WHERE a < 0;
+SELECT count(*) FROM quux WHERE a < 0
 ----
 0
 
@@ -62,7 +62,7 @@ statement ok
 INSERT INTO quux VALUES (37), (NULL)
 
 query I
-SELECT count(*) FROM quux;
+SELECT count(*) FROM quux
 ----
 2
 

--- a/test/special/memory.slt
+++ b/test/special/memory.slt
@@ -7,379 +7,379 @@
 # be measured.
 
 statement ok
-CREATE TABLE t1(
-  a1 INTEGER PRIMARY KEY,
-  b1 INTEGER,
-  x1 VARCHAR(40)
+CREATE TABLE t1 (
+  a1 integer PRIMARY KEY,
+  b1 integer,
+  x1 varchar(40)
 )
 
 statement ok
-INSERT INTO t1 VALUES(1,1,'table t1 row 1')
+INSERT INTO t1 VALUES (1, 1, 'table t1 row 1')
 
 statement ok
-INSERT INTO t1 VALUES(2,9,'table t1 row 2')
+INSERT INTO t1 VALUES (2, 9, 'table t1 row 2')
 
 statement ok
-INSERT INTO t1 VALUES(3,8,'table t1 row 3')
+INSERT INTO t1 VALUES (3, 8, 'table t1 row 3')
 
 statement ok
-INSERT INTO t1 VALUES(4,4,'table t1 row 4')
+INSERT INTO t1 VALUES (4, 4, 'table t1 row 4')
 
 statement ok
-INSERT INTO t1 VALUES(5,2,'table t1 row 5')
+INSERT INTO t1 VALUES (5, 2, 'table t1 row 5')
 
 statement ok
-INSERT INTO t1 VALUES(6,3,'table t1 row 6')
+INSERT INTO t1 VALUES (6, 3, 'table t1 row 6')
 
 statement ok
-INSERT INTO t1 VALUES(7,6,'table t1 row 7')
+INSERT INTO t1 VALUES (7, 6, 'table t1 row 7')
 
 statement ok
-INSERT INTO t1 VALUES(8,7,'table t1 row 8')
+INSERT INTO t1 VALUES (8, 7, 'table t1 row 8')
 
 statement ok
-INSERT INTO t1 VALUES(9,10,'table t1 row 9')
+INSERT INTO t1 VALUES (9, 10, 'table t1 row 9')
 
 statement ok
-INSERT INTO t1 VALUES(10,5,'table t1 row 10')
+INSERT INTO t1 VALUES (10, 5, 'table t1 row 10')
 
 statement ok
-CREATE TABLE t2(
-  a2 INTEGER PRIMARY KEY,
-  b2 INTEGER,
-  x2 VARCHAR(40)
+CREATE TABLE t2 (
+  a2 integer PRIMARY KEY,
+  b2 integer,
+  x2 varchar(40)
 )
 
 statement ok
-INSERT INTO t2 VALUES(1,7,'table t2 row 1')
+INSERT INTO t2 VALUES (1, 7, 'table t2 row 1')
 
 statement ok
-INSERT INTO t2 VALUES(2,5,'table t2 row 2')
+INSERT INTO t2 VALUES (2, 5, 'table t2 row 2')
 
 statement ok
-INSERT INTO t2 VALUES(3,9,'table t2 row 3')
+INSERT INTO t2 VALUES (3, 9, 'table t2 row 3')
 
 statement ok
-INSERT INTO t2 VALUES(4,3,'table t2 row 4')
+INSERT INTO t2 VALUES (4, 3, 'table t2 row 4')
 
 statement ok
-INSERT INTO t2 VALUES(5,2,'table t2 row 5')
+INSERT INTO t2 VALUES (5, 2, 'table t2 row 5')
 
 statement ok
-INSERT INTO t2 VALUES(6,10,'table t2 row 6')
+INSERT INTO t2 VALUES (6, 10, 'table t2 row 6')
 
 statement ok
-INSERT INTO t2 VALUES(7,8,'table t2 row 7')
+INSERT INTO t2 VALUES (7, 8, 'table t2 row 7')
 
 statement ok
-INSERT INTO t2 VALUES(8,6,'table t2 row 8')
+INSERT INTO t2 VALUES (8, 6, 'table t2 row 8')
 
 statement ok
-INSERT INTO t2 VALUES(9,4,'table t2 row 9')
+INSERT INTO t2 VALUES (9, 4, 'table t2 row 9')
 
 statement ok
-INSERT INTO t2 VALUES(10,1,'table t2 row 10')
+INSERT INTO t2 VALUES (10, 1, 'table t2 row 10')
 
 statement ok
-CREATE TABLE t3(
-  a3 INTEGER PRIMARY KEY,
-  b3 INTEGER,
-  x3 VARCHAR(40)
+CREATE TABLE t3 (
+  a3 integer PRIMARY KEY,
+  b3 integer,
+  x3 varchar(40)
 )
 
 statement ok
-INSERT INTO t3 VALUES(1,6,'table t3 row 1')
+INSERT INTO t3 VALUES (1, 6, 'table t3 row 1')
 
 statement ok
-INSERT INTO t3 VALUES(2,8,'table t3 row 2')
+INSERT INTO t3 VALUES (2, 8, 'table t3 row 2')
 
 statement ok
-INSERT INTO t3 VALUES(3,3,'table t3 row 3')
+INSERT INTO t3 VALUES (3, 3, 'table t3 row 3')
 
 statement ok
-INSERT INTO t3 VALUES(4,2,'table t3 row 4')
+INSERT INTO t3 VALUES (4, 2, 'table t3 row 4')
 
 statement ok
-INSERT INTO t3 VALUES(5,4,'table t3 row 5')
+INSERT INTO t3 VALUES (5, 4, 'table t3 row 5')
 
 statement ok
-INSERT INTO t3 VALUES(6,5,'table t3 row 6')
+INSERT INTO t3 VALUES (6, 5, 'table t3 row 6')
 
 statement ok
-INSERT INTO t3 VALUES(7,9,'table t3 row 7')
+INSERT INTO t3 VALUES (7, 9, 'table t3 row 7')
 
 statement ok
-INSERT INTO t3 VALUES(8,10,'table t3 row 8')
+INSERT INTO t3 VALUES (8, 10, 'table t3 row 8')
 
 statement ok
-INSERT INTO t3 VALUES(9,1,'table t3 row 9')
+INSERT INTO t3 VALUES (9, 1, 'table t3 row 9')
 
 statement ok
-INSERT INTO t3 VALUES(10,7,'table t3 row 10')
+INSERT INTO t3 VALUES (10, 7, 'table t3 row 10')
 
 statement ok
-CREATE TABLE t4(
-  a4 INTEGER PRIMARY KEY,
-  b4 INTEGER,
-  x4 VARCHAR(40)
+CREATE TABLE t4 (
+  a4 integer PRIMARY KEY,
+  b4 integer,
+  x4 varchar(40)
 )
 
 statement ok
-INSERT INTO t4 VALUES(1,2,'table t4 row 1')
+INSERT INTO t4 VALUES (1, 2, 'table t4 row 1')
 
 statement ok
-INSERT INTO t4 VALUES(2,6,'table t4 row 2')
+INSERT INTO t4 VALUES (2, 6, 'table t4 row 2')
 
 statement ok
-INSERT INTO t4 VALUES(3,10,'table t4 row 3')
+INSERT INTO t4 VALUES (3, 10, 'table t4 row 3')
 
 statement ok
-INSERT INTO t4 VALUES(4,4,'table t4 row 4')
+INSERT INTO t4 VALUES (4, 4, 'table t4 row 4')
 
 statement ok
-INSERT INTO t4 VALUES(5,1,'table t4 row 5')
+INSERT INTO t4 VALUES (5, 1, 'table t4 row 5')
 
 statement ok
-INSERT INTO t4 VALUES(6,8,'table t4 row 6')
+INSERT INTO t4 VALUES (6, 8, 'table t4 row 6')
 
 statement ok
-INSERT INTO t4 VALUES(7,7,'table t4 row 7')
+INSERT INTO t4 VALUES (7, 7, 'table t4 row 7')
 
 statement ok
-INSERT INTO t4 VALUES(8,5,'table t4 row 8')
+INSERT INTO t4 VALUES (8, 5, 'table t4 row 8')
 
 statement ok
-INSERT INTO t4 VALUES(9,3,'table t4 row 9')
+INSERT INTO t4 VALUES (9, 3, 'table t4 row 9')
 
 statement ok
-INSERT INTO t4 VALUES(10,9,'table t4 row 10')
+INSERT INTO t4 VALUES (10, 9, 'table t4 row 10')
 
 statement ok
-CREATE TABLE t5(
-  a5 INTEGER PRIMARY KEY,
-  b5 INTEGER,
-  x5 VARCHAR(40)
+CREATE TABLE t5 (
+  a5 integer PRIMARY KEY,
+  b5 integer,
+  x5 varchar(40)
 )
 
 statement ok
-INSERT INTO t5 VALUES(1,9,'table t5 row 1')
+INSERT INTO t5 VALUES (1, 9, 'table t5 row 1')
 
 statement ok
-INSERT INTO t5 VALUES(2,5,'table t5 row 2')
+INSERT INTO t5 VALUES (2, 5, 'table t5 row 2')
 
 statement ok
-INSERT INTO t5 VALUES(3,10,'table t5 row 3')
+INSERT INTO t5 VALUES (3, 10, 'table t5 row 3')
 
 statement ok
-INSERT INTO t5 VALUES(4,7,'table t5 row 4')
+INSERT INTO t5 VALUES (4, 7, 'table t5 row 4')
 
 statement ok
-INSERT INTO t5 VALUES(5,4,'table t5 row 5')
+INSERT INTO t5 VALUES (5, 4, 'table t5 row 5')
 
 statement ok
-INSERT INTO t5 VALUES(6,2,'table t5 row 6')
+INSERT INTO t5 VALUES (6, 2, 'table t5 row 6')
 
 statement ok
-INSERT INTO t5 VALUES(7,1,'table t5 row 7')
+INSERT INTO t5 VALUES (7, 1, 'table t5 row 7')
 
 statement ok
-INSERT INTO t5 VALUES(8,8,'table t5 row 8')
+INSERT INTO t5 VALUES (8, 8, 'table t5 row 8')
 
 statement ok
-INSERT INTO t5 VALUES(9,3,'table t5 row 9')
+INSERT INTO t5 VALUES (9, 3, 'table t5 row 9')
 
 statement ok
-INSERT INTO t5 VALUES(10,6,'table t5 row 10')
+INSERT INTO t5 VALUES (10, 6, 'table t5 row 10')
 
 statement ok
-CREATE TABLE t6(
-  a6 INTEGER PRIMARY KEY,
-  b6 INTEGER,
-  x6 VARCHAR(40)
+CREATE TABLE t6 (
+  a6 integer PRIMARY KEY,
+  b6 integer,
+  x6 varchar(40)
 )
 
 statement ok
-INSERT INTO t6 VALUES(1,2,'table t6 row 1')
+INSERT INTO t6 VALUES (1, 2, 'table t6 row 1')
 
 statement ok
-INSERT INTO t6 VALUES(2,5,'table t6 row 2')
+INSERT INTO t6 VALUES (2, 5, 'table t6 row 2')
 
 statement ok
-INSERT INTO t6 VALUES(3,9,'table t6 row 3')
+INSERT INTO t6 VALUES (3, 9, 'table t6 row 3')
 
 statement ok
-INSERT INTO t6 VALUES(4,3,'table t6 row 4')
+INSERT INTO t6 VALUES (4, 3, 'table t6 row 4')
 
 statement ok
-INSERT INTO t6 VALUES(5,1,'table t6 row 5')
+INSERT INTO t6 VALUES (5, 1, 'table t6 row 5')
 
 statement ok
-INSERT INTO t6 VALUES(6,8,'table t6 row 6')
+INSERT INTO t6 VALUES (6, 8, 'table t6 row 6')
 
 statement ok
-INSERT INTO t6 VALUES(7,10,'table t6 row 7')
+INSERT INTO t6 VALUES (7, 10, 'table t6 row 7')
 
 statement ok
-INSERT INTO t6 VALUES(8,6,'table t6 row 8')
+INSERT INTO t6 VALUES (8, 6, 'table t6 row 8')
 
 statement ok
-INSERT INTO t6 VALUES(9,4,'table t6 row 9')
+INSERT INTO t6 VALUES (9, 4, 'table t6 row 9')
 
 statement ok
-INSERT INTO t6 VALUES(10,7,'table t6 row 10')
+INSERT INTO t6 VALUES (10, 7, 'table t6 row 10')
 
 statement ok
-CREATE TABLE t7(
-  a7 INTEGER PRIMARY KEY,
-  b7 INTEGER,
-  x7 VARCHAR(40)
+CREATE TABLE t7 (
+  a7 integer PRIMARY KEY,
+  b7 integer,
+  x7 varchar(40)
 )
 
 statement ok
-INSERT INTO t7 VALUES(1,1,'table t7 row 1')
+INSERT INTO t7 VALUES (1, 1, 'table t7 row 1')
 
 statement ok
-INSERT INTO t7 VALUES(2,5,'table t7 row 2')
+INSERT INTO t7 VALUES (2, 5, 'table t7 row 2')
 
 statement ok
-INSERT INTO t7 VALUES(3,3,'table t7 row 3')
+INSERT INTO t7 VALUES (3, 3, 'table t7 row 3')
 
 statement ok
-INSERT INTO t7 VALUES(4,9,'table t7 row 4')
+INSERT INTO t7 VALUES (4, 9, 'table t7 row 4')
 
 statement ok
-INSERT INTO t7 VALUES(5,8,'table t7 row 5')
+INSERT INTO t7 VALUES (5, 8, 'table t7 row 5')
 
 statement ok
-INSERT INTO t7 VALUES(6,4,'table t7 row 6')
+INSERT INTO t7 VALUES (6, 4, 'table t7 row 6')
 
 statement ok
-INSERT INTO t7 VALUES(7,2,'table t7 row 7')
+INSERT INTO t7 VALUES (7, 2, 'table t7 row 7')
 
 statement ok
-INSERT INTO t7 VALUES(8,10,'table t7 row 8')
+INSERT INTO t7 VALUES (8, 10, 'table t7 row 8')
 
 statement ok
-INSERT INTO t7 VALUES(9,6,'table t7 row 9')
+INSERT INTO t7 VALUES (9, 6, 'table t7 row 9')
 
 statement ok
-INSERT INTO t7 VALUES(10,7,'table t7 row 10')
+INSERT INTO t7 VALUES (10, 7, 'table t7 row 10')
 
 statement ok
-CREATE TABLE t8(
-  a8 INTEGER PRIMARY KEY,
-  b8 INTEGER,
-  x8 VARCHAR(40)
+CREATE TABLE t8 (
+  a8 integer PRIMARY KEY,
+  b8 integer,
+  x8 varchar(40)
 )
 
 statement ok
-INSERT INTO t8 VALUES(1,3,'table t8 row 1')
+INSERT INTO t8 VALUES (1, 3, 'table t8 row 1')
 
 statement ok
-INSERT INTO t8 VALUES(2,10,'table t8 row 2')
+INSERT INTO t8 VALUES (2, 10, 'table t8 row 2')
 
 statement ok
-INSERT INTO t8 VALUES(3,8,'table t8 row 3')
+INSERT INTO t8 VALUES (3, 8, 'table t8 row 3')
 
 statement ok
-INSERT INTO t8 VALUES(4,6,'table t8 row 4')
+INSERT INTO t8 VALUES (4, 6, 'table t8 row 4')
 
 statement ok
-INSERT INTO t8 VALUES(5,7,'table t8 row 5')
+INSERT INTO t8 VALUES (5, 7, 'table t8 row 5')
 
 statement ok
-INSERT INTO t8 VALUES(6,4,'table t8 row 6')
+INSERT INTO t8 VALUES (6, 4, 'table t8 row 6')
 
 statement ok
-INSERT INTO t8 VALUES(7,2,'table t8 row 7')
+INSERT INTO t8 VALUES (7, 2, 'table t8 row 7')
 
 statement ok
-INSERT INTO t8 VALUES(8,9,'table t8 row 8')
+INSERT INTO t8 VALUES (8, 9, 'table t8 row 8')
 
 statement ok
-INSERT INTO t8 VALUES(9,5,'table t8 row 9')
+INSERT INTO t8 VALUES (9, 5, 'table t8 row 9')
 
 statement ok
-INSERT INTO t8 VALUES(10,1,'table t8 row 10')
+INSERT INTO t8 VALUES (10, 1, 'table t8 row 10')
 
 statement ok
-CREATE TABLE t9(
-  a9 INTEGER PRIMARY KEY,
-  b9 INTEGER,
-  x9 VARCHAR(40)
+CREATE TABLE t9 (
+  a9 integer PRIMARY KEY,
+  b9 integer,
+  x9 varchar(40)
 )
 
 statement ok
-INSERT INTO t9 VALUES(1,3,'table t9 row 1')
+INSERT INTO t9 VALUES (1, 3, 'table t9 row 1')
 
 statement ok
-INSERT INTO t9 VALUES(2,4,'table t9 row 2')
+INSERT INTO t9 VALUES (2, 4, 'table t9 row 2')
 
 statement ok
-INSERT INTO t9 VALUES(3,6,'table t9 row 3')
+INSERT INTO t9 VALUES (3, 6, 'table t9 row 3')
 
 statement ok
-INSERT INTO t9 VALUES(4,5,'table t9 row 4')
+INSERT INTO t9 VALUES (4, 5, 'table t9 row 4')
 
 statement ok
-INSERT INTO t9 VALUES(5,9,'table t9 row 5')
+INSERT INTO t9 VALUES (5, 9, 'table t9 row 5')
 
 statement ok
-INSERT INTO t9 VALUES(6,7,'table t9 row 6')
+INSERT INTO t9 VALUES (6, 7, 'table t9 row 6')
 
 statement ok
-INSERT INTO t9 VALUES(7,2,'table t9 row 7')
+INSERT INTO t9 VALUES (7, 2, 'table t9 row 7')
 
 statement ok
-INSERT INTO t9 VALUES(8,1,'table t9 row 8')
+INSERT INTO t9 VALUES (8, 1, 'table t9 row 8')
 
 statement ok
-INSERT INTO t9 VALUES(9,10,'table t9 row 9')
+INSERT INTO t9 VALUES (9, 10, 'table t9 row 9')
 
 statement ok
-INSERT INTO t9 VALUES(10,8,'table t9 row 10')
+INSERT INTO t9 VALUES (10, 8, 'table t9 row 10')
 
 statement ok
-CREATE TABLE t10(
-  a10 INTEGER PRIMARY KEY,
-  b10 INTEGER,
-  x10 VARCHAR(40)
+CREATE TABLE t10 (
+  a10 integer PRIMARY KEY,
+  b10 integer,
+  x10 varchar(40)
 )
 
 statement ok
-INSERT INTO t10 VALUES(1,8,'table t10 row 1')
+INSERT INTO t10 VALUES (1, 8, 'table t10 row 1')
 
 statement ok
-INSERT INTO t10 VALUES(2,10,'table t10 row 2')
+INSERT INTO t10 VALUES (2, 10, 'table t10 row 2')
 
 statement ok
-INSERT INTO t10 VALUES(3,7,'table t10 row 3')
+INSERT INTO t10 VALUES (3, 7, 'table t10 row 3')
 
 statement ok
-INSERT INTO t10 VALUES(4,1,'table t10 row 4')
+INSERT INTO t10 VALUES (4, 1, 'table t10 row 4')
 
 statement ok
-INSERT INTO t10 VALUES(5,5,'table t10 row 5')
+INSERT INTO t10 VALUES (5, 5, 'table t10 row 5')
 
 statement ok
-INSERT INTO t10 VALUES(6,4,'table t10 row 6')
+INSERT INTO t10 VALUES (6, 4, 'table t10 row 6')
 
 statement ok
-INSERT INTO t10 VALUES(7,3,'table t10 row 7')
+INSERT INTO t10 VALUES (7, 3, 'table t10 row 7')
 
 statement ok
-INSERT INTO t10 VALUES(8,9,'table t10 row 8')
+INSERT INTO t10 VALUES (8, 9, 'table t10 row 8')
 
 statement ok
-INSERT INTO t10 VALUES(9,6,'table t10 row 9')
+INSERT INTO t10 VALUES (9, 6, 'table t10 row 9')
 
 statement ok
-INSERT INTO t10 VALUES(10,2,'table t10 row 10')
+INSERT INTO t10 VALUES (10, 2, 'table t10 row 10')
 
 query IITIITIITIITIITIIT nosort
 SELECT *
-  FROM t1,t2,t3,t4,t5,t6
-  ORDER BY a1,a2,a3,a4,a5,a6
+  FROM t1, t2, t3, t4, t5, t6
+  ORDER BY a1, a2, a3, a4, a5, a6
   LIMIT 1
 ----
 18 values hashing to 2de53412d2ea9c3a2645ae7e81af8160

--- a/test/string.slt
+++ b/test/string.slt
@@ -14,14 +14,14 @@ CREATE TABLE asciitest (strcol CHAR(15), vccol VARCHAR(15))
 # 1: empty string to each column
 # 2: single space in each column
 statement ok
-INSERT INTO asciitest VALUES ('hello world', 'goodbye moon'), (null, null),
+INSERT INTO asciitest VALUES ('hello world', 'goodbye moon'), (NULL, NULL),
     ('你好', '再见'), ('😀', '👻')
 
 statement error
-select ascii(98)
+SELECT ascii(98)
 
 query II colnames
-select ascii(strcol) as strres, ascii(vccol) as vcres from asciitest order by strres;
+SELECT ascii(strcol) AS strres, ascii(vccol) AS vcres FROM asciitest ORDER BY strres
 ----
 strres  vcres
 NULL    NULL
@@ -30,49 +30,49 @@ NULL    NULL
 128512  128123
 
 query I
-select ascii(null);
+SELECT ascii(NULL)
 ----
 NULL
 
 query I
-select ascii(substr('inside literal', 3, 4));
+SELECT ascii(substr('inside literal', 3, 4))
 ----
 115
 
 ### substr ###
 statement ok
-CREATE TABLE substrtest (strcol CHAR(15), vccol VARCHAR(15), smicol SMALLINT, intcol INT)
+CREATE TABLE substrtest (strcol char(15), vccol varchar(15), smicol smallint, intcol int)
 
 statement ok
-INSERT INTO substrtest VALUES ('Mg', 'Mn', 1, 1), ('magnesium', 'manganese', 3, null),
-    (null, null, 0, 0), ('24.31', '54.94', 2, 3), ('长久不见', '爱不释手', null, 2),
+INSERT INTO substrtest VALUES ('Mg', 'Mn', 1, 1), ('magnesium', 'manganese', 3, NULL),
+    (NULL, NULL, 0, 0), ('24.31', '54.94', 2, 3), ('长久不见', '爱不释手', NULL, 2),
     ('', '', -1, 2)
 
-#invalid input
+# invalid input
 statement error
-select substr(192, 1, 1)
+SELECT substr(192, 1, 1)
 
 statement error
-select substr('from wrong type', 1.5, 2)
+SELECT substr('from wrong type', 1.5, 2)
 
 statement error
-select substr('for wrong type', 2, 1.5)
+SELECT substr('for wrong type', 2, 1.5)
 
 query I
-select substr('for cannot be negative', 1, -3)
+SELECT substr('for cannot be negative', 1, -3)
 ----
 NULL
 
 query I
-select substr('for still cannot be negative', 30, -2)
+SELECT substr('for still cannot be negative', 30, -2)
 ----
 NULL
 
-#standard tests
+# standard tests
 
-#TODO: materialize#589 select strcol from substrtest
+# TODO: materialize#589 SELECT strcol FROM substrtest
 query T colnames
-select substr(vccol, 1, 3) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 1, 3) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -83,7 +83,7 @@ man
 爱不释
 
 query T colnames
-select substr(vccol, 1, 5) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 1, 5) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -94,7 +94,7 @@ manga
 爱不释手
 
 query T colnames
-select substr(vccol, 1) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 1) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -105,7 +105,7 @@ manganese
 爱不释手
 
 query T colnames
-select substr(vccol, 3) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 3) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -116,7 +116,7 @@ nganese
 释手
 
 query T colnames
-select substr(vccol, 3, 1) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 3, 1) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -126,9 +126,9 @@ NULL
 n
 释
 
-#negative start position
+# negative start position
 query T colnames
-select substr(vccol, -1) as vcres from substrtest order by vcres;
+SELECT substr(vccol, -1) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -139,7 +139,7 @@ manganese
 爱不释手
 
 query T colnames
-select substr(vccol, -2, 6) as vcres from substrtest order by vcres;
+SELECT substr(vccol, -2, 6) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -150,7 +150,7 @@ man
 爱不释
 
 query T colnames
-select substr(vccol, -3, 5) as vcres from substrtest order by vcres;
+SELECT substr(vccol, -3, 5) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -161,7 +161,7 @@ m
 爱
 
 query TT colnames
-select substr(strcol, -4, 5) as strres, substr(vccol, -4, 5) as vcres from substrtest order by vcres;
+SELECT substr(strcol, -4, 5) AS strres, substr(vccol, -4, 5) AS vcres FROM substrtest ORDER BY vcres
 ----
 strres  vcres
 NULL    NULL
@@ -172,7 +172,7 @@ NULL    NULL
 (empty) (empty)
 
 query TT colnames
-select substr(strcol, -6, 6) as strres, substr(vccol, -6, 6) as vcres from substrtest order by vcres;
+SELECT substr(strcol, -6, 6) AS strres, substr(vccol, -6, 6) AS vcres FROM substrtest ORDER BY vcres
 ----
 strres  vcres
 NULL    NULL
@@ -183,7 +183,7 @@ NULL    NULL
 (empty) (empty)
 
 query TT colnames
-select substr(strcol, -5, 4) as strres, substr(vccol, -5, 4) as vcres from substrtest order by vcres;
+SELECT substr(strcol, -5, 4) AS strres, substr(vccol, -5, 4) AS vcres FROM substrtest ORDER BY vcres
 ----
 strres  vcres
 NULL    NULL
@@ -193,9 +193,9 @@ NULL    NULL
 (empty) (empty)
 (empty) (empty)
 
-#for or start is zero
+# for or start is zero
 query T colnames
-select substr(vccol, 0) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 0) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -206,7 +206,7 @@ manganese
 爱不释手
 
 query T colnames
-select substr(vccol, 0, 3) as vcres from substrtest order by vcres;
+SELECT substr(vccol, 0, 3) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -217,7 +217,7 @@ ma
 爱不
 
 query TT colnames
-select substr(strcol, 0, 0) as strres, substr(vccol, 0, 0) as vcres from substrtest order by vcres;
+SELECT substr(strcol, 0, 0) AS strres, substr(vccol, 0, 0) AS vcres FROM substrtest ORDER BY vcres
 ----
 strres  vcres
 NULL    NULL
@@ -228,7 +228,7 @@ NULL    NULL
 (empty) (empty)
 
 query TT colnames
-select substr(strcol, 3, 0) as strres, substr(vccol, 3, 0) as vcres from substrtest order by vcres;
+SELECT substr(strcol, 3, 0) AS strres, substr(vccol, 3, 0) AS vcres FROM substrtest ORDER BY vcres
 ----
 strres  vcres
 NULL    NULL
@@ -238,50 +238,50 @@ NULL    NULL
 (empty) (empty)
 (empty) (empty)
 
-#null inputs
+# NULL inputs
 query T
-select substr(null, 1);
+SELECT substr(NULL, 1)
 ----
 NULL
 
 query T
-select substr(null, 1, 3);
+SELECT substr(NULL, 1, 3)
 ----
 NULL
 
 query T
-select substr('text string', null);
+SELECT substr('text string', NULL)
 ----
 NULL
 
 query T
-select substr(null, null);
+SELECT substr(NULL, NULL)
 ----
 NULL
 
 query T
-select substr('foo', null, 3);
+SELECT substr('foo', NULL, 3)
 ----
 NULL
 
 query T
-select substr('bar', null, null);
+SELECT substr('bar', NULL, NULL)
 ----
 NULL
 
 query T
-select substr('baz', 2, null);
+SELECT substr('baz', 2, NULL)
 ----
 NULL
 
 query T
-select substr(null, null, null);
+SELECT substr(NULL, NULL, NULL)
 ----
 NULL
 
-#alternative syntax
+# alternative syntax
 query T colnames
-select substring(vccol, 1, 3) as vcres from substrtest order by vcres;
+SELECT substring(vccol, 1, 3) AS vcres FROM substrtest ORDER BY vcres
 ----
 vcres
 NULL
@@ -291,9 +291,9 @@ Mn
 man
 爱不释
 
-#testing different kinds of int columns and null content in columns
+# testing different kinds of int columns and NULL content in columns
 query T
-select substr(vccol, smicol, smicol) as vcres from substrtest order by vcres;
+SELECT substr(vccol, smicol, smicol) AS vcres FROM substrtest ORDER BY vcres
 ----
 NULL
 NULL
@@ -303,7 +303,7 @@ M
 nga
 
 query T
-select substr(vccol, intcol, intcol) as vcres from substrtest order by vcres;
+SELECT substr(vccol, intcol, intcol) AS vcres FROM substrtest ORDER BY vcres
 ----
 NULL
 NULL
@@ -313,7 +313,7 @@ M
 不释
 
 query T
-select substr(vccol, smicol, intcol) as vcres from substrtest order by vcres;
+SELECT substr(vccol, smicol, intcol) AS vcres FROM substrtest ORDER BY vcres
 ----
 NULL
 NULL
@@ -323,7 +323,7 @@ NULL
 M
 
 query T
-select substr(vccol, intcol, smicol) as vcres from substrtest order by vcres;
+SELECT substr(vccol, intcol, smicol) AS vcres FROM substrtest ORDER BY vcres
 ----
 NULL
 NULL
@@ -333,29 +333,32 @@ NULL
 M
 
 query T
-select substr('subexpression test', ascii(''), 3);
+SELECT substr('subexpression test', ascii(''), 3)
 ----
 su
 
-#TODO: materialize#606 Add tests for the alternate syntax if it is enabled
+# TODO: materialize#606 Add tests for the alternate syntax if it is enabled
 
 ### length ###
 statement ok
-create table lengthtest(strcol CHAR(15), vccol VARCHAR(15));
+CREATE TABLE lengthtest(strcol char(15), vccol varchar(15))
 
 statement ok
-insert into lengthtest values ('str', 'str'), (' str', ' str'), ('str ', 'str '), ('你好', '你好'), ('今日は', '今日は'), ('हेलो', 'हेलो'), (null, null), ('','');
+INSERT INTO lengthtest VALUES
+    ('str', 'str'), (' str', ' str'), ('str ', 'str '), ('你好', '你好'),
+    ('今日は', '今日は'), ('हेलो', 'हेलो'),
+    (NULL, NULL), ('', '')
 
-#invalid input
+# invalid input
 statement error
-select length(99)
+SELECT length(99)
 
 statement error
-select length('str', 99)
+SELECT length('str', 99)
 
-#standard tests
+# standard tests
 query I rowsort
-select length(strcol) from lengthtest;
+SELECT length(strcol) FROM lengthtest
 ----
 15
 15
@@ -367,7 +370,7 @@ select length(strcol) from lengthtest;
 NULL
 
 query I rowsort
-select length(vccol) from lengthtest;
+SELECT length(vccol) FROM lengthtest
 ----
 0
 2
@@ -379,45 +382,45 @@ select length(vccol) from lengthtest;
 NULL
 
 query I
-select length('你好', 'big5');
+SELECT length('你好', 'big5')
 ----
 3
 
 query I
-select length('你好', 'iso-8859-5');
+SELECT length('你好', 'iso-8859-5')
 ----
 6
 
-#encoding name conversion from pg to WHATWG
+# encoding name conversion FROM pg to WHATWG
 query I
-select length('你好', 'ISO_8859_5');
+SELECT length('你好', 'ISO_8859_5')
 ----
 6
 
-#invalid encoding name
+# invalid encoding name
 query I
-select length('你好', 'iso-123');
+SELECT length('你好', 'iso-123')
 ----
 NULL
 
-#null inputs
+# NULL inputs
 query I
-select length(null);
+SELECT length(NULL)
 ----
 NULL
 
 query I
-select length('str', null);
+SELECT length('str', NULL)
 ----
 NULL
 
 query T
-select replace('one', 'one', 'two');
+SELECT replace('one', 'one', 'two')
 ----
 two
 
 query T
-select replace('in a longer string', 'longer', 'shorter')
+SELECT replace('in a longer string', 'longer', 'shorter')
 ----
 in a shorter string
 

--- a/test/subquery.slt
+++ b/test/subquery.slt
@@ -11,7 +11,7 @@ CREATE TABLE peeps (
 )
 
 statement ok
-INSERT INTO peeps VALUES ('alice'), ('bob'), ('eve');
+INSERT INTO peeps VALUES ('alice'), ('bob'), ('eve')
 
 statement ok
 CREATE TABLE likes (
@@ -20,7 +20,7 @@ CREATE TABLE likes (
 )
 
 statement ok
-INSERT INTO likes VALUES ('alice', 'bob'), ('bob', 'eve'), ('alice', 'eve');
+INSERT INTO likes VALUES ('alice', 'bob'), ('bob', 'eve'), ('alice', 'eve')
 
 query TB rowsort
 SELECT peep, EXISTS(
@@ -102,7 +102,7 @@ statement ok
 CREATE TABLE age (peep text, age int)
 
 statement ok
-INSERT INTO age VALUES ('alice', 103), ('bob', 100), ('eve', 104);
+INSERT INTO age VALUES ('alice', 103), ('bob', 100), ('eve', 104)
 
 # TODO: materialize#489 This test should throw an error because
 # subquery returns more than one row

--- a/test/tpch.slt
+++ b/test/tpch.slt
@@ -27,7 +27,7 @@ CREATE TABLE part (
     p_type        varchar(25) NOT NULL,
     p_size        integer NOT NULL,
     p_container   char(10) NOT NULL,
-    p_retailprice decimal(15,2) NOT NULL,
+    p_retailprice decimal(15, 2) NOT NULL,
     p_comment     varchar(23) NOT NULL
 )
 
@@ -38,7 +38,7 @@ CREATE TABLE supplier (
     s_address     varchar(40) NOT NULL,
     s_nationkey   integer NOT NULL,
     s_phone       char(15) NOT NULL,
-    s_acctbal     decimal(15,2) NOT NULL,
+    s_acctbal     decimal(15, 2) NOT NULL,
     s_comment     varchar(101) NOT NULL
 )
 
@@ -47,7 +47,7 @@ CREATE TABLE partsupp (
     ps_partkey     integer NOT NULL,
     ps_suppkey     integer NOT NULL,
     ps_availqty    integer NOT NULL,
-    ps_supplycost  decimal(15,2) NOT NULL,
+    ps_supplycost  decimal(15, 2) NOT NULL,
     ps_comment     varchar(199) NOT NULL,
     PRIMARY KEY (ps_partkey, ps_suppkey)
 )
@@ -59,7 +59,7 @@ CREATE TABLE customer (
     c_address     varchar(40) NOT NULL,
     c_nationkey   integer NOT NULL,
     c_phone       char(15) NOT NULL,
-    c_acctbal     decimal(15,2) NOT NULL,
+    c_acctbal     decimal(15, 2) NOT NULL,
     c_mktsegment  char(10) NOT NULL,
     c_comment     varchar(117) NOT NULL
 )
@@ -69,8 +69,8 @@ CREATE TABLE orders (
     o_orderkey       integer PRIMARY KEY,
     o_custkey        integer NOT NULL,
     o_orderstatus    char(1) NOT NULL,
-    o_totalprice     decimal(15,2) NOT NULL,
-    o_orderdate      date NOT NULL,
+    o_totalprice     decimal(15, 2) NOT NULL,
+    o_orderdate      DATE NOT NULL,
     o_orderpriority  char(15) NOT NULL,
     o_clerk          char(15) NOT NULL,
     o_shippriority   integer NOT NULL,
@@ -83,10 +83,10 @@ CREATE TABLE lineitem (
     l_partkey        integer NOT NULL,
     l_suppkey        integer NOT NULL,
     l_linenumber     integer NOT NULL,
-    l_quantity       decimal(15,2) NOT NULL,
-    l_extendedprice  decimal(15,2) NOT NULL,
-    l_discount       decimal(15,2) NOT NULL,
-    l_tax            decimal(15,2) NOT NULL,
+    l_quantity       decimal(15, 2) NOT NULL,
+    l_extendedprice  decimal(15, 2) NOT NULL,
+    l_discount       decimal(15, 2) NOT NULL,
+    l_tax            decimal(15, 2) NOT NULL,
     l_returnflag     char(1) NOT NULL,
     l_linestatus     char(1) NOT NULL,
     l_shipdate       date NOT NULL,
@@ -103,18 +103,18 @@ query T multiline
 EXPLAIN PLAN FOR SELECT
 	l_returnflag,
 	l_linestatus,
-	sum(l_quantity) as sum_qty,
-	sum(l_extendedprice) as sum_base_price,
-	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
-	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
-	avg(l_quantity) as avg_qty,
-	avg(l_extendedprice) as avg_price,
-	avg(l_discount) as avg_disc,
-	count(*) as count_order
+	sum(l_quantity) AS sum_qty,
+	sum(l_extendedprice) AS sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+	avg(l_quantity) AS avg_qty,
+	avg(l_extendedprice) AS avg_price,
+	avg(l_discount) AS avg_disc,
+	count(*) AS count_order
 FROM
 	lineitem
 WHERE
-	l_shipdate <= date '1998-12-01' -- - interval '60' day (fails with an error)
+	l_shipdate <= DATE '1998-12-01' -- - INTERVAL '60' day (fails with an error)
 GROUP BY
 	l_returnflag,
 	l_linestatus
@@ -168,7 +168,7 @@ FROM
 WHERE
     p_partkey = ps_partkey
     AND s_suppkey = ps_suppkey
-    AND p_size = cast(15 as smallint)
+    AND p_size = CAST (15 AS smallint)
     AND p_type LIKE '%BRASS'
     AND s_nationkey = n_nationkey
     AND n_regionkey = r_regionkey
@@ -187,7 +187,7 @@ WHERE
                     AND r_name = 'EUROPE'
             )
 ORDER BY
-    s_acctbal DESC, n_name, s_name, p_partkey;
+    s_acctbal DESC, n_name, s_name, p_partkey
 ----
 Let {
   l0 = Join {
@@ -241,26 +241,26 @@ query T multiline
 -- Query 03
 EXPLAIN PLAN FOR SELECT
     l_orderkey,
-    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
     o_orderdate,
     o_shippriority
-from
+FROM
     customer,
     orders,
     lineitem
-where
+WHERE
     c_mktsegment = 'BUILDING'
-    and c_custkey = o_custkey
-    and l_orderkey = o_orderkey
-    and o_orderdate < date '1995-03-15'
-    and l_shipdate > date '1995-03-15'
-group by
+    AND c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate < DATE '1995-03-15'
+    AND l_shipdate > DATE '1995-03-15'
+GROUP BY
     l_orderkey,
     o_orderdate,
     o_shippriority
-order by
-    revenue desc,
-    o_orderdate;
+ORDER BY
+    revenue DESC,
+    o_orderdate
 ----
 Project {
   outputs: [0, 3, 1, 2],
@@ -287,25 +287,25 @@ query T multiline
 -- Query 04
 EXPLAIN PLAN FOR SELECT
     o_orderpriority,
-    count(*) as order_count
-from
+    count(*) AS order_count
+FROM
     orders
-where
-    o_orderdate >= date '1993-07-01'
-    and o_orderdate < date '1993-07-01' + interval '3' month
-    and exists (
-        select
+WHERE
+    o_orderdate >= DATE '1993-07-01'
+    AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' month
+    AND EXISTS (
+        SELECT
             *
-        from
+        FROM
             lineitem
-        where
+        WHERE
             l_orderkey = o_orderkey
-            and l_commitdate < l_receiptdate
+            AND l_commitdate < l_receiptdate
     )
-group by
+GROUP BY
     o_orderpriority
-order by
-    o_orderpriority;
+ORDER BY
+    o_orderpriority
 ----
 Let {
   l0 = Filter {
@@ -338,28 +338,28 @@ query T multiline
 -- Query 05
 EXPLAIN PLAN FOR SELECT
     n_name,
-    sum(l_extendedprice * (1 - l_discount)) as revenue
-from
+    sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
     customer,
     orders,
     lineitem,
     supplier,
     nation,
     region
-where
+WHERE
     c_custkey = o_custkey
-    and l_orderkey = o_orderkey
-    and l_suppkey = s_suppkey
-    and c_nationkey = s_nationkey
-    and s_nationkey = n_nationkey
-    and n_regionkey = r_regionkey
-    and r_name = 'ASIA'
-    and o_orderdate >= date '1994-01-01'
-    and o_orderdate < date '1995-01-01'
-group by
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'ASIA'
+    AND o_orderdate >= DATE '1994-01-01'
+    AND o_orderdate < DATE '1995-01-01'
+GROUP BY
     n_name
-order by
-    revenue desc;
+ORDER BY
+    revenue DESC
 ----
 Reduce {
   group_key: [9],
@@ -388,15 +388,14 @@ Reduce {
 query T multiline
 -- Query 06
 EXPLAIN PLAN FOR SELECT
-    sum(l_extendedprice * l_discount) as revenue
-from
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
     lineitem
-where
+WHERE
     l_quantity < 24
-    and l_shipdate >= date '1994-01-01'
-    and l_shipdate < date '1994-01-01' + interval '1' year
-    and l_discount between 0.06 - 0.01 and 0.07
-    ;
+    AND l_shipdate >= DATE '1994-01-01'
+    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
+    AND l_discount BETWEEN 0.06 - 0.01 AND 0.07
 ----
 Let {
   l0 = Reduce {
@@ -432,41 +431,41 @@ EXPLAIN PLAN FOR SELECT
     supp_nation,
     cust_nation,
     l_year,
-    sum(volume) as revenue
-from
+    sum(volume) AS revenue
+FROM
     (
-        select
-            n1.n_name as supp_nation,
-            n2.n_name as cust_nation,
-            extract(year from l_shipdate) as l_year,
-            l_extendedprice * (1 - l_discount) as volume
-        from
+        SELECT
+            n1.n_name AS supp_nation,
+            n2.n_name AS cust_nation,
+            extract(year FROM l_shipdate) AS l_year,
+            l_extendedprice * (1 - l_discount) AS volume
+        FROM
             supplier,
             lineitem,
             orders,
             customer,
             nation n1,
             nation n2
-        where
+        WHERE
             s_suppkey = l_suppkey
-            and o_orderkey = l_orderkey
-            and c_custkey = o_custkey
-            and s_nationkey = n1.n_nationkey
-            and c_nationkey = n2.n_nationkey
-            and (
-                (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
-                or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+            AND o_orderkey = l_orderkey
+            AND c_custkey = o_custkey
+            AND s_nationkey = n1.n_nationkey
+            AND c_nationkey = n2.n_nationkey
+            AND (
+                (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+                or (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
             )
-            and l_shipdate between date '1995-01-01' and date '1996-12-31'
-    ) as shipping
-group by
+            AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+    ) AS shipping
+GROUP BY
     supp_nation,
     cust_nation,
     l_year
-order by
+ORDER BY
     supp_nation,
     cust_nation,
-    l_year;
+    l_year
 ----
 Reduce {
   group_key: [8, 45, 48],
@@ -509,14 +508,14 @@ EXPLAIN PLAN FOR SELECT
     sum(case
         when nation = 'BRAZIL' then volume
         else 0
-    end) / sum(volume) as mkt_share
-from
+    end) / sum(volume) AS mkt_share
+FROM
     (
-        select
-            extract(year from o_orderdate) as o_year,
-            l_extendedprice * (1 - l_discount) as volume,
-            n2.n_name as nation
-        from
+        SELECT
+            extract(year FROM o_orderdate) AS o_year,
+            l_extendedprice * (1 - l_discount) AS volume,
+            n2.n_name AS nation
+        FROM
             part,
             supplier,
             lineitem,
@@ -525,22 +524,22 @@ from
             nation n1,
             nation n2,
             region
-        where
+        WHERE
             p_partkey = l_partkey
-            and s_suppkey = l_suppkey
-            and l_orderkey = o_orderkey
-            and o_custkey = c_custkey
-            and c_nationkey = n1.n_nationkey
-            and n1.n_regionkey = r_regionkey
-            and r_name = 'AMERICA'
-            and s_nationkey = n2.n_nationkey
-            and o_orderdate between date '1995-01-01' and date '1996-12-31'
-            and p_type = 'ECONOMY ANODIZED STEEL'
-    ) as all_nations
-group by
+            AND s_suppkey = l_suppkey
+            AND l_orderkey = o_orderkey
+            AND o_custkey = c_custkey
+            AND c_nationkey = n1.n_nationkey
+            AND n1.n_regionkey = r_regionkey
+            AND r_name = 'AMERICA'
+            AND s_nationkey = n2.n_nationkey
+            AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+            AND p_type = 'ECONOMY ANODIZED STEEL'
+    ) AS all_nations
+GROUP BY
     o_year
-order by
-    o_year;
+ORDER BY
+    o_year
 ----
 Project {
   outputs: [0, 3],
@@ -593,35 +592,35 @@ query T multiline
 EXPLAIN PLAN FOR SELECT
     nation,
     o_year,
-    sum(amount) as sum_profit
-from
+    sum(amount) AS sum_profit
+FROM
     (
-        select
-            n_name as nation,
-            extract(year from o_orderdate) as o_year,
-            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
-        from
+        SELECT
+            n_name AS nation,
+            extract(year FROM o_orderdate) AS o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+        FROM
             part,
             supplier,
             lineitem,
             partsupp,
             orders,
             nation
-        where
+        WHERE
             s_suppkey = l_suppkey
-            and ps_suppkey = l_suppkey
-            and ps_partkey = l_partkey
-            and p_partkey = l_partkey
-            and o_orderkey = l_orderkey
-            and s_nationkey = n_nationkey
-            and p_name like 'green'
-    ) as profit
-group by
+            AND ps_suppkey = l_suppkey
+            AND ps_partkey = l_partkey
+            AND p_partkey = l_partkey
+            AND o_orderkey = l_orderkey
+            AND s_nationkey = n_nationkey
+            AND p_name like 'green'
+    ) AS profit
+GROUP BY
     nation,
     o_year
-order by
+ORDER BY
     nation,
-    o_year desc;
+    o_year DESC
 ----
 Reduce {
   group_key: [47, 50],
@@ -654,26 +653,26 @@ query T multiline
 EXPLAIN PLAN FOR SELECT
     c_custkey,
     c_name,
-    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
     c_acctbal,
     n_name,
     c_address,
     c_phone,
     c_comment
-from
+FROM
     customer,
     orders,
     lineitem,
     nation
-where
+WHERE
     c_custkey = o_custkey
-    and l_orderkey = o_orderkey
-    and o_orderdate >= date '1993-10-01'
-    and o_orderdate < date '1994-01-01'
-    and o_orderdate < date '1993-10-01' + interval '3' month
-    and l_returnflag = 'R'
-    and c_nationkey = n_nationkey
-group by
+    AND l_orderkey = o_orderkey
+    AND o_orderdate >= DATE '1993-10-01'
+    AND o_orderdate < DATE '1994-01-01'
+    AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' month
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+GROUP BY
     c_custkey,
     c_name,
     c_acctbal,
@@ -681,8 +680,8 @@ group by
     n_name,
     c_address,
     c_comment
-order by
-    revenue desc;
+ORDER BY
+    revenue DESC
 ----
 Project {
   outputs: [0, 1, 7, 2, 4, 5, 3, 6],
@@ -715,31 +714,31 @@ query T multiline
 -- Query 11
 EXPLAIN PLAN FOR SELECT
     ps_partkey,
-    sum(ps_supplycost * ps_availqty) as value
-from
+    sum(ps_supplycost * ps_availqty) AS value
+FROM
     partsupp,
     supplier,
     nation
-where
+WHERE
     ps_suppkey = s_suppkey
-    and s_nationkey = n_nationkey
-    and n_name = 'GERMANY'
-group by
+    AND s_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+GROUP BY
     ps_partkey having
         sum(ps_supplycost * ps_availqty) > (
-            select
+            SELECT
                 sum(ps_supplycost * ps_availqty) * 0.0001
-            from
+            FROM
                 partsupp,
                 supplier,
                 nation
-            where
+            WHERE
                 ps_suppkey = s_suppkey
-                and s_nationkey = n_nationkey
-                and n_name = 'GERMANY'
+                AND s_nationkey = n_nationkey
+                AND n_name = 'GERMANY'
         )
-order by
-    value desc;
+ORDER BY
+    value DESC
 ----
 Let {
   l0 = Join {
@@ -782,27 +781,27 @@ EXPLAIN PLAN FOR SELECT
             or o_orderpriority = '2-HIGH'
             then 1
         else 0
-    end) as high_line_count,
+    end) AS high_line_count,
     sum(case
         when o_orderpriority <> '1-URGENT'
-            and o_orderpriority <> '2-HIGH'
+            AND o_orderpriority <> '2-HIGH'
             then 1
         else 0
-    end) as low_line_count
-from
+    end) AS low_line_count
+FROM
     orders,
     lineitem
-where
+WHERE
     o_orderkey = l_orderkey
-    and l_shipmode in ('MAIL', 'SHIP')
-    and l_commitdate < l_receiptdate
-    and l_shipdate < l_commitdate
-    and l_receiptdate >= date '1994-01-01'
-    and l_receiptdate < date '1994-01-01' + interval '1' year
-group by
+    AND l_shipmode IN ('MAIL', 'SHIP')
+    AND l_commitdate < l_receiptdate
+    AND l_shipdate < l_commitdate
+    AND l_receiptdate >= DATE '1994-01-01'
+    AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' year
+GROUP BY
     l_shipmode
-order by
-    l_shipmode;
+ORDER BY
+    l_shipmode
 ----
 Reduce {
   group_key: [23],
@@ -831,24 +830,24 @@ query T multiline
 -- Query 13
 EXPLAIN PLAN FOR SELECT
     c_count,
-    count(*) as custdist
-from
+    count(*) AS custdist
+FROM
     (
-        select
+        SELECT
             c_custkey,
             count(o_orderkey) c_count -- workaround for no column aliases
-        from
-            customer left outer join orders on
+        FROM
+            customer LEFT OUTER JOIN orders ON
                 c_custkey = o_custkey
-                and o_comment not like '%special%requests%'
-        group by
+                AND o_comment NOT LIKE '%special%requests%'
+        GROUP BY
             c_custkey
-    ) as c_orders -- (c_custkey, c_count) -- no column aliases yet
-group by
+    ) AS c_orders -- (c_custkey, c_count) -- no column aliases yet
+GROUP BY
     c_count
-order by
-    custdist desc,
-    c_count desc;
+ORDER BY
+    custdist DESC,
+    c_count DESC
 ----
 Let {
   l0 = Join {
@@ -897,14 +896,14 @@ EXPLAIN PLAN FOR SELECT
         when p_type like 'PROMO%'
             then l_extendedprice * (1 - l_discount)
         else 0
-    end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
-from
+    end) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
     lineitem,
     part
-where
+WHERE
     l_partkey = p_partkey
-    and l_shipdate >= date '1996-01-01'
-    and l_shipdate < date '1996-01-01' + interval '1' month
+    AND l_shipdate >= DATE '1996-01-01'
+    AND l_shipdate < DATE '1996-01-01' + INTERVAL '1' month
 ----
 Let {
   l0 = Reduce {
@@ -946,17 +945,17 @@ Project {
 
 statement ok
 create view revenue (supplier_no, total_revenue) as
-    select
+    SELECT
         l_suppkey,
         sum(l_extendedprice * (1 - l_discount))
-    from
+    FROM
         lineitem
-    where
-        l_shipdate >= date '1996-01-01'
-        and l_shipdate < date '1996-04-01'
-        and l_shipdate < date '1996-01-01' + interval '3' month
-    group by
-        l_suppkey;
+    WHERE
+        l_shipdate >= DATE '1996-01-01'
+        AND l_shipdate < DATE '1996-04-01'
+        AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' month
+    GROUP BY
+        l_suppkey
 
 query T multiline
 -- Query 15
@@ -966,19 +965,19 @@ EXPLAIN PLAN FOR SELECT
     s_address,
     s_phone,
     total_revenue
-from
+FROM
     supplier,
     revenue
-where
+WHERE
     s_suppkey = supplier_no
-    and total_revenue = (
-        select
+    AND total_revenue = (
+        SELECT
             max(total_revenue)
-        from
+        FROM
             revenue
     )
-order by
-    s_suppkey;
+ORDER BY
+    s_suppkey
 ----
 Project {
   outputs: [0 .. 2, 4, 8],
@@ -998,7 +997,7 @@ Project {
 }
 
 statement ok
-drop view revenue;
+drop view revenue
 
 
 query T multiline
@@ -1007,32 +1006,32 @@ EXPLAIN PLAN FOR SELECT
     p_brand,
     p_type,
     p_size,
-    count(distinct ps_suppkey) as supplier_cnt
-from
+    count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
     partsupp,
     part
-where
+WHERE
     p_partkey = ps_partkey
-    and p_brand <> 'Brand#45'
-    and p_type not like 'MEDIUM POLISHED%'
-    and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
-    and ps_suppkey not in (
-        select
+    AND p_brand <> 'Brand#45'
+    AND p_type NOT LIKE 'MEDIUM POLISHED%'
+    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
+        SELECT
             s_suppkey
-        from
+        FROM
             supplier
-        where
+        WHERE
             s_comment like '%Customer%Complaints%'
     )
-group by
+GROUP BY
     p_brand,
     p_type,
     p_size
-order by
-    supplier_cnt desc,
+ORDER BY
+    supplier_cnt DESC,
     p_brand,
     p_type,
-    p_size;
+    p_size
 ----
 Let {
   l0 = Join {
@@ -1100,22 +1099,22 @@ Reduce {
 query T multiline
 -- Query 17
 EXPLAIN PLAN FOR SELECT
-  sum(l_extendedprice) / 7.0 as avg_yearly
-from
+  sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
   lineitem,
   part
-where
+WHERE
   p_partkey = l_partkey
-  and p_brand = 'Brand#23'
-  and p_container = 'MED BOX'
-  and l_quantity < (
-    select
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity < (
+    SELECT
       0.2 * avg(l_quantity)
-    from
+    FROM
       lineitem
-    where
+    WHERE
       l_partkey = p_partkey
-  );
+  )
 ----
 Let {
   l1 = Join {
@@ -1183,31 +1182,31 @@ EXPLAIN PLAN FOR SELECT
     o_orderdate,
     o_totalprice,
     sum(l_quantity)
-from
+FROM
     customer,
     orders,
     lineitem
-where
-    o_orderkey in (
-        select
+WHERE
+    o_orderkey IN (
+        SELECT
             l_orderkey
-        from
+        FROM
             lineitem
-        group by
+        GROUP BY
             l_orderkey having
                 sum(l_quantity) > 300
     )
-    and c_custkey = o_custkey
-    and o_orderkey = l_orderkey
-group by
+    AND c_custkey = o_custkey
+    AND o_orderkey = l_orderkey
+GROUP BY
     c_name,
     c_custkey,
     o_orderkey,
     o_orderdate,
     o_totalprice
-order by
-    o_totalprice desc,
-    o_orderdate;
+ORDER BY
+    o_totalprice DESC,
+    o_orderdate
 ----
 Let {
   l0 = Join {
@@ -1246,40 +1245,40 @@ Reduce {
 query T multiline
 -- Query 19
 EXPLAIN PLAN FOR SELECT
-    sum(l_extendedprice* (1 - l_discount)) as revenue
-from
+    sum(l_extendedprice* (1 - l_discount)) AS revenue
+FROM
     lineitem,
     part
-where
+WHERE
     (
         p_partkey = l_partkey
-        and p_brand = 'Brand#12'
-        and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
-        and l_quantity >= cast(1 as smallint) and l_quantity <= cast(1 + 10 as smallint)
-        and p_size between cast(1 as smallint) and cast(5 as smallint)
-        and l_shipmode in ('AIR', 'AIR REG')
-        and l_shipinstruct = 'DELIVER IN PERSON'
+        AND p_brand = 'Brand#12'
+        AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        AND l_quantity >= CAST (1 AS smallint) AND l_quantity <= CAST (1 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (5 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
     )
     or
     (
         p_partkey = l_partkey
-        and p_brand = 'Brand#23'
-        and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
-        and l_quantity >= cast(10 as smallint) and l_quantity <= cast(10 + 10 as smallint)
-        and p_size between cast(1 as smallint) and cast(10 as smallint)
-        and l_shipmode in ('AIR', 'AIR REG')
-        and l_shipinstruct = 'DELIVER IN PERSON'
+        AND p_brand = 'Brand#23'
+        AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        AND l_quantity >= CAST (10 AS smallint) AND l_quantity <= CAST (10 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (10 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
     )
     or
     (
         p_partkey = l_partkey
-        and p_brand = 'Brand#34'
-        and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
-        and l_quantity >= cast(20 as smallint) and l_quantity <= cast(20 + 10 as smallint)
-        and p_size between cast(1 as smallint) and cast(15 as smallint)
-        and l_shipmode in ('AIR', 'AIR REG')
-        and l_shipinstruct = 'DELIVER IN PERSON'
-    );
+        AND p_brand = 'Brand#34'
+        AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        AND l_quantity >= CAST (20 AS smallint) AND l_quantity <= CAST (20 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (15 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
 ----
 Let {
   l0 = Reduce {
@@ -1398,40 +1397,40 @@ query T multiline
 EXPLAIN PLAN FOR SELECT
     s_name,
     s_address
-from
+FROM
     supplier,
     nation
-where
-    s_suppkey in (
-        select
+WHERE
+    s_suppkey IN (
+        SELECT
             ps_suppkey
-        from
+        FROM
             partsupp
-        where
-            ps_partkey in (
-                select
+        WHERE
+            ps_partkey IN (
+                SELECT
                     p_partkey
-                from
+                FROM
                     part
-                where
+                WHERE
                     p_name like 'forest%'
             )
-            and ps_availqty > (
-                select
+            AND ps_availqty > (
+                SELECT
                     0.5 * sum(l_quantity)
-                from
+                FROM
                     lineitem
-                where
+                WHERE
                     l_partkey = ps_partkey
-                    and l_suppkey = ps_suppkey
-                    and l_shipdate >= date '1995-01-01'
-                    and l_shipdate < date '1995-01-01' + interval '1' year
+                    AND l_suppkey = ps_suppkey
+                    AND l_shipdate >= DATE '1995-01-01'
+                    AND l_shipdate < DATE '1995-01-01' + INTERVAL '1' year
             )
     )
-    and s_nationkey = n_nationkey
-    and n_name = 'CANADA'
-order by
-    s_name;
+    AND s_nationkey = n_nationkey
+    AND n_name = 'CANADA'
+ORDER BY
+    s_name
 ----
 Let {
   l0 = Join {
@@ -1504,43 +1503,43 @@ query T multiline
 -- Query 21
 EXPLAIN PLAN FOR SELECT
     s_name,
-    count(*) as numwait
-from
+    count(*) AS numwait
+FROM
     supplier,
     lineitem l1,
     orders,
     nation
-where
+WHERE
     s_suppkey = l1.l_suppkey
-    and o_orderkey = l1.l_orderkey
-    and o_orderstatus = 'F'
-    and l1.l_receiptdate > l1.l_commitdate
-    and exists (
-        select
+    AND o_orderkey = l1.l_orderkey
+    AND o_orderstatus = 'F'
+    AND l1.l_receiptdate > l1.l_commitdate
+    AND EXISTS (
+        SELECT
             *
-        from
+        FROM
             lineitem l2
-        where
+        WHERE
             l2.l_orderkey = l1.l_orderkey
-            and l2.l_suppkey <> l1.l_suppkey
+            AND l2.l_suppkey <> l1.l_suppkey
     )
-    and not exists (
-        select
+    AND not EXISTS (
+        SELECT
             *
-        from
+        FROM
             lineitem l3
-        where
+        WHERE
             l3.l_orderkey = l1.l_orderkey
-            and l3.l_suppkey <> l1.l_suppkey
-            and l3.l_receiptdate > l3.l_commitdate
+            AND l3.l_suppkey <> l1.l_suppkey
+            AND l3.l_receiptdate > l3.l_commitdate
     )
-    and s_nationkey = n_nationkey
-    and n_name = 'SAUDI ARABIA'
-group by
+    AND s_nationkey = n_nationkey
+    AND n_name = 'SAUDI ARABIA'
+GROUP BY
     s_name
-order by
-    numwait desc,
-    s_name;
+ORDER BY
+    numwait DESC,
+    s_name
 ----
 Let {
   l1 = Join {
@@ -1656,7 +1655,7 @@ FROM
 GROUP BY
     cntrycode
 ORDER BY
-    cntrycode;
+    cntrycode
 ----
 Let {
   l0 = Filter {


### PR DESCRIPTION
Adopt the SQL formatting guidelines that PostgreSQL uses in their
manual. Write them down, too, in the developer documentation, since they
don't seem to be explicitly listed anywhere.