### PR TITLE
Aggressively push filter through map

### DIFF
--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -1233,28 +1233,28 @@ Project {
     Reduce {
       group_key: [0],
       aggregates: [any(true)],
-      Filter {
-        predicates: [#5 = i32toi64 #0],
-        Map {
-          scalars: [(#1 * #2) % 10000],
-          Filter {
-            predicates: [(2 * i32toi64 #3) > i32toi64 #4],
-            Reduce {
-              group_key: [0, 43 .. 45],
-              aggregates: [sum(#40)],
-              Join {
-                variables: [[(0, 43), (1, 0)]],
-                Get { l3 },
-                Map {
-                  scalars: [true],
-                  Join {
-                    variables: [[(0, 0), (1, 0), (2, 0)]],
-                    Get { l7 },
-                    Get { l7 },
-                    Filter {
-                      predicates: [#4 ~ ^co.*$],
-                      Get { item (u15) }
-                    }
+      Map {
+        scalars: [(#1 * #2) % 10000],
+        Filter {
+          predicates: [(2 * i32toi64 #3) > i32toi64 #4],
+          Reduce {
+            group_key: [0, 43 .. 45],
+            aggregates: [sum(#40)],
+            Join {
+              variables: [[(0, 43), (1, 0)]],
+              Filter {
+                predicates: [i32toi64 #0 = ((#43 * #44) % 10000)],
+                Get { l3 }
+              },
+              Map {
+                scalars: [true],
+                Join {
+                  variables: [[(0, 0), (1, 0), (2, 0)]],
+                  Get { l7 },
+                  Get { l7 },
+                  Filter {
+                    predicates: [#4 ~ ^co.*$],
+                    Get { item (u15) }
                   }
                 }
               }


### PR DESCRIPTION
This copies and updates #529 to push predicates through maps, despite potentially creating more work. It seems to be an important step for `IN` subqueries where the subquery produces a complex expression (rather than a column). The edit to `chbench.slt` suggests the improvement you might see, but it does not yet remove a cross join due to common subexpression issues.

If we merge this, we should close #529.