### PR TITLE
test: correct merge skew with rename

### DIFF
--- a/test/extract.slt
+++ b/test/extract.slt
@@ -9,19 +9,27 @@ statement ok
 CREATE TABLE data (input text)
 
 statement ok
-INSERT INTO data VALUES ('asdfjkl'), ('foo'), ('asdf'), ('testing,123'), (NULL), ('jkl'), ('some,csv');
+INSERT INTO data VALUES
+    ('asdfjkl'), ('foo'), ('asdf'), ('testing,123'),
+    (NULL), ('jkl'), ('some,csv')
 
-query TTT
-SELECT data.*, reg.* FROM data, regexp_extract('(asdf)|(?P<foo>jkl)', data.input) reg ORDER BY data.input
+query TTT colnames
+SELECT data.*, reg.*
+FROM data, regexp_extract('(asdf)|(?P<foo>jkl)', data.input) reg
+ORDER BY data.input
 ----
-asdf asdf NULL
-asdfjkl asdf NULL
-jkl NULL jkl
+input    column1  foo
+asdf     asdf     NULL
+asdfjkl  asdf     NULL
+jkl      NULL     jkl
 
-# TODO - Test that the regex columns have the correct nullability, once they actually do (#1685)
+# TODO(brennan): test that the regex columns have the correct nullability, once
+# they actually do (#1685).
 
-query TTT
-SELECT data.*, csv.* FROM data, csv_extract(2, data.input) csv ORDER BY data.input
+query TTT colnames
+SELECT data.*, csv.* FROM data, csv_extract(2, data.input) csv
+ORDER BY data.input
 ----
-some,csv some csv
-testing,123 testing 123
+input        column1  column2
+some,csv     some     csv
+testing,123  testing  123

--- a/test/sqllogictest/extract.slt
+++ b/test/sqllogictest/extract.slt
@@ -1,0 +1,27 @@
+# Copyright 2020 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+mode cockroach
+
+statement ok
+CREATE TABLE data (input text)
+
+statement ok
+INSERT INTO data VALUES ('asdfjkl'), ('foo'), ('asdf'), ('testing,123'), (NULL), ('jkl'), ('some,csv');
+
+query TTT
+SELECT data.*, reg.* FROM data, regexp_extract('(asdf)|(?P<foo>jkl)', data.input) reg ORDER BY data.input
+----
+asdf asdf NULL
+asdfjkl asdf NULL
+jkl NULL jkl
+
+# TODO - Test that the regex columns have the correct nullability, once they actually do (#1685)
+
+query TTT
+SELECT data.*, csv.* FROM data, csv_extract(2, data.input) csv ORDER BY data.input
+----
+some,csv some csv
+testing,123 testing 123


### PR DESCRIPTION
test/extract.slt belongs in test/sqllogictest now. Also reformat to
match de facto standard SLT style.