### PR TITLE
pgwire: restore implementation of TAIL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,6 @@ dependencies = [
  "chrono",
  "comm",
  "coord",
- "csv",
  "dataflow-types",
  "expr",
  "failure",

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -14,7 +14,6 @@ bytes = "0.5"
 cast = "0.2"
 comm = { path = "../comm" }
 coord = { path = "../coord" }
-csv = "1.1"
 chrono = "0.4"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }

--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -122,6 +122,7 @@ impl Encoder for Codec {
             BackendMessage::ErrorResponse { .. } => b'E',
             BackendMessage::CopyOutResponse => b'H',
             BackendMessage::CopyData(_) => b'd',
+            BackendMessage::CopyDone => b'c',
         };
         buf.put_u8(byte);
 
@@ -147,6 +148,7 @@ impl Encoder for Codec {
             BackendMessage::CopyData(mut data) => {
                 buf.append(&mut data);
             }
+            BackendMessage::CopyDone => (),
             BackendMessage::AuthenticationOk => {
                 buf.put_u32(0);
             }

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -49,8 +49,7 @@ pub fn describe_statement(
         | Statement::SetVariable { .. }
         | Statement::StartTransaction { .. }
         | Statement::Rollback { .. }
-        | Statement::Commit { .. }
-        | Statement::Tail { .. } => (None, vec![]),
+        | Statement::Commit { .. } => (None, vec![]),
 
         Statement::CreateSources { .. } => (
             Some(RelationDesc::empty().add_column("Topic", ScalarType::String)),
@@ -148,7 +147,7 @@ pub fn describe_statement(
             }
         }
 
-        Statement::Peek { name, .. } => {
+        Statement::Peek { name, .. } | Statement::Tail { name, .. } => {
             let sql_object = catalog.get(&name.try_into()?)?;
             (Some(sql_object.desc()?.clone()), vec![])
         }


### PR DESCRIPTION
I accidentally deleted this in the async/await upgrade. Restore it.

@umanwizard it seemed easier to just use the tab-delimited text format here since the escaping rules are simpler, so that's one notable deviation from the old implementation. Otherwise it is a straightforward translation into async/await!