### PR TITLE
catalog,coord: share sqlite connection

### DIFF
--- a/src/catalog/sql.rs
+++ b/src/catalog/sql.rs
@@ -45,6 +45,14 @@ CREATE TABLE items (
     UNIQUE (schema_id, name)
 );
 
+CREATE TABLE timestamps (
+    sid blob NOT NULL,
+    vid blob NOT NULL,
+    timestamp integer NOT NULL,
+    offset blob NOT NULL,
+    PRIMARY KEY (sid, vid, timestamp)
+);
+
 INSERT INTO gid_alloc VALUES (1);
 INSERT INTO databases VALUES (1, 'materialize');
 INSERT INTO schemas VALUES
@@ -137,6 +145,14 @@ impl Connection {
                 ))
             })?
             .collect()
+    }
+
+    pub fn prepare(&self, sql: &str) -> rusqlite::Result<rusqlite::Statement> {
+        self.inner.prepare(sql)
+    }
+
+    pub fn prepare_cached(&self, sql: &str) -> rusqlite::Result<rusqlite::CachedStatement> {
+        self.inner.prepare_cached(sql)
     }
 
     pub fn allocate_id(&mut self) -> Result<GlobalId, failure::Error> {

--- a/src/coord/lib.rs
+++ b/src/coord/lib.rs
@@ -26,5 +26,5 @@ mod persistence;
 mod timestamp;
 
 pub use self::coord::{Config, Coordinator};
-pub use self::timestamp::{TimestampChannel, TimestampMessage, Timestamper};
+pub use self::timestamp::TimestampConfig;
 pub use command::{Command, ExecuteResponse, Response, RowsFuture, StartupMessage};

--- a/src/coord/tests/noblock.rs
+++ b/src/coord/tests/noblock.rs
@@ -35,7 +35,7 @@ fn no_block() {
         logging: logging_config.as_ref(),
         data_directory: None,
         executor: &executor,
-        ts_channel: None,
+        timestamp: None,
     })
     .unwrap();
 

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -39,7 +39,6 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Runtime;
 
 use comm::Switchboard;
-use coord::TimestampChannel;
 use dataflow_types::logging::LoggingConfig;
 use ore::future::OreTryFutureExt;
 use ore::netio;
@@ -73,9 +72,9 @@ pub struct Config {
     /// The interval at which the internal Timely cluster should publish updates
     /// about its state.
     pub logging_granularity: Option<Duration>,
-    /// The interval at which sources should be timestamped
+    /// The interval at which sources should be timestamped.
     pub timestamp_frequency: Option<Duration>,
-    /// The maximum size of a timestamp batch
+    /// The maximum size of a timestamp batch.
     pub max_increment_ts_size: i64,
     /// The number of Timely worker threads that this process should host.
     pub threads: usize,
@@ -247,9 +246,6 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
 
     let logging_config = config.logging_granularity.map(|d| LoggingConfig::new(d));
 
-    let (source_tx, source_rx) = std::sync::mpsc::channel::<coord::TimestampMessage>();
-    let (ts_tx, ts_rx) = std::sync::mpsc::channel::<coord::TimestampMessage>();
-
     // Initialize command queue and sql planner, but only on the primary.
     let coord_thread = if is_primary {
         let mut coord = coord::Coordinator::new(coord::Config {
@@ -258,33 +254,16 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
             symbiosis_url: config.symbiosis_url.as_deref(),
             logging: logging_config.as_ref(),
             data_directory: config.data_directory.as_deref(),
-            ts_channel: if config.timestamp_frequency.is_some() {
-                Some(TimestampChannel {
-                    sender: source_tx,
-                    receiver: ts_rx,
-                })
-            } else {
-                None
+            timestamp: match config.timestamp_frequency {
+                Some(freq) => Some(coord::TimestampConfig {
+                    frequency: freq,
+                    max_size: config.max_increment_ts_size,
+                }),
+                None => None,
             },
             executor: &executor,
         })?;
         Some(thread::spawn(move || coord.serve(cmd_rx)).join_on_drop())
-    } else {
-        None
-    };
-
-    // Initialise a timestamp advancement service, but only on the primary
-    let timestamp_thread = if is_primary && config.timestamp_frequency.is_some() {
-        let mut tsper = coord::Timestamper::new(
-            config.timestamp_frequency.expect("Duration cannot be none"),
-            config.max_increment_ts_size,
-            config.data_directory.as_deref(),
-            coord::TimestampChannel {
-                sender: ts_tx,
-                receiver: source_rx,
-            },
-        );
-        Some(thread::spawn(move || tsper.update()).join_on_drop())
     } else {
         None
     };
@@ -306,7 +285,6 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
         _cmd_tx: cmd_tx,
         _dataflow_guard: Box::new(dataflow_guard),
         _coord_thread: coord_thread,
-        _timestamp_thread: timestamp_thread,
         _runtime: runtime,
     })
 }
@@ -317,7 +295,6 @@ pub struct Server {
     // Drop order matters for these fields.
     _cmd_tx: Arc<mpsc::UnboundedSender<coord::Command>>,
     _dataflow_guard: Box<dyn Any>,
-    _timestamp_thread: Option<JoinOnDropHandle<()>>,
     _coord_thread: Option<JoinOnDropHandle<()>>,
     _runtime: Runtime,
 }


### PR DESCRIPTION
Opening two SQLite connections leads to conflicts between the main
coordinator thread and the timestamper thread. According to the SQLite
documentation, the correct way to handle this is by sharing one
connection via a mutex across the two threads.

This should fix the "database is locked" error we're seeing with v0.1.