### PR TITLE
Synchronize counters once per invocation

### DIFF
--- a/src/dataflow/decode/protobuf.rs
+++ b/src/dataflow/decode/protobuf.rs
@@ -44,8 +44,8 @@ where
                     for (payload, _) in data.iter() {
                         match decoder.decode(payload) {
                             Ok(row) => {
-                                events_success += 1;
                                 if let Some(row) = row {
+                                    events_success += 1;
                                     session.give((row, *cap.time(), 1));
                                 } else {
                                     events_error += 1;


### PR DESCRIPTION
Prometheus counters were being incremented on a per-record basis, which has the potential to synchronize all of the worker threads as they compete on counters. This changes the behavior to synchronize at most once per operator invocation.

Also, it seems that the `protobuf` logic has a code path where it can increment both success and error. I'm not sure if that is intended (there are two types of errors) but I wanted to call it out.