### PR TITLE
Fix explain now() crash. Better optimize constant expressions.

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -659,7 +659,8 @@ where
 
             Plan::SendRows(rows) => send_immediate_rows(rows),
 
-            Plan::ExplainPlan(mut relation_expr, eval_env) => {
+            Plan::ExplainPlan(mut relation_expr, mut eval_env) => {
+                eval_env.wall_time = Some(chrono::Utc::now());
                 self.optimizer.optimize(&mut relation_expr, &eval_env);
                 let pretty = relation_expr.pretty_humanized(&self.catalog);
                 let rows = vec![Row::pack(&[Datum::from(&*pretty)])];

--- a/src/materialized/tests/date_time_funcs.rs
+++ b/src/materialized/tests/date_time_funcs.rs
@@ -37,6 +37,21 @@ fn test_current_timestamp_and_now() -> util::TestResult {
 }
 
 #[test]
+fn test_explain_current_timestamp_and_now() -> util::TestResult {
+    ore::log::init();
+
+    let (_server, mut client) = util::start_server(util::Config::default())?;
+
+    let rows = &client.query("EXPLAIN PLAN FOR SELECT current_timestamp()", &[])?;
+    assert_eq!(1, rows.len());
+
+    let rows = &client.query("EXPLAIN PLAN FOR SELECT now()", &[])?;
+    assert_eq!(1, rows.len());
+
+    Ok(())
+}
+
+#[test]
 fn test_to_char() -> util::TestResult {
     ore::log::init();
 


### PR DESCRIPTION
This fixes a panic that happens if you, say, run `EXPLAIN PLAN FOR SELECT now()`.

Previous attempt at fixing optimizing constant expressions has been aborted due to test failures.