### PR TITLE
parse decimals without leading integer, e.g. .1

### DIFF
--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -486,6 +486,12 @@ fn parse_number() {
 }
 
 #[test]
+fn parse_numeric_begin_with_decimal() {
+    let expr = verified_expr(".1");
+    assert_eq!(expr, Expr::Value(Value::Number(".1".into())));
+}
+
+#[test]
 fn parse_approximate_numeric_literal() {
     let expr = verified_expr("1.0E2");
     assert_eq!(expr, Expr::Value(Value::Number("1.0E2".into())));

--- a/test/decimal.slt
+++ b/test/decimal.slt
@@ -294,3 +294,16 @@ query R
 SELECT CAST (null::float AS decimal(38, 7))
 ----
 NULL
+
+### No leading integer ###
+
+query R
+SELECT .123
+----
+0.123
+
+statement error
+SELECT ..123
+
+statement error
+SELECT .1.23


### PR DESCRIPTION
Moving MaterializeInc/sqlparser#33 over

Added test case to assuage concern of parsing something like `..07` as a valid number. `..07` doesn't pass parsing because there are no expressions that begin with with a period; this is the same as the current behavior when trying to parse `.07`, which results in a SQL parsing error:

> ERROR:  sql parser error: Expected an expression, found: .

@benesch lmk if you'd still like this refactored!