### PR TITLE
Add more detail to the 'Connecting Metabase to Materialize' documentation

### DIFF
--- a/doc/developer/metabase-demo.md
+++ b/doc/developer/metabase-demo.md
@@ -99,7 +99,7 @@ Metabase expects you to input data into three sets of fields:
 
 1. "Usage data preferences"
 
-    In this section, you will either agree or disagree to send 
+    In this section, you will either agree or disagree to send
     analytics back to Metabase. You will be able to proceed either way.
 
 You should now be able to see the main Metabase dashboard.


### PR DESCRIPTION
It seemed a little unclear to me!

This change directly matches the Metabase configuration sections (split into three parts) to provide more detail.