### PR TITLE
Fixing CHBench Loading Behavior

### DIFF
--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -193,6 +193,7 @@ dc_stop() {
             runv docker-compose stop "$1"
             return
         else
+            echo "No running container"
             return
         fi
     fi
@@ -309,6 +310,14 @@ clean_load_test() {
     load_test --up
 }
 
+# Purges Kafka topic and restarts Materialize/peeker
+drop_kafka_topics() {
+    dc_stop chbench
+    dc_stop materialized peeker
+    runv docker exec -it chbench_kafka_1 kafka-topics --delete --bootstrap-server localhost:9092 --topic "mysql.tpcch.*" || true
+    dc_up materialized
+}
+
 # Long-running load test
 load_test() {
     if [[ "${1:-}" = --up ]]; then
@@ -316,6 +325,7 @@ load_test() {
         bring_up_source_data
         bring_up_introspection
     fi
+    drop_kafka_topics
     dc_run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
     dc_run -d chbench run \
         --dsn=mysql --gen-dir=/var/lib/mysql-files \
@@ -332,7 +342,7 @@ load_test() {
 
 # Generate changes for the demo
 demo_load() {
-    dc_run docker-compose run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
+    drop_kafka_topics
     dc_run -d chbench run \
         --dsn=mysql --gen-dir=/var/lib/mysql-files \
         --peek-conns=0 --flush-every=30 \

--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     depends_on: [zookeeper, kafka]
   connector:
     build: connector
-    depends_on: [schema-registry, control-center, chbench-init]
+    depends_on: [schema-registry, control-center]
   control-center:
     image: confluentinc/cp-enterprise-control-center:5.3.0
     restart: always
@@ -132,17 +132,6 @@ services:
     # state.
     volumes:
       - chbench-gen:/gen
-  chbench-init:
-    # TODO: we should make chbench into its own image/use our new benchmark image,
-    # instead of just rebuilding
-    build: chbench
-    depends_on: [mysql]
-    command: >
-       run
-       --dsn=mysql --gen-dir=/var/lib/mysql-files
-       --analytic-threads=0 --transactional-threads=5
-       --run-seconds=1
-
   cli:
     image: materialize/cli
     init: true


### PR DESCRIPTION
**The problem:**

Debezeum does not clear Kafka topics when a table is dropped. ChBench drops tables and recreates them before each run. This was causing Materialize to treat all inserts (those before the drop and after the drop
Running : `./dc.sh :init: ; ./dc.sh :load: ; ./dc.sh :load: ; ./dc.sh :load:` would cause queries in materialize to return triplicate entries (due to the triplicate entries in the Kafka sources)

ChBench-Init was being run unnecessarily. This was worsening the problem above as each load was causing data to be inserted twice

**The fix:**
./dc.sh now purges all Kafka sources in between runs and restarts materialize after the logs have been purged. It also ensures that there is only a single instance of chbench running at any time.