### PR TITLE
Separate encoding from connector; support Avro Object Container files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,6 +1705,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 name = "materialized"
 version = "0.1.1"
 dependencies = [
+ "avro-rs 0.6.5",
  "backtrace",
  "chrono",
  "comm",
@@ -1728,6 +1729,7 @@ dependencies = [
  "postgres",
  "pretty_assertions",
  "prometheus",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-postgres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,13 +130,28 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "avro-rs"
 version = "0.6.5"
-source = "git+https://github.com/MaterializeInc/avro-rs.git#dd965e4560ae0c600a52acc2e250ffad891355fc"
 dependencies = [
  "chrono",
  "digest",
  "failure",
+ "futures",
  "libflate",
  "log",
+ "rand 0.4.6",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "avro-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bbe285d473a84df9f7fc25668d3ef50430eab208eeb5c635d323f5d30ebefbd"
+dependencies = [
+ "digest",
+ "failure",
+ "libflate",
  "rand 0.4.6",
  "serde",
  "serde_json",
@@ -710,6 +725,7 @@ dependencies = [
 name = "dataflow"
 version = "0.1.0"
 dependencies = [
+ "avro-rs 0.6.5",
  "bincode",
  "ccsr",
  "comm",
@@ -718,8 +734,10 @@ dependencies = [
  "differential-dataflow",
  "dogsdogsdogs",
  "expr",
+ "failure",
  "futures",
  "interchange",
+ "itertools",
  "lazy_static 1.4.0",
  "log",
  "notify",
@@ -754,6 +772,8 @@ version = "0.1.0"
 dependencies = [
  "comm",
  "expr",
+ "failure",
+ "interchange",
  "pdqselect",
  "pretty_assertions",
  "regex",
@@ -1475,13 +1495,14 @@ checksum = "6c346c299e3fe8ef94dc10c2c0253d858a69aac1245157a3bf4125915d528caf"
 name = "interchange"
 version = "0.1.0"
 dependencies = [
- "avro-rs",
+ "avro-rs 0.6.5",
  "base64 0.11.0",
  "byteorder",
  "ccsr",
  "chrono",
  "criterion",
  "failure",
+ "futures",
  "num-traits",
  "ordered-float",
  "ore",
@@ -3333,6 +3354,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "sql"
 version = "0.1.0"
 dependencies = [
+ "avro-rs 0.7.0",
  "catalog",
  "ccsr",
  "chrono",
@@ -3347,6 +3369,7 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "repr",
+ "serde_json",
  "sql-parser",
  "tokio",
  "unicase",
@@ -3551,7 +3574,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "atty",
- "avro-rs",
+ "avro-rs 0.6.5",
  "backoff",
  "byteorder",
  "ccsr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "avro-rs"
 version = "0.6.5"
+source = "git+https://github.com/umanwizard/avro-rs.git?branch=async#b2a857eb1b970517828c628aee431e3d07487bf4"
 dependencies = [
  "chrono",
  "digest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 [[package]]
 name = "avro-rs"
 version = "0.6.5"
-source = "git+https://github.com/umanwizard/avro-rs.git?branch=async#b2a857eb1b970517828c628aee431e3d07487bf4"
+source = "git+https://github.com/MaterializeInc/avro-rs.git#f83e5a76dccd78e5e0d71d8cbbbb682375fc85b5"
 dependencies = [
  "chrono",
  "digest",
@@ -142,20 +142,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "avro-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bbe285d473a84df9f7fc25668d3ef50430eab208eeb5c635d323f5d30ebefbd"
-dependencies = [
- "digest",
- "failure",
- "libflate",
- "rand 0.4.6",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -726,7 +712,7 @@ dependencies = [
 name = "dataflow"
 version = "0.1.0"
 dependencies = [
- "avro-rs 0.6.5",
+ "avro-rs",
  "bincode",
  "ccsr",
  "comm",
@@ -1496,7 +1482,7 @@ checksum = "6c346c299e3fe8ef94dc10c2c0253d858a69aac1245157a3bf4125915d528caf"
 name = "interchange"
 version = "0.1.0"
 dependencies = [
- "avro-rs 0.6.5",
+ "avro-rs",
  "base64 0.11.0",
  "byteorder",
  "ccsr",
@@ -1705,7 +1691,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 name = "materialized"
 version = "0.1.1"
 dependencies = [
- "avro-rs 0.6.5",
+ "avro-rs",
  "backtrace",
  "chrono",
  "comm",
@@ -3357,7 +3343,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 name = "sql"
 version = "0.1.0"
 dependencies = [
- "avro-rs 0.7.0",
+ "avro-rs",
  "catalog",
  "ccsr",
  "chrono",
@@ -3577,7 +3563,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "atty",
- "avro-rs 0.6.5",
+ "avro-rs",
  "backoff",
  "byteorder",
  "ccsr",

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -360,10 +360,12 @@ impl Timestamper {
                 connector: RtTimestampConnector::Kafka(self.create_rt_kafka_connector(id, kc)),
                 last_offset,
             },
-            ExternalSourceConnector::File(fc) => RtTimestampConsumer {
-                connector: RtTimestampConnector::File(self.create_rt_file_connector(id, fc)),
-                last_offset,
-            },
+            ExternalSourceConnector::File(fc) | ExternalSourceConnector::AvroOcf(fc) => {
+                RtTimestampConsumer {
+                    connector: RtTimestampConnector::File(self.create_rt_file_connector(id, fc)),
+                    last_offset,
+                }
+            }
             ExternalSourceConnector::Kinesis(kinc) => RtTimestampConsumer {
                 connector: RtTimestampConnector::Kinesis(block_on(
                     self.create_rt_kinesis_connector(id, kinc),
@@ -466,7 +468,7 @@ impl Timestamper {
                     timestamp_topic,
                 )),
             },
-            ExternalSourceConnector::File(fc) => {
+            ExternalSourceConnector::File(fc) | ExternalSourceConnector::AvroOcf(fc) => {
                 error!("File sources are unsupported for timestamping");
                 ByoTimestampConsumer {
                     source_name: String::from(""),

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -9,8 +9,10 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+interchange = { path = "../interchange" }
 comm = { path = "../comm" }
 expr = { path = "../expr" }
+failure = "0.1"
 pdqselect = "0.1.0"
 regex = "1.3.4"
 repr = { path = "../repr" }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -342,8 +342,13 @@ impl DataEncoding {
             DataEncoding::AvroOcf { schema } => {
                 avro::validate_value_schema(&*schema, envelope == Envelope::Debezium)?
             }
-            DataEncoding::Avro(AvroEncoding { value_schema, key_schema, .. }) => {
-                let mut desc = avro::validate_value_schema(value_schema, envelope == Envelope::Debezium)?;
+            DataEncoding::Avro(AvroEncoding {
+                value_schema,
+                key_schema,
+                ..
+            }) => {
+                let mut desc =
+                    avro::validate_value_schema(value_schema, envelope == Envelope::Debezium)?;
                 if let Some(key_schema) = key_schema {
                     let keys = avro::validate_key_schema(key_schema, &desc)?;
                     desc = desc.add_keys(keys);

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 bincode = "1.2.1"
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-avro-rs = {path = "../../../avro-rs" }
+avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
 bincode = "1.2.1"
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+avro-rs = {path = "../../../avro-rs" }
 bincode = "1.2.1"
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
@@ -17,8 +18,10 @@ dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
+failure = "0.1"
 futures = "0.3"
 interchange = { path = "../interchange" }
+itertools = "0.8"
 lazy_static = "1.4"
 log = "0.4"
 notify = "4.0"

--- a/src/dataflow/decode/avro.rs
+++ b/src/dataflow/decode/avro.rs
@@ -22,6 +22,7 @@ pub fn avro<G>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,
     raw_schema: &str,
     schema_registry: Option<Url>,
+    is_debezium: bool,
 ) -> Stream<G, (Row, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -30,7 +31,8 @@ where
         Exchange::new(|x: &(Vec<u8>, _)| x.0.hashed()),
         "AvroDecode",
         move |_, _| {
-            let mut decoder = interchange::avro::Decoder::new(raw_schema, schema_registry);
+            let mut decoder =
+                interchange::avro::Decoder::new(raw_schema, schema_registry, is_debezium);
             move |input, output| {
                 let mut events_success = 0;
                 let mut events_error = 0;

--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -18,7 +18,7 @@ use timely::dataflow::{
     Scope, Stream,
 };
 
-use dataflow_types::{DataEncoding, Diff, Timestamp};
+use dataflow_types::{DataEncoding, Diff, Envelope, Timestamp};
 use repr::Datum;
 use repr::Row;
 
@@ -30,8 +30,13 @@ mod regex;
 use self::csv::csv;
 use self::regex::regex as regex_fn;
 use avro::avro;
+use avro_rs::types::Value;
+use interchange::avro::{extract_debezium_slow, extract_row, DiffPair};
+
+use log::error;
 use protobuf::protobuf;
 use std::iter;
+use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline};
 
 make_static_metric! {
     struct EventsRead: IntCounter {
@@ -50,55 +55,118 @@ lazy_static! {
     static ref EVENTS_COUNTER: EventsRead = EventsRead::from(&EVENTS_COUNTER_INTERNAL);
 }
 
-fn raw<G>(stream: &Stream<G, (Vec<u8>, Option<i64>)>) -> Stream<G, (Row, Timestamp, Diff)>
+fn pass_through<G, Data, P>(
+    stream: &Stream<G, Data>,
+    name: &str,
+    pact: P,
+) -> Stream<G, (Data, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
+    Data: timely::Data,
+    P: ParallelizationContract<Timestamp, Data>,
 {
     stream.unary(
-        Exchange::new(|x: &(Vec<u8>, _)| x.0.hashed()),
-        "RawBytes",
+        pact,
+        //Exchange::new(|x: &Data| x.hashed()),
+        name,
         move |_, _| {
             move |input, output| {
                 input.for_each(|cap, data| {
+                    let mut v = Vec::new();
+                    data.swap(&mut v);
                     let mut session = output.session(&cap);
-                    for (payload, line_no) in data.iter() {
-                        session.give((
-                            Row::pack(
-                                iter::once(Datum::from(payload.as_slice()))
-                                    .chain(line_no.map(Datum::from)),
-                            ),
-                            *cap.time(),
-                            1,
-                        ));
-                    }
+                    session.give_iterator(v.into_iter().map(|payload| (payload, *cap.time(), 1)));
                 });
             }
         },
     )
 }
 
-pub fn decode<G>(
-    stream: &Stream<G, (Vec<u8>, Option<i64>)>,
-    encoding: DataEncoding,
-    name: &str,
+pub fn decode_avro_values<G>(
+    stream: &Stream<G, (Value, Option<i64>)>,
+    envelope: Envelope,
 ) -> Stream<G, (Row, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    match encoding {
-        DataEncoding::Csv(enc) => csv(stream, enc.n_cols, enc.delimiter),
-        DataEncoding::Avro(enc) => avro(stream, &enc.raw_schema, enc.schema_registry_url),
-        DataEncoding::Regex { regex } => regex_fn(stream, regex, name),
-        DataEncoding::Protobuf(enc) => protobuf(stream, &enc.descriptors, &enc.message_name),
-        DataEncoding::Bytes => raw(stream),
-        DataEncoding::Text => raw(stream).map(|(row, r, d)| {
-            let datums = row.unpack();
+    // TODO(brennan) -- If this ends up being a bottleneck,
+    // refactor the avro `Reader` to separate reading from decoding,
+    // so that we can spread the decoding among all the workers.
+    pass_through(stream, "AvroValues", Pipeline).flat_map(move |((value, index), r, d)| {
+        let diffs = match envelope {
+            Envelope::None => extract_row(value, false, index.map(Datum::from)).map(|r| DiffPair {
+                before: None,
+                after: r,
+            }),
+            Envelope::Debezium => extract_debezium_slow(value),
+        }
+        .unwrap_or_else(|e| {
+            error!("Failed to extract avro row: {}", e);
+            DiffPair {
+                before: None,
+                after: None,
+            }
+        });
+
+        diffs
+            .before
+            .into_iter()
+            .chain(diffs.after.into_iter())
+            .map(move |row| (row, r, d))
+    })
+}
+
+pub fn decode<G>(
+    stream: &Stream<G, (Vec<u8>, Option<i64>)>,
+    encoding: DataEncoding,
+    name: &str,
+    envelope: Envelope,
+) -> Stream<G, (Row, Timestamp, Diff)>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    match (encoding, envelope) {
+        (DataEncoding::Csv(enc), Envelope::None) => csv(stream, enc.n_cols, enc.delimiter),
+        (DataEncoding::Avro(enc), envelope) => avro(
+            stream,
+            &enc.value_schema,
+            enc.schema_registry_url,
+            envelope == Envelope::Debezium,
+        ),
+        (DataEncoding::AvroOcf { .. }, _) => {
+            unreachable!("Internal error: Cannot decode Avro OCF separately from reading")
+        }
+        (_, Envelope::Debezium) => unreachable!(
+            "Internal error: A non-Avro Debezium-envelope source should not have been created."
+        ),
+        (DataEncoding::Regex { regex }, Envelope::None) => regex_fn(stream, regex, name),
+        (DataEncoding::Protobuf(enc), Envelope::None) => {
+            protobuf(stream, &enc.descriptors, &enc.message_name)
+        }
+        (DataEncoding::Bytes, Envelope::None) => pass_through(
+            stream,
+            "RawBytes",
+            Exchange::new(|payload: &(Vec<u8>, Option<i64>)| payload.0.hashed()),
+        )
+        .map(|((payload, line_no), r, d)| {
             (
                 Row::pack(
-                    iter::once(Datum::from(
-                        std::str::from_utf8(datums[0].unwrap_bytes()).ok(),
-                    ))
-                    .chain(iter::once(datums[1])),
+                    iter::once(Datum::from(payload.as_slice())).chain(line_no.map(Datum::from)),
+                ),
+                r,
+                d,
+            )
+        }),
+        (DataEncoding::Text, Envelope::None) => pass_through(
+            stream,
+            "Text",
+            Exchange::new(|payload: &(Vec<u8>, Option<i64>)| payload.0.hashed()),
+        )
+        .map(|((payload, line_no), r, d)| {
+            (
+                Row::pack(
+                    iter::once(Datum::from(std::str::from_utf8(&payload).ok()))
+                        .chain(line_no.map(Datum::from)),
                 ),
                 r,
                 d,

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -146,118 +146,124 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         vid: first_export_id,
                     };
 
-                    let (stream, capability) = if let ExternalSourceConnector::AvroOcf(c) =
-                        connector
-                    {
-                        // Distribute read responsibility among workers.
-                        use differential_dataflow::hashable::Hashable;
-                        let hash = src_id.hashed() as usize;
-                        let should_read = hash % worker_peers == worker_index;
-                        let read_style = if should_read {
-                            if c.tail {
-                                FileReadStyle::TailFollowFd
-                            } else {
-                                FileReadStyle::ReadOnce
-                            }
-                        } else {
-                            FileReadStyle::None
-                        };
-
-                        let reader_schema = match &encoding {
-                            DataEncoding::AvroOcf { schema } => schema,
-                            _ => unreachable!("Internal error: \
-                                              Avro OCF schema should have already been resolved.\n\
-                                              Encoding is: {:?}", encoding)
-                        };
-                        let reader_schema = Schema::parse_str(reader_schema).unwrap();
-                        let ctor = |file| {
-                            async move { avro_rs::Reader::with_schema_owned(reader_schema, file).await.map(|r| r.into_stream()) }
-                        };
-                        let (source, capability) = source::file(
-                            src_id,
-                            region,
-                            format!("ocf-{}", src_id),
-                            c.path,
-                            executor,
-                            read_style,
-                            ctor,
-                        );
-                        (decode_avro_values(&source, envelope), capability)
-                    } else {
-                        let (source, capability) = match connector {
-                            ExternalSourceConnector::Kafka(c) => {
-                                // Distribute read responsibility among workers.
-                                use differential_dataflow::hashable::Hashable;
-                                let hash = src_id.hashed() as usize;
-                                let read_from_kafka = hash % worker_peers == worker_index;
-                                source::kafka(
-                                    region,
-                                    format!("kafka-{}-{}", first_export_id, source_number),
-                                    c,
-                                    uid,
-                                    advance_timestamp,
-                                    timestamp_histories.clone(),
-                                    timestamp_channel.clone(),
-                                    consistency,
-                                    read_from_kafka,
-                                )
-                            }
-                            ExternalSourceConnector::Kinesis(c) => {
-                                // Distribute read responsibility among workers.
-                                use differential_dataflow::hashable::Hashable;
-                                let hash = src_id.hashed() as usize;
-                                let read_from_kinesis = hash % worker_peers == worker_index;
-                                source::kinesis(
-                                    region,
-                                    format!("kinesis-{}-{}", first_export_id, source_number),
-                                    c,
-                                    uid,
-                                    advance_timestamp,
-                                    timestamp_histories.clone(),
-                                    timestamp_channel.clone(),
-                                    consistency,
-                                    read_from_kinesis,
-                                )
-                            }
-                            ExternalSourceConnector::File(c) => {
-                                // Distribute read responsibility among workers.
-                                use differential_dataflow::hashable::Hashable;
-                                let hash = src_id.hashed() as usize;
-                                let should_read = hash % worker_peers == worker_index;
-                                let read_style = if should_read {
-                                    if c.tail {
-                                        FileReadStyle::TailFollowFd
-                                    } else {
-                                        FileReadStyle::ReadOnce
-                                    }
+                    let (stream, capability) =
+                        if let ExternalSourceConnector::AvroOcf(c) = connector {
+                            // Distribute read responsibility among workers.
+                            use differential_dataflow::hashable::Hashable;
+                            let hash = src_id.hashed() as usize;
+                            let should_read = hash % worker_peers == worker_index;
+                            let read_style = if should_read {
+                                if c.tail {
+                                    FileReadStyle::TailFollowFd
                                 } else {
-                                    FileReadStyle::None
-                                };
+                                    FileReadStyle::ReadOnce
+                                }
+                            } else {
+                                FileReadStyle::None
+                            };
 
-                                let ctor = |file| {
-                                    futures::future::ok(
-                                        FramedRead::new(file, LinesCodec::new())
-                                            .map(|res| res.map(String::into_bytes)),
+                            let reader_schema = match &encoding {
+                                DataEncoding::AvroOcf { schema } => schema,
+                                _ => unreachable!(
+                                    "Internal error: \
+                                     Avro OCF schema should have already been resolved.\n\
+                                     Encoding is: {:?}",
+                                    encoding
+                                ),
+                            };
+                            let reader_schema = Schema::parse_str(reader_schema).unwrap();
+                            let ctor = |file| {
+                                async move {
+                                    avro_rs::Reader::with_schema_owned(reader_schema, file)
+                                        .await
+                                        .map(|r| r.into_stream())
+                                }
+                            };
+                            let (source, capability) = source::file(
+                                src_id,
+                                region,
+                                format!("ocf-{}", src_id),
+                                c.path,
+                                executor,
+                                read_style,
+                                ctor,
+                            );
+                            (decode_avro_values(&source, envelope), capability)
+                        } else {
+                            let (source, capability) = match connector {
+                                ExternalSourceConnector::Kafka(c) => {
+                                    // Distribute read responsibility among workers.
+                                    use differential_dataflow::hashable::Hashable;
+                                    let hash = src_id.hashed() as usize;
+                                    let read_from_kafka = hash % worker_peers == worker_index;
+                                    source::kafka(
+                                        region,
+                                        format!("kafka-{}-{}", first_export_id, source_number),
+                                        c,
+                                        uid,
+                                        advance_timestamp,
+                                        timestamp_histories.clone(),
+                                        timestamp_channel.clone(),
+                                        consistency,
+                                        read_from_kafka,
                                     )
-                                };
-                                source::file(
-                                    src_id,
-                                    region,
-                                    format!("csv-{}", src_id),
-                                    c.path,
-                                    executor,
-                                    read_style,
-                                    ctor,
-                                )
-                            }
-                            ExternalSourceConnector::AvroOcf(_) => unreachable!(),
-                        };
-                        // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
-                        // a hypothetical future avro_extract, protobuf_extract, etc.
-                        let stream = decode(&source, encoding, &dataflow.debug_name, envelope);
+                                }
+                                ExternalSourceConnector::Kinesis(c) => {
+                                    // Distribute read responsibility among workers.
+                                    use differential_dataflow::hashable::Hashable;
+                                    let hash = src_id.hashed() as usize;
+                                    let read_from_kinesis = hash % worker_peers == worker_index;
+                                    source::kinesis(
+                                        region,
+                                        format!("kinesis-{}-{}", first_export_id, source_number),
+                                        c,
+                                        uid,
+                                        advance_timestamp,
+                                        timestamp_histories.clone(),
+                                        timestamp_channel.clone(),
+                                        consistency,
+                                        read_from_kinesis,
+                                    )
+                                }
+                                ExternalSourceConnector::File(c) => {
+                                    // Distribute read responsibility among workers.
+                                    use differential_dataflow::hashable::Hashable;
+                                    let hash = src_id.hashed() as usize;
+                                    let should_read = hash % worker_peers == worker_index;
+                                    let read_style = if should_read {
+                                        if c.tail {
+                                            FileReadStyle::TailFollowFd
+                                        } else {
+                                            FileReadStyle::ReadOnce
+                                        }
+                                    } else {
+                                        FileReadStyle::None
+                                    };
 
-                        (stream, capability)
-                    };
+                                    let ctor = |file| {
+                                        futures::future::ok(
+                                            FramedRead::new(file, LinesCodec::new())
+                                                .map(|res| res.map(String::into_bytes)),
+                                        )
+                                    };
+                                    source::file(
+                                        src_id,
+                                        region,
+                                        format!("csv-{}", src_id),
+                                        c.path,
+                                        executor,
+                                        read_style,
+                                        ctor,
+                                    )
+                                }
+                                ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+                            };
+                            // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
+                            // a hypothetical future avro_extract, protobuf_extract, etc.
+                            let stream = decode(&source, encoding, &dataflow.debug_name, envelope);
+
+                            (stream, capability)
+                        };
 
                     let collection = match envelope {
                         Envelope::None => stream.as_collection(),

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -162,7 +162,9 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         };
                         let reader_schema = match &encoding {
                             DataEncoding::AvroOcf { schema } => schema,
-                            _ => unreachable!("Internal error: Avro OCF schema should have already been resolved.\nEncoding is: {:?}", encoding)
+                            _ => unreachable!("Internal error: \
+                                              Avro OCF schema should have already been resolved.\n\
+                                              Encoding is: {:?}", encoding)
                         };
                         let reader_schema = Schema::parse_str(reader_schema).unwrap();
                         let ctor = |file| {

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -26,7 +26,9 @@ use timely::worker::Worker as TimelyWorker;
 use dataflow_types::Timestamp;
 use dataflow_types::*;
 use expr::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr, SourceInstanceId};
+use futures::stream::StreamExt;
 use repr::{Datum, RelationType, Row, RowArena};
+use tokio_util::codec::{FramedRead, LinesCodec};
 
 use self::context::{ArrangementFlavor, Context};
 use super::sink;
@@ -34,10 +36,11 @@ use super::source;
 use super::source::FileReadStyle;
 use super::source::SourceToken;
 use crate::arrangement::manager::{TraceManager, WithDrop};
-use crate::decode::decode;
+use crate::decode::{decode, decode_avro_values};
 use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::server::LocalInput;
 use crate::server::{TimestampChanges, TimestampHistories};
+use avro_rs::Schema;
 
 mod context;
 mod delta_join;
@@ -142,62 +145,103 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         sid: src_id.sid,
                         vid: first_export_id,
                     };
-                    let (source, capability) = match connector {
-                        ExternalSourceConnector::Kafka(c) => {
-                            // Distribute read responsibility among workers.
-                            use differential_dataflow::hashable::Hashable;
-                            let hash = src_id.hashed() as usize;
-                            let read_from_kafka = hash % worker_peers == worker_index;
-                            source::kafka(
-                                region,
-                                format!("kafka-{}-{}", first_export_id, source_number),
-                                c,
-                                uid,
-                                advance_timestamp,
-                                timestamp_histories.clone(),
-                                timestamp_channel.clone(),
-                                consistency,
-                                read_from_kafka,
-                            )
-                        }
-                        ExternalSourceConnector::Kinesis(c) => {
-                            // Distribute read responsibility among workers.
-                            use differential_dataflow::hashable::Hashable;
-                            let hash = src_id.hashed() as usize;
-                            let read_from_kinesis = hash % worker_peers == worker_index;
-                            source::kinesis(
-                                region,
-                                format!("kinesis-{}-{}", first_export_id, source_number),
-                                c,
-                                uid,
-                                advance_timestamp,
-                                timestamp_histories.clone(),
-                                timestamp_channel.clone(),
-                                consistency,
-                                read_from_kinesis,
-                            )
-                        }
-                        ExternalSourceConnector::File(c) => {
-                            let read_style = if worker_index != 0 {
-                                FileReadStyle::None
-                            } else if c.tail {
-                                FileReadStyle::TailFollowFd
-                            } else {
-                                FileReadStyle::ReadOnce
-                            };
-                            source::file(
-                                src_id,
-                                region,
-                                format!("csv-{}", src_id),
-                                c.path,
-                                executor,
-                                read_style,
-                            )
-                        }
+
+                    let (stream, capability) = if let ExternalSourceConnector::AvroOcf(c) =
+                        connector
+                    {
+                        let read_style = if worker_index != 0 {
+                            FileReadStyle::None
+                        } else if c.tail {
+                            FileReadStyle::TailFollowFd
+                        } else {
+                            FileReadStyle::ReadOnce
+                        };
+                        let reader_schema = match &encoding {
+                            DataEncoding::AvroOcf { schema } => schema,
+                            _ => unreachable!("Internal error: Avro OCF schema should have already been resolved.\nEncoding is: {:?}", encoding)
+                        };
+                        let reader_schema = Schema::parse_str(reader_schema).unwrap();
+                        let ctor = |file| {
+                            async move { avro_rs::Reader::with_schema_owned(reader_schema, file).await.map(|r| r.into_stream()) }
+                        };
+                        let (source, capability) = source::file(
+                            src_id,
+                            region,
+                            format!("ocf-{}", src_id),
+                            c.path,
+                            executor,
+                            read_style,
+                            ctor,
+                        );
+                        (decode_avro_values(&source, envelope), capability)
+                    } else {
+                        let (source, capability) = match connector {
+                            ExternalSourceConnector::Kafka(c) => {
+                                // Distribute read responsibility among workers.
+                                use differential_dataflow::hashable::Hashable;
+                                let hash = src_id.hashed() as usize;
+                                let read_from_kafka = hash % worker_peers == worker_index;
+                                source::kafka(
+                                    region,
+                                    format!("kafka-{}-{}", first_export_id, source_number),
+                                    c,
+                                    uid,
+                                    advance_timestamp,
+                                    timestamp_histories.clone(),
+                                    timestamp_channel.clone(),
+                                    consistency,
+                                    read_from_kafka,
+                                )
+                            }
+                            ExternalSourceConnector::Kinesis(c) => {
+                                // Distribute read responsibility among workers.
+                                use differential_dataflow::hashable::Hashable;
+                                let hash = src_id.hashed() as usize;
+                                let read_from_kinesis = hash % worker_peers == worker_index;
+                                source::kinesis(
+                                    region,
+                                    format!("kinesis-{}-{}", first_export_id, source_number),
+                                    c,
+                                    uid,
+                                    advance_timestamp,
+                                    timestamp_histories.clone(),
+                                    timestamp_channel.clone(),
+                                    consistency,
+                                    read_from_kinesis,
+                                )
+                            }
+                            ExternalSourceConnector::File(c) => {
+                                let read_style = if worker_index != 0 {
+                                    FileReadStyle::None
+                                } else if c.tail {
+                                    FileReadStyle::TailFollowFd
+                                } else {
+                                    FileReadStyle::ReadOnce
+                                };
+                                let ctor = |file| {
+                                    futures::future::ok(
+                                        FramedRead::new(file, LinesCodec::new())
+                                            .map(|res| res.map(String::into_bytes)),
+                                    )
+                                };
+                                source::file(
+                                    src_id,
+                                    region,
+                                    format!("csv-{}", src_id),
+                                    c.path,
+                                    executor,
+                                    read_style,
+                                    ctor,
+                                )
+                            }
+                            ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+                        };
+                        // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
+                        // a hypothetical future avro_extract, protobuf_extract, etc.
+                        let stream = decode(&source, encoding, &dataflow.debug_name, envelope);
+
+                        (stream, capability)
                     };
-                    // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
-                    // a hypothetical future avro_extract, protobuf_extract, etc.
-                    let stream = decode(&source, encoding, &dataflow.debug_name);
 
                     let collection = match envelope {
                         Envelope::None => stream.as_collection(),

--- a/src/dataflow/source/file.rs
+++ b/src/dataflow/source/file.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fmt::Display;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -33,8 +34,6 @@ use dataflow_types::Timestamp;
 
 use crate::source::util::source;
 use crate::source::{SourceStatus, SourceToken};
-
-use std::fmt::Display;
 
 #[derive(PartialEq, Eq)]
 pub enum FileReadStyle {

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -14,7 +14,7 @@ path = "benches/benches.rs"
 harness = false
 
 [dependencies]
-avro-rs = { path = "../../../avro-rs" }
+avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -14,7 +14,7 @@ path = "benches/benches.rs"
 harness = false
 
 [dependencies]
-avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -14,11 +14,12 @@ path = "benches/benches.rs"
 harness = false
 
 [dependencies]
-avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
+avro-rs = { path = "../../../avro-rs" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"
 failure = "0.1.6"
+futures = "0.3"
 num-traits = "0.2.11" # don't want to upgrade to autocfg 1.0 until more things use it
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -16,6 +16,7 @@ use avro_rs::schema::{RecordField, Schema, SchemaFingerprint, UnionSchema};
 use avro_rs::types::Value;
 use byteorder::{BigEndian, ByteOrder, NetworkEndian, WriteBytesExt};
 use failure::bail;
+use futures::executor::block_on;
 use serde_json::json;
 
 use sha2::Sha256;
@@ -57,57 +58,61 @@ pub fn validate_key_schema(key_schema: &str, value_desc: &RelationDesc) -> Resul
 }
 
 /// Converts an Apache Avro schema into a [`repr::RelationDesc`].
-pub fn validate_value_schema(schema: &str) -> Result<RelationDesc> {
+pub fn validate_value_schema(schema: &str, is_debezium: bool) -> Result<RelationDesc> {
     let schema = parse_schema(schema)?;
 
-    // The top-level record needs to be a diff "envelope" that contains
-    // `before` and `after` fields, where the `before` and `after` fields
-    // have the same schema.
-    let row_schema = match &schema {
-        Schema::Record { fields, .. } => {
-            let before = fields.iter().find(|f| f.name == "before");
-            let after = fields.iter().find(|f| f.name == "after");
-            match (before, after) {
-                (Some(before), Some(after)) => {
-                    if let Some((left, right)) =
-                        first_mismatched_schema_types(&before.schema, &after.schema)
-                    {
-                        bail!(
+    let row_schema = if is_debezium {
+        // The top-level record needs to be a diff "envelope" that contains
+        // `before` and `after` fields, where the `before` and `after` fields
+        // have the same schema.
+        let row_schema = match &schema {
+            Schema::Record { fields, .. } => {
+                let before = fields.iter().find(|f| f.name == "before");
+                let after = fields.iter().find(|f| f.name == "after");
+                match (before, after) {
+                    (Some(before), Some(after)) => {
+                        if let Some((left, right)) =
+                            first_mismatched_schema_types(&before.schema, &after.schema)
+                        {
+                            bail!(
                             "source schema has mismatched 'before' and 'after' schemas: before={:?} after={:?}",
                             left,
                             right
                         )
+                        }
+                        &before.schema
                     }
-                    &before.schema
+                    (None, _) => bail!("source schema is missing 'before' field"),
+                    (_, None) => bail!("source schema is missing 'after' field"),
                 }
-                (None, _) => bail!("source schema is missing 'before' field"),
-                (_, None) => bail!("source schema is missing 'after' field"),
             }
-        }
-        _ => bail!("source schema does not match required envelope format"),
-    };
+            _ => bail!("source schema does not match required envelope format"),
+        };
 
-    // The "row" schema used by the `before` and `after` fields needs to be
-    // a nullable record type.
-    let row_schema = match &row_schema {
-        Schema::Union(us) => {
-            if us.variants().len() != 2 {
-                bail!("source schema 'before'/'after' fields are not of expected type");
+        // The "row" schema used by the `before` and `after` fields needs to be
+        // a nullable record type.
+        match &row_schema {
+            Schema::Union(us) => {
+                if us.variants().len() != 2 {
+                    bail!("source schema 'before'/'after' fields are not of expected type");
+                }
+                let has_null = us.variants().iter().any(|s| is_null(s));
+                let record = us.variants().iter().find(|s| match s {
+                    Schema::Record { .. } => true,
+                    _ => false,
+                });
+                if !has_null {
+                    bail!("source schema has non-nullable 'before'/'after' fields");
+                }
+                match record {
+                    Some(record) => record,
+                    None => bail!("source schema 'before/'after' fields are not of expected type"),
+                }
             }
-            let has_null = us.variants().iter().any(|s| is_null(s));
-            let record = us.variants().iter().find(|s| match s {
-                Schema::Record { .. } => true,
-                _ => false,
-            });
-            if !has_null {
-                bail!("source schema has non-nullable 'before'/'after' fields");
-            }
-            match record {
-                Some(record) => record,
-                None => bail!("source schema 'before/'after' fields are not of expected type"),
-            }
+            _ => bail!("source schema has non-nullable 'before'/'after' fields"),
         }
-        _ => bail!("source schema has non-nullable 'before'/'after' fields"),
+    } else {
+        &schema
     };
 
     // The diff envelope is sane. Convert the actual record schema for the row.
@@ -132,7 +137,7 @@ fn validate_schema_1(schema: &Schema) -> Result<RelationDesc> {
                 column_names,
             ))
         }
-        _ => bail!("row schemas must be records, got {:?}", schema),
+        _ => bail!("row schemas must be records, got: {:?}", schema),
     }
 }
 
@@ -310,6 +315,77 @@ fn first_mismatched_schema_types<'a>(
     }
 }
 
+pub fn value_to_datum(v: &Value) -> Result<Datum<'_>> {
+    match v {
+        Value::Null => Ok(Datum::Null),
+        Value::Boolean(true) => Ok(Datum::True),
+        Value::Boolean(false) => Ok(Datum::False),
+        Value::Int(i) => Ok(Datum::Int32(*i)),
+        Value::Long(i) => Ok(Datum::Int64(*i)),
+        Value::Float(f) => Ok(Datum::Float32((*f).into())),
+        Value::Double(f) => Ok(Datum::Float64((*f).into())),
+        Value::Date(d) => Ok(Datum::Date(*d)),
+        Value::Timestamp(d) => Ok(Datum::Timestamp(*d)),
+        Value::Decimal { unscaled, .. } => Ok(Datum::Decimal(
+            Significand::from_twos_complement_be(&unscaled)?,
+        )),
+        Value::Bytes(b) => Ok(Datum::Bytes(b)),
+        Value::String(s) => Ok(Datum::String(s)),
+        Value::Union(v) => value_to_datum(v),
+        other @ Value::Fixed(..)
+        | other @ Value::Enum(..)
+        | other @ Value::Array(_)
+        | other @ Value::Map(_)
+        | other @ Value::Record(_) => bail!("unsupported avro value: {:?}", other),
+    }
+}
+
+pub fn extract_row<'a, I>(mut v: Value, strip_union: bool, extra: I) -> Result<Option<Row>>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
+    if strip_union {
+        v = match v {
+            Value::Union(v) => *v,
+            _ => bail!("unsupported avro value: {:?}", v),
+        }
+    }
+    match v {
+        Value::Record(fields) => {
+            let mut row = RowPacker::new();
+            for (_, col) in fields.iter() {
+                row.push(value_to_datum(col)?);
+            }
+            for d in extra {
+                row.push(d);
+            }
+            Ok(Some(row.finish()))
+        }
+        Value::Null => Ok(None),
+        _ => bail!("unsupported avro value: {:?}", v),
+    }
+}
+
+pub fn extract_debezium_slow(v: Value) -> Result<DiffPair> {
+    let mut before = None;
+    let mut after = None;
+    match v {
+        Value::Record(fields) => {
+            for (name, val) in fields {
+                if name == "before" {
+                    before = extract_row(val, true, iter::once(Datum::Int64(-1)))?;
+                } else if name == "after" {
+                    after = extract_row(val, true, iter::once(Datum::Int64(1)))?;
+                } else {
+                    // Intentionally ignore other fields.
+                }
+            }
+        }
+        _ => bail!("avro envelope had unexpected type: {:?}", v),
+    };
+    Ok(DiffPair { before, after })
+}
+
 #[derive(Debug)]
 pub struct DiffPair {
     pub before: Option<Row>,
@@ -321,6 +397,7 @@ pub struct Decoder {
     reader_schema: Schema,
     writer_schemas: Option<SchemaCache>,
     fast_row_schema: Option<Schema>,
+    is_debezium: bool,
 }
 
 impl fmt::Debug for Decoder {
@@ -346,7 +423,11 @@ impl Decoder {
     /// The provided schema is called the "reader schema", which is the schema
     /// that we are expecting to use to decode records. The records may indicate
     /// that they are encoded with a different schema; as long as those.
-    pub fn new(reader_schema: &str, schema_registry_url: Option<url::Url>) -> Decoder {
+    pub fn new(
+        reader_schema: &str,
+        schema_registry_url: Option<url::Url>,
+        is_debezium: bool,
+    ) -> Decoder {
         // It is assumed that the reader schema has already been verified
         // to be a valid Avro schema.
         let reader_schema = parse_schema(reader_schema).unwrap();
@@ -371,6 +452,7 @@ impl Decoder {
             reader_schema,
             writer_schemas,
             fast_row_schema,
+            is_debezium,
         }
     }
 
@@ -409,86 +491,42 @@ impl Decoder {
             None => (&self.reader_schema, None),
         };
 
-        fn value_to_datum(v: &Value) -> Result<Datum<'_>> {
-            match v {
-                Value::Null => Ok(Datum::Null),
-                Value::Boolean(true) => Ok(Datum::True),
-                Value::Boolean(false) => Ok(Datum::False),
-                Value::Int(i) => Ok(Datum::Int32(*i)),
-                Value::Long(i) => Ok(Datum::Int64(*i)),
-                Value::Float(f) => Ok(Datum::Float32((*f).into())),
-                Value::Double(f) => Ok(Datum::Float64((*f).into())),
-                Value::Date(d) => Ok(Datum::Date(*d)),
-                Value::Timestamp(d) => Ok(Datum::Timestamp(*d)),
-                Value::Decimal { unscaled, .. } => Ok(Datum::Decimal(
-                    Significand::from_twos_complement_be(&unscaled)?,
-                )),
-                Value::Bytes(b) => Ok(Datum::Bytes(b)),
-                Value::String(s) => Ok(Datum::String(s)),
-                Value::Union(v) => value_to_datum(v),
-                other @ Value::Fixed(..)
-                | other @ Value::Enum(..)
-                | other @ Value::Array(_)
-                | other @ Value::Map(_)
-                | other @ Value::Record(_) => bail!("unsupported avro value: {:?}", other),
+        let result = if self.is_debezium {
+            if let (Some(schema), None) = (&self.fast_row_schema, reader_schema) {
+                // The record is laid out such that we can extract the `before` and
+                // `after` fields without decoding the entire record.
+                let before = extract_row(
+                    block_on(avro_rs::from_avro_datum(&schema, &mut bytes, None))?,
+                    true,
+                    iter::once(Datum::Int64(-1)),
+                )?;
+                let after = extract_row(
+                    block_on(avro_rs::from_avro_datum(&schema, &mut bytes, None))?,
+                    true,
+                    iter::once(Datum::Int64(1)),
+                )?;
+                DiffPair { before, after }
+            } else {
+                let val = block_on(avro_rs::from_avro_datum(
+                    writer_schema,
+                    &mut bytes,
+                    reader_schema,
+                ))?;
+                extract_debezium_slow(val)?
+            }
+        } else {
+            let val = block_on(avro_rs::from_avro_datum(
+                writer_schema,
+                &mut bytes,
+                reader_schema,
+            ))?;
+            let row = extract_row(val, false, iter::empty())?;
+            DiffPair {
+                before: None,
+                after: row,
             }
         };
-
-        fn extract_row<'a, I>(v: Value, extra: I) -> Result<Option<Row>>
-        where
-            I: IntoIterator<Item = Datum<'a>>,
-        {
-            let v = match v {
-                Value::Union(v) => *v,
-                _ => bail!("unsupported avro value: {:?}", v),
-            };
-            match v {
-                Value::Record(fields) => {
-                    let mut row = RowPacker::new();
-                    for (_, col) in fields.iter() {
-                        row.push(value_to_datum(col)?);
-                    }
-                    for d in extra {
-                        row.push(d);
-                    }
-                    Ok(Some(row.finish()))
-                }
-                Value::Null => Ok(None),
-                _ => bail!("unsupported avro value: {:?}", v),
-            }
-        }
-
-        let mut before = None;
-        let mut after = None;
-        if let (Some(schema), None) = (&self.fast_row_schema, reader_schema) {
-            // The record is laid out such that we can extract the `before` and
-            // `after` fields without decoding the entire record.
-            before = extract_row(
-                avro_rs::from_avro_datum(&schema, &mut bytes, None)?,
-                iter::once(Datum::Int64(-1)),
-            )?;
-            after = extract_row(
-                avro_rs::from_avro_datum(&schema, &mut bytes, None)?,
-                iter::once(Datum::Int64(1)),
-            )?;
-        } else {
-            let val = avro_rs::from_avro_datum(writer_schema, &mut bytes, reader_schema)?;
-            match val {
-                Value::Record(fields) => {
-                    for (name, val) in fields {
-                        if name == "before" {
-                            before = extract_row(val, iter::once(Datum::Int64(-1)))?;
-                        } else if name == "after" {
-                            after = extract_row(val, iter::once(Datum::Int64(1)))?;
-                        } else {
-                            // Intentionally ignore other fields.
-                        }
-                    }
-                }
-                _ => bail!("avro envelope had unexpected type: {:?}", val),
-            }
-        }
-        Ok(DiffPair { before, after })
+        Ok(result)
     }
 }
 
@@ -782,7 +820,7 @@ mod tests {
             // avoids embedding JSON strings inside of JSON, which is hard on
             // the eyes.
             let schema = serde_json::to_string(&tc.input)?;
-            let output = super::validate_value_schema(&schema)?;
+            let output = super::validate_value_schema(&schema, true)?;
             assert_eq!(output, tc.expected, "failed test case name: {}", tc.name)
         }
 

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -366,6 +366,9 @@ where
     }
 }
 
+/// Extract a debezium-format Avro object by parsing it fully,
+/// i.e., when the record isn't laid out such that we can extract the `before` and
+/// `after` fields without decoding the entire record.
 pub fn extract_debezium_slow(v: Value) -> Result<DiffPair> {
     let mut before = None;
     let mut after = None;
@@ -417,6 +420,7 @@ impl fmt::Debug for Decoder {
     }
 }
 
+// TODO (#2133) -- Avro coding can probably be made significantly faster.
 impl Decoder {
     /// Creates a new `Decoder`
     ///

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -288,7 +288,7 @@ pub fn bench_avro(c: &mut Criterion) {
     buf.extend(avro_rs::to_avro_datum(&schema, record).unwrap());
     let len = buf.len() as u64;
 
-    let mut decoder = Decoder::new(schema_str, None, false);
+    let mut decoder = Decoder::new(schema_str, None, true);
 
     let mut bg = c.benchmark_group("avro");
     bg.throughput(Throughput::Bytes(len));

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -288,7 +288,7 @@ pub fn bench_avro(c: &mut Criterion) {
     buf.extend(avro_rs::to_avro_datum(&schema, record).unwrap());
     let len = buf.len() as u64;
 
-    let mut decoder = Decoder::new(schema_str, None);
+    let mut decoder = Decoder::new(schema_str, None, false);
 
     let mut bg = c.benchmark_group("avro");
     bg.throughput(Throughput::Bytes(len));

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -17,7 +17,7 @@ name = "materialized"
 path = "bin/materialized.rs"
 
 [dependencies]
-avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 backtrace = { version = "0.3.44", features = ["coresymbolication"] }
 comm = { path = "../comm" }
 compile-time-run = "0.2.8"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -17,6 +17,7 @@ name = "materialized"
 path = "bin/materialized.rs"
 
 [dependencies]
+avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
 backtrace = { version = "0.3.44", features = ["coresymbolication"] }
 comm = { path = "../comm" }
 compile-time-run = "0.2.8"
@@ -35,6 +36,7 @@ ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgwire = { path = "../pgwire" }
 prometheus = { git = "https://github.com/quodlibetor/rust-prometheus.git", branch = "include-unaggregated", default-features = false, features = ["process"] }
+serde_json = "1"
 tempfile = "3.1"
 tokio = "0.2"
 tracing = "0.1.12"

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -21,6 +21,8 @@ use std::thread;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use avro_rs::Schema;
+use avro_rs::types::Value;
 
 pub mod util;
 
@@ -157,6 +159,16 @@ fn test_file_sources() -> Result<(), Box<dyn Error>> {
             .collect::<Vec<(String, String, String, i64)>>())
     };
 
+    let fetch_avro_rows = |client: &mut postgres::Client, source| -> Result<_, Box<dyn Error>> {
+        // TODO(brennan): use a blocking SELECT when that exists.
+        thread::sleep(Duration::from_secs(1));
+        Ok(
+            client.
+                query(&*format!("SELECT * FROM {} ORDER BY mz_obj_no", source),
+                &[])?.into_iter()
+                .map(|row| (row.get(0), row.get(1), row.get(2))).collect::<Vec<(f64, f64, i64)>>())
+    };
+
     let append = |file: &mut File, data| -> Result<_, Box<dyn Error>> {
         file.write_all(data)?;
         file.sync_all()?;
@@ -169,7 +181,20 @@ fn test_file_sources() -> Result<(), Box<dyn Error>> {
 
     let static_path = Path::join(temp_dir.path(), "static.csv");
     let dynamic_path = Path::join(temp_dir.path(), "dynamic.csv");
+    let avro_path = Path::join(temp_dir.path(), "dynamic.avro");
+    let avro_schema = serde_json::from_str(r#"
+    {
+     "type": "record",
+     "name": "cpx",
+     "fields" : [
+         {"name": "im", "type" : "double"},
+         {"name": "re", "type": "double"}
+     ]
+    }
+    "#)?;
+    let avro_schema = Schema::parse(&avro_schema)?;
     let mut dynamic_file = File::create(&dynamic_path)?;
+    let mut avro_writer = avro_rs::Writer::new(&avro_schema, File::create(&avro_path)?);
 
     fs::write(
         &static_path,
@@ -218,6 +243,39 @@ New York,NY,10004
     assert_eq!(
         fetch_rows(&mut client, "dynamic_csv")?,
         &[line1, line2, line3]
+    );
+
+    fn get_record(i: i32) -> Value {
+        Value::Record(vec![("im".to_owned(), Value::Double(i as f64)), ("re".to_owned(), Value::Double((i as f64) * std::f64::consts::PI))])
+    }
+
+    for i in 0..100 {
+        let val = get_record(i);
+        avro_writer.append(val)?;
+    }
+    avro_writer.flush()?;
+
+    client.batch_execute(&*format!(
+        "CREATE SOURCE dynamic_ocf_source FROM AVRO OCF '{}' WITH (tail = true)",
+        avro_path.display()
+    ))?;
+    client.batch_execute(
+        "CREATE MATERIALIZED VIEW dynamic_ocf AS SELECT * FROM dynamic_ocf_source"
+    )?;
+    assert_eq!(
+        fetch_avro_rows(&mut client, "dynamic_ocf")?,
+        (0..100).map(|i| (i as f64, (i as f64) * std::f64::consts::PI, i + 1)).collect::<Vec<_>>()
+    );
+
+    for i in 100..150 {
+        let val = get_record(i);
+        avro_writer.append(val)?;
+    }
+    avro_writer.flush()?;
+
+    assert_eq!(
+        fetch_avro_rows(&mut client, "dynamic_ocf")?,
+        (0..150).map(|i| (i as f64, (i as f64) * std::f64::consts::PI, i + 1)).collect::<Vec<_>>()
     );
 
     // Test the TAIL SQL command on the tailed file source. This is end-to-end

--- a/src/repr/relation.rs
+++ b/src/repr/relation.rs
@@ -175,6 +175,24 @@ impl RelationDesc {
         RelationDesc { typ, names }
     }
 
+    pub fn from_cols(cols: Vec<(ColumnType, Option<String>)>) -> RelationDesc {
+        Self::new(
+            RelationType::new(cols.iter().map(|(typ, _)| typ.clone()).collect()),
+            cols.into_iter().map(|(_, name)| name),
+        )
+    }
+
+    pub fn add_cols<I, N>(&mut self, cols: I)
+    where
+        I: IntoIterator<Item = (ColumnType, Option<N>)>,
+        N: Into<ColumnName>,
+    {
+        for (typ, name) in cols.into_iter() {
+            self.typ.column_types.push(typ);
+            self.names.push(name.map(Into::into));
+        }
+    }
+
     /// Adds a new named, nonnullable column with the specified type.
     pub fn add_column(mut self, name: impl Into<ColumnName>, scalar_type: ScalarType) -> Self {
         self.typ.column_types.push(ColumnType::new(scalar_type));

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -2898,19 +2898,15 @@ fn parse_create_source_inline_schema() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
             materialized,
         } => {
             assert_eq!("foo", name.to_string());
-            assert_eq!(
-                Connector::File {
-                    path: "bar".into(),
-                    with_options: vec![]
-                },
-                connector
-            );
+            assert_eq!(Connector::File { path: "bar".into() }, connector);
+            assert!(with_options.is_empty());
             assert_eq!(
                 Format::Avro(AvroSchema::Schema(Schema::Inline("baz".into()))),
                 format.unwrap()
@@ -2932,6 +2928,7 @@ fn parse_create_source_kafka() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
@@ -2942,18 +2939,21 @@ fn parse_create_source_kafka() {
                 Connector::Kafka {
                     broker: "bar".into(),
                     topic: "baz".into(),
-                    with_options: vec![
-                        SqlOption {
-                            name: "consistency".into(),
-                            value: Value::SingleQuotedString("lug".into()),
-                        },
-                        SqlOption {
-                            name: "ssl_certificate_file".into(),
-                            value: Value::SingleQuotedString("/Path/to/file".into()),
-                        },
-                    ],
                 },
                 connector
+            );
+            assert_eq!(
+                vec![
+                    SqlOption {
+                        name: "consistency".into(),
+                        value: Value::SingleQuotedString("lug".into()),
+                    },
+                    SqlOption {
+                        name: "ssl_certificate_file".into(),
+                        value: Value::SingleQuotedString("/Path/to/file".into()),
+                    },
+                ],
+                with_options
             );
             assert_eq!(Format::Bytes, format.unwrap());
             assert_eq!(Envelope::None, envelope);
@@ -2972,19 +2972,15 @@ fn parse_create_source_file_schema_protobuf_multiple_args() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
             materialized,
         } => {
             assert_eq!("foo", name.to_string());
-            assert_eq!(
-                Connector::File {
-                    path: "bar".into(),
-                    with_options: vec![]
-                },
-                connector
-            );
+            assert_eq!(Connector::File { path: "bar".into() }, connector);
+            assert!(with_options.is_empty());
             assert_eq!(
                 Format::Protobuf {
                     message_name: "somemessage".into(),
@@ -3009,21 +3005,20 @@ fn parse_create_source_regex() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
             materialized,
         } => {
             assert_eq!("foo", name.to_string());
+            assert_eq!(Connector::File { path: "bar".into() }, connector);
             assert_eq!(
-                Connector::File {
-                    path: "bar".into(),
-                    with_options: vec![SqlOption {
-                        name: "tail".into(),
-                        value: Value::Boolean(true)
-                    }]
-                },
-                connector
+                vec![SqlOption {
+                    name: "tail".into(),
+                    value: Value::Boolean(true)
+                }],
+                with_options,
             );
             assert_eq!(Format::Regex("(asdf)|(jkl)".into()), format.unwrap());
             assert_eq!(Envelope::None, envelope);
@@ -3043,21 +3038,20 @@ fn parse_create_source_csv() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
             materialized,
         } => {
             assert_eq!("foo", name.to_string());
+            assert_eq!(Connector::File { path: "bar".into() }, connector);
             assert_eq!(
-                Connector::File {
-                    path: "bar".into(),
-                    with_options: vec![SqlOption {
-                        name: "tail".into(),
-                        value: Value::Boolean(false)
-                    }]
-                },
-                connector
+                vec![SqlOption {
+                    name: "tail".into(),
+                    value: Value::Boolean(false)
+                }],
+                with_options
             );
             assert_eq!(
                 Format::Csv {
@@ -3083,21 +3077,20 @@ fn parse_create_source_csv_custom_delim() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
             materialized,
         } => {
             assert_eq!("foo", name.to_string());
+            assert_eq!(Connector::File { path: "bar".into() }, connector);
             assert_eq!(
-                Connector::File {
-                    path: "bar".into(),
-                    with_options: vec![SqlOption {
-                        name: "tail".into(),
-                        value: Value::Boolean(true)
-                    }]
-                },
-                connector
+                vec![SqlOption {
+                    name: "tail".into(),
+                    value: Value::Boolean(true)
+                }],
+                with_options
             );
             assert_eq!(
                 Format::Csv {
@@ -3132,16 +3125,17 @@ fn parse_avro_object() {
             name,
             connector,
             format,
+            with_options,
             ..
         } => {
             assert_eq!("foo", name.to_string());
             assert_eq!(
                 Connector::AvroOcf {
                     path: "/tmp/bar".into(),
-                    with_options: vec![]
                 },
                 connector
             );
+            assert!(with_options.is_empty());
             assert_eq!(None, format);
         }
         _ => unreachable!(),
@@ -3157,19 +3151,15 @@ fn parse_create_source_registry() {
         Statement::CreateSource {
             name,
             connector,
+            with_options,
             format,
             envelope,
             if_not_exists,
             materialized,
         } => {
             assert_eq!("foo", name.to_string());
-            assert_eq!(
-                Connector::File {
-                    path: "bar".into(),
-                    with_options: vec![]
-                },
-                connector
-            );
+            assert_eq!(Connector::File { path: "bar".into() }, connector);
+            assert!(with_options.is_empty());
             assert_eq!(
                 Format::Avro(AvroSchema::CsrUrl {
                     url: "http://localhost:8081".into(),
@@ -3265,13 +3255,7 @@ fn parse_create_sink() {
         } => {
             assert_eq!("foo", name.to_string());
             assert_eq!("bar", from.to_string());
-            assert_eq!(
-                Connector::File {
-                    path: "baz".into(),
-                    with_options: vec![]
-                },
-                connector
-            );
+            assert_eq!(Connector::File { path: "baz".into() }, connector);
             assert_eq!(Format::Bytes, format);
             assert!(!if_not_exists);
         }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
-avro-rs = "0.7"
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 # TODO(benesch): eventually only the tests will need the bincode feature.
 catalog = { path = "../catalog", features = ["bincode"] }
 ccsr = { path = "../ccsr" }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+avro-rs = "0.7"
 # TODO(benesch): eventually only the tests will need the bincode feature.
 catalog = { path = "../catalog", features = ["bincode"] }
 ccsr = { path = "../ccsr" }
@@ -23,6 +24,7 @@ ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 regex = "1.3.4"
 repr = { path = "../repr" }
+serde_json = "1"
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "0.2.11", features = ["fs"] }
 unicase = "2.6.0"

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -159,6 +159,7 @@ pub fn create_statement(
         Statement::CreateSource {
             name,
             connector: _,
+            with_options: _,
             format: _,
             envelope: _,
             if_not_exists,

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1045,7 +1045,6 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             let mut desc = encoding.desc(envelope)?;
             desc.add_cols(external_connector.metadata_columns());
 
-
             let if_not_exists = *if_not_exists;
             let materialized = *materialized;
             let name = scx.allocate_name(normalize::object_name(name.clone())?);

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 
 [dependencies]
 atty = "0.2"
-avro-rs = { path = "../../../avro-rs" }
+avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
 backoff = "0.1.6"
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 
 [dependencies]
 atty = "0.2"
-avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
+avro-rs = { path = "../../../avro-rs" }
 backoff = "0.1.6"
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -14,7 +14,7 @@ path = "main.rs"
 
 [dependencies]
 atty = "0.2"
-avro-rs = { git = "https://github.com/umanwizard/avro-rs.git", branch = "async" }
+avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 backoff = "0.1.6"
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }

--- a/src/testdrive/action/kafka.rs
+++ b/src/testdrive/action/kafka.rs
@@ -114,7 +114,7 @@ impl Action for VerifyAction {
                                 ));
                             }
                             actual_messages.push(
-                                avro_rs::from_avro_datum(&schema, &mut bytes, None)
+                                block_on(avro_rs::from_avro_datum(&schema, &mut bytes, None))
                                     .map_err(|e| format!("from_avro_datum: {}", e.to_string()))?,
                             );
                         }

--- a/test/testdrive/basic.td
+++ b/test/testdrive/basic.td
@@ -500,6 +500,32 @@ a  b
 -4 0
 -2 -1
 
+$ set schema={
+     "type": "record",
+     "name": "cpx",
+     "fields": [
+       {"name": "a", "type": "long"},
+       {"name": "b", "type": "long"}
+     ]
+   }
+
+$ kafka-ingest format=avro topic=non-dbz-data schema=${schema} timestamp=1
+{"a": 1, "b": 2}
+{"a": 2, "b": 3}
+
+> CREATE SOURCE non_dbz_data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE NONE;
+
+> CREATE MATERIALIZED VIEW test9 AS SELECT * FROM non_dbz_data;
+
+> SELECT * FROM test9
+a b
+---
+1 2
+2 3
+
 # N.B. it is important to test sinks that depend on sources directly vs. sinks
 # that depend on views, as the code paths are different.
 


### PR DESCRIPTION
This commit refactors source handling to enable Kafka sources in arbitrary formats. It also implements support for the Avro OCF format (i.e. Avro files).

Avro files are implemented as a new connector type, since the connector is inseparable from the decoding step.