### PR TITLE
doc/user: update for v0.1.2

### DIFF
--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -5,9 +5,12 @@ menu: "main"
 weight: 2
 ---
 
-You can access Materialize through the `materialized` binary, which you can install on macOS and Linux.
+You can access Materialize through the `materialized` binary, which you can
+install on macOS and Linux. These instructions install the latest release of
+Materialize, **{{< version >}}**. For prior releases, see the [Versions
+page](../versions).
 
-**Note**: We have unofficial support for other operating systems, e.g. BSD, if you [build from source](#build-from-source).
+**Note**: We have unofficial support for other operating systems, e.g. FreeBSD, if you [build from source](#build-from-source).
 
 ## macOS installation
 
@@ -21,10 +24,8 @@ brew install MaterializeInc/materialize/materialized
 
 ### curl
 
-For `v0.1.0`, this method only works on macOS Catalina (10.15).
-
 ```shell
-curl -L https://downloads.mtrlz.dev/materialized-latest-x86_64-apple-darwin.tar.gz | tar -xzC /usr/local --strip-components=1
+curl -L https://downloads.mtrlz.dev/materialized-{{< version >}}-x86_64-apple-darwin.tar.gz | tar -xzC /usr/local --strip-components=1
 ```
 
 ## Linux installation
@@ -39,14 +40,27 @@ apt install materialized
 
 ### curl
 ```shell
-curl -L https://downloads.mtrlz.dev/materialized-latest-x86_64-unknown-linux-gnu.tar.gz | tar -xzC /usr/local --strip-components=1
+curl -L https://downloads.mtrlz.dev/materialized-{{< version >}}-x86_64-unknown-linux-gnu.tar.gz | tar -xzC /usr/local --strip-components=1
 ```
 
 ## Build from source
 
-Materialize is written in Rust, and relies on `cargo` to build binaries.
+Materialize is written in Rust and requires a recent Rust toolchain to build
+from source. Follow [Rust's getting started
+guide](https://www.rust-lang.org/learn/get-started) if you don't already have
+Rust installed.
 
-To build your own `materialized` binary, you can clone the [`MaterializeInc/materialize` repo from GitHub](https://github.com/materializeinc/materialize), and build it using `cargo build`.
+Then, to build your own `materialized` binary, you can clone the
+[`MaterializeInc/materialize` repo from GitHub](https://github.com/MaterializeInc/materialize),
+and build it using `cargo build`. Be sure to check out the tag for the correct
+release.
+
+```shell
+git clone https://github.com/MaterializeInc/materialize.git
+cd materialize
+git checkout {{< version >}}
+cargo build
+```
 
 ## Run the binary
 

--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -13,15 +13,53 @@ This page details changes between versions of Materialize, including:
 
 For information about available versions, see our [Versions page](../versions).
 
-## 0.1.0 &rarr; 0.1.1 (unreleased)
+## 0.1.1 &rarr; 0.1.2 (unreleased)
+<span id="v0.1.2"></span>
+
+- Change [`SHOW CREATE SOURCE`] to render the full SQL statement used to create
+  the source, in the style of [`SHOW CREATE VIEW`], rather than displaying a URL
+  that partially describes the source. The URL was a vestigial format used in
+  [`CREATE SOURCE`] statements before v0.1.0.
+
+- Raise the maximum SQL statement length from approximately 8KiB to
+  approximately 64MiB.
+
+- Support casts from [`text`] to [`date`], [`timestamp`], [`timestamptz`], and
+  [`interval`].
+
+- Support the `IF NOT EXISTS` clause in [`CREATE VIEW`] and
+  [`CREATE MATERIALIZED VIEW`].
+
+- Attempt to automatically increase the nofile rlimit to acceptable levels, as
+  creating multiple Kafka sources can quickly exhaust the default nofile rlimit
+  on some platforms.
+
+- Improve CSV parsing speed by 5-6x.
+
+[`CREATE SOURCE`]: ../sql/create-source
+[`SHOW CREATE SOURCE`]: ../sql/show-create-source
+[`SHOW CREATE VIEW`]: ../sql/show-create-view
+[`CREATE MATERIALIZED VIEW`]: ../sql/create-materialized-view
+[`CREATE VIEW`]: ../sql/create-view
+[`text`]: ../sql/types/text
+[`date`]: ../sql/types/date
+[`timestamp`]: ../sql/types/timestamp
+[`timestamptz`]: ../sql/types/timestamptz
+[`interval`]: ../sql/types/interval
+
+## 0.1.0 &rarr; 0.1.1
+<span id="v0.1.1"></span>
+
+* Specifying the message name in a Protobuf-formatted source no longer requires
+  a leading period.
 
 - **Indexes on sources**: You can now create and drop indexes on sources, which
   lets you automatically store all of a source's data in an index. Previously,
   you would have to create a source, and then create a materialized view that
   selected all of the source's content.
-- [`CREATE MATERIALIZED VIEW`](../sql/create-materialized-view) and [`CREATE VIEW`](../sql/create-view) now support the `IF NOT EXISTS` clause.
 
 ## _NULL_ &rarr; 0.1.0
+<span id="v0.1.1"></span>
 
 - [What is Materialize?](../overview/what-is-materialize/)
 - [Architecture overview](../overview/architecture/)

--- a/doc/user/versions.md
+++ b/doc/user/versions.md
@@ -5,13 +5,34 @@ menu: "main"
 weight: 80
 ---
 
-Type | Version | Binary links
------|---------|--------------
-**Latest release** | {{< version >}} | [Linux](https://downloads.mtrlz.dev/materialized-latest-x86_64-unknown-linux-gnu.tar.gz)/[macOS](https://downloads.mtrlz.dev/materialized-latest-x86_64-apple-darwin.tar.gz)
-**Up next (unreleased)** | {{< next_version >}} | Build from [source using `master`](../install/#build-from-source)
+## Stable releases
 
-## Binary links
+Binary tarballs for all stable releases are provided below. Other installation
+options are available for the latest stable release on the [Install
+page](../install).
 
-Version | Links
---------|------
-v0.1.0 | [Linux](https://downloads.mtrlz.dev/materialized-v0.1.0-x86_64-unknown-linux-gnu.tar.gz)/[macOS](https://downloads.mtrlz.dev/materialized-v0.1.0-x86_64-apple-darwin.tar.gz)
+{{< version-list >}}
+
+Binary tarballs require a recent version of their stated platform:
+
+* macOS binary tarballs require macOS 10.14 and later.
+* Linux binary tarballs require a glibc-based Linux distribution whose kernel
+  and glibc versions are compatible with Ubuntu Xenial. Glibc-based Linux
+  distributions released mid-2016 or later are likely to be compatible.
+
+## Unstable builds
+
+Binary tarballs are built for every merge to the [master branch on
+GitHub][github]. These tarballs are not suitable for use in production.
+**Run unstable builds at your own risk.**
+
+Version | Binary tarball links
+--------|---------------------
+master  | [Linux] / [macOS]
+
+The tarballs for other commits on master can be constructed by replacing
+`latest` in the links above with the full 40-character commit hash.
+
+[Linux]: http://downloads.mtrlz.dev/materialized-latest-x86_64-unknown-linux-gnu.tar.gz
+[macOS]: http://downloads.mtrlz.dev/materialized-latest-x86_64-apple-darwin.tar.gz
+[github]: https://github.com/MaterializeInc/materialize

--- a/www/assets/sass/_docs_body.scss
+++ b/www/assets/sass/_docs_body.scss
@@ -123,7 +123,8 @@ main {
   }
 
   h4 {
-    margin-top: 4rem;
+    font-size: 1.6rem;
+    margin-top: 2rem;
     a {
       color: black !important;
     }

--- a/www/config.toml
+++ b/www/config.toml
@@ -6,8 +6,12 @@ pygmentsStyle = "xcode"
 disableKinds = ["home"]
 
 [params]
-  current_version = "v0.1.0"
-  next_version = "v0.1.1"
+  # Keep the releases in reverse order of their release date. The first release
+  # in the list is assumed to be the most recent.
+  versions = [
+      { name = "v0.1.1", date = "22 February 2020" },
+      { name = "v0.1.0", date = "13 February 2020" }
+  ]
 
 [menu]
     [[menu.main]]

--- a/www/layouts/shortcodes/next_version.html
+++ b/www/layouts/shortcodes/next_version.html
@@ -1,1 +1,0 @@
-{{ $.Site.Params.next_version -}}

--- a/www/layouts/shortcodes/version-list.html
+++ b/www/layouts/shortcodes/version-list.html
@@ -1,0 +1,22 @@
+<table>
+  <thead>
+    <th>Version</th>
+    <th>Release date</th>
+    <th>Binary tarball links</th>
+  </thead>
+
+  <tbody>
+    {{range $_, $version := .Site.Params.Versions}}
+      <tr>
+        <td>
+          <strong><a href="../release-notes/#{{$version.name}}">{{$version.name}}</a></strong>
+        </td>
+        <td>{{$version.date}}</td>
+        <td>
+          <a href="https://downloads.mtrlz.dev/materialized-{{$version.name}}-x86_64-unknown-linux-gnu.tar.gz">Linux</a>
+          /
+          <a href="https://downloads.mtrlz.dev/materialized-{{$version.name}}-x86_64-apple-darwin.tar.gz">macOS</a>
+        </td>
+    {{end}}
+  </tbody>
+</table>

--- a/www/layouts/shortcodes/version.html
+++ b/www/layouts/shortcodes/version.html
@@ -1,1 +1,1 @@
-{{ $.Site.Params.current_version -}}
+{{ (index $.Site.Params.versions 0).name -}}


### PR DESCRIPTION
This adds release notes for v0.1.2, and additionally fixes several links
that were pointing folks at the latest master version, rather than the
latest stable version.