### PR TITLE
ex/chbench -> demo/chbench

### DIFF
--- a/demo/chbench/README.md
+++ b/demo/chbench/README.md
@@ -26,7 +26,9 @@ want to increase memory available to Docker Engine using the following steps:
    4. Click "Apply and Restart".
    5. Continue with the `docker-compose` steps listed above.
 
-To get started, bring up the Docker Compose containers in the background. To do this, open up a new shell, and from the Materialize repository, change to the `ex/chbench` directory and type the following three commands after each other:
+To get started, bring up the Docker Compose containers in the background. To do
+this, open up a new shell, and from the Materialize repository, change to the
+`demo/chbench` directory and type the following three commands after each other:
 
 ```shell session
 $ docker-compose up -d --build
@@ -136,7 +138,7 @@ $ docker-compose run schema-registry flush-tables
 ## Using the MySQL CLI
 
 If you want to access a MySQL shell, run the following in the
-`ex/chbench` directory:
+`demo/chbench` directory:
 
 ```
 docker-compose run mysqlcli
@@ -219,7 +221,7 @@ Finally, we're ready to go change into the `terraform` directory and run
 `terraform apply`:
 
 ```shell
-cd ex/chbench/terraform
+cd demo/chbench/terraform
 terraform init # this is only needed the first time
 terraform apply
 ```
@@ -246,6 +248,10 @@ Welcome to Ubuntu 18.04.3 LTS (GNU/Linux 4.15.0-1051-aws x86_64)
  * Documentation:  https://help.ubuntu.com
  * Management:     https://landscape.canonical.com
  * Support:        https://ubuntu.com/advantage
+
+
+To save money, *please* make sure you run `terraform destroy` when you're done
+with your AWS instance.
 
 ---- 8< ----
 ```
@@ -280,7 +286,7 @@ brew install packer
 Then, from this directory, run Packer:
 
 ```shell
-cd ex/chbench
+cd demo/chbench
 packer build packer.json
 ```
 

--- a/demo/chbench/docker-local.md
+++ b/demo/chbench/docker-local.md
@@ -26,12 +26,12 @@ distributions or for macOS.
    sudo apt install -y jq
    ```
 
-2. Edit `ex/chbench/docker-compose.yml` to remove all references to the
+2. Edit `demo/chbench/docker-compose.yml` to remove all references to the
    following containers: `materialize`, `cli`, and all the metrics-related
    containers (beginning with `grafana` and continuing to the end of the file).
    Make sure you don't delete the `volumes` section at the bottom.
 
-1. From the `ex/chbench` directory, start up all the containers (except the ones
+1. From the `demo/chbench` directory, start up all the containers (except the ones
    you removed):
 
    ```shell

--- a/demo/chbench/terraform/README.md
+++ b/demo/chbench/terraform/README.md
@@ -2,5 +2,5 @@
 
 This configures a single ec2 instance to run chbench.
 
-See the `Running on AWS EC2` section in the [parent README](../README.md) for details on
-settup and usage.
+See the `Running on AWS EC2` section in the [parent README](../README.md) for
+details on setup and usage.

--- a/demo/chbench/terraform/main.tf
+++ b/demo/chbench/terraform/main.tf
@@ -35,7 +35,7 @@ resource "aws_instance" "chbench" {
     }
 
     provisioner "remote-exec" {
-        inline = ["cd materialize/ex/chbench && docker-compose build --pull"]
+        inline = ["cd materialize/demo/chbench && docker-compose build --pull"]
     }
 
     connection {

--- a/doc/developer/develop-testing.md
+++ b/doc/developer/develop-testing.md
@@ -20,7 +20,7 @@ There are broadly three test suites:
 
   3. The long-running **performance and stability test suite**. This test suite
      has yet to be automated. At the moment it consists of engineers manually
-     running the demo in [ex/chbench/](/ex/chbench).
+     running the demo in [demo/chbench/](/demo/chbench).
 
 The unit/integration and system test suites are run on every PR and can easily
 be run locally. The goal is for these test suites to be quite fast, ideally

--- a/doc/developer/metabase-demo.md
+++ b/doc/developer/metabase-demo.md
@@ -15,7 +15,7 @@ with Docker, although many steps are the same between the three.
 
 ### Starting the Docker containers and loading data
 
-First, we use [this script](https://github.com/MaterializeInc/materialize/blob/master/ex/chbench/dc.sh)
+First, we use [this script](https://github.com/MaterializeInc/materialize/blob/master/demo/chbench/dc.sh)
 to pull the necessary Docker images, bring containers up with Docker compose, and
 load an initial set of data. To do that, we run:
 

--- a/doc/user/demos/business-intelligence.md
+++ b/doc/user/demos/business-intelligence.md
@@ -111,10 +111,10 @@ Metabase](/images/demos/bi_architecture_diagram.png)
     git clone git@github.com:MaterializeInc/materialize.git
     ```
 
-2. Move to the `ex/chBench` dir:
+2. Move to the `demo/chbench` dir:
 
     ```shell
-    cd <path to materialize>/ex/chbench
+    cd <path to materialize>/demo/chbench
     ```
 
 3. Deploy and start all of the components we've listed above.
@@ -137,7 +137,7 @@ Now that our deployment is running (and looks like the diagram shown above), we
 can get Materialize to read data from Kafka, and define the views we want
 Materialize to maintain for us.
 
-1. Launch a new terminal window and `cd <path to materialize>/ex/chbench`.
+1. Launch a new terminal window and `cd <path to materialize>/demo/chbench`.
 
 1. Launch the Materialize CLI (`mzcli`) by running:
 

--- a/doc/user/get-started.md
+++ b/doc/user/get-started.md
@@ -66,9 +66,9 @@ overview and doesn't contain any actual instruction.
 ## Hands-on experience
 
 To see what this feels like in action, we have a simple demo in
-`materialize/ex/simple-demo`.
+`materialize/demo/simple-demo`.
 
-For something slightly more involved, check out `materialize/ex/chbench`.
+For something slightly more involved, check out `materialize/demo/chbench`.
 
 ## Related pages
 


### PR DESCRIPTION
One outdated instance of ex/chbench was causing the Terraform chbench
config to fail during init