### PR TITLE
chbench: add docker build script and fix docker build/compose

### DIFF
--- a/demo/chbench/chbench/.dockerignore
+++ b/demo/chbench/chbench/.dockerignore
@@ -4,4 +4,6 @@
 !src
 !flush-tables
 !mz-default.cfg
+!*.asc
+!*.ini
 **/*.o

--- a/demo/chbench/chbench/docker-build.sh
+++ b/demo/chbench/chbench/docker-build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO=materialize/chbenchmark
+PUSH=n
+
+usage() {
+    echo "$0 [-p|--push]
+
+Build the docker image, and optionally push the latest tag"
+    exit 1
+}
+
+main() {
+    parse_args "$@"
+    cd "${0%/*}"
+    docker build -t $REPO:latest -t $REPO:local .
+    if [[ $PUSH = y ]]; then
+        docker push $REPO:latest
+    fi
+}
+
+parse_args() {
+    if [[ $# -gt 0 ]]; then
+        case "$1" in
+            --push|-p) PUSH=y ;;
+            *) usage ;;
+        esac
+    fi
+}
+
+main "$@"

--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE: "true"
   chbench:
     init: true
-    build: chbench
+    image: materialize/chbenchmark
     depends_on: [mysql]
     volumes:
       - chbench-gen:/gen


### PR DESCRIPTION
This changes the chbenchmark docker repo to use the same standard we use for other
in-tree build projects, where they are required to be manually built, but also expose a
`:local` tag for development within docker-compose.