### PR TITLE
ChBench now materializes views passed in with --mz-sources

### DIFF
--- a/demo/chbench/chbench/src/mz-config.cpp
+++ b/demo/chbench/chbench/src/mz-config.cpp
@@ -24,18 +24,18 @@ const mz::Config& mz::defaultConfig() {
     int_distribution zero_const {static_cast<inner_type>(std::uniform_int_distribution<int64_t>(0, 0))};
     static Config singleton {
         .expectedSources = {
-            "materialize.public.mysql_tpcch_customer",
-            "materialize.public.mysql_tpcch_history",
-            "materialize.public.mysql_tpcch_district",
-            "materialize.public.mysql_tpcch_neworder",
-            "materialize.public.mysql_tpcch_order",
-            "materialize.public.mysql_tpcch_orderline",
-            "materialize.public.mysql_tpcch_warehouse",
-            "materialize.public.mysql_tpcch_item",
-            "materialize.public.mysql_tpcch_stock",
-            "materialize.public.mysql_tpcch_nation",
-            "materialize.public.mysql_tpcch_region",
-            "materialize.public.mysql_tpcch_supplier"
+            "mysql_tpcch_customer",
+            "mysql_tpcch_history",
+            "mysql_tpcch_district",
+            "mysql_tpcch_neworder",
+            "mysql_tpcch_order",
+            "mysql_tpcch_orderline",
+            "mysql_tpcch_warehouse",
+            "mysql_tpcch_item",
+            "mysql_tpcch_stock",
+            "mysql_tpcch_nation",
+            "mysql_tpcch_region",
+            "mysql_tpcch_supplier"
         },
         .viewPattern = "mysql.tpcch.%",
         .materializedUrl = "postgresql://materialized:6875/materialize?sslmode=disable",

--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -242,7 +242,7 @@ nuke_docker() {
 load_test() {
     runv docker-compose run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
     runv docker-compose run -d chbench run \
-        --mz-sources --mz-views=q01,q02,q06,q08,q09,q12,q14,q17,q19 \
+        --mz-sources --mz-views=q01,q02,q05,q06,q08,q09,q12,q14,q17,q19 \
         --dsn=mysql --gen-dir=/var/lib/mysql-files \
         --peek-conns=5 \
         --analytic-threads=0 --transactional-threads=1 --run-seconds=432000 \

--- a/demo/chbench/mzcli/Dockerfile
+++ b/demo/chbench/mzcli/Dockerfile
@@ -32,4 +32,4 @@ RUN apt-get update \
 
 COPY watch-sql /usr/local/bin/watch-sql
 
-CMD ["mzcli", "host=materialized port=6875 sslmode=disable dbname=materialize"]
+CMD ["mzcli", "host=materialized port=6875 dbname=materialize sslmode=disable"]


### PR DESCRIPTION
Inconsistent naming was causing thread to hang indefinitely on CREATE SOURCES and never reached code responsible for creating materialized views