### PR TITLE
repr/benches: use 2018 syntax

### DIFF
--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -6,6 +6,7 @@
 use avro_rs::types::Value as AvroValue;
 use byteorder::{NetworkEndian, WriteBytesExt};
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
 use interchange::avro::{parse_schema, Decoder};
 
 fn bench_interchange(c: &mut Criterion) {

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -3,14 +3,11 @@
 // This file is part of Materialize. Materialize may not be used or
 // distributed without the express permission of Materialize, Inc.
 
-#[macro_use]
-extern crate criterion;
-extern crate repr;
-
 use chrono::NaiveDate;
-use criterion::{Bencher, Criterion};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use rand::Rng;
-use repr::*;
+
+use repr::{Datum, Row, RowUnpacker};
 
 fn bench_sort_datums(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
     b.iter_with_setup(|| rows.clone(), |mut rows| rows.sort())


### PR DESCRIPTION
Somehow this module was still using 2015 syntax.