### PR TITLE
Don't log a `Surprising, but...` every time there's a static query

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1170,7 +1170,8 @@ where
                     }
                 } else {
                     // A complete trace can be read in its final form with this time.
-                    println!("Surprising, but...");
+                    //
+                    // This should only happen for literals that have no sources
                     Timestamp::max_value()
                 }
             }


### PR DESCRIPTION
e.g. `SELECT 'libpq/ping-test'` was causing us to print `Surprising, but...` every
second.