### PR TITLE
repr,interchange: avoid unsafe code when decoding into lists/dicts

### DIFF
--- a/src/repr/lib.rs
+++ b/src/repr/lib.rs
@@ -19,7 +19,7 @@ mod row;
 mod scalar;
 
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{DatumDict, DatumList, Row, RowArena, RowPacker};
+pub use row::{DatumDict, DatumList, DatumPacker, DictPacker, Row, RowArena, RowPacker};
 pub use scalar::decimal;
 pub use scalar::jsonb;
 pub use scalar::regex;

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -380,7 +380,7 @@ fn push_column(
         DataType::Custom(name) if name.to_string().to_lowercase() == "jsonb" => {
             let serde = get_column_inner::<serde_json::Value>(postgres_row, i, nullable)?;
             if let Some(serde) = serde {
-                row = Jsonb::new(serde)?.pack_into(row)
+                Jsonb::new(serde)?.pack_into(&mut row)
             } else {
                 row.push(Datum::Null)
             }


### PR DESCRIPTION
`RowPacker::push_list_with` and `RowPacker::push_dict_with` are safe
wrappers around `RowPacker::{start,finish}_{list,dict}`, as they
guarantee that the `RowPacker` is left in a valid state after returning.
If we adjust the closure so that it can return an arbitrary value,
including an error, we can use the safe variants everywhere the unsafe
variants are currently used. This also cleans up some API signatures,
since the functions can take RowPacker by the more natural `&mut` ref
rather than taking and returning ownership.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/1472)
<!-- Reviewable:end -->
