### PR TITLE
billing-demo: add API docs

### DIFF
--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "billing-demo"
+description = "Microservice demo using Materialize to power a real-time billing usecase"
 version = "0.1.0"
 authors = ["Brandon W Maister <bwm@materialize.io>"]
 edition = "2018"

--- a/src/billing-demo/src/main.rs
+++ b/src/billing-demo/src/main.rs
@@ -7,7 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Demonstrate sticking a whole lot of protobuf messages into materialized
+//! Microservice demo using materialized to build a real-time billing application
+//!
+//! Specifically, this demo shows off materialized's ability to ingest Protobuf
+//! messages, normalize incoming data with jsonb functions, perform joins between
+//! a Kafka topic and a local file, and perform time based aggregates.
+//!
+//! Further details can be found on the Materialize docs:
+//! <https://materialize.io/docs/demos/microservice/>
 
 #![deny(missing_debug_implementations, missing_docs)]
 


### PR DESCRIPTION
Touches #2015

Rn this only adds api docs for the billing-demo crate -- I can add further commits to add them for the other crates that have nothing