### PR TITLE
catalog,sql: support CREATE {DATABASE|SCHEMA}

### DIFF
--- a/src/coord/command.rs
+++ b/src/coord/command.rs
@@ -48,6 +48,12 @@ pub type RowsFuture = Pin<Box<dyn Future<Output = Result<PeekResponse, comm::Err
 pub enum ExecuteResponse {
     /// The current session has been taken out of transaction mode by COMMIT
     Commit,
+    CreatedDatabase {
+        existed: bool,
+    },
+    CreatedSchema {
+        existed: bool,
+    },
     CreatedIndex {
         existed: bool,
     },
@@ -86,6 +92,16 @@ pub enum ExecuteResponse {
 impl fmt::Debug for ExecuteResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            ExecuteResponse::CreatedDatabase { existed } => write!(
+                f,
+                "ExecuteResponse::CreatedDatabase {{ existed: {} }}",
+                existed
+            ),
+            ExecuteResponse::CreatedSchema { existed } => write!(
+                f,
+                "ExecuteResponse::CreatedSchema {{ existed: {} }}",
+                existed
+            ),
             ExecuteResponse::CreatedIndex { existed } => write!(
                 f,
                 "ExecuteResponse::CreatedIndex {{ existed: {} }}",

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -413,6 +413,25 @@ where
         conn_id: u32,
     ) -> Result<ExecuteResponse, failure::Error> {
         match plan {
+            Plan::CreateDatabase {
+                name,
+                if_not_exists,
+            } => match self.catalog.create_database(name) {
+                Ok(()) => Ok(ExecuteResponse::CreatedDatabase { existed: false }),
+                Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedDatabase { existed: true }),
+                Err(err) => Err(err),
+            },
+
+            Plan::CreateSchema {
+                database_name,
+                schema_name,
+                if_not_exists,
+            } => match self.catalog.create_schema(database_name, schema_name) {
+                Ok(()) => Ok(ExecuteResponse::CreatedSchema { existed: false }),
+                Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedSchema { existed: true }),
+                Err(err) => Err(err),
+            },
+
             Plan::CreateTable {
                 name,
                 desc,

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -35,6 +35,15 @@ pub use query::scalar_type_from_sql;
 /// Instructions for executing a SQL query.
 #[derive(Debug)]
 pub enum Plan {
+    CreateDatabase {
+        name: String,
+        if_not_exists: bool,
+    },
+    CreateSchema {
+        database_name: String,
+        schema_name: String,
+        if_not_exists: bool,
+    },
     CreateIndex {
         name: FullName,
         index: Index,

--- a/src/testdrive/action/sql.rs
+++ b/src/testdrive/action/sql.rs
@@ -45,6 +45,15 @@ pub fn build_sql(mut cmd: SqlCommand) -> Result<SqlAction, String> {
 impl Action for SqlAction {
     fn undo(&self, state: &mut State) -> Result<(), String> {
         match &self.stmt {
+            // TODO(benesch): enable once DROP {DATABASE | SCHEMA} is supported.
+            // Statement::CreateDatabase { name, .. } => self.try_drop(
+            //     &mut state.pgclient,
+            //     &format!("DROP DATABASE IF EXISTS {}", name.to_string()),
+            // ),
+            // Statement::CreateSchema { name, .. } => self.try_drop(
+            //     &mut state.pgclient,
+            //     &format!("DROP SCHEMA IF EXISTS {} CASCADE", name.to_string()),
+            // ),
             Statement::CreateSource { name, .. } => self.try_drop(
                 &mut state.pgclient,
                 &format!("DROP SOURCE IF EXISTS {} CASCADE", name.to_string()),

--- a/test/databases.td
+++ b/test/databases.td
@@ -3,22 +3,8 @@
 # This file is part of Materialize. Materialize may not be used or
 # distributed without the express permission of Materialize, Inc.
 
-! CREATE DATABASE d
-unsupported SQL statement: CreateDatabase
-
-! CREATE SCHEMA s
-unsupported SQL statement: CreateSchema
-
-> SHOW DATABASES
-Database
-----
-materialize
-
 > SHOW SCHEMAS
-Schema
-----
 public
-
 
 > SHOW EXTENDED SCHEMAS
 Schema
@@ -26,3 +12,45 @@ Schema
 public
 mz_catalog
 pg_catalog
+
+> CREATE SCHEMA s
+
+> SHOW SCHEMAS
+Schema
+----
+public
+s
+
+# TODO(benesch): fix DROP SCHEMA.
+! DROP SCHEMA s
+catalog item 's' does not exist
+
+> SHOW DATABASES
+Database
+----
+materialize
+
+> CREATE DATABASE d
+
+> SHOW DATABASES
+Database
+----
+d
+materialize
+
+> SHOW SCHEMAS FROM d
+Schema
+----
+public
+
+> CREATE SCHEMA d.s
+
+> SHOW SCHEMAS FROM d
+Schema
+----
+public
+s
+
+# TODO(benesch): implement DROP DATABASE.
+! DROP DATABASE d
+unsupported SQL statement


### PR DESCRIPTION
This is mostly just a matter of plumbing the mutation commands through
to the catalog. The name resolution is already in place.

Future commits will add support for 1) DROP {DATABASE|SCHEMA}, and 2)
setting the correct session database and schema search path.