### PR TITLE
expr: propagate errors through evaluation and optimization

### DIFF
--- a/src/dataflow/render/delta_join.rs
+++ b/src/dataflow/render/delta_join.rs
@@ -339,13 +339,16 @@ where
         let temp_storage = repr::RowArena::new();
         updates.filter(move |input_row| {
             let datums = input_row.unpack();
-            ready_to_go.iter().all(
-                |predicate| match predicate.eval(&datums, &env, &temp_storage) {
+            ready_to_go.iter().all(|predicate| {
+                match predicate
+                    .eval(&datums, &env, &temp_storage)
+                    .unwrap_or(Datum::Null)
+                {
                     Datum::True => true,
                     Datum::False | Datum::Null => false,
                     _ => unreachable!(),
-                },
-            )
+                }
+            })
         })
     }
 }

--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -80,11 +80,9 @@ where
                             let temp_storage = RowArena::new();
                             let datums = row.unpack();
                             (
-                                Row::pack(
-                                    group_key
-                                        .iter()
-                                        .map(|i| i.eval(&datums, &env, &temp_storage)),
-                                ),
+                                Row::pack(group_key.iter().map(|i| {
+                                    i.eval(&datums, &env, &temp_storage).unwrap_or(Datum::Null)
+                                })),
                                 (),
                             )
                         }
@@ -180,9 +178,12 @@ where
                 Row::pack(
                     group_key
                         .iter()
-                        .map(|i| i.eval(&datums, &env, &temp_storage)),
+                        .map(|i| i.eval(&datums, &env, &temp_storage).unwrap_or(Datum::Null)),
                 ),
-                Row::pack(Some(expr.eval(&datums, &env, &temp_storage))),
+                Row::pack(Some(
+                    expr.eval(&datums, &env, &temp_storage)
+                        .unwrap_or(Datum::Null),
+                )),
             )
         }
     });

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -807,7 +807,10 @@ impl PendingPeek {
                 // we have, let's eliminate rows that we don't care about.
                 if self.filter.iter().all(|predicate| {
                     let temp_storage = RowArena::new();
-                    predicate.eval(&datums, &self.eval_env, &temp_storage) == Datum::True
+                    predicate
+                        .eval(&datums, &self.eval_env, &temp_storage)
+                        .unwrap_or(Datum::Null)
+                        == Datum::True
                 }) {
                     // Differential dataflow represents collections with binary counts,
                     // but our output representation is unary (as many rows as reported

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -325,7 +325,8 @@ impl std::fmt::Display for ScalarExpr {
         use ScalarExpr::*;
         match self {
             Column(i) => write!(f, "#{}", i)?,
-            Literal(row, _) => write!(f, "{}", row.unpack_first())?,
+            Literal(Ok(row), _) => write!(f, "{}", row.unpack_first())?,
+            Literal(Err(e), _) => write!(f, "(err: {})", e)?,
             CallNullary(func) => write!(f, "{}()", func)?,
             CallUnary { func, expr } => {
                 write!(f, "{}({})", func, expr)?;

--- a/src/expr/relation/func.rs
+++ b/src/expr/relation/func.rs
@@ -375,18 +375,28 @@ fn any<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    datums
-        .into_iter()
-        .fold(Datum::False, |a, b| crate::scalar::func::or(a, b))
+    for d in datums {
+        match d {
+            Datum::Null | Datum::True => return d,
+            Datum::False => (),
+            _ => unreachable!(),
+        }
+    }
+    Datum::False
 }
 
 fn all<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    datums
-        .into_iter()
-        .fold(Datum::True, |a, b| crate::scalar::func::and(a, b))
+    for d in datums {
+        match d {
+            Datum::Null | Datum::False => return d,
+            Datum::True => (),
+            _ => unreachable!(),
+        }
+    }
+    Datum::True
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -23,7 +23,7 @@ use repr::regex::Regex;
 use repr::{strconv, ColumnType, Datum, RowArena, RowPacker, ScalarType};
 
 use crate::scalar::func::format::DateTimeFormat;
-use crate::{like_pattern, EvalEnv, EvalError};
+use crate::{like_pattern, EvalEnv, EvalError, ScalarExpr};
 
 mod format;
 
@@ -36,6 +36,7 @@ pub enum NullaryFunc {
 impl NullaryFunc {
     pub fn eval<'a>(
         &'a self,
+        _datums: &[Datum<'a>],
         env: &'a EvalEnv,
         _temp_storage: &'a RowArena,
     ) -> Result<Datum<'a>, EvalError> {
@@ -73,25 +74,29 @@ fn now(env: &EvalEnv) -> Datum<'static> {
     Datum::from(env.wall_time.expect("now missing wall time in env"))
 }
 
-pub fn and<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
-    match (a, b) {
-        (Datum::False, _) => Datum::False,
-        (_, Datum::False) => Datum::False,
-        (Datum::Null, _) => Datum::Null,
-        (_, Datum::Null) => Datum::Null,
-        (Datum::True, Datum::True) => Datum::True,
-        _ => unreachable!(),
+pub fn and<'a>(
+    datums: &[Datum<'a>],
+    env: &'a EvalEnv,
+    temp_storage: &'a RowArena,
+    a_expr: &'a ScalarExpr,
+    b_expr: &'a ScalarExpr,
+) -> Datum<'a> {
+    match a_expr.eval(datums, env, temp_storage) {
+        Datum::True => b_expr.eval(datums, env, temp_storage),
+        d => d,
     }
 }
 
-pub fn or<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
-    match (a, b) {
-        (Datum::True, _) => Datum::True,
-        (_, Datum::True) => Datum::True,
-        (Datum::Null, _) => Datum::Null,
-        (_, Datum::Null) => Datum::Null,
-        (Datum::False, Datum::False) => Datum::False,
-        _ => unreachable!(),
+pub fn or<'a>(
+    datums: &[Datum<'a>],
+    env: &'a EvalEnv,
+    temp_storage: &'a RowArena,
+    a_expr: &'a ScalarExpr,
+    b_expr: &'a ScalarExpr,
+) -> Datum<'a> {
+    match a_expr.eval(datums, env, temp_storage) {
+        Datum::False => b_expr.eval(datums, env, temp_storage),
+        d => d,
     }
 }
 
@@ -1612,75 +1617,87 @@ impl FromStr for DateTruncTo {
 impl BinaryFunc {
     pub fn eval<'a>(
         &'a self,
-        a: Datum<'a>,
-        b: Datum<'a>,
-        _env: &'a EvalEnv,
+        datums: &[Datum<'a>],
+        env: &'a EvalEnv,
         temp_storage: &'a RowArena,
+        a_expr: &'a ScalarExpr,
+        b_expr: &'a ScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
+        macro_rules! eager {
+            ($func:ident $(, $args:expr)*) => {{
+                let a = a_expr.eval(datums, env, temp_storage);
+                let b = b_expr.eval(datums, env, temp_storage);
+                if self.propagates_nulls() && (a.is_null() || b.is_null()) {
+                    return Ok(Datum::Null);
+                }
+                $func(a, b $(, $args)*)
+            }}
+        }
+
         match self {
-            BinaryFunc::And => Ok(and(a, b)),
-            BinaryFunc::Or => Ok(or(a, b)),
-            BinaryFunc::AddInt32 => Ok(add_int32(a, b)),
-            BinaryFunc::AddInt64 => Ok(add_int64(a, b)),
-            BinaryFunc::AddFloat32 => Ok(add_float32(a, b)),
-            BinaryFunc::AddFloat64 => Ok(add_float64(a, b)),
-            BinaryFunc::AddTimestampInterval => Ok(add_timestamp_interval(a, b)),
-            BinaryFunc::AddTimestampTzInterval => Ok(add_timestamptz_interval(a, b)),
-            BinaryFunc::AddDateTime => Ok(add_date_time(a, b)),
-            BinaryFunc::AddDateInterval => Ok(add_date_interval(a, b)),
-            BinaryFunc::AddTimeInterval => Ok(add_time_interval(a, b)),
-            BinaryFunc::AddDecimal => Ok(add_decimal(a, b)),
-            BinaryFunc::AddInterval => Ok(add_interval(a, b)),
-            BinaryFunc::SubInt32 => Ok(sub_int32(a, b)),
-            BinaryFunc::SubInt64 => Ok(sub_int64(a, b)),
-            BinaryFunc::SubFloat32 => Ok(sub_float32(a, b)),
-            BinaryFunc::SubFloat64 => Ok(sub_float64(a, b)),
-            BinaryFunc::SubTimestamp => Ok(sub_timestamp(a, b)),
-            BinaryFunc::SubTimestampTz => Ok(sub_timestamptz(a, b)),
-            BinaryFunc::SubTimestampInterval => Ok(sub_timestamp_interval(a, b)),
-            BinaryFunc::SubTimestampTzInterval => Ok(sub_timestamptz_interval(a, b)),
-            BinaryFunc::SubInterval => Ok(sub_interval(a, b)),
-            BinaryFunc::SubDate => Ok(sub_date(a, b)),
-            BinaryFunc::SubDateInterval => Ok(sub_date_interval(a, b)),
-            BinaryFunc::SubTime => Ok(sub_time(a, b)),
-            BinaryFunc::SubTimeInterval => Ok(sub_time_interval(a, b)),
-            BinaryFunc::SubDecimal => Ok(sub_decimal(a, b)),
-            BinaryFunc::MulInt32 => Ok(mul_int32(a, b)),
-            BinaryFunc::MulInt64 => Ok(mul_int64(a, b)),
-            BinaryFunc::MulFloat32 => Ok(mul_float32(a, b)),
-            BinaryFunc::MulFloat64 => Ok(mul_float64(a, b)),
-            BinaryFunc::MulDecimal => Ok(mul_decimal(a, b)),
-            BinaryFunc::DivInt32 => div_int32(a, b),
-            BinaryFunc::DivInt64 => div_int64(a, b),
-            BinaryFunc::DivFloat32 => div_float32(a, b),
-            BinaryFunc::DivFloat64 => div_float64(a, b),
-            BinaryFunc::DivDecimal => div_decimal(a, b),
-            BinaryFunc::ModInt32 => mod_int32(a, b),
-            BinaryFunc::ModInt64 => mod_int64(a, b),
-            BinaryFunc::ModFloat32 => mod_float32(a, b),
-            BinaryFunc::ModFloat64 => mod_float64(a, b),
-            BinaryFunc::ModDecimal => mod_decimal(a, b),
-            BinaryFunc::Eq => Ok(eq(a, b)),
-            BinaryFunc::NotEq => Ok(not_eq(a, b)),
-            BinaryFunc::Lt => Ok(lt(a, b)),
-            BinaryFunc::Lte => Ok(lte(a, b)),
-            BinaryFunc::Gt => Ok(gt(a, b)),
-            BinaryFunc::Gte => Ok(gte(a, b)),
-            BinaryFunc::MatchLikePattern => match_like_pattern(a, b),
-            BinaryFunc::ToCharTimestamp => Ok(to_char_timestamp(a, b, temp_storage)),
-            BinaryFunc::ToCharTimestampTz => Ok(to_char_timestamptz(a, b, temp_storage)),
-            BinaryFunc::DateTrunc => date_trunc(a, b),
-            BinaryFunc::CastFloat32ToDecimal => cast_float32_to_decimal(a, b),
-            BinaryFunc::CastFloat64ToDecimal => cast_float64_to_decimal(a, b),
-            BinaryFunc::TextConcat => Ok(text_concat_binary(a, b, temp_storage)),
-            BinaryFunc::JsonbGetInt64 => Ok(jsonb_get_int64(a, b)),
-            BinaryFunc::JsonbGetString => Ok(jsonb_get_string(a, b)),
-            BinaryFunc::JsonbContainsString => Ok(jsonb_contains_string(a, b)),
-            BinaryFunc::JsonbConcat => Ok(jsonb_concat(a, b, temp_storage)),
-            BinaryFunc::JsonbContainsJsonb => Ok(jsonb_contains_jsonb(a, b)),
-            BinaryFunc::JsonbDeleteInt64 => Ok(jsonb_delete_int64(a, b, temp_storage)),
-            BinaryFunc::JsonbDeleteString => Ok(jsonb_delete_string(a, b, temp_storage)),
-            BinaryFunc::RoundDecimal(scale) => Ok(round_decimal(a, b, *scale)),
+            BinaryFunc::And => Ok(and(datums, env, temp_storage, a_expr, b_expr)),
+            BinaryFunc::Or => Ok(or(datums, env, temp_storage, a_expr, b_expr)),
+            BinaryFunc::AddInt32 => Ok(eager!(add_int32)),
+            BinaryFunc::AddInt64 => Ok(eager!(add_int64)),
+            BinaryFunc::AddFloat32 => Ok(eager!(add_float32)),
+            BinaryFunc::AddFloat64 => Ok(eager!(add_float64)),
+            BinaryFunc::AddTimestampInterval => Ok(eager!(add_timestamp_interval)),
+            BinaryFunc::AddTimestampTzInterval => Ok(eager!(add_timestamptz_interval)),
+            BinaryFunc::AddDateTime => Ok(eager!(add_date_time)),
+            BinaryFunc::AddDateInterval => Ok(eager!(add_date_interval)),
+            BinaryFunc::AddTimeInterval => Ok(eager!(add_time_interval)),
+            BinaryFunc::AddDecimal => Ok(eager!(add_decimal)),
+            BinaryFunc::AddInterval => Ok(eager!(add_interval)),
+            BinaryFunc::SubInt32 => Ok(eager!(sub_int32)),
+            BinaryFunc::SubInt64 => Ok(eager!(sub_int64)),
+            BinaryFunc::SubFloat32 => Ok(eager!(sub_float32)),
+            BinaryFunc::SubFloat64 => Ok(eager!(sub_float64)),
+            BinaryFunc::SubTimestamp => Ok(eager!(sub_timestamp)),
+            BinaryFunc::SubTimestampTz => Ok(eager!(sub_timestamptz)),
+            BinaryFunc::SubTimestampInterval => Ok(eager!(sub_timestamp_interval)),
+            BinaryFunc::SubTimestampTzInterval => Ok(eager!(sub_timestamptz_interval)),
+            BinaryFunc::SubInterval => Ok(eager!(sub_interval)),
+            BinaryFunc::SubDate => Ok(eager!(sub_date)),
+            BinaryFunc::SubDateInterval => Ok(eager!(sub_date_interval)),
+            BinaryFunc::SubTime => Ok(eager!(sub_time)),
+            BinaryFunc::SubTimeInterval => Ok(eager!(sub_time_interval)),
+            BinaryFunc::SubDecimal => Ok(eager!(sub_decimal)),
+            BinaryFunc::MulInt32 => Ok(eager!(mul_int32)),
+            BinaryFunc::MulInt64 => Ok(eager!(mul_int64)),
+            BinaryFunc::MulFloat32 => Ok(eager!(mul_float32)),
+            BinaryFunc::MulFloat64 => Ok(eager!(mul_float64)),
+            BinaryFunc::MulDecimal => Ok(eager!(mul_decimal)),
+            BinaryFunc::DivInt32 => eager!(div_int32),
+            BinaryFunc::DivInt64 => eager!(div_int64),
+            BinaryFunc::DivFloat32 => eager!(div_float32),
+            BinaryFunc::DivFloat64 => eager!(div_float64),
+            BinaryFunc::DivDecimal => eager!(div_decimal),
+            BinaryFunc::ModInt32 => eager!(mod_int32),
+            BinaryFunc::ModInt64 => eager!(mod_int64),
+            BinaryFunc::ModFloat32 => eager!(mod_float32),
+            BinaryFunc::ModFloat64 => eager!(mod_float64),
+            BinaryFunc::ModDecimal => eager!(mod_decimal),
+            BinaryFunc::Eq => Ok(eager!(eq)),
+            BinaryFunc::NotEq => Ok(eager!(not_eq)),
+            BinaryFunc::Lt => Ok(eager!(lt)),
+            BinaryFunc::Lte => Ok(eager!(lte)),
+            BinaryFunc::Gt => Ok(eager!(gt)),
+            BinaryFunc::Gte => Ok(eager!(gte)),
+            BinaryFunc::MatchLikePattern => eager!(match_like_pattern),
+            BinaryFunc::ToCharTimestamp => Ok(eager!(to_char_timestamp, temp_storage)),
+            BinaryFunc::ToCharTimestampTz => Ok(eager!(to_char_timestamptz, temp_storage)),
+            BinaryFunc::DateTrunc => eager!(date_trunc),
+            BinaryFunc::CastFloat32ToDecimal => eager!(cast_float32_to_decimal),
+            BinaryFunc::CastFloat64ToDecimal => eager!(cast_float64_to_decimal),
+            BinaryFunc::TextConcat => Ok(eager!(text_concat_binary, temp_storage)),
+            BinaryFunc::JsonbGetInt64 => Ok(eager!(jsonb_get_int64)),
+            BinaryFunc::JsonbGetString => Ok(eager!(jsonb_get_string)),
+            BinaryFunc::JsonbContainsString => Ok(eager!(jsonb_contains_string)),
+            BinaryFunc::JsonbConcat => Ok(eager!(jsonb_concat, temp_storage)),
+            BinaryFunc::JsonbContainsJsonb => Ok(eager!(jsonb_contains_jsonb)),
+            BinaryFunc::JsonbDeleteInt64 => Ok(eager!(jsonb_delete_int64, temp_storage)),
+            BinaryFunc::JsonbDeleteString => Ok(eager!(jsonb_delete_string, temp_storage)),
+            BinaryFunc::RoundDecimal(scale) => Ok(eager!(round_decimal, *scale)),
         }
     }
 
@@ -2073,10 +2090,16 @@ pub enum UnaryFunc {
 impl UnaryFunc {
     pub fn eval<'a>(
         &'a self,
-        a: Datum<'a>,
-        _env: &'a EvalEnv,
+        datums: &[Datum<'a>],
+        env: &'a EvalEnv,
         temp_storage: &'a RowArena,
+        a: &'a ScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
+        let a = a.eval(datums, env, temp_storage);
+        if self.propagates_nulls() && a.is_null() {
+            return Ok(Datum::Null);
+        }
+
         match self {
             UnaryFunc::Not => Ok(not(a)),
             UnaryFunc::IsNull => Ok(is_null(a)),
@@ -2525,11 +2548,16 @@ impl fmt::Display for UnaryFunc {
     }
 }
 
-fn coalesce<'a>(datums: &[Datum<'a>]) -> Datum<'a> {
-    datums
+fn coalesce<'a>(
+    datums: &[Datum<'a>],
+    env: &'a EvalEnv,
+    temp_storage: &'a RowArena,
+    exprs: &'a [ScalarExpr],
+) -> Datum<'a> {
+    exprs
         .iter()
+        .map(|e| e.eval(datums, env, temp_storage))
         .find(|d| !d.is_null())
-        .cloned()
         .unwrap_or(Datum::Null)
 }
 
@@ -2698,18 +2726,29 @@ impl VariadicFunc {
     pub fn eval<'a>(
         &'a self,
         datums: &[Datum<'a>],
-        _env: &'a EvalEnv,
+        env: &'a EvalEnv,
         temp_storage: &'a RowArena,
+        exprs: &'a [ScalarExpr],
     ) -> Result<Datum<'a>, EvalError> {
+        macro_rules! eager {
+            ($func:ident $(, $args:expr)*) => {{
+                let ds: Vec<_> = exprs.iter().map(|e| e.eval(datums, env, temp_storage)).collect();
+                if self.propagates_nulls() && ds.iter().any(|d| d.is_null()) {
+                    return Ok(Datum::Null);
+                }
+                $func(&ds $(, $args)*)
+            }}
+        }
+
         match self {
-            VariadicFunc::Coalesce => Ok(coalesce(datums)),
-            VariadicFunc::Concat => Ok(text_concat_variadic(datums, temp_storage)),
-            VariadicFunc::MakeTimestamp => Ok(make_timestamp(datums)),
-            VariadicFunc::Substr => Ok(substr(datums)),
-            VariadicFunc::LengthString => length_string(datums),
-            VariadicFunc::Replace => Ok(replace(datums, temp_storage)),
-            VariadicFunc::JsonbBuildArray => Ok(jsonb_build_array(datums, temp_storage)),
-            VariadicFunc::JsonbBuildObject => Ok(jsonb_build_object(datums, temp_storage)),
+            VariadicFunc::Coalesce => Ok(coalesce(datums, env, temp_storage, exprs)),
+            VariadicFunc::Concat => Ok(eager!(text_concat_variadic, temp_storage)),
+            VariadicFunc::MakeTimestamp => Ok(eager!(make_timestamp)),
+            VariadicFunc::Substr => Ok(eager!(substr)),
+            VariadicFunc::LengthString => eager!(length_string),
+            VariadicFunc::Replace => Ok(eager!(replace, temp_storage)),
+            VariadicFunc::JsonbBuildArray => Ok(eager!(jsonb_build_array, temp_storage)),
+            VariadicFunc::JsonbBuildObject => Ok(eager!(jsonb_build_object, temp_storage)),
         }
     }
 

--- a/src/expr/scalar/mod.rs
+++ b/src/expr/scalar/mod.rs
@@ -27,7 +27,7 @@ pub enum ScalarExpr {
     Column(usize),
     /// A literal value.
     /// (Stored as a row, because we can't own a Datum)
-    Literal(Row, ColumnType),
+    Literal(Result<Row, EvalError>, ColumnType),
     /// A function call that takes no arguments.
     CallNullary(NullaryFunc),
     /// A function call that takes one expression as an argument.
@@ -62,13 +62,17 @@ impl ScalarExpr {
         ScalarExpr::Column(column)
     }
 
-    pub fn literal(datum: Datum, typ: ColumnType) -> Self {
-        let row = Row::pack(&[datum]);
+    pub fn literal(res: Result<Datum, EvalError>, typ: ColumnType) -> Self {
+        let row = res.map(|datum| Row::pack(&[datum]));
         ScalarExpr::Literal(row, typ)
     }
 
+    pub fn literal_ok(datum: Datum, typ: ColumnType) -> Self {
+        ScalarExpr::literal(Ok(datum), typ)
+    }
+
     pub fn literal_null(typ: ColumnType) -> Self {
-        ScalarExpr::literal(Datum::Null, typ)
+        ScalarExpr::literal_ok(Datum::Null, typ)
     }
 
     pub fn call_unary(self, func: UnaryFunc) -> Self {
@@ -192,16 +196,13 @@ impl ScalarExpr {
     pub fn take(&mut self) -> Self {
         mem::replace(
             self,
-            ScalarExpr::Literal(
-                Row::pack(&[Datum::Null]),
-                ColumnType::new(ScalarType::Unknown),
-            ),
+            ScalarExpr::literal_null(ColumnType::new(ScalarType::Unknown)),
         )
     }
 
-    pub fn as_literal(&self) -> Option<Datum> {
-        if let ScalarExpr::Literal(row, _column_type) = self {
-            Some(row.unpack_first())
+    pub fn as_literal(&self) -> Option<Result<Datum, &EvalError>> {
+        if let ScalarExpr::Literal(lit, _column_type) = self {
+            Some(lit.as_ref().map(|row| row.unpack_first()))
         } else {
             None
         }
@@ -217,21 +218,35 @@ impl ScalarExpr {
 
     pub fn as_literal_str(&self) -> Option<&str> {
         match self.as_literal() {
-            Some(Datum::String(s)) => Some(s),
+            Some(Ok(Datum::String(s))) => Some(s),
             _ => None,
         }
     }
 
     pub fn is_literal_true(&self) -> bool {
-        Some(Datum::True) == self.as_literal()
+        Some(Ok(Datum::True)) == self.as_literal()
     }
 
     pub fn is_literal_false(&self) -> bool {
-        Some(Datum::False) == self.as_literal()
+        Some(Ok(Datum::False)) == self.as_literal()
     }
 
     pub fn is_literal_null(&self) -> bool {
-        Some(Datum::Null) == self.as_literal()
+        Some(Ok(Datum::Null)) == self.as_literal()
+    }
+
+    pub fn is_literal_ok(&self) -> bool {
+        match self {
+            ScalarExpr::Literal(Ok(_), _typ) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_literal_err(&self) -> bool {
+        match self {
+            ScalarExpr::Literal(Err(_), _typ) => true,
+            _ => false,
+        }
     }
 
     /// Reduces a complex expression where possible.
@@ -241,8 +256,8 @@ impl ScalarExpr {
     /// use repr::{ColumnType, Datum, RelationType, ScalarType};
     ///
     /// let expr_0 = ScalarExpr::Column(0);
-    /// let expr_t = ScalarExpr::literal(Datum::True, ColumnType::new(ScalarType::Bool));
-    /// let expr_f = ScalarExpr::literal(Datum::False, ColumnType::new(ScalarType::Bool));
+    /// let expr_t = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool));
+    /// let expr_f = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
     ///
     /// let mut test =
     /// expr_t
@@ -276,6 +291,10 @@ impl ScalarExpr {
                     && func.propagates_nulls()
                 {
                     *e = ScalarExpr::literal_null(e.typ(relation_type));
+                } else if expr1.is_literal_err() {
+                    *e = expr1.take();
+                } else if expr2.is_literal_err() {
+                    *e = expr2.take();
                 } else if *func == BinaryFunc::MatchLikePattern && expr2.is_literal() {
                     // We can at least precompile the regex.
                     let pattern = expr2.as_literal_str().unwrap();
@@ -313,11 +332,14 @@ impl ScalarExpr {
                     *e = eval(e);
                 } else if func.propagates_nulls() && exprs.iter().any(|e| e.is_literal_null()) {
                     *e = ScalarExpr::literal_null(e.typ(&relation_type));
+                } else if let Some(err_expr) = exprs.iter_mut().find(|e| e.is_literal_err()) {
+                    *e = err_expr.take();
                 }
             }
             ScalarExpr::If { cond, then, els } => match cond.as_literal() {
-                Some(Datum::True) => *e = then.take(),
-                Some(Datum::False) | Some(Datum::Null) => *e = els.take(),
+                Some(Ok(Datum::True)) => *e = then.take(),
+                Some(Ok(Datum::False)) | Some(Ok(Datum::Null)) => *e = els.take(),
+                Some(Err(_)) => *e = cond.take(),
                 Some(_) => unreachable!(),
                 None => (),
             },
@@ -384,23 +406,20 @@ impl ScalarExpr {
         datums: &[Datum<'a>],
         env: &'a EvalEnv,
         temp_storage: &'a RowArena,
-    ) -> Datum<'a> {
+    ) -> Result<Datum<'a>, EvalError> {
         match self {
-            ScalarExpr::Column(index) => datums[*index].clone(),
-            ScalarExpr::Literal(row, _column_type) => row.unpack_first(),
-            ScalarExpr::CallNullary(func) => {
-                func.eval(datums, env, temp_storage).unwrap_or(Datum::Null)
+            ScalarExpr::Column(index) => Ok(datums[*index].clone()),
+            ScalarExpr::Literal(res, _column_type) => match res {
+                Ok(row) => Ok(row.unpack_first()),
+                Err(e) => Err(e.clone()),
+            },
+            ScalarExpr::CallNullary(func) => func.eval(datums, env, temp_storage),
+            ScalarExpr::CallUnary { func, expr } => func.eval(datums, env, temp_storage, expr),
+            ScalarExpr::CallBinary { func, expr1, expr2 } => {
+                func.eval(datums, env, temp_storage, expr1, expr2)
             }
-            ScalarExpr::CallUnary { func, expr } => func
-                .eval(datums, env, temp_storage, expr)
-                .unwrap_or(Datum::Null),
-            ScalarExpr::CallBinary { func, expr1, expr2 } => func
-                .eval(datums, env, temp_storage, expr1, expr2)
-                .unwrap_or(Datum::Null),
-            ScalarExpr::CallVariadic { func, exprs } => func
-                .eval(datums, env, temp_storage, exprs)
-                .unwrap_or(Datum::Null),
-            ScalarExpr::If { cond, then, els } => match cond.eval(datums, env, temp_storage) {
+            ScalarExpr::CallVariadic { func, exprs } => func.eval(datums, env, temp_storage, exprs),
+            ScalarExpr::If { cond, then, els } => match cond.eval(datums, env, temp_storage)? {
                 Datum::True => then.eval(datums, env, temp_storage),
                 Datum::False | Datum::Null => els.eval(datums, env, temp_storage),
                 d => panic!("IF condition evaluated to non-boolean datum {:?}", d),

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -15,7 +15,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{EvalEnv, EvalError, GlobalId, RelationExpr, ScalarExpr};
 
 pub mod binding;
 pub mod column_knowledge;
@@ -56,18 +56,26 @@ pub trait Transform: std::fmt::Debug {
 /// Errors that can occur during a transformation.
 #[derive(Debug, Clone)]
 pub enum TransformError {
+    Eval(EvalError),
     Internal(String),
 }
 
 impl fmt::Display for TransformError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            TransformError::Eval(e) => write!(f, "{}", e),
             TransformError::Internal(msg) => write!(f, "internal transform error: {}", msg),
         }
     }
 }
 
 impl Error for TransformError {}
+
+impl From<EvalError> for TransformError {
+    fn from(e: EvalError) -> TransformError {
+        TransformError::Eval(e)
+    }
+}
 
 #[derive(Debug)]
 pub struct Fixpoint {

--- a/src/expr/transform/nonnullable.rs
+++ b/src/expr/transform/nonnullable.rs
@@ -105,7 +105,7 @@ fn scalar_nonnullable(expr: &mut ScalarExpr, metadata: &RelationType) {
         {
             if let ScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = ScalarExpr::literal(Datum::False, ColumnType::new(ScalarType::Bool));
+                    *e = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
                 }
             }
         }
@@ -118,10 +118,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     if let (AggregateFunc::Count, ScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
             expr.func = AggregateFunc::CountAll;
-            expr.expr = ScalarExpr::literal(
-                Datum::Null,
-                ColumnType::new(ScalarType::Bool).nullable(true),
-            );
+            expr.expr = ScalarExpr::literal_null(ColumnType::new(ScalarType::Bool).nullable(true));
         }
     }
 }

--- a/src/expr/transform/predicate_pushdown.rs
+++ b/src/expr/transform/predicate_pushdown.rs
@@ -34,7 +34,7 @@
 //! let predicate0 = ScalarExpr::column(0);
 //! let predicate1 = ScalarExpr::column(1);
 //! let predicate01 = ScalarExpr::column(0).call_binary(ScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = ScalarExpr::literal(Datum::False, ColumnType::new(ScalarType::Bool));
+//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
 //!
 //! let mut expr = join.filter(
 //!    vec![
@@ -270,7 +270,7 @@ impl PredicatePushdown {
                                 && aggregates[0].func == AggregateFunc::Any
                             {
                                 push_down.push(aggregates[0].expr.clone());
-                                aggregates[0].expr = ScalarExpr::literal(
+                                aggregates[0].expr = ScalarExpr::literal_ok(
                                     Datum::True,
                                     ColumnType::new(ScalarType::Bool),
                                 );

--- a/src/expr/transform/reduce_elision.rs
+++ b/src/expr/transform/reduce_elision.rs
@@ -58,17 +58,21 @@ impl ReduceElision {
                         AggregateFunc::Count => {
                             let column_type = a.typ(&input_type);
                             a.expr.clone().call_unary(UnaryFunc::IsNull).if_then_else(
-                                ScalarExpr::literal(
+                                ScalarExpr::literal_ok(
                                     Datum::Int64(0),
                                     column_type.clone().nullable(false),
                                 ),
-                                ScalarExpr::literal(Datum::Int64(1), column_type.nullable(false)),
+                                ScalarExpr::literal_ok(
+                                    Datum::Int64(1),
+                                    column_type.nullable(false),
+                                ),
                             )
                         }
                         // CountAll is one no matter what the input.
-                        AggregateFunc::CountAll => {
-                            ScalarExpr::literal(Datum::Int64(1), a.typ(&input_type).nullable(false))
-                        }
+                        AggregateFunc::CountAll => ScalarExpr::literal_ok(
+                            Datum::Int64(1),
+                            a.typ(&input_type).nullable(false),
+                        ),
                         // All other variants should return the argument to the aggregation.
                         _ => a.expr.clone(),
                     })

--- a/src/sql/expr.rs
+++ b/src/sql/expr.rs
@@ -638,7 +638,7 @@ impl ScalarExpr {
 
         Ok(match self {
             Column(col_ref) => SS::Column(col_map.get(&col_ref)),
-            Literal(row, typ) => SS::Literal(row, typ),
+            Literal(row, typ) => SS::Literal(Ok(row), typ),
             Parameter(_) => panic!("cannot decorrelate expression with unbound parameters"),
             CallNullary(func) => SS::CallNullary(func),
             CallUnary { func, expr } => SS::CallUnary {
@@ -903,7 +903,7 @@ impl ScalarExpr {
 
         match self {
             Column(ColumnRef { level: 0, column }) => SS::Column(column),
-            Literal(datum, typ) => SS::Literal(datum, typ),
+            Literal(datum, typ) => SS::Literal(Ok(datum), typ),
             CallNullary(func) => SS::CallNullary(func),
             CallUnary { func, expr } => SS::CallUnary {
                 func,

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -198,15 +198,11 @@ SELECT mod(0, 1.23)
 ----
 0.00
 
-query R
+query error division by zero
 SELECT mod(4, 0.0)
-----
-NULL
 
-query I
+query error division by zero
 SELECT mod(0, 0)
-----
-NULL
 
 query I
 SELECT mod(0, NULL)
@@ -228,55 +224,35 @@ SELECT mod(NULL, 0.45)
 ----
 NULL
 
-query I
+query error division by zero
 SELECT 1 % 0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1 % 0.0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1.0 % 0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1.0 % 0.0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1 % CAST (0.0 AS float)
-----
-NULL
 
-query I
+query error division by zero
 SELECT 1 / 0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1 / 0.0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1.0 / 0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1.0 / 0.0
-----
-NULL
 
-query R
+query error division by zero
 SELECT 1 / CAST (0.0 AS float)
-----
-NULL
 
 query I
 SELECT 1 + CAST ('5' AS double precision)

--- a/test/sqllogictest/cockroach/like.slt
+++ b/test/sqllogictest/cockroach/like.slt
@@ -429,11 +429,5 @@ true
 
 # Test bad escaping.
 
-# TODO(benesch): this should return "LIKE pattern must not end with escape
-# character." Since we don't yet support runtime errors, it currently
-# returns NULL instead.
-
-query B
+query error unterminated escape sequence in LIKE
 SELECT 'a' LIKE '\'
-----
-NULL

--- a/test/sqllogictest/decimal.slt
+++ b/test/sqllogictest/decimal.slt
@@ -308,10 +308,8 @@ SELECT CAST (3.141529::float AS decimal(38, 8))
 3.14152900
 
 # Numeric overflow
-query R
+query error numeric field overflow
 SELECT CAST (100::float AS decimal(38, 37))
-----
-NULL
 
 # Null input
 query R

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -418,11 +418,8 @@ SELECT length('你好', 'ISO_8859_5')
 ----
 6
 
-# invalid encoding name
-query I
+query error invalid encoding name 'iso-123'
 SELECT length('你好', 'iso-123')
-----
-NULL
 
 # NULL inputs
 query I


### PR DESCRIPTION
Builds on #2233 to propagate errors that occur at optimization time to the client.

----

This patch allows scalar expressions evaluation to return an error. As
optimization might involve evaluating the constituent scalar
expressions, optimization can now return errors as well. If such an
error is discovered during optimization (i.e., somewhere between plan
time and run time), it will be returned to the client.

Errors that truly occur at runtime are still replaced with NULLs, as
before. A future commit will wire up a separate error pathway for
runtime errors.