### PR TITLE
dataflow: poll tailed files every 100ms on macOS

### DIFF
--- a/src/dataflow/source/file.rs
+++ b/src/dataflow/source/file.rs
@@ -46,8 +46,14 @@ type WatcherType = notify::PollWatcher;
 #[cfg(not(target_os = "macos"))]
 type WatcherType = notify::RecommendedWatcher;
 
+#[cfg(target_os = "macos")]
 fn get_watcher(tx: std::sync::mpsc::Sender<RawEvent>) -> notify::Result<WatcherType> {
-    Watcher::new_raw(tx)
+    WatcherType::with_delay_ms(tx, 100 /* poll every 100ms */)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn get_watcher(tx: std::sync::mpsc::Sender<RawEvent>) -> notify::Result<WatcherType> {
+    WatcherType::new_raw(tx)
 }
 
 /// Wraps a Tokio file, producing a stream that is tailed forever.


### PR DESCRIPTION
We expect file sources to be used primarily for demo purposes, so it
makes sense to have the default be tuned for a good demo experience, and
not being able to support massive amounts of file sources. (The default
before was 30s, which made Materialize seem rather unimpressive.) Plus
with enough engineering effort we could use something like kqueue on
macOS instead, which provides precise notifications of when a file has
been written.