### PR TITLE
xcompile: don't install libssl-dev

### DIFF
--- a/bin/xcompile
+++ b/bin/xcompile
@@ -82,7 +82,6 @@ EOF
     curl -fsSLO "$pkg_url"/dists/bionic/main/binary-amd64/Packages.gz
     gunzip Packages.gz
 
-    install_pkg libssl-dev
     install_pkg zlib1g
     install_pkg zlib1g-dev
 }


### PR DESCRIPTION
We use the version of openssl bundled with the openssl-sys crate now, so
bin/xcompile no longer needs to install libssl-dev so that it can be
statically linked. Doing so actually causes problems, because librdkafka
picks up the headers from an old version of libssl while linking against
a new version of openssl.

There is a deeper problem here, which is that librdkafka and Cargo can
disagree about which version of a dependency to link, but not much we
can do about that. From rdkafka-sys's known issues:

> When any of librdkafka's optional dependencies are enabled, like libz or
> OpenSSL, if you have multiple versions of that library installed upon your
> system, librdkafka's build system may disagree with Cargo about which version
> of the library to use! This can result in subtly broken builds, if librdkafka
> compiles against the headers for one version but Cargo links against a
> different version. For complete confidence when building release binaries, use
> an environment like a Docker container or a chroot jail where you can
> guarantee that only one version of each dependency is present. Unfortunately,
> the current design of Cargo makes this nearly impossible to fix.