### PR TITLE
sql-parser: use enum for if exists behavior

### DIFF
--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -781,10 +781,9 @@ pub enum Statement {
         name: ObjectName,
         columns: Vec<Ident>,
         query: Box<Query>,
+        if_exists: IfExistsBehavior,
         materialized: bool,
-        replace: bool,
         with_options: Vec<SqlOption>,
-        if_not_exists: bool,
     },
     /// `CREATE TABLE`
     CreateTable {
@@ -1049,12 +1048,11 @@ impl fmt::Display for Statement {
                 columns,
                 query,
                 materialized,
-                replace,
+                if_exists,
                 with_options,
-                if_not_exists,
             } => {
                 write!(f, "CREATE")?;
-                if *replace {
+                if *if_exists == IfExistsBehavior::Replace {
                     write!(f, " OR REPLACE")?;
                 }
                 if *materialized {
@@ -1063,7 +1061,7 @@ impl fmt::Display for Statement {
 
                 write!(f, " VIEW")?;
 
-                if *if_not_exists {
+                if *if_exists == IfExistsBehavior::Skip {
                     write!(f, " IF NOT EXISTS")?;
                 }
 
@@ -1424,4 +1422,11 @@ impl fmt::Display for SetVariableValue {
             Literal(literal) => write!(f, "{}", literal),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IfExistsBehavior {
+    Error,
+    Skip,
+    Replace,
 }

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -425,11 +425,10 @@ macro_rules! make_visitor {
                 columns: &'ast $($mut)* [Ident],
                 query: &'ast $($mut)* Query,
                 materialized: bool,
-                replace: bool,
+                if_exists: IfExistsBehavior,
                 with_options: &'ast $($mut)* [SqlOption],
-                if_not_exists: bool,
             ) {
-                visit_create_view(self, name, columns, query, materialized, replace, with_options, if_not_exists)
+                visit_create_view(self, name, columns, query, materialized, if_exists, with_options)
             }
 
             fn visit_create_index(
@@ -686,10 +685,9 @@ macro_rules! make_visitor {
                     columns,
                     query,
                     materialized,
-                    replace,
+                    if_exists,
                     with_options,
-                    if_not_exists,
-                } => visitor.visit_create_view(name, columns, query, *materialized, *replace, with_options, *if_not_exists),
+                } => visitor.visit_create_view(name, columns, query, *materialized, *if_exists, with_options),
                 Statement::CreateIndex {
                     name,
                     on_name,
@@ -1457,9 +1455,8 @@ macro_rules! make_visitor {
             columns: &'ast $($mut)* [Ident],
             query: &'ast $($mut)* Query,
             _materialized: bool,
-            _replace: bool,
+            _if_exists: IfExistsBehavior,
             with_options: &'ast $($mut)* [SqlOption],
-            _if_not_exists: bool,
         ) {
             visitor.visit_object_name(name);
             for column in columns {

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -13,7 +13,7 @@ use catalog::names::{DatabaseSpecifier, FullName, PartialName};
 use ore::collections::CollectionExt;
 use repr::ColumnName;
 use sql_parser::ast::visit_mut::VisitMut;
-use sql_parser::ast::{Expr, Function, Ident, ObjectName, Statement, TableAlias};
+use sql_parser::ast::{Expr, Function, Ident, IfExistsBehavior, ObjectName, Statement, TableAlias};
 
 use crate::statement::StatementContext;
 
@@ -186,9 +186,8 @@ pub fn create_statement(
             columns,
             query,
             materialized,
-            replace,
+            if_exists,
             with_options: _,
-            if_not_exists,
         } => {
             *name = allocate_name(name)?;
             for c in columns {
@@ -202,8 +201,7 @@ pub fn create_statement(
                 }
             }
             *materialized = false;
-            *replace = false;
-            *if_not_exists = false;
+            *if_exists = IfExistsBehavior::Error;
         }
 
         Statement::CreateIndex {


### PR DESCRIPTION
CREATE VIEW now supports both OR REPLACE and IF NOT EXISTS. These
options are mutually exclusive. Make that clear in the AST by using an
enum rather than two bools.