### PR TITLE
ore: absorb responsibility for safe cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,6 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "bytes",
- "cast",
  "chrono",
  "comm",
  "coord",

--- a/src/ore/cast.rs
+++ b/src/ore/cast.rs
@@ -1,0 +1,39 @@
+// Copyright 2019 Materialize, Inc. All rights reserved.
+//
+// This file is part of Materialize. Materialize may not be used or
+// distributed without the express permission of Materialize, Inc.
+
+//! Cast utilities.
+
+/// A trait for safe, simple, and infallible casts.
+///
+/// `CastFrom` is like [`std::convert::From`], but it is implemented for some
+/// platform-specific casts that are missing from the standard library. For
+/// example, there is no `From<u32> for usize` implementation, because Rust may
+/// someday support platforms where usize is smaller than 32 bits. Since we
+/// don't care about such platforms, we are happy to provide a `CastFrom<u32>
+/// for usize` implementation.
+///
+/// `CastFrom` should be preferred to the `as` operator, since the `as` operator
+/// will silently truncate if the target type is smaller than the source type.
+/// When applicable, `CastFrom` should also be preferred to the
+/// [`std::convert::TryFrom`] trait, as `TryFrom` will produce a runtime error,
+/// while `CastFrom` will produce a compile-time error.
+pub trait CastFrom<T> {
+    /// Performs the cast.
+    fn cast_from(from: T) -> Self;
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl CastFrom<u32> for usize {
+    fn cast_from(from: u32) -> usize {
+        from as usize
+    }
+}
+
+#[cfg(target_pointer_width = "64")]
+impl CastFrom<u64> for usize {
+    fn cast_from(from: u64) -> usize {
+        from as usize
+    }
+}

--- a/src/ore/lib.rs
+++ b/src/ore/lib.rs
@@ -11,6 +11,7 @@
 
 #![deny(missing_docs, missing_debug_implementations)]
 
+pub mod cast;
 pub mod collections;
 pub mod future;
 pub mod hash;

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -11,7 +11,6 @@ path = "lib.rs"
 [dependencies]
 byteorder = "1.3"
 bytes = "0.5"
-cast = "0.2"
 chrono = "0.4"
 comm = { path = "../comm" }
 coord = { path = "../coord" }

--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -18,11 +18,13 @@ use bytes::{Buf, BufMut, BytesMut};
 use tokio::io;
 use tokio_util::codec::{Decoder, Encoder};
 
+use ore::cast::CastFrom;
+use ore::netio;
+
 use crate::message::{
     BackendMessage, EncryptionType, FrontendMessage, TransactionStatus, VERSION_CANCEL,
     VERSION_GSSENC, VERSION_SSL,
 };
-use ore::netio;
 
 #[derive(Debug)]
 enum CodecError {
@@ -252,7 +254,7 @@ enum DecodeState {
 const MAX_FRAME_SIZE: usize = 8 << 10;
 
 fn parse_frame_len(src: &[u8]) -> Result<usize, io::Error> {
-    let n = cast::usize(NetworkEndian::read_u32(src));
+    let n = usize::cast_from(NetworkEndian::read_u32(src));
     if n > MAX_FRAME_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,


### PR DESCRIPTION
The `cast` crate is a heavyweight dependency for a very simple task:
infallible conversions from u32 -> usize. Introduce a trait in ore to
take over this responsibility, so that we can drop the dependency on
`cast`.

Closes #1437.