### PR TITLE
Clear render cache between views.

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -202,7 +202,40 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         worker_index,
                         Some(&object.id.to_string()),
                     );
+                    // Under the premise that this is always an arrange_by aroung a global get,
+                    // this will leave behind the arrangements bound to the global get, so that
+                    // we will not tidy them up in the next pass.
                 }
+
+                // After building each object, we want to tear down all other cached collections
+                // and arrangements to avoid accidentally providing hits on local identifiers.
+                // We could relax this if we better understood which expressions are dangerous
+                // (e.g. expressions containing gets of local identifiers not covered by a let).
+                //
+                // TODO: Improve collection and arrangement re-use.
+                context.collections.retain(|e, _| {
+                    if let RelationExpr::Get {
+                        id: Id::Global(_),
+                        typ: _,
+                    } = e
+                    {
+                        true
+                    } else {
+                        false
+                    }
+                });
+                context.local.retain(|e, _| {
+                    if let RelationExpr::Get {
+                        id: Id::Global(_),
+                        typ: _,
+                    } = e
+                    {
+                        true
+                    } else {
+                        false
+                    }
+                });
+                // We do not install in `context.trace`, and can skip deleting things from it.
             }
 
             for (export_id, index_desc, typ) in &dataflow.index_exports {


### PR DESCRIPTION
Each view uses various local identifiers in building its collections and arrangements, and there is no guarantee that they will be unique across views. This causes problems with false hits and panics if we attempt to rebind any definitions. To address this, we clear out from the context anything that is not a `Get` of a global identifier. Each view builds a collection (and perhaps arrangements) bound to its global identifier, and each index build instruction is around a global get for the view (we do not allow you to index a non-view query).

cc @wangandi @benesch @jamii 