### PR TITLE
Make sort order stable by adding a tiebreaker.

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -1001,6 +1001,7 @@ where
                                     &order_clone,
                                     &*left_unpacker.unpack(&left.0),
                                     &*right_unpacker.unpack(&right.0),
+                                    || left.cmp(right),
                                 )
                             };
                             target.sort_by(sort_by);

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -680,6 +680,7 @@ impl PendingPeek {
                         &self.finishing.order_by,
                         &left_unpacker.unpack(left.iter()),
                         &right_unpacker.unpack(right.iter()),
+                        || left.cmp(right),
                     )
                 });
                 results.truncate(offset_plus_limit);


### PR DESCRIPTION
This is especially important in the case where the order list is empty. Unstable orderings can cause diff churn in differential. 

In all existing cases this pr uses the serialized representation to break ties.