### PR TITLE
deps: downgrade to log 0.4.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.10"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ad466a945c9c40f6f9a449c55675547e59bc75a2722d4689042ab3ae80c9c"
+checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
 ]

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.6"
-log = "0.4"
+log = "0.4.8"
 repr = { path = "../repr" }
 rusqlite = { version = "0.20", features = ["bundled"] }
 serde = "1.0"

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -12,7 +12,7 @@ path = "lib.rs"
 bincode = "1.2"
 bytes = "0.5"
 futures = "0.3"
-log = "0.4"
+log = "0.4.8"
 num_enum = "0.4.2"
 ore = { path = "../ore" }
 rand = "0.7"

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3"
 getopts = "0.2"
 interchange = { path = "../interchange" }
 lazy_static = "1.4.0"
-log = "0.4"
+log = "0.4.8"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 pdqselect = "0.1.0"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -25,7 +25,7 @@ getopts = "0.2"
 hyper = "0.13.0"
 jemallocator = { version = "0.3.0", features = ["profiling"] }
 lazy_static = "1.4.0"
-log = "0.4"
+log = "0.4.8"
 ore = { path = "../ore" }
 parse_duration = "2.0.1"
 pgwire = { path = "../pgwire" }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -15,7 +15,7 @@ fallible-iterator = "0.2.0"
 futures = "0.3"
 lazy_static = "1.4.0"
 libc = "0.2.66"
-log = "0.4"
+log = "0.4.8"
 tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp"] }
 smallvec = "1.0"
 

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -18,6 +18,6 @@ lazy_static = "1.4"
 prometheus = { git = "https://github.com/quodlibetor/rust-prometheus.git", branch = "include-unaggregated", default-features = false, features = ["process"] }
 chrono = "0.4.10"
 postgres = { version = "0.15", features = ["with-chrono"] }
-log = "0.4.10"
+log = "0.4.8"
 env_logger = "0.7.1"
 tokio = "0.2.4"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -20,7 +20,7 @@ expr = { path = "../expr" }
 failure = "0.1.5"
 futures = "0.3"
 lazy_static = "1.4.0"
-log = "0.4"
+log = "0.4.8"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 prometheus = { git = "https://github.com/quodlibetor/rust-prometheus.git", branch = "include-unaggregated", default-features = false, features = ["process"] }

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -13,6 +13,7 @@ catalog = { path = "../catalog" }
 chrono = { version = "0.4", features = ["serde"] }
 dataflow-types = { path = "../dataflow-types" }
 failure = "0.1.6"
+log = "0.4.8"
 ore = { path = "../ore" }
 postgres = { version = "0.15", features = ["with-chrono", "with-serde_json"] }
 pg_interval = "0.3"
@@ -23,4 +24,3 @@ sql = { path = "../sql" }
 expr = { path = "../expr" }
 serde_json = "1.0"
 whoami = "0.6"
-log = "0.4.10"


### PR DESCRIPTION
0.4.10 was yanked for breaking named arguments in macros. Downgrade to
0.4.8 for now.