### PR TITLE
Adding hint for fd error

### DIFF
--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -449,16 +449,19 @@ impl Timestamper {
                     "Failed to prepare insert statement into persistent store. \
                      Hint: increase the system file descriptor limit.",
                 );
-            stmt.execute(params![
+            while let Err(e) = stmt.execute(params![
                 SqlVal(&id.sid),
                 SqlVal(&id.vid),
                 SqlVal(&self.current_timestamp),
                 SqlVal(&offset)
-            ])
-            .expect(
-                "Failed to insert statement into persistent store. \
-                 Hint: increase the system file descriptor limit.",
-            );
+            ]) {
+                error!(
+                    "Failed to insert statement into persistent store: {}. \
+                     Hint: increase the system file descriptor limit.",
+                    e
+                );
+                std::thread::sleep(Duration::from_secs(1));
+            }
         }
     }
 


### PR DESCRIPTION
If we fail to open the SQL lite database, add as a hint that the user might consider increasing the number of file descriptors on his/her system.