### PR TITLE
catalog: use structured errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ checksum = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 name = "catalog"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "bincode",
  "dataflow-types",
  "expr",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+backtrace = "0.3.43"
 bincode = { version = "1.2", optional = true }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }

--- a/src/catalog/error.rs
+++ b/src/catalog/error.rs
@@ -1,0 +1,99 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+
+use backtrace::Backtrace;
+
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    backtrace: Backtrace,
+}
+
+#[derive(Debug)]
+pub(crate) enum ErrorKind {
+    Corruption { detail: String },
+    IdExhaustion,
+    UnknownDatabase(String),
+    UnknownSchema(String),
+    UnknownItem(String),
+    DatabaseAlreadyExists(String),
+    SchemaAlreadyExists(String),
+    ItemAlreadyExists(String),
+    UnacceptableSchemaName(String),
+    ReadOnlySystemSchema(String),
+    UnsatisfiableLoggingDependency { depender_name: String },
+    Storage(rusqlite::Error),
+}
+
+impl Error {
+    pub(crate) fn new(kind: ErrorKind) -> Error {
+        Error {
+            kind,
+            backtrace: Backtrace::new_unresolved(),
+        }
+    }
+}
+
+impl From<rusqlite::Error> for Error {
+    fn from(e: rusqlite::Error) -> Error {
+        Error::new(ErrorKind::Storage(e))
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            ErrorKind::Corruption { .. }
+            | ErrorKind::IdExhaustion
+            | ErrorKind::UnknownDatabase(_)
+            | ErrorKind::UnknownSchema(_)
+            | ErrorKind::UnknownItem(_)
+            | ErrorKind::DatabaseAlreadyExists(_)
+            | ErrorKind::SchemaAlreadyExists(_)
+            | ErrorKind::ItemAlreadyExists(_)
+            | ErrorKind::UnacceptableSchemaName(_)
+            | ErrorKind::ReadOnlySystemSchema(_)
+            | ErrorKind::UnsatisfiableLoggingDependency { .. } => None,
+            ErrorKind::Storage(e) => Some(e),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.kind {
+            ErrorKind::Corruption { detail } => write!(f, "corrupt catalog: {}", detail),
+            ErrorKind::IdExhaustion => write!(f, "id counter overflows i64"),
+            ErrorKind::UnknownDatabase(name) => write!(f, "unknown database '{}'", name),
+            ErrorKind::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
+            ErrorKind::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
+            ErrorKind::DatabaseAlreadyExists(name) => {
+                write!(f, "database '{}' already exists", name)
+            }
+            ErrorKind::SchemaAlreadyExists(name) => write!(f, "schema '{}' already exists", name),
+            ErrorKind::ItemAlreadyExists(name) => {
+                write!(f, "catalog item '{}' already exists", name)
+            }
+            ErrorKind::UnacceptableSchemaName(name) => {
+                write!(f, "unacceptable schema name '{}'", name)
+            }
+            ErrorKind::ReadOnlySystemSchema(name) => {
+                write!(f, "system schema '{}' cannot be modified", name)
+            }
+            ErrorKind::UnsatisfiableLoggingDependency { depender_name } => write!(
+                f,
+                "catalog item '{}' depends on system logging, but logging is disabled",
+                depender_name
+            ),
+            ErrorKind::Storage(e) => write!(f, "sqlite error: {}", e),
+        }
+    }
+}

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1104,7 +1104,7 @@ fn handle_drop_database(
             // TODO(benesch): generate a notice indicating that the database
             // does not exist.
         }
-        Err(err) => return Err(err),
+        Err(err) => return Err(err.into()),
     }
     Ok(Plan::DropDatabase { name })
 }
@@ -1165,7 +1165,7 @@ fn handle_drop_schema(
             // TODO(benesch): generate a notice indicating that the
             // database does not exist.
         }
-        Err(err) => return Err(err),
+        Err(err) => return Err(err.into()),
     }
     Ok(Plan::DropSchema {
         database_name,
@@ -1247,7 +1247,7 @@ fn handle_drop_item(
             // item does not exist.
             Ok(None)
         }
-        Err(err) => Err(err),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -1510,7 +1510,8 @@ impl<'a> StatementContext<'a> {
 
     pub fn resolve_name(&self, name: ObjectName) -> Result<FullName, failure::Error> {
         let name = normalize::object_name(name)?;
-        self.catalog
-            .resolve(self.session.database(), self.session.search_path(), &name)
+        Ok(self
+            .catalog
+            .resolve(self.session.database(), self.session.search_path(), &name)?)
     }
 }

--- a/test/sqllogictest/cockroach/case_sensitive_names.slt
+++ b/test/sqllogictest/cockroach/case_sensitive_names.slt
@@ -45,7 +45,7 @@ mode cockroach
 statement ok
 CREATE TABLE A(x INT)
 
-statement error pgcode 42P01 catalog item 'A' does not exist
+statement error pgcode 42P01 unknown catalog item 'A'
 SHOW COLUMNS FROM "A"
 
 # statement error pgcode 42P01 catalog item '"A"' does not exist
@@ -63,7 +63,7 @@ SHOW COLUMNS FROM "A"
 # statement error pgcode 42P01 catalog item '"A"' does not exist
 # SHOW CONSTRAINTS FROM "A"
 
-statement error pgcode 42P01 catalog item 'A' does not exist
+statement error pgcode 42P01 unknown catalog item 'A'
 SELECT * FROM "A"
 
 # statement error pgcode 42P01 catalog item '"A"' does not exist
@@ -117,7 +117,7 @@ DROP TABLE a
 statement ok
 CREATE TABLE "B"(x INT)
 
-statement error pgcode 42P01 catalog item 'b' does not exist
+statement error pgcode 42P01 unknown catalog item 'b'
 SHOW COLUMNS FROM B
 
 # statement error pgcode 42P01 catalog item 'b' does not exist
@@ -135,7 +135,7 @@ SHOW COLUMNS FROM B
 # statement error pgcode 42P01 catalog item 'b' does not exist
 # SHOW CONSTRAINTS FROM B
 
-statement error pgcode 42P01 catalog item 'b' does not exist
+statement error pgcode 42P01 unknown catalog item 'b'
 SELECT * FROM B
 
 # statement error pgcode 42P01 catalog item 'b' does not exist

--- a/test/sqllogictest/index.slt
+++ b/test/sqllogictest/index.slt
@@ -76,7 +76,7 @@ materialize.public.foo  materialize.public.foo_primary_idx  a            NULL   
 materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3
 
-query error catalog item 'nonexistent' does not exist
+query error unknown catalog item 'nonexistent'
 SHOW INDEX FROM nonexistent
 
 query error bar_idx is not a view

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -181,10 +181,10 @@ s is not of type VIEW
 # Test that drop without if exists does not work if the object does not exist
 
 ! DROP INDEX nonexistent
-catalog item 'nonexistent' does not exist
+unknown catalog item 'nonexistent'
 
 ! DROP VIEW nonexistent
-catalog item 'nonexistent' does not exist
+unknown catalog item 'nonexistent'
 
 ! DROP SOURCE nonexistent
-catalog item 'nonexistent' does not exist
+unknown catalog item 'nonexistent'

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -93,10 +93,10 @@ cannot drop materialize.public.test1: still depended upon by catalog item 'mater
 # rather than verifying the drop by checking whether DROP VIEW fails.
 
 ! DROP VIEW test1;
-catalog item 'test1' does not exist
+unknown catalog item 'test1'
 
 ! DROP VIEW test2;
-catalog item 'test2' does not exist
+unknown catalog item 'test2'
 
 # Test that DROP VIEW IF EXISTS succeeds even if the view does not exist.
 
@@ -110,7 +110,7 @@ catalog item 'test2' does not exist
 > DROP SOURCE s CASCADE;
 
 ! DROP VIEW test4;
-catalog item 'test4' does not exist
+unknown catalog item 'test4'
 
 > CREATE SOURCE s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -164,7 +164,7 @@ materialize.public.v2  materialize.public.v2_primary_idx     x           <null> 
 > DROP VIEW v2a;
 
 ! DROP VIEW v2a;
-catalog item 'v2a' does not exist
+unknown catalog item 'v2a'
 
 > SHOW INDEX in v2;
 View                   Key_name                              Column_name Expression Null  Seq_in_index
@@ -173,7 +173,7 @@ materialize.public.v2    materialize.public.i1                   x           <nu
 materialize.public.v2    materialize.public.v2_primary_idx       x           <null>     false 1
 
 ! DROP INDEX i2;
-catalog item 'i2' does not exist
+unknown catalog item 'i2'
 
 > CREATE MATERIALIZED VIEW v4 AS SELECT x, y from s;
 
@@ -200,10 +200,10 @@ materialize.public.v4   materialize.public.v4_primary_idx  y           <null>   
 > DROP VIEW v4a CASCADE;
 
 ! DROP VIEW v4a;
-catalog item 'v4a' does not exist
+unknown catalog item 'v4a'
 
 ! DROP INDEX i3;
-catalog item 'i3' does not exist
+unknown catalog item 'i3'
 
 > SHOW INDEX in v4;
 View                     Key_name                              Column_name Expression Null  Seq_in_index
@@ -235,16 +235,16 @@ materialize.public.multicol  materialize.public.i6  d            <null>       fa
 > DROP VIEW v4 CASCADE;
 
 ! DROP VIEW v4;
-catalog item 'v4' does not exist
+unknown catalog item 'v4'
 
 ! DROP INDEX i5;
-catalog item 'i5' does not exist
+unknown catalog item 'i5'
 
 ! DROP VIEW v5;
-catalog item 'v5' does not exist
+unknown catalog item 'v5'
 
 ! DROP INDEX i4;
-catalog item 'i4' does not exist
+unknown catalog item 'i4'
 
 # Test that dropping indexies even with cascade does not cause the underlying view to be dropped
 > DROP INDEX i1 CASCADE;


### PR DESCRIPTION
Resubmission of #1984 from new fork.

----

@quodlibetor this is my alternative proposal for how to handle errors. I'd like to eventually bring this same structure to errors generated by the sql package. Capturing the backtrace will allow us to stick the backtrace in the logs (and in the file/line/routine fields of the pgerror returned to the client: https://www.postgresql.org/docs/9.5/protocol-error-fields.html) so we can pinpoint these errors if they are unexpected; doing it this way has the nice property that it avoids a lot of IMO noisy context lines.

We'll need to ditch failure to make this work, but I think it's worth it.