### PR TITLE
sql,expr: support length on bytes

### DIFF
--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -1652,6 +1652,7 @@ pub enum UnaryFunc {
     FloorFloat64,
     FloorDecimal(u8),
     Ascii,
+    LengthBytes,
     MatchRegex(Regex),
     ExtractIntervalYear,
     ExtractIntervalMonth,
@@ -1755,6 +1756,7 @@ impl UnaryFunc {
             UnaryFunc::SqrtFloat32 => sqrt_float32(a),
             UnaryFunc::SqrtFloat64 => sqrt_float64(a),
             UnaryFunc::Ascii => ascii(a),
+            UnaryFunc::LengthBytes => length_bytes(a),
             UnaryFunc::MatchRegex(regex) => match_cached_regex(a, &regex),
             UnaryFunc::ExtractIntervalYear => extract_interval_year(a),
             UnaryFunc::ExtractIntervalMonth => extract_interval_month(a),
@@ -1825,7 +1827,7 @@ impl UnaryFunc {
         match self {
             IsNull | CastInt32ToBool | CastInt64ToBool => ColumnType::new(ScalarType::Bool),
 
-            Ascii => ColumnType::new(ScalarType::Int32).nullable(in_nullable),
+            Ascii | LengthBytes => ColumnType::new(ScalarType::Int32).nullable(in_nullable),
 
             MatchRegex(_) => ColumnType::new(ScalarType::Bool).nullable(in_nullable),
 
@@ -2036,6 +2038,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::SqrtFloat32 => f.write_str("sqrtf32"),
             UnaryFunc::SqrtFloat64 => f.write_str("sqrtf64"),
             UnaryFunc::Ascii => f.write_str("ascii"),
+            UnaryFunc::LengthBytes => f.write_str("lengthbytes"),
             UnaryFunc::MatchRegex(regex) => write!(f, "{} ~", regex.as_str()),
             UnaryFunc::ExtractIntervalYear => f.write_str("ivextractyear"),
             UnaryFunc::ExtractIntervalMonth => f.write_str("ivextractmonth"),
@@ -2109,7 +2112,7 @@ fn substr<'a>(datums: &[Datum<'a>]) -> Datum<'a> {
     }
 }
 
-fn length<'a>(datums: &[Datum<'a>]) -> Datum<'a> {
+fn length_string<'a>(datums: &[Datum<'a>]) -> Datum<'a> {
     let string = datums[0].unwrap_str();
 
     if datums.len() == 2 {
@@ -2142,6 +2145,10 @@ fn length<'a>(datums: &[Datum<'a>]) -> Datum<'a> {
     } else {
         Datum::from(string.chars().count() as i32)
     }
+}
+
+fn length_bytes<'a>(a: Datum<'a>) -> Datum<'a> {
+    Datum::Int32(a.unwrap_bytes().len() as i32)
 }
 
 fn replace<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
@@ -2194,7 +2201,7 @@ pub enum VariadicFunc {
     Coalesce,
     MakeTimestamp,
     Substr,
-    Length,
+    LengthString,
     Replace,
 }
 
@@ -2209,7 +2216,7 @@ impl VariadicFunc {
             VariadicFunc::Coalesce => coalesce(datums),
             VariadicFunc::MakeTimestamp => make_timestamp(datums),
             VariadicFunc::Substr => substr(datums),
-            VariadicFunc::Length => length(datums),
+            VariadicFunc::LengthString => length_string(datums),
             VariadicFunc::Replace => replace(datums, temp_storage),
         }
     }
@@ -2228,7 +2235,7 @@ impl VariadicFunc {
             }
             MakeTimestamp => ColumnType::new(ScalarType::Timestamp).nullable(true),
             Substr => ColumnType::new(ScalarType::String).nullable(true),
-            Length => ColumnType::new(ScalarType::Int32).nullable(true),
+            LengthString => ColumnType::new(ScalarType::Int32).nullable(true),
             Replace => ColumnType::new(ScalarType::String).nullable(true),
         }
     }
@@ -2248,7 +2255,7 @@ impl fmt::Display for VariadicFunc {
             VariadicFunc::Coalesce => f.write_str("coalesce"),
             VariadicFunc::MakeTimestamp => f.write_str("makets"),
             VariadicFunc::Substr => f.write_str("substr"),
-            VariadicFunc::Length => f.write_str("length"),
+            VariadicFunc::LengthString => f.write_str("lengthstr"),
             VariadicFunc::Replace => f.write_str("replace"),
         }
     }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1768,27 +1768,43 @@ fn plan_function<'a>(
                 let mut exprs = Vec::new();
                 let expr1 = plan_expr(catalog, ecx, &sql_func.args[0], Some(ScalarType::String))?;
                 let typ1 = ecx.column_type(&expr1);
-                if typ1.scalar_type != ScalarType::String && typ1.scalar_type != ScalarType::Null {
-                    bail!("length first argument has non-string type {:?}", typ1);
-                }
-                exprs.push(expr1);
+                match typ1.scalar_type {
+                    ScalarType::String | ScalarType::Null => {
+                        exprs.push(expr1);
 
-                if sql_func.args.len() == 2 {
-                    let expr2 =
-                        plan_expr(catalog, ecx, &sql_func.args[1], Some(ScalarType::String))?;
-                    let typ2 = ecx.column_type(&expr2);
-                    if typ2.scalar_type != ScalarType::String
-                        && typ2.scalar_type != ScalarType::Null
-                    {
-                        bail!("length second argument has non-string type {:?}", typ1);
+                        if sql_func.args.len() == 2 {
+                            let expr2 = plan_expr(
+                                catalog,
+                                ecx,
+                                &sql_func.args[1],
+                                Some(ScalarType::String),
+                            )?;
+                            let typ2 = ecx.column_type(&expr2);
+                            if typ2.scalar_type != ScalarType::String
+                                && typ2.scalar_type != ScalarType::Null
+                            {
+                                bail!("length second argument has non-string type {:?}", typ1);
+                            }
+                            exprs.push(expr2);
+                        }
+                        let expr = ScalarExpr::CallVariadic {
+                            func: VariadicFunc::LengthString,
+                            exprs,
+                        };
+                        Ok(expr)
                     }
-                    exprs.push(expr2);
+                    ScalarType::Bytes => {
+                        if sql_func.args.len() != 1 {
+                            bail!(
+                                "length expects only one argument when first argument \
+                                 has type bytea, got {:?}",
+                                sql_func.args.len(),
+                            );
+                        }
+                        Ok(expr1.call_unary(UnaryFunc::LengthBytes))
+                    }
+                    _ => bail!("length first argument has non-string type {:?}", typ1),
                 }
-                let expr = ScalarExpr::CallVariadic {
-                    func: VariadicFunc::Length,
-                    exprs,
-                };
-                Ok(expr)
             }
 
             // Promotes a numeric type to the smallest fractional type that

--- a/test/bytea.slt
+++ b/test/bytea.slt
@@ -1,0 +1,27 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc
+
+# Tests for the bytea type.
+
+mode cockroach
+
+statement ok
+CREATE TABLE test (ord int, b bytea)
+
+statement ok
+INSERT INTO test VALUES (0, 'hello'), (1, '你好'), (2, NULL), (3, ''), (4, 'nonprintablechar:')
+
+query II rowsort
+SELECT ord, length(b::bytea) FROM test
+----
+0 5
+1 6
+2 NULL
+3 0
+4 18
+
+
+query error length expects only one argument when first argument has type bytea, got 2
+SELECT length('a'::bytea, 'utf-8')


### PR DESCRIPTION
PostgreSQL allows asking about the length of a byte array, in addition
to the length of a string.