### PR TITLE
sql: propagate column names through casts

### DIFF
--- a/test/string.slt
+++ b/test/string.slt
@@ -12,6 +12,16 @@ SELECT length('a'), ascii('a'), substr('a', 1) LIMIT 0
 ----
 length  ascii  substr
 
+query T colnames
+SELECT length(column1) FROM (VALUES ('a')) GROUP BY length(column1) LIMIT 0
+----
+length
+
+query T colnames
+SELECT column1::text FROM (VALUES ('a')) LIMIT 0
+----
+column1
+
 ### ascii ###
 
 statement ok


### PR DESCRIPTION
Also fix a related but untracked bug where using an expression in a
GROUP BY would prevent its name from propagating correctly.

Fix MaterializeInc/database-issues#518.