### PR TITLE
Use the metabase docker images that come bundled with the mz driver

### DIFF
--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -157,12 +157,6 @@ bring_up_introspection() {
 }
 
 bring_up_metabase() {
-    if [ ! -f metabase/materialize-driver-0.0.4.jar ]; then
-        echo "Materialize Metabase driver not found, downloading..."
-        curl -L "https://github.com/MaterializeInc/metabase-materialize-driver/releases/download/0.0.4/materialize-driver.jar" \
-          -o metabase/materialize-driver-0.0.4.jar
-    fi
-
     dc_up metabase
 }
 

--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -157,10 +157,8 @@ services:
   # We need to ~manually add our `metabase-materialize-driver` to /plugins
   # for Metabase to automatically load Materialize as a connection option.
   metabase:
-    image: metabase/metabase:v0.34.2
+    image: materialize/metabase:v0.0.5
     depends_on: [materialized]
-    volumes:
-      - ./metabase/materialize-driver-0.0.4.jar:/plugins/materialize-driver.jar
     ports:
       - *metabase
 


### PR DESCRIPTION
Since MaterializeInc/materialize-metabase-driver#10 we can do this.