### PR TITLE
demo: add a low-memory option for the billing-demo

### DIFF
--- a/src/billing-demo/resources/views/drop_index_billing_raw_data.sql.in
+++ b/src/billing-demo/resources/views/drop_index_billing_raw_data.sql.in
@@ -1,0 +1,1 @@
+DROP INDEX billing_raw_data_primary_idx;

--- a/src/billing-demo/resources/views/drop_index_billing_records.sql.in
+++ b/src/billing-demo/resources/views/drop_index_billing_records.sql.in
@@ -1,0 +1,1 @@
+DROP INDEX billing_records_primary_idx;

--- a/src/billing-demo/src/config.rs
+++ b/src/billing-demo/src/config.rs
@@ -48,6 +48,10 @@ pub struct Args {
     /// Whether or not to delete the sources and views before starting
     #[structopt(long)]
     pub preserve_source: bool,
+
+    /// Whether or not to run the billing-demo in a low memory mode
+    #[structopt(long)]
+    pub low_memory: bool,
 }
 
 impl Args {
@@ -69,6 +73,7 @@ impl Args {
             kafka_topic: self.kafka_topic.clone(),
             csv_file_name: self.csv_file_name.clone(),
             preserve_source: self.preserve_source,
+            low_memory: self.low_memory,
         }
     }
 
@@ -94,4 +99,5 @@ pub struct MzConfig {
     pub kafka_topic: String,
     pub csv_file_name: String,
     pub preserve_source: bool,
+    pub low_memory: bool,
 }

--- a/src/billing-demo/src/main.rs
+++ b/src/billing-demo/src/main.rs
@@ -144,6 +144,10 @@ async fn create_materialized_source(config: MzConfig) -> Result<()> {
         exec_query!(client, "billing_agg_by_day");
         exec_query!(client, "billing_agg_by_month");
         exec_query!(client, "billing_monthly_statement");
+        if config.low_memory {
+            exec_query!(client, "drop_index_billing_raw_data");
+            exec_query!(client, "drop_index_billing_records");
+        }
     } else {
         log::info!(
             "source '{}' already exists, not recreating",


### PR DESCRIPTION
Rework of my previous approach -- now I've just added a flag that gets rid of the intermediate materializations in billing_raw_data and billing_records to free up RAM usage, but preserve the teachability of the previous setup 