### PR TITLE
dataflow: enable necessary tokio features

### DIFF
--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -29,7 +29,7 @@ repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
-tokio = { version = "0.2", features = ["fs"] }
+tokio = { version = "0.2", features = ["blocking", "fs", "rt-threaded"] }
 tokio-util = { version = "0.2", features = ["codec"] }
 url = "1.7.2"
 url_serde = "0.2.0"


### PR DESCRIPTION
These go unnoticed when compiling materialized, since features across
all dependencies are unioned, but cause compilation failures if
compiling dataflow directly via e.g. `cargo build -p dataflow`.