### PR TITLE
Avoid CREATE SINK crash

### DIFF
--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -511,9 +511,7 @@ fn handle_create_sink(scx: &StatementContext, stmt: Statement) -> Result<Plan, f
     // Send new schema to registry, get back the schema id for the sink
     let url: Url = schema_registry_url.clone().parse().unwrap();
     let ccsr_client = ccsr::Client::new(url);
-    let schema_id = ccsr_client
-        .publish_schema(&topic, &schema.to_string())
-        .unwrap();
+    let schema_id = ccsr_client.publish_schema(&topic, &schema.to_string())?;
 
     let sink = Sink {
         from: (catalog_entry.id(), relation_desc),


### PR DESCRIPTION
@benesch reported that `CREATE SINK` statements cause Materialize to crash if the schema-registry isn't running. This PR turns a misguided `unwrap()` into a `?`.

I tested this locally by: turning everything on (Confluent and Materialize), creating a test Kafka topic and populating it with data from [our easy demo](https://github.com/MaterializeInc/materialize/blob/master/doc/developer/demo.md), creating a source, turning the schema-registry off, and then trying to create a sink from the source.


New error message:
```
jessicalaughlin=> CREATE SINK foo FROM quotes INTO 'kafka://localhost/foo' WITH (schema_registry_url = 'http://localhost:8081');
ERROR:  transport: error sending request for url (http://localhost:8081/subjects/foo/versions): error trying to connect: tcp connect error: Connection refused (os error 61)
```