### PR TITLE
expr,sql: add to_timestamp(double) function

### DIFF
--- a/test/dates-times.slt
+++ b/test/dates-times.slt
@@ -705,3 +705,35 @@ query T
 SELECT to_char(TIMESTAMP '2000-01-01', 'no patterns at all')
 ----
 no patterns at all
+
+query T
+SELECT to_timestamp(-1)
+----
+1969-12-31 23:59:59 UTC
+
+query T
+SELECT to_timestamp(0)
+----
+1970-01-01 00:00:00 UTC
+
+query T
+SELECT to_timestamp(946684800)
+----
+2000-01-01 00:00:00 UTC
+
+query T
+SELECT to_timestamp(1262349296.7890123)
+----
+2010-01-01 12:34:56.789012 UTC
+
+# TODO(benesch): this should return an error, not NULL.
+query T
+SELECT to_timestamp('inf'::double)
+----
+NULL
+
+# TODO(benesch): this should return an error, not NULL.
+query T
+SELECT to_timestamp('nan'::double)
+----
+NULL


### PR DESCRIPTION
This is our first supported means of taking a non-timestamp to a
timestamp at runtime. Note that to_timestamp(double) is distinct from
the far more complicated to_timestamp(text, text) form, which is like
strptime and far harder to support.