### PR TITLE
sql: fix column name handling

### DIFF
--- a/test/joins.slt
+++ b/test/joins.slt
@@ -48,3 +48,19 @@ SELECT l.la, l.lb, r.ra, r.rb FROM l RIGHT JOIN r ON l.la = r.ra
 NULL  NULL  4  r4
 1     l1    1  r1
 3     l3    3  r3
+
+
+# Test that columns detected to be equivalent retain the names that the user
+# asks for. Protects against regression of #1217.
+query II colnames rowsort
+SELECT ra, r.ra FROM l JOIN r ON l.la = r.ra LIMIT 0
+----
+ra  ra
+
+
+# Test that columns detected to be equivalent retain the names that the user
+# asks for. Protects against regression of #1217.
+query ITIT colnames rowsort
+SELECT * FROM l JOIN r ON l.la = r.ra LIMIT 0
+----
+la  lb  ra  rb

--- a/test/scoping.slt
+++ b/test/scoping.slt
@@ -11,9 +11,20 @@ CREATE TABLE t1 (a int)
 statement ok
 CREATE TABLE t2 (a int)
 
+statement ok
+CREATE TABLE t3 (a int)
+
 # This works in MySQL, but not PostgreSQL.
 query I
 SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t2.a
+
+# As above, this works in MySQL, but not PostgreSQL.
+query I
+SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.a = t3.a GROUP BY t2.a
+
+# Same as last query, but with associativity reversed.
+query I
+SELECT t1.a FROM t1 JOIN (t2 JOIN t3 ON t2.a = t3.a) ON t1.a = t2.a GROUP BY t3.a
 
 # This works in PostgreSQL.
 query I

--- a/test/string.slt
+++ b/test/string.slt
@@ -5,6 +5,13 @@
 
 mode cockroach
 
+### column names ###
+
+query TTT colnames
+SELECT length('a'), ascii('a'), substr('a', 1) LIMIT 0
+----
+length  ascii  substr
+
 ### ascii ###
 
 statement ok


### PR DESCRIPTION
Don't clobber column names when finding column equivalences in an inner
join.

For good measure, while I'm in here, assign names to expressions that
have an outer function call, like in `SELECT length('a')`, for
compatibility with postgres.

Fix MaterializeInc/database-issues#402.
Fix MaterializeInc/database-issues#429.