### PR TITLE
Basic Metabase demo CI test

### DIFF
--- a/ci/test/metabase-demo.compose.yml
+++ b/ci/test/metabase-demo.compose.yml
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3'
+services:
+  metabase:
+    image: materialize/metabase:latest
+    depends_on: [materialized]
+  materialized:
+    image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
+    command: --logging-granularity=10ms
+    depends_on: [kafka]
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
+  zookeeper:
+    image: zookeeper:3.4.13
+  kafka:
+    image: wurstmeister/kafka:2.12-2.2.0
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_HOST_NAME=kafka
+    depends_on: [zookeeper]
+
+volumes:
+  db-data:

--- a/ci/test/metabase-demo.compose.yml
+++ b/ci/test/metabase-demo.compose.yml
@@ -7,13 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Map from host-port:internal port
-#
-# This mostly just shows all the ports that are available to the host system, if you want
-# to change these you must restart the docker-compose cluster.
-x-port-mappings:
-  - &metabase 3000:3000
-
 version: '3.7'
 services:
   healthcheck:
@@ -23,7 +16,7 @@ services:
     image: materialize/metabase:latest
     depends_on: [materialized]
     ports:
-      - *metabase
+      - "3000:3000"
   materialized:
     image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
     command: --logging-granularity=10ms

--- a/ci/test/metabase-demo.compose.yml
+++ b/ci/test/metabase-demo.compose.yml
@@ -17,7 +17,7 @@ x-port-mappings:
 version: '3.7'
 services:
   healthcheck:
-    image: materialize/healthcheck:latest
+    image: materialize/ci-healthcheck:latest
     depends_on: [metabase]
   metabase:
     image: materialize/metabase:latest

--- a/ci/test/metabase-demo.compose.yml
+++ b/ci/test/metabase-demo.compose.yml
@@ -7,11 +7,23 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-version: '3'
+# Map from host-port:internal port
+#
+# This mostly just shows all the ports that are available to the host system, if you want
+# to change these you must restart the docker-compose cluster.
+x-port-mappings:
+  - &metabase 3000:3000
+
+version: '3.7'
 services:
+  healthcheck:
+    image: materialize/healthcheck:latest
+    depends_on: [metabase]
   metabase:
     image: materialize/metabase:latest
     depends_on: [materialized]
+    ports:
+      - *metabase
   materialized:
     image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
     command: --logging-granularity=10ms

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -116,7 +116,7 @@ steps:
   - id: metabase-demo
     label: "metabase-demo"
     depends_on: build
-    timeout_in_minutes: 5
+    timeout_in_minutes: 10
     plugins:
       - MaterializeInc/uid#master: ~
       - docker-compose#v3.0.3:

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -120,7 +120,7 @@ steps:
     plugins:
       - MaterializeInc/uid#master: ~
       - docker-compose#v3.0.3:
-          config: ci/test/metabase.compose.yml
+          config: ci/test/metabase-demo.compose.yml
           run: metabase
     if: $CHANGED_RUST
 

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -121,6 +121,7 @@ steps:
       - MaterializeInc/uid#master: ~
       - docker-compose#v3.0.3:
           config: ci/test/metabase.compose.yml
+          run: metabase
     if: $CHANGED_RUST
 
   - id: full-sqllogictest

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -113,6 +113,16 @@ steps:
           run: billing-demo
     if: $CHANGED_RUST
 
+  - id: metabase-demo
+    label: "metabase-demo"
+    depends_on: build
+    timeout_in_minutes: 5
+    plugins:
+      - MaterializeInc/uid#master: ~
+      - docker-compose#v3.0.3:
+          config: ci/test/metabase.compose.yml
+    if: $CHANGED_RUST
+
   - id: full-sqllogictest
     label: ":bulb: :bulb: Full SQL logic tests"
     depends_on: build
@@ -126,7 +136,7 @@ steps:
 
   - id: deploy
     label: ":rocket: Deploy"
-    depends_on: [lint-fast, lint-slow, cargo-test, testdrive, streaming-demo, short-sqllogictest]
+    depends_on: [lint-fast, lint-slow, cargo-test, testdrive, streaming-demo, metabase-demo, short-sqllogictest]
     trigger: deploy
     async: true
     branches: "master v*.*"

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -121,7 +121,7 @@ steps:
       - MaterializeInc/uid#master: ~
       - docker-compose#v3.0.3:
           config: ci/test/metabase-demo.compose.yml
-          run: metabase
+          run: healthcheck
     if: $CHANGED_RUST
 
   - id: full-sqllogictest

--- a/misc/docker/ci-healthcheck/Dockerfile
+++ b/misc/docker/ci-healthcheck/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y curl
+
+COPY healthcheck /usr/local/bin/healthcheck
+
+ENTRYPOINT ["healthcheck"]

--- a/misc/docker/ci-healthcheck/healthcheck
+++ b/misc/docker/ci-healthcheck/healthcheck
@@ -15,7 +15,7 @@
 #   - If we don't see a successful curl, Buildkite will time out
 #     and fail this test.
 
-while [ ! "$(curl -fsS metabase:3000)" ]; do
+while ! curl -fsS metabase:3000; do
     echo "Failed to curl metabase:3000. Sleeping..."
     sleep 15
 done

--- a/misc/docker/ci-healthcheck/healthcheck
+++ b/misc/docker/ci-healthcheck/healthcheck
@@ -15,16 +15,9 @@
 #   - If we don't see a successful curl, Buildkite will time out
 #     and fail this test.
 
-passed=false
-while ! $passed; do
-    echo "Curl-ing localhost:3000"
-    out=$(curl -s -o /dev/null -w "%{http_code}" host.docker.internal:3000)
-    if [ "$out" == 200 ]; then
-        passed=true
-    else
-        echo "Got status code: $out. Sleeping..."
-        sleep 15
-    fi
+while [ ! "$(curl -fsS metabase:3000)" ]; do
+    echo "Failed to curl metabase:3000. Sleeping..."
+    sleep 15
 done
 
 echo "Successfully pinged Metabase!"

--- a/misc/docker/ci-healthcheck/healthcheck
+++ b/misc/docker/ci-healthcheck/healthcheck
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Point of this test: Assert Metabase and related containers
+# can run.
+#   - If we see a successful curl, Metabase is up and working!
+#   - If we don't see a successful curl, Buildkite will time out
+#     and fail this test.
+
+passed=false
+while ! $passed; do
+    echo "Curl-ing localhost:3000"
+    out=$(curl -s -o /dev/null -w "%{http_code}" host.docker.internal:3000)
+    if [ "$out" == 200 ]; then
+        passed=true
+    else
+        echo "Got status code: $out. Sleeping..."
+        sleep 15
+    fi
+done
+
+echo "Successfully pinged Metabase!"


### PR DESCRIPTION
### Background
(For this issue: #1839)

We have a [Metabase demo](https://github.com/MaterializeInc/materialize/blob/master/doc/developer/metabase-demo.md) aimed at illustrating how easy it is to plug Materialize into open-source BI tools. Running the demo requires bringing up a handful of Docker containers using `docker-compose`. 

### The Problem
In the past, we've merged changes that broke Metabase's interactions with Materialize. Ideally, we'd like to create tests that cover all of a user's interaction with Metabase and Materialize (connecting to Materialize via Metabase's UI, running queries, setting up dashboards, etc.). But, those types of tests would require we put a lot of work in to automated UI testing.

### The Solution
In this PR, I'm introducing the most basic CI test for Metabase: confirm that we can bring up the required containers and that they don't fail. @cuongdo and I decided this is sufficient for now, but we should revisit our demo test coverage in the future.