### PR TITLE
Drop views better.

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -586,10 +586,7 @@ where
                                 eval_env,
                             },
                         );
-                        broadcast(
-                            &mut self.broadcast_tx,
-                            SequencedCommand::DropViews(vec![view_id]),
-                        );
+                        self.drop_views(vec![view_id]);
                     }
 
                     let rows_rx = rows_rx


### PR DESCRIPTION
Transient views due to SELECT statements were installing view monitoring information in the coordinator, and never uninstalling it. This was a result of the custom view creation, peek, view deletion workflow not doing the same thing as for normal views and stuff.