### PR TITLE
coord: properly persist auto-created primary keys on ambiguous columns

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1932,17 +1932,12 @@ fn index_sql(
         on_name: sql::normalize::unresolve(view_name),
         key_parts: keys
             .iter()
-            .map(|i| {
-                view_desc
-                    .get_name(i)
-                    .as_ref()
-                    .map(|n| {
-                        Expr::Identifier(Ident {
-                            value: n.to_string(),
-                            quote_style: Some('"'),
-                        })
-                    })
-                    .unwrap_or_else(|| Expr::Value(Value::Number(i.to_string())))
+            .map(|i| match view_desc.get_unambiguous_name(*i) {
+                Some(n) => Expr::Identifier(Ident {
+                    value: n.to_string(),
+                    quote_style: Some('"'),
+                }),
+                _ => Expr::Value(Value::Number((i + 1).to_string())),
             })
             .collect(),
         if_not_exists: false,

--- a/src/repr/relation.rs
+++ b/src/repr/relation.rs
@@ -209,8 +209,17 @@ impl RelationDesc {
             .map(|i| (i, &self.typ.column_types[i]))
     }
 
-    pub fn get_name(&self, i: &usize) -> &Option<ColumnName> {
-        &self.names[*i]
+    pub fn get_unambiguous_name(&self, i: usize) -> Option<&ColumnName> {
+        let name = self.get_name(i);
+        if self.iter_names().filter(|n| n == &name).count() == 1 {
+            name
+        } else {
+            None
+        }
+    }
+
+    pub fn get_name(&self, i: usize) -> Option<&ColumnName> {
+        self.names[i].as_ref()
     }
 
     pub fn set_name(&mut self, i: usize, name: Option<ColumnName>) {

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -506,7 +506,7 @@ fn handle_show_indexes(
                     let arena = RowArena::new();
                     let (col_name, func) = match key_expr {
                         expr::ScalarExpr::Column(i) => {
-                            let col_name = match desc.get_name(i) {
+                            let col_name = match desc.get_unambiguous_name(*i) {
                                 Some(col_name) => col_name.to_string(),
                                 None => format!("@{}", i + 1),
                             };


### PR DESCRIPTION
CREATE MATERIALIZED VIEW can create an index on columns in a view whose
names are ambiguous, either because the column has no name or because
two columns have the same name. We were properly detecting the former
case, but not the latter. In either case the column reference needs to
use a column index instead of the column name.

This commit fixes the issue and adds a test case.

Fix MaterializeInc/database-issues#674.