### PR TITLE
docs: convert logo to png

### DIFF
--- a/www/layouts/partials/header.html
+++ b/www/layouts/partials/header.html
@@ -1,7 +1,10 @@
 <header id="main">
   <div class="row middle-xs">
     <div class="col-sm-3 col-xs-7 logo-wrapper">
-      <a href="/"><img src="https://materialize.io/wp-content/themes/materialize/img/logo.svg" alt="Materialize Logo">
+      <a href="/"><img class=" lazyloaded"
+        src="https://materialize.io/wp-content/uploads/2020/02/materialize_logo_primary-1.png"
+        data-src="https://materialize.io/wp-content/uploads/2020/02/materialize_logo_primary-1.png"
+        alt="Materialize Logo">
       </a>
     </div>
     <div class="col-sm-9 col-xs-5 nav-wrapper text-right">


### PR DESCRIPTION
Act 3 of The Logo Saga™: Sometimes, Simple is Best

The last time we saw our heroes, they were struggling to fix a pixelated logo. In a move of erudition and cunning, the technical writer converted the entire logo to an SVG file. But little did he know, lurking in the shadows and ready to pounce, were CSS compatibility issues that would prevent the company's name from rendering in the specified font!

Undeterred, our intrepid protagonist opens the scene with a straightforward solution: making the whole thing an unembedded PNG.