### PR TITLE
demo: run streaming demo as part of our CI process

### DIFF
--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -98,6 +98,17 @@ steps:
           run: sqllogictest
     if: $CHANGED_RUST || $CHANGED_SLT
 
+  - id: streaming-demo
+    label: ":shower: streaming-demo"
+    depends_on: build
+    timeout_in_minutes: 30
+    plugins:
+      - MaterializeInc/uid#master: ~
+      - docker-compose#v3.0.3:
+          config: ci/test/streaming-demo.compose.yml
+          run: billing-demo
+    if: $CHANGED_RUST
+
   - id: full-sqllogictest
     label: ":bulb: :bulb: Full SQL logic tests"
     depends_on: build
@@ -111,7 +122,7 @@ steps:
 
   - id: deploy
     label: ":rocket: Deploy"
-    depends_on: [lint-fast, lint-slow, cargo-test, testdrive, short-sqllogictest]
+    depends_on: [lint-fast, lint-slow, cargo-test, testdrive, streaming-demo, short-sqllogictest]
     trigger: deploy
     async: true
     branches: master

--- a/ci/test/streaming-demo.compose.yml
+++ b/ci/test/streaming-demo.compose.yml
@@ -1,0 +1,36 @@
+# Copyright 2019 Materialize, Inc. All rights reserved.
+#
+# This file is part of Materialize. Materialize may not be used or
+# distributed without the express permission of Materialize, Inc.
+
+version: '3'
+services:
+  billing-demo:
+    image: materialize/ci-billing-demo:${BUILDKITE_BUILD_NUMBER}
+    entrypoint: /bin/bash
+    volumes:
+      - db-data:/var/lib/billing-demo/data
+    command: -c "wait-for-it materialized:6875 kafka:9092 --
+      billing-demo --message-count 1000 --materialized-host materialized
+      --kafka-host kafka --csv-file-name /var/lib/billing-demo/data/prices.csv"
+    environment:
+    - RUST_LOG=billing-demo=debug,info
+    user: $BUILDKITE_AGENT_UID:$BUILDKITE_AGENT_GID
+    depends_on: [kafka, zookeeper, materialized]
+  materialized:
+    image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
+    volumes:
+      - db-data:/var/lib/billing-demo/data
+    command: --logging-granularity=10ms
+    depends_on: [kafka]
+  zookeeper:
+    image: zookeeper:3.4.13
+  kafka:
+    image: wurstmeister/kafka:2.12-2.2.0
+    environment:
+    - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+    - KAFKA_ADVERTISED_HOST_NAME=kafka
+    depends_on: [zookeeper]
+
+volumes:
+  db-data:

--- a/misc/docker/ci-billing-demo/Dockerfile
+++ b/misc/docker/ci-billing-demo/Dockerfile
@@ -6,6 +6,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && apt-get install -qy postgresql-client
+RUN apt-get install -qy wait-for-it
 
 COPY billing-demo /usr/local/bin
 

--- a/src/billing-demo/docker-compose.yml
+++ b/src/billing-demo/docker-compose.yml
@@ -47,12 +47,15 @@ services:
       KAFKA_JMX_PORT: 9991
   billing-demo:
     image: materialize/billing-demo:latest
+    entrypoint: /bin/bash
     volumes:
       - db-data:/var/lib/billing-demo/data
     environment:
       - RUST_LOG=billing-demo=debug,info
-    command: --message-count 1000 --materialized-host materialized --kafka-host kafka --csv-file-name /var/lib/billing-demo/data/prices.csv
+    command: -c "wait-for-it materialized:6875 kafka:9092 --
+      billing-demo --message-count 1000 --materialized-host materialized
+      --kafka-host kafka --csv-file-name /var/lib/billing-demo/data/prices.csv"
     depends_on: [kafka, materialized]
 
 volumes:
-    db-data:
+  db-data:


### PR DESCRIPTION
* not sure exactly how to test this
* currently the demo just loads a bunch of data into materialize -- maybe we should have something that also connects to it via a CLI and validates that the number of ingested messages is what we expect? not sure how to do that
* todo: streaming demo should also have a README