### PR TITLE
Separate temp_storage role into a new RowArena type

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -358,7 +358,7 @@ where
                     let mut temp_storage = RowPacker::new();
                     let collection = self.collection(input).unwrap().map(move |input_row| {
                         let mut datums = unpacker.unpack(&input_row);
-                        let temp_storage = &mut temp_storage.packable();
+                        let temp_storage = &mut temp_storage.arena();
                         for scalar in &scalars {
                             let datum = scalar.eval(&datums, &env, temp_storage);
                             // Scalar is allowed to see the outputs of previous scalars.
@@ -381,7 +381,7 @@ where
                     let collection = self.collection(input).unwrap().filter(move |input_row| {
                         let datums = unpacker.unpack(input_row);
                         predicates.iter().all(|predicate| {
-                            let temp_storage = &mut temp_storage.packable();
+                            let temp_storage = &mut temp_storage.arena();
                             match predicate.eval(&datums, &env, temp_storage) {
                                 Datum::True => true,
                                 Datum::False | Datum::Null => false,
@@ -459,7 +459,7 @@ where
                 let keyed = built
                     .map(move |row| {
                         let datums = unpacker.unpack(&row);
-                        let temp_storage = &mut eval_packer.packable();
+                        let temp_storage = &mut eval_packer.arena();
                         let key_row = key_row_packer
                             .pack(keys2.iter().map(|k| k.eval(&datums, &env, temp_storage)));
                         drop(datums);
@@ -807,7 +807,7 @@ where
                             // consider restructuring the plan to pre-distinct the right
                             // data and then use a non-distinctness-requiring aggregation.
 
-                            let temp_storage = &mut temp_storage.packable();
+                            let temp_storage = &mut temp_storage.arena();
                             let eval = aggregate.expr.eval(&datums, &env, temp_storage);
 
                             // Non-Abelian values cannot be accumulated, and just need to
@@ -982,7 +982,7 @@ where
                                                     }
                                                 })
                                                 .collect::<HashSet<_>>();
-                                            let temp_storage = &mut temp_storage.packable();
+                                            let temp_storage = &mut temp_storage.arena();
                                             result.push((agg.func.func())(iter, &env, temp_storage));
                                         } else {
                                             let iter = source.iter().flat_map(|(v, w)| {
@@ -990,7 +990,7 @@ where
                                                 std::iter::repeat(v.iter().nth(non_abelian_pos).unwrap())
                                                     .take(std::cmp::max(w[0], 0) as usize)
                                             });
-                                            let temp_storage = &mut temp_storage.packable();
+                                            let temp_storage = &mut temp_storage.arena();
                                             result.push((agg.func.func())(iter, &env, temp_storage));
                                         }
                                         non_abelian_pos += 1;

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -690,7 +690,7 @@ impl PendingPeek {
                 let datums = unpacker.unpack(row);
                 // Before (expensively) determining how many copies of a row
                 // we have, let's eliminate rows that we don't care about.
-                let temp_storage = &mut temp_storage.packable();
+                let temp_storage = &mut temp_storage.arena();
                 if self.filter.iter().all(|predicate| {
                     predicate.eval(&datums, &self.eval_env, temp_storage) == Datum::True
                 }) {

--- a/src/expr/relation/func.rs
+++ b/src/expr/relation/func.rs
@@ -12,14 +12,14 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 use repr::decimal::Significand;
-use repr::{ColumnType, Datum, PackableRow, ScalarType};
+use repr::{ColumnType, Datum, RowArena, ScalarType};
 
 use crate::EvalEnv;
 
 // TODO(jamii) be careful about overflow in sum/avg
 // see https://timely.zulipchat.com/#narrow/stream/186635-engineering/topic/additional.20work/near/163507435
 
-pub fn max_int32<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_int32<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -31,7 +31,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_int64<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_int64<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -43,7 +43,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_float32<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_float32<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -55,7 +55,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_float64<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_float64<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -67,7 +67,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_decimal<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_decimal<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -79,7 +79,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_bool<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_bool<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -91,7 +91,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_string<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_string<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -105,7 +105,7 @@ where
     }
 }
 
-pub fn max_date<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_date<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -117,7 +117,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_timestamp<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_timestamp<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -129,7 +129,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_timestamptz<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_timestamptz<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -141,14 +141,14 @@ where
     Datum::from(x)
 }
 
-pub fn max_null<'a, I>(_datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn max_null<'a, I>(_datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     Datum::Null
 }
 
-pub fn min_int32<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_int32<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -160,7 +160,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_int64<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_int64<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -172,7 +172,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_float32<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_float32<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -184,7 +184,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_float64<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_float64<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -196,7 +196,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_decimal<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_decimal<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -208,7 +208,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_bool<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_bool<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -220,7 +220,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_string<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_string<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -234,7 +234,7 @@ where
     }
 }
 
-pub fn min_date<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_date<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -246,7 +246,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_timestamp<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_timestamp<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -258,7 +258,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_timestamptz<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_timestamptz<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -270,14 +270,14 @@ where
     Datum::from(x)
 }
 
-pub fn min_null<'a, I>(_datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn min_null<'a, I>(_datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     Datum::Null
 }
 
-pub fn sum_int32<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn sum_int32<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -290,7 +290,7 @@ where
     }
 }
 
-pub fn sum_int64<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn sum_int64<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -303,7 +303,7 @@ where
     }
 }
 
-pub fn sum_float32<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn sum_float32<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -316,7 +316,7 @@ where
     }
 }
 
-pub fn sum_float64<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn sum_float64<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -329,7 +329,7 @@ where
     }
 }
 
-pub fn sum_decimal<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn sum_decimal<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -342,14 +342,14 @@ where
     }
 }
 
-pub fn sum_null<'a, I>(_datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn sum_null<'a, I>(_datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     Datum::Null
 }
 
-pub fn count<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn count<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -357,7 +357,7 @@ where
     Datum::from(x)
 }
 
-pub fn count_all<'a, I>(datums: I, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a>
+pub fn count_all<'a, I>(datums: I, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -365,7 +365,7 @@ where
     Datum::from(x)
 }
 
-pub fn any<'a, I>(datums: I, env: &EvalEnv, temp_storage: &mut PackableRow<'a>) -> Datum<'a>
+pub fn any<'a, I>(datums: I, env: &EvalEnv, temp_storage: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -374,7 +374,7 @@ where
     })
 }
 
-pub fn all<'a, I>(datums: I, env: &EvalEnv, temp_storage: &mut PackableRow<'a>) -> Datum<'a>
+pub fn all<'a, I>(datums: I, env: &EvalEnv, temp_storage: &mut RowArena<'a>) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -420,7 +420,7 @@ pub enum AggregateFunc {
 }
 
 impl AggregateFunc {
-    pub fn func<'a, I>(self) -> fn(I, &EvalEnv, &mut PackableRow<'a>) -> Datum<'a>
+    pub fn func<'a, I>(self) -> fn(I, &EvalEnv, &mut RowArena<'a>) -> Datum<'a>
     where
         I: IntoIterator<Item = Datum<'a>>,
     {

--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -20,7 +20,7 @@ pub use crate::like::build_like_regex_from_string;
 use crate::EvalEnv;
 use repr::decimal::MAX_DECIMAL_PRECISION;
 use repr::regex::Regex;
-use repr::{ColumnType, Datum, Interval, PackableRow, ScalarType};
+use repr::{ColumnType, Datum, Interval, RowArena, ScalarType};
 
 #[derive(Ord, PartialOrd, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum NullaryFunc {
@@ -29,7 +29,7 @@ pub enum NullaryFunc {
 }
 
 impl NullaryFunc {
-    pub fn func(self) -> for<'a> fn(&EvalEnv, &mut PackableRow<'a>) -> Datum<'a> {
+    pub fn func(self) -> for<'a> fn(&EvalEnv, &mut RowArena<'a>) -> Datum<'a> {
         match self {
             NullaryFunc::MzLogicalTimestamp => mz_logical_time,
             NullaryFunc::Now => now,
@@ -53,18 +53,18 @@ impl fmt::Display for NullaryFunc {
     }
 }
 
-pub fn mz_logical_time<'a>(env: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn mz_logical_time<'a>(env: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(
         env.logical_time
             .expect("mz_logical_time missing logical time") as i128,
     )
 }
 
-pub fn now<'a>(env: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn now<'a>(env: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(env.wall_time.expect("now missing wall time in env"))
 }
 
-pub fn and<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn and<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     match (a, b) {
         (Datum::False, _) => Datum::False,
         (_, Datum::False) => Datum::False,
@@ -75,7 +75,7 @@ pub fn and<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>)
     }
 }
 
-pub fn or<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn or<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     match (a, b) {
         (Datum::True, _) => Datum::True,
         (_, Datum::True) => Datum::True,
@@ -86,68 +86,68 @@ pub fn or<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) 
     }
 }
 
-pub fn not<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn not<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(!a.unwrap_bool())
 }
 
-pub fn abs_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn abs_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32().abs())
 }
 
-pub fn abs_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn abs_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64().abs())
 }
 
-pub fn abs_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn abs_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32().abs())
 }
 
-pub fn abs_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn abs_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float64().abs())
 }
 
-pub fn cast_bool_to_string<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_bool_to_string<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     match a.unwrap_bool() {
         true => Datum::from("true"),
         false => Datum::from("false"),
     }
 }
 
-pub fn cast_int32_to_bool<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int32_to_bool<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() != 0)
 }
 
 pub fn cast_int32_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_int32().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_int32().to_string()))
 }
 
-pub fn cast_int32_to_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int32_to_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): is this cast valid?
     Datum::from(a.unwrap_int32() as f32)
 }
 
-pub fn cast_int32_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int32_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): is this cast valid?
     Datum::from(f64::from(a.unwrap_int32()))
 }
 
-pub fn cast_int32_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int32_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(i64::from(a.unwrap_int32()))
 }
 
-pub fn cast_int32_to_decimal<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int32_to_decimal<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(i128::from(a.unwrap_int32()))
 }
 
-pub fn cast_int64_to_bool<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int64_to_bool<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() != 0)
 }
 
-pub fn cast_int64_to_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int64_to_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): we need to do something better than panicking if the
     // datum doesn't fit in an int32, but what? Poison the whole dataflow?
     // The SQL standard says this an error, but runtime errors are complicated
@@ -155,16 +155,16 @@ pub fn cast_int64_to_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a
     Datum::from(i32::try_from(a.unwrap_int64()).unwrap())
 }
 
-pub fn cast_int64_to_decimal<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int64_to_decimal<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(i128::from(a.unwrap_int64()))
 }
 
-pub fn cast_int64_to_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int64_to_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): is this cast valid?
     Datum::from(a.unwrap_int64() as f32)
 }
 
-pub fn cast_int64_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_int64_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): is this cast valid?
     Datum::from(a.unwrap_int64() as f64)
 }
@@ -172,22 +172,18 @@ pub fn cast_int64_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<
 pub fn cast_int64_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_int64().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_int64().to_string()))
 }
 
-pub fn cast_float32_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_float32_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): this is undefined behavior if the f32 doesn't fit in an
     // i64 (https://github.com/rust-lang/rust/issues/10184).
     Datum::from(a.unwrap_float32() as i64)
 }
 
-pub fn cast_float32_to_float64<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn cast_float32_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): is this cast valid?
     Datum::from(f64::from(a.unwrap_float32()))
 }
@@ -196,7 +192,7 @@ pub fn cast_float32_to_decimal<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let f = a.unwrap_float32();
     let scale = b.unwrap_int32();
@@ -216,12 +212,12 @@ pub fn cast_float32_to_decimal<'a>(
 pub fn cast_float32_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_float32().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_float32().to_string()))
 }
 
-pub fn cast_float64_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_float64_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     // TODO(benesch): this is undefined behavior if the f32 doesn't fit in an
     // i64 (https://github.com/rust-lang/rust/issues/10184).
     Datum::from(a.unwrap_float64() as i64)
@@ -231,7 +227,7 @@ pub fn cast_float64_to_decimal<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let f = a.unwrap_float64();
     let scale = b.unwrap_int32();
@@ -251,23 +247,23 @@ pub fn cast_float64_to_decimal<'a>(
 pub fn cast_float64_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_float64().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_float64().to_string()))
 }
 
-pub fn cast_decimal_to_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_decimal_to_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_decimal().as_i128() as i32)
 }
 
-pub fn cast_decimal_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_decimal_to_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_decimal().as_i128() as i64)
 }
 
 pub fn cast_significand_to_float32<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     // The second half of this function is defined in plan_cast_internal
     Datum::from(a.unwrap_decimal().as_i128() as f32)
@@ -276,7 +272,7 @@ pub fn cast_significand_to_float32<'a>(
 pub fn cast_significand_to_float64<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     // The second half of this function is defined in plan_cast_internal
     Datum::from(a.unwrap_decimal().as_i128() as f64)
@@ -286,14 +282,14 @@ pub fn cast_decimal_to_string<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     // TODO(benesch): a better way to pass the scale into the dataflow layer.
     let scale = b.unwrap_int32() as u8;
-    Datum::String(temp_storage.push_string(&a.unwrap_decimal().with_scale(scale).to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_decimal().with_scale(scale).to_string()))
 }
 
-pub fn cast_string_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_string_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let val: Result<f64, _> = a.unwrap_str().to_lowercase().parse();
     Datum::from(val.ok())
 }
@@ -301,20 +297,16 @@ pub fn cast_string_to_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow
 pub fn cast_string_to_bytes<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::Bytes(&temp_storage.push_bytes(&a.unwrap_str().as_bytes().to_vec()))
+    Datum::Bytes(&temp_storage.push_bytes(a.unwrap_str().as_bytes().to_vec()))
 }
 
-pub fn cast_date_to_timestamp<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_date_to_timestamp<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::Timestamp(a.unwrap_date().and_hms(0, 0, 0))
 }
 
-pub fn cast_date_to_timestamptz<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn cast_date_to_timestamptz<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::TimestampTz(DateTime::<Utc>::from_utc(
         a.unwrap_date().and_hms(0, 0, 0),
         Utc,
@@ -324,19 +316,19 @@ pub fn cast_date_to_timestamptz<'a>(
 pub fn cast_date_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_date().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_date().to_string()))
 }
 
-pub fn cast_timestamp_to_date<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn cast_timestamp_to_date<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::Date(a.unwrap_timestamp().date())
 }
 
 pub fn cast_timestamp_to_timestamptz<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     Datum::TimestampTz(DateTime::<Utc>::from_utc(a.unwrap_timestamp(), Utc))
 }
@@ -344,23 +336,19 @@ pub fn cast_timestamp_to_timestamptz<'a>(
 pub fn cast_timestamp_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_timestamp().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_timestamp().to_string()))
 }
 
-pub fn cast_timestamptz_to_date<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn cast_timestamptz_to_date<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::Date(a.unwrap_timestamptz().naive_utc().date())
 }
 
 pub fn cast_timestamptz_to_timestamp<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     Datum::Timestamp(a.unwrap_timestamptz().naive_utc())
 }
@@ -368,23 +356,23 @@ pub fn cast_timestamptz_to_timestamp<'a>(
 pub fn cast_timestamptz_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_timestamptz().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_timestamptz().to_string()))
 }
 
 pub fn cast_interval_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&a.unwrap_interval().to_string()))
+    Datum::String(temp_storage.push_string(a.unwrap_interval().to_string()))
 }
 
 pub fn cast_bytes_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let bytes = a.unwrap_bytes();
     let mut out = String::from("\\x");
@@ -392,11 +380,11 @@ pub fn cast_bytes_to_string<'a>(
     for byte in bytes {
         write!(&mut out, "{:x}", byte).expect("writing to string cannot fail");
     }
-    Datum::String(temp_storage.push_string(&out))
+    Datum::String(temp_storage.push_string(out))
 }
 
 pub fn serde_to_datum<'a>(
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
     serde: serde_json::Value,
 ) -> Result<Datum<'a>, failure::Error> {
     use serde_json::Value;
@@ -416,7 +404,7 @@ pub fn serde_to_datum<'a>(
                 bail!("{} is out of range for json number", n)
             }
         }
-        Value::String(s) => Datum::String(temp_storage.push_string(&s)),
+        Value::String(s) => Datum::String(temp_storage.push_string(s)),
         Value::Array(array) => {
             let elems = array
                 .into_iter()
@@ -472,7 +460,7 @@ pub fn datum_to_serde(datum: Datum) -> serde_json::Value {
 pub fn cast_string_to_jsonb<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     match serde_json::from_str(a.unwrap_str()) {
         Err(_) => Datum::Null,
@@ -487,15 +475,15 @@ pub fn cast_string_to_jsonb<'a>(
 pub fn cast_jsonb_to_string<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
-    Datum::String(temp_storage.push_string(&datum_to_serde(a).to_string()))
+    Datum::String(temp_storage.push_string(datum_to_serde(a).to_string()))
 }
 
 pub fn cast_jsonb_to_string_unless_string<'a>(
     a: Datum<'a>,
     eval_env: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     match a {
         Datum::JsonNull => Datum::Null,
@@ -504,39 +492,19 @@ pub fn cast_jsonb_to_string_unless_string<'a>(
     }
 }
 
-pub fn add_int32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn add_int32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() + b.unwrap_int32())
 }
 
-pub fn add_int64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn add_int64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() + b.unwrap_int64())
 }
 
-pub fn add_float32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn add_float32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32() + b.unwrap_float32())
 }
 
-pub fn add_float64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn add_float64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float64() + b.unwrap_float64())
 }
 
@@ -544,7 +512,7 @@ pub fn add_timestamp_interval<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let dt = a.unwrap_timestamp();
     Datum::Timestamp(match b {
@@ -561,7 +529,7 @@ pub fn add_timestamptz_interval<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let dt = a.unwrap_timestamptz().naive_utc();
 
@@ -577,19 +545,19 @@ pub fn add_timestamptz_interval<'a>(
     Datum::TimestampTz(DateTime::<Utc>::from_utc(new_ndt, Utc))
 }
 
-pub fn ceil_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn ceil_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32().ceil())
 }
 
-pub fn ceil_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn ceil_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float64().ceil())
 }
 
-pub fn floor_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn floor_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32().floor())
 }
 
-pub fn floor_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn floor_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float64().floor())
 }
 
@@ -597,7 +565,7 @@ pub fn sub_timestamp_interval<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     env: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let inverse = match b {
         Datum::Interval(Interval::Months(months)) => Datum::Interval(Interval::Months(-months)),
@@ -620,7 +588,7 @@ pub fn sub_timestamptz_interval<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     env: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let inverse = match b {
         Datum::Interval(Interval::Months(months)) => Datum::Interval(Interval::Months(-months)),
@@ -690,113 +658,53 @@ fn add_timestamp_duration(
     }
 }
 
-pub fn add_decimal<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn add_decimal<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_decimal() + b.unwrap_decimal())
 }
 
-pub fn sub_int32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn sub_int32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() - b.unwrap_int32())
 }
 
-pub fn sub_int64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() - b.unwrap_int64())
 }
 
-pub fn sub_float32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn sub_float32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32() - b.unwrap_float32())
 }
 
-pub fn sub_float64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn sub_float64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float64() - b.unwrap_float64())
 }
 
-pub fn sub_decimal<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn sub_decimal<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_decimal() - b.unwrap_decimal())
 }
 
-pub fn mul_int32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mul_int32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int32() * b.unwrap_int32())
 }
 
-pub fn mul_int64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64() * b.unwrap_int64())
 }
 
-pub fn mul_float32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mul_float32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32() * b.unwrap_float32())
 }
 
-pub fn mul_float64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mul_float64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float64() * b.unwrap_float64())
 }
 
-pub fn mul_decimal<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mul_decimal<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_decimal() * b.unwrap_decimal())
 }
 
 // TODO(jamii) we don't currently have any way of reporting errors from functions, so for now we just adopt sqlite's approach 1/0 = null
 
-pub fn div_int32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_int32();
     if b == 0 {
         Datum::Null
@@ -805,12 +713,7 @@ pub fn div_int32<'a>(
     }
 }
 
-pub fn div_int64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_int64();
     if b == 0 {
         Datum::Null
@@ -819,12 +722,7 @@ pub fn div_int64<'a>(
     }
 }
 
-pub fn div_float32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn div_float32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_float32();
     if b == 0.0 {
         Datum::Null
@@ -833,12 +731,7 @@ pub fn div_float32<'a>(
     }
 }
 
-pub fn div_float64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn div_float64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_float64();
     if b == 0.0 {
         Datum::Null
@@ -847,12 +740,7 @@ pub fn div_float64<'a>(
     }
 }
 
-pub fn div_decimal<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn div_decimal<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_decimal();
     if b == 0 {
         Datum::Null
@@ -865,7 +753,7 @@ pub fn ceil_decimal<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let decimal = a.unwrap_decimal();
     let scale = b.unwrap_int32() as u8;
@@ -876,19 +764,14 @@ pub fn floor_decimal<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let decimal = a.unwrap_decimal();
     let scale = b.unwrap_int32() as u8;
     Datum::from(decimal.with_scale(scale).floor().significand())
 }
 
-pub fn mod_int32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_int32();
     if b == 0 {
         Datum::Null
@@ -897,12 +780,7 @@ pub fn mod_int32<'a>(
     }
 }
 
-pub fn mod_int64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_int64();
     if b == 0 {
         Datum::Null
@@ -911,12 +789,7 @@ pub fn mod_int64<'a>(
     }
 }
 
-pub fn mod_float32<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_float32();
     if b == 0.0 {
         Datum::Null
@@ -925,12 +798,7 @@ pub fn mod_float32<'a>(
     }
 }
 
-pub fn mod_float64<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_float64();
     if b == 0.0 {
         Datum::Null
@@ -939,12 +807,7 @@ pub fn mod_float64<'a>(
     }
 }
 
-pub fn mod_decimal<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn mod_decimal<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let b = b.unwrap_decimal();
     if b == 0 {
         Datum::Null
@@ -953,27 +816,27 @@ pub fn mod_decimal<'a>(
     }
 }
 
-pub fn neg_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn neg_int32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(-a.unwrap_int32())
 }
 
-pub fn neg_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn neg_int64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(-a.unwrap_int64())
 }
 
-pub fn neg_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn neg_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(-a.unwrap_float32())
 }
 
-pub fn neg_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn neg_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(-a.unwrap_float64())
 }
 
-pub fn neg_decimal<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn neg_decimal<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(-a.unwrap_decimal())
 }
 
-pub fn sqrt_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn sqrt_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let x = a.unwrap_float32();
     if x < 0.0 {
         return Datum::Null;
@@ -981,7 +844,7 @@ pub fn sqrt_float32<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> D
     Datum::from(x.sqrt())
 }
 
-pub fn sqrt_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn sqrt_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let x = a.unwrap_float64();
     if x < 0.0 {
         return Datum::Null;
@@ -989,27 +852,27 @@ pub fn sqrt_float64<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> D
     Datum::from(x.sqrt())
 }
 
-pub fn eq<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn eq<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a == b)
 }
 
-pub fn not_eq<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn not_eq<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a != b)
 }
 
-pub fn lt<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn lt<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a < b)
 }
 
-pub fn lte<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn lte<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a <= b)
 }
 
-pub fn gt<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn gt<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a > b)
 }
 
-pub fn gte<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn gte<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a >= b)
 }
 
@@ -1017,7 +880,7 @@ pub fn jsonb_get_int64<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let i = b.unwrap_int64();
     match a {
@@ -1046,7 +909,7 @@ pub fn jsonb_get_string<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let k = b.unwrap_str();
     match a {
@@ -1062,7 +925,7 @@ pub fn jsonb_contains_string<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let k = b.unwrap_str();
     // https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT
@@ -1079,7 +942,7 @@ pub fn jsonb_contains_jsonb<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     // https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT
     fn contains(a: Datum, b: Datum, at_top_level: bool) -> bool {
@@ -1112,7 +975,7 @@ pub fn jsonb_concat<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     match (a, b) {
         (Datum::Dict(dict_a), Datum::Dict(dict_b)) => {
@@ -1142,7 +1005,7 @@ pub fn jsonb_delete_int64<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let i = b.unwrap_int64();
     match a {
@@ -1168,7 +1031,7 @@ pub fn jsonb_delete_string<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     match a {
         Datum::List(list) => {
@@ -1188,7 +1051,7 @@ pub fn to_char<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let datetime = a.unwrap_timestamptz();
     let format_string = b.unwrap_str();
@@ -1198,19 +1061,14 @@ pub fn to_char<'a>(
     if format_string == "YYYY-MM-DD HH24:MI:SS.MS TZ" {
         let interpreted_format_string = "%Y-%m-%d %H:%M:%S.%f";
         Datum::String(
-            temp_storage.push_string(&datetime.format(interpreted_format_string).to_string()),
+            temp_storage.push_string(datetime.format(interpreted_format_string).to_string()),
         )
     } else {
         Datum::Null
     }
 }
 
-pub fn match_regex<'a>(
-    a: Datum<'a>,
-    b: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn match_regex<'a>(a: Datum<'a>, b: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let haystack = a.unwrap_str();
     match build_like_regex_from_string(b.unwrap_str()) {
         Ok(needle) => Datum::from(needle.is_match(haystack)),
@@ -1227,134 +1085,94 @@ pub fn match_cached_regex<'a>(a: Datum<'a>, needle: &Regex) -> Datum<'a> {
     Datum::from(needle.is_match(haystack))
 }
 
-pub fn ascii<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn ascii<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     match a.unwrap_str().chars().next() {
         None => Datum::Int32(0),
         Some(v) => Datum::Int32(v as i32),
     }
 }
 
-pub fn extract_interval_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_interval_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_interval().years())
 }
 
-pub fn extract_interval_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_interval_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_interval().months())
 }
 
-pub fn extract_interval_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_interval_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_interval().days())
 }
 
-pub fn extract_interval_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_interval_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_interval().hours())
 }
 
-pub fn extract_interval_minute<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_interval_minute<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_interval().minutes())
 }
 
-pub fn extract_interval_second<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_interval_second<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_interval().seconds())
 }
 
-pub fn extract_timestamp_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_timestamp_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamp().year()))
 }
 
-pub fn extract_timestamptz_year<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamptz_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamptz().year()))
 }
 
-pub fn extract_timestamp_quarter<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamp_quarter<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from((f64::from(a.unwrap_timestamp().month()) / 3.0).ceil())
 }
 
 pub fn extract_timestamptz_quarter<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     Datum::from((f64::from(a.unwrap_timestamptz().month()) / 3.0).ceil())
 }
 
-pub fn extract_timestamp_month<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamp_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamp().month()))
 }
 
-pub fn extract_timestamptz_month<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamptz_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamptz().month()))
 }
 
-pub fn extract_timestamp_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_timestamp_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamp().day()))
 }
 
-pub fn extract_timestamptz_day<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamptz_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamptz().day()))
 }
 
-pub fn extract_timestamp_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_timestamp_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamp().hour()))
 }
 
-pub fn extract_timestamptz_hour<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamptz_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamptz().hour()))
 }
 
-pub fn extract_timestamp_minute<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamp_minute<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamp().minute()))
 }
 
 pub fn extract_timestamptz_minute<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_timestamptz().minute()))
 }
 
-pub fn extract_timestamp_second<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamp_second<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let a = a.unwrap_timestamp();
     let s = f64::from(a.second());
     let ns = f64::from(a.nanosecond()) / 1e9;
@@ -1364,7 +1182,7 @@ pub fn extract_timestamp_second<'a>(
 pub fn extract_timestamptz_second<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamptz();
     let s = f64::from(a.second());
@@ -1376,7 +1194,7 @@ pub fn extract_timestamptz_second<'a>(
 ///
 /// Note that because isoweeks are defined in terms of January 4th, Jan 1 is only in week
 /// 1 about half of the time
-pub fn extract_timestamp_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn extract_timestamp_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let a = a.unwrap_timestamp();
     Datum::from(f64::from(a.iso_week().week()))
 }
@@ -1385,11 +1203,7 @@ pub fn extract_timestamp_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow
 ///
 /// Note that because isoweeks are defined in terms of January 4th, Jan 1 is only in week
 /// 1 about half of the time
-pub fn extract_timestamptz_week<'a>(
-    a: Datum<'a>,
-    _: &EvalEnv,
-    _: &mut PackableRow<'a>,
-) -> Datum<'a> {
+pub fn extract_timestamptz_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let a = a.unwrap_timestamptz();
     Datum::from(f64::from(a.iso_week().week()))
 }
@@ -1397,7 +1211,7 @@ pub fn extract_timestamptz_week<'a>(
 pub fn extract_timestamp_dayofyear<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamp();
     Datum::from(f64::from(a.ordinal()))
@@ -1406,7 +1220,7 @@ pub fn extract_timestamp_dayofyear<'a>(
 pub fn extract_timestamptz_dayofyear<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamptz();
     Datum::from(f64::from(a.ordinal()))
@@ -1416,7 +1230,7 @@ pub fn extract_timestamptz_dayofyear<'a>(
 pub fn extract_timestamp_dayofweek<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamp();
     Datum::from(a.weekday().num_days_from_sunday() as f64)
@@ -1426,7 +1240,7 @@ pub fn extract_timestamp_dayofweek<'a>(
 pub fn extract_timestamptz_dayofweek<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamptz();
     Datum::from(a.weekday().num_days_from_sunday() as f64)
@@ -1436,7 +1250,7 @@ pub fn extract_timestamptz_dayofweek<'a>(
 pub fn extract_timestamp_isodayofweek<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamp();
     Datum::from(a.weekday().number_from_monday() as f64)
@@ -1446,7 +1260,7 @@ pub fn extract_timestamp_isodayofweek<'a>(
 pub fn extract_timestamptz_isodayofweek<'a>(
     a: Datum<'a>,
     _: &EvalEnv,
-    _: &mut PackableRow<'a>,
+    _: &mut RowArena<'a>,
 ) -> Datum<'a> {
     let a = a.unwrap_timestamptz();
     Datum::from(a.weekday().number_from_monday() as f64)
@@ -1456,7 +1270,7 @@ pub fn date_trunc<'a>(
     a: Datum<'a>,
     b: Datum<'a>,
     env: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     match a.unwrap_str().parse::<DateTruncTo>() {
         Ok(DateTruncTo::Micros) => date_trunc_microseconds(b, env, temp_storage),
@@ -1477,7 +1291,7 @@ pub fn date_trunc<'a>(
     }
 }
 
-fn date_trunc_microseconds<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_microseconds<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     let time = NaiveTime::from_hms_micro(
         source_timestamp.hour(),
@@ -1488,7 +1302,7 @@ fn date_trunc_microseconds<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a
     Datum::Timestamp(NaiveDateTime::new(source_timestamp.date(), time))
 }
 
-fn date_trunc_milliseconds<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_milliseconds<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     let time = NaiveTime::from_hms_milli(
         source_timestamp.hour(),
@@ -1499,7 +1313,7 @@ fn date_trunc_milliseconds<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a
     Datum::Timestamp(NaiveDateTime::new(source_timestamp.date(), time))
 }
 
-fn date_trunc_second<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_second<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         source_timestamp.date(),
@@ -1511,7 +1325,7 @@ fn date_trunc_second<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> 
     ))
 }
 
-fn date_trunc_minute<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_minute<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         source_timestamp.date(),
@@ -1519,7 +1333,7 @@ fn date_trunc_minute<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> 
     ))
 }
 
-fn date_trunc_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         source_timestamp.date(),
@@ -1527,7 +1341,7 @@ fn date_trunc_hour<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Da
     ))
 }
 
-fn date_trunc_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         source_timestamp.date(),
@@ -1535,7 +1349,7 @@ fn date_trunc_day<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Dat
     ))
 }
 
-fn date_trunc_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     let num_days_from_monday = source_timestamp.date().weekday().num_days_from_monday();
     Datum::Timestamp(NaiveDateTime::new(
@@ -1548,7 +1362,7 @@ fn date_trunc_week<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Da
     ))
 }
 
-fn date_trunc_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         NaiveDate::from_ymd(source_timestamp.year(), source_timestamp.month(), 1),
@@ -1556,7 +1370,7 @@ fn date_trunc_month<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> D
     ))
 }
 
-fn date_trunc_quarter<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_quarter<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     let month = source_timestamp.month();
     let quarter = if month <= 3 {
@@ -1575,7 +1389,7 @@ fn date_trunc_quarter<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) ->
     ))
 }
 
-fn date_trunc_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         NaiveDate::from_ymd(source_timestamp.year(), 1, 1),
@@ -1583,7 +1397,7 @@ fn date_trunc_year<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Da
     ))
 }
 
-fn date_trunc_decade<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_decade<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     Datum::Timestamp(NaiveDateTime::new(
         NaiveDate::from_ymd(
@@ -1595,7 +1409,7 @@ fn date_trunc_decade<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> 
     ))
 }
 
-fn date_trunc_century<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_century<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     // Expects the first year of the century, meaning 2001 instead of 2000.
     let century = source_timestamp.year() - ((source_timestamp.year() % 100) - 1);
@@ -1605,7 +1419,7 @@ fn date_trunc_century<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) ->
     ))
 }
 
-fn date_trunc_millennium<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+fn date_trunc_millennium<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let source_timestamp = a.unwrap_timestamp();
     // Expects the first year of the millennium, meaning 2001 instead of 2000.
     let millennium = source_timestamp.year() - ((source_timestamp.year() % 1000) - 1);
@@ -1727,7 +1541,7 @@ impl FromStr for DateTruncTo {
 impl BinaryFunc {
     pub fn func(
         self,
-    ) -> for<'a> fn(Datum<'a>, Datum<'a>, &EvalEnv, &mut PackableRow<'a>) -> Datum<'a> {
+    ) -> for<'a> fn(Datum<'a>, Datum<'a>, &EvalEnv, &mut RowArena<'a>) -> Datum<'a> {
         match self {
             BinaryFunc::And => and,
             BinaryFunc::Or => or,
@@ -1958,7 +1772,7 @@ impl fmt::Display for BinaryFunc {
     }
 }
 
-pub fn is_null<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn is_null<'a>(a: Datum<'a>, _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     Datum::from(a == Datum::Null)
 }
 
@@ -2052,7 +1866,7 @@ pub enum UnaryFunc {
 }
 
 impl UnaryFunc {
-    pub fn func(self) -> for<'a> fn(Datum<'a>, &EvalEnv, &mut PackableRow<'a>) -> Datum<'a> {
+    pub fn func(self) -> for<'a> fn(Datum<'a>, &EvalEnv, &mut RowArena<'a>) -> Datum<'a> {
         match self {
             UnaryFunc::Not => not,
             UnaryFunc::IsNull => is_null,
@@ -2386,7 +2200,7 @@ impl fmt::Display for UnaryFunc {
     }
 }
 
-pub fn coalesce<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn coalesce<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     datums
         .iter()
         .find(|d| !d.is_null())
@@ -2394,7 +2208,7 @@ pub fn coalesce<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut PackableRow<'a>) 
         .unwrap_or(Datum::Null)
 }
 
-pub fn substr<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn substr<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let string: &'a str = datums[0].unwrap_str();
     let mut chars = string.chars();
 
@@ -2422,7 +2236,7 @@ pub fn substr<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut PackableRow<'a>) ->
     }
 }
 
-pub fn length<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut PackableRow<'a>) -> Datum<'a> {
+pub fn length<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut RowArena<'a>) -> Datum<'a> {
     let string = datums[0].unwrap_str();
 
     if datums.len() == 2 {
@@ -2460,11 +2274,11 @@ pub fn length<'a>(datums: &[Datum<'a>], _: &EvalEnv, _: &mut PackableRow<'a>) ->
 pub fn replace<'a>(
     datums: &[Datum<'a>],
     _: &EvalEnv,
-    temp_storage: &mut PackableRow<'a>,
+    temp_storage: &mut RowArena<'a>,
 ) -> Datum<'a> {
     Datum::String(
         temp_storage.push_string(
-            &datums[0]
+            datums[0]
                 .unwrap_str()
                 .replace(datums[1].unwrap_str(), datums[2].unwrap_str()),
         ),
@@ -2480,7 +2294,7 @@ pub enum VariadicFunc {
 }
 
 impl VariadicFunc {
-    pub fn func(self) -> for<'a> fn(&[Datum<'a>], &EvalEnv, &mut PackableRow<'a>) -> Datum<'a> {
+    pub fn func(self) -> for<'a> fn(&[Datum<'a>], &EvalEnv, &mut RowArena<'a>) -> Datum<'a> {
         match self {
             VariadicFunc::Coalesce => coalesce,
             VariadicFunc::Substr => substr,

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -63,7 +63,7 @@ impl FoldConstants {
                             .map(|i| datums[*i].clone())
                             .collect::<Vec<_>>();
                         let mut temp_storage = RowPacker::new();
-                        let temp_storage = &mut temp_storage.packable();
+                        let temp_storage = &mut temp_storage.arena();
                         let mut packer = RowPacker::new();
                         let val = aggregates
                             .iter()
@@ -84,7 +84,7 @@ impl FoldConstants {
                         .into_iter()
                         .map(|(key, vals)| {
                             let mut temp_storage = RowPacker::new();
-                            let temp_storage = &mut temp_storage.packable();
+                            let temp_storage = &mut temp_storage.arena();
                             let row = Row::pack(key.into_iter().chain(
                                 aggregates.iter().enumerate().map(|(i, agg)| {
                                     (agg.func.func())(
@@ -135,7 +135,7 @@ impl FoldConstants {
                         .map(|(input_row, diff)| {
                             let mut unpacked = input_row.unpack();
                             let mut temp_storage = RowPacker::new();
-                            let temp_storage = &mut temp_storage.packable();
+                            let temp_storage = &mut temp_storage.arena();
                             for scalar in scalars.iter() {
                                 unpacked.push(scalar.eval(&unpacked, env, temp_storage))
                             }
@@ -167,7 +167,7 @@ impl FoldConstants {
                         .filter(|(row, _diff)| {
                             let datums = row.unpack();
                             let mut temp_storage = RowPacker::new();
-                            let temp_storage = &mut temp_storage.packable();
+                            let temp_storage = &mut temp_storage.arena();
                             predicates
                                 .iter()
                                 .all(|p| p.eval(&datums, env, temp_storage) == Datum::True)

--- a/src/repr/lib.rs
+++ b/src/repr/lib.rs
@@ -22,7 +22,9 @@ mod scalar;
 
 pub use qualname::{LiteralName, QualName};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{DatumDict, DatumList, PackableRow, Row, RowPacker, RowUnpacker, UnpackedRow};
+pub use row::{
+    DatumDict, DatumList, PackableRow, Row, RowArena, RowPacker, RowUnpacker, UnpackedRow,
+};
 pub use scalar::decimal;
 pub use scalar::regex;
 pub use scalar::{Datum, Interval, ScalarType};

--- a/src/repr/scalar/mod.rs
+++ b/src/repr/scalar/mod.rs
@@ -244,6 +244,20 @@ impl<'a> Datum<'a> {
         }
     }
 
+    pub fn unwrap_list(&self) -> DatumList<'a> {
+        match self {
+            Datum::List(list) => *list,
+            _ => panic!("Datum::unwrap_list called on {:?}", self),
+        }
+    }
+
+    pub fn unwrap_dict(&self) -> DatumDict<'a> {
+        match self {
+            Datum::Dict(dict) => *dict,
+            _ => panic!("Datum::unwrap_dict called on {:?}", self),
+        }
+    }
+
     pub fn is_instance_of(self, column_type: &ColumnType) -> bool {
         fn is_instance_of_scalar(datum: Datum, scalar_type: &ScalarType) -> bool {
             if let ScalarType::Jsonb = scalar_type {

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -447,7 +447,7 @@ fn push_column(
             let serde = get_column_inner::<serde_json::Value>(postgres_row, i, nullable)?;
             if let Some(serde) = serde {
                 let mut temp_storage = RowPacker::new();
-                let datum = expr::serde_to_datum(&mut temp_storage.packable(), serde).unwrap();
+                let datum = expr::serde_to_datum(&mut temp_storage.arena(), serde).unwrap();
                 row.push(datum)
             } else {
                 row.push(Datum::Null)


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/1215 I reused `PackableRow` as a buffer for temporary data. This was a mistake - the underlying vec can move when it grows, leading to non-deterministic use-after-free bugs.

This pr separates that role into a new `RowArena` type, which moves each temporary value into a separate fixed heap allocation.

This is a hot fix - the api for building complex nested datums needs more thought, but I don't want to leave tests randomly failing in the meantime.