### PR TITLE
don't construct a new session for every record in file reader

### DIFF
--- a/src/dataflow/source/file.rs
+++ b/src/dataflow/source/file.rs
@@ -231,10 +231,11 @@ where
 
             let mut lines_read = 0;
 
+            let mut session = output.session(cap);
             while lines_read < MAX_LINES_PER_INVOCATION {
                 if let Ok(line) = rx.try_next() {
                     match line {
-                        Some(line) => output.session(cap).give(line.into_bytes()),
+                        Some(line) => session.give(line.into_bytes()),
                         None => return SourceStatus::Done,
                     }
                     lines_read += 1;


### PR DESCRIPTION
Frank told me this has significant overhead.