### PR TITLE
Normalize let binding names

### DIFF
--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -1113,7 +1113,8 @@ pub struct IdGen {
 }
 
 impl IdGen {
-    fn allocate_id(&mut self) -> usize {
+    /// Allocates a new identifier and advances the generator.
+    pub fn allocate_id(&mut self) -> usize {
         let id = self.id;
         self.id += 1;
         id

--- a/src/expr/transform/update_let.rs
+++ b/src/expr/transform/update_let.rs
@@ -7,8 +7,14 @@ use std::collections::HashMap;
 
 use repr::RelationType;
 
-use crate::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::{EvalEnv, GlobalId, Id, IdGen, LocalId, RelationExpr, ScalarExpr};
 
+/// Refreshes identifiers and types for local let bindings.
+///
+/// The analysis is caapable of handling shadowing of identifiers, which
+/// *shouldn't* happen, but if it does and we wanted to kick and scream,
+/// this is one place we could do that. Instead, we'll just come up with
+/// guaranteed unique names for each let binding.
 #[derive(Debug)]
 pub struct UpdateLet;
 
@@ -25,25 +31,39 @@ impl super::Transform for UpdateLet {
 
 impl UpdateLet {
     pub fn transform(&self, relation: &mut RelationExpr) {
-        self.action(relation, &mut HashMap::new());
+        let mut id_gen: IdGen = Default::default();
+        self.action(relation, &mut HashMap::new(), &mut id_gen);
     }
 
-    pub fn action(&self, relation: &mut RelationExpr, types: &mut HashMap<Id, RelationType>) {
+    pub fn action(
+        &self,
+        relation: &mut RelationExpr,
+        remap: &mut HashMap<LocalId, (LocalId, RelationType)>,
+        id_gen: &mut IdGen,
+    ) {
         match relation {
             RelationExpr::Let { id, value, body } => {
-                let local_id = Id::Local(id.clone());
-                self.action(value, types);
-                types.insert(local_id.clone(), value.typ());
-                self.action(body, types);
-                types.remove(&local_id);
+                self.action(value, remap, id_gen);
+                // If a local id, assign a new identifier and refresh the type.
+                let new_id = LocalId::new(id_gen.allocate_id());
+                let prev = remap.insert(id.clone(), (new_id, value.typ()));
+                self.action(body, remap, id_gen);
+                remap.remove(id);
+                if let Some(prev_stuff) = prev {
+                    remap.insert(id.clone(), prev_stuff);
+                }
+                *id = new_id;
             }
             RelationExpr::Get { id, typ } => {
-                if let Some(new_type) = types.get(id) {
-                    *typ = new_type.clone()
+                if let Id::Local(local_id) = id {
+                    if let Some((new_id, new_type)) = remap.get(local_id) {
+                        *local_id = new_id.clone();
+                        *typ = new_type.clone()
+                    }
                 }
             }
             _ => {
-                relation.visit1_mut(&mut |e| self.action(e, types));
+                relation.visit1_mut(&mut |e| self.action(e, remap, id_gen));
             }
         }
     }

--- a/test/chbench.slt
+++ b/test/chbench.slt
@@ -399,7 +399,7 @@ GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt
 ----
 Let {
-  l4 = Filter {
+  l0 = Filter {
     predicates: [
       datetots #4 < 2012-01-02 00:00:00,
       datetots #4 >= 2007-01-02 00:00:00
@@ -417,7 +417,7 @@ Reduce {
       [(0, 2), (1, 2)],
       [(0, 4), (1, 3)]
     ],
-    Get { l4 },
+    Get { l0 },
     Distinct {
       group_key: [#10, #11, #12, #14],
       Filter {
@@ -429,7 +429,7 @@ Reduce {
             [(0, 2), (1, 2)]
           ],
           Get { materialize.public.orderline (u13) },
-          Get { l4 }
+          Get { l0 }
         }
       }
     }
@@ -512,7 +512,7 @@ AND ol_delivery_d < TIMESTAMP '2020-01-01 00:00:00.000000'
 AND ol_quantity BETWEEN 1 AND 100000
 ----
 Let {
-  l4 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#8)],
     Filter {
@@ -527,11 +527,11 @@ Let {
   }
 } in
 Union {
-  Get { l4 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { l4 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -945,7 +945,7 @@ GROUP BY c_count
 ORDER BY custdist DESC, c_count DESC
 ----
 Let {
-  l7 = Join {
+  l0 = Join {
     variables: [[(0, 3), (1, 0)], [(0, 1), (1, 1)], [(0, 2), (1, 2)]],
     Filter {
       predicates: [#5 > 8],
@@ -964,7 +964,7 @@ Reduce {
     group_key: [#0],
     aggregates: [count(#22)],
     Union {
-      Project { outputs: [8 .. 29, 0, 9, 10, 8, 4 .. 7], Get { l7 } },
+      Project { outputs: [8 .. 29, 0, 9, 10, 8, 4 .. 7], Get { l0 } },
       Map {
         scalars: [null, null, null, null, null, null, null, null],
         Union {
@@ -975,7 +975,7 @@ Reduce {
                 #16, #17, #18, #19, #20, #21, #22, #23,
                 #24, #25, #26, #27, #28, #29
               ],
-              Get { l7 }
+              Get { l0 }
             }
           },
           Get { materialize.public.customer (u5) }
@@ -996,7 +996,7 @@ AND ol_delivery_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
 AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 ----
 Let {
-  l7 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(if ^PR.*$ ~ #14 then #8 else 0dec), sum(#8)],
     Join {
@@ -1022,11 +1022,11 @@ Project {
       (((10000dec * #0) * 10000000dec) / (100dec + #1)) * 10dec
     ],
     Union {
-      Get { l7 },
+      Get { l0 },
       Map {
         scalars: [null, null],
         Union {
-          Project { outputs: [], Negate { Get { l7 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -1114,7 +1114,7 @@ GROUP BY i_name, substr(i_data, 1, 3), i_price
 ORDER BY supplier_cnt DESC
 ----
 Let {
-  l7 = Filter {
+  l0 = Filter {
     predicates: [!(^zz.*$ ~ #22)],
     Join {
       variables: [[(0, 0), (1, 0)]],
@@ -1126,14 +1126,14 @@ Let {
     }
   }
 } in
-Let { l8 = Distinct { group_key: [#17], Get { l7 } } } in
+Let { l1 = Distinct { group_key: [#17], Get { l0 } } } in
 Let {
-  l12 = Reduce {
+  l2 = Reduce {
     group_key: [#0],
     aggregates: [all(#0 != #1)],
     Join {
       variables: [],
-      Get { l8 },
+      Get { l1 },
       Filter {
         predicates: [^.*bad.*$ ~ #6],
         Get { materialize.public.supplier (u21) }
@@ -1146,14 +1146,14 @@ Reduce {
   aggregates: [count(distinct #17)],
   Join {
     variables: [[(0, 17), (1, 0)]],
-    Get { l7 },
+    Get { l0 },
     Union {
-      Filter { predicates: [#1], Get { l12 } },
+      Filter { predicates: [#1], Get { l2 } },
       Map {
         scalars: [true],
         Union {
-          Project { outputs: [0], Negate { Get { l12 } } },
-          Get { l8 }
+          Project { outputs: [0], Negate { Get { l2 } } },
+          Get { l1 }
         }
       }
     }
@@ -1177,7 +1177,7 @@ WHERE ol_i_id = t.i_id
 AND ol_quantity < t.a
 ----
 Let {
-  l13 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#8)],
     Filter {
@@ -1214,11 +1214,11 @@ Project {
   Map {
     scalars: [(#0 * 10000000dec) / 20dec],
     Union {
-      Get { l13 },
+      Get { l0 },
       Map {
         scalars: [null],
         Union {
-          Project { outputs: [], Negate { Get { l13 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -1298,7 +1298,7 @@ WHERE (
 )
 ----
 Let {
-  l7 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#8)],
     Filter {
@@ -1329,11 +1329,11 @@ Let {
   }
 } in
 Union {
-  Get { l7 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { l7 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -1359,7 +1359,7 @@ AND n_name = 'GERMANY'
 ORDER BY su_name
 ----
 Let {
-  l7 = Filter {
+  l0 = Filter {
     predicates: [#8 = "GERMANY"],
     Join {
       variables: [[(0, 3), (1, 0)]],
@@ -1372,9 +1372,9 @@ Let {
   }
 } in
 Let {
-  l15 = Join {
+  l1 = Join {
     variables: [[(1, 4), (2, 0)]],
-    Get { l7 },
+    Get { l0 },
     Filter {
       predicates: [datetots #6 > 2010-05-23 12:00:00],
       Get { materialize.public.orderline (u13) }
@@ -1386,7 +1386,7 @@ Project {
   outputs: [1, 2],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { l7 },
+    Get { l0 },
     Reduce {
       group_key: [#0],
       aggregates: [any(true)],
@@ -1403,9 +1403,9 @@ Project {
                 variables: [[(0, 21), (1, 0), (2, 0)]],
                 Filter {
                   predicates: [#0 = ((#21 * #22) % 10000)],
-                  Get { l15 }
+                  Get { l1 }
                 },
-                Distinct { group_key: [#21], Get { l15 } },
+                Distinct { group_key: [#21], Get { l1 } },
                 ArrangeBy {
                   keys: [[#0]],
                   Get { materialize.public.item (u15) }
@@ -1447,7 +1447,7 @@ GROUP BY su_name
 ORDER BY numwait DESC, su_name
 ----
 Let {
-  l16 = Filter {
+  l0 = Filter {
     predicates: [#6 > #14],
     Filter {
       predicates: [#44 = "GERMANY"],
@@ -1481,7 +1481,7 @@ Let {
     }
   }
 } in
-Let { l17 = Distinct { group_key: [#0, #1, #2, #6], Get { l16 } } } in
+Let { l1 = Distinct { group_key: [#0, #1, #2, #6], Get { l0 } } } in
 Reduce {
   group_key: [#37],
   aggregates: [countall(null)],
@@ -1492,7 +1492,7 @@ Reduce {
       [(0, 2), (1, 2)],
       [(0, 6), (1, 3)]
     ],
-    Get { l16 },
+    Get { l0 },
     Union {
       Project {
         outputs: [0 .. 3],
@@ -1509,7 +1509,7 @@ Reduce {
                     [(0, 1), (1, 1)],
                     [(0, 2), (1, 2)]
                   ],
-                  Get { l17 },
+                  Get { l1 },
                   Get { materialize.public.orderline (u13) }
                 }
               }
@@ -1517,7 +1517,7 @@ Reduce {
           }
         }
       },
-      Get { l17 }
+      Get { l1 }
     }
   }
 }
@@ -1546,7 +1546,7 @@ GROUP BY substr(c_state, 1, 1)
 ORDER BY substr(c_state, 1, 1)
 ----
 Let {
-  l11 = Filter {
+  l0 = Filter {
     predicates: [(#16 * 1000000dec) > #24],
     Join {
       variables: [],
@@ -1639,14 +1639,14 @@ Reduce {
                   [(0, 3), (1, 0)]
                 ],
                 Get { materialize.public.order (u11) },
-                Get { l11 }
+                Get { l0 }
               }
             }
           }
         }
       },
-      Project { outputs: [0 .. 2], Get { l11 } }
+      Project { outputs: [0 .. 2], Get { l0 } }
     },
-    Get { l11 }
+    Get { l0 }
   }
 }

--- a/test/subquery.slt
+++ b/test/subquery.slt
@@ -222,7 +222,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2 WHERE t3.b = t2.b)
 ----
 Let {
-  l7 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 0)]],
     Get { materialize.public.t1 (u37) },
     Get { materialize.public.t3 (u41) }
@@ -234,13 +234,13 @@ Project {
     scalars: [true],
     Join {
       variables: [[(0, 2), (1, 0)]],
-      Get { l7 },
+      Get { l0 },
       Distinct {
         group_key: [#1],
         Join {
           variables: [[(0, 0), (1, 0)]],
           Get { materialize.public.t2 (u39) },
-          Distinct { group_key: [#2], Get { l7 } }
+          Distinct { group_key: [#2], Get { l0 } }
         }
       }
     }

--- a/test/tpch.slt
+++ b/test/tpch.slt
@@ -190,7 +190,7 @@ ORDER BY
     s_acctbal DESC, n_name, s_name, p_partkey
 ----
 Let {
-  l16 = Filter {
+  l0 = Filter {
     predicates: [^.*BRASS$ ~ #9, #10 = 15, #26 = "EUROPE"],
     Join {
       variables: [
@@ -223,7 +223,7 @@ Project {
   outputs: [19, 15, 22, 5, 7, 16, 18, 20],
   Join {
     variables: [[(0, 5), (1, 0)], [(0, 3), (1, 1)]],
-    Get { l16 },
+    Get { l0 },
     Reduce {
       group_key: [#5],
       aggregates: [min(#3)],
@@ -237,7 +237,7 @@ Project {
             [(3, 2), (4, 0)]
           ],
           Get { materialize.public.partsupp (u9) },
-          Distinct { group_key: [#5], Get { l16 } },
+          Distinct { group_key: [#5], Get { l0 } },
           ArrangeBy {
             keys: [[#0]],
             Get { materialize.public.supplier (u7) }
@@ -334,7 +334,7 @@ ORDER BY
     o_orderpriority
 ----
 Let {
-  l4 = Filter {
+  l0 = Filter {
     predicates: [datetots #4 < 1993-10-01 00:00:00, #4 >= 1993-07-01],
     Get { materialize.public.orders (u13) }
   }
@@ -344,7 +344,7 @@ Reduce {
   aggregates: [countall(null)],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { l4 },
+    Get { l0 },
     Distinct {
       group_key: [#16],
       Join {
@@ -353,7 +353,7 @@ Reduce {
           predicates: [#11 < #12],
           Get { materialize.public.lineitem (u15) }
         },
-        Get { l4 }
+        Get { l0 }
       }
     }
   }
@@ -436,7 +436,7 @@ WHERE
     AND l_discount BETWEEN 0.06 - 0.01 AND 0.07
 ----
 Let {
-  l4 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#5 * #6)],
     Filter {
@@ -452,11 +452,11 @@ Let {
   }
 } in
 Union {
-  Get { l4 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { l4 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -953,7 +953,7 @@ ORDER BY
     c_count DESC
 ----
 Let {
-  l7 = Join {
+  l0 = Join {
     variables: [[(0, 1), (1, 0)]],
     Filter {
       predicates: [!(^.*special.*requests.*$ ~ #8)],
@@ -972,7 +972,7 @@ Reduce {
     group_key: [#0],
     aggregates: [count(#8)],
     Union {
-      Project { outputs: [9 .. 16, 0, 9, 2 .. 8], Get { l7 } },
+      Project { outputs: [9 .. 16, 0, 9, 2 .. 8], Get { l0 } },
       Map {
         scalars: [
           null,
@@ -989,7 +989,7 @@ Reduce {
           Negate {
             Distinct {
               group_key: [#9, #10, #11, #12, #13, #14, #15, #16],
-              Get { l7 }
+              Get { l0 }
             }
           },
           Get { materialize.public.customer (u11) }
@@ -1017,7 +1017,7 @@ WHERE
     AND l_shipdate < DATE '1996-01-01' + INTERVAL '1' month
 ----
 Let {
-  l7 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [
       sum(if ^PROMO.*$ ~ #20 then #5 * (100dec - #6) else 0dec),
@@ -1041,11 +1041,11 @@ Project {
   Map {
     scalars: [(((10000dec * #0) * 10000000dec) / #1) * 1000dec],
     Union {
-      Get { l7 },
+      Get { l0 },
       Map {
         scalars: [null, null],
         Union {
-          Project { outputs: [], Negate { Get { l7 } } },
+          Project { outputs: [], Negate { Get { l0 } } },
           Constant [[]]
         }
       }
@@ -1151,7 +1151,7 @@ ORDER BY
     p_size
 ----
 Let {
-  l7 = Filter {
+  l0 = Filter {
     predicates: [
       !(^MEDIUM POLISHED.*$ ~ #9),
       (
@@ -1178,14 +1178,14 @@ Let {
     }
   }
 } in
-Let { l8 = Distinct { group_key: [#1], Get { l7 } } } in
+Let { l1 = Distinct { group_key: [#1], Get { l0 } } } in
 Let {
-  l12 = Reduce {
+  l2 = Reduce {
     group_key: [#0],
     aggregates: [all(#0 != #1)],
     Join {
       variables: [],
-      Get { l8 },
+      Get { l1 },
       Filter {
         predicates: [^.*Customer.*Complaints.*$ ~ #6],
         Get { materialize.public.supplier (u7) }
@@ -1198,14 +1198,14 @@ Reduce {
   aggregates: [count(distinct #1)],
   Join {
     variables: [[(0, 1), (1, 0)]],
-    Get { l7 },
+    Get { l0 },
     Union {
-      Filter { predicates: [#1], Get { l12 } },
+      Filter { predicates: [#1], Get { l2 } },
       Map {
         scalars: [true],
         Union {
-          Project { outputs: [0], Negate { Get { l12 } } },
-          Get { l8 }
+          Project { outputs: [0], Negate { Get { l2 } } },
+          Get { l1 }
         }
       }
     }
@@ -1234,7 +1234,7 @@ WHERE
   )
 ----
 Let {
-  l7 = Filter {
+  l0 = Filter {
     predicates: [#19 = "Brand#23", #22 = "MED BOX"],
     Join {
       variables: [[(0, 1), (1, 0)]],
@@ -1244,14 +1244,14 @@ Let {
   }
 } in
 Let {
-  l14 = Reduce {
+  l1 = Reduce {
     group_key: [],
     aggregates: [sum(#5)],
     Filter {
       predicates: [(#4 * 10000000dec) < #28],
       Join {
         variables: [[(0, 1), (1, 0)]],
-        Get { l7 },
+        Get { l0 },
         Map {
           scalars: [
             2dec
@@ -1264,7 +1264,7 @@ Let {
             Join {
               variables: [[(0, 1), (1, 0)]],
               Get { materialize.public.lineitem (u15) },
-              Distinct { group_key: [#1], Get { l7 } }
+              Distinct { group_key: [#1], Get { l0 } }
             }
           }
         }
@@ -1277,11 +1277,11 @@ Project {
   Map {
     scalars: [(#0 * 10000000dec) / 70dec],
     Union {
-      Get { l14 },
+      Get { l1 },
       Map {
         scalars: [null],
         Union {
-          Project { outputs: [], Negate { Get { l14 } } },
+          Project { outputs: [], Negate { Get { l1 } } },
           Constant [[]]
         }
       }
@@ -1326,7 +1326,7 @@ ORDER BY
     o_orderdate
 ----
 Let {
-  l10 = Join {
+  l0 = Join {
     variables: [[(0, 0), (1, 0)], [(1, 1), (2, 0)]],
     Get { materialize.public.lineitem (u15) },
     ArrangeBy {
@@ -1344,7 +1344,7 @@ Reduce {
   aggregates: [sum(#4)],
   Join {
     variables: [[(0, 16), (1, 0)]],
-    Get { l10 },
+    Get { l0 },
     Reduce {
       group_key: [#0],
       aggregates: [any(true)],
@@ -1356,7 +1356,7 @@ Reduce {
           Join {
             variables: [[(0, 0), (1, 0)]],
             Get { materialize.public.lineitem (u15) },
-            Distinct { group_key: [#16], Get { l10 } }
+            Distinct { group_key: [#16], Get { l0 } }
           }
         }
       }
@@ -1404,7 +1404,7 @@ WHERE
     )
 ----
 Let {
-  l7 = Reduce {
+  l0 = Reduce {
     group_key: [],
     aggregates: [sum(#5 * (100dec - #6))],
     Filter {
@@ -1510,11 +1510,11 @@ Let {
   }
 } in
 Union {
-  Get { l7 },
+  Get { l0 },
   Map {
     scalars: [null],
     Union {
-      Project { outputs: [], Negate { Get { l7 } } },
+      Project { outputs: [], Negate { Get { l0 } } },
       Constant [[]]
     }
   }
@@ -1562,7 +1562,7 @@ ORDER BY
     s_name
 ----
 Let {
-  l7 = Filter {
+  l0 = Filter {
     predicates: [#8 = "CANADA"],
     Join {
       variables: [[(0, 3), (1, 0)]],
@@ -1575,21 +1575,21 @@ Let {
   }
 } in
 Let {
-  l12 = Join {
+  l1 = Join {
     variables: [],
-    Get { l7 },
+    Get { l0 },
     Get { materialize.public.partsupp (u9) }
   }
 } in
 Let {
-  l19 = Filter {
+  l2 = Filter {
     predicates: [^forest.*$ ~ #18],
     Map {
       scalars: [true],
       Join {
         variables: [[(0, 11), (1, 0), (2, 0)]],
-        Get { l12 },
-        Distinct { group_key: [#11], Get { l12 } },
+        Get { l1 },
+        Distinct { group_key: [#11], Get { l1 } },
         ArrangeBy {
           keys: [[#0]],
           Get { materialize.public.part (u5) }
@@ -1602,7 +1602,7 @@ Project {
   outputs: [1, 2],
   Join {
     variables: [[(0, 0), (1, 0)]],
-    Get { l7 },
+    Get { l0 },
     Reduce {
       group_key: [#0],
       aggregates: [any(true)],
@@ -1610,7 +1610,7 @@ Project {
         predicates: [(i32todec #13 * 1000dec) > #30],
         Join {
           variables: [[(0, 11), (1, 0)], [(0, 12), (1, 1)]],
-          Filter { predicates: [#0 = #12], Get { l19 } },
+          Filter { predicates: [#0 = #12], Get { l2 } },
           Map {
             scalars: [5dec * #2],
             Reduce {
@@ -1625,7 +1625,7 @@ Project {
                   ],
                   Get { materialize.public.lineitem (u15) }
                 },
-                Distinct { group_key: [#11, #12], Get { l19 } }
+                Distinct { group_key: [#11, #12], Get { l2 } }
               }
             }
           }
@@ -1679,7 +1679,7 @@ ORDER BY
     s_name
 ----
 Let {
-  l13 = Filter {
+  l0 = Filter {
     predicates: [#25 = "F", #33 = "SAUDI ARABIA"],
     Join {
       variables: [
@@ -1707,18 +1707,18 @@ Let {
   }
 } in
 Let {
-  l19 = Map {
+  l1 = Map {
     scalars: [true],
     Join {
       variables: [[(0, 0), (1, 0)], [(0, 16), (1, 1)]],
-      Get { l13 },
+      Get { l0 },
       Distinct {
         group_key: [#0, #1],
         Filter {
           predicates: [#4 != #1],
           Join {
             variables: [[(0, 0), (1, 0)]],
-            Distinct { group_key: [#0, #16], Get { l13 } },
+            Distinct { group_key: [#0, #16], Get { l0 } },
             Get { materialize.public.lineitem (u15) }
           }
         }
@@ -1726,13 +1726,13 @@ Let {
     }
   }
 } in
-Let { l20 = Distinct { group_key: [#0, #16], Get { l19 } } } in
+Let { l2 = Distinct { group_key: [#0, #16], Get { l1 } } } in
 Reduce {
   group_key: [#17],
   aggregates: [countall(null)],
   Join {
     variables: [[(0, 0), (1, 0)], [(0, 16), (1, 1)]],
-    Get { l19 },
+    Get { l1 },
     Union {
       Project {
         outputs: [0, 1],
@@ -1745,7 +1745,7 @@ Reduce {
                 predicates: [#4 != #1],
                 Join {
                   variables: [[(0, 0), (1, 0)]],
-                  Get { l20 },
+                  Get { l2 },
                   Filter {
                     predicates: [#12 > #11],
                     Get { materialize.public.lineitem (u15) }
@@ -1756,7 +1756,7 @@ Reduce {
           }
         }
       },
-      Get { l20 }
+      Get { l2 }
     }
   }
 }
@@ -1813,7 +1813,7 @@ ORDER BY
     cntrycode
 ----
 Let {
-  l12 = Filter {
+  l0 = Filter {
     predicates: [(#5 * 1000000dec) > #10],
     Join {
       variables: [],
@@ -1902,14 +1902,14 @@ Reduce {
               Join {
                 variables: [[(0, 1), (1, 0)]],
                 Get { materialize.public.orders (u13) },
-                Get { l12 }
+                Get { l0 }
               }
             }
           }
         }
       },
-      Project { outputs: [0], Get { l12 } }
+      Project { outputs: [0], Get { l0 } }
     },
-    Get { l12 }
+    Get { l0 }
   }
 }


### PR DESCRIPTION
Updated `update_let.rs` transform to not only refresh type information, but also to produce new let binding identifiers in an attempt to normalize them. I wasn't sure if we should create the identifier in "pre-order" or "in-order", which only matters if the value binding contains lets.