### PR TITLE
bin/pre-push: don't run `cargo test`

### DIFF
--- a/bin/pre-push
+++ b/bin/pre-push
@@ -16,6 +16,5 @@ SHLIB_NOT_IN_CI=1
 ci_try bin/lint
 ci_try cargo fmt -- --check
 ci_try bin/check
-ci_try cargo test
 
 ci_status_report


### PR DESCRIPTION
Empirically, running `cargo test` in the pre-push hook causes people to
not use the pre-push hook. Drop it, so that people are hopefully less
frustrated by rustfmt and clippy.