### PR TITLE
testdrive: prepare to parse different kinds of messages

### DIFF
--- a/src/testdrive/action/mod.rs
+++ b/src/testdrive/action/mod.rs
@@ -119,6 +119,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Inp
     Ok(out)
 }
 
+/// Substituted `${}`-delimited variables from `vars` into `msg`
 fn substitute_vars(msg: &str, vars: &HashMap<String, String>) -> Result<String, String> {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"\$\{([^}]+)\}").unwrap();


### PR DESCRIPTION
This is a light refactoring to make it possible to support protobuf messages in the same
testdrive-over-kafka format.

Part of MaterializeInc/database-issues#500