### PR TITLE
sql: share and correct WITH option normalization

### DIFF
--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -7,13 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+
 use failure::bail;
 
 use catalog::names::{DatabaseSpecifier, FullName, PartialName};
 use ore::collections::CollectionExt;
 use repr::ColumnName;
 use sql_parser::ast::visit_mut::VisitMut;
-use sql_parser::ast::{Expr, Function, Ident, IfExistsBehavior, ObjectName, Statement, TableAlias};
+use sql_parser::ast::{
+    Expr, Function, Ident, IfExistsBehavior, ObjectName, SqlOption, Statement, TableAlias, Value,
+};
 
 use crate::statement::StatementContext;
 
@@ -55,6 +59,13 @@ pub fn object_name(mut name: ObjectName) -> Result<PartialName, failure::Error> 
     };
     assert!(name.0.is_empty());
     Ok(out)
+}
+
+pub fn with_options(options: &[SqlOption]) -> HashMap<String, Value> {
+    options
+        .iter()
+        .map(|o| (ident(o.name.clone()), o.value.clone()))
+        .collect()
 }
 
 pub fn unresolve(name: FullName) -> ObjectName {

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -11,7 +11,7 @@
 //!
 //! This module turns SQL `Statement`s into `Plan`s - commands which will drive the dataflow layer
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use failure::{bail, format_err, ResultExt};
 use itertools::Itertools;
@@ -815,10 +815,7 @@ pub async fn purify_statement(mut stmt: Statement) -> Result<Statement, failure:
         ..
     } = &mut stmt
     {
-        let with_options_map: HashMap<_, _> = with_options
-            .iter()
-            .map(|op| (op.name.value.to_ascii_lowercase(), op.value.clone()))
-            .collect();
+        let with_options_map = normalize::with_options(with_options);
 
         match connector {
             Connector::Kafka { broker, .. } if !broker.contains(':') => {
@@ -973,10 +970,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                 })
             };
 
-            let mut with_options: HashMap<_, _> = with_options
-                .iter()
-                .map(|op| (op.name.value.to_ascii_lowercase(), op.value.clone()))
-                .collect();
+            let mut with_options = normalize::with_options(with_options);
 
             let mut consistency = Consistency::RealTime;
             let (external_connector, encoding) = match connector {


### PR DESCRIPTION
Normalizing WITH options was not correctly accounting for double-quoted
option names. (Not that we use those, but it was a bug wating to be
discovered.) Also extract the code into a normalization routine so that
it is not duplicated in two places.