### PR TITLE
pgwire: fix encryption type handling

### DIFF
--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -22,8 +22,8 @@ use tokio::codec::{Decoder, Encoder};
 use tokio::io;
 
 use crate::message::{
-    BackendMessage, FieldFormat, FrontendMessage, TransactionStatus, VERSION_CANCEL,
-    VERSION_GSSENC, VERSION_SSL,
+    BackendMessage, EncryptionType, FieldFormat, FrontendMessage, TransactionStatus,
+    VERSION_CANCEL, VERSION_GSSENC, VERSION_SSL,
 };
 use ore::netio;
 use repr::{Datum, ScalarType};
@@ -87,8 +87,12 @@ impl Encoder for Codec {
     type Error = io::Error;
 
     fn encode(&mut self, msg: BackendMessage, dst: &mut BytesMut) -> Result<(), io::Error> {
-        if let BackendMessage::EncryptionResponse(enable) = msg {
-            dst.put(if enable { b'Y' } else { b'N' });
+        if let BackendMessage::EncryptionResponse(typ) = msg {
+            dst.put(match typ {
+                EncryptionType::None => b'N',
+                EncryptionType::Ssl => b'S',
+                EncryptionType::GssApi => b'G',
+            });
             return Ok(());
         }
 

--- a/src/pgwire/message.rs
+++ b/src/pgwire/message.rs
@@ -185,10 +185,16 @@ pub enum FrontendMessage {
     Terminate,
 }
 
+#[derive(Debug)]
+pub enum EncryptionType {
+    None,
+    Ssl,
+    GssApi,
+}
+
 /// Internal representation of a backend [message]
 ///
 /// [message]: https://www.postgresql.org/docs/11/protocol-message-formats.html
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum BackendMessage {
     AuthenticationOk,
@@ -196,7 +202,7 @@ pub enum BackendMessage {
         tag: String,
     },
     EmptyQueryResponse,
-    EncryptionResponse(bool),
+    EncryptionResponse(EncryptionType),
     ReadyForQuery(TransactionStatus),
     RowDescription(Vec<FieldDescription>),
     DataRow(Vec<Option<FieldValue>>, FieldFormatIter),

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -32,8 +32,8 @@ use sql::Session;
 
 use crate::codec::Codec;
 use crate::message::{
-    self, BackendMessage, FieldFormat, FieldFormatIter, FrontendMessage, ParameterDescription,
-    Severity, VERSIONS, VERSION_3,
+    self, BackendMessage, EncryptionType, FieldFormat, FieldFormatIter, FrontendMessage,
+    ParameterDescription, Severity, VERSIONS, VERSION_3,
 };
 use crate::secrets::SecretManager;
 
@@ -382,7 +382,7 @@ impl<A: Conn> PollStateMachine<A> for StateMachine<A> {
             }
             FrontendMessage::GssEncRequest | FrontendMessage::SslRequest => {
                 transition!(SendEncryptionResponse {
-                    send: conn.send(BackendMessage::EncryptionResponse(false)),
+                    send: conn.send(BackendMessage::EncryptionResponse(EncryptionType::None)),
                     session: state.session,
                 })
             }


### PR DESCRIPTION
As promised in #1271, @quodlibetor! Also fixes a bug where the correct yes response is 'S' or 'G' (SSL or GSSAPI), not 'Y'. (This code path isn't actually hit at the moment.)