### PR TITLE
Repair peek

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1124,31 +1124,6 @@ where
         }
     }
 
-    // /// Collects frontiers from the earliest views.
-    // ///
-    // /// This method recursively traverses views and discovers other views on which
-    // /// they depend, collecting the frontiers of views that depend directly on sources.
-    // /// The `reached` input allows us to deduplicate views, and avoid e.g. recursion.
-    // fn sources_frontier(
-    //     &self,
-    //     id: GlobalId,
-    //     sources: &mut HashSet<GlobalId>,
-    //     reached: &mut HashSet<GlobalId>,
-    // ) {
-    //     reached.insert(id);
-    //     if let Some(view) = self.views.get(&id) {
-    //         if view.depends_on_source {
-    //             sources.insert(id);
-    //         } else {
-    //             for id in view.uses.iter() {
-    //                 if !reached.contains(id) {
-    //                     self.sources_frontier(*id, sources, reached);
-    //                 }
-    //             }
-    //         }
-    //     }
-    // }
-
     /// Updates the upper frontier of a named view.
     pub fn update_upper(&mut self, name: &GlobalId, mut changes: ChangeBatch<Timestamp>) {
         if let Some(entry) = self.views.get_mut(name) {


### PR DESCRIPTION
This PR removes the distinction between Immediately and EarliestSource, because whichever one peek was using was broken (EarliestSource). At the moment all queries need to be against materialized inputs and we can just choose the least among their timestamps.

I'm having a hard time reconstructing the reasoning for the more complicated logic. My recollection was that when handling `SELECT` queries we would create and populate a temp materialization, but the timestamp would be zero (because it was only just created). However, the historical record does not support this, and anyhow currently `SELECT` uses `PeekWhen::Immediately` rather than `EarliestSource`.

If we merge the PR we get peeks back, by changing their behavior to be selects. Perhaps we should ditch peek? This has come up before, and perhaps we should do a "high level concept shake-out" session.