### PR TITLE
Make views in billing demo + bootstrap materialized views.

### DIFF
--- a/src/billing-demo/resources/views/billing_agg_by_day.sql.in
+++ b/src/billing-demo/resources/views/billing_agg_by_day.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_agg_by_day AS
+CREATE MATERIALIZED VIEW billing_agg_by_day AS
 SELECT substr as day, client_id, meter, cpu_num, memory_gb, disk_gb, sum(value)
 FROM billing_records
 GROUP BY substr(interval_start, 0, 11), client_id, meter, cpu_num, memory_gb, disk_gb;

--- a/src/billing-demo/resources/views/billing_agg_by_hour.sql.in
+++ b/src/billing-demo/resources/views/billing_agg_by_hour.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_agg_by_hour AS
+CREATE MATERIALIZED VIEW billing_agg_by_hour AS
 SELECT substr as hour, client_id, meter, cpu_num, memory_gb, disk_gb, sum(value)
 FROM billing_records
 GROUP BY substr(interval_start, 0, 14), client_id, meter, cpu_num, memory_gb, disk_gb;

--- a/src/billing-demo/resources/views/billing_agg_by_minute.sql.in
+++ b/src/billing-demo/resources/views/billing_agg_by_minute.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_agg_by_minute AS
+CREATE MATERIALIZED VIEW billing_agg_by_minute AS
 SELECT substr as minute, client_id, meter, cpu_num, memory_gb, disk_gb, sum(value)
 FROM billing_records
 GROUP BY substr(interval_start, 0, 17), client_id, meter, cpu_num, memory_gb, disk_gb;

--- a/src/billing-demo/resources/views/billing_agg_by_month.sql.in
+++ b/src/billing-demo/resources/views/billing_agg_by_month.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_agg_by_month AS
+CREATE MATERIALIZED VIEW billing_agg_by_month AS
 SELECT substr as month, client_id, meter, cpu_num, memory_gb, disk_gb, sum(value)
 FROM billing_records
 GROUP BY substr(interval_start, 0, 8), client_id, meter, cpu_num, memory_gb, disk_gb;

--- a/src/billing-demo/resources/views/billing_batches.sql.in
+++ b/src/billing-demo/resources/views/billing_batches.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_batches AS
+CREATE MATERIALIZED VIEW billing_batches AS
 SELECT
     billing_raw_data.id,
     billing_raw_data.interval_start,

--- a/src/billing-demo/resources/views/billing_raw_data.sql.in
+++ b/src/billing-demo/resources/views/billing_raw_data.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_raw_data AS
+CREATE MATERIALIZED VIEW billing_raw_data AS
 SELECT
     *
 FROM

--- a/src/billing-demo/resources/views/billing_records.sql.in
+++ b/src/billing-demo/resources/views/billing_records.sql.in
@@ -1,4 +1,4 @@
-CREATE VIEW billing_records AS
+CREATE MATERIALIZED VIEW billing_records AS
 SELECT
     r.value->>'id' id,
     billing_raw_data.id batch_id,


### PR DESCRIPTION
#1641 caused views in the billing demo to not be queryable right off the bat.

Even though they are queryable without the `MATERIALIZED` keyword because the underlying logs are materialized, our bootstrap views should be materialized since we often query those views multiple times.

Thanks @ruchirK ! 