### PR TITLE
sql: don't backtrack when planning json delete

### DIFF
--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -98,6 +98,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
             "SELECT $1::int, $1 + $2",
             vec![ScalarType::Int64, ScalarType::Int64],
         ),
+        ("SELECT '[0, 1, 2]'::jsonb - $1", vec![ScalarType::String]),
     ];
     for (sql, types) in test_cases {
         println!("> {}", sql);


### PR DESCRIPTION
Just pretend JSON delete is an arithmetic operation. It's not really any
different from (TIME - INTERVAL).

The ultimate goal is to make operators more pluggable, e.g., by
maintaining a list of all operators, their overloads, and their
preferred types, and at plan time traversing the list of overloads and
applying a set of rules to determine which overload to choose. This
actually moves us towards that goal, where the single binary "minus"
operator backs both arithmetic and JSON delete.

Touches MaterializeInc/database-issues#456.