### PR TITLE
WIP: Add round() function

### DIFF
--- a/src/repr/scalar/decimal.rs
+++ b/src/repr/scalar/decimal.rs
@@ -354,6 +354,43 @@ impl Decimal {
             scale: self.scale,
         }
     }
+
+    /// Round a decimal number
+    ///
+    /// ```
+    /// use repr::decimal::Decimal;
+    ///
+    /// let d: Decimal = "100.11".parse().unwrap();
+    /// assert_eq!(&d.round(1).to_string(), "100.10");
+    ///
+    /// let d: Decimal = "99.0".parse().unwrap();
+    /// assert_eq!(&d.round(2).to_string(), "99.0");
+    ///
+    /// let nd: Decimal = "-40.1".parse().unwrap();
+    /// assert_eq!(nd.round(0).to_string(), "-40.0");
+    ///
+    /// let d: Decimal = "55.5555".parse().unwrap();
+    /// assert_eq!(d.round(-2).to_string(), "100.0000");
+    ///
+    /// let d: Decimal = "55.5555".parse().unwrap();
+    /// assert_eq!(d.round(-3).to_string(), "0.0000");
+    /// ```
+    pub fn round(&self, new_scale: i64) -> Decimal {
+        let significand = {
+            if new_scale <= self.scale as i64 {
+                let scale = self.scale as i64 - new_scale;
+                let factor = 10_i128.pow(scale as u32);
+                let new_significand = rounding_downscale(self.significand, scale as usize) * factor;
+                new_significand
+            } else {
+                self.significand
+            }
+        };
+        Decimal {
+            significand,
+            scale: self.scale,
+        }
+    }
 }
 
 impl FromStr for Decimal {

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -317,3 +317,205 @@ query TTT
 SELECT 1.1::text, 1.1::float::text, 1.1::double::text
 ----
 1.1  1.1  1.1
+
+query R
+SELECT round(CAST (1.5678 AS float))
+----
+2
+
+query R
+SELECT round(CAST (-1.4678 AS float))
+----
+-1
+
+query R
+SELECT round(CAST (1.5678 AS double precision))
+----
+2
+
+query R
+SELECT round(CAST (-1.4678 AS double precision))
+----
+-1
+
+statement ok
+CREATE TABLE nums (
+  n integer
+)
+
+statement ok
+INSERT INTO nums VALUES (4)
+
+query R
+SELECT round(1.5678, CAST ((SELECT n FROM nums) AS integer))
+----
+1.5678
+
+statement ok
+DELETE FROM nums
+
+query R
+SELECT floor(1.5678)
+----
+1.0000
+
+query R
+SELECT round(1.5678, 3)
+----
+1.5680
+
+query R
+SELECT round(1.5678, 2)
+----
+1.5700
+
+query R
+SELECT round(1.5678, 1)
+----
+1.6000
+
+query R
+SELECT round(1.5678, 0)
+----
+2.0000
+
+query R
+SELECT round(1.5678, 7)
+----
+1.5678
+
+query R
+SELECT round(515, 0)
+----
+515
+
+query R
+SELECT round(515, 1)
+----
+515
+
+query R
+SELECT round(515, -1)
+----
+520
+
+query R
+SELECT round(515, -2)
+----
+500
+
+query RRR
+SELECT round(CAST (515 AS decimal), -3), round(515, -3), round(CAST (515 AS decimal(4, 0)), -3)
+----
+1000  1000  1000
+
+query R
+SELECT round(748.58, -4)
+----
+0.00
+
+query RR
+SELECT round(123.9994, 3), round(123.9995, 3)
+----
+123.9990  124.0000
+
+query RR
+SELECT round(123.4545, 2), round(123.45, -2)
+----
+123.4500  100.00
+
+query R
+SELECT round(150.75, 0)
+----
+151.00
+
+query R
+SELECT round(NULL)
+----
+NULL
+
+query R
+SELECT round(NULL, 2)
+----
+NULL
+
+query R
+SELECT round(1.567, NULL)
+----
+NULL
+
+query R
+SELECT round(NULL, NULL)
+----
+NULL
+
+statement ok
+INSERT INTO nums VALUES (NULL)
+
+query R
+SELECT round((SELECT * FROM nums))
+----
+NULL
+
+query R
+SELECT round((SELECT * FROM nums), 2)
+----
+NULL
+
+query R
+SELECT round(2, (SELECT * FROM nums))
+----
+NULL
+
+query R
+SELECT round((SELECT * FROM nums), (SELECT * FROM nums))
+----
+NULL
+
+statement ok
+DROP TABLE nums
+
+statement ok
+CREATE TABLE nums (
+  n float
+)
+
+statement ok
+INSERT INTO nums VALUES (NULL)
+
+query R
+SELECT round((SELECT * FROM nums));
+----
+NULL
+
+query error first round argument has non-integer type Float64
+SELECT round((SELECT * FROM nums), 2)
+
+query error first round argument has non-integer type Float64
+SELECT round((SELECT * FROM nums), (SELECT * FROM nums))
+
+query error second round argument has non-integer type Float64
+SELECT round(5.0, (SELECT * FROM nums))
+
+query R
+SELECT round(5.0, CAST ((SELECT * FROM nums) AS integer))
+----
+NULL
+
+query error first round argument has non-integer type Float64
+SELECT round(CAST (5.0 AS double precision), 3)
+
+query error first round argument has non-integer type Float64
+SELECT round(CAST (5.0 AS float), 3)
+
+query error first round argument has non-integer type Bool
+SELECT round(true, 3)
+
+query error round argument has non-numeric type Bool
+SELECT round(true)
+
+query error first round argument has non-integer type Float64
+SELECT round(CAST (5.0 AS float), 3.0)
+
+query error first round argument has non-integer type Float64
+SELECT round(CAST (5.0 AS float), CAST (3.0 AS float))


### PR DESCRIPTION
#1327
[T-sql](https://docs.microsoft.com/en-us/sql/t-sql/functions/round-transact-sql?view=sql-server-ver15#remarks)
[postgresql](https://www.postgresql.org/docs/current/functions-math.html#id-1.5.8.8.7.2.2.18.1.1)
@benesch  Some questions:
1. `round` and `trunc` are the same one, `round`, in T-sql while they are separated in postgresql. Which one is used in materialize?
2. T-sql requires `ROUND(748.58, -4) => 0`. However, as "748.58" has `scale` of 2, the output would be 0.00. How can I enforce the result to be 0 instead of 0.00?
3. T-sql requires `ROUND(748.58, -3) => Results in an arithmetic overflow, because 748.58 defaults to decimal(5,2), which cannot return 1000.00.` Is this behavior required? Right now, it seems I can only panic! instead of bail! an error message inside BinaryFunc::eval. 

