### PR TITLE
Default to one thread per physical cpu, and be loud about it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "jemallocator",
  "lazy_static",
  "log",
+ "num_cpus",
  "ore",
  "parse_duration",
  "pgwire",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -27,6 +27,7 @@ hyper = "0.13.1"
 jemallocator = { version = "0.3.0", features = ["profiling"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
+num_cpus = "1.0"
 ore = { path = "../ore" }
 parse_duration = "2.0.1"
 pgwire = { path = "../pgwire" }

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -111,7 +111,7 @@ fn run() -> Result<(), failure::Error> {
         Some("off") => None,
         Some(d) => Some(parse_duration::parse(&d)?),
     };
-    let threads = popts.opt_get_default("threads", 1)?;
+    let threads = popts.opt_get_default("threads", num_cpus::get_physical())?;
     let process = popts.opt_get_default("process", 0)?;
     let processes = popts.opt_get_default("processes", 1)?;
     let address_file = popts.opt_str("address-file");

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -166,9 +166,15 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
     let local_addr = listener.local_addr()?;
     config.addresses[config.process].set_port(local_addr.port());
 
+    println!("materialized {}", version(),);
     println!(
-        "materialized {} listening on {}...",
-        version(),
+        "    process {} of {}",
+        config.process,
+        config.addresses.len()
+    );
+    println!("    {} threads", config.threads);
+    println!(
+        "    listening on {}",
         SocketAddr::new(listen_addr.ip(), local_addr.port()),
     );
 


### PR DESCRIPTION
From conversation with @rjnn - the original idea was to use one thread for extra boasting rights, but the fact that we can make good use of multiple cpus is impressive and non-obvious so we should show it off by default.