### PR TITLE
sql: support naive variance and stddev computations

### DIFF
--- a/src/sql/transform.rs
+++ b/src/sql/transform.rs
@@ -9,13 +9,15 @@
 //! are much easier to perform in SQL. Someday, we'll want our own SQL IR,
 //! but for now we just use the parser's AST directly.
 
+use std::convert::TryFrom;
+
 use sqlparser::ast::visit_mut::{self, VisitMut};
-use sqlparser::ast::{BinaryOperator, Expr, Function, ObjectName, Query};
+use sqlparser::ast::{BinaryOperator, Expr, Function, ObjectName, Query, Value};
 
 use repr::QualName;
 
 pub fn transform(query: &mut Query) {
-    AvgFuncRewriter.visit_query(query);
+    AggFuncRewriter.visit_query(query);
     IdentFuncRewriter.visit_query(query);
 }
 
@@ -23,38 +25,138 @@ pub fn transform(query: &mut Query) {
 // `avg` aggregate function doesn't exist from here on out. This also has the
 // nice side effect of reusing the division planning logic, which is not trivial
 // for some types, like decimals.
-struct AvgFuncRewriter;
+struct AggFuncRewriter;
 
-impl<'ast> VisitMut<'ast> for AvgFuncRewriter {
+impl AggFuncRewriter {
+    fn plan_avg(expr: Expr, distinct: bool) -> Expr {
+        let sum = Expr::Function(Function {
+            name: ObjectName(vec!["sum".into()]),
+            args: vec![expr.clone()],
+            over: None,
+            distinct,
+        });
+        let sum = Expr::Function(Function {
+            name: ObjectName(vec!["internal".into(), "avg_promotion".into()]),
+            args: vec![sum],
+            over: None,
+            distinct: false,
+        });
+        let count = Expr::Function(Function {
+            name: ObjectName(vec!["count".into()]),
+            args: vec![expr],
+            over: None,
+            distinct,
+        });
+        Expr::BinaryOp {
+            left: Box::new(sum),
+            op: BinaryOperator::Divide,
+            right: Box::new(count),
+        }
+    }
+
+    fn plan_variance(expr: Expr, distinct: bool, sample: bool) -> Expr {
+        // N.B. this variance calculation uses the "textbook" algorithm, which
+        // is known to accumulate problematic amounts of error. The numerically
+        // stable variants, the most well-known of which is Welford's, are
+        // however difficult to implement inside of Differential Dataflow, as
+        // they do not obviously support retractions efficiently (#1240).
+        //
+        // The code below converts var_samp(x) into
+        //
+        //     (sum(x²) - sum(x)² / count(x)) / (count(x) - 1)
+        //
+        // and var_pop(x) into:
+        //
+        //     (sum(x²) - sum(x)² / count(x)) / count(x)
+        //
+        let expr = Expr::Function(Function {
+            name: ObjectName(vec!["internal".into(), "avg_promotion".into()]),
+            args: vec![expr],
+            over: None,
+            distinct: false,
+        });
+        let sum_squares = Expr::Function(Function {
+            name: ObjectName(vec!["sum".into()]),
+            args: vec![Expr::BinaryOp {
+                left: Box::new(expr.clone()),
+                op: BinaryOperator::Multiply,
+                right: Box::new(expr.clone()),
+            }],
+            over: None,
+            distinct,
+        });
+        let sum = Expr::Function(Function {
+            name: ObjectName(vec!["sum".into()]),
+            args: vec![expr.clone()],
+            over: None,
+            distinct,
+        });
+        let sum_squared = Expr::BinaryOp {
+            left: Box::new(sum.clone()),
+            op: BinaryOperator::Multiply,
+            right: Box::new(sum),
+        };
+        let count = Expr::Function(Function {
+            name: ObjectName(vec!["count".into()]),
+            args: vec![expr],
+            over: None,
+            distinct,
+        });
+        Expr::BinaryOp {
+            left: Box::new(Expr::BinaryOp {
+                left: Box::new(sum_squares),
+                op: BinaryOperator::Minus,
+                right: Box::new(Expr::BinaryOp {
+                    left: Box::new(sum_squared),
+                    op: BinaryOperator::Divide,
+                    right: Box::new(count.clone()),
+                }),
+            }),
+            op: BinaryOperator::Divide,
+            right: Box::new(if sample {
+                Expr::BinaryOp {
+                    left: Box::new(count),
+                    op: BinaryOperator::Minus,
+                    right: Box::new(Expr::Value(Value::Number("1".into()))),
+                }
+            } else {
+                count
+            }),
+        }
+    }
+
+    fn plan_stddev(expr: Expr, distinct: bool, sample: bool) -> Expr {
+        Expr::Function(Function {
+            name: ObjectName(vec!["sqrt".into()]),
+            args: vec![Self::plan_variance(expr, distinct, sample)],
+            over: None,
+            distinct: false,
+        })
+    }
+}
+
+impl<'ast> VisitMut<'ast> for AggFuncRewriter {
     fn visit_expr(&mut self, expr: &'ast mut Expr) {
         visit_mut::visit_expr(self, expr);
         if let Expr::Function(func) = expr {
-            if QualName::name_equals(func.name.clone(), "avg") {
-                let args = func.args.clone();
-                let sum = Expr::Function(Function {
-                    name: ObjectName(vec!["sum".into()]),
-                    args: args.clone(),
-                    over: None,
-                    distinct: func.distinct,
-                });
-                let sum = Expr::Function(Function {
-                    name: ObjectName(vec!["internal".into(), "avg_promotion".into()]),
-                    args: vec![sum],
-                    over: None,
-                    distinct: false,
-                });
-                let count = Expr::Function(Function {
-                    name: ObjectName(vec!["count".into()]),
-                    args: args.clone(),
-                    over: None,
-                    distinct: func.distinct,
-                });
-                let div = Expr::BinaryOp {
-                    left: Box::new(sum),
-                    op: BinaryOperator::Divide,
-                    right: Box::new(count),
-                };
-                *expr = Expr::Nested(Box::new(div));
+            let name = match QualName::try_from(func.name.clone()) {
+                Ok(name) => name,
+                Err(_) => return,
+            };
+            if func.args.len() != 1 {
+                return;
+            }
+            let arg = func.args[0].clone();
+            if &name == "avg" {
+                *expr = Self::plan_avg(arg, func.distinct)
+            } else if &name == "variance" || &name == "var_samp" {
+                *expr = Self::plan_variance(arg, func.distinct, true)
+            } else if &name == "var_pop" {
+                *expr = Self::plan_variance(arg, func.distinct, false)
+            } else if &name == "stddev" || &name == "stddev_samp" {
+                *expr = Self::plan_stddev(arg, func.distinct, true)
+            } else if &name == "stddev_pop" {
+                *expr = Self::plan_stddev(arg, func.distinct, false)
             }
         }
     }

--- a/test/aggregates.slt
+++ b/test/aggregates.slt
@@ -69,3 +69,13 @@ NULL
 
 statement error
 SELECT * ORDER BY SUM(fake_column)
+
+query RRRRRR
+SELECT variance(a), var_samp(a), var_pop(a), stddev(a), stddev_samp(a), stddev_pop(a) FROM t
+----
+0.916666600000  0.916666600000  0.687500000000  0.957427072940  0.957427072940  0.829156197588
+
+query RRRRRR
+SELECT variance(a), var_samp(a), var_pop(a), stddev(a), stddev_samp(a), stddev_pop(a) FROM t2
+----
+0.9166666666666666  0.9166666666666666  0.6875  0.9574271077563381  0.9574271077563381  0.82915619758885

--- a/www/data/sql_funcs.json
+++ b/www/data/sql_funcs.json
@@ -37,6 +37,30 @@
             {
                 "signature": "sum(x: T) -> T",
                 "description": "Sum of `T`'s values"
+            },
+            {
+                "signature": "stddev(x: T) -> T",
+                "description": "Historical alias for `stddev_samp`\n\n*NUMERICALLY UNSTABLE: do not use if high accuracy is required.*"
+            },
+            {
+                "signature": "stddev_pop(x: T) -> T",
+                "description": "Population standard deviation of `T`'s values\n\n*NUMERICALLY UNSTABLE: do not use if high accuracy is required.*"
+            },
+            {
+                "signature": "stddev_samp(x: T) -> T",
+                "description": "Sample standard deviation of `T`'s values\n\n*NUMERICALLY UNSTABLE: do not use if high accuracy is required.*"
+            },
+            {
+                "signature": "variance(x: T) -> T",
+                "description": "Historical alias for `variance_samp`\n\n*NUMERICALLY UNSTABLE: do not use if high accuracy is required.*"
+            },
+            {
+                "signature": "variance_pop(x: T) -> T",
+                "description": "Population variance of `T`'s values\n\n*NUMERICALLY UNSTABLE: do not use if high accuracy is required.*"
+            },
+            {
+                "signature": "variance_samp(x: T) -> T",
+                "description": "Sample variance of `T`'s values\n\n*NUMERICALLY UNSTABLE: do not use if high accuracy is required.*"
             }
         ]
     },


### PR DESCRIPTION
Add support for computing the stddev of float and decimal data using the
"textbook" algorithm. This algorithm is known to accumulate problematic
amounts of error, but it is much more straightforward to implement in
differential dataflow than any of the numerically-stable algorithms. In
fact, it requires no changes to the dataflow layer at all, as the SQL
function can simply be decomposed into the sum, count, and sqrt
functions.

It's also worth noting that PostgreSQL got away with using this
algorithm until version 12, released last year.

Implementing a more accurate variance/stddev algorithm is tracked in
issue MaterializeInc/database-issues#436.

Fix MaterializeInc/database-issues#422.