### PR TITLE
materialized: limit splash screen to successful server starts

### DIFF
--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -99,9 +99,6 @@ fn run() -> Result<(), failure::Error> {
     opts.optopt("", "symbiosis", "(internal use only)", "URL");
     opts.optflag("", "no-prometheus", "Do not gather prometheus metrics");
 
-    // Inform the user about what they are using, and how to contact us.
-    beta_splash();
-
     let popts = opts.parse(&args[1..])?;
     if popts.opt_present("h") {
         print!("{}", opts.usage("usage: materialized [options]"));
@@ -154,6 +151,9 @@ fn run() -> Result<(), failure::Error> {
     };
 
     let data_directory = popts.opt_get_default("data-directory", PathBuf::from("mzdata"))?;
+
+    // Inform the user about what they are using, and how to contact us.
+    beta_splash();
 
     let _server = materialized::serve(materialized::Config {
         logging_granularity,


### PR DESCRIPTION
This prevents `materialized --version` and `materalized --help` from
printing the splash screen, as it gets in the way of finding the version
or help text.