### PR TITLE
coord,materialized: Fix failure to start when missing mzdata

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -17,7 +17,6 @@
 //! must accumulate to the same value as would an un-compacted trace.
 
 use std::collections::{BTreeMap, HashMap};
-use std::fs;
 use std::iter;
 use std::path::Path;
 use std::thread;
@@ -123,7 +122,6 @@ where
         };
 
         let catalog_path = if let Some(data_directory) = config.data_directory {
-            fs::create_dir_all(data_directory)?;
             Some(data_directory.join("catalog"))
         } else {
             None

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -161,6 +161,8 @@ fn run() -> Result<(), failure::Error> {
     };
 
     let data_directory = popts.opt_get_default("data-directory", PathBuf::from("mzdata"))?;
+    fs::create_dir_all(&data_directory)
+        .with_context(|e| format!("creating data directory: {}", e))?;
 
     // Configure tracing.
     {


### PR DESCRIPTION
Move the create directory logic to the materialized crate, out of the coord crate

will manually validate that this fixes the issue, can also add a unit test if reviewers think thats warranted