### PR TITLE
Upload master builds as `materialized-unstable` package

### DIFF
--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -47,7 +47,7 @@ tokio-postgres = { version = "0.5", features = ["with-chrono-0_4"] }
 
 [package.metadata.deb]
 depends = "$auto, systemd"
-name = "materialized-git"
+name = "materialized-unstable"
 conflicts = "materialized"
 assets = [
     ["../../dist/materialized.service", "lib/systemd/system/", "644"],


### PR DESCRIPTION
The `materialized` package in our APT repo should only contain released builds. For now, the release manager can upload those manually as part of the release process. The tip of master (after automated tests pass) will go into its own package, called `materialized-unstable`.