### PR TITLE
ex/chbench: upgrade to Debezium 1.0 to fix dates

### DIFF
--- a/doc/developer/setup-mysql-debezium.md
+++ b/doc/developer/setup-mysql-debezium.md
@@ -74,8 +74,8 @@ Check out [`mtrlz-setup`](https://github.com/MaterializeInc/mtrlz-setup)'s
     mysql -uroot --local-infile < ddl.sql
     ```
 
-1. Download the [latest stable Debezium MySQL
-   connector](https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/0.9.5.Final/debezium-connector-mysql-0.9.5.Final-plugin.tar.gz)
+1. Download the [latest 1.0 Debezium MySQL
+   connector](https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/1.0.0.Beta3/debezium-connector-mysql-1.0.0.Beta3-plugin.tar.gz)
    and place the `debezium-connector-mysql` directory in
    `/usr/local/opt/confluent-platform/share/java/`. If this directory doesn't
    exist, put the contents of the `tar` into the `share/java` directory under
@@ -84,15 +84,18 @@ Check out [`mtrlz-setup`](https://github.com/MaterializeInc/mtrlz-setup)'s
    where you installed Confluent.
 
     ```shell
-    curl -O https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/0.9.5.Final/debezium-connector-mysql-0.9.5.Final-plugin.tar.gz
-    tar -zxvf debezium-connector-mysql-0.9.5.Final-plugin.tar.gz
-    rm debezium-connector-mysql-0.9.5.Final-plugin.tar.gz
-    if [ -d "/usr/local/opt/confluent-platform/share/java/" ]; then
+    curl -O https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/1.0.0.Beta3/debezium-connector-mysql-1.0.0.Beta3-plugin.tar.gz
+    tar -zxvf debezium-connector-mysql-1.0.0.Beta3-plugin.tar.gz
+    rm debezium-connector-mysql-1.0.0.Beta3-plugin.tar.gz
+    if [ -d /usr/local/opt/confluent-platform/share/java/ ]; then
       mv debezium-connector-mysql /usr/local/opt/confluent-platform/share/java
     else
       echo "Move debezium-connector-mysql into the share/java directory under your Confluent install directory"
     fi
     ```
+
+    **Note that Debezium versions before 1.0 mishandled dates in a way that
+    can cause incorrect results when loading data into Materialize.**
 
 ## Loading TPCH
 

--- a/ex/chbench/docker-compose.yml
+++ b/ex/chbench/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       # 1000 was chosen by fair dice roll
       - DIFFERENTIAL_EAGER_MERGE=1000
   mysql:
-    image: debezium/example-mysql:0.9
+    image: debezium/example-mysql:1.0
     ports:
      - *mysql
     environment:
@@ -48,7 +48,7 @@ services:
         target: /var/lib/mysql-files
         read_only: true
   mysqlcli:
-    image: debezium/example-mysql:0.9
+    image: debezium/example-mysql:1.0
     command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=debezium", "--database=tpcch"]
     init: true
     depends_on:
@@ -72,7 +72,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
   connect:
-    image: debezium/connect:0.9
+    image: debezium/connect:1.0
     environment:
       BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: 1


### PR DESCRIPTION
DATE handling is fixed in Debezium 1.0. The version we were using
previously, Debezium 0.9, had off-by-one errors when reading dates from
a snapshot.

Someone will need to make the same adjustments to the Nix build. cc @jamii 