### PR TITLE
Remove SELECTs against sources from Metabase demo docs

### DIFF
--- a/doc/developer/metabase-demo.md
+++ b/doc/developer/metabase-demo.md
@@ -128,7 +128,8 @@ the Metabase interactive SQL editor.
     - For comparison, you can run the full query on a source once you
       have materialized it. To do so:
       ```sql
-      CREATE VIEW mysql_tpcch_orderline_view;
+      CREATE VIEW orderline_view
+      AS SELECT * FROM mysql_tpcch_orderline;
       ```
       And then running the full query on the view:
       ```sql
@@ -158,7 +159,8 @@ the Metabase interactive SQL editor.
     - For comparison, you can run the full query on the underlying
       source once you have materialized it. To do so:
       ```sql
-      CREATE VIEW mysql_tpcch_orderline_view;
+      CREATE VIEW orderline_view
+      AS SELECT * FROM mysql_tpcch_orderline;
       ```
       And then running the full query on the view:
       ```sql


### PR DESCRIPTION
In the Metabase demo, we had been using queries like `SELECT something FROM source ...` to highlight the difference in performance between querying a source and querying a materialized view. Because we no longer mirror sources, we can no longer run `SELECT` queries directly against sources. 

This PR removes any queries that ran directly against sources and adds a few `CREATE VIEW` instructions.