### PR TITLE
expr: fix bugs in ScalarExpr::non_null_requirements

### DIFF
--- a/src/expr/scalar/mod.rs
+++ b/src/expr/scalar/mod.rs
@@ -345,30 +345,24 @@ impl ScalarExpr {
             ScalarExpr::Literal(..) => {}
             ScalarExpr::CallNullary(_) => (),
             ScalarExpr::CallUnary { func, expr } => {
-                if func != &UnaryFunc::IsNull {
+                if func.propagates_nulls() {
                     expr.non_null_requirements(columns);
                 }
             }
             ScalarExpr::CallBinary { func, expr1, expr2 } => {
-                if func != &BinaryFunc::Or {
+                if func.propagates_nulls() {
                     expr1.non_null_requirements(columns);
                     expr2.non_null_requirements(columns);
                 }
             }
             ScalarExpr::CallVariadic { func, exprs } => {
-                if func != &VariadicFunc::Coalesce {
+                if func.propagates_nulls() {
                     for expr in exprs {
                         expr.non_null_requirements(columns);
                     }
                 }
             }
-            ScalarExpr::If {
-                cond,
-                then: _,
-                els: _,
-            } => {
-                cond.non_null_requirements(columns);
-            }
+            ScalarExpr::If { .. } => (),
             ScalarExpr::MatchCachedRegex { expr, .. } => {
                 expr.non_null_requirements(columns);
             }


### PR DESCRIPTION
This function can now be implemented in terms of
[Nullary | Unary | Binary | Variadic ]Func::propagates_nulls,
which avoids duplicating information and also fixes a buglet where
BinaryFunc::And was not propertly marked as not propagating nulls.

While I'm in here, fix a bug in ScalarExpr::If, which does *not*
necessarily propagate null (thanks, SQL) if the condition is null,
because the else condition will still be evaluated.