### PR TITLE
docs: add install page

### DIFF
--- a/doc/user/get-started.md
+++ b/doc/user/get-started.md
@@ -2,7 +2,7 @@
 title: "Get started"
 description: "Get started with Materialize"
 menu: "main"
-weight: 2
+weight: 3
 ---
 
 To get started with Materialize, we'll cover:

--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -1,0 +1,64 @@
+---
+title: "Install"
+description: "Get started with Materialize"
+menu: "main"
+weight: 2
+---
+
+You can access Materialize through the `materialized` binary, which you can install on macOS and Linux.
+
+## macOS installation
+
+### Homebrew
+
+Assuming you've installed [Homebrew](https://brew.sh/):
+
+```shell
+brew install materialized
+```
+
+### curl
+
+```shell
+curl -L https://downloads.mtrlz.dev/materialized-latest-x86_64-apple-darwin.tar.gz | tar -xzC /usr/local --strip-components=1 
+```
+
+## Linux installation
+
+### apt
+
+```shell
+apt install materialized
+```
+
+### curl
+```shell
+curl -L https://downloads.mtrlz.dev/materialized-latest-x86_64-unknown-linux-gnu.tar.gz | tar -xzC /usr/local --strip-components=1
+```
+
+## Build from source
+
+Materialize is written in Rust, and relies on `cargo` to build binaries.
+
+To build your own `materialized` binary, you can clone the [`MaterializeInc/materialize` repo from GitHub](https://github.com/materializeinc/materialize), and build it using `cargo build`.
+
+## Run the binary
+
+You can start the `materialized` process by simply running the binary, e.g.
+
+```nofmt
+./materialized
+```
+
+By default `materialized` uses:
+
+Detail | Info
+----------|------
+**Database** | `materialize`
+**Port** | `6875`
+
+For more information, see [CLI Connections](../connect/cli/).
+
+## Up next
+
+With `materialized` installed, let's [get started](../get-started).

--- a/www/config.toml
+++ b/www/config.toml
@@ -5,6 +5,7 @@ pygmentsCodeFences = true
 pygmentsStyle = "xcode"
 
 [menu]
+
     [[menu.main]]
     identifier = "overview"
     name = "Overview"
@@ -13,12 +14,12 @@ pygmentsStyle = "xcode"
     [[menu.main]]
     identifier = "connections"
     name = "Connect"
-    weight = 10
+    weight = 20
 
     [[menu.main]]
     identifier = "sql"
     name = "SQL"
-    weight = 20
+    weight = 30
 
     [[menu.main]]
     identifier = "sql-types"


### PR DESCRIPTION
Just getting an install page up; the stuff this links to is not ideal atm, but will iterate on in the coming days.

Also, should we just include the link for the release binaries? Or is the timing of including those links in lieu of `master` not right yet?