### PR TITLE
docs: create release notes template + versioning info

### DIFF
--- a/doc/user/known-limitations.md
+++ b/doc/user/known-limitations.md
@@ -5,13 +5,14 @@ menu: "main"
 weight: 100
 ---
 
+This document applies to Materialize {{< version >}}.
+
 The following links describe features that Materialize does not yet support, but
 plans to in future releases. If any of these issues impact you, feel free to let
 us know on the linked-to GitHub issue.
 
 For a complete and current overview, check out our [`known-limitations`
 tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue+label%3Aknown-limitation).
-
 
 ## SQL
 

--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -1,0 +1,26 @@
+---
+title: "Release Notes"
+description: "What's new in this version of Materialize"
+menu: "main"
+weight: 500
+---
+
+This page details changes between versions of Materialize, including:
+
+- New features
+- Major bug fixes
+- Substantial API changes
+
+For information about available versions, see our [Versions page](../versions).
+
+## 0.1.0 &rarr; 0.1.1 (unreleased)
+
+- **Indexes on sources**: You can now create and drop indexes on sources, which
+  lets you automatically store all of a source's data in an index. Previously,
+  you would have to create a source, and then create a materialized view that
+  selected all of the source's content.
+
+## _NULL_ &rarr; 0.1.0
+
+- [What is Materialize?](../overview/what-is-materialize/)
+- [Architecture overview](../overview/architecture/)

--- a/doc/user/versions.md
+++ b/doc/user/versions.md
@@ -1,0 +1,17 @@
+---
+title: "Versions"
+description: "Materialize's version information"
+menu: "main"
+weight: 80
+---
+
+Type | Version | Binary links
+-----|---------|--------------
+**Latest release** | {{< version >}} | [Linux](https://downloads.mtrlz.dev/materialized-latest-x86_64-unknown-linux-gnu.tar.gz)/[macOS](https://downloads.mtrlz.dev/materialized-latest-x86_64-apple-darwin.tar.gz)
+**Up next (unreleased)** | {{< next_version >}} | Build from [source using `master`](../install/#build-from-source)
+
+## Binary links
+
+Version | Links
+--------|------
+v0.1.0 | [Linux](https://downloads.mtrlz.dev/materialized-v0.1.0-x86_64-unknown-linux-gnu.tar.gz)/[macOS](https://downloads.mtrlz.dev/materialized-v0.1.0-x86_64-apple-darwin.tar.gz)

--- a/www/config.toml
+++ b/www/config.toml
@@ -5,6 +5,10 @@ pygmentsCodeFences = true
 pygmentsStyle = "xcode"
 disableKinds = ["home"]
 
+[params]
+  current_version = "v0.1.0"
+  next_version = "v0.1.1"
+
 [menu]
     [[menu.main]]
     identifier = "overview"

--- a/www/layouts/shortcodes/next_version.html
+++ b/www/layouts/shortcodes/next_version.html
@@ -1,0 +1,1 @@
+{{ $.Site.Params.next_version -}}

--- a/www/layouts/shortcodes/version.html
+++ b/www/layouts/shortcodes/version.html
@@ -1,0 +1,1 @@
+{{ $.Site.Params.current_version -}}


### PR DESCRIPTION
Create a new release notes page.
- Provides point release-over-point release granularity. The thinking here is that for a while, we'll want to keep a log of the last few batches of changes.
- We can compress the point releases to major releases at any point.
- As we have more releases in the future, Hugo makes it straightforward to create archives of these pages.

In addition, I want to surface a little more information about the current and next versions of the binary. It feels a little weird, but I think is understandable.

@wangandi Can you PTAL at the description for `CREATE MATERIALIZED SOURCES`?
@benesch This seems like something you care about; you have any requests for changing the structure of these things?