### PR TITLE
www: add Ruchir to team page

### DIFF
--- a/www/data/team/ruchir.yml
+++ b/www/data/team/ruchir.yml
@@ -1,0 +1,10 @@
+name: Ruchir Khaitan
+handle: ruchir
+title: Engineer
+blurb: >
+  Ruchir is a systems software engineer who strives to write code that is fast,
+  safe and correct. Previously, Ruchir was an engineer on the adserver team at
+  AppNexus, where he worked on the bidding engine.
+headshot: /images/uploads/team-ruchir.jpg
+homepage: https://github.com/ruchirK
+order: 13

--- a/www/static/images/uploads/team-ruchir.jpg
+++ b/www/static/images/uploads/team-ruchir.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e5f4ca3e911795df189d7284746f0e70e03d45e7b17ed8cc334a345bd0d43f0
+size 161100


### PR DESCRIPTION
Even though a website redesign that removes the team page entirely is
imminent, add him to the team page for now in the interest of posterity.