### PR TITLE
dataflow-types: don't persist derivable metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "expr",
  "failure",
  "futures",
+ "itertools",
  "log",
  "ore",
  "pgrepr",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -18,6 +18,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 expr = { path = "../expr" }
 failure = "0.1.5"
 futures = "0.3"
+itertools = "0.8"
 log = "0.4"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -88,11 +88,7 @@ pub fn plan_index_exprs<'a>(
     on_desc: &RelationDesc,
     exprs: &[Expr],
 ) -> Result<Vec<::expr::ScalarExpr>, failure::Error> {
-    let scope = Scope::from_source(
-        None,
-        on_desc.iter_names(),
-        Some(Scope::empty(None)),
-    );
+    let scope = Scope::from_source(None, on_desc.iter_names(), Some(Scope::empty(None)));
     let qcx = &QueryContext::root(scx, QueryLifetime::Static);
     let ecx = &ExprContext {
         qcx: &qcx,


### PR DESCRIPTION
Information about whether the columns in an index are nullable is
trivially rederivable when `SHOW INDEXES` is executed. Don't persist it
in the catalog, because it might get out of sync.

This is a step towards proper backwards compatibility for the catalog.