### PR TITLE
sql: use correct column names for complicated aggregates

### DIFF
--- a/test/aggregates.slt
+++ b/test/aggregates.slt
@@ -14,11 +14,11 @@ INSERT INTO t (a, b) VALUES (1, 1), (1, 2), (2, 3), (3, 1)
 statement error aggregate functions are not allowed in WHERE clause
 SELECT a FROM t WHERE sum(b) = 3 GROUP BY a
 
-query III colnames
-SELECT 1 AS literal, sum(a) as sum_a, sum(b) FROM t
+query IIIR colnames
+SELECT 1 AS literal, sum(a) as sum_a, sum(b), avg(a) FROM t
 ----
-literal  sum_a  sum
-1        7      7
+literal  sum_a  sum  avg
+1        7      7    1.750000
 
 query I rowsort
 SELECT a FROM t GROUP BY a HAVING sum(b) = 3
@@ -70,9 +70,10 @@ NULL
 statement error
 SELECT * ORDER BY SUM(fake_column)
 
-query RRRRRR
+query RRRRRR colnames
 SELECT variance(a), var_samp(a), var_pop(a), stddev(a), stddev_samp(a), stddev_pop(a) FROM t
 ----
+variance        var_samp        var_pop         stddev          stddev_samp     stddev_pop
 0.916666600000  0.916666600000  0.687500000000  0.957427072940  0.957427072940  0.829156197588
 
 query RRRRRR


### PR DESCRIPTION
Complicated aggregates like avg and stddev are decomposed into their
constituent parts by the SQL transformation pipeline. This pipeline runs
early enough that it impacts the column names chosen for these aggregate
functions; the avg function was resulting in no column name, while the
stddev function was resulting in the column name `sqrt`. Fix this by
teaching the transformation pipeline to preserve the name of the
original function when necessary.