### PR TITLE
expr: allow functions to take typed data as input

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -367,11 +367,8 @@ where
                     let collection = self.collection(input).unwrap().flat_map(move |input_row| {
                         let datums = input_row.unpack();
                         let temp_storage = RowArena::new();
-                        let output_rows = (func.func())(
-                            expr.eval(&datums, &env, &temp_storage),
-                            &env,
-                            &temp_storage,
-                        );
+                        let output_rows =
+                            func.eval(expr.eval(&datums, &env, &temp_storage), &env, &temp_storage);
                         output_rows
                             .into_iter()
                             .map(|output_row| {
@@ -896,7 +893,7 @@ where
 
                                 for (agg, abl) in aggregates.iter().zip(abelian.iter()) {
                                     if *abl {
-                                        let value = match agg.func {
+                                        let value = match &agg.func {
                                             AggregateFunc::SumInt32 => {
                                                 let total = sums[abelian_pos] as i32;
                                                 let non_nulls = sums[abelian_pos + 1] as i32;
@@ -978,7 +975,7 @@ where
                                                 })
                                                 .collect::<HashSet<_>>();
                                             let temp_storage = RowArena::new();
-                                            result.push((agg.func.func())(iter, &env, &temp_storage));
+                                            result.push(agg.func.eval(iter, &env, &temp_storage));
                                         } else {
                                             let iter = source.iter().flat_map(|(v, w)| {
                                                 // let eval = agg.expr.eval(v);
@@ -986,7 +983,7 @@ where
                                                     .take(std::cmp::max(w[0], 0) as usize)
                                             });
                                             let temp_storage = RowArena::new();
-                                            result.push((agg.func.func())(iter, &env, &temp_storage));
+                                            result.push(agg.func.eval(iter, &env, &temp_storage));
                                         }
                                         non_abelian_pos += 1;
                                     }

--- a/src/expr/relation/func.rs
+++ b/src/expr/relation/func.rs
@@ -19,7 +19,7 @@ use crate::EvalEnv;
 // TODO(jamii) be careful about overflow in sum/avg
 // see https://timely.zulipchat.com/#narrow/stream/186635-engineering/topic/additional.20work/near/163507435
 
-pub fn max_int32<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_int32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -31,7 +31,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_int64<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_int64<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -43,7 +43,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_float32<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_float32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -55,7 +55,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_float64<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_float64<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -67,7 +67,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_decimal<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_decimal<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -79,7 +79,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_bool<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_bool<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -91,7 +91,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_string<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_string<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -105,7 +105,7 @@ where
     }
 }
 
-pub fn max_date<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_date<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -117,7 +117,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_timestamp<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_timestamp<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -129,7 +129,7 @@ where
     Datum::from(x)
 }
 
-pub fn max_timestamptz<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_timestamptz<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -141,14 +141,14 @@ where
     Datum::from(x)
 }
 
-pub fn max_null<'a, I>(_datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn max_null<'a, I>(_datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     Datum::Null
 }
 
-pub fn min_int32<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_int32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -160,7 +160,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_int64<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_int64<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -172,7 +172,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_float32<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_float32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -184,7 +184,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_float64<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_float64<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -196,7 +196,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_decimal<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_decimal<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -208,7 +208,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_bool<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_bool<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -220,7 +220,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_string<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_string<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -234,7 +234,7 @@ where
     }
 }
 
-pub fn min_date<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_date<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -246,7 +246,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_timestamp<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_timestamp<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -258,7 +258,7 @@ where
     Datum::from(x)
 }
 
-pub fn min_timestamptz<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_timestamptz<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -270,14 +270,14 @@ where
     Datum::from(x)
 }
 
-pub fn min_null<'a, I>(_datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn min_null<'a, I>(_datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     Datum::Null
 }
 
-pub fn sum_int32<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn sum_int32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -290,7 +290,7 @@ where
     }
 }
 
-pub fn sum_int64<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn sum_int64<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -303,7 +303,7 @@ where
     }
 }
 
-pub fn sum_float32<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn sum_float32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -316,7 +316,7 @@ where
     }
 }
 
-pub fn sum_float64<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn sum_float64<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -329,7 +329,7 @@ where
     }
 }
 
-pub fn sum_decimal<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn sum_decimal<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -342,14 +342,14 @@ where
     }
 }
 
-pub fn sum_null<'a, I>(_datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn sum_null<'a, I>(_datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
     Datum::Null
 }
 
-pub fn count<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn count<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -357,7 +357,7 @@ where
     Datum::from(x)
 }
 
-pub fn count_all<'a, I>(datums: I, _: &EvalEnv, _: &'a RowArena) -> Datum<'a>
+fn count_all<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -365,25 +365,25 @@ where
     Datum::from(x)
 }
 
-pub fn any<'a, I>(datums: I, env: &EvalEnv, temp_storage: &'a RowArena) -> Datum<'a>
+fn any<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    datums.into_iter().fold(Datum::False, |a, b| {
-        crate::scalar::func::or(a, b, env, temp_storage)
-    })
+    datums
+        .into_iter()
+        .fold(Datum::False, |a, b| crate::scalar::func::or(a, b))
 }
 
-pub fn all<'a, I>(datums: I, env: &EvalEnv, temp_storage: &'a RowArena) -> Datum<'a>
+fn all<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    datums.into_iter().fold(Datum::True, |a, b| {
-        crate::scalar::func::and(a, b, env, temp_storage)
-    })
+    datums
+        .into_iter()
+        .fold(Datum::True, |a, b| crate::scalar::func::and(a, b))
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum AggregateFunc {
     MaxInt32,
     MaxInt64,
@@ -420,47 +420,52 @@ pub enum AggregateFunc {
 }
 
 impl AggregateFunc {
-    pub fn func<'a, I>(self) -> fn(I, &EvalEnv, &'a RowArena) -> Datum<'a>
+    pub fn eval<'a, I>(
+        &self,
+        datums: I,
+        _env: &'a EvalEnv,
+        _temp_storage: &'a RowArena,
+    ) -> Datum<'a>
     where
         I: IntoIterator<Item = Datum<'a>>,
     {
         match self {
-            AggregateFunc::MaxInt32 => max_int32,
-            AggregateFunc::MaxInt64 => max_int64,
-            AggregateFunc::MaxFloat32 => max_float32,
-            AggregateFunc::MaxFloat64 => max_float64,
-            AggregateFunc::MaxDecimal => max_decimal,
-            AggregateFunc::MaxBool => max_bool,
-            AggregateFunc::MaxString => max_string,
-            AggregateFunc::MaxDate => max_date,
-            AggregateFunc::MaxTimestamp => max_timestamp,
-            AggregateFunc::MaxTimestampTz => max_timestamptz,
-            AggregateFunc::MaxNull => max_null,
-            AggregateFunc::MinInt32 => min_int32,
-            AggregateFunc::MinInt64 => min_int64,
-            AggregateFunc::MinFloat32 => min_float32,
-            AggregateFunc::MinFloat64 => min_float64,
-            AggregateFunc::MinDecimal => min_decimal,
-            AggregateFunc::MinBool => min_bool,
-            AggregateFunc::MinString => min_string,
-            AggregateFunc::MinDate => min_date,
-            AggregateFunc::MinTimestamp => min_timestamp,
-            AggregateFunc::MinTimestampTz => min_timestamptz,
-            AggregateFunc::MinNull => min_null,
-            AggregateFunc::SumInt32 => sum_int32,
-            AggregateFunc::SumInt64 => sum_int64,
-            AggregateFunc::SumFloat32 => sum_float32,
-            AggregateFunc::SumFloat64 => sum_float64,
-            AggregateFunc::SumDecimal => sum_decimal,
-            AggregateFunc::SumNull => sum_null,
-            AggregateFunc::Count => count,
-            AggregateFunc::CountAll => count_all,
-            AggregateFunc::Any => any,
-            AggregateFunc::All => all,
+            AggregateFunc::MaxInt32 => max_int32(datums),
+            AggregateFunc::MaxInt64 => max_int64(datums),
+            AggregateFunc::MaxFloat32 => max_float32(datums),
+            AggregateFunc::MaxFloat64 => max_float64(datums),
+            AggregateFunc::MaxDecimal => max_decimal(datums),
+            AggregateFunc::MaxBool => max_bool(datums),
+            AggregateFunc::MaxString => max_string(datums),
+            AggregateFunc::MaxDate => max_date(datums),
+            AggregateFunc::MaxTimestamp => max_timestamp(datums),
+            AggregateFunc::MaxTimestampTz => max_timestamptz(datums),
+            AggregateFunc::MaxNull => max_null(datums),
+            AggregateFunc::MinInt32 => min_int32(datums),
+            AggregateFunc::MinInt64 => min_int64(datums),
+            AggregateFunc::MinFloat32 => min_float32(datums),
+            AggregateFunc::MinFloat64 => min_float64(datums),
+            AggregateFunc::MinDecimal => min_decimal(datums),
+            AggregateFunc::MinBool => min_bool(datums),
+            AggregateFunc::MinString => min_string(datums),
+            AggregateFunc::MinDate => min_date(datums),
+            AggregateFunc::MinTimestamp => min_timestamp(datums),
+            AggregateFunc::MinTimestampTz => min_timestamptz(datums),
+            AggregateFunc::MinNull => min_null(datums),
+            AggregateFunc::SumInt32 => sum_int32(datums),
+            AggregateFunc::SumInt64 => sum_int64(datums),
+            AggregateFunc::SumFloat32 => sum_float32(datums),
+            AggregateFunc::SumFloat64 => sum_float64(datums),
+            AggregateFunc::SumDecimal => sum_decimal(datums),
+            AggregateFunc::SumNull => sum_null(datums),
+            AggregateFunc::Count => count(datums),
+            AggregateFunc::CountAll => count_all(datums),
+            AggregateFunc::Any => any(datums),
+            AggregateFunc::All => all(datums),
         }
     }
 
-    pub fn default(self) -> Datum<'static> {
+    pub fn default(&self) -> Datum<'static> {
         match self {
             AggregateFunc::Count | AggregateFunc::CountAll => Datum::Int64(0),
             AggregateFunc::Any => Datum::False,
@@ -474,7 +479,7 @@ impl AggregateFunc {
     /// The output column type also contains nullability information, which
     /// is (without further information) true for aggregations that are not
     /// counts.
-    pub fn output_type(self, input_type: ColumnType) -> ColumnType {
+    pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
         let scalar_type = match self {
             AggregateFunc::Count => ScalarType::Int64,
             AggregateFunc::CountAll => ScalarType::Int64,
@@ -491,7 +496,7 @@ impl AggregateFunc {
     }
 }
 
-fn jsonb_each<'a>(a: Datum<'a>, _: &EvalEnv, _: &'a RowArena) -> Vec<Row> {
+fn jsonb_each<'a>(a: Datum<'a>) -> Vec<Row> {
     match a {
         Datum::Dict(dict) => dict
             .iter()
@@ -540,19 +545,24 @@ impl fmt::Display for AggregateFunc {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum UnaryTableFunc {
     JsonbEach,
 }
 
 impl UnaryTableFunc {
-    pub fn func(self) -> for<'a> fn(Datum<'a>, &EvalEnv, &'a RowArena) -> Vec<Row> {
+    pub fn eval<'a>(
+        &'a self,
+        datum: Datum<'a>,
+        _env: &'a EvalEnv,
+        _temp_storage: &'a RowArena,
+    ) -> Vec<Row> {
         match self {
-            UnaryTableFunc::JsonbEach => jsonb_each,
+            UnaryTableFunc::JsonbEach => jsonb_each(datum),
         }
     }
 
-    pub fn output_type(self, _input_type: &ColumnType) -> RelationType {
+    pub fn output_type(&self, _input_type: &ColumnType) -> RelationType {
         match self {
             UnaryTableFunc::JsonbEach => RelationType::new(vec![
                 // key
@@ -563,7 +573,7 @@ impl UnaryTableFunc {
         }
     }
 
-    pub fn output_arity(self) -> usize {
+    pub fn output_arity(&self) -> usize {
         match self {
             UnaryTableFunc::JsonbEach => 2,
         }

--- a/src/expr/transform/column_knowledge.rs
+++ b/src/expr/transform/column_knowledge.rs
@@ -283,9 +283,5 @@ pub fn optimize(
                 }
             }
         }
-        ScalarExpr::MatchCachedRegex { .. } => DatumKnowledge {
-            value: None,
-            nullable: true,
-        },
     }
 }

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -85,7 +85,7 @@ impl FoldConstants {
                             let temp_storage = RowArena::new();
                             let row = Row::pack(key.into_iter().chain(
                                 aggregates.iter().enumerate().map(|(i, agg)| {
-                                    (agg.func.func())(
+                                    agg.func.eval(
                                         vals.iter().map(|val| val[i].unpack_first()),
                                         env,
                                         &temp_storage,
@@ -155,7 +155,7 @@ impl FoldConstants {
                         .flat_map(|(input_row, diff)| {
                             let datums = input_row.unpack();
                             let temp_storage = RowArena::new();
-                            let output_rows = (func.func())(
+                            let output_rows = func.eval(
                                 expr.eval(&datums, env, &temp_storage),
                                 env,
                                 &temp_storage,

--- a/src/sql/expr.rs
+++ b/src/sql/expr.rs
@@ -296,12 +296,13 @@ impl RelationExpr {
                 let old_arity = input.arity();
                 let expr = expr.applied_to(id_gen, get_outer.arity(), &mut input)?;
                 let new_arity = input.arity();
+                let output_arity = func.output_arity();
                 input = input.flat_map_unary(func, expr);
                 if old_arity != new_arity {
                     // this means we added some columns to handle subqueries, and now we need to get rid of them
                     input = input.project(
                         (0..old_arity)
-                            .chain(new_arity..new_arity + func.output_arity())
+                            .chain(new_arity..new_arity + output_arity)
                             .collect(),
                     );
                 }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1535,13 +1535,7 @@ fn plan_function<'a>(
                 Ok(match ecx.column_type(&expr).scalar_type {
                     ScalarType::Float32 => expr.call_unary(UnaryFunc::CeilFloat32),
                     ScalarType::Float64 => expr.call_unary(UnaryFunc::CeilFloat64),
-                    ScalarType::Decimal(_, scale) => expr.call_binary(
-                        ScalarExpr::literal(
-                            Datum::from(scale as i32),
-                            ColumnType::new(ScalarType::Null), // ignored
-                        ),
-                        BinaryFunc::CeilDecimal,
-                    ),
+                    ScalarType::Decimal(_, s) => expr.call_unary(UnaryFunc::CeilDecimal(s)),
                     _ => unreachable!(),
                 })
             }
@@ -1582,13 +1576,7 @@ fn plan_function<'a>(
                 Ok(match ecx.column_type(&expr).scalar_type {
                     ScalarType::Float32 => expr.call_unary(UnaryFunc::FloorFloat32),
                     ScalarType::Float64 => expr.call_unary(UnaryFunc::FloorFloat64),
-                    ScalarType::Decimal(_, scale) => expr.call_binary(
-                        ScalarExpr::literal(
-                            Datum::from(scale as i32),
-                            ColumnType::new(ScalarType::Null), // ignored
-                        ),
-                        BinaryFunc::FloorDecimal,
-                    ),
+                    ScalarType::Decimal(_, s) => expr.call_unary(UnaryFunc::FloorDecimal(s)),
                     _ => unreachable!(),
                 })
             }
@@ -2893,10 +2881,7 @@ where
                 .call_binary(factor, BinaryFunc::DivFloat64)
         }
         (Decimal(_, s1), Decimal(_, s2)) => rescale_decimal(expr, s1, s2),
-        (Decimal(_, s), String) => {
-            let s = ScalarExpr::literal(Datum::from(s as i32), ColumnType::new(to_scalar_type));
-            expr.call_binary(s, BinaryFunc::CastDecimalToString)
-        }
+        (Decimal(_, s), String) => expr.call_unary(UnaryFunc::CastDecimalToString(s)),
         (Date, Timestamp) => expr.call_unary(CastDateToTimestamp),
         (Date, TimestampTz) => expr.call_unary(CastDateToTimestampTz),
         (Date, String) => expr.call_unary(CastDateToString),

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -273,7 +273,7 @@ Project {
       [(3, 3), (4, 0)],
       [(4, 2), (5, 0)]
     ],
-    Filter { predicates: [#4 ~ ^.*b$], Get { item (u15) } },
+    Filter { predicates: [^.*b$ ~ #4], Get { item (u15) } },
     Filter {
       predicates: [!isnull #1],
       Reduce {
@@ -289,7 +289,7 @@ Project {
           Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
           Get { nation (u19) },
           Filter {
-            predicates: [#1 ~ ^EUROP.*$],
+            predicates: [^EUROP.*$ ~ #1],
             Get { region (u23) }
           }
         }
@@ -298,7 +298,7 @@ Project {
     Filter { predicates: [!isnull #2], Get { stock (u17) } },
     Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
     Get { nation (u19) },
-    Filter { predicates: [#1 ~ ^EUROP.*$], Get { region (u23) } }
+    Filter { predicates: [^EUROP.*$ ~ #1], Get { region (u23) } }
   }
 }
 
@@ -339,7 +339,7 @@ Project {
         predicates: [datetots #4 > 2007-01-02 00:00:00],
         Get { "order" (u11) }
       },
-      Filter { predicates: [#9 ~ ^A.*$], Get { customer (u5) } }
+      Filter { predicates: [^A.*$ ~ #9], Get { customer (u5) } }
     }
   }
 }
@@ -610,7 +610,7 @@ Project {
           [(5, 2), (6, 0)],
           [(7, 3), (8, 0)]
         ],
-        Filter { predicates: [#4 ~ ^.*b$], Get { item (u15) } },
+        Filter { predicates: [^.*b$ ~ #4], Get { item (u15) } },
         Filter {
           predicates: [!isnull #4, #4 < 1000],
           Get { orderline (u13) }
@@ -665,7 +665,7 @@ Reduce {
       [(3, 17), (4, 7)],
       [(4, 3), (5, 0)]
     ],
-    Filter { predicates: [#4 ~ ^.*BB$], Get { item (u15) } },
+    Filter { predicates: [^.*BB$ ~ #4], Get { item (u15) } },
     Get { orderline (u13) },
     Get { "order" (u11) },
     Get { stock (u17) },
@@ -864,7 +864,7 @@ AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 Let {
   l0 = Reduce {
     group_key: [],
-    aggregates: [sum(if #14 ~ ^PR.*$ then #8 else 0dec), sum(#8)],
+    aggregates: [sum(if ^PR.*$ ~ #14 then #8 else 0dec), sum(#8)],
     Join {
       variables: [[(0, 4), (1, 0)]],
       Filter {
@@ -977,7 +977,7 @@ Let {
   l0 = Join {
     variables: [[(0, 0), (1, 0)]],
     Get { stock (u17) },
-    Filter { predicates: [!(#4 ~ ^zz.*$)], Get { item (u15) } }
+    Filter { predicates: [!(^zz.*$ ~ #4)], Get { item (u15) } }
   }
 } in
 Let { l3 = Distinct { group_key: [#17], Get { l0 } } } in
@@ -989,7 +989,7 @@ Let {
       variables: [[(0, 0), (1, 0)]],
       Get { l3 },
       Get { l3 },
-      Filter { predicates: [#6 ~ ^.*bad.*$], Get { supplier (u21) } }
+      Filter { predicates: [^.*bad.*$ ~ #6], Get { supplier (u21) } }
     }
   }
 } in
@@ -1047,7 +1047,7 @@ Let {
             Join {
               variables: [[(0, 4), (1, 0)]],
               Get { orderline (u13) },
-              Filter { predicates: [#4 ~ ^.*b$], Get { item (u15) } }
+              Filter { predicates: [^.*b$ ~ #4], Get { item (u15) } }
             }
           }
         }
@@ -1144,12 +1144,12 @@ Let {
     Filter {
       predicates: [
         (
-          ((#14 ~ ^.*a$) && (((#2 = 1) || (#2 = 2)) || (#2 = 3)))
+          ((^.*a$ ~ #14) && (((#2 = 1) || (#2 = 2)) || (#2 = 3)))
           ||
-          ((#14 ~ ^.*b$) && (((#2 = 1) || (#2 = 2)) || (#2 = 4)))
+          ((^.*b$ ~ #14) && (((#2 = 1) || (#2 = 2)) || (#2 = 4)))
         )
         ||
-        ((#14 ~ ^.*c$) && (((#2 = 1) || (#2 = 5)) || (#2 = 3)))
+        ((^.*c$ ~ #14) && (((#2 = 1) || (#2 = 5)) || (#2 = 3)))
       ],
       Join {
         variables: [[(0, 4), (1, 0)]],
@@ -1237,7 +1237,7 @@ Project {
             },
             Get { l7 },
             Get { l7 },
-            Filter { predicates: [#4 ~ ^co.*$], Get { item (u15) } }
+            Filter { predicates: [^co.*$ ~ #4], Get { item (u15) } }
           }
         }
       }

--- a/test/tpch.slt
+++ b/test/tpch.slt
@@ -198,7 +198,7 @@ Let {
       [(3, 2), (4, 0)]
     ],
     Filter {
-      predicates: [#5 = 15, #4 ~ ^.*BRASS$],
+      predicates: [^.*BRASS$ ~ #4, #5 = 15],
       Get { part (u5) }
     },
     Get { partsupp (u9) },
@@ -623,7 +623,7 @@ Reduce {
       [(2, 0), (3, 0)],
       [(4, 3), (5, 0)]
     ],
-    Filter { predicates: [#1 ~ ^green$], Get { part (u5) } },
+    Filter { predicates: [^green$ ~ #1], Get { part (u5) } },
     Get { partsupp (u9) },
     Get { lineitem (u15) },
     Get { orders (u13) },
@@ -839,7 +839,7 @@ Let {
     variables: [[(0, 0), (1, 1)]],
     Get { customer (u11) },
     Filter {
-      predicates: [!(#8 ~ ^.*special.*requests.*$)],
+      predicates: [!(^.*special.*requests.*$ ~ #8)],
       Get { orders (u13) }
     }
   }
@@ -899,7 +899,7 @@ Let {
   l0 = Reduce {
     group_key: [],
     aggregates: [
-      sum(if #20 ~ ^PROMO.*$ then #5 * (100dec - #6) else 0dec),
+      sum(if ^PROMO.*$ ~ #20 then #5 * (100dec - #6) else 0dec),
       sum(#5 * (100dec - #6))
     ],
     Join {
@@ -1029,7 +1029,7 @@ Let {
     Get { partsupp (u9) },
     Filter {
       predicates: [
-        !(#4 ~ ^MEDIUM POLISHED.*$),
+        !(^MEDIUM POLISHED.*$ ~ #4),
         (
           (
             (
@@ -1061,7 +1061,7 @@ Let {
       Get { l3 },
       Get { l3 },
       Filter {
-        predicates: [#6 ~ ^.*Customer.*Complaints.*$],
+        predicates: [^.*Customer.*Complaints.*$ ~ #6],
         Get { supplier (u7) }
       }
     }
@@ -1453,7 +1453,7 @@ Let {
       aggregates: [any(true)],
       Join {
         variables: [[(0, 0), (1, 0), (2, 0)]],
-        Filter { predicates: [#1 ~ ^forest.*$], Get { part (u5) } },
+        Filter { predicates: [^forest.*$ ~ #1], Get { part (u5) } },
         Get { l8 },
         Get { l8 }
       }


### PR DESCRIPTION
Various functions want to take typed Rust data as plan-time input, in
addition to the zero, one, two, or variadic datums the functions take at
runtime. For example, BinaryFunc::FloorDecimal needs to know the scale
of the decimal at runtime, and ScalarExpr::MatchCachedRegex passes a
compiled regex::Regex to the match_regex function.

There are two approaches to this that have been taken so far. The first
is to stuff the input into a datum, like BinaryFunc::FloorDecimal does.
FloorDecimal is really a unary function--it naturally would only take
one datum as input--but we use a binary function so we can stuff the
scale into the second parameter. The second approach is what
ScalarExpr::MatchCachedRegex does, i.e., a dedicated ScalarExpr variant.
This approach is particularly ugly, as every ScalarExpr transformation
now needs to handle MatchCachedRegex explicitly.

This pain is all caused because we need to construct a uniform function
ponter type for all {nullary, unary, binary, variadic} functions.
Consider UnaryFunc, for example, which presently exposes this API:

    fn func(self) -> for<'a> fn(Datum<'a>, &EvalEnv, &'a RowArena) -> Datum<'a>

Every UnaryFunc must therefore take exactly one datum, an evaluation
environment, and a row buffer. There is no provision for a function like
UnaryFunc::FloorDecimal, which takes an additional u8 scale parameter.

This commit adjusts UnaryFunc to instead expose this API:

    fn eval<'a>(
        &'a self,
        a: Datum<'a>,
        _env: &'a EvalEnv,
        temp_storage: &'a RowArena,
    ) -> Datum<'a>

Now the caller has no insight into how the individual functions are
implemented. floor_float32 has a very simple signature

    fn floor_float32<'a>(a: Datum<'a>) -> Datum<'a>

while floor_decimal can take the extra parameter it desires

    fn floor_decimal<'a>(a: Datum<'a>, scale: u8) -> Datum<'a>

and only functions that use temp_storage need to take it as a parameter:

    fn cast_int32_to_string<'a>(
        a: Datum<'a>,
        temp_storage: &'a RowArena,
    ) -> Datum<'a>

Analogous changes are made to the other function types, including the
relational functions, to keep everything symmetric.
BinaryFunc::FloorDecimal, BinaryFunc::CeilDecimal, and
BinaryFunc::CastDecimalToString all become UnaryFuncs, as they naturally
should be. ScalarExpr::MatchCachedRegex is replaced with
UnaryFunc::MatchRegex, which removes a nice amount of special cases from
the optimizer.

This also paves the way for a UnaryFunc::CastStringToDecimal function,
which can't currently be expressed as UnaryFunc::output_type has no way
to derive the output type for UnaryFunc::CastStringToDecimal without
this patch (as how would it figure out what scale to report?).