### PR TITLE
sqllogictest: properly handle int32 columns declared as text

### DIFF
--- a/src/sqllogictest/runner.rs
+++ b/src/sqllogictest/runner.rs
@@ -314,9 +314,6 @@ fn format_row(
                         (*string).to_owned()
                     }
                 }
-                (Type::Text, Datum::Int32(chr)) => std::char::from_u32(chr as u32)
-                    .map(|chr| format!("{}", chr))
-                    .unwrap_or_else(|| format!("Invalid utf8 character: {}", chr)),
                 (Type::Bool, Datum::False) => "false".to_owned(),
                 (Type::Bool, Datum::True) => "true".to_owned(),
 
@@ -332,6 +329,7 @@ fn format_row(
                 (Type::Integer, Datum::True) => "1".to_owned(),
                 (Type::Real, Datum::Int32(i)) => format!("{:.3}", i),
                 (Type::Real, Datum::Int64(i)) => format!("{:.3}", i),
+                (Type::Text, Datum::Int32(i)) => format!("{}", i),
                 (Type::Text, Datum::Int64(i)) => format!("{}", i),
                 (Type::Text, Datum::Float64(f)) => format!("{:.3}", f),
                 (Type::Text, Datum::Date(d)) => d.to_string(),

--- a/test/cockroach/case_sensitive_names.slt
+++ b/test/cockroach/case_sensitive_names.slt
@@ -306,4 +306,4 @@ Amélie Amélie
 query T
 SELECT AsCIi('abc')
 ----
-a
+97


### PR DESCRIPTION
We were incorrectly trying to convert them to an ASCII character, which
is not what sqllogictest intends; it just wants the integer converted
to a string.