### PR TITLE
Fix ChBench load generation to work with multiple loads

### DIFF
--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -200,6 +200,7 @@ dc_stop() {
             runv docker-compose stop "$1"
             return
         else
+            echo "No running container"
             return
         fi
     fi
@@ -281,6 +282,10 @@ nuke_docker() {
 
 # Long-running load test
 load_test() {
+    dc_stop chbench
+    dc_stop materialized peeker
+    runv docker exec -it chbench_kafka_1 kafka-topics --delete --bootstrap-server localhost:9092 --topic mysql.tpcch.*
+    dc_up materialized peeker
     runv docker-compose run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
     runv docker-compose run -d chbench run \
         --mz-sources --mz-views=q01,q02,q05,q06,q08,q09,q12,q14,q17,q19 \
@@ -293,6 +298,10 @@ load_test() {
 
 # Generate changes for the demo
 demo_load() {
+    dc_stop chbench
+    dc_stop materialized peeker
+    runv docker exec -it chbench_kafka_1 kafka-topics --delete --bootstrap-server localhost:9092 --topic mysql.tpcch.*
+    dc_up materialized peeker
     runv docker-compose run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
     runv docker-compose run -d chbench run \
         --mz-sources --mz-views=q01 \

--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     depends_on: [zookeeper, kafka]
   connector:
     build: connector
-    depends_on: [schema-registry, control-center, chbench-init]
+    depends_on: [schema-registry, control-center]
   control-center:
     image: confluentinc/cp-enterprise-control-center:5.3.0
     restart: always
@@ -130,17 +130,6 @@ services:
     depends_on: [mysql]
     volumes:
       - chbench-gen:/gen
-  chbench-init:
-    # TODO: we should make chbench into its own image/use our new benchmark image,
-    # instead of just rebuilding
-    build: chbench
-    depends_on: [mysql]
-    command: >
-       run
-       --dsn=mysql --gen-dir=/var/lib/mysql-files
-       --analytic-threads=0 --transactional-threads=5
-       --run-seconds=1
-
   cli:
     image: materialize/cli
     init: true


### PR DESCRIPTION
The problem:
1) Debezeum does not clear Kafka topics when a table is dropped. ChBench drops tables and recreates them before each run. This was causing Materialize to treat *all inserts* (those before the drop and after the drop

Running : `./dc.sh :init: ; ./dc.sh :load: ; ./dc.sh :load: ; ./dc.sh :load: `would cause queries in materialize to return triplicate entries (due to the triplicate entries in the Kafka sources)

2) ChBench-Init was being run unnecessarily. This was worsening the problem above as each load was causing data to be inserted twice

The fix: 
./dc.sh now purges all Kafka sources in between runs and restarts materialize after the logs have been purged. It also ensures that there is only a single instance of chbench running at any time.