### PR TITLE
deps: use https url for avro dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 debug = true
 
 [patch.crates-io]
-avro-rs = { git = "ssh://git@github.com/MaterializeInc/avro-rs.git" }
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 
 # This is a slightly confusing syntax because of the fact that ssh urls use `:`
 # instead of `/` to separate the domain, so this serves as an example


### PR DESCRIPTION
Our fork of avro-rs is public, so there's no reason to use an SSH URL, which
requires Cargo to be set up with an SSH agent even when the repository is
publicly available. This is likely to be problematic when we make the
repository public.