### PR TITLE
ci/deploy: increase macOS timeout

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -36,6 +36,6 @@ steps:
   - command: ci/deploy/macos.sh
     agents:
       queue: mac
-    timeout_in_minutes: 10
+    timeout_in_minutes: 15
     concurrency: 1
     concurrency_group: deploy/macos


### PR DESCRIPTION
The macOS deploy job is routinely timing out. Increase the timeout to
15m, which seems like it will be safe.