### PR TITLE
WIP: Add support for filtering intermediate join results.

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -100,6 +100,9 @@ pub enum RelationExpr {
         /// dummy values at the end of its computation, avoiding the maintenance of values
         /// not present in this list (when it is non-None).
         demand: Option<Vec<Vec<usize>>>,
+        /// This field, which is potentially empty, lists filters that should be applied to the
+        /// intermediate result of the join as soon as the relevant columns exist.
+        predicates: Vec<ScalarExpr>,
     },
     /// Group a dataflow by some columns and aggregate over each group
     Reduce {
@@ -498,6 +501,7 @@ impl RelationExpr {
             inputs,
             variables,
             demand: None,
+            predicates: vec![],
         }
     }
 

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -115,6 +115,7 @@ impl Demand {
                 inputs,
                 variables,
                 demand,
+                predicates,
             } => {
                 let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
                 let input_arities = input_types
@@ -170,6 +171,16 @@ impl Demand {
                 for variable in variables.iter() {
                     for (rel, col) in variable {
                         new_columns[*rel].insert(*col);
+                    }
+                }
+
+                // Permute each predicate and add its support to the demand for each input
+                for predicate in predicates.iter_mut() {
+                    predicate.permute(&permutation);
+                    for pred_column in predicate.support() {
+                        let rel = input_relation[pred_column];
+                        let col = pred_column - prior_arities[rel];
+                        new_columns[rel].insert(col);
                     }
                 }
 

--- a/src/expr/transform/join_order.rs
+++ b/src/expr/transform/join_order.rs
@@ -70,6 +70,7 @@ impl JoinOrder {
             inputs,
             variables,
             demand,
+            predicates,
         } = relation
         {
             let types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
@@ -126,6 +127,12 @@ impl JoinOrder {
             for variable in new_variables.iter_mut() {
                 variable.sort();
             }
+
+            // permute predicates
+            for predicate in predicates.iter_mut() {
+                predicate.permute(&projection);
+            }
+
             // disable variable sorting
             if !new_inputs.iter().any(|new_input| match new_input {
                 RelationExpr::ArrangeBy { .. } => true,
@@ -143,9 +150,15 @@ impl JoinOrder {
                     inputs: new_inputs,
                     variables: new_variables,
                     demand: Some(new_demand),
+                    predicates: predicates.to_vec(),
                 }
             } else {
-                RelationExpr::join(new_inputs, new_variables)
+                RelationExpr::Join {
+                    inputs: new_inputs,
+                    variables: new_variables,
+                    demand: None,
+                    predicates: predicates.to_vec(),
+                }
             };
 
             // Output projection

--- a/src/expr/transform/projection_lifting.rs
+++ b/src/expr/transform/projection_lifting.rs
@@ -136,6 +136,7 @@ impl ProjectionLifting {
                 inputs,
                 variables,
                 demand,
+                predicates,
             } => {
                 for input in inputs.iter_mut() {
                     self.action(input, gets);
@@ -173,6 +174,9 @@ impl ProjectionLifting {
                 }
 
                 if projection.len() != temp_arity || (0..temp_arity).any(|i| projection[i] != i) {
+                    for predicate in predicates.iter_mut() {
+                        predicate.permute(&projection);
+                    }
                     *relation = relation.take_dangerous().project(projection);
                 }
             }

--- a/src/expr/transform/redundant_join.rs
+++ b/src/expr/transform/redundant_join.rs
@@ -37,6 +37,7 @@ impl RedundantJoin {
             inputs,
             variables,
             demand,
+            predicates,
         } = relation
         {
             let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
@@ -102,6 +103,9 @@ impl RedundantJoin {
                 *demand = None;
             }
             if projection.iter().enumerate().any(|(i, p)| i != *p) {
+                for predicate in predicates.iter_mut() {
+                    predicate.permute(&projection);
+                }
                 *relation = relation.take_dangerous().project(projection);
             }
         }


### PR DESCRIPTION
Posting my WIP on filtering intermediate join results in case @frankmcsherry wants to pick this up.

Add a new field `predicates` to RelationExpr::Join as `Vec<ScalarExpr>`.

What I have so far compiles, but I have not thought out resolving conflicts with the Delta Query, there may be design aspects that could be improved, and testing has not been done.

Things not done yet:
--I have missed a bunch of transforms that look for the pattern Join{inputs, variables, ..}. (Since the addition of the new `predicates` field does not cause compilation to fail for those transforms.)
--Pushing filtered filters back into joins