### PR TITLE
pgwire: bump max frame size to 64 mb

### DIFF
--- a/src/ore/netio/framed.rs
+++ b/src/ore/netio/framed.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 
 /// The maximum allowable size of a frame in a framed stream.
-pub const MAX_FRAME_SIZE: u32 = 8 << 10;
+pub const MAX_FRAME_SIZE: usize = 64 << 20;
 
 /// An error indicating that a frame in a framed stream exceeded
 /// [`MAX_FRAME_SIZE`].

--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -290,11 +290,9 @@ enum DecodeState {
     Data(u8, usize),
 }
 
-const MAX_FRAME_SIZE: usize = 8 << 10;
-
 fn parse_frame_len(src: &[u8]) -> Result<usize, io::Error> {
     let n = usize::cast_from(NetworkEndian::read_u32(src));
-    if n > MAX_FRAME_SIZE {
+    if n > netio::MAX_FRAME_SIZE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             netio::FrameTooBig,


### PR DESCRIPTION
Fixes #2052

Note that this approach means that queries exceeding 64 MB in size will still
be rejected and cause Materialize to close the connection upon receiving them.
This is done by design to avoid attacks that could cause us to go out of memory

manually validated that this now accepts much larger queries that previously failed and caused the connection to close. If someone wants me to add a unit test im happy to but idt its worth it