### PR TITLE
Fix wrong logic when printing `magic`

### DIFF
--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -392,10 +392,7 @@ impl Decoder {
         bytes = &bytes[5..];
 
         if magic != 0 {
-            bail!(
-                "wrong avro serialization magic: expected 0, got {}",
-                magic
-            );
+            bail!("wrong avro serialization magic: expected 0, got {}", magic);
         }
 
         let (writer_schema, reader_schema) = match &mut self.writer_schemas {

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -394,7 +394,7 @@ impl Decoder {
         if magic != 0 {
             bail!(
                 "wrong avro serialization magic: expected 0, got {}",
-                bytes[0]
+                magic
             );
         }
 


### PR DESCRIPTION
`bytes` has already been reassigned by this point