### PR TITLE
catalog: log inserts and removals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "dataflow-types",
  "expr",
  "failure",
+ "log",
  "repr",
  "rusqlite",
  "serde",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.6"
+log = "0.4"
 repr = { path = "../repr" }
 rusqlite = { version = "0.20", features = ["bundled"] }
 serde = "1.0"


### PR DESCRIPTION
While debugging materialize it is crucial to know the mapping between
the catalog names used by the SQL layer and the IDs used by the dataflow
layer. Debugging panics in particular is challenging, as the server will
have crashed and it may be impossible to recover the ID mapping after
the fact (e.g., because the Docker container has disappeared).

Add logging of every catalog insertion and removal, so that a human
debugger can manually perform the name -> id mapping while debugging.
The output looks like this:

    [2019-12-09T20:08:19.001031Z  INFO catalog/lib:261] new source mz_view_frontiers (s11)
    [2019-12-09T20:08:19.001264Z  INFO catalog/lib:261] new source mz_scheduling_elapsed (s3)
    [2019-12-09T20:08:19.001340Z  INFO catalog/lib:261] new source mz_view_keys (s14)
    [2019-12-09T20:08:19.001403Z  INFO catalog/lib:261] new source mz_arrangement_sizes (s7)
    [2019-12-09T20:08:19.001465Z  INFO catalog/lib:261] new source mz_dataflow_operators (s1)
    [2019-12-09T20:08:19.001525Z  INFO catalog/lib:261] new source mz_dataflow_channels (s2)
    [2019-12-09T20:08:19.001578Z  INFO catalog/lib:261] new source mz_peek_active (s12)
    [2019-12-09T20:08:19.001634Z  INFO catalog/lib:261] new source mz_peek_durations (s13)
    [2019-12-09T20:08:19.001703Z  INFO catalog/lib:261] new source mz_dataflow_operator_addresses (s5)
    [2019-12-09T20:08:19.001761Z  INFO catalog/lib:261] new source mz_scheduling_parks (s6)
    [2019-12-09T20:08:19.001817Z  INFO catalog/lib:261] new source mz_view_foreign_keys (s15)
    [2019-12-09T20:08:19.001868Z  INFO catalog/lib:261] new source mz_views (s9)
    [2019-12-09T20:08:19.001942Z  INFO catalog/lib:261] new source mz_scheduling_histogram (s4)
    [2019-12-09T20:08:19.002000Z  INFO catalog/lib:261] new source mz_view_dependencies (s10)
    [2019-12-09T20:08:19.002055Z  INFO catalog/lib:261] new source mz_arrangement_sharing (s8)
    [2019-12-09T20:08:19.003023Z  INFO catalog/lib:261] new view v (u1)
    [2019-12-09T20:08:24.978798Z  INFO catalog/lib:261] new view v2 (u2)
    [2019-12-09T20:08:27.285492Z  INFO catalog/lib:338] remove view v (u1)

This patch logs at the INFO level because inserts and removes are
infrequent enough that the log won't be too spammy.

We'll want to introduce a catalog table that exposes this mapping as
well, but that's a) harder than this, and b) less useful than this for
debugging panics, for the reasons described above.