### PR TITLE
catalog: persist all ID allocations

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -576,7 +576,7 @@ where
                 desc,
                 if_not_exists,
             } => {
-                let view_id = self.catalog.allocate_id();
+                let view_id = self.catalog.allocate_id()?;
                 let view = catalog::View {
                     create_sql: "<created by CREATE TABLE>".to_string(),
                     expr: OptimizedRelationExpr::declare_optimized(
@@ -590,7 +590,7 @@ where
                     eval_env: EvalEnv::default(),
                     desc,
                 };
-                let index_id = self.catalog.allocate_id();
+                let index_id = self.catalog.allocate_id()?;
                 let mut index_name = name.clone();
                 index_name.item += "_primary_idx";
                 let index = auto_generate_primary_idx(
@@ -644,7 +644,7 @@ where
                     connector: source.connector,
                     desc: source.desc,
                 };
-                let source_id = self.catalog.allocate_id();
+                let source_id = self.catalog.allocate_id()?;
                 let op = catalog::Op::CreateItem {
                     id: source_id,
                     name,
@@ -667,7 +667,7 @@ where
                     from: sink.from,
                     connector: sink.connector,
                 };
-                let id = self.catalog.allocate_id();
+                let id = self.catalog.allocate_id()?;
                 let op = catalog::Op::CreateItem {
                     id,
                     name: name.clone(),
@@ -693,7 +693,7 @@ where
                 if let Some(id) = replace {
                     ops.extend(self.catalog.drop_items_ops(&[id]));
                 }
-                let view_id = self.catalog.allocate_id();
+                let view_id = self.catalog.allocate_id()?;
                 let eval_env = EvalEnv::default();
                 let view = catalog::View {
                     create_sql: view.create_sql,
@@ -717,7 +717,7 @@ where
                         &view,
                         view_id,
                     );
-                    let index_id = self.catalog.allocate_id();
+                    let index_id = self.catalog.allocate_id()?;
                     ops.push(catalog::Op::CreateItem {
                         id: index_id,
                         name: index_name,
@@ -753,7 +753,7 @@ where
                     on: index.on,
                     eval_env: EvalEnv::default(),
                 };
-                let id = self.catalog.allocate_id();
+                let id = self.catalog.allocate_id()?;
                 let op = catalog::Op::CreateItem {
                     id,
                     name: name.clone(),
@@ -897,7 +897,7 @@ where
                         {
                             (true, *index_id)
                         } else if materialize {
-                            (false, self.catalog.allocate_id())
+                            (false, self.catalog.allocate_id()?)
                         } else {
                             bail!(
                                 "{} is not materialized",
@@ -905,7 +905,7 @@ where
                             )
                         }
                     } else {
-                        (false, self.catalog.allocate_id())
+                        (false, self.catalog.allocate_id()?)
                     };
 
                     let index = if !fast_path {
@@ -926,7 +926,7 @@ where
                             typ.clone(),
                             iter::repeat::<Option<ColumnName>>(None).take(ncols),
                         );
-                        let view_id = self.catalog.allocate_id();
+                        let view_id = self.catalog.allocate_id()?;
                         let view_name = FullName {
                             database: DatabaseSpecifier::Ambient,
                             schema: "temp".into(),
@@ -1009,7 +1009,7 @@ where
                         .humanize_id(Id::Global(source_id))
                         .expect("Source id is known to exist in catalog")
                 );
-                let sink_id = self.catalog.allocate_id();
+                let sink_id = self.catalog.allocate_id()?;
                 self.active_tails.insert(conn_id, sink_id);
                 let (tx, rx) = self.switchboard.mpsc_limited(self.num_timely_workers);
                 let since = self

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -38,12 +38,12 @@ pub trait IdHumanizer {
 
 /// The identifier for a local component of a dataflow.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub struct LocalId(usize);
+pub struct LocalId(u64);
 
 impl LocalId {
     /// Constructs a new local identifier. It is the caller's responsibility
     /// to provide a unique `v`.
-    pub fn new(v: usize) -> LocalId {
+    pub fn new(v: u64) -> LocalId {
         LocalId(v)
     }
 }
@@ -58,21 +58,21 @@ impl fmt::Display for LocalId {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum GlobalId {
     /// System namespace.
-    System(usize),
+    System(u64),
     /// User namespace.
-    User(usize),
+    User(u64),
 }
 
 impl GlobalId {
     /// Constructs a new global identifier in the system namespace. It is the
     /// caller's responsibility to provide a unique `v`.
-    pub fn system(v: usize) -> GlobalId {
+    pub fn system(v: u64) -> GlobalId {
         GlobalId::System(v)
     }
 
     /// Constructs a new global identifier in the user namespace. It is the
     /// caller's responsiblity to provide a unique `v`.
-    pub fn user(v: usize) -> GlobalId {
+    pub fn user(v: u64) -> GlobalId {
         GlobalId::User(v)
     }
 

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -1170,12 +1170,12 @@ impl fmt::Display for ColumnOrder {
 /// Manages the allocation of locally unique IDs when building a [`RelationExpr`].
 #[derive(Debug, Default)]
 pub struct IdGen {
-    id: usize,
+    id: u64,
 }
 
 impl IdGen {
     /// Allocates a new identifier and advances the generator.
-    pub fn allocate_id(&mut self) -> usize {
+    pub fn allocate_id(&mut self) -> u64 {
         let id = self.id;
         self.id += 1;
         id

--- a/src/expr/transform/binding.rs
+++ b/src/expr/transform/binding.rs
@@ -120,7 +120,7 @@ impl Drop for LocalBinding<'_> {
 #[derive(Debug, Default)]
 pub struct Environment {
     bindings: IndexMap<LocalId, RelationExpr>,
-    id: usize,
+    id: u64,
 }
 
 impl Environment {
@@ -501,13 +501,13 @@ mod tests {
 
     fn r(id: char, t: RelationType) -> RelationExpr {
         RelationExpr::Get {
-            id: Id::Local(LocalId::new(id as usize)),
+            id: Id::Local(LocalId::new(id as u64)),
             typ: t,
         }
     }
 
     pub fn force_bind(id: char, value: RelationExpr, body: RelationExpr) -> RelationExpr {
-        bind_local(LocalId::new(id as usize), value, body)
+        bind_local(LocalId::new(id as u64), value, body)
     }
 
     #[test]


### PR DESCRIPTION
Global IDs could previously get reused after a crash, because upon
reboot the ID allocator was reset to one greater than the maximum ID
present in the catalog. This was once safe, because any state that
referred to those reused IDs would have evaporated during the crash, but
causes trouble for the timestamp persistence code, which might persist
messages referring to those recycled IDs.

Instead, have every ID allocation durably record the new state of the ID
allocator, so that we can guarantee IDs are not reused even after a
reboot. This has potential performance implications, as there is now an
fsync on the path for slow-path peeks (not fast-path peeks, though!),
but there are bigger fish to fry with slow-path peeks anyway.