### PR TITLE
Change materialized threads to 1 for billing demo

### DIFF
--- a/src/billing-demo/docker-compose.yml
+++ b/src/billing-demo/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: --threads 8
+    command: --threads 1
     environment:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000


### PR DESCRIPTION
8 threads kills my 4-core laptop. This also brings this demo in line
with the chbench demo:

https://github.com/MaterializeInc/materialize/blob/master/demo/chbench/docker-compose.yml#L27

Even with this change, Docker for Mac still uses about 200% CPU. The difference is that I can still use my machine for other purposes while running the billing demo.