### PR TITLE
lint: fix copyright header lint

### DIFF
--- a/misc/lint/copyright.awk
+++ b/misc/lint/copyright.awk
@@ -10,8 +10,9 @@ function done()
     if (!copyright) {
         print "lint: copyright: " FILENAME " is missing copyright header" > "/dev/stderr"
         exit 1
-    } else if (copyright !~ /Copyright 2019 Materialize, Inc./) {
+    } else if (copyright !~ /Copyright 20(19|2[0-9]) Materialize, Inc./) {
         print "lint: copyright: " FILENAME " has malformatted copyright header" > "/dev/stderr"
+        exit 1
     }
     exit 0
 }


### PR DESCRIPTION
This was both a) incorrectly printing an error on files from this
decade, and b) not failing after printing a warning. Fix both of these
problems.