### PR TITLE
Enable materialized sources.

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -380,11 +380,14 @@ pub enum Envelope {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct SourceConnector {
-    pub connector: ExternalSourceConnector,
-    pub encoding: DataEncoding,
-    pub envelope: Envelope,
-    pub consistency: Consistency,
+pub enum SourceConnector {
+    External {
+        connector: ExternalSourceConnector,
+        encoding: DataEncoding,
+        envelope: Envelope,
+        consistency: Consistency,
+    },
+    Local,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -754,6 +754,7 @@ pub enum Statement {
         format: Format,
         envelope: Envelope,
         if_not_exists: bool,
+        materialized: bool,
     },
     /// `CREATE SINK`
     CreateSink {
@@ -994,8 +995,13 @@ impl fmt::Display for Statement {
                 format,
                 envelope,
                 if_not_exists,
+                materialized,
             } => {
-                write!(f, "CREATE SOURCE ")?;
+                write!(f, "CREATE ")?;
+                if *materialized {
+                    write!(f, "MATERIALIZED ")?;
+                }
+                write!(f, "SOURCE ")?;
                 if *if_not_exists {
                     write!(f, "IF NOT EXISTS ")?;
                 }

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -363,8 +363,9 @@ macro_rules! make_visitor {
                 format: &'ast $($mut)* Format,
                 envelope: &'ast $($mut)* Envelope,
                 if_not_exists: bool,
+                materialized: bool,
             ) {
-                visit_create_source(self, name, connector, format, envelope, if_not_exists)
+                visit_create_source(self, name, connector, format, envelope, if_not_exists, materialized)
             }
 
             fn visit_connector(
@@ -670,7 +671,8 @@ macro_rules! make_visitor {
                     format,
                     envelope,
                     if_not_exists,
-                } => visitor.visit_create_source(name, connector, format, envelope, *if_not_exists),
+                    materialized,
+                } => visitor.visit_create_source(name, connector, format, envelope, *if_not_exists, *materialized),
                 Statement::CreateSink {
                     name,
                     from,
@@ -1324,6 +1326,7 @@ macro_rules! make_visitor {
             format: &'ast $($mut)* Format,
             envelope: &'ast $($mut)* Envelope,
             _if_not_exists: bool,
+            _materialized: bool,
         ) {
             visitor.visit_object_name(name);
             visitor.visit_connector(connector);

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -51,6 +51,7 @@ pub enum Plan {
         name: FullName,
         source: Source,
         if_not_exists: bool,
+        materialized: bool,
     },
     CreateSink {
         name: FullName,
@@ -124,7 +125,8 @@ pub enum Plan {
     ShowViews {
         ids: Vec<(String, GlobalId)>,
         full: bool,
-        materialized: bool,
+        show_queryable: bool,
+        limit_materialized: bool,
     },
 }
 

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -162,9 +162,11 @@ pub fn create_statement(
             format: _,
             envelope: _,
             if_not_exists,
+            materialized,
         } => {
             *name = allocate_name(name)?;
             *if_not_exists = false;
+            *materialized = false;
         }
 
         Statement::CreateSink {

--- a/test/sqllogictest/index.slt
+++ b/test/sqllogictest/index.slt
@@ -37,14 +37,14 @@ CREATE INDEX bar_idx ON bar (substr(z, 3))
 query TTTTBI colnames
 SHOW INDEX IN bar
 ----
-View                     Key_name                            Column_name  Expression     Null  Seq_in_index
+Source_or_view           Key_name                            Column_name  Expression     Null  Seq_in_index
 materialize.public.bar   materialize.public.bar_primary_idx  z            NULL           false 1
 materialize.public.bar   materialize.public.bar_idx          NULL         substr("z",␠3) true  1
 
 query TTTTBI colnames
 SHOW INDEX FROM foo
 ----
-View                     Key_name                            Column_name  Expression  Null   Seq_in_index
+Source_or_view                     Key_name                            Column_name  Expression  Null   Seq_in_index
 materialize.public.foo   materialize.public.foo_primary_idx  a            NULL        false  1
 materialize.public.foo   materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo   materialize.public.foo_primary_idx  c            NULL        true   3
@@ -58,7 +58,7 @@ DROP INDEX foo_idx
 query TTTTBI colnames,rowsort
 SHOW INDEX in foo
 ----
-View                    Key_name                            Column_name  Expression  Null   Seq_in_index
+Source_or_view                    Key_name                            Column_name  Expression  Null   Seq_in_index
 materialize.public.foo  materialize.public.foo_primary_idx  a            NULL        false  1
 materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3
@@ -71,7 +71,7 @@ DROP INDEX edge_columns
 query TTTTBI colnames,rowsort
 SHOW INDEX in foo
 ----
-View                    Key_name                            Column_name  Expression  Null   Seq_in_index
+Source_or_view                    Key_name                            Column_name  Expression  Null   Seq_in_index
 materialize.public.foo  materialize.public.foo_primary_idx  a            NULL        false  1
 materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3
@@ -79,5 +79,5 @@ materialize.public.foo  materialize.public.foo_primary_idx  c            NULL   
 query error catalog item 'nonexistent' does not exist
 SHOW INDEX FROM nonexistent
 
-query error bar_idx is not a view
+query error cannot show indexes on materialize.public.bar_idx because it is a index
 SHOW INDEX FROM bar_idx

--- a/test/testdrive/basic.td
+++ b/test/testdrive/basic.td
@@ -13,6 +13,13 @@
 > VALUES (1)
 1
 
+> CREATE VIEW select_constant as SELECT true
+
+> SELECT * from select_constant;
+true
+
+> DROP VIEW select_constant;
+
 $ set schema={
     "type": "record",
     "name": "envelope",
@@ -63,12 +70,12 @@ Source   Create Source
 materialize.public.data  "kafka://${testdrive.kafka-addr}/testdrive-data-${testdrive.seed}"
 
 ! SELECT * FROM data
-Cannot construct query out of existing materialized views
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 > CREATE VIEW data_view as SELECT * from data
 
 ! SELECT * FROM data_view
-Cannot construct query out of existing materialized views
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 #TODO (materialize#1725) This test consistently in fails on buildkite but not locally
 #> CREATE SINK not_mat_sink FROM data_view INTO 'kafka://${testdrive.kafka-addr}/data-view-sink' WITH (schema_registry_url = '${testdrive.schema-registry-url}')
@@ -99,7 +106,7 @@ test1       USER     true        true
 > SHOW MATERIALIZED VIEWS
 test1
 
-> SHOW VIEWS FROM mz_catalog
+> SHOW SOURCES FROM mz_catalog
 mz_arrangement_sharing
 mz_arrangement_sizes
 mz_catalog_names
@@ -116,6 +123,8 @@ mz_scheduling_histogram
 mz_scheduling_parks
 mz_view_foreign_keys
 mz_view_keys
+
+> SHOW VIEWS FROM mz_catalog
 mz_addresses_with_unit_length
 mz_dataflow_names
 mz_dataflow_operator_dataflows
@@ -140,9 +149,11 @@ Field Nullable Type
 b     NO       int8
 sum   YES      int8
 
-> SHOW VIEWS FROM mz_catalog LIKE '%peek%';
+> SHOW MATERIALIZED SOURCES FROM mz_catalog LIKE '%peek%';
 mz_peek_active
 mz_peek_durations
+
+> SHOW VIEWS FROM mz_catalog LIKE '%peek%';
 mz_perf_peek_durations_aggregates
 mz_perf_peek_durations_bucket
 mz_perf_peek_durations_core
@@ -211,7 +222,7 @@ b  max
 
 # cannot select from unmaterialized view
 ! SELECT * from data_view
-Cannot construct query out of existing materialized views
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 # can create sink from unmaterialized view
 > CREATE SINK not_mat_sink2 FROM data_view
@@ -261,7 +272,7 @@ c-b
 > DROP INDEX idx1;
 
 ! SELECT * from test5
-Cannot construct query out of existing materialized views
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 # test that materialized views can be even if it requires multiple layers of recursing through the AST
 # to find a source
@@ -275,10 +286,10 @@ d
 
 # dependencies have not re-materialized as a result of creating a dependent materialized view
 ! SELECT * from test5
-Cannot construct query out of existing materialized views
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 ! SELECT * from data_view
-Cannot construct query out of existing materialized views
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
 # rematerialize data_view creating an index on it
 > CREATE INDEX data_view_idx on data_view(a)
@@ -351,10 +362,152 @@ b  c
 1  3
 2  1
 
+# Materialized sources tests
+
+$ set mat={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-ingest format=avro topic=mat schema=${mat} timestamp=1
+{"before": null, "after": null}
+
+> CREATE MATERIALIZED SOURCE mat_data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mat-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${mat}'
+  ENVELOPE DEBEZIUM
+
+> SELECT * from mat_data;
+
+$ kafka-ingest format=avro topic=mat schema=${schema} timestamp=42
+{"before": null, "after": {"a": -1, "b": 0}}
+{"before": null, "after": {"a": -1, "b": 1}}
+{"before": null, "after": {"a": 3, "b": 4}}
+{"before": null, "after": {"a": 1, "b": 2}}
+
+$ kafka-ingest format=avro topic=mat schema=${schema} timestamp=43
+{"before": null, "after": null}
+
+> SELECT * from mat_data;
+a  b
+----
+-1 0
+-1 1
+3  4
+1  2
+
+# if there exists another index, dropping the primary index will not unmaterialize the source
+
+> CREATE INDEX mat_data_idx2 ON mat_data(a);
+
+> DROP INDEX mat_data_primary_idx;
+
+> SELECT a+b from mat_data;
+a+b
+----
+-1
+0
+7
+3
+
+# Can create both materialized and unmaterialized views from materialized source
+> CREATE MATERIALIZED VIEW test7 as SELECT count(*) from mat_data;
+
+> SELECT * from test7;
+count
+-----
+4
+
+> CREATE VIEW test8 as SELECT -b as c, -a as d from mat_data;
+
+> SELECT * from test8;
+c  d
+-----
+0  1
+-1 1
+-4 -3
+-2 -1
+
+# unmaterialize source
+> DROP INDEX mat_data_idx2;
+
+! SELECT * from mat_data;
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
+
+> SELECT * from test7;
+count
+-----
+4
+
+! SELECT * from test8;
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
+
+$ kafka-ingest format=avro topic=mat schema=${schema} timestamp=44
+{"before": null, "after": {"a": -3, "b": 0}}
+{"before": null, "after": {"a": -1, "b": 0}}
+{"before": null, "after": {"a": 0, "b": 4}}
+{"before": null, "after": {"a": 1, "b": 2}}
+
+$ kafka-ingest format=avro topic=mat schema=${schema} timestamp=45
+{"before": null, "after": null}
+
+# rematerialize source
+> CREATE INDEX mat_data_idx3 on mat_data(b);
+
+> SELECT * from mat_data;
+a  b
+----
+-1 0
+-1 1
+3  4
+1  2
+-3 0
+-1 0
+0  4
+1  2
+
+> SELECT * from test7;
+count
+-----
+8
+
+> SELECT * from test8;
+a  b
+----
+0  1
+-1 1
+-4 -3
+-2 -1
+0  3
+0  1
+-4 0
+-2 -1
+
 # N.B. it is important to test sinks that depend on sources directly vs. sinks
 # that depend on views, as the code paths are different.
 
 # Depends on source.
+> CREATE SINK mat_source_sink FROM mat_data
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'mat-sink'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
 > CREATE SINK source_sink FROM data
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -367,3 +520,5 @@ b  c
 > DROP SINK source_sink
 
 > DROP SINK view_sink
+
+> DROP SINK mat_source_sink

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -51,13 +51,18 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=34
 
 > CREATE INDEX i ON v(a)
 
-! CREATE INDEX no_index_on_source ON s("X")
-s is not a view
+> CREATE INDEX j on s("X");
 
 # Test that creating objects of the same name does not work
 
 ! CREATE MATERIALIZED VIEW i AS SELECT 1.5 AS c
 catalog item 'i' already exists
+
+! CREATE INDEX i ON s("Y")
+catalog item 'i' already exists
+
+! CREATE INDEX j on v2(x)
+catalog item 'j' already exists
 
 ! CREATE INDEX v ON v2(x)
 catalog item 'v' already exists
@@ -145,6 +150,8 @@ s is not of type VIEW
 s is not of type VIEW
 
 # Delete objects
+
+> DROP INDEX j
 
 > DROP INDEX i
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -148,13 +148,13 @@ catalog item 'materialize.public.i1' is an index and so cannot be depended upon
 > CREATE INDEX i2 ON v2a(x*2);
 
 > SHOW INDEX in v2a;
-View                     Key_name                             Column_name Expression     Null   Seq_in_index
+Source_or_view           Key_name                             Column_name Expression     Null   Seq_in_index
 ------------------------------------------------------------------------------------------------------------
 materialize.public.v2a   materialize.public.i2                <null>      "\"x\" * 2"    false  1
 materialize.public.v2a   materialize.public.v2a_primary_idx   x           <null>         false  1
 
 > SHOW INDEX in v2;
-View                   Key_name                              Column_name Expression Null   Seq_in_index
+Source_or_view         Key_name                              Column_name Expression Null   Seq_in_index
 -------------------------------------------------------------------------------------------------------
 materialize.public.v2  materialize.public.i1                 x           <null>     false  1
 materialize.public.v2  materialize.public.v2_primary_idx     x           <null>     false  1
@@ -167,10 +167,10 @@ materialize.public.v2  materialize.public.v2_primary_idx     x           <null> 
 catalog item 'v2a' does not exist
 
 > SHOW INDEX in v2;
-View                   Key_name                              Column_name Expression Null  Seq_in_index
+Source_or_view           Key_name                              Column_name Expression Null  Seq_in_index
 ------------------------------------------------------------------------------------------------------
-materialize.public.v2    materialize.public.i1                   x           <null>     false 1
-materialize.public.v2    materialize.public.v2_primary_idx       x           <null>     false 1
+materialize.public.v2    materialize.public.i1                 x           <null>     false 1
+materialize.public.v2    materialize.public.v2_primary_idx     x           <null>     false 1
 
 ! DROP INDEX i2;
 catalog item 'i2' does not exist
@@ -182,15 +182,15 @@ catalog item 'i2' does not exist
 > CREATE INDEX i3 ON v4a(y);
 
 > SHOW INDEX in v4a;
-View                   Key_name                               Column_name Expression Null  Seq_in_index
+Source_or_view           Key_name                               Column_name Expression Null  Seq_in_index
 -------------------------------------------------------------------------------------------------------
-materialize.public.v4a   materialize.public.i3                    y           <null>     false 1
-materialize.public.v4a   materialize.public.v4a_primary_idx       y           <null>     false 1
+materialize.public.v4a   materialize.public.i3                  y           <null>     false 1
+materialize.public.v4a   materialize.public.v4a_primary_idx     y           <null>     false 1
 
 > CREATE INDEX i4 ON v4(x);
 
 > SHOW INDEX in v4;
-View                  Key_name                         Column_name Expression Null  Seq_in_index
+Source_or_view          Key_name                           Column_name Expression Null  Seq_in_index
 ------------------------------------------------------------------------------------------------
 materialize.public.v4   materialize.public.i4              x           <null>     false 1
 materialize.public.v4   materialize.public.v4_primary_idx  x           <null>     false 1
@@ -206,7 +206,7 @@ catalog item 'v4a' does not exist
 catalog item 'i3' does not exist
 
 > SHOW INDEX in v4;
-View                     Key_name                              Column_name Expression Null  Seq_in_index
+Source_or_view          Key_name                              Column_name Expression Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------
 materialize.public.v4   materialize.public.i4                  x           <null>     false 1
 materialize.public.v4   materialize.public.v4_primary_idx      x           <null>     false 1
@@ -217,7 +217,7 @@ materialize.public.v4   materialize.public.v4_primary_idx      y           <null
 > CREATE INDEX i5 ON v5(substr);
 
 > SHOW INDEX in v5;
-View                    Key_name                            Column_name Expression Null  Seq_in_index
+Source_or_view               Key_name                            Column_name Expression Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------
 materialize.public.v5   materialize.public.i5               substr      <null>     true  1
 materialize.public.v5   materialize.public.v5_primary_idx   substr      <null>     true  1
@@ -225,7 +225,7 @@ materialize.public.v5   materialize.public.v5_primary_idx   substr      <null>  
 > CREATE VIEW multicol AS SELECT 'a' AS a, 'b', 'c', 'd' AS d
 > CREATE INDEX i6 ON multicol (2, a, 4)
 > SHOW INDEX IN multicol
-View                         Key_name               Column_name  Expression   Null    Seq_in_index
+Source_or_view               Key_name               Column_name  Expression   Null    Seq_in_index
 -----------------------------------------------------------------------------------------------------
 materialize.public.multicol  materialize.public.i6  a            <null>       false   2
 materialize.public.multicol  materialize.public.i6  @2           <null>       false   1
@@ -246,12 +246,88 @@ catalog item 'v5' does not exist
 ! DROP INDEX i4;
 catalog item 'i4' does not exist
 
-# Test that dropping indexies even with cascade does not cause the underlying view to be dropped
+# Test that dropping indexes even with cascade does not cause the underlying view to be dropped
+
 > DROP INDEX i1 CASCADE;
 
-#cleanup
 > DROP VIEW v2;
 
+# Materialized source tests
+
+> CREATE MATERIALIZED SOURCE s3
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+# Test that dependent indexes do not prevent source deletion when restrict is specified
+> CREATE INDEX j1 on s3(ascii(y))
+
+> SHOW INDEX in s3;
+Source_or_view          Key_name                              Column_name Expression     Null  Seq_in_index
+----------------------------------------------------------------------------------------------------
+materialize.public.s3   materialize.public.j1                 <null>      "ascii(\"y\")" false 1
+materialize.public.s3   materialize.public.s3_primary_idx     x           <null>         false 1
+materialize.public.s3   materialize.public.s3_primary_idx     y           <null>         false 2
+
+> DROP SOURCE s3;
+
+! DROP SOURCE s3;
+catalog item 's3' does not exist
+
+! DROP INDEX j1;
+catalog item 'j1' does not exist
+
+# Test cascade deletes all indexes associated with cascaded sources and views
+
+> CREATE MATERIALIZED SOURCE s4
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+> CREATE INDEX j2 on s4(x+2);
+
+> CREATE VIEW w as SELECT y, x + 2 as z from s4;
+
+> CREATE INDEX j3 on w(z);
+
+> SHOW INDEX in s4;
+Source_or_view          Key_name                              Column_name Expression  Null  Seq_in_index
+----------------------------------------------------------------------------------------------------
+materialize.public.s4   materialize.public.j2                 <null>      "\"x\" + 2" false 1
+materialize.public.s4   materialize.public.s4_primary_idx     x           <null>      false 1
+materialize.public.s4   materialize.public.s4_primary_idx     y           <null>      false 2
+
+> SHOW INDEX in w;
+Source_or_view         Key_name                            Column_name Expression Null  Seq_in_index
+----------------------------------------------------------------------------------------------------
+materialize.public.w   materialize.public.j3               z           <null>     false 1
+
+> DROP SOURCE s4 CASCADE;
+
+! DROP VIEW w;
+catalog item 'w' does not exist
+
+! DROP INDEX j3;
+catalog item 'j3' does not exist
+
+! DROP SOURCE s4;
+catalog item 's4' does not exist
+
+! DROP INDEX j2;
+catalog item 'j2' does not exist
+
+# Test that dropping indexes even with cascade does not cause the underlying source to be dropped
+
+> CREATE MATERIALIZED SOURCE s5
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+> DROP INDEX s5_primary_idx CASCADE;
+
+> DROP SOURCE s5;
+
+#cleanup
 > DROP SINK s1;
 
 > DROP SOURCE s;

--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -225,3 +225,13 @@ num name num mod
 <null> <null> 0 even
 <null> <null> 1 odd
 <null> <null> 2 even
+
+> CREATE VIEW test15 AS
+  SELECT * FROM names FULL OUTER JOIN mods_source ON 1 = 0;
+
+! SELECT * FROM test15;
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
+
+# this will fail with an error message
+! SELECT * FROM names FULL OUTER JOIN mods_source ON 1 = 0;
+Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources

--- a/test/testdrive/registry.td
+++ b/test/testdrive/registry.td
@@ -162,14 +162,12 @@ $ kafka-ingest format=avro topic=data schema=${schema_v1} key_schema=${valid_key
   publish=true timestamp=6
 {"before": null, "after": null}
 
-> CREATE SOURCE data_v3
+> CREATE MATERIALIZED SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
 
-> CREATE MATERIALIZED VIEW data_v3_view as SELECT * from data_v3
-
-> SELECT * FROM data_v3_view
+> SELECT * FROM data_v3
 a
 ---
 1 42

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -7,6 +7,27 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+> CREATE VIEW select_constant as SELECT false;
+
+> CREATE MATERIALIZED VIEW select_constant2 as SELECT 'hello';
+
+> SHOW VIEWS
+select_constant
+select_constant2
+
+> SHOW FULL VIEWS
+VIEWS             TYPE QUERYABLE MATERIALIZED
+---------------------------------------------
+select_constant   USER true      false
+select_constant2  USER true      true
+
+> SHOW MATERIALIZED VIEWS
+VIEWS
+--------
+select_constant2
+
+> DROP VIEW select_constant, select_constant2;
+
 $ set names-schema={
     "type": "record",
     "name": "envelope",
@@ -78,7 +99,7 @@ $ set plurals-schema={
   FORMAT AVRO USING SCHEMA '${names-schema}'
   ENVELOPE DEBEZIUM
 
-> CREATE SOURCE mods FROM
+> CREATE MATERIALIZED SOURCE mods FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${mods-schema}'
   ENVELOPE DEBEZIUM
@@ -90,7 +111,7 @@ $ set plurals-schema={
 
 > CREATE MATERIALIZED VIEW names_view as SELECT * from names;
 
-> CREATE MATERIALIZED VIEW mods_view as SELECT * from mods;
+> CREATE VIEW mods_view as SELECT * from mods;
 
 > CREATE VIEW plurals_view as SELECT * from plurals;
 
@@ -107,14 +128,22 @@ names
 mods
 plurals
 
-
 > SHOW FULL SOURCES
-SOURCES  TYPE
+SOURCES  TYPE  MATERIALIZED
 -----------------------------
-names    USER
-mods     USER
-plurals  USER
+names    USER  false
+mods     USER  true
+plurals  USER  false
 
+> SHOW MATERIALIZED SOURCES
+SOURCES
+----
+mods
+
+> SHOW MATERIALIZED SOURCES from materialize.public
+SOURCES
+----
+mods
 
 > SHOW VIEWS
 VIEWS
@@ -158,7 +187,7 @@ Expected one of SCHEMAS or COLUMNS or TABLES, found: VIEWS
 > SHOW FULL VIEWS
 VIEWS        TYPE QUERYABLE MATERIALIZED
 ----------------------------------
-mods_view    USER true      true
+mods_view    USER true      false
 names_view   USER true      true
 plurals_view USER false     false
 test1        USER true      false
@@ -167,33 +196,31 @@ test2        USER false     false
 > SHOW FULL MATERIALIZED VIEWS
 VIEWS        TYPE
 -----------------
-mods_view    USER
 names_view   USER
 
-> SHOW MATERIALIZED VIEWS LIKE '%name%'
-VIEWS
------
-names_view
+> SHOW FULL SOURCES FROM mz_catalog
+VIEWS                             TYPE   MATERIALIZED
+-----------------------------------------------------
+mz_arrangement_sharing            SYSTEM true
+mz_arrangement_sizes              SYSTEM true
+mz_catalog_names                  SYSTEM true
+mz_dataflow_channels              SYSTEM true
+mz_dataflow_operator_addresses    SYSTEM true
+mz_dataflow_operators             SYSTEM true
+mz_materialization_dependencies   SYSTEM true
+mz_materialization_frontiers      SYSTEM true
+mz_materializations               SYSTEM true
+mz_peek_active                    SYSTEM true
+mz_peek_durations                 SYSTEM true
+mz_scheduling_elapsed             SYSTEM true
+mz_scheduling_histogram           SYSTEM true
+mz_scheduling_parks               SYSTEM true
+mz_view_foreign_keys              SYSTEM true
+mz_view_keys                      SYSTEM true
 
 > SHOW FULL VIEWS FROM mz_catalog
 VIEWS                             TYPE   QUERYABLE MATERIALIZED
 ---------------------------------------------------------------
-mz_arrangement_sharing            SYSTEM true      true
-mz_arrangement_sizes              SYSTEM true      true
-mz_catalog_names                  SYSTEM true      true
-mz_dataflow_channels              SYSTEM true      true
-mz_dataflow_operator_addresses    SYSTEM true      true
-mz_dataflow_operators             SYSTEM true      true
-mz_materialization_dependencies   SYSTEM true      true
-mz_materialization_frontiers      SYSTEM true      true
-mz_materializations               SYSTEM true      true
-mz_peek_active                    SYSTEM true      true
-mz_peek_durations                 SYSTEM true      true
-mz_scheduling_elapsed             SYSTEM true      true
-mz_scheduling_histogram           SYSTEM true      true
-mz_scheduling_parks               SYSTEM true      true
-mz_view_foreign_keys              SYSTEM true      true
-mz_view_keys                      SYSTEM true      true
 mz_addresses_with_unit_length     SYSTEM true      true
 mz_dataflow_names                 SYSTEM true      true
 mz_dataflow_operator_dataflows    SYSTEM true      true
@@ -206,14 +233,14 @@ mz_records_per_dataflow           SYSTEM true      true
 mz_records_per_dataflow_global    SYSTEM true      true
 mz_records_per_dataflow_operator  SYSTEM true      true
 
-# test that information in shows correctly responds to materialization and unmaterialization
+# test that information in shows correctly responds to materialization and unmaterialization of views
 
 > CREATE INDEX plurals_idx ON plurals_view(noun)
 
 > SHOW FULL VIEWS
 VIEWS        TYPE QUERYABLE MATERIALIZED
 ----------------------------------
-mods_view    USER true      true
+mods_view    USER true      false
 names_view   USER true      true
 plurals_view USER true      true
 test1        USER true      false
@@ -222,23 +249,26 @@ test2        USER true      false
 > SHOW FULL MATERIALIZED VIEWS
 VIEWS        TYPE
 -----------------
-mods_view    USER
 names_view   USER
 plurals_view USER
 
 > SHOW MATERIALIZED VIEWS
 VIEWS
 --------
-mods_view
 names_view
 plurals_view
+
+> SHOW MATERIALIZED VIEWS LIKE '%name%'
+VIEWS
+-----
+names_view
 
 > DROP INDEX names_view_primary_idx
 
 > SHOW FULL VIEWS
 VIEWS        TYPE QUERYABLE MATERIALIZED
 ----------------------------------
-mods_view    USER true      true
+mods_view    USER true      false
 names_view   USER false     false
 plurals_view USER true      true
 test1        USER false     false
@@ -247,11 +277,72 @@ test2        USER false     false
 > SHOW FULL MATERIALIZED VIEWS
 VIEWS        TYPE
 -----------------
-mods_view    USER
 plurals_view USER
 
 > SHOW MATERIALIZED VIEWS
 VIEWS
 --------
-mods_view
 plurals_view
+
+# test that information in shows correctly responds to materialization and unmaterialization of views
+> CREATE INDEX names_idx on names(num)
+
+> SHOW FULL VIEWS
+VIEWS        TYPE QUERYABLE MATERIALIZED
+----------------------------------
+mods_view    USER true      false
+names_view   USER true      false
+plurals_view USER true      true
+test1        USER true      false
+test2        USER true      false
+
+> SHOW MATERIALIZED VIEWS
+VIEWS
+--------
+plurals_view
+
+> SHOW FULL SOURCES
+SOURCES  TYPE  MATERIALIZED
+-----------------------------
+names    USER  true
+mods     USER  true
+plurals  USER  false
+
+> SHOW FULL MATERIALIZED SOURCES
+SOURCES TYPE
+-----------
+names   USER
+mods    USER
+
+> SHOW MATERIALIZED SOURCES LIKE '%ds'
+SOURCES
+----
+mods
+
+> DROP INDEX mods_primary_idx;
+
+> SHOW FULL VIEWS
+VIEWS        TYPE QUERYABLE MATERIALIZED
+----------------------------------
+mods_view    USER false     false
+names_view   USER true      false
+plurals_view USER true      true
+test1        USER false     false
+test2        USER false     false
+
+> SHOW MATERIALIZED VIEWS
+VIEWS
+--------
+plurals_view
+
+> SHOW FULL SOURCES
+SOURCES  TYPE  MATERIALIZED
+-----------------------------
+names    USER  true
+mods     USER  false
+plurals  USER  false
+
+> SHOW MATERIALIZED SOURCES
+SOURCES
+----
+names


### PR DESCRIPTION
Resolves #1868, #1970, #1973.

LocalInput sources like tables and logs are now registered in the catalog as sources again instead of views. A consequence of this is that I have revived SourceConnector::Local.

Selecting on views defined as `SELECT <constant` work now.

I have decided to postpone refactoring references to "views" in the coordinator to "collections" to make it easier to distinguish actual substantive changes vs spurious renaming.
 