### PR TITLE
materialized: add a splash screen on startup

### DIFF
--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -245,7 +245,7 @@ to improve both our software and your queries! Please reach out at:
 
     Web: https://materialize.io
     GitHub issues: https://github.com/MaterializeInc/materialize/issues
-    Email: bugs@materialize.io
+    Email: support@materialize.io
     Twitter: @MaterializeInc
 =======================================================================
 "


### PR DESCRIPTION
We want to remind people about how to get in touch with questions about materialize, somewhat more persistently than having gotten them through the download flow.

Questions:

1. The catalog loading blows past this text pretty fast. I don't think we want the splash after `materialized` is up and running.

2. The contact information is probably wrong, but I'm not sure about the right stuff to put in there. Bikeshed away!
