### PR TITLE
test/testdrive: use materialized sources in more places

### DIFF
--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -67,19 +67,15 @@ $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
 $ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE names_source
+> CREATE MATERIALIZED SOURCE names
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${names-schema}'
   ENVELOPE DEBEZIUM
 
-> CREATE SOURCE mods_source
+> CREATE MATERIALIZED SOURCE mods
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${mods-schema}'
   ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED VIEW names AS SELECT * FROM names_source
-
-> CREATE MATERIALIZED VIEW mods AS SELECT * FROM mods_source
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT * FROM names JOIN mods USING (num);
@@ -226,12 +222,16 @@ num name num mod
 <null> <null> 1 odd
 <null> <null> 2 even
 
+> CREATE SOURCE mods_unmat
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${mods-schema}'
+  ENVELOPE DEBEZIUM
+
 > CREATE VIEW test15 AS
-  SELECT * FROM names FULL OUTER JOIN mods_source ON 1 = 0;
+  SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
 
 ! SELECT * FROM test15;
 Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources
 
-# this will fail with an error message
-! SELECT * FROM names FULL OUTER JOIN mods_source ON 1 = 0;
+! SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
 Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources

--- a/test/testdrive/multijoins.td
+++ b/test/testdrive/multijoins.td
@@ -98,17 +98,17 @@ $ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=2
 $ kafka-ingest format=avro topic=plurals schema=${plurals-schema} timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE names
+> CREATE MATERIALIZED SOURCE names
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${names-schema}'
   ENVELOPE DEBEZIUM
 
-> CREATE SOURCE mods
+> CREATE MATERIALIZED SOURCE mods
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${mods-schema}'
   ENVELOPE DEBEZIUM
 
-> CREATE SOURCE plurals
+> CREATE MATERIALIZED SOURCE plurals
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-plurals-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${plurals-schema}'
   ENVELOPE DEBEZIUM

--- a/test/testdrive/registry.td
+++ b/test/testdrive/registry.td
@@ -65,14 +65,12 @@ $ kafka-ingest format=avro topic=data schema=${schema_v1} publish=true timestamp
 $ kafka-ingest format=avro topic=data schema=${schema_v1} publish=true timestamp=2
 {"before": null, "after": null}
 
-> CREATE SOURCE data_v1
+> CREATE MATERIALIZED SOURCE data_v1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
 
-> CREATE MATERIALIZED VIEW data_v1_view as SELECT * from data_v1
-
-> SELECT * FROM data_v1_view
+> SELECT * FROM data_v1
 a
 ---
 1
@@ -83,20 +81,18 @@ $ kafka-ingest format=avro topic=data schema=${schema_v2} publish=true timestamp
 $ kafka-ingest format=avro topic=data schema=${schema_v2} publish=true timestamp=4
 {"before": null, "after": null}
 
-> CREATE SOURCE data_v2
+> CREATE MATERIALIZED SOURCE data_v2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
 
-> CREATE MATERIALIZED VIEW data_v2_view as SELECT * from data_v2
-
-> SELECT * FROM data_v1_view
+> SELECT * FROM data_v1
 a
 ---
 1
 2
 
-> SELECT * FROM data_v2_view
+> SELECT * FROM data_v2
 a b
 ----
 1 42

--- a/test/testdrive/sort.td
+++ b/test/testdrive/sort.td
@@ -29,7 +29,7 @@ $ set schema={
     ]
   }
 
-> CREATE SOURCE foobar FROM
+> CREATE MATERIALIZED SOURCE foobar FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foobar-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
@@ -48,9 +48,7 @@ $ kafka-ingest format=avro topic=foobar schema=${schema} timestamp=42
 $ kafka-ingest format=avro topic=foobar schema=${schema} timestamp=43
 {"before": null, "after": null}
 
-> CREATE MATERIALIZED VIEW foobar_view as SELECT * from foobar
-
-> SELECT val, quote FROM foobar_view ORDER BY quote LIMIT 5
+> SELECT val, quote FROM foobar ORDER BY quote LIMIT 5
 val    quote
 --------------------------------------------------------------------------------------
 12345  "All power corrupts, but we need electricity."
@@ -59,7 +57,7 @@ val    quote
 12345  "If it pours before seven, it has rained by eleven."
 12345  "It was a virgin forest, a place where the Hand of Man had never set foot."
 
-> SELECT val, quote FROM foobar_view ORDER BY quote ASC LIMIT 5
+> SELECT val, quote FROM foobar ORDER BY quote ASC LIMIT 5
 val    quote
 --------------------------------------------------------------------------------------
 12345  "All power corrupts, but we need electricity."
@@ -68,7 +66,7 @@ val    quote
 12345  "If it pours before seven, it has rained by eleven."
 12345  "It was a virgin forest, a place where the Hand of Man had never set foot."
 
-> SELECT * FROM foobar_view ORDER BY quote DESC LIMIT 5
+> SELECT * FROM foobar ORDER BY quote DESC LIMIT 5
 quote                                                                        val
 ----------------------------------------------------------------------------------
 "You are magnetic in your bearing."                                          24223
@@ -78,7 +76,7 @@ quote                                                                        val
 "It was a virgin forest, a place where the Hand of Man had never set foot."  12345
 
 # Test that the second-column sort works fine
-> SELECT * FROM foobar_view ORDER BY val, quote LIMIT 6
+> SELECT * FROM foobar ORDER BY val, quote LIMIT 6
 quote val
 ---------
 "Ring around the collar."                                                         1735
@@ -88,7 +86,7 @@ quote val
 "If it pours before seven, it has rained by eleven."                              12345
 "It was a virgin forest, a place where the Hand of Man had never set foot."       12345
 
-> SELECT * FROM foobar_view ORDER BY val, quote DESC LIMIT 6
+> SELECT * FROM foobar ORDER BY val, quote DESC LIMIT 6
 quote                                                                             val
 ---------------------------------------------------------------------------------------
 "Ring around the collar."                                                         1735
@@ -98,7 +96,7 @@ quote                                                                           
 "If it pours before seven, it has rained by eleven."                              12345
 "All power corrupts, but we need electricity."                                    12345
 
-> SELECT val, quote FROM foobar_view ORDER BY quote OFFSET 5 ROWS
+> SELECT val, quote FROM foobar ORDER BY quote OFFSET 5 ROWS
 val    quote
 ----------------------------------------------------------------------------
 25040  "New York is real.  The rest is done with mirrors."
@@ -106,7 +104,7 @@ val    quote
 21243  "Yes, but every time I try to see things your way, I get a headache."
 24223  "You are magnetic in your bearing."
 
-> SELECT val, quote FROM foobar_view ORDER BY quote LIMIT 4 OFFSET 0 ROWS
+> SELECT val, quote FROM foobar ORDER BY quote LIMIT 4 OFFSET 0 ROWS
 val    quote
 --------------------------------------------------------------------------------------
 12345  "All power corrupts, but we need electricity."
@@ -114,29 +112,29 @@ val    quote
 6745   "I want to read my new poem about pork brains and outer space ..."
 12345  "If it pours before seven, it has rained by eleven."
 
-> SELECT val, quote FROM foobar_view ORDER BY val, quote LIMIT 3 OFFSET 2 ROWS
+> SELECT val, quote FROM foobar ORDER BY val, quote LIMIT 3 OFFSET 2 ROWS
 val    quote
 --------------------------------------------------------------------------------------
 6745   "I want to read my new poem about pork brains and outer space ..."
 12345  "All power corrupts, but we need electricity."
 12345  "If it pours before seven, it has rained by eleven."
 
-> SELECT val, quote FROM foobar_view ORDER BY quote DESC LIMIT 5 OFFSET 6 ROWS
+> SELECT val, quote FROM foobar ORDER BY quote DESC LIMIT 5 OFFSET 6 ROWS
 val    quote
 --------------------------------------------------------------------------------------
 6745   "I want to read my new poem about pork brains and outer space ..."
 2079   "I have a theory that it's impossible to prove anything, but I can't prove it."
 12345  "All power corrupts, but we need electricity."
 
-> SELECT val, quote FROM foobar_view ORDER BY quote DESC LIMIT 4 OFFSET 10 ROWS
+> SELECT val, quote FROM foobar ORDER BY quote DESC LIMIT 4 OFFSET 10 ROWS
 val    quote
 --------------------------------------------------------------------------------------
 
-> SELECT val, quote FROM foobar_view ORDER BY quote DESC OFFSET 10 ROWS
+> SELECT val, quote FROM foobar ORDER BY quote DESC OFFSET 10 ROWS
 val    quote
 --------------------------------------------------------------------------------------
 
-> SELECT val, quote FROM foobar_view ORDER BY quote DESC OFFSET 0 ROWS
+> SELECT val, quote FROM foobar ORDER BY quote DESC OFFSET 0 ROWS
 val    quote
 --------------------------------------------------------------------------------------
 24223  "You are magnetic in your bearing."

--- a/test/testdrive/timestamps.td
+++ b/test/testdrive/timestamps.td
@@ -44,16 +44,35 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 {"before": null, "after": {"a": 3, "b": 1}}
 {"before": null, "after": {"a": 1, "b": 2}}
 
+> CREATE MATERIALIZED SOURCE data_byo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
 
-> CREATE SOURCE data_byo FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}') FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-> CREATE SOURCE data2_byo FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'  WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}') FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-> CREATE SOURCE data_rt FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-> CREATE SOURCE data2_rt FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+> CREATE MATERIALIZED SOURCE data2_byo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
+    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
 
-> CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo  GROUP BY b
-> CREATE MATERIALIZED VIEW view2_byo AS SELECT b, sum(a) FROM data2_byo  GROUP BY b
-> CREATE MATERIALIZED VIEW view_rt AS SELECT b, sum(a) FROM data_rt  GROUP BY b
-> CREATE MATERIALIZED VIEW view2_rt AS SELECT b, sum(a) FROM data2_rt  GROUP BY b
+> CREATE MATERIALIZED SOURCE data_rt
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE data2_rt
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo GROUP BY b
+
+> CREATE MATERIALIZED VIEW view2_byo AS SELECT b, sum(a) FROM data2_byo GROUP BY b
+
+> CREATE MATERIALIZED VIEW view_rt AS SELECT b, sum(a) FROM data_rt GROUP BY b
+
+> CREATE MATERIALIZED VIEW view2_rt AS SELECT b, sum(a) FROM data2_rt GROUP BY b
 
 ! SELECT * FROM view_byo;
 At least one input has no complete timestamps yet.
@@ -62,12 +81,12 @@ $ kafka-ingest format=raw topic=data-consistency timestamp=1
 testdrive-data-${testdrive.seed},1,0
 testdrive-data2-${testdrive.seed},1,3
 
-> SELECT * FROM view_byo;
+> SELECT * FROM view_byo
 b  sum
 ------
 1 1
 
-> SELECT * FROM view2_byo ;
+> SELECT * FROM view2_byo
 b  sum
 ------
 1  6
@@ -76,28 +95,20 @@ b  sum
 $ kafka-ingest format=raw topic=data timestamp=2
 testdrive-data-${testdrive.seed}-2-3
 
-> SELECT * FROM view2_byo ;
+> SELECT * FROM view2_byo
 b  sum
 ------
 1  6
 2  1
 
-
-
-> SELECT * FROM view_rt ;
+> SELECT * FROM view_rt
 b  sum
 ------
 1  6
 2  1
 
-> SELECT * FROM view2_rt ;
+> SELECT * FROM view2_rt
 b  sum
 ------
 1  6
 2  1
-
-
-> DROP VIEW view_byo;
-> DROP VIEW view2_byo;
-> DROP VIEW view_rt;
-> DROP VIEW view2_rt;


### PR DESCRIPTION
This a) vastly decreases file descriptor usage, and b) speeds up
testdrive, because we don't create a billion independent Kafka sources.