### PR TITLE
sql: use int32 as the default int type

### DIFF
--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -212,6 +212,15 @@ fn cast_float32_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum
     Datum::String(temp_storage.push_string(buf))
 }
 
+fn cast_float64_to_int32<'a>(a: Datum<'a>) -> Datum<'a> {
+    let f = a.unwrap_float64();
+    if f > (i32::max_value() as f64) || f < (i32::min_value() as f64) {
+        Datum::Null
+    } else {
+        Datum::from(f as i32)
+    }
+}
+
 fn cast_float64_to_int64<'a>(a: Datum<'a>) -> Datum<'a> {
     // TODO(benesch): this is undefined behavior if the f32 doesn't fit in an
     // i64 (https://github.com/rust-lang/rust/issues/10184).
@@ -1699,6 +1708,7 @@ pub enum UnaryFunc {
     CastFloat32ToInt64,
     CastFloat32ToFloat64,
     CastFloat32ToString,
+    CastFloat64ToInt32,
     CastFloat64ToInt64,
     CastFloat64ToString,
     CastDecimalToInt32,
@@ -1813,6 +1823,7 @@ impl UnaryFunc {
             UnaryFunc::CastFloat32ToInt64 => cast_float32_to_int64(a),
             UnaryFunc::CastFloat32ToFloat64 => cast_float32_to_float64(a),
             UnaryFunc::CastFloat32ToString => cast_float32_to_string(a, temp_storage),
+            UnaryFunc::CastFloat64ToInt32 => cast_float64_to_int32(a),
             UnaryFunc::CastFloat64ToInt64 => cast_float64_to_int64(a),
             UnaryFunc::CastFloat64ToString => cast_float64_to_string(a, temp_storage),
             UnaryFunc::CastDecimalToInt32 => cast_decimal_to_int32(a),
@@ -1981,6 +1992,8 @@ impl UnaryFunc {
                 ColumnType::new(ScalarType::Int32).nullable(in_nullable)
             }
 
+            CastFloat64ToInt32 => ColumnType::new(ScalarType::Int32).nullable(true),
+
             CastInt32ToInt64 | CastDecimalToInt64 | CastFloat32ToInt64 | CastFloat64ToInt64 => {
                 ColumnType::new(ScalarType::Int64).nullable(in_nullable)
             }
@@ -2141,6 +2154,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::CastFloat32ToInt64 => f.write_str("f32toi64"),
             UnaryFunc::CastFloat32ToFloat64 => f.write_str("f32tof64"),
             UnaryFunc::CastFloat32ToString => f.write_str("f32tostr"),
+            UnaryFunc::CastFloat64ToInt32 => f.write_str("f64toi32"),
             UnaryFunc::CastFloat64ToInt64 => f.write_str("f64toi64"),
             UnaryFunc::CastFloat64ToString => f.write_str("f64tostr"),
             UnaryFunc::CastDecimalToInt32 => f.write_str("dectoi32"),

--- a/src/materialized/tests/prepared.rs
+++ b/src/materialized/tests/prepared.rs
@@ -26,22 +26,22 @@ fn test_bind_params() -> util::TestResult {
         .collect();
     assert_eq!(rows, &["42"]);
 
-    let rows: Vec<i64> = client
-        .query("SELECT $1 + 1", &[&42_i64])?
+    let rows: Vec<i32> = client
+        .query("SELECT $1 + 1", &[&42_i32])?
         .into_iter()
         .map(|row| row.get(0))
         .collect();
     assert_eq!(rows, &[43]);
 
-    let rows: Vec<i64> = client
-        .query("SELECT $1 - 1", &[&42_i64])?
+    let rows: Vec<i32> = client
+        .query("SELECT $1 - 1", &[&42_i32])?
         .into_iter()
         .map(|row| row.get(0))
         .collect();
     assert_eq!(rows, &[41]);
 
-    let rows: Vec<i64> = client
-        .query("SELECT 1 - $1", &[&42_i64])?
+    let rows: Vec<i32> = client
+        .query("SELECT 1 - $1", &[&42_i32])?
         .into_iter()
         .map(|row| row.get(0))
         .collect();

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -2643,7 +2643,7 @@ fn sql_value_to_datum<'a>(l: &'a Value) -> Result<(Datum<'a>, ScalarType), failu
             let d: Decimal = s.parse()?;
             if d.scale() == 0 {
                 match d.significand().try_into() {
-                    Ok(n) => (Datum::Int64(n), ScalarType::Int64),
+                    Ok(n) => (Datum::Int32(n), ScalarType::Int32),
                     Err(_) => (
                         Datum::from(d.significand()),
                         ScalarType::Decimal(MAX_DECIMAL_PRECISION, d.scale()),
@@ -2921,6 +2921,7 @@ where
             expr.call_binary(s, BinaryFunc::CastFloat32ToDecimal)
         }
         (Float32, String) => expr.call_unary(CastFloat32ToString),
+        (Float64, Int32) => expr.call_unary(CastFloat64ToInt32),
         (Float64, Int64) => expr.call_unary(CastFloat64ToInt64),
         (Float64, Decimal(_, s)) => {
             let s = ScalarExpr::literal(Datum::from(s as i32), ColumnType::new(to_scalar_type));
@@ -3063,8 +3064,8 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, failure:
             ScalarType::String
         }
         DataType::Char(_) | DataType::Varchar(_) | DataType::Text => ScalarType::String,
-        DataType::SmallInt => ScalarType::Int32,
-        DataType::Int | DataType::BigInt => ScalarType::Int64,
+        DataType::SmallInt | DataType::Int => ScalarType::Int32,
+        DataType::BigInt => ScalarType::Int64,
         DataType::Float(_) | DataType::Real | DataType::Double => ScalarType::Float64,
         DataType::Decimal(precision, scale) => {
             let precision = precision.unwrap_or(MAX_DECIMAL_PRECISION.into());

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -33,7 +33,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
             vec![Type::Text, Type::Text, Type::Text],
         ),
         ("SELECT ($1), (((($2))))", vec![Type::Text, Type::Text]),
-        ("SELECT $1::int", vec![Type::Int8]),
+        ("SELECT $1::int", vec![Type::Int4]),
         ("SELECT 1 WHERE $1", vec![Type::Bool]),
         ("SELECT 1 HAVING $1", vec![Type::Bool]),
         (
@@ -45,14 +45,14 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
             "SELECT CASE WHEN true THEN $1 ELSE $2 END",
             vec![Type::Text, Type::Text],
         ),
-        ("SELECT CASE WHEN true THEN $1 ELSE 1 END", vec![Type::Int8]),
+        ("SELECT CASE WHEN true THEN $1 ELSE 1 END", vec![Type::Int4]),
         ("SELECT abs($1)", vec![Type::Float8]),
         ("SELECT ascii($1)", vec![Type::Text]),
         (
             "SELECT coalesce($1, $2, $3)",
             vec![Type::Text, Type::Text, Type::Text],
         ),
-        ("SELECT coalesce($1, 1)", vec![Type::Int8]),
+        ("SELECT coalesce($1, 1)", vec![Type::Int4]),
         ("SELECT substr($1, $2)", vec![Type::Text, Type::Int8]),
         ("SELECT substring($1, $2)", vec![Type::Text, Type::Int8]),
         ("SELECT $1 LIKE $2", vec![Type::Text, Type::Text]),
@@ -61,9 +61,9 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
         ("SELECT $1 OR $2", vec![Type::Bool, Type::Bool]),
         ("SELECT +$1", vec![Type::Float8]),
         ("SELECT -$1", vec![Type::Float8]),
-        ("SELECT $1 < 1", vec![Type::Int8]),
+        ("SELECT $1 < 1", vec![Type::Int4]),
         ("SELECT $1 < $2", vec![Type::Text, Type::Text]),
-        ("SELECT $1 + 1", vec![Type::Int8]),
+        ("SELECT $1 + 1", vec![Type::Int4]),
         ("SELECT $1 + 1.0", vec![Type::Numeric]),
         ("SELECT DATE '1970-01-01' + $1", vec![Type::Interval]),
         (
@@ -75,7 +75,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
             "SELECT $1 + TIMESTAMP '1970-01-01 00:00:00'",
             vec![Type::Interval],
         ),
-        ("SELECT $1::int, $1 + $2", vec![Type::Int8, Type::Int8]),
+        ("SELECT $1::int, $1 + $2", vec![Type::Int4, Type::Int4]),
         ("SELECT '[0, 1, 2]'::jsonb - $1", vec![Type::Text]),
     ];
     for (sql, types) in test_cases {

--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -330,6 +330,7 @@ fn format_row(
                 (Type::Integer, Datum::String(_)) => "0".to_owned(),
                 (Type::Integer, Datum::False) => "0".to_owned(),
                 (Type::Integer, Datum::True) => "1".to_owned(),
+                (Type::Real, Datum::Int32(i)) => format!("{:.3}", i),
                 (Type::Real, Datum::Int64(i)) => format!("{:.3}", i),
                 (Type::Text, Datum::Int64(i)) => format!("{}", i),
                 (Type::Text, Datum::Float64(f)) => format!("{:.3}", f),

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -307,7 +307,7 @@ fn push_column(
             row.push(i.into());
         }
         DataType::Int => {
-            let i = get_column_inner::<i32>(postgres_row, i, nullable)?.map(|i| i64::from(i));
+            let i = get_column_inner::<i32>(postgres_row, i, nullable)?;
             row.push(i.into());
         }
         DataType::BigInt => {

--- a/test/aggregates.slt
+++ b/test/aggregates.slt
@@ -36,8 +36,8 @@ query TTT colnames
 SHOW COLUMNS FROM t
 ----
 Field  Nullable  Type
- a     YES       int8
- b     YES       int8
+ a     YES       int4
+ b     YES       int4
 
 # avg on an integer column should return a decimal with the default decimal
 # division scale increase.

--- a/test/boolean.slt
+++ b/test/boolean.slt
@@ -48,25 +48,25 @@ SELECT 'blah'::bool
 ----
 NULL
 
-query error Cannot apply operator Not to non-boolean type Int64
+query error Cannot apply operator Not to non-boolean type Int32
 SELECT NOT 1
 
-query error Cannot apply operator And to non-boolean type Int64
+query error Cannot apply operator And to non-boolean type Int32
 SELECT 1 AND 1
 
-query error Cannot apply operator Or to non-boolean type Int64
+query error Cannot apply operator Or to non-boolean type Int32
 SELECT 1 OR 1
 
-query error Cannot apply operator Or to non-boolean type Int64
+query error Cannot apply operator Or to non-boolean type Int32
 SELECT 1 OR FALSE
 
-query error Cannot apply operator Or to non-boolean type Int64
+query error Cannot apply operator Or to non-boolean type Int32
 SELECT FALSE OR 1
 
-query error Cannot apply operator And to non-boolean type Int64
+query error Cannot apply operator And to non-boolean type Int32
 SELECT 1 AND FALSE
 
-query error Cannot apply operator And to non-boolean type Int64
+query error Cannot apply operator And to non-boolean type Int32
 SELECT FALSE AND 1
 
 query B

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -264,18 +264,18 @@ AND s_quantity = m_s_quantity
 ORDER BY n_name, su_name, i_id
 ----
 Project {
-  outputs: [23, 24, 32, 18, 20, 25, 27, 29],
+  outputs: [23, 24, 31, 18, 20, 25, 27, 29],
   Join {
     variables: [
       [(0, 0), (1, 0), (5, 0)],
       [(0, 2), (5, 1)],
-      [(0, 17), (2, 7)],
+      [(0, 17), (2, 0)],
       [(2, 3), (3, 0)],
       [(3, 2), (4, 0)]
     ],
     Filter { predicates: [!isnull #2], Get { stock (u17) } },
     Filter { predicates: [^.*b$ ~ #4], Get { item (u15) } },
-    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    Get { supplier (u21) },
     Get { nation (u19) },
     Filter { predicates: [^EUROP.*$ ~ #1], Get { region (u23) } },
     Filter {
@@ -285,12 +285,12 @@ Project {
         aggregates: [min(#2)],
         Join {
           variables: [
-            [(0, 17), (1, 7)],
+            [(0, 17), (1, 0)],
             [(1, 3), (2, 0)],
             [(2, 2), (3, 0)]
           ],
           Get { stock (u17) },
-          Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+          Get { supplier (u21) },
           Get { nation (u19) },
           Filter {
             predicates: [^EUROP.*$ ~ #1],
@@ -425,31 +425,27 @@ GROUP BY n_name
 ORDER BY revenue DESC
 ----
 Reduce {
-  group_key: [#68],
-  aggregates: [sum(#38)],
+  group_key: [#66],
+  aggregates: [sum(#8)],
   Join {
     variables: [
-      [(0, 0), (1, 3)],
+      [(0, 0), (1, 0)],
       [(0, 1), (1, 1), (2, 1)],
       [(0, 2), (1, 2), (2, 2), (3, 1)],
-      [(0, 21), (4, 8)],
-      [(1, 0), (2, 0)],
-      [(2, 4), (3, 0)],
-      [(3, 17), (4, 7)],
-      [(4, 3), (5, 0)],
+      [(0, 4), (3, 0)],
+      [(1, 3), (2, 0)],
+      [(2, 21), (4, 3), (5, 0)],
+      [(3, 17), (4, 0)],
       [(5, 2), (6, 0)]
     ],
-    Get { customer (u5) },
+    Get { orderline (u13) },
     Filter {
       predicates: [datetots #4 >= 2007-01-02 00:00:00],
       Get { "order" (u11) }
     },
-    Get { orderline (u13) },
+    Get { customer (u5) },
     Get { stock (u17) },
-    Map {
-      scalars: [i32toi64 #0, i32toi64 #3],
-      Get { supplier (u21) }
-    },
+    Get { supplier (u21) },
     Get { nation (u19) },
     Filter { predicates: [#1 = "EUROPE"], Get { region (u23) } }
   }
@@ -471,8 +467,8 @@ Let {
     Filter {
       predicates: [
         datetots #6 < 2020-01-01 00:00:00,
-        i32toi64 #7 <= 100000,
-        i32toi64 #7 >= 1,
+        #7 <= 100000,
+        #7 >= 1,
         datetots #6 >= 1999-01-01 00:00:00
       ],
       Get { orderline (u13) }
@@ -520,13 +516,13 @@ GROUP BY su_nationkey, substr(c_state, 1, 1), EXTRACT(year FROM o_entry_d)
 ORDER BY su_nationkey, cust_nation, l_year
 ----
 Reduce {
-  group_key: [#31, substr(#53, 1, 1), tsextractyear datetots #40],
+  group_key: [#31, substr(#52, 1, 1), tsextractyear datetots #39],
   aggregates: [sum(#8)],
   Filter {
     predicates: [
-      ((#67 = "GERMANY") && (#71 = "CAMBODIA"))
+      ((#66 = "GERMANY") && (#70 = "CAMBODIA"))
       ||
-      ((#67 = "CAMBODIA") && (#71 = "GERMANY"))
+      ((#66 = "CAMBODIA") && (#70 = "GERMANY"))
     ],
     Join {
       variables: [
@@ -535,10 +531,10 @@ Reduce {
         [(0, 2), (3, 2), (4, 2)],
         [(0, 4), (1, 0)],
         [(0, 5), (1, 1)],
-        [(1, 17), (2, 7)],
+        [(1, 17), (2, 0)],
         [(2, 3), (5, 0)],
         [(3, 3), (4, 0)],
-        [(4, 21), (6, 4)]
+        [(4, 21), (6, 0)]
       ],
       Filter {
         predicates: [
@@ -548,11 +544,11 @@ Reduce {
         Get { orderline (u13) }
       },
       Get { stock (u17) },
-      Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+      Get { supplier (u21) },
       Get { "order" (u11) },
       Get { customer (u5) },
       Get { nation (u19) },
-      Map { scalars: [i32toi64 #0], Get { nation (u19) } }
+      Get { nation (u19) }
     }
   }
 }
@@ -590,9 +586,9 @@ Project {
   Map {
     scalars: [((#1 * 10000000dec) / #2) * 10dec],
     Reduce {
-      group_key: [tsextractyear datetots #45],
+      group_key: [tsextractyear datetots #44],
       aggregates: [
-        sum(if #77 = "GERMANY" then #8 else 0dec),
+        sum(if #75 = "GERMANY" then #8 else 0dec),
         sum(#8)
       ],
       Join {
@@ -602,10 +598,10 @@ Project {
           [(0, 2), (4, 2), (5, 2)],
           [(0, 4), (1, 0), (2, 0)],
           [(0, 5), (2, 1)],
-          [(2, 17), (3, 7)],
+          [(2, 17), (3, 0)],
           [(3, 3), (7, 0)],
           [(4, 3), (5, 0)],
-          [(5, 21), (6, 4)],
+          [(5, 21), (6, 0)],
           [(6, 2), (8, 0)]
         ],
         Filter {
@@ -614,7 +610,7 @@ Project {
         },
         Filter { predicates: [^.*b$ ~ #4], Get { item (u15) } },
         Get { stock (u17) },
-        Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+        Get { supplier (u21) },
         Filter {
           predicates: [
             datetots #4 <= 2012-01-02 00:00:00,
@@ -623,7 +619,7 @@ Project {
           Get { "order" (u11) }
         },
         Get { customer (u5) },
-        Map { scalars: [i32toi64 #0], Get { nation (u19) } },
+        Get { nation (u19) },
         Get { nation (u19) },
         Filter { predicates: [#1 = "EUROPE"], Get { region (u23) } }
       }
@@ -651,7 +647,7 @@ GROUP BY n_name, EXTRACT(year FROM o_entry_d)
 ORDER BY n_name, l_year DESC
 ----
 Reduce {
-  group_key: [#50, tsextractyear datetots #45],
+  group_key: [#49, tsextractyear datetots #44],
   aggregates: [sum(#8)],
   Join {
     variables: [
@@ -660,13 +656,13 @@ Reduce {
       [(0, 2), (4, 2)],
       [(0, 4), (1, 0), (2, 0)],
       [(0, 5), (2, 1)],
-      [(2, 17), (3, 7)],
+      [(2, 17), (3, 0)],
       [(3, 3), (5, 0)]
     ],
     Get { orderline (u13) },
     Filter { predicates: [^.*BB$ ~ #4], Get { item (u15) } },
     Get { stock (u17) },
-    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    Get { supplier (u21) },
     Get { "order" (u11) },
     Get { nation (u19) }
   }
@@ -703,7 +699,7 @@ Project {
           [(0, 1), (1, 1), (2, 1)],
           [(0, 2), (1, 2), (2, 2)],
           [(1, 3), (2, 0)],
-          [(2, 21), (3, 4)]
+          [(2, 21), (3, 0)]
         ],
         Get { orderline (u13) },
         Filter {
@@ -711,7 +707,7 @@ Project {
           Get { "order" (u11) }
         },
         Get { customer (u5) },
-        Map { scalars: [i32toi64 #0], Get { nation (u19) } }
+        Get { nation (u19) }
       }
     }
   }
@@ -737,9 +733,9 @@ ORDER BY ordercount DESC
 ----
 Let {
   l0 = Join {
-    variables: [[(0, 17), (1, 7)], [(1, 3), (2, 0)]],
+    variables: [[(0, 17), (1, 0)], [(1, 3), (2, 0)]],
     Get { stock (u17) },
-    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    Get { supplier (u21) },
     Filter { predicates: [#1 = "GERMANY"], Get { nation (u19) } }
   }
 } in
@@ -778,8 +774,8 @@ ORDER BY o_ol_cnt
 Reduce {
   group_key: [#16],
   aggregates: [
-    sum(if (i32toi64 #15 = 1) || (i32toi64 #15 = 2) then 1 else 0),
-    sum(if (i32toi64 #15 != 1) && (i32toi64 #15 != 2) then 1 else 0)
+    sum(if (#15 = 1) || (#15 = 2) then 1 else 0),
+    sum(if (#15 != 1) && (#15 != 2) then 1 else 0)
   ],
   Filter {
     predicates: [#14 <= #6],
@@ -817,7 +813,7 @@ ORDER BY custdist DESC, c_count DESC
 Let {
   l0 = Join {
     variables: [[(0, 1), (1, 1)], [(0, 2), (1, 2)], [(0, 3), (1, 0)]],
-    Filter { predicates: [i32toi64 #5 > 8], Get { "order" (u11) } },
+    Filter { predicates: [#5 > 8], Get { "order" (u11) } },
     Get { customer (u5) }
   }
 } in
@@ -942,10 +938,10 @@ Let {
   }
 } in
 Project {
-  outputs: [0 .. 2, 4, 9],
+  outputs: [0 .. 2, 4, 8],
   Join {
-    variables: [[(0, 7), (1, 0)], [(1, 1), (2, 0)]],
-    Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+    variables: [[(0, 0), (1, 0)], [(1, 1), (2, 0)]],
+    Get { supplier (u21) },
     Filter { predicates: [!isnull #1], Get { l0 } },
     Filter {
       predicates: [!isnull #0],
@@ -982,7 +978,7 @@ Let { l3 = Distinct { group_key: [#17], Get { l0 } } } in
 Let {
   l2 = Reduce {
     group_key: [#0],
-    aggregates: [all(#0 != i32toi64 #1)],
+    aggregates: [all(#0 != #1)],
     Join {
       variables: [],
       Get { l3 },
@@ -1151,7 +1147,7 @@ Let {
       Join {
         variables: [[(0, 4), (1, 0)]],
         Filter {
-          predicates: [i32toi64 #7 <= 10, i32toi64 #7 >= 1],
+          predicates: [#7 <= 10, #7 >= 1],
           Get { orderline (u13) }
         },
         Filter {
@@ -1219,14 +1215,14 @@ Project {
       group_key: [#0],
       aggregates: [any(true)],
       Filter {
-        predicates: [(2 * i32toi64 #3) > i32toi64 #4],
+        predicates: [(2 * #3) > #4],
         Reduce {
           group_key: [#0, #21, #22, #23],
           aggregates: [sum(#18)],
           Join {
             variables: [[(0, 21), (1, 0), (2, 0)]],
             Filter {
-              predicates: [i32toi64 #0 = ((#21 * #22) % 10000)],
+              predicates: [#0 = ((#21 * #22) % 10000)],
               Get { l3 }
             },
             Distinct { group_key: [#21], Get { l3 } },
@@ -1274,13 +1270,13 @@ Let {
         [(0, 1), (1, 1)],
         [(0, 2), (1, 2), (2, 1)],
         [(0, 4), (2, 0)],
-        [(2, 17), (3, 7)],
+        [(2, 17), (3, 0)],
         [(3, 3), (4, 0)]
       ],
       Get { orderline (u13) },
       Get { "order" (u11) },
       Get { stock (u17) },
-      Map { scalars: [i32toi64 #0], Get { supplier (u21) } },
+      Get { supplier (u21) },
       Filter { predicates: [#1 = "GERMANY"], Get { nation (u19) } }
     }
   }

--- a/test/cockroach/union.slt
+++ b/test/cockroach/union.slt
@@ -227,13 +227,13 @@ SELECT 1, 2 INTERSECT SELECT 3
 query error pgcode 42601 each EXCEPT query must have the same number of columns: 2 vs 1
 SELECT 1, 2 EXCEPT SELECT 3
 
-query error pgcode 42804 UNION types i64 and string cannot be matched
+query error pgcode 42804 UNION types i32 and string cannot be matched
 SELECT 1 UNION SELECT '3'
 
-query error pgcode 42804 INTERSECT types i64 and string cannot be matched
+query error pgcode 42804 INTERSECT types i32 and string cannot be matched
 SELECT 1 INTERSECT SELECT '3'
 
-query error pgcode 42804 EXCEPT types i64 and string cannot be matched
+query error pgcode 42804 EXCEPT types i32 and string cannot be matched
 SELECT 1 EXCEPT SELECT '3'
 
 query error pgcode 42703 column "z" does not exist

--- a/test/quoting.slt
+++ b/test/quoting.slt
@@ -19,14 +19,14 @@ statement ok
 INSERT INTO "t" VALUES
     (3)
 
-query T
+query I
 SELECT * FROM "t" ORDER BY v
 ----
 1
 2
 3
 
-query T
+query I
 SELECT * FROM t ORDER BY "v"
 ----
 1
@@ -64,14 +64,14 @@ statement ok
 INSERT INTO "q" VALUES
     (3)
 
-query T
+query I
 SELECT * FROM "q" ORDER BY p
 ----
 1
 2
 3
 
-query T
+query I
 SELECT * FROM q ORDER BY "p"
 ----
 1

--- a/test/tpch.slt
+++ b/test/tpch.slt
@@ -734,14 +734,14 @@ Project {
       variables: [],
       Reduce {
         group_key: [#0],
-        aggregates: [sum(#3 * (i64todec #2 * 100dec))],
+        aggregates: [sum(#3 * (i32todec #2 * 100dec))],
         Get { l0 }
       },
       Map {
         scalars: [#0 * 1dec],
         Reduce {
           group_key: [],
-          aggregates: [sum(#3 * (i64todec #2 * 100dec))],
+          aggregates: [sum(#3 * (i32todec #2 * 100dec))],
           Get { l0 }
         }
       }
@@ -1453,7 +1453,7 @@ Project {
       group_key: [#0],
       aggregates: [any(true)],
       Filter {
-        predicates: [(i64todec #3 * 1000dec) > #11],
+        predicates: [(i32todec #3 * 1000dec) > #11],
         Join {
           variables: [[(0, 1), (1, 0)], [(0, 2), (1, 1)]],
           Filter { predicates: [#0 = #2], Get { l3 } },


### PR DESCRIPTION
This brings us in line with Postgres's behavior, and also removes a
bunch of casts from the chbench setup.