### PR TITLE
ci/www: remove submodules from netlify cache

### DIFF
--- a/ci/www/changed.sh
+++ b/ci/www/changed.sh
@@ -18,6 +18,11 @@ else
     spec=FETCH_HEAD...
 fi
 
+# The www build doesn't depend on submodules, so remove them from the working
+# tree so they don't take up ~500MB of space in the Netlify cache.
+# shellcheck disable=SC2016
+git submodule foreach 'git -C $toplevel submodule deinit $sm_path'
+
 # Netlify doesn't follow symlinks as of 03 Feb 2020, so we need to explicitly
 # check for changes in doc/user too.
 exec git diff --quiet "$spec" -- doc/user www 1>&2


### PR DESCRIPTION
This should speed up Netlify builds by about 30s.