### PR TITLE
misc: remove errant printlns

### DIFF
--- a/src/repr/scalar/datetime.rs
+++ b/src/repr/scalar/datetime.rs
@@ -2866,8 +2866,6 @@ mod test {
             match parse_timezone_offset_second(test.0) {
                 Ok(tz_offset) => {
                     let expected: i64 = test.1 as i64;
-
-                    println!("{} {}", expected, tz_offset);
                     assert_eq!(tz_offset, expected);
                 }
                 Err(e) => panic!(

--- a/src/repr/scalar/mod.rs
+++ b/src/repr/scalar/mod.rs
@@ -866,12 +866,6 @@ impl Interval {
                 self.duration = Duration::new(self.duration.as_secs(), nanos - remainder);
             }
             dhm => {
-                println!("self.duration.as_secs() {}", self.duration.as_secs());
-                println!("seconds_multiplier(dhm) {}", seconds_multiplier(dhm));
-                println!(
-                    "self.duration.as_secs() / seconds_multiplier(dhm) {}",
-                    self.duration.as_secs() - (self.duration.as_secs() % seconds_multiplier(dhm))
-                );
                 self.duration = Duration::new(
                     self.duration.as_secs() - self.duration.as_secs() % (seconds_multiplier(dhm)),
                     0,


### PR DESCRIPTION
@benesch Did a quick scan and also found one in `src/repr/scalar/datetime.rs` that `git blame`s you--lmk if that one should be left in, or if it's good to axe.