### PR TITLE
dataflow: don't notify coordinator if no frontiers have changed

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -485,11 +485,13 @@ where
                     }
                 }
             }
-            block_on(feedback_tx.send(WorkerFeedbackWithMeta {
-                worker_id: self.inner.index(),
-                message: WorkerFeedback::FrontierUppers(progress),
-            }))
-            .unwrap();
+            if !progress.is_empty() {
+                block_on(feedback_tx.send(WorkerFeedbackWithMeta {
+                    worker_id: self.inner.index(),
+                    message: WorkerFeedback::FrontierUppers(progress),
+                }))
+                .unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
We don't want to notify the coordinator if nothing has changed.
Unfortunately, after working really hard to suppress updates from
frontiers that hadn't changed, we'd then send a

    WorkerFeedback::FrontierUppers([])

message to the coordinator, which rather defeated the point. The inner
loop can run as often as every 10us, but frontiers can only change at
most every 1ms, so in the worst case we'd be waking the coordinator up
100x per millisecond to say that nothing had changed.