### PR TITLE
Revert "Revert "Make CCSR client async. (#1473)" (#1482)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ name = "ccsr"
 version = "0.1.0"
 dependencies = [
  "failure",
+ "futures",
  "hyper",
  "lazy_static",
  "reqwest",
@@ -3046,6 +3047,7 @@ dependencies = [
  "serde_json",
  "sql-parser",
  "termcolor",
+ "tokio",
 ]
 
 [[package]]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -10,6 +10,7 @@ path = "lib.rs"
 
 [dependencies]
 failure = "0.1"
+futures = "0.3"
 reqwest = { version = "0.10.0", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.44"

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -24,105 +24,109 @@ lazy_static! {
 
 #[test]
 fn test_client() -> Result<(), failure::Error> {
-    let client = Client::new(SCHEMA_REGISTRY_URL.clone());
+    tokio::runtime::Runtime::new().unwrap().enter(|| {
+        let client = Client::new(SCHEMA_REGISTRY_URL.clone());
 
-    let existing_subjects = client.list_subjects()?;
-    for s in existing_subjects {
-        if s.starts_with("ccsr-test-") {
-            client.delete_subject(&s)?;
+        let existing_subjects = client.list_subjects()?;
+        for s in existing_subjects {
+            if s.starts_with("ccsr-test-") {
+                client.delete_subject(&s)?;
+            }
         }
-    }
 
-    let schema_v1 = r#"{ "type": "record", "name": "na", "fields": [
+        let schema_v1 = r#"{ "type": "record", "name": "na", "fields": [
         { "name": "a", "type": "long" }
     ]}"#;
 
-    let schema_v2 = r#"{ "type": "record", "name": "na", "fields": [
+        let schema_v2 = r#"{ "type": "record", "name": "na", "fields": [
         { "name": "a", "type": "long" },
         { "name": "b", "type": "long", "default": 0 }
     ]}"#;
 
-    let schema_v2_incompat = r#"{ "type": "record", "name": "na", "fields": [
+        let schema_v2_incompat = r#"{ "type": "record", "name": "na", "fields": [
         { "name": "a", "type": "string" }
     ]}"#;
 
-    assert_eq!(count_schemas(&client, "ccsr-test-")?, 0);
+        assert_eq!(count_schemas(&client, "ccsr-test-")?, 0);
 
-    let schema_v1_id = client.publish_schema("ccsr-test-schema", schema_v1)?;
-    assert!(schema_v1_id > 0);
+        let schema_v1_id = client.publish_schema("ccsr-test-schema", schema_v1)?;
+        assert!(schema_v1_id > 0);
 
-    match client.publish_schema("ccsr-test-schema", schema_v2_incompat) {
-        Err(PublishError::IncompatibleSchema) => (),
-        res => panic!("expected IncompatibleSchema error, got {:?}", res),
-    }
+        match client.publish_schema("ccsr-test-schema", schema_v2_incompat) {
+            Err(PublishError::IncompatibleSchema) => (),
+            res => panic!("expected IncompatibleSchema error, got {:?}", res),
+        }
 
-    {
-        let res = client.get_schema_by_subject("ccsr-test-schema")?;
-        assert_eq!(schema_v1_id, res.id);
-        assert_raw_schemas_eq(schema_v1, &res.raw);
-    }
+        {
+            let res = client.get_schema_by_subject("ccsr-test-schema")?;
+            assert_eq!(schema_v1_id, res.id);
+            assert_raw_schemas_eq(schema_v1, &res.raw);
+        }
 
-    let schema_v2_id = client.publish_schema("ccsr-test-schema", schema_v2)?;
-    assert!(schema_v2_id > 0);
-    assert!(schema_v2_id > schema_v1_id);
+        let schema_v2_id = client.publish_schema("ccsr-test-schema", schema_v2)?;
+        assert!(schema_v2_id > 0);
+        assert!(schema_v2_id > schema_v1_id);
 
-    assert_eq!(
-        schema_v1_id,
-        client.publish_schema("ccsr-test-schema", schema_v1)?
-    );
+        assert_eq!(
+            schema_v1_id,
+            client.publish_schema("ccsr-test-schema", schema_v1)?
+        );
 
-    {
-        let res1 = client.get_schema_by_id(schema_v1_id)?;
-        let res2 = client.get_schema_by_id(schema_v2_id)?;
-        assert_eq!(schema_v1_id, res1.id);
-        assert_eq!(schema_v2_id, res2.id);
-        assert_raw_schemas_eq(schema_v1, &res1.raw);
-        assert_raw_schemas_eq(schema_v2, &res2.raw);
-    }
+        {
+            let res1 = client.get_schema_by_id(schema_v1_id)?;
+            let res2 = client.get_schema_by_id(schema_v2_id)?;
+            assert_eq!(schema_v1_id, res1.id);
+            assert_eq!(schema_v2_id, res2.id);
+            assert_raw_schemas_eq(schema_v1, &res1.raw);
+            assert_raw_schemas_eq(schema_v2, &res2.raw);
+        }
 
-    {
-        let res = client.get_schema_by_subject("ccsr-test-schema")?;
-        assert_eq!(schema_v2_id, res.id);
-        assert_raw_schemas_eq(schema_v2, &res.raw);
-    }
+        {
+            let res = client.get_schema_by_subject("ccsr-test-schema")?;
+            assert_eq!(schema_v2_id, res.id);
+            assert_raw_schemas_eq(schema_v2, &res.raw);
+        }
 
-    assert_eq!(count_schemas(&client, "ccsr-test-")?, 1);
+        assert_eq!(count_schemas(&client, "ccsr-test-")?, 1);
 
-    client.publish_schema("ccsr-test-another-schema", "\"int\"")?;
-    assert_eq!(count_schemas(&client, "ccsr-test-")?, 2);
+        client.publish_schema("ccsr-test-another-schema", "\"int\"")?;
+        assert_eq!(count_schemas(&client, "ccsr-test-")?, 2);
 
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
 fn test_client_errors() -> Result<(), failure::Error> {
-    let client = Client::new(SCHEMA_REGISTRY_URL.clone());
+    tokio::runtime::Runtime::new().unwrap().enter(|| {
+        let client = Client::new(SCHEMA_REGISTRY_URL.clone());
 
-    // Get-by-id-specific errors.
-    match client.get_schema_by_id(i32::max_value()) {
-        Err(GetByIdError::SchemaNotFound) => (),
-        res => panic!("expected GetError::SchemaNotFound, got {:?}", res),
-    }
+        // Get-by-id-specific errors.
+        match client.get_schema_by_id(i32::max_value()) {
+            Err(GetByIdError::SchemaNotFound) => (),
+            res => panic!("expected GetError::SchemaNotFound, got {:?}", res),
+        }
 
-    // Get-by-subject-specific errors.
-    match client.get_schema_by_subject("ccsr-test-noexist") {
-        Err(GetBySubjectError::SubjectNotFound) => (),
-        res => panic!("expected GetBySubjectError::SubjectNotFound, got {:?}", res),
-    }
+        // Get-by-subject-specific errors.
+        match client.get_schema_by_subject("ccsr-test-noexist") {
+            Err(GetBySubjectError::SubjectNotFound) => (),
+            res => panic!("expected GetBySubjectError::SubjectNotFound, got {:?}", res),
+        }
 
-    // Publish-specific errors.
-    match client.publish_schema("ccsr-test-schema", "blah") {
-        Err(PublishError::InvalidSchema) => (),
-        res => panic!("expected PublishError::InvalidSchema, got {:?}", res),
-    }
+        // Publish-specific errors.
+        match client.publish_schema("ccsr-test-schema", "blah") {
+            Err(PublishError::InvalidSchema) => (),
+            res => panic!("expected PublishError::InvalidSchema, got {:?}", res),
+        }
 
-    // Delete-specific errors.
-    match client.delete_subject("ccsr-test-noexist") {
-        Err(DeleteError::SubjectNotFound) => (),
-        res => panic!("expected DeleteError::SubjectNotFound, got {:?}", res),
-    }
+        // Delete-specific errors.
+        match client.delete_subject("ccsr-test-noexist") {
+            Err(DeleteError::SubjectNotFound) => (),
+            res => panic!("expected DeleteError::SubjectNotFound, got {:?}", res),
+        }
 
-    Ok(())
+        Ok(())
+    })
 }
 
 #[test]
@@ -139,81 +143,84 @@ fn test_server_errors() -> Result<(), failure::Error> {
         r#"{ "error_code": 50001, "message": "overloaded; try again later" }"#,
     );
 
-    match client_graceful.publish_schema("foo", "bar") {
-        Err(PublishError::Server {
-            code: 50001,
-            ref message,
-        }) if message == "overloaded; try again later" => (),
-        res => panic!("expected PublishError::Server, got {:?}", res),
-    }
+    runtime.enter(|| {
+        match client_graceful.publish_schema("foo", "bar") {
+            Err(PublishError::Server {
+                code: 50001,
+                ref message,
+            }) if message == "overloaded; try again later" => (),
+            res => panic!("expected PublishError::Server, got {:?}", res),
+        }
 
-    match client_graceful.get_schema_by_id(0) {
-        Err(GetByIdError::Server {
-            code: 50001,
-            ref message,
-        }) if message == "overloaded; try again later" => (),
-        res => panic!("expected GetByIdError::Server, got {:?}", res),
-    }
+        match client_graceful.get_schema_by_id(0) {
+            Err(GetByIdError::Server {
+                code: 50001,
+                ref message,
+            }) if message == "overloaded; try again later" => (),
+            res => panic!("expected GetByIdError::Server, got {:?}", res),
+        }
 
-    match client_graceful.get_schema_by_subject("foo") {
-        Err(GetBySubjectError::Server {
-            code: 50001,
-            ref message,
-        }) if message == "overloaded; try again later" => (),
-        res => panic!("expected GetBySubjectError::Server, got {:?}", res),
-    }
+        match client_graceful.get_schema_by_subject("foo") {
+            Err(GetBySubjectError::Server {
+                code: 50001,
+                ref message,
+            }) if message == "overloaded; try again later" => (),
+            res => panic!("expected GetBySubjectError::Server, got {:?}", res),
+        }
 
-    match client_graceful.delete_subject("foo") {
-        Err(DeleteError::Server {
-            code: 50001,
-            ref message,
-        }) if message == "overloaded; try again later" => (),
-        res => panic!("expected DeleteError::Server, got {:?}", res),
-    }
+        match client_graceful.delete_subject("foo") {
+            Err(DeleteError::Server {
+                code: 50001,
+                ref message,
+            }) if message == "overloaded; try again later" => (),
+            res => panic!("expected DeleteError::Server, got {:?}", res),
+        }
+    });
 
     // If the schema registry crashes so hard that it spits out an exception
     // handler in the response, we should report the HTTP status code and a
     // generic message indicating that no further details were available.
-
     let client_crash = start_server(
         &runtime,
         StatusCode::INTERNAL_SERVER_ERROR,
         r#"panic! an exception occured!"#,
     );
 
-    match client_crash.publish_schema("foo", "bar") {
-        Err(PublishError::Server {
-            code: 500,
-            ref message,
-        }) if message == "unable to decode error details" => (),
-        res => panic!("expected PublishError::Server, got {:?}", res),
-    }
+    runtime.enter(|| {
+        match client_crash.publish_schema("foo", "bar") {
+            Err(PublishError::Server {
+                code: 500,
+                ref message,
+            }) if message == "unable to decode error details" => (),
+            res => panic!("expected PublishError::Server, got {:?}", res),
+        }
 
-    match client_crash.get_schema_by_id(0) {
-        Err(GetByIdError::Server {
-            code: 500,
-            ref message,
-        }) if message == "unable to decode error details" => (),
-        res => panic!("expected GetError::Server, got {:?}", res),
-    }
+        match client_crash.get_schema_by_id(0) {
+            Err(GetByIdError::Server {
+                code: 500,
+                ref message,
+            }) if message == "unable to decode error details" => (),
+            res => panic!("expected GetError::Server, got {:?}", res),
+        }
 
-    match client_crash.get_schema_by_subject("foo") {
-        Err(GetBySubjectError::Server {
-            code: 500,
-            ref message,
-        }) if message == "unable to decode error details" => (),
-        res => panic!("expected GetError::Server, got {:?}", res),
-    }
+        match client_crash.get_schema_by_subject("foo") {
+            Err(GetBySubjectError::Server {
+                code: 500,
+                ref message,
+            }) if message == "unable to decode error details" => (),
+            res => panic!("expected GetError::Server, got {:?}", res),
+        }
 
-    match client_crash.delete_subject("foo") {
-        Err(DeleteError::Server {
-            code: 500,
-            ref message,
-        }) if message == "unable to decode error details" => (),
-        res => panic!("expected DeleteError::Server, got {:?}", res),
-    }
+        match client_crash.delete_subject("foo") {
+            Err(DeleteError::Server {
+                code: 500,
+                ref message,
+            }) if message == "unable to decode error details" => (),
+            res => panic!("expected DeleteError::Server, got {:?}", res),
+        }
 
-    Ok(())
+        Ok(())
+    })
 }
 
 fn start_server(runtime: &Runtime, status_code: StatusCode, body: &'static str) -> Client {

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = "0.10.0"
 serde_json = { version = "1.0.44", features = ["preserve_order"] }
 sql-parser = { path = "../sql-parser" }
 termcolor = "1.0.5"
+tokio = "0.2"
 
 [dev-dependencies]
 assert_cmd = "0.12.0"

--- a/src/testdrive/lib.rs
+++ b/src/testdrive/lib.rs
@@ -102,6 +102,7 @@ fn run_line_reader(config: &Config, line_reader: &mut LineReader) -> Result<(), 
     let mut state = action::create_state(config)?;
     let actions = action::build(cmds, &state)?;
     let mut ddl = Ddl::new(&mut state.pgclient())?;
+
     for a in &actions {
         a.action.redo(&mut state).map_err(|e| {
             let _ = ddl.clear_since_new(state.pgclient());


### PR DESCRIPTION
This reverts commit 7ce6cea84940b695b6eab12f042b4bf9276f54e4.

As it turns out, the flaky tests were due to a Tokio bug,
which has been fixed in https://github.com/tokio-rs/tokio/pull/2074 ,
which went out in v0.2.9.