### PR TITLE
*: format all Cargo.toml manifests

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,18 +2,11 @@
 name = "fuzz"
 description = "Fuzz testing for Materialize."
 version = "0.0.1"
-publish = false
 edition = "2018"
+publish = false
 
 [package.metadata]
 cargo-fuzz = true
-
-[dependencies]
-libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-testdrive = { path = "../src/testdrive" }
-sqllogictest = { path = "../src/sqllogictest" }
-walkdir = "2"
-rand = { version = "0.7.2", features = ["small_rng"] }
 
 [[bin]]
 name = "fuzz_testdrive"
@@ -26,3 +19,10 @@ path = "fuzz_targets/fuzz_sqllogictest.rs"
 [[bin]]
 name = "build_corpus"
 path = "bin/build_corpus.rs"
+
+[dependencies]
+libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+rand = { version = "0.7.2", features = ["small_rng"] }
+sqllogictest = { path = "../src/sqllogictest" }
+testdrive = { path = "../src/testdrive" }
+walkdir = "2"

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -10,8 +10,8 @@ path = "lib.rs"
 
 [dependencies]
 catalog = { path = "../catalog" }
-comm = { path = "../comm" }
 chrono = "0.4"
+comm = { path = "../comm" }
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -18,21 +18,21 @@ avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 failure = "0.1.6"
-sha2 = "0.8"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 protobuf = "2.8.1"
 protoc = "2.8.1"
 repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.44"
-url = "2.1.0"
 serde-protobuf = "0.8.1"
 serde-value = "0.6.0"
+serde_json = "1.0.44"
+sha2 = "0.8"
+url = "2.1.0"
+
+[dev-dependencies]
+criterion = "0.3"
+pretty_assertions = "0.6.1"
 
 [build-dependencies]
 protoc-rust = "2.8.1"
-
-[dev-dependencies]
-pretty_assertions = "0.6.1"
-criterion = "0.3"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 publish = false
 default-run = "materialized"
 
+[lib]
+path = "lib.rs"
+
 [[bin]]
 name = "materialized"
 path = "bin/materialized.rs"
-
-[lib]
-path = "lib.rs"
 
 [dependencies]
 backtrace = { version = "0.3.40", features = ["coresymbolication"] }
@@ -38,9 +38,9 @@ chrono = "0.4"
 fallible-iterator = "0.2.0"
 itertools = "0.8.2"
 postgres = { version = "0.17", features = ["with-chrono-0_4"] }
-tokio-postgres = { version = "0.5", features = ["with-chrono-0_4"] }
 pretty_assertions = "0.6.1"
+tokio-postgres = { version = "0.5", features = ["with-chrono-0_4"] }
 
 [build-dependencies]
-duct = "0.13.3"
 chrono = "0.4"
+duct = "0.13.3"

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -16,8 +16,8 @@ futures = "0.3"
 lazy_static = "1.4.0"
 libc = "0.2.66"
 log = "0.4.8"
-tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp"] }
 smallvec = "1.1"
+tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp"] }
 
 [dev-dependencies]
 crossbeam = "0.7.2"

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -17,8 +17,8 @@ getopts = "0.2"
 hyper = "0.13"
 lazy_static = "1.4"
 log = "0.4.8"
+ore = { path = "../ore" }
 postgres = "0.17"
 prometheus = { git = "https://github.com/quodlibetor/rust-prometheus.git", branch = "include-unaggregated", default-features = false, features = ["process"] }
-ore = { path = "../ore" }
 regex = "1.3.1"
 tokio = { version = "0.2.6", features = ["rt-threaded"] }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -12,9 +12,9 @@ path = "lib.rs"
 byteorder = "1.3"
 bytes = "0.5"
 cast = "0.2"
+chrono = "0.4"
 comm = { path = "../comm" }
 coord = { path = "../coord" }
-chrono = "0.4"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.5"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -8,9 +8,14 @@ publish = false
 [lib]
 path = "lib.rs"
 
+[[bench]]
+name = "row"
+harness = false
+
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1.6"
+itertools = "0.8.2"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 pretty = "0.7.1"
@@ -18,13 +23,8 @@ regex = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_regex = "0.4.0"
 sql-parser = { path = "../sql-parser" }
-itertools = "0.8.2"
 
 [dev-dependencies]
 criterion = "0.3"
 rand = "0.7.2"
 rand_chacha = "0.2.1"
-
-[[bench]]
-name = "row"
-harness = false

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 log = "0.4.5"
 
 [dev-dependencies]
-simple_logger = "1.0.1"
 matches = "0.1"
+simple_logger = "1.0.1"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -4,12 +4,12 @@ description = "A driver for sqllogictest, a SQL correctness testing framework."
 version = "0.0.1"
 edition = "2018"
 
+[lib]
+path = "lib.rs"
+
 [[bin]]
 name = "sqllogictest"
 path = "main.rs"
-
-[lib]
-path = "lib.rs"
 
 [dependencies]
 chrono = "0.4"

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -12,15 +12,15 @@ path = "lib.rs"
 catalog = { path = "../catalog" }
 chrono = { version = "0.4", features = ["serde"] }
 dataflow-types = { path = "../dataflow-types" }
+expr = { path = "../expr" }
 failure = "0.1.6"
 log = "0.4.8"
 ore = { path = "../ore" }
-postgres = { version = "0.15", features = ["with-chrono", "with-serde_json"] }
 pg_interval = "0.3"
+postgres = { version = "0.15", features = ["with-chrono", "with-serde_json"] }
 repr = { path = "../repr" }
 rust_decimal = { version = "1.0", features = ["postgres"] }
-sql-parser = { path = "../sql-parser" }
-sql = { path = "../sql" }
-expr = { path = "../expr" }
 serde_json = "1.0"
+sql = { path = "../sql" }
+sql-parser = { path = "../sql-parser" }
 whoami = "0.7"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -27,13 +27,13 @@ lazy_static = "1.4.0"
 ore = { path = "../ore" }
 pg_interval = "0.3"
 postgres = { version = "0.15", features = ["with-chrono"] }
-serde_json = { version = "1.0.44", features = ["preserve_order"] }
-sql-parser = { path = "../sql-parser" }
 rand = "0.7.2"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build"] }
 regex = "1"
 reqwest = { git = "https://github.com/seanmonstar/reqwest.git" }
 rust_decimal = { version = "1.0", features = ["postgres"] }
+serde_json = { version = "1.0.44", features = ["preserve_order"] }
+sql-parser = { path = "../sql-parser" }
 termcolor = "1.0.5"
 
 [dev-dependencies]


### PR DESCRIPTION
Enforce a consistent style on our Cargo.toml manifests via
cargo-manifmt. This reduces diff noise when dependencies are updated.

cargo-manifmt is really unstable, so we don't want to run it in CI yet.