### PR TITLE
[WIP] coord: refresh type for view descriptions.

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -990,10 +990,15 @@ where
     }
 
     fn optimize_view(&mut self, view: View<RelationExpr>) -> View<OptimizedRelationExpr> {
+        let relation_expr = self.optimize(view.relation_expr, &view.eval_env);
+        let desc = RelationDesc::new(
+            relation_expr.as_ref().typ(),
+            view.desc.iter_names().map(|c| c.cloned()),
+        );
         View {
             raw_sql: view.raw_sql,
-            relation_expr: self.optimize(view.relation_expr, &view.eval_env),
-            desc: view.desc,
+            relation_expr,
+            desc,
             eval_env: view.eval_env,
         }
     }

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1091,16 +1091,13 @@ ORDER BY
     s_suppkey
 ----
 Project {
-  outputs: [2 .. 4, 6, 1],
+  outputs: [0 .. 2, 4, 8],
   Join {
-    variables: [[(0, 0), (1, 0)], [(0, 1), (2, 0)]],
+    variables: [[(0, 0), (1, 0)], [(1, 1), (2, 0)]],
+    Get { materialize.public.supplier (u7) },
     Filter {
       predicates: [!isnull #1],
       Get { materialize.public.revenue (u17) }
-    },
-    ArrangeBy {
-      keys: [[#0]],
-      Get { materialize.public.supplier (u7) }
     },
     Filter {
       predicates: [!isnull #0],


### PR DESCRIPTION
We now refresh the type when we optimize the view, which folds in any new information
about unique keys, non-null columns, and things like this. This was previously blocked
on unintended removal of type information relation to nulls, and this change may now
exercise these changes, and possibly other defects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/1759)
<!-- Reviewable:end -->
