### PR TITLE
Remove `description`, which is deprecated, from FrameTooBig impl

### DIFF
--- a/src/ore/netio/framed.rs
+++ b/src/ore/netio/framed.rs
@@ -30,4 +30,4 @@ impl Display for FrameTooBig {
     }
 }
 
-impl Error for FrameTooBig { }
+impl Error for FrameTooBig {}

--- a/src/ore/netio/framed.rs
+++ b/src/ore/netio/framed.rs
@@ -29,3 +29,5 @@ impl Display for FrameTooBig {
         f.write_str("frame size too big")
     }
 }
+
+impl Error for FrameTooBig { }

--- a/src/ore/netio/framed.rs
+++ b/src/ore/netio/framed.rs
@@ -26,12 +26,6 @@ impl Debug for FrameTooBig {
 
 impl Display for FrameTooBig {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.write_str(self.description())
-    }
-}
-
-impl Error for FrameTooBig {
-    fn description(&self) -> &str {
-        "frame size too big"
+        f.write_str("frame size too big")
     }
 }


### PR DESCRIPTION
See https://doc.rust-lang.org/std/error/trait.Error.html