### PR TITLE
www: remove git lfs files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-www/static/images/uploads/** filter=lfs diff=lfs merge=lfs -text

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,0 @@
-[lfs]
-	url = https://ce53d959-e8fa-42d2-ada0-89a17bd659f9.netlify.com/.netlify/large-media

--- a/www/static/images/uploads/team-andi.jpg
+++ b/www/static/images/uploads/team-andi.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:13c8f98f30b62e7af1c4782764fe48cd447e6df57567545ed844bb52e450cf46
-size 551922

--- a/www/static/images/uploads/team-arjun.jpg
+++ b/www/static/images/uploads/team-arjun.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea2c8f6653db4347e879041fff07886c25fa5d3be4b8dbfd299bb45b0f759599
-size 125619

--- a/www/static/images/uploads/team-benesch.jpg
+++ b/www/static/images/uploads/team-benesch.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9205738c4122a3cc5b5e05001a717ecbde52c644ecdd04e94bcb2e915ffedeb7
-size 142058

--- a/www/static/images/uploads/team-brennan.jpg
+++ b/www/static/images/uploads/team-brennan.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9769c02907cfab477a4c4614f19bbd81b32a75a4cd0f6322bae83e76fdf8d4ad
-size 181881

--- a/www/static/images/uploads/team-bwm.jpg
+++ b/www/static/images/uploads/team-bwm.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d850070a01b39c8f11a21d8990ba371a2d829f603c7fc56f412b3e4743ccdfa7
-size 111975

--- a/www/static/images/uploads/team-cdo.jpg
+++ b/www/static/images/uploads/team-cdo.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:20152be58f1077c6ebd51a066aa603529925c66fab934bff2be6d4dd15edf6c1
-size 223566

--- a/www/static/images/uploads/team-jamii.jpg
+++ b/www/static/images/uploads/team-jamii.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d28668e4c99726190a6a936748aa7104343607dc6e32fae7a8642f6a7e49f84b
-size 1899099

--- a/www/static/images/uploads/team-jessica.jpg
+++ b/www/static/images/uploads/team-jessica.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b5d4e3873ab67fde78ca7b67e23d07793e18cfec44027f2954bfde5c4b715f21
-size 381059

--- a/www/static/images/uploads/team-mcsherry.jpg
+++ b/www/static/images/uploads/team-mcsherry.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e67d0b281e5b883c36c11c94324e33c16aaf2690cb58a9b21094567fc2039ca0
-size 135750

--- a/www/static/images/uploads/team-ruchir.jpg
+++ b/www/static/images/uploads/team-ruchir.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e5f4ca3e911795df189d7284746f0e70e03d45e7b17ed8cc334a345bd0d43f0
-size 161100

--- a/www/static/images/uploads/team-sean.jpg
+++ b/www/static/images/uploads/team-sean.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3675057542f5048d683579b65052f59624774e312a21a60da19868fac7fd9fd3
-size 675532

--- a/www/static/images/uploads/team-venus.jpg
+++ b/www/static/images/uploads/team-venus.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:99a01f7e5a3243ba6bf33cf2ecd4ece6f8d500450002d0b33253c21c1416c2cf
-size 451540

--- a/www/static/images/uploads/team-walid.jpg
+++ b/www/static/images/uploads/team-walid.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:647ac336d96e0d15d5b0cdfd83f08e4a305a08bd9ade53c67feade9039c4a3fa
-size 141106


### PR DESCRIPTION
The website is now managed elsewhere, so we no longer need to store any
LFS files in this repository.