### PR TITLE
Making automatic timestamping default

### DIFF
--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -53,7 +53,7 @@ fn run() -> Result<(), failure::Error> {
     opts.optopt(
         "",
         "timestamp-frequency",
-        "timestamp advancement frequency (default off)",
+        "timestamp advancement frequency (default 10ms)",
         "DURATION/\"off\"",
     );
     opts.optopt(
@@ -123,7 +123,7 @@ fn run() -> Result<(), failure::Error> {
         .as_ref()
         .map(|x| x.as_str())
     {
-        None => None,
+        None => Some(parse_duration::parse("10ms")?),
         Some("off") => None,
         Some(d) => Some(parse_duration::parse(&d)?),
     };

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -19,10 +19,6 @@ $ kafka-ingest format=protobuf topic=messages message=.Struct timestamp=1
 {"int": 1, "bad_int": 1, "bin": "One", "st": "my-string"}
 {"int": 2, "bad_int": 2, "bin": "One", "st": "something-valid"}
 
-# TODO: default values for enums, strings, bytes do not work right now
-$ kafka-ingest format=protobuf topic=messages message=.Struct timestamp=10
-{"int": 0, "bad_int": 0, "bin": "Zero", "st": ""}
-
 # TODO: these should be fully json
 > SELECT * FROM pm
 1 1 ONE  my-string

--- a/test/testdrive/timestamps.td
+++ b/test/testdrive/timestamps.td
@@ -3,97 +3,97 @@
 ## This file is part of Materialize. Materialize may not be used or
 ## distributed without the express permission of Materialize, Inc.
 #
-#$ set schema={
-#    "type": "record",
-#    "name": "envelope",
-#    "fields": [
-#      {
-#        "name": "before",
-#        "type": [
-#          {
-#            "name": "row",
-#            "type": "record",
-#            "fields": [
-#              {"name": "a", "type": "long"},
-#              {"name": "b", "type": "long"}
-#            ]
-#          },
-#          "null"
-#        ]
-#      },
-#      { "name": "after", "type": ["row", "null"] }
-#    ]
-#  }
-#
-#$ kafka-ingest format=raw topic=data-consistency timestamp=1
-#dummy,0,0
-#
-#$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-#{"before": null, "after": {"a": 1, "b": 1}}
-#{"before": null, "after": {"a": 2, "b": 1}}
-#{"before": null, "after": {"a": 3, "b": 1}}
-#{"before": null, "after": {"a": 1, "b": 2}}
-#
-#$ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
-#{"before": null, "after": {"a": 1, "b": 1}}
-#{"before": null, "after": {"a": 2, "b": 1}}
-#{"before": null, "after": {"a": 3, "b": 1}}
-#{"before": null, "after": {"a": 1, "b": 2}}
-#
-#
-#> CREATE SOURCE data_byo FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
-#> CREATE SOURCE data2_byo FROM 'kafka://${testdrive.kafka-addr}/testdrive-data2-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
-#> CREATE SOURCE data_rt FROM 'kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-#> CREATE SOURCE data2_rt FROM 'kafka://${testdrive.kafka-addr}/testdrive-data2-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-#
-#> CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo  GROUP BY b
-#> CREATE MATERIALIZED VIEW view2_byo AS SELECT b, sum(a) FROM data2_byo  GROUP BY b
-#> CREATE MATERIALIZED VIEW view_rt AS SELECT b, sum(a) FROM data_rt  GROUP BY b
-#> CREATE MATERIALIZED VIEW view2_rt AS SELECT b, sum(a) FROM data2_rt  GROUP BY b
-#
-#! SELECT * FROM view_byo;
-#At least one input has no complete timestamps yet.
-#
-#$ kafka-ingest format=raw topic=data-consistency timestamp=1
-#testdrive-data-${testdrive.seed},1,0
-#testdrive-data2-${testdrive.seed},1,3
-#
-#> SELECT * FROM view_byo;
-#b  sum
-#------
-#1 1
-#
-#> SELECT * FROM view2_byo ;
-#b  sum
-#------
-#1  6
-#2  1
-#
-#$ kafka-ingest format=raw topic=data timestamp=2
-#testdrive-data-${testdrive.seed}-2-3
-#
-#> SELECT * FROM view2_byo ;
-#b  sum
-#------
-#1  6
-#2  1
-#
-#
-#
-#> SELECT * FROM view_rt ;
-#b  sum
-#------
-#1  6
-#2  1
-#
-#> SELECT * FROM view2_rt ;
-#b  sum
-#------
-#1  6
-#2  1
-#
-#
-#> DROP VIEW view_byo;
-#> DROP VIEW view2_byo;
-#> DROP VIEW view_rt;
-#> DROP VIEW view2_rt;
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-ingest format=raw topic=data-consistency timestamp=1
+dummy,0,0
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+{"before": null, "after": {"a": 1, "b": 1}}
+{"before": null, "after": {"a": 2, "b": 1}}
+{"before": null, "after": {"a": 3, "b": 1}}
+{"before": null, "after": {"a": 1, "b": 2}}
+
+$ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
+{"before": null, "after": {"a": 1, "b": 1}}
+{"before": null, "after": {"a": 2, "b": 1}}
+{"before": null, "after": {"a": 3, "b": 1}}
+{"before": null, "after": {"a": 1, "b": 2}}
+
+
+> CREATE SOURCE data_byo FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}') FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+> CREATE SOURCE data2_byo FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'  WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}') FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+> CREATE SOURCE data_rt FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+> CREATE SOURCE data2_rt FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo  GROUP BY b
+> CREATE MATERIALIZED VIEW view2_byo AS SELECT b, sum(a) FROM data2_byo  GROUP BY b
+> CREATE MATERIALIZED VIEW view_rt AS SELECT b, sum(a) FROM data_rt  GROUP BY b
+> CREATE MATERIALIZED VIEW view2_rt AS SELECT b, sum(a) FROM data2_rt  GROUP BY b
+
+! SELECT * FROM view_byo;
+At least one input has no complete timestamps yet.
+
+$ kafka-ingest format=raw topic=data-consistency timestamp=1
+testdrive-data-${testdrive.seed},1,0
+testdrive-data2-${testdrive.seed},1,3
+
+> SELECT * FROM view_byo;
+b  sum
+------
+1 1
+
+> SELECT * FROM view2_byo ;
+b  sum
+------
+1  6
+2  1
+
+$ kafka-ingest format=raw topic=data timestamp=2
+testdrive-data-${testdrive.seed}-2-3
+
+> SELECT * FROM view2_byo ;
+b  sum
+------
+1  6
+2  1
+
+
+
+> SELECT * FROM view_rt ;
+b  sum
+------
+1  6
+2  1
+
+> SELECT * FROM view2_rt ;
+b  sum
+------
+1  6
+2  1
+
+
+> DROP VIEW view_byo;
+> DROP VIEW view2_byo;
+> DROP VIEW view_rt;
+> DROP VIEW view2_rt;


### PR DESCRIPTION
Materialize is configured to timestamp records automatically at a frequency of 10ms. 

Timestamping frequency can be turned off using --timestamp-frequency=off or tuned --timestamp-frequency=1s