### PR TITLE
coord: don't panic when sinks depend on sources

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -855,6 +855,18 @@ where
                     }
                 })
             }
+            for (_sink_id, sink) in dataflow.sinks.iter_mut() {
+                let (source_id, _) = &mut sink.from;
+                // If the source has a corresponding view, use its name instead.
+                if let Some((_source, new_id)) = self.sources.get(source_id) {
+                    // If the source has a corresponding view, use its name instead.
+                    if let Some(new_id) = new_id {
+                        *source_id = *new_id;
+                    } else {
+                        sources.push(*source_id);
+                    }
+                }
+            }
             sources.sort();
             sources.dedup();
             for id in sources {

--- a/test/basic.td
+++ b/test/basic.td
@@ -151,3 +151,12 @@ b  c
 
 ! PEEK idx1
 catalog item 'idx1' is an index and so cannot be depended upon
+
+# N.B. it is important to test sinks that depend on sources directly vs. sinks
+# that depend on views, as the code paths are different.
+
+> CREATE SINK data_sink FROM data INTO 'kafka://${testdrive.kafka-addr}/data-sink'
+
+> CREATE SINK test1_sink FROM data INTO 'kafka://${testdrive.kafka-addr}/test1-sink'
+
+# TODO: more tests.


### PR DESCRIPTION
Fix MaterializeInc/database-issues#482, as well as the more general case of a sink depending directly upon a source.

/cc @JLDLaughlin 