### PR TITLE
deps: upgrade to custom prometheus version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,17 +149,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder",
  "safemem",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder 1.3.2",
 ]
 
 [[package]]
@@ -174,7 +165,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder",
  "serde",
 ]
 
@@ -202,7 +193,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
  "byte-tools 0.3.1",
- "byteorder 1.3.2",
+ "byteorder",
  "generic-array 0.12.0",
 ]
 
@@ -228,12 +219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
-
-[[package]]
 name = "bumpalo"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,12 +238,6 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
-name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
@@ -269,8 +248,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.2",
- "either",
+ "byteorder",
  "iovec",
 ]
 
@@ -321,12 +299,12 @@ name = "ccsr"
 version = "0.1.0"
 dependencies = [
  "failure",
- "hyper 0.13.0",
+ "hyper",
  "lazy_static",
- "reqwest 0.10.0-alpha.2",
+ "reqwest",
  "serde",
  "serde_json",
- "tokio 0.2.4",
+ "tokio",
 ]
 
 [[package]]
@@ -391,10 +369,10 @@ dependencies = [
  "predicates",
  "rand 0.7.2",
  "serde",
- "tokio 0.2.4",
+ "tokio",
  "tokio-serde",
  "tokio-util",
- "uuid 0.8.1",
+ "uuid",
 ]
 
 [[package]]
@@ -404,39 +382,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 
 [[package]]
-name = "cookie"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
-dependencies = [
- "time",
- "url 1.7.2",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
-dependencies = [
- "cookie",
- "failure",
- "idna 0.1.5",
- "log",
- "publicsuffix",
- "serde",
- "serde_json",
- "time",
- "try_from",
- "url 1.7.2",
-]
-
-[[package]]
 name = "coord"
 version = "0.1.0"
 dependencies = [
  "backtrace",
- "byteorder 1.3.2",
+ "byteorder",
  "bytes 0.4.12",
  "catalog",
  "ccsr",
@@ -464,10 +414,10 @@ dependencies = [
  "sql",
  "symbiosis",
  "timely",
- "tokio 0.2.4",
+ "tokio",
  "tokio-threadpool",
- "url 2.1.0",
- "uuid 0.8.1",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -485,15 +435,6 @@ name = "core-foundation-sys"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
 
 [[package]]
 name = "crc32fast"
@@ -593,7 +534,7 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
- "scopeguard 1.0.0",
+ "scopeguard",
 ]
 
 [[package]]
@@ -682,10 +623,10 @@ dependencies = [
  "serde",
  "serde_json",
  "timely",
- "tokio 0.2.4",
+ "tokio",
  "tokio-util",
- "url 2.1.0",
- "uuid 0.8.1",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -707,8 +648,8 @@ dependencies = [
  "repr",
  "serde",
  "serde_json",
- "url 2.1.0",
- "uuid 0.8.1",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -883,15 +824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
-dependencies = [
- "version_check 0.1.5",
-]
-
-[[package]]
 name = "escargot"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,7 +853,7 @@ dependencies = [
  "serde",
  "serde_json",
  "unicase",
- "uuid 0.8.1",
+ "uuid",
 ]
 
 [[package]]
@@ -980,17 +912,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.7",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
-dependencies = [
- "crc32fast",
- "libc",
- "miniz_oxide_c_api",
 ]
 
 [[package]]
@@ -1108,16 +1029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
 
 [[package]]
-name = "futures-cpupool"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-dependencies = [
- "futures 0.1.29",
- "num_cpus",
-]
-
-[[package]]
 name = "futures-executor"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,24 +1140,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42e3daed5a7e17b12a0c23b5b2fbff23a925a570938ebee4baca1a9a1a2240"
-dependencies = [
- "byteorder 1.3.2",
- "bytes 0.4.12",
- "fnv",
- "futures 0.1.29",
- "http 0.1.17",
- "indexmap",
- "log",
- "slab",
- "string",
- "tokio-io",
-]
-
-[[package]]
-name = "h2"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9433d71e471c1736fd5a61b671fc0b148d7a2992f666c958d03cd8feb3b88d1"
@@ -1256,11 +1149,11 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.0",
+ "http",
  "indexmap",
  "log",
  "slab",
- "tokio 0.2.4",
+ "tokio",
  "tokio-util",
 ]
 
@@ -1280,6 +1173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 
 [[package]]
+name = "hex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
+
+[[package]]
 name = "hmac"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,17 +1186,6 @@ checksum = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 dependencies = [
  "crypto-mac",
  "digest 0.7.6",
-]
-
-[[package]]
-name = "http"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
-dependencies = [
- "bytes 0.4.12",
- "fnv",
- "itoa",
 ]
 
 [[package]]
@@ -1313,24 +1201,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "http 0.1.17",
- "tokio-buf",
-]
-
-[[package]]
-name = "http-body"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
  "bytes 0.5.3",
- "http 0.2.0",
+ "http",
 ]
 
 [[package]]
@@ -1350,36 +1226,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "futures-cpupool",
- "h2 0.1.23",
- "http 0.1.17",
- "http-body 0.1.0",
- "httparse",
- "iovec",
- "itoa",
- "log",
- "net2",
- "rustc_version 0.2.3",
- "time",
- "tokio 0.1.22",
- "tokio-buf",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "want 0.2.0",
-]
-
-[[package]]
-name = "hyper"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31aca065a2f6049464bb9a37dd316e51d9b7f502469e0e02e18586931f0cfcdf"
@@ -1388,31 +1234,18 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.1",
- "http 0.2.0",
- "http-body 0.3.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "log",
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.4",
+ "tokio",
  "tower-service",
- "want 0.3.0",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "hyper 0.12.35",
- "native-tls",
- "tokio-io",
+ "want",
 ]
 
 [[package]]
@@ -1421,21 +1254,10 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab58a31960b2f78c5c24cf255216789863754438a1e48849a956846f899e762e"
 dependencies = [
- "hyper 0.13.0",
+ "hyper",
  "native-tls",
- "tokio 0.2.4",
+ "tokio",
  "tokio-tls",
-]
-
-[[package]]
-name = "idna"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1480,7 +1302,7 @@ name = "interchange"
 version = "0.1.0"
 dependencies = [
  "avro-rs",
- "byteorder 1.3.2",
+ "byteorder",
  "ccsr",
  "criterion",
  "failure",
@@ -1490,7 +1312,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.8.0",
- "url 2.1.0",
+ "url",
 ]
 
 [[package]]
@@ -1627,16 +1449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
-name = "lock_api"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
-dependencies = [
- "owning_ref",
- "scopeguard 0.3.3",
-]
-
-[[package]]
 name = "log"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1675,7 +1487,7 @@ dependencies = [
  "fallible-iterator 0.1.6",
  "futures 0.3.1",
  "getopts",
- "hyper 0.13.0",
+ "hyper",
  "itertools",
  "jemallocator",
  "lazy_static",
@@ -1687,7 +1499,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "tempfile",
- "tokio 0.2.4",
+ "tokio",
 ]
 
 [[package]]
@@ -1732,7 +1544,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1766,27 +1578,6 @@ checksum = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide_c_api"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
-dependencies = [
- "cc",
- "crc",
- "libc",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1877,12 +1668,6 @@ name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
-
-[[package]]
-name = "nom"
-version = "1.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
 name = "nom"
@@ -2095,7 +1880,7 @@ dependencies = [
  "libc",
  "log",
  "smallvec 1.0.0",
- "tokio 0.2.4",
+ "tokio",
 ]
 
 [[package]]
@@ -2118,38 +1903,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
-dependencies = [
- "libc",
- "rand 0.6.5",
- "rustc_version 0.2.3",
- "smallvec 0.6.13",
- "winapi 0.3.7",
-]
-
-[[package]]
 name = "parse_duration"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,12 +1921,6 @@ checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
@@ -2184,7 +1931,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e445870a4b4c91a285b863e90ec5b3190f31f263a5f68e3e81b3987021e45802"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder",
  "chrono",
  "postgres",
 ]
@@ -2193,7 +1940,7 @@ dependencies = [
 name = "pgwire"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder",
  "bytes 0.5.3",
  "cast",
  "chrono",
@@ -2212,7 +1959,7 @@ dependencies = [
  "rand 0.7.2",
  "repr",
  "sql",
- "tokio 0.2.4",
+ "tokio",
  "tokio-util",
 ]
 
@@ -2293,7 +2040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2487e66455bf88a1b247bf08a3ce7fe5197ac6d67228d920b0ee6a0e97fd7312"
 dependencies = [
  "base64 0.6.0",
- "byteorder 1.3.2",
+ "byteorder",
  "bytes 0.4.12",
  "fallible-iterator 0.1.6",
  "generic-array 0.9.0",
@@ -2313,7 +2060,7 @@ checksum = "ffac35b3e0029b404c24a3b82149b4e904f293e8ca4a327eefa24d3ca50df36f"
 dependencies = [
  "chrono",
  "fallible-iterator 0.1.6",
- "hex",
+ "hex 0.2.0",
  "phf",
  "postgres-protocol",
  "serde_json",
@@ -2429,32 +2176,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "procinfo"
-version = "0.3.1"
+name = "procfs"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42e8578852a3306838981aedad8c5642ba794929aa12af0c9eb6c072b77af6c"
+checksum = "13a8f3e183534522128d84f7adbee1834aac1ea99171cd69d7fc93a3bc38b993"
 dependencies = [
- "byteorder 0.5.3",
+ "bitflags",
+ "byteorder",
+ "hex 0.4.0",
+ "lazy_static",
  "libc",
- "nom 1.2.4",
- "rustc_version 0.1.7",
+ "libflate",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
+version = "0.8.0"
+source = "git+https://github.com/benesch/rust-prometheus.git?branch=reqwest-010#1bc4340dc33396cdd894a47a77c2b401d6ed33ca"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "libc",
- "procinfo",
+ "procfs",
  "protobuf",
- "quick-error",
- "reqwest 0.9.24",
+ "reqwest",
  "spin",
+ "thiserror",
 ]
 
 [[package]]
@@ -2474,19 +2222,6 @@ name = "protobuf"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40361836defdd5871ff7e84096c6f6444af7fc157f8ef1789f54f147687caa20"
-
-[[package]]
-name = "publicsuffix"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
-dependencies = [
- "error-chain",
- "idna 0.2.0",
- "lazy_static",
- "regex",
- "url 2.1.0",
-]
 
 [[package]]
 name = "quick-error"
@@ -2804,7 +2539,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder",
 ]
 
 [[package]]
@@ -2843,40 +2578,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
-dependencies = [
- "base64 0.10.1",
- "bytes 0.4.12",
- "cookie",
- "cookie_store",
- "encoding_rs",
- "flate2",
- "futures 0.1.29",
- "http 0.1.17",
- "hyper 0.12.35",
- "hyper-tls 0.3.2",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "serde",
- "serde_json",
- "serde_urlencoded 0.5.5",
- "time",
- "tokio 0.1.22",
- "tokio-executor",
- "tokio-io",
- "tokio-threadpool",
- "tokio-timer",
- "url 1.7.2",
- "uuid 0.7.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.10.0-alpha.2"
 source = "git+https://github.com/seanmonstar/reqwest.git#ce43f80d8be3fef72267483aeba0a6927f150035"
 dependencies = [
@@ -2886,25 +2587,25 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 0.2.0",
- "http-body 0.3.1",
- "hyper 0.13.0",
- "hyper-tls 0.4.0",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
  "native-tls",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded 0.6.1",
+ "serde_urlencoded",
  "time",
- "tokio 0.2.4",
+ "tokio",
  "tokio-tls",
- "url 2.1.0",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -2938,7 +2639,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7a28ded8f10361cefb69a8d8e1d195acf59344150534c165c401d6611cf013d"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder",
  "num",
  "postgres",
  "serde",
@@ -2952,20 +2653,11 @@ checksum = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 
 [[package]]
 name = "rustc_version"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
-dependencies = [
- "semver 0.1.20",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0",
+ "semver",
 ]
 
 [[package]]
@@ -3001,12 +2693,6 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-
-[[package]]
-name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -3031,12 +2717,6 @@ checksum = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 dependencies = [
  "core-foundation-sys",
 ]
-
-[[package]]
-name = "semver"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "semver"
@@ -3097,18 +2777,6 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url 1.7.2",
-]
-
-[[package]]
-name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
@@ -3116,7 +2784,7 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.1.0",
+ "url",
 ]
 
 [[package]]
@@ -3226,8 +2894,8 @@ dependencies = [
  "repr",
  "sqlparser",
  "unicase",
- "url 2.1.0",
- "uuid 0.8.1",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3254,8 +2922,8 @@ dependencies = [
  "sql",
  "sqlparser",
  "timely",
- "tokio 0.2.4",
- "uuid 0.8.1",
+ "tokio",
+ "uuid",
  "walkdir",
 ]
 
@@ -3268,19 +2936,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-
-[[package]]
 name = "stdweb"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version 0.2.3",
+ "rustc_version",
  "serde",
  "serde_json",
  "stdweb-derive",
@@ -3323,15 +2985,6 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "string"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
-dependencies = [
- "bytes 0.4.12",
-]
 
 [[package]]
 name = "stringprep"
@@ -3446,7 +3099,7 @@ dependencies = [
  "atty",
  "avro-rs",
  "backoff",
- "byteorder 1.3.2",
+ "byteorder",
  "ccsr",
  "chrono",
  "failure",
@@ -3461,7 +3114,7 @@ dependencies = [
  "rand 0.7.2",
  "rdkafka",
  "regex",
- "reqwest 0.10.0-alpha.2",
+ "reqwest",
  "rust_decimal",
  "serde_json",
  "sqlparser",
@@ -3475,6 +3128,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
+dependencies = [
+ "proc-macro2 1.0.1",
+ "quote 1.0.2",
+ "syn 1.0.11",
 ]
 
 [[package]]
@@ -3554,25 +3227,6 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "mio",
- "num_cpus",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
-]
-
-[[package]]
-name = "tokio"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcced6bb623d4bff3739c176c415f13c418f426395c169c9c3cd9a492c715b16"
@@ -3592,27 +3246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-buf"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
-dependencies = [
- "bytes 0.4.12",
- "either",
- "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-current-thread"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
-dependencies = [
- "futures 0.1.29",
- "tokio-executor",
-]
-
-[[package]]
 name = "tokio-executor"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3623,17 +3256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "log",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3641,25 +3263,6 @@ checksum = "d5795a71419535c6dcecc9b6ca95bdd3c2d6142f7e8343d7beb9923f129aa87e"
 dependencies = [
  "quote 1.0.2",
  "syn 1.0.11",
-]
-
-[[package]]
-name = "tokio-reactor"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af16bfac7e112bea8b0442542161bfc41cbfa4466b580bdda7d18cb88b911ce"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
- "lazy_static",
- "log",
- "mio",
- "num_cpus",
- "parking_lot",
- "slab",
- "tokio-executor",
- "tokio-io",
- "tokio-sync",
 ]
 
 [[package]]
@@ -3674,30 +3277,6 @@ dependencies = [
  "futures 0.3.1",
  "pin-project",
  "serde",
-]
-
-[[package]]
-name = "tokio-sync"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
-dependencies = [
- "fnv",
- "futures 0.1.29",
-]
-
-[[package]]
-name = "tokio-tcp"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.29",
- "iovec",
- "mio",
- "tokio-io",
- "tokio-reactor",
 ]
 
 [[package]]
@@ -3718,25 +3297,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-timer"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
-dependencies = [
- "crossbeam-utils",
- "futures 0.1.29",
- "slab",
- "tokio-executor",
-]
-
-[[package]]
 name = "tokio-tls"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bde02a3a5291395f59b06ec6945a3077602fac2b07eeeaf0dee2122f3619828"
 dependencies = [
  "native-tls",
- "tokio 0.2.4",
+ "tokio",
 ]
 
 [[package]]
@@ -3750,7 +3317,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.4",
+ "tokio",
 ]
 
 [[package]]
@@ -3779,15 +3346,6 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
-
-[[package]]
-name = "try_from"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "typed-arena"
@@ -3854,34 +3412,14 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-dependencies = [
- "idna 0.1.5",
- "matches",
- "percent-encoding 1.0.1",
-]
-
-[[package]]
-name = "url"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 dependencies = [
- "idna 0.2.0",
+ "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "serde",
-]
-
-[[package]]
-name = "uuid"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
-dependencies = [
- "rand 0.6.5",
 ]
 
 [[package]]
@@ -3921,17 +3459,6 @@ dependencies = [
  "same-file",
  "winapi 0.3.7",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-dependencies = [
- "futures 0.1.29",
- "log",
- "try-lock",
 ]
 
 [[package]]
@@ -4047,7 +3574,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 dependencies = [
- "nom 4.2.3",
+ "nom",
 ]
 
 [[package]]

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 notify = "4.0"
 ore = { path = "../ore" }
 pdqselect = "0.1.0"
-prometheus = { version = "0.7.0", default-features = false }
+prometheus = { git = "https://github.com/benesch/rust-prometheus.git", branch = "reqwest-010", default-features = false }
 prometheus-static-metric = "0.2.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build"] }
 repr = { path = "../repr" }

--- a/src/dataflow/decode/avro.rs
+++ b/src/dataflow/decode/avro.rs
@@ -3,19 +3,18 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-use dataflow_types::{Diff, Timestamp};
 use differential_dataflow::Hashable;
-use log::error;
-use repr::Row;
-use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::{Scope, Stream};
-
 use lazy_static::lazy_static;
+use log::error;
 use prometheus::IntCounterVec;
-
 use prometheus_static_metric::make_static_metric;
+use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::Operator;
+use timely::dataflow::{Scope, Stream};
 use url::Url;
+
+use dataflow_types::{Diff, Timestamp};
+use repr::Row;
 
 make_static_metric! {
     struct EventsRead: IntCounter {
@@ -24,7 +23,7 @@ make_static_metric! {
 }
 
 lazy_static! {
-    static ref EVENTS_COUNTER_INTERNAL: IntCounterVec = register_int_counter_vec!(
+    static ref EVENTS_COUNTER_INTERNAL: IntCounterVec = prometheus::register_int_counter_vec!(
         "mz_kafka_events_read_total",
         "Count of kafka events we have read from the wire",
         &["status"]

--- a/src/dataflow/lib.rs
+++ b/src/dataflow/lib.rs
@@ -5,14 +5,6 @@
 
 //! Driver for timely/differential dataflow.
 
-// the prometheus macros (e.g. `register*`) all depend on each other, including on
-// internal `__register*` macros, instead of doing the right thing and I assume using
-// something like `$crate::__register_*`. That means that without using a macro_use here,
-// we would end up needing to import several internal macros everywhere we want to use
-// any of the prometheus macros.
-#[macro_use]
-extern crate prometheus;
-
 mod arrangement;
 mod decode;
 mod render;

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -3,24 +3,25 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
+use std::sync::Mutex;
+use std::time::Duration;
+
+use lazy_static::lazy_static;
 use log::error;
+use prometheus::IntCounter;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::{ClientConfig, ClientContext};
 use rdkafka::{Message, Timestamp as KafkaTimestamp};
-use std::sync::Mutex;
-use std::time::Duration;
 use timely::dataflow::{Scope, Stream};
 use timely::scheduling::activate::SyncActivator;
 
-use super::util::source;
-use super::{SharedCapability, SourceStatus};
 use dataflow_types::{KafkaSourceConnector, Timestamp};
 
-use lazy_static::lazy_static;
-use prometheus::IntCounter;
+use super::util::source;
+use super::{SharedCapability, SourceStatus};
 
 lazy_static! {
-    static ref BYTES_READ_COUNTER: IntCounter = register_int_counter!(
+    static ref BYTES_READ_COUNTER: IntCounter = prometheus::register_int_counter!(
         "mz_kafka_bytes_read_total",
         "Count of kafka bytes we have read from the wire"
     )

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4"
 ore = { path = "../ore" }
 parse_duration = "2.0.1"
 pgwire = { path = "../pgwire" }
-prometheus = { version = "0.7.0", default-features = false, features = ["process"] }
+prometheus = { git = "https://github.com/benesch/rust-prometheus.git", branch = "reqwest-010", default-features = false, features = ["process"] }
 tempfile = "3.1"
 tokio = "0.2"
 

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -13,7 +13,7 @@ path = "bin/metrics.rs"
 getopts = "0.2"
 failure = "0.1.6"
 regex = "1.3.1"
-prometheus = { version = "0.7", features = ["push", "process"] }
+prometheus = { git = "https://github.com/benesch/rust-prometheus.git", branch = "reqwest-010", features = ["push", "process"] }
 chrono = "0.4.10"
 postgres = { version = "0.15", features = ["with-chrono"] }
 log = "0.4.10"

--- a/src/metrics/bin/metrics.rs
+++ b/src/metrics/bin/metrics.rs
@@ -3,14 +3,6 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc..
 
-// the prometheus macros (e.g. `register*`) all depend on each other, including on
-// internal `__register*` macros, instead of doing the right thing and I assume using
-// something like `$crate::__register_*`. That means that without using a macro_use here,
-// we would end up needing to import several internal macros everywhere we want to use
-// any of the prometheus macros.
-#[macro_use]
-extern crate prometheus;
-
 use std::cmp::min;
 use std::collections::HashMap;
 use std::thread;
@@ -141,7 +133,7 @@ fn print_error_and_backoff(backoff: &mut Duration, error_message: String) {
 }
 
 fn create_histogram(query: &str) -> Histogram {
-    let hist_vec = register_histogram_vec!(
+    let hist_vec = prometheus::register_histogram_vec!(
         "mz_client_peek_seconds",
         "how long peeks took",
         &["query"],

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1.4.0"
 log = "0.4"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
-prometheus = { version = "0.7.0", default-features = false, features = ["process"] }
+prometheus = { git = "https://github.com/benesch/rust-prometheus.git", branch = "reqwest-010", default-features = false, features = ["process"] }
 rand = "0.7"
 repr = { path = "../repr" }
 sql = { path = "../sql" }

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -14,7 +14,6 @@ use futures::sink::SinkExt;
 use futures::stream;
 use lazy_static::lazy_static;
 use log::{debug, trace};
-use prometheus::{histogram_opts, register_histogram_vec};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
@@ -53,7 +52,7 @@ pub fn match_handshake(buf: &[u8]) -> bool {
 }
 
 lazy_static! {
-    static ref COMMAND_DURATIONS: prometheus::HistogramVec = register_histogram_vec!(
+    static ref COMMAND_DURATIONS: prometheus::HistogramVec = prometheus::register_histogram_vec!(
         "mz_command_durations",
         "how long individual commands took",
         &["command", "status"],


### PR DESCRIPTION
The main impetus for this is removing the last dependency on the reqwest
0.9/hyper 0.12/tokio 0.1 stack. This upgrade removes a dozen or so
duplicated dependencies from our crate graph and should have a nice
speedup on a clean build.

As a side effect it pulls in an unreleased change from the prometheus
upstream that handles macro imports properly, so we no longer need the
 #[macro_use] attribute in every crate that depends on prometheus.