### PR TITLE
DO NOT MERGE: introduce lots of clones for IDs

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -189,7 +189,7 @@ impl DataflowDesc {
             view.relation_expr.global_uses(&mut out);
         }
         for (_id, index) in self.indexes.iter() {
-            out.push(index.on_id);
+            out.push(index.on_id.clone());
         }
         out.sort();
         out.dedup();

--- a/src/dataflow/arrangement/manager.rs
+++ b/src/dataflow/arrangement/manager.rs
@@ -96,9 +96,9 @@ impl TraceManager {
     /// Returns a copy of all by_key arrangements, should they exist.
     pub fn get_all_keyed(
         &mut self,
-        id: GlobalId,
+        id: &GlobalId,
     ) -> Option<impl Iterator<Item = (&Vec<usize>, &mut WithDrop<KeysValsHandle>)>> {
-        let collection_trace = self.traces.get_mut(&id)?;
+        let collection_trace = self.traces.get_mut(id)?;
         Some(
             collection_trace
                 .system
@@ -125,8 +125,8 @@ impl TraceManager {
     }
 
     /// get the default arrangement, which is by primary key
-    pub fn get_default(&self, id: GlobalId) -> Option<&WithDrop<KeysValsHandle>> {
-        if let Some(collection) = self.traces.get(&id) {
+    pub fn get_default(&self, id: &GlobalId) -> Option<&WithDrop<KeysValsHandle>> {
+        if let Some(collection) = self.traces.get(id) {
             collection.system.get(&collection.default_arr_key)
         } else {
             None

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -20,6 +20,6 @@ pretty = "0.7.0"
 regex = "1.3.1"
 regex-syntax = "0.6.12"
 repr = { path = "../repr" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 unicase = "2.6.0"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// An opaque identifier for a dataflow component. In other words, identifies
 /// the target of a [`RelationExpr::Get`](crate::RelationExpr::Get).
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Id {
     /// An identifier that refers to a local component of a dataflow.
     Local(LocalId),
@@ -50,13 +50,15 @@ impl fmt::Display for LocalId {
     }
 }
 
+use std::sync::Arc;
+
 /// The identifier for a global dataflow.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum GlobalId {
     /// System namespace.
     System(usize),
     /// User namespace.
-    User(usize),
+    User(usize, Arc<String>),
 }
 
 impl GlobalId {
@@ -68,8 +70,8 @@ impl GlobalId {
 
     /// Constructs a new global identifier in the user namespace. It is the
     /// caller's responsiblity to provide a unique `v`.
-    pub fn user(v: usize) -> GlobalId {
-        GlobalId::User(v)
+    pub fn user(v: usize, name: String) -> GlobalId {
+        GlobalId::User(v, Arc::new(name))
     }
 }
 
@@ -77,7 +79,7 @@ impl fmt::Display for GlobalId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             GlobalId::System(id) => write!(f, "s{}", id),
-            GlobalId::User(id) => write!(f, "u{}", id),
+            GlobalId::User(id, name) => write!(f, "u{}-{}", id, name),
         }
     }
 }

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -502,7 +502,7 @@ impl RelationExpr {
             id: Id::Global(id), ..
         } = self
         {
-            out.push(*id);
+            out.push(id.clone());
         }
         self.visit1(|e| e.global_uses(out))
     }
@@ -662,7 +662,7 @@ impl RelationExpr {
                 )
                 .tightly_embrace("Constant [", "]"),
             RelationExpr::Get { id, typ: _ } => {
-                let id = match id_humanizer.humanize_id(*id) {
+                let id = match id_humanizer.humanize_id(id.clone()) {
                     Some(s) => format!("{} ({})", s, id),
                     None => id.to_string(),
                 };

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -47,13 +47,15 @@ impl Demand {
                 // Nothing clever to do with constants, that I can think of.
             }
             RelationExpr::Get { id, .. } => {
-                gets.entry(*id).or_insert(HashSet::new()).extend(columns);
+                gets.entry(id.clone())
+                    .or_insert(HashSet::new())
+                    .extend(columns);
             }
             RelationExpr::Let { id, value, body } => {
                 // Let harvests any requirements of get from its body,
                 // and pushes the union of the requirements at its value.
-                let id = Id::Local(*id);
-                let prior = gets.insert(id, HashSet::new());
+                let id = Id::Local(id.clone());
+                let prior = gets.insert(id.clone(), HashSet::new());
                 self.action(body, columns, gets);
                 let needs = gets.remove(&id).unwrap();
                 if let Some(prior) = prior {

--- a/src/expr/transform/nonnull_requirements.rs
+++ b/src/expr/transform/nonnull_requirements.rs
@@ -51,14 +51,16 @@ impl NonNullRequirements {
                 columns.iter().all(|c| datums[*c] != repr::Datum::Null)
             }),
             RelationExpr::Get { id, .. } => {
-                gets.entry(*id).or_insert(Vec::new()).push(columns.clone());
+                gets.entry(id.clone())
+                    .or_insert(Vec::new())
+                    .push(columns.clone());
             }
             RelationExpr::Let { id, value, body } => {
                 // Let harvests any non-null requirements from its body,
                 // and acts on the intersection of the requirements for
                 // each corresponding Get, pushing them at its value.
                 let id = Id::Local(*id);
-                let prior = gets.insert(id, Vec::new());
+                let prior = gets.insert(id.clone(), Vec::new());
                 self.action(body, columns, gets);
                 let mut needs = gets.remove(&id).unwrap();
                 if let Some(prior) = prior {

--- a/src/expr/transform/projection_lifting.rs
+++ b/src/expr/transform/projection_lifting.rs
@@ -34,7 +34,7 @@ impl ProjectionLifting {
             RelationExpr::Get { id, .. } => {
                 if let Some((typ, columns)) = gets.get(id) {
                     *relation = RelationExpr::Get {
-                        id: *id,
+                        id: id.clone(),
                         typ: typ.clone(),
                     }
                     .project(columns.clone());
@@ -42,10 +42,10 @@ impl ProjectionLifting {
             }
             RelationExpr::Let { id, value, body } => {
                 self.action(value, gets);
-                let id = Id::Local(*id);
+                let id = Id::Local(id.clone());
                 if let RelationExpr::Project { input, outputs } = &mut **value {
                     let typ = input.typ();
-                    let prior = gets.insert(id, (typ, outputs.clone()));
+                    let prior = gets.insert(id.clone(), (typ, outputs.clone()));
                     assert!(!prior.is_some());
                     **value = input.take_dangerous();
                 }


### PR DESCRIPTION
This includes user ID names as Arc<String>s so that all logging, panics, and etc include
the name that was provided.

I'm not specifically arguing that we should do this, but it's a lot nicer for debugging so I at least want the commit up until we have a real catalog so that people can cherry-pick it.