### PR TITLE
doc: expand warning on CREATE INDEX page

### DIFF
--- a/doc/user/sql/create-index.md
+++ b/doc/user/sql/create-index.md
@@ -6,10 +6,10 @@ menu:
     parent: 'sql'
 ---
 
-{{< warning >}}
-This is an advanced feature of Materialized; most users will not
-need to manually create indexes to maximize the value Materialize offers.
-{{< /warning >}}
+{{< warning >}} This is an advanced feature of Materialized; most users will not
+need to manually create indexes to maximize the value Materialize offers, as
+running `CREATE MATERIALIZED VIEW` automatically creates all required indexes to
+eagerly materialize that view. {{< /warning >}}
 
 `CREATE INDEX` creates an in-memory index on a view.
 


### PR DESCRIPTION
Right now the warning says 'don't worry materialize does the thing'
but that's not helpful if there's something off - this redirects
attention to the statement they probably cared about.