### PR TITLE
catalog: transactionalize api

### DIFF
--- a/test/createdrop.td
+++ b/test/createdrop.td
@@ -50,10 +50,10 @@ s is not a view
 # Test that creating objects of the same name does not work
 
 ! CREATE MATERIALIZED VIEW i AS SELECT 1.5 AS c
-catalog item 'materialize.public.i' already exists
+catalog item 'i' already exists
 
 ! CREATE INDEX v ON v2(x)
-catalog item 'materialize.public.v' already exists
+catalog item 'v' already exists
 
 $ set dummy={
     "type": "record",
@@ -83,16 +83,16 @@ $ set dummy={
   }
 
 ! CREATE SOURCE v2 FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${dummy}'
-catalog item 'materialize.public.v2' already exists
+catalog item 'v2' already exists
 
 ! CREATE SOURCE i FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${dummy}'
-catalog item 'materialize.public.i' already exists
+catalog item 'i' already exists
 
 ! CREATE INDEX s ON v2(x)
-catalog item 'materialize.public.s' already exists
+catalog item 's' already exists
 
 ! CREATE MATERIALIZED VIEW s AS SELECT 'bloop' AS d
-catalog item 'materialize.public.s' already exists
+catalog item 's' already exists
 
 # Test that objects do not get dropped if the drop command does not specify the correct type
 ! DROP SOURCE v

--- a/test/databases.td
+++ b/test/databases.td
@@ -21,6 +21,9 @@ Schema
 public
 s
 
+! CREATE SCHEMA s
+schema 's' already exists
+
 # TODO(benesch): fix DROP SCHEMA.
 ! DROP SCHEMA s
 catalog item 's' does not exist
@@ -38,6 +41,9 @@ Database
 d
 materialize
 
+! CREATE DATABASE d
+database 'd' already exists
+
 > SHOW SCHEMAS FROM d
 Schema
 ----
@@ -54,3 +60,12 @@ s
 # TODO(benesch): implement DROP DATABASE.
 ! DROP DATABASE d
 unsupported SQL statement
+
+! CREATE VIEW noexist.ignored AS SELECT 1
+unknown schema 'noexist'
+
+! CREATE VIEW materialize.noexist.ignored AS SELECT 1
+unknown schema 'noexist'
+
+! CREATE VIEW noexist.ignored.ignored AS SELECT 1
+unknown database 'noexist'

--- a/test/dependencies.td
+++ b/test/dependencies.td
@@ -31,7 +31,7 @@ $ set schema={
 > CREATE SOURCE s FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' USING SCHEMA '${schema}'
 
 ! CREATE SOURCE s FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-blah-${testdrive.seed}' USING SCHEMA '${schema}'
-catalog item 'materialize.public.s' already exists
+catalog item 's' already exists
 
 > CREATE SOURCE IF NOT EXISTS s FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-blah-${testdrive.seed}' USING SCHEMA '${schema}'
 
@@ -104,7 +104,7 @@ catalog item 'test4' does not exist
 > CREATE SINK s1 FROM s INTO 'kafka://${testdrive.kafka-addr}/v' WITH (schema_registry_url = '${testdrive.schema-registry-url}');
 
 ! CREATE SINK s1 FROM s INTO 'kafka://${testdrive.kafka-addr}/v2' WITH (schema_registry_url = '${testdrive.schema-registry-url}');
-catalog item 'materialize.public.s1' already exists
+catalog item 's1' already exists
 
 > CREATE SINK IF NOT EXISTS s1 FROM s INTO 'kafka://${testdrive.kafka-addr}/v2' WITH (schema_registry_url = '${testdrive.schema-registry-url}');
 


### PR DESCRIPTION
Rework the catalog API so that updates happen transactionally. This is
necessary for DROP {DATABASE|SCHEMA}, where dropping a database or
schema requires dropping all the items contained within atomically. It
also, incidentally, fixes a bug in DROP VIEW ... CASCADE, where removal
of the cascaded objects would not be persisted atomically.