### PR TITLE
Heartbeat every second in file sources

### DIFF
--- a/src/dataflow/source/file.rs
+++ b/src/dataflow/source/file.rs
@@ -178,7 +178,7 @@ pub fn file<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    const HEARTBEAT: Duration = Duration::from_secs(1);  // Update the capability every second if there are no new changes.
+    const HEARTBEAT: Duration = Duration::from_secs(1); // Update the capability every second if there are no new changes.
     const MAX_LINES_PER_INVOCATION: usize = 1024;
     let n2 = name.clone();
     let read_file = read_style != FileReadStyle::None;


### PR DESCRIPTION
This causes tailed file sources to update themselves every second, even if they are not written to.