### PR TITLE
sql: move type name computation to pgrepr

### DIFF
--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -58,6 +58,11 @@ impl Type {
         }
     }
 
+    /// Returns the name that PostgreSQL uses for this type.
+    pub fn name(self) -> &'static str {
+        self.inner().name()
+    }
+
     /// Returns the [OID] of this type.
     ///
     /// [OID]: https://www.postgresql.org/docs/current/datatype-oid.html

--- a/src/repr/scalar/mod.rs
+++ b/src/repr/scalar/mod.rs
@@ -261,7 +261,7 @@ impl<'a> Datum<'a> {
     }
 
     pub fn is_instance_of(self, column_type: &ColumnType) -> bool {
-        fn is_instance_of_scalar(datum: Datum, scalar_type: &ScalarType) -> bool {
+        fn is_instance_of_scalar(datum: Datum, scalar_type: ScalarType) -> bool {
             if let ScalarType::Jsonb = scalar_type {
                 // json type checking
                 match datum {
@@ -320,7 +320,7 @@ impl<'a> Datum<'a> {
                 return true;
             }
         }
-        is_instance_of_scalar(self, &column_type.scalar_type)
+        is_instance_of_scalar(self, column_type.scalar_type)
     }
 }
 
@@ -519,7 +519,7 @@ impl fmt::Display for Datum<'_> {
 /// an optional default value and nullability, that must also be considered part
 /// of a datum's type.
 #[serde(rename_all = "snake_case")]
-#[derive(Clone, Debug, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ScalarType {
     /// The type of a datum that can only be null.
     ///
@@ -551,14 +551,14 @@ pub enum ScalarType {
 }
 
 impl<'a> ScalarType {
-    pub fn unwrap_decimal_parts(&self) -> (u8, u8) {
+    pub fn unwrap_decimal_parts(self) -> (u8, u8) {
         match self {
-            ScalarType::Decimal(p, s) => (*p, *s),
+            ScalarType::Decimal(p, s) => (p, s),
             _ => panic!("ScalarType::unwrap_decimal_parts called on {:?}", self),
         }
     }
 
-    pub fn dummy_datum(&self) -> Datum<'a> {
+    pub fn dummy_datum(self) -> Datum<'a> {
         match self {
             ScalarType::Null => Datum::Null,
             ScalarType::Bool => Datum::False,

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -385,7 +385,7 @@ fn handle_show_columns(
             Row::pack(&[
                 Datum::String(name.as_deref().unwrap_or("?")),
                 Datum::String(if typ.nullable { "YES" } else { "NO" }),
-                Datum::String(&postgres_type_name(&typ.scalar_type)),
+                Datum::String(pgrepr::Type::from(typ.scalar_type).name()),
             ])
         })
         .collect();
@@ -1131,28 +1131,6 @@ fn object_type_as_plural_str(object_type: ObjectType) -> &'static str {
         ObjectType::View => "VIEWS",
         ObjectType::Source => "SOURCES",
         ObjectType::Sink => "SINKS",
-    }
-}
-
-/// Returns the name that PostgreSQL would use for this `ScalarType`. Note that
-/// PostgreSQL does not have an explicit NULL type, so this function panics if
-/// called with `ScalarType::Null`.
-fn postgres_type_name(typ: &ScalarType) -> String {
-    match typ {
-        ScalarType::Null => panic!("postgres_type_name called on ScalarType::Null"),
-        ScalarType::Bool => "bool".to_owned(),
-        ScalarType::Int32 => "int4".to_owned(),
-        ScalarType::Int64 => "int8".to_owned(),
-        ScalarType::Float32 => "float4".to_owned(),
-        ScalarType::Float64 => "float8".to_owned(),
-        ScalarType::Decimal(_, _) => "numeric".to_owned(),
-        ScalarType::Date => "date".to_owned(),
-        ScalarType::Timestamp => "timestamp".to_owned(),
-        ScalarType::TimestampTz => "timestamptz".to_owned(),
-        ScalarType::Interval => "interval".to_owned(),
-        ScalarType::Bytes => "bytea".to_owned(),
-        ScalarType::String => "text".to_owned(),
-        ScalarType::Jsonb => "jsonb".to_owned(),
     }
 }
 


### PR DESCRIPTION
This way we can outsource knowledge of the names to the postgres-types
library.