### PR TITLE
sql: limit state for catalog persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "expr",
  "failure",
  "itertools",
+ "lazy_static 1.4.0",
  "log",
  "repr",
  "rusqlite",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.6"
+lazy_static = "1.4.0"
 log = "0.4.8"
 itertools = "0.8.2"
 repr = { path = "../repr" }

--- a/src/catalog/names.rs
+++ b/src/catalog/names.rs
@@ -31,6 +31,15 @@ pub enum DatabaseSpecifier {
     Name(String),
 }
 
+impl fmt::Display for DatabaseSpecifier {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DatabaseSpecifier::Ambient => f.write_str("<none>"),
+            DatabaseSpecifier::Name(name) => f.write_str(name),
+        }
+    }
+}
+
 impl From<Option<String>> for DatabaseSpecifier {
     fn from(s: Option<String>) -> DatabaseSpecifier {
         match s {

--- a/src/sql/session.rs
+++ b/src/sql/session.rs
@@ -33,6 +33,6 @@ mod statement;
 mod transaction;
 mod var;
 
-pub use session::Session;
+pub use session::{InternalSession, PlanSession, Session};
 pub use statement::{Portal, PreparedStatement};
 pub use transaction::TransactionStatus;


### PR DESCRIPTION
**sql: make coord responsible for creating EvalEnv**

The EvalEnv controls runtime behavior of the query. The SQL planner
should not be in charge of creating the EvalEnv so that it is as
stateless as possible.

----

**sql: allow planning with an internal session**

When catalog persistence is implemented in terms of SQL, we don't want
the persisted SQL queries to be reliant on session state. Put another
way, on boot up, there is no user session to use to plan the catalog's
SQL queries.

Introduce a PlanSession trait that is a restriction of a sql::Session to
just the parameters that control the planning of a SQL statement. Then
introduce a new InternalSession implementation that hardcodes sensible
defaults for the plan-time session parameters. So far we just unset the
session database and use an empty search path, which has the desired
effect of requiring all table names to be fully qualified.