### PR TITLE
Fix ssh-keysync to avoid locking users out of VMs

### DIFF
--- a/demo/chbench/packer/ssh-keysync
+++ b/demo/chbench/packer/ssh-keysync
@@ -9,4 +9,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-fetch-ssh-keys github --organization MaterializeInc > ~/.ssh/auto_authorized_keys
+temp_file=/tmp/auto_authorized_keys
+
+if fetch-ssh-keys github --organization MaterializeInc > "$temp_file"
+then
+	echo "Installing new auto_authorized_keys"
+	mv "$temp_file" ~/.ssh/auto_authorized_keys
+fi

--- a/demo/chbench/terraform/main.tf
+++ b/demo/chbench/terraform/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 
 resource "aws_instance" "chbench" {
     # See the README for instructions on updating this AMI.
-    ami = "ami-0bae027361530dc31"
+    ami = "ami-0deb636bc0d02ee0b"
     instance_type = "r5ad.4xlarge"
     associate_public_ip_address = true
     vpc_security_group_ids = ["${aws_security_group.chbench.id}"]


### PR DESCRIPTION
* Sometimes GitHub's API rate-limits us. This was causing `~/.ssh/auto_authorized_keys` to be truncated. Now we only overwrite it when the API call succeeds.
* Update AMI to include the updated `ssh-keysync`

Fixes MaterializeInc/database-issues#667