### PR TITLE
catalog: report nice error if logging view missing

### DIFF
--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -71,6 +71,22 @@ impl GlobalId {
     pub fn user(v: usize) -> GlobalId {
         GlobalId::User(v)
     }
+
+    /// Reports whether this ID is in the system namespace.
+    pub fn is_system(&self) -> bool {
+        match self {
+            GlobalId::System(_) => true,
+            GlobalId::User(_) => false,
+        }
+    }
+
+    /// Reports whether this ID is in the user namespace.
+    pub fn is_user(&self) -> bool {
+        match self {
+            GlobalId::System(_) => false,
+            GlobalId::User(_) => true,
+        }
+    }
 }
 
 impl fmt::Display for GlobalId {

--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -214,7 +214,7 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
     }
 
     {
-        let (_server, mut client) = util::start_server(config)?;
+        let (_server, mut client) = util::start_server(config.clone())?;
         assert_eq!(
             client
                 .query("SHOW VIEWS", &[])?
@@ -231,6 +231,18 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
                 .collect::<Vec<String>>(),
             &["v"]
         );
+    }
+
+    {
+        let config = config.logging_granularity(None);
+        match util::start_server(config) {
+            Ok(_) => panic!("server unexpectedly booted with corrupted catalog"),
+            Err(e) => assert_eq!(
+                e.to_string(),
+                "catalog item 'materialize.public.logging_derived' depends on system logging, \
+                 but logging is disabled"
+            ),
+        }
     }
 
     Ok(())

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -8,12 +8,27 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Config {
     data_directory: Option<PathBuf>,
+    logging_granularity: Option<Duration>,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            data_directory: None,
+            logging_granularity: Some(Duration::from_millis(10)),
+        }
+    }
 }
 
 impl Config {
+    pub fn logging_granularity(mut self, granularity: Option<Duration>) -> Self {
+        self.logging_granularity = granularity;
+        self
+    }
+
     pub fn data_directory(mut self, data_directory: impl Into<PathBuf>) -> Self {
         self.data_directory = Some(data_directory.into());
         self
@@ -22,7 +37,7 @@ impl Config {
 
 pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dyn Error>> {
     let server = Server(materialized::serve(materialized::Config {
-        logging_granularity: Some(Duration::from_millis(10)),
+        logging_granularity: config.logging_granularity,
         timestamp_frequency: None,
         max_increment_ts_size: 1000,
         threads: 1,


### PR DESCRIPTION
A missing logging view is almost certainly because
--logging-granularity=off was specified with a catalog that has
persisted a user view that depends upon a logging view. Yield a much
nicer error message in that situation.

Fix MaterializeInc/database-issues#641.