### PR TITLE
Remove timestamp frequency parameter for chbench

### DIFF
--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: -w1 --timestamp-frequency=1ms
+    command: -w1
     environment:
       # you can for example add `pgwire=trace` or change `info` to `debug` to get more verbose logs
       - MZ_LOG=pgwire=debug,info


### PR DESCRIPTION
There isn't a good reason from letting it deviate from the default value. We've also done much less testing with a setting of 1ms.