### PR TITLE
dataflow: avoid depending on Index type

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -602,7 +602,8 @@ where
                             SequencedCommand::CreateLocalInput {
                                 name: name.to_string(),
                                 index_id,
-                                index: index.clone(),
+                                index: index.desc.clone(),
+                                on_type: index.relation_type,
                                 advance_to: self.local_input_time,
                             },
                         );


### PR DESCRIPTION
This type is going away in favor of the dataflow layer depending on just
dataflow_types::IndexDesc.