### PR TITLE
docs: add integration section with docker details

### DIFF
--- a/doc/user/demos/business-intelligence.md
+++ b/doc/user/demos/business-intelligence.md
@@ -109,7 +109,8 @@ Metabase](/images/demos/bi_architecture_diagram.png)
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine.
+1. Start the Docker daemon for your machine, and [follow our Docker integration
+   guide](../../integrations/docker).
 
 1. Clone the Materialize repo:
 

--- a/doc/user/demos/log-parsing.md
+++ b/doc/user/demos/log-parsing.md
@@ -237,7 +237,8 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine.
+1. Start the Docker daemon for your machine, and [follow our Docker integration
+   guide](../../integrations/docker).
 
 1. Clone the Materialize repo:
 

--- a/doc/user/demos/microservice.md
+++ b/doc/user/demos/microservice.md
@@ -411,7 +411,8 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine.
+1. Start the Docker daemon for your machine, and [follow our Docker integration
+   guide](../../integrations/docker).
 
 1. Clone the Materialize repo:
 

--- a/doc/user/third-party/_index.md
+++ b/doc/user/third-party/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Third-Party Tools"
+description: "Find details about using Materialize with other tools."
+disable_toc: true
+---

--- a/doc/user/third-party/docker.md
+++ b/doc/user/third-party/docker.md
@@ -1,0 +1,28 @@
+---
+title: "Using Docker"
+description: "Get details about using Materialize with Docker"
+menu:
+  main:
+    parent: 'third-party'
+---
+
+Many of our demos rely on Docker and Docker Compose to make it easy to deploy
+Materialize, along with any other infrastructure the demo needs.
+
+For the best experience using Docker, we recommend following the guidelines
+outlined here.
+
+### Increase Docker Memory
+
+Because many of our Docker-based demos leverage a large number of pieces of
+infrastructure, we recommend running Docker with at least **8 GB** of memory.
+
+On macOS:
+
+1. Open **Docker for Mac**'s **Preferences** window.
+1. Click **Resources**.
+1. Click **Advanced**.
+1. Move the **Memory** slider to at least **8.00 GB**.
+1. Click **Apply & Restart**.
+
+Note that on Linux, Docker automatically shares memory with the host machines; as long as your host machine has more than 8 GB of memory, you shouldn't run into issues.

--- a/www/config.toml
+++ b/www/config.toml
@@ -42,7 +42,12 @@ disableKinds = ["home"]
     [[menu.main]]
     identifier = "demos"
     name = "Demos"
-    weight = 30
+    weight = 40
+
+    [[menu.main]]
+    identifier = "third-party"
+    name = "Third-Party Tools"
+    weight = 50
 
 [markup.goldmark.renderer]
 # allow <a name="link-target">, the old syntax no longer works


### PR DESCRIPTION
@quodlibetor What do you think of something like this as an approach for the Docker docs you mentioned in #2014 ? This seems like it'll be extensible/flexible, e.g.  I was keeping the fact that we might need to start including more details for things like Debezium in mind. However, I don't know if the notion of "integration" is really the right thing.

Fixes #2014