### PR TITLE
Reduce the application of simplification

### DIFF
--- a/src/expr/transform/simplify.rs
+++ b/src/expr/transform/simplify.rs
@@ -139,10 +139,7 @@ impl SimplifyFilterPredicates {
                                 support2.insert(input_relation[*i]);
                             }
                         });
-                        if support1.len() == 1
-                            && support2.len() == 1
-                            && !support1.iter().any(|c| support2.contains(c))
-                        {
+                        if support1.len() == 1 && support2.len() == 1 && support1 != support2 {
                             match (
                                 supports_complex_equality_on_input(&*expr1, &input_relation),
                                 supports_complex_equality_on_input(&*expr2, &input_relation),

--- a/src/expr/transform/simplify.rs
+++ b/src/expr/transform/simplify.rs
@@ -42,7 +42,7 @@
 //! let complex_equality = ScalarExpr::Column(0).call_binary(ScalarExpr::Column(0), BinaryFunc::Eq);
 //! let mut relation = RelationExpr::filter(
 //!     join,
-//!     vec![ScalarExpr::Column(1).call_binary(complex_equality.clone(), BinaryFunc::Eq)]
+//!     vec![ScalarExpr::Column(2).call_binary(complex_equality.clone(), BinaryFunc::Eq)]
 //! );
 //!
 //! SimplifyFilterPredicates.transform(&mut relation);
@@ -54,7 +54,7 @@
 //! //             pointing to the newly Map-ped column
 //! //     2) The whole RelationExpr to be wrapped in a Project to remove the newly Map-ped column
 //! let expected_join = RelationExpr::join(vec![input0.map(vec![complex_equality]), input1], vec![vec![]]);
-//! let updated_equality = ScalarExpr::Column(1).call_binary(ScalarExpr::Column(2), BinaryFunc::Eq);
+//! let updated_equality = ScalarExpr::Column(3).call_binary(ScalarExpr::Column(2), BinaryFunc::Eq);
 //! let expected_relation = expected_join.filter(vec![updated_equality]).project(vec![0, 1, 3, 4]);
 //!
 //! assert_eq!(relation, expected_relation);


### PR DESCRIPTION
This PR restricts the application of the simplification transformation (which unpacks equality predicates on complex expressions, so that they can be used as join keys). It now ensures that it is only applied when each of the two expressions in an equality depend on exactly one input collection and the two are not the same input collection (otherwise, the constraint can, and probably should, but pushed down into that collection).

Changes are much smaller with whitespace ignored. Lots of code got one additional indentation level.

fixes #761