### PR TITLE
bump deb.sh timeout to 10m

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -24,7 +24,7 @@ steps:
     concurrency: 1
     concurrency_group: deploy/docker
   - command: ci/deploy/deb.sh
-    timeout_in_minutes: 1
+    timeout_in_minutes: 10
     concurrency: 1
     concurrency_group: deploy/deb
   - command: ci/deploy/macos.sh


### PR DESCRIPTION
To fix e.g. https://buildkite.com/materialize/deploy/builds/1369#972b8aab-5f04-4307-9dac-b7b41f3f5803