### PR TITLE
Forward-port v0.1.1 release to master.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "materialized"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "backtrace",
  "chrono",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "materialized"
 description = "Streaming SQL materialized views."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 publish = false
 default-run = "materialized"


### PR DESCRIPTION
These commits are already in the release; now bring them into master.

Contents: 

* One commit from @quodlibetor fixing some argument-parsing logic in the peeker
* Version bump to v0.1.1