### PR TITLE
ex/chbench: fix chbench build

### DIFF
--- a/ex/chbench/chbench/Dockerfile
+++ b/ex/chbench/chbench/Dockerfile
@@ -14,7 +14,7 @@ RUN gpg --import mysql.asc \
     && echo "trusted-key 8C718D3B5072E1F5" >> ~/.gnupg/gpg.conf
 
 RUN curl -fsSL https://dev.mysql.com/get/Downloads/Connector-ODBC/8.0/mysql-connector-odbc-8.0.17-linux-ubuntu18.04-x86-64bit.tar.gz > mysql-odbc.tar.gz \
-    && curl -fsSL https://dev.mysql.com/downloads/gpg/?file=mysql-connector-odbc-8.0.17-linux-ubuntu18.04-x86-64bit.tar.gz > mysql-odbc.asc \
+    && curl -fsSL "https://dev.mysql.com/downloads/gpg/?file=mysql-connector-odbc-8.0.17-linux-ubuntu18.04-x86-64bit.tar.gz&p=10" > mysql-odbc.asc \
     && gpg --verify mysql-odbc.asc mysql-odbc.tar.gz \
     && tar -xzf mysql-odbc.tar.gz -C /usr/local --strip-components=1 --wildcards '*/bin' '*/lib' \
     && rm mysql-odbc.asc mysql-odbc.tar.gz \


### PR DESCRIPTION
The URL for downloading GPG signatures for the MySQL ODBC connector has
changed.