### PR TITLE
Reduce empty join

### DIFF
--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -229,7 +229,10 @@ impl FoldConstants {
             RelationExpr::Join { inputs, .. } => {
                 if inputs.iter().any(|e| e.is_empty()) {
                     relation.take_safely();
+                } else if inputs.is_empty() {
+                    *relation = RelationExpr::constant(vec![vec![]], repr::RelationType::empty());
                 }
+                // TODO: General constant folding for all constant inputs.
             }
             RelationExpr::Union { .. } => {
                 let mut can_reduce = false;


### PR DESCRIPTION
This PR improves `reduction.rs` to propagate empty joins as the constant collection containing a single 0-ary row. It stops short of evaluating larger joins, because maybe that isn't a great idea.

cc @wangandi 