### PR TITLE
Add metabase to docker-compose

### DIFF
--- a/ex/chbench/docker-compose.yml
+++ b/ex/chbench/docker-compose.yml
@@ -13,6 +13,7 @@ x-port-mappings:
   mysql: &mysql 3306:3306
   kafka-control-center: &control-center 9021:9021
   grafana: &grafana 3000:3000
+  metabase: &metabase 3030:3000
   prometheus: &prometheus 9090:9090
   pushgateway: &pushgateway 9091:9091
 
@@ -136,6 +137,13 @@ services:
   inspect:
     image: ubuntu:bionic
     command: "true"
+
+  # Metabase
+  metabase:
+    image: materialize/metabase:mz-2019-12-04
+    depends_on: [materialized]
+    ports:
+      - *metabase
 
   # All the metrics containers
   #


### PR DESCRIPTION
The metabase version that we are using was built by running these commands:

    cd /tmp
    git clone --depth 5 --recursive git@github.com:MaterializeInc/metabase.git
    bin/docker/build_image.sh source mz-2019-12-04

You will be able to connect to metabase on port 3030, but you will need to manually
connect it to materialized (at host `materialized` port `6875`). At which point pretty
much everything should work.

Fixes MaterializeInc/database-issues#310
