### PR TITLE
ci: don't auto-update the Cargo.lock

### DIFF
--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -33,7 +33,7 @@ docker_run() {
 ci_init
 
 ci_collapsed_heading "Building standalone binaries"
-docker_run "cargo build --release"
+docker_run "cargo build --locked --release"
 
 # NOTE(benesch): The two invocations of `cargo test --no-run` here deserve some
 # explanation. The first invocation prints error messages to stdout in a human
@@ -45,7 +45,7 @@ docker_run "cargo build --release"
 # tests will build, since errors may be present in test code but not in release
 # code.
 ci_collapsed_heading "Building test binaries"
-docker_run "cargo test --no-run && cargo test --no-run --message-format=json > test-binaries.json"
+docker_run "cargo test --locked --no-run && cargo test --locked --no-run --message-format=json > test-binaries.json"
 
 ci_collapsed_heading "Preparing Docker context"
 {

--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 ci_init
 
-ci_try cargo test --doc
+ci_try cargo test --locked --doc
 # Intentionally run check last, since otherwise it won't use the cache.
 # https://github.com/rust-lang/rust-clippy/issues/3840
 ci_try bin/check


### PR DESCRIPTION
If the Cargo.lock is out-of-date wrt to the Cargo.toml, CI shouldn't
pass the build, as that means that everyone who runs cargo locally on
that commit will generate diffs to Cargo.lock.

We can tell cargo not to auto-update the lockfile, and instead produce
an error, by passing --locked to every cargo invocation.