### PR TITLE
materialized: attempt to increase soft nofile rlimit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,7 +1715,9 @@ dependencies = [
  "postgres",
  "pretty_assertions",
  "prometheus",
+ "rlimit",
  "serde_json",
+ "sysctl",
  "tempfile",
  "tokio",
  "tokio-postgres",
@@ -2962,6 +2964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
+name = "rlimit"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d26e65e82a1e2628c5f209ec12f4508fa50e644bd2f264138e60129d61eae8"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "rusoto_core"
 version = "0.43.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +3538,19 @@ dependencies = [
  "quote 1.0.2",
  "syn 1.0.11",
  "unicode-xid 0.2.0",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0501f0d0c2aa64b419abff97c209f4b82c4e67caa63e8dc5b222ecc1b574cb5c"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "failure",
+ "libc",
+ "walkdir",
 ]
 
 [[package]]

--- a/ci/test/metabase-demo.compose.yml
+++ b/ci/test/metabase-demo.compose.yml
@@ -19,10 +19,6 @@ services:
     image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
     command: --logging-granularity=10ms
     depends_on: [kafka]
-    ulimits:
-      nofile:
-        soft: "65536"
-        hard: "65536"
   zookeeper:
     image: zookeeper:3.4.13
   kafka:

--- a/ci/test/streaming-demo.compose.yml
+++ b/ci/test/streaming-demo.compose.yml
@@ -27,10 +27,6 @@ services:
       - db-data:/share/billing-demo/data
     command: --logging-granularity=10ms
     depends_on: [kafka]
-    ulimits:
-      nofile:
-        soft: "65536"
-        hard: "65536"
   zookeeper:
     image: zookeeper:3.4.13
   kafka:

--- a/ci/test/testdrive.compose.yml
+++ b/ci/test/testdrive.compose.yml
@@ -33,10 +33,6 @@ services:
     volumes:
     - mzdata:/share/mzdata
     - tmp:/share/tmp
-    ulimits:
-      nofile:
-        soft: "65536"
-        hard: "65536"
   zookeeper:
     image: zookeeper:3.4.13
   kafka:

--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -38,10 +38,6 @@ services:
       #
       # 1000 was chosen by fair dice roll
       - DIFFERENTIAL_EAGER_MERGE=1000
-    ulimits:
-      nofile:
-        soft: "65536"
-        hard: "65536"
   mysql:
     image: debezium/example-mysql:1.0
     ports:

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -36,6 +36,8 @@ ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgwire = { path = "../pgwire" }
 prometheus = { git = "https://github.com/quodlibetor/rust-prometheus.git", branch = "include-unaggregated", default-features = false, features = ["process"] }
+rlimit = "0.3.0"
+sysctl = "0.4.0"
 tempfile = "3.1"
 tokio = "0.2"
 tracing = "0.1.12"


### PR DESCRIPTION
On most platforms, including macOS, we can increase the soft nofile
rlimit by calling setrlimit. The implementation requires some care,
since macOS in particular does not report its hard limit properly.

If we fail to increase the file limit to 1024 or greater, we now log a
warning. Since only Kafka sources are file descriptor hungry, I don't
think it ever makes sense to refuse to start if the file descriptor
limit is too low.

Fix #1939.