### PR TITLE
sql: introduce per-statement context

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1394,7 +1394,8 @@ where
             0 => (None, None, vec![]),
             1 => {
                 let stmt = stmts.into_element();
-                let (desc, param_types) = match sql::describe(&self.catalog, stmt.clone()) {
+                let (desc, param_types) = match sql::describe(&self.catalog, session, stmt.clone())
+                {
                     Ok((desc, param_types)) => (desc, param_types),
                     // Describing the query failed. If we're running in symbiosis with
                     // Postgres, see if Postgres can handle it. Note that Postgres

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -114,9 +114,10 @@ pub fn plan(
 /// of types will be empty.
 pub fn describe(
     catalog: &Catalog,
+    session: &Session,
     stmt: Statement,
 ) -> Result<(Option<RelationDesc>, Vec<pgrepr::Type>), failure::Error> {
-    let (desc, types) = statement::describe_statement(catalog, stmt)?;
+    let (desc, types) = statement::describe_statement(catalog, session, stmt)?;
     let types = types.into_iter().map(pgrepr::Type::from).collect();
     Ok((desc, types))
 }

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -9,10 +9,12 @@ use std::iter;
 use catalog::Catalog;
 use ore::collections::CollectionExt;
 use pgrepr::Type;
+use sql::Session;
 
 #[test]
 fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     let catalog = Catalog::open(None, iter::empty())?;
+    let session = Session::default();
     let test_cases = vec![
         (
             "SELECT $1, $2, $3",
@@ -79,7 +81,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     for (sql, types) in test_cases {
         println!("> {}", sql);
         let stmt = sql::parse(sql.into())?.into_element();
-        let (_desc, param_types) = sql::describe(&catalog, stmt)?;
+        let (_desc, param_types) = sql::describe(&catalog, &session, stmt)?;
         assert_eq!(param_types, types);
     }
     Ok(())


### PR DESCRIPTION
Supporting databases and schemas will require more complicated name
resolution routines that depend on both the catalog and the session, as
the session contains a "schema search path" that determines in which
schemas to search for catalog items. Presently we only plumb a catalog
through the SQL planner. This commit creates a new type,
StatementContext, that bundles a catalog and session together, and
plumbs that through the planner instead of a bare catalog, in
preparation for supporting proper databases and schemas.

There is no behavioral change in this patch, to keep the review easier.