### PR TITLE
lint: make chbench clang-format script lint-clean

### DIFF
--- a/demo/chbench/chbench/bin/fmt
+++ b/demo/chbench/chbench/bin/fmt
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-find . -name '*.cc' -o -name '*.h' | xargs clang-format -i
+find . \( -name '*.cc' -o -name '*.h' \) -print0 | xargs -0 clang-format -i


### PR DESCRIPTION
The script is not actually being used much (running it causes several changes) but this
makes bin/lint not give me an error every time I run it locally. It's also slightly safer.