### PR TITLE
materialized: allow overriding the embedded build sha

### DIFF
--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -43,7 +43,11 @@ mod http;
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The SHA identifying the Git commit at which the crate was built.
-pub const BUILD_SHA: &str = run_command_str!("git", "rev-parse", "--verify", "HEAD");
+pub const BUILD_SHA: &str = run_command_str!(
+    "sh",
+    "-c",
+    r#"[ -n "$MZ_DEV_BUILD_SHA" ] && echo "$MZ_DEV_BUILD_SHA" || git rev-parse --verify HEAD"#
+);
 
 /// The time in UTC at which the crate was built as an ISO 8601-compliant
 /// string.


### PR DESCRIPTION
Allow overriding the build SHA that's embedded into the binary by
setting the MZ_DEV_BUILD_SHA environment variable at compile time. This
is necessary to support distribution platforms that compile from source
tarballs, rather than from the Git repository.