### PR TITLE
deps: drop avro patch; use fork directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
 [[package]]
 name = "avro-rs"
 version = "0.6.5"
-source = "git+ssh://git@github.com/MaterializeInc/avro-rs.git#dd965e4560ae0c600a52acc2e250ffad891355fc"
+source = "git+https://github.com/MaterializeInc/avro-rs.git#dd965e4560ae0c600a52acc2e250ffad891355fc"
 dependencies = [
  "chrono",
  "digest 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ members = [
 [profile.release]
 debug = true
 
-[patch.crates-io]
-avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
-
 # This is a slightly confusing syntax because of the fact that ssh urls use `:`
 # instead of `/` to separate the domain, so this serves as an example
 #

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -14,7 +14,7 @@ path = "benches/avro.rs"
 harness = false
 
 [dependencies]
-avro-rs = "0.6.5"
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 failure = "0.1.6"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 
 [dependencies]
 atty = "0.2"
-avro-rs = "0.6.5"
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 backoff = "0.1.5"
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }


### PR DESCRIPTION
v0.6.6 of avro-rs was just released, which means Cargo no longer honors
our patch directive, because our fork is still claiming to be v0.6.5.
The patch directive is extremely fragile like this, so just switch to
using a direct git dependency.