### PR TITLE
dataflow: speed up compilation cycle for downstream dependencies

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -878,3 +878,14 @@ impl PendingPeek {
         })
     }
 }
+
+/// The presence of this function forces `rustc` to instantiate the
+/// slow-to-compile differential and timely templates while compiling this
+/// crate. This means that iterating on crates that depend upon this crate is
+/// much faster, because these templates don't need to be reinstantiated
+/// whenever a downstream dependency changes. And iterating on this crate
+/// doesn't really become slower, because you needed to instantiate these
+/// templates anyway to run tests.
+pub fn __explicit_instantiation__() {
+    ore::hint::black_box(serve::<tokio::net::TcpStream> as fn(_, _, _, _, _, _, _) -> _);
+}

--- a/src/ore/hint.rs
+++ b/src/ore/hint.rs
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+//
+// Portions of this file are derived from the criterion project.
+// The original source code was retrieved on February 19, 2020 from:
+//
+//     https://github.com/bheisler/criterion.rs/blob/76061c756347c0575bcfd044a9027dcf66f85a3e/src/lib.rs
+//
+// The original source code is dual-licensed under the Apache 2.0 and MIT
+// licenses, copies of which can be found in the LICENSE file at the root of
+// this repository.
+
+//! Extensions to `std::hint`.
+
+/// A function that is opaque to the optimizer, used to prevent the compiler
+/// from optimizing away computations in a benchmark.
+///
+/// This variant is stable-compatible, but it may cause some performance
+/// overhead or fail to prevent code from being eliminated.
+///
+/// When `std::hint::black_box` is stabilized, this function can be removed.
+pub fn black_box<T>(dummy: T) -> T {
+    unsafe {
+        let ret = std::ptr::read_volatile(&dummy);
+        std::mem::forget(dummy);
+        ret
+    }
+}

--- a/src/ore/lib.rs
+++ b/src/ore/lib.rs
@@ -20,6 +20,7 @@ pub mod collections;
 pub mod fmt;
 pub mod future;
 pub mod hash;
+pub mod hint;
 pub mod iter;
 pub mod log;
 pub mod netio;


### PR DESCRIPTION
Force rustc to instantiate timely and differential templates while
compiling the dataflow crate. From the comment within:

    The presence of this function forces `rustc` to instantiate the
    slow-to-compile differential and timely templates while compiling this
    crate. This means that iterating on crates that depend upon this crate is
    much faster, because these templates don't need to be reinstantiated
    whenever a downstream dependency changes. And iterating on this crate
    doesn't really become slower, because you needed to instantiate these
    templates anyway to run tests.