### PR TITLE
Add bootstrap.sql to materialized Docker image

### DIFF
--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -49,7 +49,8 @@ docker_run "cargo test --no-run && cargo test --no-run --message-format=json > t
 
 ci_collapsed_heading "Preparing Docker context"
 {
-    cp target/release/materialized misc/docker/ci-raw-materialized
+    cp target/release/materialized misc/dist/etc/materialized/bootstrap.sql \
+        misc/docker/ci-raw-materialized
 
     # NOTE(benesch): the debug information is large enough that it slows down CI,
     # since we're packaging these binaries up into Docker images and shipping them

--- a/misc/docker/ci-raw-materialized/Dockerfile
+++ b/misc/docker/ci-raw-materialized/Dockerfile
@@ -6,5 +6,6 @@
 FROM ubuntu:bionic
 
 COPY materialized /usr/local/bin
+COPY bootstrap.sql /usr/local/etc
 
 ENTRYPOINT ["materialized"]


### PR DESCRIPTION
A subsequent change will patch ex/chbench/docker-compose.yml to add the
--bootstrap-sql parameter to materialized.