### PR TITLE
Disable jemalloc on macOS

### DIFF
--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -9,6 +9,11 @@
 //! [differential dataflow]: ../differential_dataflow/index.html
 //! [timely dataflow]: ../timely/index.html
 
+// Temporarily disable jemalloc on macOS as we have observed latency issues
+// when we run load tests with jemalloc, but not the macOS system allocator
+// todo(rkhaitan) figure out which allocator we want to use for all supported
+// platforms
+#[cfg(not(target_os = "macos"))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
We've observed latency spikes when running the billing-demo
with 100k+ messages with jemalloc on macOS. This issue does not
persist with the system allocator.

This is a temporary fix - we will have to figure out which allocator
to use on all platforms in the medium to near future.