### PR TITLE
doc: only list library crates in the index

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -76,7 +76,7 @@ cat > target/doc/index.html <<EOF
     <!--[if lte IE 8]><div class="warning">This old browser is unsupported and will most likely display funky things.</div><![endif]-->
     <nav class="sidebar">
         <div class="sidebar-menu">&#9776;</div>
-        <a href='index.html'><img src='rust-logo.png' alt='logo' width='100'></a>
+        <a href='index.html'><div class='logo-container'><img src='rust-logo.png' alt='logo'></div></a>
         <p class='location'>Home</p>
         <div class="sidebar-elems">
         </div>
@@ -127,7 +127,7 @@ EOF
 # links to the root of whatever crate you happen to be looking at.
 cat >> target/doc/main.js <<EOF
 ;
-var el = document.querySelector("img[alt=logo]").parentNode;
+var el = document.querySelector("img[alt=logo]").closest("a");
 if (el.href != "index.html") {
     el.href = "../index.html";
 }

--- a/misc/doc/crates.jq
+++ b/misc/doc/crates.jq
@@ -13,4 +13,7 @@
   | sort_by(.name)
   | .[]
   | select(.manifest_path | startswith($pwd))
-  | "<tr class='module-item'><td><a href='\(.name | gsub("-"; "_") | @uri)/index.html' class='mod'>\(.name | @html)</a></td><td>\(.description | @html)</td></tr>"
+  | .description as $desc
+  | .targets[]
+  | select(.kind | contains(["lib"]))
+  | "<tr class='module-item'><td><a href='\(.name | gsub("-"; "_") | @uri)/index.html' class='mod'>\(.name | @html)</a></td><td>\($desc | @html)</td></tr>"


### PR DESCRIPTION
Binary crates don't typically have useful API surface, and many of the
links 404 anyway. If they *do* have useful API surface, it's not useable
unless folks extract a library crate, at which point it will appear in
the crate index.

Fix #2015.