### PR TITLE
Better error message when sqlogictest fails due to no running postgres

### DIFF
--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -43,7 +43,9 @@ pub struct Postgres {
 
 impl Postgres {
     pub async fn open_and_erase(url: &str) -> Result<Self, failure::Error> {
-        let (client, conn) = tokio_postgres::connect(url, tokio_postgres::NoTls).await?;
+        let (client, conn) = tokio_postgres::connect(url, tokio_postgres::NoTls)
+            .await
+            .map_err(|err| format_err!("Postgres connection failed: {}", err))?;
 
         tokio::spawn(async move {
             if let Err(e) = conn.await {


### PR DESCRIPTION
Before:
```
~/c/materialize ❯❯❯ cargo run --bin sqllogictest -- -vvv test/extract.slt                                    ✘ 130 
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `target/debug/sqllogictest -vvv test/extract.slt`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: Connect, cause: Some(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }) }', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
[1]    99317 abort (core dumped)  cargo run --bin sqllogictest -- -vvv test/extract.slt
```

After:
```
~/c/materialize ❯❯❯ cargo run --bin sqllogictest -- -vvv test/extract.slt                                    ✘ 130 
    Finished dev [unoptimized + debuginfo] target(s) in 38.39s
     Running `target/debug/sqllogictest -vvv test/extract.slt`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ErrorMessage { msg: "Postgres connection failed: error connecting to server: Connection refused (os error 111)" }', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
[1]    101625 abort (core dumped)  cargo run --bin sqllogictest -- -vvv test/extract.slt
```