### PR TITLE
chbench-demo: Increase open files ulimit in chbench demo

### DIFF
--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -34,6 +34,11 @@ services:
       #
       # 1000 was chosen by fair dice roll
       - DIFFERENTIAL_EAGER_MERGE=1000
+    ulimits:
+        nofile:
+          soft: "65536"
+          hard: "65536"
+
   mysql:
     image: debezium/example-mysql:1.0
     ports:


### PR DESCRIPTION
We occasionally create a few thousand open sockets because of thread:thread and mz:kafka
communication, which causes many problems when docker stops us from opening new ones.

This seems to fix the "database is locked" problem for our catalog in chbench.