### PR TITLE
Re-use CSV parser across multiple records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
@@ -605,7 +605,7 @@ dependencies = [
  "bincode",
  "ccsr",
  "comm",
- "csv",
+ "csv-core",
  "dataflow-types",
  "differential-dataflow",
  "dogsdogsdogs",
@@ -1576,9 +1576,6 @@ name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "memoffset"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -13,7 +13,7 @@ avro-rs = { git = "https://github.com/MaterializeInc/avro-rs.git" }
 bincode = "1.2.1"
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
-csv = "1.1.3"
+csv-core = "0.1.10"
 dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -27,10 +27,18 @@ pub fn csv<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    // Delimiters must be single-byte utf8 to safely treat all matched fields as valid utf8.
+    assert!(delimiter.is_ascii());
+
     stream.unary(
         Exchange::new(|x: &(Vec<u8>, _)| x.0.hashed()),
         "CsvDecode",
         |_, _| {
+            // Temporary storage, and a re-useable CSV reader.
+            let mut buffer = vec![0u8];
+            let mut bounds = vec![0usize];
+            let mut csv_reader = csv_core::ReaderBuilder::new().delimiter(delimiter).build();
+
             move |input, output| {
                 let mut events_success = 0;
                 let mut events_error = 0;
@@ -42,32 +50,86 @@ where
                     // This is mainly an aesthetic/performance-golfing
                     // issue as I doubt it will ever be a bottleneck.
                     for (line, line_no) in &*lines {
-                        let mut csv_reader = csv::ReaderBuilder::new()
-                            .has_headers(false)
-                            .delimiter(delimiter)
-                            .from_reader(line.as_slice());
-                        for result in csv_reader.records() {
-                            let record = result.unwrap();
-                            if record.len() != n_cols {
-                                events_error += 1;
-                                error!(
-                                    "CSV error: expected {} columns, got {}. Ignoring row.",
-                                    n_cols,
-                                    record.len()
-                                );
-                                continue;
+                        // We only want to process utf8 strings, as this ensures that all fields
+                        // will be utf8 as well, allowing some unsafe shenanigans.
+                        if std::str::from_utf8(line.as_slice()).is_err() {
+                            events_error += 1;
+                            error!("CSV error: input text is not utf8");
+                        } else {
+                            // Reset the reader to read a new series of records.
+                            csv_reader.reset();
+                            if let Some(line_no) = line_no {
+                                csv_reader.set_line(*line_no as u64);
                             }
-                            events_success += 1;
-                            session.give((
-                                Row::pack(
-                                    record
-                                        .iter()
-                                        .map(|s| Datum::String(s))
-                                        .chain(iter::once(line_no.map(Datum::Int64).into())),
-                                ),
-                                *cap.time(),
-                                1,
-                            ));
+
+                            let mut input = line.as_slice();
+                            let mut buffer_valid = 0;
+                            let mut bounds_valid = 0;
+                            let mut done = false;
+
+                            while !done {
+
+                                // Note that we protect the first element of `bounds`, a zero, so that ranges are easier to extract below.
+                                let (result, in_read, _out_wrote, ends_wrote) = csv_reader
+                                    .read_record(input, &mut buffer[buffer_valid..], &mut bounds[1+bounds_valid..]);
+
+                                // Advance buffers, as requested by return values.
+                                input = &input[in_read..];
+                                buffer_valid += _out_wrote;
+                                bounds_valid += ends_wrote;
+
+                                match result {
+                                    csv_core::ReadRecordResult::InputEmpty => {
+                                        // We will go around the loop again with an empty input buffer and flush any final record.
+                                    }
+                                    csv_core::ReadRecordResult::OutputFull => {
+                                        let length = buffer.len();
+                                        buffer.extend(std::iter::repeat(0).take(length));
+                                    }
+                                    csv_core::ReadRecordResult::OutputEndsFull => {
+                                        let length = bounds.len();
+                                        bounds.extend(std::iter::repeat(0).take(length));
+                                    }
+                                    csv_core::ReadRecordResult::Record => {
+                                        if bounds_valid != n_cols {
+                                            events_error += 1;
+                                            error!(
+                                                "CSV error: expected {} columns, got {}. Ignoring row.",
+                                                n_cols, bounds_valid,
+                                            );
+                                        } else {
+                                            events_success += 1;
+                                            session.give((
+                                                Row::pack(
+                                                    (0..n_cols)
+                                                        .map(|i| {
+                                                            // Unsafety rationalized as 1. the input text is determined to be
+                                                            // valid utf8, and 2. the delimiter is ascii, which should make each
+                                                            // delimited region also utf8.
+                                                            Datum::String(unsafe {
+                                                                std::str::from_utf8_unchecked(
+                                                                    &buffer
+                                                                        [bounds[i]..bounds[i + 1]],
+                                                                )
+                                                            })
+                                                        })
+                                                        .chain(iter::once(
+                                                            line_no.map(Datum::Int64).into(),
+                                                        )),
+                                                ),
+                                                *cap.time(),
+                                                1,
+                                            ));
+                                            // Reset valid data to extract the next record, should one exist.
+                                            buffer_valid = 0;
+                                            bounds_valid = 0;
+                                        }
+                                    }
+                                    csv_core::ReadRecordResult::End => {
+                                        done = true;
+                                    }
+                                }
+                            }
                         }
                     }
                 });

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -70,12 +70,12 @@ where
                             while !done {
 
                                 // Note that we protect the first element of `bounds`, a zero, so that ranges are easier to extract below.
-                                let (result, in_read, _out_wrote, ends_wrote) = csv_reader
+                                let (result, in_read, out_wrote, ends_wrote) = csv_reader
                                     .read_record(input, &mut buffer[buffer_valid..], &mut bounds[1+bounds_valid..]);
 
                                 // Advance buffers, as requested by return values.
                                 input = &input[in_read..];
-                                buffer_valid += _out_wrote;
+                                buffer_valid += out_wrote;
                                 bounds_valid += ends_wrote;
 
                                 match result {


### PR DESCRIPTION
This PR changes our CSV parsing from the `csv` crate to its underlying `csv-core` crate, which allows the re-use of a CSV parser across multiple lines.

Rough estimates are that for a simple task of loading and maintaining a count (meant to be minimal non-parsing work) the old code took ~160 seconds to process 8.75 million lines, whereas the new code now takes ~24 seconds.

fixes #2074 