### PR TITLE
catalog,coord: add timestamps table during bootstrap

### DIFF
--- a/src/catalog/sql.rs
+++ b/src/catalog/sql.rs
@@ -42,7 +42,6 @@ INSERT INTO schemas VALUES
     (1, NULL, 'mz_catalog'),
     (2, NULL, 'pg_catalog'),
     (3, 1, 'public');
-
 ";
 
 #[derive(Debug)]


### PR DESCRIPTION
Install the timestamps table as part of the catalog bootstrap
transaction. Installing the catalog schema transactionally means we
don't need to think about the state where some of the catalog schema
exists and some does not.

Also name the table "timestamps" for consistency with the other (plural)
tables in the catalog.