### PR TITLE
misc/doc: account for packages with hyphen

### DIFF
--- a/misc/doc/crates.jq
+++ b/misc/doc/crates.jq
@@ -13,4 +13,4 @@
   | sort_by(.name)
   | .[]
   | select(.manifest_path | startswith($pwd))
-  | "<tr class='module-item'><td><a href='\(.name | @uri)/index.html' class='mod'>\(.name | @html)</a></td><td>\(.description | @html)</td></tr>"
+  | "<tr class='module-item'><td><a href='\(.name | gsub("-"; "_") | @uri)/index.html' class='mod'>\(.name | @html)</a></td><td>\(.description | @html)</td></tr>"


### PR DESCRIPTION
The doc index page needs to rewrite hyphens to underscores when
constructing paths to crate documentation.