### PR TITLE
Fixing race condition with Peeker in Chbenchmark

### DIFF
--- a/demo/chbench/chbench/src/materialized.cc
+++ b/demo/chbench/chbench/src/materialized.cc
@@ -43,7 +43,7 @@ mz::createSource(pqxx::connection &c, const std::string& kafkaUrl, const std::st
     auto topic = source;
     std::replace(topic.begin(), topic.end(), '_', '.'); // Kafka topics are delimited by periods
     try {
-        w.exec0("CREATE SOURCE " + source + " FROM KAFKA BROKER '" + kafkaUrl + "' TOPIC '" + topic + "' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '" + registry + "' ENVELOPE DEBEZIUM");
+        w.exec0("CREATE SOURCE IF NOT EXISTS " + source + " FROM KAFKA BROKER '" + kafkaUrl + "' TOPIC '" + topic + "' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '" + registry + "' ENVELOPE DEBEZIUM");
     } catch (const pqxx::sql_error &e) {
         fprintf(stderr, "Possibly temporary error creating source %s: %s\n", source.c_str(), e.what());
         return false;

--- a/src/peeker/peeker.rs
+++ b/src/peeker/peeker.rs
@@ -138,7 +138,7 @@ fn print_error_and_backoff(backoff: &mut Duration, error_message: String) {
 /// This ignores errors (just logging them), and can just be run multiple times.
 fn try_initialize(client: &mut Client) {
     match client.batch_execute(
-        "CREATE SOURCE IF NOT EXISTS orderline \
+        "CREATE SOURCE IF NOT EXISTS mysql_tpcch_orderline \
         FROM KAFKA BROKER 'kafka:9092' TOPIC 'mysql.tpcch.orderline' \
         FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
         ENVELOPE DEBEZIUM",
@@ -147,7 +147,7 @@ fn try_initialize(client: &mut Client) {
         Err(err) => warn!("error trying to create sources: {}", err),
     }
     match client.batch_execute(
-        "CREATE OR REPLACE MATERIALIZED VIEW q01 AS
+        "CREATE MATERIALIZED VIEW q01 AS
          SELECT
             ol_number,
             sum(ol_quantity) as sum_qty,


### PR DESCRIPTION
1) Problem: q01 not showing complete timestamps

Peeker was repeatedly creating and dropping view q01 after receiving the "no complete timestamps" error. Solved by switching to "CREATE VIEW" rather than "CREATE OR REPLACE".

2) Problem: on some runs, ChBenchmark would fail to create views

There was a race condition between ChBenchmark and seeker on who created the source. If Peeker won, ChBenchmark would repeatedly fail to create the source Orderline and loop indefinitely. 
Solved by switching to "CREATE SOURCE IF NOT EXISTS" in ChBenchmark