### PR TITLE
catalog: take responsibility for QualNames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,11 +281,13 @@ dependencies = [
  "dataflow-types",
  "expr",
  "failure",
+ "itertools",
  "log",
  "repr",
  "rusqlite",
  "serde",
  "serde_json",
+ "sql-parser",
 ]
 
 [[package]]
@@ -2704,7 +2706,6 @@ dependencies = [
  "chrono",
  "criterion",
  "failure",
- "itertools",
  "ordered-float",
  "ore",
  "pretty",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -13,7 +13,9 @@ dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.6"
 log = "0.4.8"
+itertools = "0.8.2"
 repr = { path = "../repr" }
 rusqlite = { version = "0.20", features = ["bundled"] }
 serde = "1.0"
 serde_json = "1.0.41"
+sql-parser = { path = "../sql-parser" }

--- a/src/catalog/lib.rs
+++ b/src/catalog/lib.rs
@@ -14,12 +14,14 @@ use serde::{Deserialize, Serialize};
 
 use dataflow_types::{Index, Sink, Source, SourceConnector, View};
 use expr::{GlobalId, Id, IdHumanizer};
-use repr::QualName;
 use repr::RelationDesc;
 
 use crate::sql::SqlVal;
 
+mod qualname;
 mod sql;
+
+pub use crate::qualname::QualName;
 
 const APPLICATION_ID: i32 = 0x1854_47dc;
 

--- a/src/catalog/qualname.rs
+++ b/src/catalog/qualname.rs
@@ -13,7 +13,9 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use sql_parser::ast::{Ident, ObjectName};
 
-use crate::errors::{Error as ReprError, Result};
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub type Error = failure::Error;
 
 /// A generalized name that may be qualified
 ///
@@ -30,7 +32,7 @@ use crate::errors::{Error as ReprError, Result};
 /// ```
 /// use std::convert::TryFrom;
 /// use sql_parser::ast::{Ident, ObjectName};
-/// use repr::QualName;
+/// use catalog::QualName;
 ///
 /// let with = Ident::with_quote('"', "one");
 /// let without = Ident::new("two");
@@ -55,7 +57,7 @@ impl QualName {
     /// # Example
     ///
     /// ```
-    /// use repr::QualName;
+    /// use catalog::QualName;
     /// use sql_parser::ast::Ident;
     ///
     /// let (one, two) = (Ident::new("HoWdY"), Ident::with_quote('"', "wOwZeR"));
@@ -91,7 +93,7 @@ impl QualName {
     /// Create a new QualName from a list of other qualnames, in order
     ///
     /// ```
-    /// # use repr::QualName;
+    /// # use catalog::QualName;
     /// let qn1: QualName = "one.two".parse().unwrap();
     /// let qn2: QualName = "three".parse().unwrap();
     /// let both: QualName = "one.two.three".parse().unwrap();
@@ -135,7 +137,7 @@ impl QualName {
     /// # Example
     ///
     /// ```
-    /// use repr::QualName;
+    /// use catalog::QualName;
     /// use sql_parser::ast::{ObjectName, Ident};
     ///
     /// let one = Ident::new("one");
@@ -155,7 +157,7 @@ impl QualName {
     /// # Example
     ///
     /// ```
-    /// use repr::QualName;
+    /// use catalog::QualName;
     /// let qn: QualName = "one.two".parse().unwrap();
     /// let qn2 = qn.with_trailing_string("-YOU_BRED_RAPTORS?");
     /// assert_eq!(qn.to_string(), "one.two");
@@ -199,7 +201,7 @@ impl From<&QualName> for QualName {
 }
 
 impl TryFrom<ObjectName> for QualName {
-    type Error = ReprError;
+    type Error = Error;
 
     fn try_from(other: ObjectName) -> Result<QualName> {
         QualName::new_normalized(other.0)
@@ -207,7 +209,7 @@ impl TryFrom<ObjectName> for QualName {
 }
 
 impl TryFrom<&ObjectName> for QualName {
-    type Error = ReprError;
+    type Error = Error;
 
     fn try_from(other: &ObjectName) -> Result<QualName> {
         QualName::new_normalized(other.0.iter().cloned())
@@ -215,7 +217,7 @@ impl TryFrom<&ObjectName> for QualName {
 }
 
 impl TryFrom<&mut ObjectName> for QualName {
-    type Error = ReprError;
+    type Error = Error;
 
     fn try_from(other: &mut ObjectName) -> Result<QualName> {
         QualName::new_normalized(other.0.iter().cloned())
@@ -223,14 +225,14 @@ impl TryFrom<&mut ObjectName> for QualName {
 }
 
 impl TryFrom<Ident> for QualName {
-    type Error = ReprError;
+    type Error = Error;
     fn try_from(other: Ident) -> Result<QualName> {
         QualName::new_normalized(vec![other])
     }
 }
 
 impl TryFrom<&Ident> for QualName {
-    type Error = ReprError;
+    type Error = Error;
     /// TODO: a version that takes a borrowed ident
     fn try_from(other: &Ident) -> Result<QualName> {
         QualName::new_normalized(vec![other.clone()])
@@ -238,7 +240,7 @@ impl TryFrom<&Ident> for QualName {
 }
 
 impl TryFrom<&str> for QualName {
-    type Error = ReprError;
+    type Error = Error;
     /// An alias for [`FromStr`] for use in a generic context
     fn try_from(s: &str) -> Result<QualName> {
         s.parse()
@@ -246,7 +248,7 @@ impl TryFrom<&str> for QualName {
 }
 
 impl TryFrom<QualName> for Ident {
-    type Error = ReprError;
+    type Error = Error;
     fn try_from(other: QualName) -> Result<Ident> {
         if other.0.len() == 1 {
             let ident = other.0.into_iter().next().unwrap();
@@ -288,7 +290,7 @@ impl PartialEq<str> for QualName {
     /// # Examples
     ///
     /// ```
-    /// # use repr::QualName;
+    /// # use catalog::QualName;
     /// let qn: &QualName = &"one.TWO".parse().unwrap();
     ///
     /// assert_eq!(qn, "one.\"two\"");
@@ -376,7 +378,7 @@ impl PartialEq for Identifier {
 }
 
 impl TryFrom<Ident> for Identifier {
-    type Error = ReprError;
+    type Error = Error;
 
     /// Construct a valid identifier
     ///

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -20,6 +20,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::iter;
 use std::path::Path;
+use std::str::FromStr;
 
 use failure::bail;
 use futures::executor::block_on;
@@ -29,7 +30,7 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
 use timely::progress::ChangeBatch;
 
-use catalog::{Catalog, CatalogItem};
+use catalog::{Catalog, CatalogItem, QualName};
 use dataflow::logging::materialized::MaterializedEvent;
 use dataflow::{SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};
 use dataflow_types::logging::LoggingConfig;
@@ -39,7 +40,7 @@ use dataflow_types::{
 };
 use expr::{EvalEnv, GlobalId, Id, IdHumanizer, RelationExpr, ScalarExpr};
 use ore::collections::CollectionExt;
-use repr::{ColumnName, Datum, QualName, RelationDesc, Row};
+use repr::{ColumnName, Datum, RelationDesc, Row};
 use sql::{MutationKind, ObjectType, Plan, Session};
 use sql::{Params, PreparedStatement};
 
@@ -119,7 +120,7 @@ where
                 logging_config.active_logs().iter().map(|log| {
                     (
                         log.id(),
-                        log.name(),
+                        QualName::from_str(log.name()).expect("invalid logging name"),
                         CatalogItem::Source(Source {
                             connector: SourceConnector::Local,
                             desc: log.schema(),

--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use expr::GlobalId;
-use repr::{LiteralName, QualName, RelationDesc, ScalarType};
+use repr::{RelationDesc, ScalarType};
 
 /// Logging configuration.
 #[derive(Debug, Clone)]
@@ -92,27 +92,25 @@ impl LogVariant {
         ]
     }
 
-    pub fn name(&self) -> QualName {
+    pub fn name(&self) -> &'static str {
         // Bind all names in one place to avoid accidental clashes.
         match self {
-            LogVariant::Timely(TimelyLog::Operates) => "mz_dataflow_operators".lit(),
-            LogVariant::Timely(TimelyLog::Addresses) => "mz_dataflow_operator_addresses".lit(),
-            LogVariant::Timely(TimelyLog::Channels) => "mz_dataflow_channels".lit(),
-            LogVariant::Timely(TimelyLog::Elapsed) => "mz_scheduling_elapsed".lit(),
-            LogVariant::Timely(TimelyLog::Histogram) => "mz_scheduling_histogram".lit(),
-            LogVariant::Timely(TimelyLog::Parks) => "mz_scheduling_parks".lit(),
-            LogVariant::Differential(DifferentialLog::Arrangement) => "mz_arrangement_sizes".lit(),
-            LogVariant::Differential(DifferentialLog::Sharing) => "mz_arrangement_sharing".lit(),
-            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => "mz_views".lit(),
-            LogVariant::Materialized(MaterializedLog::DataflowDependency) => {
-                "mz_view_dependencies".lit()
-            }
-            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => "mz_view_frontiers".lit(),
-            LogVariant::Materialized(MaterializedLog::PeekCurrent) => "mz_peek_active".lit(),
-            LogVariant::Materialized(MaterializedLog::PeekDuration) => "mz_peek_durations".lit(),
-            LogVariant::Materialized(MaterializedLog::PrimaryKeys) => "mz_view_keys".lit(),
-            LogVariant::Materialized(MaterializedLog::ForeignKeys) => "mz_view_foreign_keys".lit(),
-            LogVariant::Materialized(MaterializedLog::Catalog) => "mz_catalog_names".lit(),
+            LogVariant::Timely(TimelyLog::Operates) => "mz_dataflow_operators",
+            LogVariant::Timely(TimelyLog::Addresses) => "mz_dataflow_operator_addresses",
+            LogVariant::Timely(TimelyLog::Channels) => "mz_dataflow_channels",
+            LogVariant::Timely(TimelyLog::Elapsed) => "mz_scheduling_elapsed",
+            LogVariant::Timely(TimelyLog::Histogram) => "mz_scheduling_histogram",
+            LogVariant::Timely(TimelyLog::Parks) => "mz_scheduling_parks",
+            LogVariant::Differential(DifferentialLog::Arrangement) => "mz_arrangement_sizes",
+            LogVariant::Differential(DifferentialLog::Sharing) => "mz_arrangement_sharing",
+            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => "mz_views",
+            LogVariant::Materialized(MaterializedLog::DataflowDependency) => "mz_view_dependencies",
+            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => "mz_view_frontiers",
+            LogVariant::Materialized(MaterializedLog::PeekCurrent) => "mz_peek_active",
+            LogVariant::Materialized(MaterializedLog::PeekDuration) => "mz_peek_durations",
+            LogVariant::Materialized(MaterializedLog::PrimaryKeys) => "mz_view_keys",
+            LogVariant::Materialized(MaterializedLog::ForeignKeys) => "mz_view_foreign_keys",
+            LogVariant::Materialized(MaterializedLog::Catalog) => "mz_catalog_names",
         }
     }
 

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -15,7 +15,6 @@ harness = false
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1.6"
-itertools = "0.8.2"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 pretty = "0.7.1"

--- a/src/repr/errors.rs
+++ b/src/repr/errors.rs
@@ -1,9 +1,0 @@
-// Copyright 2019 Materialize, Inc. All rights reserved.
-//
-// This file is part of Materialize. Materialize may not be used or
-// distributed without the express permission of Materialize, Inc.
-
-/// A type for all repr results
-pub type Result<T> = std::result::Result<T, Error>;
-
-pub type Error = failure::Error;

--- a/src/repr/lib.rs
+++ b/src/repr/lib.rs
@@ -14,13 +14,10 @@
 
 #![deny(missing_debug_implementations)]
 
-mod errors;
-mod qualname;
 mod relation;
 mod row;
 mod scalar;
 
-pub use qualname::{LiteralName, QualName};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{
     DatumDict, DatumList, PackableRow, Row, RowArena, RowPacker, RowUnpacker, UnpackedRow,

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -10,8 +10,8 @@
 use dataflow_types::{Index, PeekWhen, RowSetFinishing, Sink, Source, View};
 
 use ::expr::GlobalId;
-use catalog::{Catalog, CatalogEntry};
-use repr::{QualName, RelationDesc, Row, ScalarType};
+use catalog::{Catalog, CatalogEntry, QualName};
+use repr::{RelationDesc, Row, ScalarType};
 use sql_parser::parser::Parser as SqlParser;
 
 pub use session::{FieldFormat, PreparedStatement, Session, TransactionStatus};

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -34,11 +34,11 @@ use sql_parser::ast::{
 use uuid::Uuid;
 
 use ::expr::{DateTruncTo, Id};
-use catalog::{Catalog, CatalogEntry};
+use catalog::{Catalog, CatalogEntry, QualName};
 use dataflow_types::RowSetFinishing;
 use ore::iter::{FallibleIteratorExt, IteratorExt};
 use repr::decimal::{Decimal, MAX_DECIMAL_PRECISION};
-use repr::{ColumnName, ColumnType, Datum, QualName, RelationDesc, RelationType, ScalarType};
+use repr::{ColumnName, ColumnType, Datum, RelationDesc, RelationType, ScalarType};
 
 use super::expr::{
     AggregateExpr, AggregateFunc, BinaryFunc, ColumnOrder, ColumnRef, JoinKind, NullaryFunc,

--- a/src/sql/scope.rs
+++ b/src/sql/scope.rs
@@ -24,8 +24,10 @@
 
 use failure::bail;
 
+use catalog::QualName;
+use repr::ColumnName;
+
 use super::expr::ColumnRef;
-use repr::{ColumnName, QualName};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScopeItemName {

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -19,7 +19,7 @@ use sql_parser::ast::{
 };
 use url::Url;
 
-use catalog::{Catalog, CatalogItem, RemoveMode};
+use catalog::{Catalog, CatalogItem, QualName, RemoveMode};
 use dataflow_types::{
     AvroEncoding, CsvEncoding, DataEncoding, ExternalSourceConnector, FileSourceConnector, Index,
     IndexDesc, KafkaSinkConnector, KafkaSourceConnector, KeySql, PeekWhen, ProtobufEncoding,
@@ -28,7 +28,7 @@ use dataflow_types::{
 use expr as relationexpr;
 use interchange::{avro, protobuf};
 use relationexpr::{EvalEnv, Id};
-use repr::{ColumnType, Datum, QualName, RelationDesc, RelationType, Row, ScalarType};
+use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, ScalarType};
 
 use crate::expr::like::build_like_regex_from_string;
 use crate::query::QueryLifetime;

--- a/src/sql/transform.rs
+++ b/src/sql/transform.rs
@@ -14,7 +14,7 @@ use std::convert::TryFrom;
 use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{BinaryOperator, Expr, Function, ObjectName, Query, Value};
 
-use repr::QualName;
+use catalog::QualName;
 
 pub fn transform(query: &mut Query) {
     AggFuncRewriter.visit_query(query);

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -34,11 +34,11 @@ use rust_decimal::Decimal;
 use sql_parser::ast::ColumnOption;
 use sql_parser::ast::{DataType, ObjectType, Statement};
 
-use catalog::Catalog;
+use catalog::{Catalog, QualName};
 use ore::option::OptionExt;
 use repr::decimal::Significand;
 use repr::{
-    ColumnType, Datum, Interval, PackableRow, QualName, RelationDesc, RelationType, Row, RowPacker,
+    ColumnType, Datum, Interval, PackableRow, RelationDesc, RelationType, Row, RowPacker,
     ScalarType,
 };
 use sql::{scalar_type_from_sql, MutationKind, Plan};


### PR DESCRIPTION
Qualified names are fundamentally a SQL/catalog concept; the dataflow
layer is intended to be entirely agnostic to names. Move QualNames out
of repr, which is intended to be SQL-agnostic, and into catalog.

This is the first step towards supporting proper databases and schemas
(#1126). It is also the second-to-last step for breaking repr's
dependence on the sql-parser crate (#1006).