### PR TITLE
Allow ScalarExpr in Join keys

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -60,7 +60,7 @@ impl PeekResponse {
         match self {
             PeekResponse::Rows(rows) => rows,
             PeekResponse::Error(_) | PeekResponse::Canceled => {
-                panic!("PeekResponse::unwrap_rows called on an invalid response")
+                panic!("PeekResponse::unwrap_rows called on {:?}", self)
             }
         }
     }

--- a/src/dataflow/render/delta_join.rs
+++ b/src/dataflow/render/delta_join.rs
@@ -286,7 +286,7 @@ where
             *key = Row::pack(
                 prev_key
                     .iter()
-                    .map(|e| e.eval(&datums, &env, &temp_storage)),
+                    .map(|e| e.eval(&datums, &env, &temp_storage).unwrap_or(Datum::Null)),
             );
         },
         |prev_row, diff1, next_row, diff2| {

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -901,13 +901,7 @@ where
                     })
                     .collect::<Vec<_>>();
                 let next_vals = (0..arities[*input])
-                    .filter_map(|c| {
-                        if column_demand.contains(&c) {
-                            Some(c)
-                        } else {
-                            None
-                        }
-                    })
+                    .filter(|c| column_demand.contains(&c))
                     .collect::<Vec<_>>();
 
                 // Identify the columns we intend to retain.

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -199,7 +199,7 @@ impl RelationExpr {
                 }
                 Join {
                     inputs,
-                    variables,
+                    equivalences,
                     demand,
                     implementation,
                 } => {
@@ -216,21 +216,12 @@ impl RelationExpr {
                         ),
                         Separated(
                             " ",
-                            variables
+                            equivalences
                                 .iter()
-                                .map(|variable| Bracketed(
+                                .map(|equivalence| Bracketed(
                                     "(= ",
                                     ")",
-                                    Separated(
-                                        " ",
-                                        variable
-                                            .iter()
-                                            .map(|(input_pos, column)| format!(
-                                                "%{}.#{}",
-                                                input_chains[*input_pos], column
-                                            ))
-                                            .collect()
-                                    )
+                                    Separated(" ", equivalence.clone())
                                 ))
                                 .collect()
                         )
@@ -241,13 +232,8 @@ impl RelationExpr {
                         implementation.fmt_with(&input_chains)
                     ));
                     if let Some(demand) = demand {
-                        for (input_chain, input_demand) in demand.iter().enumerate() {
-                            annotations.push(format!(
-                                "demand for %{} = {}",
-                                expr_chain(&inputs[input_chain]),
-                                Bracketed("(", ")", Indices(input_demand)),
-                            ));
-                        }
+                        annotations
+                            .push(format!("demand = {}", Bracketed("(", ")", Indices(demand))));
                     }
                 }
                 Reduce {

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -297,6 +297,13 @@ impl RelationExpr {
                     .map(|i| i.column_types.len())
                     .collect::<Vec<_>>();
 
+                let mut offset = 0;
+                let mut prior_arities = Vec::new();
+                for input in 0..inputs.len() {
+                    prior_arities.push(offset);
+                    offset += input_arities[input];
+                }
+
                 let input_relation = input_arities
                     .iter()
                     .enumerate()
@@ -325,10 +332,10 @@ impl RelationExpr {
                             }
                         }
                     }
-                    input_types[index]
-                        .keys
-                        .iter()
-                        .any(|ks| ks.iter().all(|k| prior_bound.contains(&k)))
+                    input_types[index].keys.iter().any(|ks| {
+                        ks.iter()
+                            .all(|k| prior_bound.contains(&&(prior_arities[index] + k)))
+                    })
                 });
                 if remains_unique && !inputs.is_empty() {
                     for keys in input_types[0].keys.iter() {

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -320,9 +320,7 @@ impl RelationExpr {
                         }) {
                             for expr in equivalence {
                                 if let ScalarExpr::Column(c) = expr {
-                                    if input_relation[*c] == index {
-                                        prior_bound.push(c);
-                                    }
+                                    prior_bound.push(c);
                                 }
                             }
                         }

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -96,17 +96,22 @@ pub enum RelationExpr {
     Join {
         /// A sequence of input relations.
         inputs: Vec<RelationExpr>,
-        /// A sequence of equivalence classes of `(input_index, column_index)`.
+        /// A sequence of equivalence classes of expressions on the cross product of inputs.
         ///
-        /// Each element of the sequence is a set of pairs, where the values described by each pair must
-        /// be equal to all other values in the same set.
-        variables: Vec<Vec<(usize, usize)>>,
-        /// This optional field is a hint for which columns from each input are
+        /// Each equivalence class is a list of scalar expressions, where for each class the
+        /// intended interpretation is that all evaluated expressions should be equal.
+        ///
+        /// Each scalar expression is to be evaluated over the cross-product of all records
+        /// from all inputs. In many cases this may just be column selection from specific
+        /// inputs, but more general cases exist (e.g. complex functions of multiple columns
+        /// from multiple inputs, or just constant literals).
+        equivalences: Vec<Vec<ScalarExpr>>,
+        /// This optional field is a hint for which columns are
         /// actually used by operators that use this collection. Although the
         /// join does not have permission to change the schema, it can introduce
         /// dummy values at the end of its computation, avoiding the maintenance of values
         /// not present in this list (when it is non-None).
-        demand: Option<Vec<Vec<usize>>>,
+        demand: Option<Vec<usize>>,
         /// Join implementation information.
         implementation: JoinImplementation,
     },
@@ -273,7 +278,9 @@ impl RelationExpr {
             }
             RelationExpr::Filter { input, .. } => input.typ(),
             RelationExpr::Join {
-                inputs, variables, ..
+                inputs,
+                equivalences,
+                ..
             } => {
                 let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
 
@@ -285,6 +292,17 @@ impl RelationExpr {
                     .collect::<Vec<_>>();
                 let mut typ = RelationType::new(column_types);
 
+                let input_arities = input_types
+                    .iter()
+                    .map(|i| i.column_types.len())
+                    .collect::<Vec<_>>();
+
+                let input_relation = input_arities
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
+                    .collect::<Vec<_>>();
+
                 // A relation's uniqueness constraint holds if there is a
                 // sequence of the other relations such that each one has
                 // a uniqueness constraint whose columns are used in join
@@ -294,11 +312,17 @@ impl RelationExpr {
                 // first relation, and attempt to use the presented order.
                 let remains_unique = (1..inputs.len()).all(|index| {
                     let mut prior_bound = Vec::new();
-                    for variable in variables {
-                        if variable.iter().any(|(r, _c)| *r < index) {
-                            for (r, c) in variable {
-                                if r == &index {
-                                    prior_bound.push(c);
+                    for equivalence in equivalences {
+                        if equivalence.iter().any(|expr| {
+                            expr.support()
+                                .into_iter()
+                                .all(|i| input_relation[i] < index)
+                        }) {
+                            for expr in equivalence {
+                                if let ScalarExpr::Column(c) = expr {
+                                    if input_relation[*c] == index {
+                                        prior_bound.push(c);
+                                    }
                                 }
                             }
                         }
@@ -509,9 +533,32 @@ impl RelationExpr {
     /// let result = joined.project(vec![0, 1, 3]);
     /// ```
     pub fn join(inputs: Vec<RelationExpr>, variables: Vec<Vec<(usize, usize)>>) -> Self {
+        let arities = inputs.iter().map(|input| input.arity()).collect::<Vec<_>>();
+
+        let mut offset = 0;
+        let mut prior_arities = Vec::new();
+        for input in 0..inputs.len() {
+            prior_arities.push(offset);
+            offset += arities[input];
+        }
+
+        let equivalences = variables
+            .into_iter()
+            .map(|vs| {
+                vs.into_iter()
+                    .map(|(r, c)| ScalarExpr::Column(prior_arities[r] + c))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        Self::join_scalars(inputs, equivalences)
+    }
+
+    /// Constructs a join operator from inputs and required-equal scalar expressions.
+    pub fn join_scalars(inputs: Vec<RelationExpr>, equivalences: Vec<Vec<ScalarExpr>>) -> Self {
         RelationExpr::Join {
             inputs,
-            variables,
+            equivalences,
             demand: None,
             implementation: JoinImplementation::Unimplemented,
         }

--- a/src/expr/transform/column_knowledge.rs
+++ b/src/expr/transform/column_knowledge.rs
@@ -133,26 +133,37 @@ impl ColumnKnowledge {
                 input_knowledge
             }
             RelationExpr::Join {
-                inputs, variables, ..
+                inputs,
+                equivalences,
+                ..
             } => {
-                let mut knowledges = inputs
-                    .iter_mut()
-                    .map(|i| ColumnKnowledge::harvest(i, env, knowledge))
-                    .collect::<Result<Vec<_>, _>>()?;
+                let mut knowledges = Vec::new();
+                for input in inputs.iter_mut() {
+                    for knowledge in ColumnKnowledge::harvest(i, env, knowledge)? {
+                        knowledges.push(knowledge);
+                    }
+                }
 
-                for variable in variables.iter() {
-                    if !variable.is_empty() {
-                        let mut know = knowledges[variable[0].0][variable[0].1].clone();
-                        for (rel, col) in variable {
-                            know.absorb(&knowledges[*rel][*col]);
+                for equivalence in equivalences.iter_mut() {
+                    let mut knowledge = DatumKnowledge {
+                        value: None,
+                        nullable: true,
+                    };
+
+                    // We can produce composite knowledge for everything in the equivalence class.
+                    for expr in equivalence.iter_mut() {
+                        if let ScalarExpr::Column(c) = expr {
+                            knowledge.absorb(&knowledges[*c]);
                         }
-                        for (rel, col) in variable {
-                            knowledges[*rel][*col] = know.clone();
+                    }
+                    for expr in equivalence.iter_mut() {
+                        if let ScalarExpr::Column(c) = expr {
+                            knowledges[*c] = knowledge.clone();
                         }
                     }
                 }
 
-                knowledges.into_iter().flat_map(|k| k).collect()
+                knowledges
             }
             RelationExpr::Reduce {
                 input,

--- a/src/expr/transform/column_knowledge.rs
+++ b/src/expr/transform/column_knowledge.rs
@@ -139,7 +139,7 @@ impl ColumnKnowledge {
             } => {
                 let mut knowledges = Vec::new();
                 for input in inputs.iter_mut() {
-                    for knowledge in ColumnKnowledge::harvest(i, env, knowledge)? {
+                    for knowledge in ColumnKnowledge::harvest(input, env, knowledge)? {
                         knowledges.push(knowledge);
                     }
                 }

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -168,6 +168,7 @@ impl Demand {
                 let mut demand_vec = columns.iter().map(|c| permutation[*c]).collect::<Vec<_>>();
                 demand_vec.sort();
                 *demand = Some(demand_vec);
+                let should_permute = columns.iter().any(|c| permutation[*c] != *c);
 
                 // Each equivalence class imposes internal demand for columns.
                 for equivalence in equivalences.iter() {
@@ -188,7 +189,9 @@ impl Demand {
                     self.action(input, columns, gets);
                 }
 
-                if columns.into_iter().any(|i| permutation[i] != i) {
+                // Install a permutation if any demanded column is not the
+                // canonical column.
+                if should_permute {
                     *relation = relation.take_dangerous().project(permutation);
                 }
             }

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -37,7 +37,7 @@ pub mod reduce_elision;
 pub mod reduction;
 pub mod reduction_pushdown;
 pub mod redundant_join;
-pub mod simplify;
+// pub mod simplify;
 pub mod split_predicates;
 pub mod topk_elision;
 pub mod update_let;
@@ -170,7 +170,7 @@ impl Default for Optimizer {
                 transforms: vec![
                     Box::new(crate::transform::nonnullable::NonNullable),
                     Box::new(crate::transform::reduction::FoldConstants),
-                    Box::new(crate::transform::simplify::SimplifyFilterPredicates),
+                    // Box::new(crate::transform::simplify::SimplifyFilterPredicates),
                     Box::new(crate::transform::predicate_pushdown::PredicatePushdown),
                     Box::new(crate::transform::fusion::join::Join),
                     Box::new(crate::transform::fusion::filter::Filter),

--- a/src/expr/transform/predicate_pushdown.rs
+++ b/src/expr/transform/predicate_pushdown.rs
@@ -142,6 +142,8 @@ impl PredicatePushdown {
                             {
                                 // TODO: We could attempt to localize these here, otherwise they'll be localized
                                 // and pushed down in the next iteration of the fixed point optimization.
+                                // TODO: Retaining *both* predicates is not strictly necessary, as either
+                                // will ensure no matches on `Datum::Null`.
                                 retain.push(
                                     expr1
                                         .clone()

--- a/src/expr/transform/redundant_join.rs
+++ b/src/expr/transform/redundant_join.rs
@@ -94,8 +94,11 @@ impl RedundantJoin {
             }
 
             // Update constraints to reference `prior`. Shift subsequent references.
-            while let Some(index) = to_remove.pop() {
-                inputs.remove(index);
+            if !to_remove.is_empty() {
+                // remove in reverse order.
+                while let Some(index) = to_remove.pop() {
+                    inputs.remove(index);
+                }
                 for equivalence in equivalences.iter_mut() {
                     for expr in equivalence.iter_mut() {
                         expr.permute(&projection[..]);
@@ -106,6 +109,7 @@ impl RedundantJoin {
                 equivalences.retain(|v| v.len() > 1);
                 *demand = None;
             }
+
             // Implement a projection if the projection removed any columns.
             let orig_arity = input_arities.iter().sum::<usize>();
             if projection.len() != orig_arity || projection.iter().enumerate().any(|(i, p)| i != *p)

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -304,26 +304,18 @@ ORDER BY n_name, su_name, i_id
 | ArrangeBy (#0)
 
 9 =
-| Join %5 %6 %7 %8 (= %5.#17 %6.#0) (= %6.#3 %7.#0) (= %7.#2 %8.#0)
+| Join %5 %6 %7 %8 (= #27 #29) (= #21 #25) (= #17 #18)
 | | implementation = DeltaQuery %5 %6.(#0) %7.(#0) %8.(#0) | %6 %7.(#0) %8.(#0) %5.(#17) | %7 %8.(#0) %6.(#3) %5.(#17) | %8 %7.(#2) %6.(#3) %5.(#17)
-| | demand for %5 = (#0, #2)
-| | demand for %6 = ()
-| | demand for %7 = ()
-| | demand for %8 = (#1)
+| | demand = (#0, #2, #30)
 | Filter "^EUROP.*$" ~(#30)
 | Reduce group=(#0) min(#2)
 | Filter !(isnull(#1))
 | ArrangeBy (#0, #1)
 
 10 =
-| Join %0 %1 %2 %3 %4 %9 (= %0.#0 %2.#0 %9.#0) (= %1.#0 %2.#17) (= %1.#3 %3.#0) (= %2.#2 %9.#1) (= %3.#2 %4.#0)
+| Join %0 %1 %2 %3 %4 %9 (= #0 #12 #37) (= #5 #29) (= #8 #30) (= #14 #38) (= #32 #34)
 | | implementation = Differential %2 %9.(#0, #1) %0.(#0) %1.(#0) %3.(#0) %4.(#0)
-| | demand for %0 = (#0, #2, #4)
-| | demand for %1 = (#0..#2, #4, #6)
-| | demand for %2 = ()
-| | demand for %3 = (#1)
-| | demand for %4 = (#1)
-| | demand for %9 = ()
+| | demand = (#0, #2, #4..#7, #9, #11, #31, #35)
 | Filter "^.*b$" ~(#4) "^EUROP.*$" ~(#35)
 | Project (#5, #6, #31, #0, #2, #7, #9, #11)
 
@@ -365,12 +357,9 @@ ORDER BY revenue DESC, o_entry_d
 | ArrangeBy (#2, #1, #0)
 
 4 =
-| Join %0 %1 %2 %3 (= %0.#0 %2.#3) (= %0.#1 %1.#1 %2.#1 %3.#1) (= %0.#2 %1.#2 %2.#2 %3.#2) (= %1.#0 %2.#0 %3.#0)
+| Join %0 %1 %2 %3 (= #2 #24 #27 #35) (= #1 #23 #26 #34) (= #22 #25 #33) (= #0 #28)
 | | implementation = DeltaQuery %0 %2.(#2, #1, #3) %1.(#0, #1, #2) %3.(#2, #1, #0) | %1 %2.(#0, #1, #2) %0.(#0, #1, #2) %3.(#2, #1, #0) | %2 %0.(#0, #1, #2) %1.(#0, #1, #2) %3.(#2, #1, #0) | %3 %1.(#0, #1, #2) %2.(#0, #1, #2) %0.(#0, #1, #2)
-| | demand for %0 = (#1, #2, #9)
-| | demand for %1 = (#0)
-| | demand for %2 = (#4)
-| | demand for %3 = (#8)
+| | demand = (#1, #2, #9, #22, #29, #41)
 | Filter "^A.*$" ~(#9) (datetots(#29) > 2007-01-02 00:00:00)
 | Reduce group=(#22, #2, #1, #29) sum(#41)
 | Project (#0..#2, #4, #3)
@@ -411,19 +400,17 @@ ORDER BY o_ol_cnt
 | ArrangeBy (#2, #1, #0)
 
 4 =
-| Join %2 %3 (= %2.#0 %3.#0) (= %2.#1 %3.#1) (= %2.#2 %3.#2)
+| Join %2 %3 (= #0 #8) (= #1 #9) (= #2 #10)
 | | implementation = DeltaQuery %2 %3.(#2, #1, #0) | %3 %2.(#0, #1, #2)
-| | demand for %2 = (#0..#2, #4)
-| | demand for %3 = (#6)
+| | demand = (#0..#2, #4, #14)
 | Filter (#14 >= #4)
 | Distinct group=(#0, #1, #2, #4)
 | ArrangeBy (#0, #1, #2, #3)
 
 5 =
-| Join %1 %4 (= %1.#0 %4.#0) (= %1.#1 %4.#1) (= %1.#2 %4.#2) (= %1.#4 %4.#3)
+| Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
 | | implementation = Differential %1 %4.(#0, #1, #2, #3)
-| | demand for %1 = (#6)
-| | demand for %4 = ()
+| | demand = (#6)
 | Reduce group=(#6) countall(null)
 
 EOF
@@ -480,15 +467,9 @@ ORDER BY revenue DESC
 | ArrangeBy (#0)
 
 7 =
-| Join %0 %1 %2 %3 %4 %5 %6 (= %0.#0 %1.#3) (= %0.#1 %1.#1 %2.#1) (= %0.#2 %1.#2 %2.#2 %3.#1) (= %0.#21 %4.#3 %5.#0) (= %1.#0 %2.#0) (= %2.#4 %3.#0) (= %3.#17 %4.#0) (= %5.#2 %6.#0)
+| Join %0 %1 %2 %3 %4 %5 %6 (= #0 #25) (= #1 #23 #31) (= #2 #24 #32 #41) (= #21 #61 #65) (= #22 #30) (= #34 #40) (= #57 #58) (= #67 #69)
 | | implementation = Differential %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0, #1) %4.(#0, #3) %5.(#0) %6.(#0)
-| | demand for %0 = ()
-| | demand for %1 = (#4)
-| | demand for %2 = (#8)
-| | demand for %3 = ()
-| | demand for %4 = ()
-| | demand for %5 = (#1)
-| | demand for %6 = (#1)
+| | demand = (#26, #38, #66, #70)
 | Filter (#70 = "EUROPE") (datetots(#26) >= 2007-01-02 00:00:00)
 | Reduce group=(#66) sum(#38)
 
@@ -586,15 +567,9 @@ ORDER BY su_nationkey, cust_nation, l_year
 | ArrangeBy (#0)
 
 7 =
-| Join %0 %1 %2 %3 %4 %5 %6 (= %0.#0 %1.#17) (= %0.#3 %5.#0) (= %1.#0 %2.#4) (= %1.#1 %2.#5) (= %2.#0 %3.#0) (= %2.#1 %3.#1 %4.#1) (= %2.#2 %3.#2 %4.#2) (= %3.#3 %4.#0) (= %4.#21 %6.#0)
+| Join %0 %1 %2 %3 %4 %5 %6 (= #64 #69) (= #38 #43) (= #27 #37 #45) (= #26 #36 #44) (= #25 #35) (= #8 #30) (= #7 #29) (= #3 #65) (= #0 #24)
 | | implementation = DeltaQuery %0 %5.(#0) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0) | %1 %0.(#0) %5.(#0) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0) | %2 %3.(#0, #1, #2) %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %5.(#0) %6.(#0) | %3 %4.(#0, #1, #2) %6.(#0) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0) | %4 %6.(#0) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0) | %5 %0.(#3) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0) | %6 %4.(#21) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
-| | demand for %0 = (#3)
-| | demand for %1 = ()
-| | demand for %2 = (#6, #8)
-| | demand for %3 = (#4)
-| | demand for %4 = (#9)
-| | demand for %5 = (#1)
-| | demand for %6 = (#1)
+| | demand = (#3, #31, #33, #39, #52, #66, #70)
 | Filter (((#66 = "GERMANY") && (#70 = "CAMBODIA")) || ((#66 = "CAMBODIA") && (#70 = "GERMANY"))) (datetots(#31) <= 2012-01-02 00:00:00) (datetots(#31) >= 2007-01-02 00:00:00)
 | Reduce group=(#3, substr(#52, 1, 1), tsextractyear(datetots(#39))) sum(#33)
 
@@ -665,17 +640,9 @@ ORDER BY l_year
 | ArrangeBy (#0)
 
 9 =
-| Join %0 %1 %2 %3 %4 %5 %6 %7 %8 (= %0.#0 %2.#0 %3.#4) (= %1.#0 %2.#17) (= %1.#3 %7.#0) (= %2.#1 %3.#5) (= %3.#0 %4.#0) (= %3.#1 %4.#1 %5.#1) (= %3.#2 %4.#2 %5.#2) (= %4.#3 %5.#0) (= %5.#21 %6.#0) (= %6.#2 %8.#0)
+| Join %0 %1 %2 %3 %4 %5 %6 %7 %8 (= #72 #78) (= #69 #70) (= #43 #48) (= #32 #42 #50) (= #31 #41 #49) (= #30 #40) (= #13 #35) (= #0 #12 #34) (= #8 #74) (= #5 #29)
 | | implementation = DeltaQuery %0 %2.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %1 %7.(#0) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %2 %0.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %0.(#0) %1.(#0) %6.(#0) %7.(#0) %8.(#0) | %4 %5.(#0, #1, #2) %6.(#0) %8.(#0) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0) | %5 %6.(#0) %8.(#0) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0) | %6 %8.(#0) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0) | %7 %1.(#3) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %8 %6.(#2) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
-| | demand for %0 = (#0, #4)
-| | demand for %1 = ()
-| | demand for %2 = ()
-| | demand for %3 = (#8)
-| | demand for %4 = (#4)
-| | demand for %5 = ()
-| | demand for %6 = ()
-| | demand for %7 = (#1)
-| | demand for %8 = (#1)
+| | demand = (#0, #4, #38, #44, #75, #79)
 | Filter !(isnull(#0)) "^.*b$" ~(#4) (#79 = "EUROPE") (#0 < 1000) (datetots(#44) <= 2012-01-02 00:00:00) (datetots(#44) >= 2007-01-02 00:00:00)
 | Reduce group=(tsextractyear(datetots(#44))) sum(if (#75 = "GERMANY") then {#38} else {0dec}) sum(#38)
 | Map (((#1 * 10000000dec) / #2) * 10dec)
@@ -727,14 +694,9 @@ ORDER BY n_name, l_year DESC
 | ArrangeBy (#0)
 
 6 =
-| Join %0 %1 %2 %3 %4 %5 (= %0.#0 %1.#0 %3.#4) (= %1.#1 %3.#5) (= %1.#17 %2.#0) (= %2.#3 %5.#0) (= %3.#0 %4.#0) (= %3.#1 %4.#1) (= %3.#2 %4.#2)
+| Join %0 %1 %2 %3 %4 %5 (= #32 #42) (= #31 #41) (= #30 #40) (= #26 #48) (= #22 #23) (= #6 #35) (= #0 #5 #34)
 | | implementation = DeltaQuery %0 %1.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2) | %1 %0.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2) | %2 %5.(#0) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) | %3 %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0) | %4 %3.(#2, #1, #0) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0) | %5 %2.(#3) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
-| | demand for %0 = (#4)
-| | demand for %1 = ()
-| | demand for %2 = ()
-| | demand for %3 = (#8)
-| | demand for %4 = (#4)
-| | demand for %5 = (#1)
+| | demand = (#4, #38, #44, #49)
 | Filter "^.*BB$" ~(#4)
 | Reduce group=(#49, tsextractyear(datetots(#44))) sum(#38)
 
@@ -775,12 +737,9 @@ ORDER BY revenue DESC
 | ArrangeBy (#0)
 
 4 =
-| Join %0 %1 %2 %3 (= %0.#0 %1.#3) (= %0.#1 %1.#1 %2.#1) (= %0.#2 %1.#2 %2.#2) (= %0.#21 %3.#0) (= %1.#0 %2.#0)
+| Join %0 %1 %2 %3 (= #2 #24 #32) (= #1 #23 #31) (= #22 #30) (= #21 #40) (= #0 #25)
 | | implementation = DeltaQuery %0 %3.(#0) %1.(#2, #1, #3) %2.(#2, #1, #0) | %1 %0.(#0, #1, #2) %3.(#0) %2.(#2, #1, #0) | %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0) | %3 %0.(#21) %1.(#2, #1, #3) %2.(#2, #1, #0)
-| | demand for %0 = (#0, #5, #8, #11)
-| | demand for %1 = (#4)
-| | demand for %2 = (#6, #8)
-| | demand for %3 = (#1)
+| | demand = (#0, #5, #8, #11, #26, #36, #38, #41)
 | Filter (#26 <= #36) (datetots(#26) >= 2007-01-02 00:00:00)
 | Reduce group=(#0, #5, #8, #11, #41) sum(#38)
 | Project (#0, #1, #5, #2..#4)
@@ -818,11 +777,9 @@ ORDER BY ordercount DESC
 | ArrangeBy (#0)
 
 3 =
-| Join %0 %1 %2 (= %0.#17 %1.#0) (= %1.#3 %2.#0)
+| Join %0 %1 %2 (= #21 #25) (= #17 #18)
 | | implementation = DeltaQuery %0 %1.(#0) %2.(#0) | %1 %2.(#0) %0.(#17) | %2 %1.(#3) %0.(#17)
-| | demand for %0 = (#0, #14)
-| | demand for %1 = ()
-| | demand for %2 = (#1)
+| | demand = (#0, #14, #26)
 | Filter (#26 = "GERMANY")
 
 4 =
@@ -838,8 +795,7 @@ ORDER BY ordercount DESC
 6 =
 | Join %4 %5
 | | implementation = Differential %4 %5.()
-| | demand for %4 = (#0, #1)
-| | demand for %5 = (#1)
+| | demand = (#0, #1, #3)
 | Filter ((i32todec(#1) * 1000000dec) > #3)
 | Project (#0, #1)
 
@@ -871,10 +827,9 @@ ORDER BY o_ol_cnt
 | ArrangeBy (#2, #1, #0)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#0) (= %0.#1 %1.#1) (= %0.#2 %1.#2)
+| Join %0 %1 (= #2 #10) (= #1 #9) (= #0 #8)
 | | implementation = DeltaQuery %0 %1.(#2, #1, #0) | %1 %0.(#0, #1, #2)
-| | demand for %0 = (#4..#6)
-| | demand for %1 = (#6)
+| | demand = (#4..#6, #14)
 | Filter (datetots(#14) < 2020-01-01 00:00:00) (#4 <= #14)
 | Reduce group=(#6) sum(if ((#5 = 1) || (#5 = 2)) then {1} else {0}) sum(if ((#5 != 1) && (#5 != 2)) then {1} else {0})
 
@@ -905,10 +860,9 @@ ORDER BY custdist DESC, c_count DESC
 | ArrangeBy (#2, #1, #3)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#3) (= %0.#1 %1.#1) (= %0.#2 %1.#2)
+| Join %0 %1 (= #2 #24) (= #1 #23) (= #0 #25)
 | | implementation = DeltaQuery %0 %1.(#2, #1, #3) | %1 %0.(#0, #1, #2)
-| | demand for %0 = (#0..#21)
-| | demand for %1 = (#0, #5)
+| | demand = (#0..#22, #27)
 | Filter (#27 > 8)
 
 3 =
@@ -952,10 +906,9 @@ AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#4 %1.#0)
+| Join %0 %1 (= #4 #10)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#4)
-| | demand for %0 = (#6, #8)
-| | demand for %1 = (#4)
+| | demand = (#6, #8, #14)
 | Filter (datetots(#6) < 2020-01-02 00:00:00) (datetots(#6) >= 2007-01-02 00:00:00)
 | Reduce group=() sum(if "^PR.*$" ~(#14) then {#8} else {0dec}) sum(#8)
 
@@ -1022,10 +975,9 @@ ORDER BY su_suppkey
 | ArrangeBy (#0, #1)
 
 2 =
-| Join %0 %1 (= %0.#4 %1.#0) (= %0.#5 %1.#1)
+| Join %0 %1 (= #5 #11) (= #4 #10)
 | | implementation = DeltaQuery %0 %1.(#0, #1) | %1 %0.(#5, #4)
-| | demand for %0 = (#6, #8)
-| | demand for %1 = (#17)
+| | demand = (#6, #8, #27)
 | Filter (datetots(#6) >= 2007-01-02 00:00:00)
 | Reduce group=(#27) sum(#8)
 
@@ -1043,11 +995,9 @@ ORDER BY su_suppkey
 | ArrangeBy (#0)
 
 6 =
-| Join %3 %4 %5 (= %3.#0 %4.#0) (= %4.#1 %5.#0)
+| Join %3 %4 %5 (= #0 #7) (= #8 #9)
 | | implementation = Differential %3 %4.(#0) %5.(#0)
-| | demand for %3 = (#0..#2, #4)
-| | demand for %4 = (#1)
-| | demand for %5 = ()
+| | demand = (#0..#2, #4, #8)
 | Filter !(isnull(#8))
 | Project (#0..#2, #4, #8)
 
@@ -1079,10 +1029,9 @@ ORDER BY supplier_cnt DESC
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#0)
+| Join %0 %1 (= #0 #18)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
-| | demand for %0 = (#17)
-| | demand for %1 = (#2..#4)
+| | demand = (#17, #20..#22)
 | Filter !("^zz.*$" ~(#22))
 
 3 =
@@ -1100,8 +1049,7 @@ ORDER BY supplier_cnt DESC
 6 =
 | Join %4 %5
 | | implementation = Differential %5 %4.()
-| | demand for %4 = (#0)
-| | demand for %5 = (#0)
+| | demand = (#0, #1)
 | Reduce group=(#0) all((#0 != #1))
 
 7 =
@@ -1128,10 +1076,9 @@ ORDER BY supplier_cnt DESC
 | Union %8 %11
 
 13 =
-| Join %7 %12 (= %7.#17 %12.#0)
+| Join %7 %12 (= #17 #23)
 | | implementation = Differential %12 %7.(#17)
-| | demand for %7 = (#17, #20..#22)
-| | demand for %12 = ()
+| | demand = (#17, #20..#22)
 | Reduce group=(#20, substr(#22, 1, 3), #21) count(distinct #17)
 
 EOF
@@ -1165,20 +1112,18 @@ AND ol_quantity < t.a
 | ArrangeBy (#4)
 
 3 =
-| Join %1 %2 (= %1.#0 %2.#4)
+| Join %1 %2 (= #0 #9)
 | | implementation = DeltaQuery %1 %2.(#4) | %2 %1.(#0)
-| | demand for %1 = (#0, #4)
-| | demand for %2 = (#7)
+| | demand = (#0, #4, #12)
 | Filter "^.*b$" ~(#4)
 | Reduce group=(#0) sum(#12) count(#12)
 | Map (((i32todec(#1) * 10000000dec) / i64todec(#2)) / 10dec)
 | ArrangeBy (#0)
 
 4 =
-| Join %0 %3 (= %0.#4 %3.#0)
+| Join %0 %3 (= #4 #10)
 | | implementation = DeltaQuery %0 %3.(#0) | %3 %0.(#4)
-| | demand for %0 = (#7, #8)
-| | demand for %3 = (#3)
+| | demand = (#7, #8, #13)
 | Filter ((i32todec(#7) * 1000000dec) < #13)
 | Reduce group=() sum(#8)
 
@@ -1232,11 +1177,9 @@ ORDER BY sum(ol_amount) DESC, o_entry_d
 | ArrangeBy (#2, #1, #0)
 
 3 =
-| Join %0 %1 %2 (= %0.#0 %1.#3) (= %0.#1 %1.#1 %2.#1) (= %0.#2 %1.#2 %2.#2) (= %1.#0 %2.#0)
+| Join %0 %1 %2 (= #2 #24 #32) (= #1 #23 #31) (= #22 #30) (= #0 #25)
 | | implementation = DeltaQuery %0 %1.(#2, #1, #3) %2.(#2, #1, #0) | %1 %0.(#0, #1, #2) %2.(#2, #1, #0) | %2 %1.(#0, #1, #2) %0.(#0, #1, #2)
-| | demand for %0 = (#0..#2, #5)
-| | demand for %1 = (#0, #4, #6)
-| | demand for %2 = (#8)
+| | demand = (#0..#2, #5, #22, #26, #28, #38)
 | Reduce group=(#22, #2, #1, #0, #5, #26, #28) sum(#38)
 | Filter (#7 > 20000dec)
 | Project (#4, #3, #0, #5..#7)
@@ -1280,10 +1223,9 @@ WHERE (
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#4 %1.#0)
+| Join %0 %1 (= #4 #10)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#4)
-| | demand for %0 = (#2, #7, #8)
-| | demand for %1 = (#3, #4)
+| | demand = (#2, #7, #8, #13, #14)
 | Filter ((("^.*a$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 3))) || ("^.*b$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 4)))) || ("^.*c$" ~(#14) && (((#2 = 1) || (#2 = 5)) || (#2 = 3)))) (#7 <= 10) (#13 <= 40000000dec) (#7 >= 1) (#13 >= 100dec)
 | Reduce group=() sum(#8)
 
@@ -1335,14 +1277,14 @@ ORDER BY su_name
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#3 %1.#0)
+| Join %0 %1 (= #3 #7)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#3)
-| | demand for %0 = (#0..#2)
-| | demand for %1 = (#1)
+| | demand = (#0..#2, #8)
 | Filter (#8 = "GERMANY")
 
 3 =
 | Get %2
+| Distinct group=(#0)
 | ArrangeBy ()
 
 4 =
@@ -1353,23 +1295,21 @@ ORDER BY su_name
 | ArrangeBy (#4)
 
 6 =
-| Join %3 %4 %5 (= %4.#0 %5.#4)
+| Join %3 %4 %5 (= #1 #23)
 | | implementation = Differential %4 %5.(#4) %3.()
-| | demand for %3 = (#0)
-| | demand for %4 = (#0..#2)
-| | demand for %5 = (#6, #7)
-| Filter (datetots(#35) > 2010-05-23 12:00:00)
+| | demand = (#0..#3, #25, #26)
+| Filter (datetots(#25) > 2010-05-23 12:00:00)
 
 7 =
 | Get %2
 
 8 =
 | Get %6
-| Filter (#0 = ((#11 * #12) % 10000))
+| Filter (#0 = ((#1 * #2) % 10000))
 
 9 =
 | Get %6
-| Distinct group=(#11)
+| Distinct group=(#1)
 | ArrangeBy (#0)
 
 10 =
@@ -1377,22 +1317,26 @@ ORDER BY su_name
 | ArrangeBy (#0)
 
 11 =
-| Join %8 %9 %10 (= %8.#11 %9.#0 %10.#0)
-| | implementation = Differential %8 %9.(#0) %10.(#0)
-| | demand for %8 = (#0, #11..#13, #36)
-| | demand for %9 = ()
-| | demand for %10 = (#4)
-| Filter "^co.*$" ~(#44)
-| Reduce group=(#0, #11, #12, #13) sum(#36)
-| Filter ((2 * #3) > #4)
+| Join %9 %10 (= #0 #1)
+| | implementation = DeltaQuery %9 %10.(#0) | %10 %9.(#0)
+| | demand = (#0, #5)
+| Filter "^co.*$" ~(#5)
 | Reduce group=(#0) any(true)
 | ArrangeBy (#0)
 
 12 =
-| Join %7 %11 (= %7.#0 %11.#0)
-| | implementation = Differential %7 %11.(#0)
-| | demand for %7 = (#1, #2)
-| | demand for %11 = ()
+| Join %8 %11 (= #1 #29)
+| | implementation = Differential %8 %11.(#0)
+| | demand = (#0..#3, #26)
+| Reduce group=(#0, #1, #2, #3) sum(#26)
+| Filter ((2 * #3) > #4)
+| Reduce group=(#0) any(true)
+| ArrangeBy (#0)
+
+13 =
+| Join %7 %12 (= #0 #11)
+| | implementation = Differential %7 %12.(#0)
+| | demand = (#1, #2)
 | Project (#1, #2)
 
 EOF
@@ -1444,13 +1388,9 @@ ORDER BY numwait DESC, su_name
 | ArrangeBy (#0)
 
 5 =
-| Join %0 %1 %2 %3 %4 (= %0.#0 %3.#17) (= %0.#3 %4.#0) (= %1.#0 %2.#0) (= %1.#1 %2.#1) (= %1.#2 %2.#2 %3.#1) (= %1.#4 %3.#0)
+| Join %0 %1 %2 %3 %4 (= #0 #42) (= #3 #43) (= #7 #17) (= #8 #18) (= #9 #19 #26) (= #11 #25)
 | | implementation = Differential %1 %2.(#0, #1, #2) %3.(#0, #1) %0.(#0) %4.(#0)
-| | demand for %0 = (#1)
-| | demand for %1 = (#0..#2, #6)
-| | demand for %2 = (#4)
-| | demand for %3 = ()
-| | demand for %4 = (#1)
+| | demand = (#1, #7..#9, #13, #21, #44)
 | Filter (#44 = "GERMANY") (#13 > #21)
 
 6 =
@@ -1469,10 +1409,9 @@ ORDER BY numwait DESC, su_name
 | ArrangeBy (#2, #1, #0)
 
 10 =
-| Join %8 %9 (= %8.#0 %9.#0) (= %8.#1 %9.#1) (= %8.#2 %9.#2)
+| Join %8 %9 (= #0 #4) (= #1 #5) (= #2 #6)
 | | implementation = Differential %8 %9.(#2, #1, #0)
-| | demand for %8 = (#0..#3)
-| | demand for %9 = (#6)
+| | demand = (#0..#3, #10)
 | Filter (#10 > #3)
 | Distinct group=(#0, #1, #2, #3)
 | Map true
@@ -1486,10 +1425,9 @@ ORDER BY numwait DESC, su_name
 | Union %10 %11
 
 13 =
-| Join %7 %12 (= %7.#7 %12.#0) (= %7.#8 %12.#1) (= %7.#9 %12.#2) (= %7.#13 %12.#3)
+| Join %7 %12 (= #7 #47) (= #8 #48) (= #9 #49) (= #13 #50)
 | | implementation = Differential %12 %7.(#7, #8, #9, #13)
-| | demand for %7 = (#1)
-| | demand for %12 = ()
+| | demand = (#1)
 | Reduce group=(#1) countall(null)
 
 EOF
@@ -1531,8 +1469,7 @@ ORDER BY substr(c_state, 1, 1)
 2 =
 | Join %0 %1
 | | implementation = Differential %0 %1.()
-| | demand for %0 = (#0..#2, #9, #16)
-| | demand for %1 = (#2)
+| | demand = (#0..#2, #9, #16, #24)
 | Filter ((#16 * 1000000dec) > #24)
 
 3 =
@@ -1548,10 +1485,9 @@ ORDER BY substr(c_state, 1, 1)
 | ArrangeBy (#2, #1, #3)
 
 6 =
-| Join %4 %5 (= %4.#0 %5.#3) (= %4.#1 %5.#1) (= %4.#2 %5.#2)
+| Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
 | | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
-| | demand for %4 = (#0..#2)
-| | demand for %5 = ()
+| | demand = (#0..#2)
 | Distinct group=(#0, #1, #2)
 | Map true
 | Negate
@@ -1565,10 +1501,9 @@ ORDER BY substr(c_state, 1, 1)
 | Union %6 %7
 
 9 =
-| Join %3 %8 (= %3.#0 %8.#0) (= %3.#1 %8.#1) (= %3.#2 %8.#2)
+| Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
 | | implementation = Differential %8 %3.(#0, #1, #2)
-| | demand for %3 = (#9, #16)
-| | demand for %8 = ()
+| | demand = (#9, #16)
 | Reduce group=(substr(#9, 1, 1)) countall(null) sum(#16)
 
 EOF

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -390,6 +390,7 @@ ORDER BY o_ol_cnt
 
 1 =
 | Get %0
+| ArrangeBy (#0, #1, #2, #4)
 
 2 =
 | Get %0
@@ -404,12 +405,10 @@ ORDER BY o_ol_cnt
 | | implementation = DeltaQuery %2 %3.(#2, #1, #0) | %3 %2.(#0, #1, #2)
 | | demand = (#0..#2, #4, #14)
 | Filter (#14 >= #4)
-| Distinct group=(#0, #1, #2, #4)
-| ArrangeBy (#0, #1, #2, #3)
 
 5 =
-| Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
-| | implementation = Differential %1 %4.(#0, #1, #2, #3)
+| Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #12)
+| | implementation = Differential %4 %1.(#0, #1, #2, #4)
 | | demand = (#6)
 | Reduce group=(#6) countall(null)
 
@@ -862,7 +861,7 @@ ORDER BY custdist DESC, c_count DESC
 2 =
 | Join %0 %1 (= #2 #24) (= #1 #23) (= #0 #25)
 | | implementation = DeltaQuery %0 %1.(#2, #1, #3) | %1 %0.(#0, #1, #2)
-| | demand = (#0..#22, #27)
+| | demand = (#0, #22, #27)
 | Filter (#27 > 8)
 
 3 =
@@ -870,8 +869,8 @@ ORDER BY custdist DESC, c_count DESC
 
 4 =
 | Get %2
-| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 | Negate
+| Project (#0..#21)
 
 5 =
 | Get materialize.public.customer (u6)
@@ -1050,7 +1049,7 @@ ORDER BY supplier_cnt DESC
 | Join %4 %5
 | | implementation = Differential %5 %4.()
 | | demand = (#0, #1)
-| Reduce group=(#0) all((#0 != #1))
+| Map (#0 != #1)
 
 7 =
 | Get %2
@@ -1058,7 +1057,8 @@ ORDER BY supplier_cnt DESC
 
 8 =
 | Get %6
-| Filter #1
+| Filter #8
+| Project (#0, #8)
 
 9 =
 | Get %6
@@ -1321,7 +1321,7 @@ ORDER BY su_name
 | | implementation = DeltaQuery %9 %10.(#0) | %10 %9.(#0)
 | | demand = (#0, #5)
 | Filter "^co.*$" ~(#5)
-| Reduce group=(#0) any(true)
+| Map (#0 = #1)
 | ArrangeBy (#0)
 
 12 =
@@ -1413,7 +1413,6 @@ ORDER BY numwait DESC, su_name
 | | implementation = Differential %8 %9.(#2, #1, #0)
 | | demand = (#0..#3, #10)
 | Filter (#10 > #3)
-| Distinct group=(#0, #1, #2, #3)
 | Map true
 | Negate
 | Project (#0..#3)
@@ -1488,7 +1487,6 @@ ORDER BY substr(c_state, 1, 1)
 | Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
 | | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
 | | demand = (#0..#2)
-| Distinct group=(#0, #1, #2)
 | Map true
 | Negate
 | Project (#0..#2)

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -390,7 +390,6 @@ ORDER BY o_ol_cnt
 
 1 =
 | Get %0
-| ArrangeBy (#0, #1, #2, #4)
 
 2 =
 | Get %0
@@ -405,10 +404,12 @@ ORDER BY o_ol_cnt
 | | implementation = DeltaQuery %2 %3.(#2, #1, #0) | %3 %2.(#0, #1, #2)
 | | demand = (#0..#2, #4, #14)
 | Filter (#14 >= #4)
+| Distinct group=(#0, #1, #2, #4)
+| ArrangeBy (#0, #1, #2, #3)
 
 5 =
-| Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #12)
-| | implementation = Differential %4 %1.(#0, #1, #2, #4)
+| Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
+| | implementation = Differential %1 %4.(#0, #1, #2, #3)
 | | demand = (#6)
 | Reduce group=(#6) countall(null)
 
@@ -861,7 +862,7 @@ ORDER BY custdist DESC, c_count DESC
 2 =
 | Join %0 %1 (= #2 #24) (= #1 #23) (= #0 #25)
 | | implementation = DeltaQuery %0 %1.(#2, #1, #3) | %1 %0.(#0, #1, #2)
-| | demand = (#0, #22, #27)
+| | demand = (#0..#22, #27)
 | Filter (#27 > 8)
 
 3 =
@@ -869,8 +870,8 @@ ORDER BY custdist DESC, c_count DESC
 
 4 =
 | Get %2
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 | Negate
-| Project (#0..#21)
 
 5 =
 | Get materialize.public.customer (u6)
@@ -1049,7 +1050,7 @@ ORDER BY supplier_cnt DESC
 | Join %4 %5
 | | implementation = Differential %5 %4.()
 | | demand = (#0, #1)
-| Map (#0 != #1)
+| Reduce group=(#0) all((#0 != #1))
 
 7 =
 | Get %2
@@ -1057,8 +1058,7 @@ ORDER BY supplier_cnt DESC
 
 8 =
 | Get %6
-| Filter #8
-| Project (#0, #8)
+| Filter #1
 
 9 =
 | Get %6
@@ -1284,7 +1284,6 @@ ORDER BY su_name
 
 3 =
 | Get %2
-| Distinct group=(#0)
 | ArrangeBy ()
 
 4 =
@@ -1295,21 +1294,21 @@ ORDER BY su_name
 | ArrangeBy (#4)
 
 6 =
-| Join %3 %4 %5 (= #1 #23)
+| Join %3 %4 %5 (= #11 #33)
 | | implementation = Differential %4 %5.(#4) %3.()
-| | demand = (#0..#3, #25, #26)
-| Filter (datetots(#25) > 2010-05-23 12:00:00)
+| | demand = (#0, #11..#13, #35, #36)
+| Filter (datetots(#35) > 2010-05-23 12:00:00)
 
 7 =
 | Get %2
 
 8 =
 | Get %6
-| Filter (#0 = ((#1 * #2) % 10000))
+| Filter (#0 = ((#11 * #12) % 10000))
 
 9 =
 | Get %6
-| Distinct group=(#1)
+| Distinct group=(#11)
 | ArrangeBy (#0)
 
 10 =
@@ -1317,25 +1316,18 @@ ORDER BY su_name
 | ArrangeBy (#0)
 
 11 =
-| Join %9 %10 (= #0 #1)
-| | implementation = DeltaQuery %9 %10.(#0) | %10 %9.(#0)
-| | demand = (#0, #5)
-| Filter "^co.*$" ~(#5)
-| Map (#0 = #1)
-| ArrangeBy (#0)
-
-12 =
-| Join %8 %11 (= #1 #29)
-| | implementation = Differential %8 %11.(#0)
-| | demand = (#0..#3, #26)
-| Reduce group=(#0, #1, #2, #3) sum(#26)
+| Join %8 %9 %10 (= #11 #39 #40)
+| | implementation = Differential %8 %9.(#0) %10.(#0)
+| | demand = (#0, #11..#13, #36, #44)
+| Filter "^co.*$" ~(#44)
+| Reduce group=(#0, #11, #12, #13) sum(#36)
 | Filter ((2 * #3) > #4)
 | Reduce group=(#0) any(true)
 | ArrangeBy (#0)
 
-13 =
-| Join %7 %12 (= #0 #11)
-| | implementation = Differential %7 %12.(#0)
+12 =
+| Join %7 %11 (= #0 #11)
+| | implementation = Differential %7 %11.(#0)
 | | demand = (#1, #2)
 | Project (#1, #2)
 
@@ -1413,6 +1405,7 @@ ORDER BY numwait DESC, su_name
 | | implementation = Differential %8 %9.(#2, #1, #0)
 | | demand = (#0..#3, #10)
 | Filter (#10 > #3)
+| Distinct group=(#0, #1, #2, #3)
 | Map true
 | Negate
 | Project (#0..#3)
@@ -1487,6 +1480,7 @@ ORDER BY substr(c_state, 1, 1)
 | Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
 | | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
 | | demand = (#0..#2)
+| Distinct group=(#0, #1, #2)
 | Map true
 | Negate
 | Project (#0..#2)

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -143,8 +143,7 @@ EXPLAIN PLAN FOR SELECT date_trunc(field, ts) FROM date_trunc_fields, date_trunc
 2 =
 | Join %0 %1
 | | implementation = Differential %1 %0.()
-| | demand for %0 = (#0)
-| | demand for %1 = (#0)
+| | demand = (#0, #1)
 | Map date_truncts(#0, #1)
 | Project (#2)
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -68,3 +68,35 @@ query ITIT colnames,rowsort
 SELECT * FROM l JOIN r ON l.la = r.ra LIMIT 0
 ----
 la  lb  ra  rb
+
+# Test that with scalars introduced to join plans we still get the right answers.
+query ITITIT rowsort
+SELECT * FROM l as l1, l as l2, l as l3 WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
+----
+1  l1  2  l2  3  l3
+
+# Test that scalar expressions are introduced to join plans.
+query T multiline
+EXPLAIN PLAN FOR SELECT * FROM l as l1, l as l2, l as l3 WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
+----
+0 =
+| Get materialize.public.l (u1)
+| Filter !(isnull((#0 + 1)))
+
+1 =
+| Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+2 =
+| Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+3 =
+| Join %0 %1 %2 (= #2 (#0 + 1)) (= #4 (#0 + #2))
+| | implementation = Differential %0 %1.(#0) %2.(#0)
+| | demand = (#0..#5)
+| Filter !(isnull((#0 + #2)))
+
+EOF

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -121,3 +121,71 @@ WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 | Project (#0, #3, #5)
 
 EOF
+
+# Confirm that a +1 can exist in a subquery based join.
+# Note that the other +1 is found instead in a filter,
+# because subquery planning re-uses the relation it wraps.
+query T multiline
+EXPLAIN PLAN FOR
+SELECT l1.la, l1.lb
+FROM l as l1
+WHERE l1.la IN (
+    SELECT l2.la + 1
+    FROM l AS l2
+    WHERE l2.la IN (
+        SELECT l3.la + 1
+        FROM l as l3
+    )
+)
+----
+0 =
+| Get materialize.public.l (u1)
+| Distinct group=(#0)
+| ArrangeBy ()
+
+1 =
+| Get materialize.public.l (u1)
+
+2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0, #1)
+
+3 =
+| Get materialize.public.l (u1)
+
+4 =
+| Get %2
+| Filter (#0 = (#1 + 1))
+
+5 =
+| Get %2
+| Filter !(isnull(#1))
+| Distinct group=(#1)
+| ArrangeBy (#0)
+
+6 =
+| Get materialize.public.l (u1)
+| Filter !(isnull((#0 + 1)))
+
+7 =
+| Join %5 %6 (= #0 (#1 + 1))
+| | implementation = Differential %6 %5.(#0)
+| | demand = (#0)
+| Reduce group=(#0) any(true)
+| ArrangeBy (#0)
+
+8 =
+| Join %4 %7 (= #1 #3)
+| | implementation = Differential %4 %7.(#0)
+| | demand = (#0)
+| Reduce group=(#0) any(true)
+| ArrangeBy (#0)
+
+9 =
+| Join %3 %8 (= #0 #2)
+| | implementation = Differential %3 %8.(#0)
+| | demand = (#0, #1)
+| Project (#0, #1)
+
+EOF

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -125,6 +125,8 @@ EOF
 # Confirm that a +1 can exist in a subquery based join.
 # Note that the other +1 is found instead in a filter,
 # because subquery planning re-uses the relation it wraps.
+# It is perfectly acceptable for this plan to change, esp
+# if it improves (i.e. the cross join is removed).
 query T multiline
 EXPLAIN PLAN FOR
 SELECT l1.la, l1.lb

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -69,15 +69,35 @@ SELECT * FROM l JOIN r ON l.la = r.ra LIMIT 0
 ----
 la  lb  ra  rb
 
-# Test that with scalars introduced to join plans we still get the right answers.
-query ITITIT rowsort
-SELECT * FROM l as l1, l as l2, l as l3 WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
+# Test that projections work through join plans with scalars.
+query ITT rowsort
+SELECT l1.la, l2.lb, l3.lb
+FROM l as l1, l as l2, l as l3
+WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 ----
-1  l1  2  l2  3  l3
+1  l2  l3
+
+# Test that join plans with scalars work in subqueries
+query IT rowsort
+SELECT l1.la, l1.lb
+FROM l as l1
+WHERE l1.la IN (
+    SELECT l2.la + 1
+    FROM l AS l2
+    WHERE l2.la IN (
+        SELECT l3.la + 1
+        FROM l as l3
+    )
+)
+----
+3  l3
 
 # Test that scalar expressions are introduced to join plans.
 query T multiline
-EXPLAIN PLAN FOR SELECT * FROM l as l1, l as l2, l as l3 WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
+EXPLAIN PLAN FOR
+SELECT l1.la, l2.lb, l3.lb
+FROM l as l1, l as l2, l as l3
+WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 ----
 0 =
 | Get materialize.public.l (u1)
@@ -96,7 +116,8 @@ EXPLAIN PLAN FOR SELECT * FROM l as l1, l as l2, l as l3 WHERE l1.la + 1 = l2.la
 3 =
 | Join %0 %1 %2 (= #2 (#0 + 1)) (= #4 (#0 + #2))
 | | implementation = Differential %0 %1.(#0) %2.(#0)
-| | demand = (#0..#5)
+| | demand = (#0, #2, #3, #5)
 | Filter !(isnull((#0 + #2)))
+| Project (#0, #3, #5)
 
 EOF

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -207,8 +207,7 @@ EXPLAIN PLAN FOR SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 2 =
 | Join %0 %1
 | | implementation = Differential %0 %1.()
-| | demand for %0 = (#0)
-| | demand for %1 = ()
+| | demand = (#0)
 | Map true
 | Project (#0)
 
@@ -230,11 +229,9 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | ArrangeBy ()
 
 3 =
-| Join %0 %1 %2 (= %0.#0 %1.#0)
+| Join %0 %1 %2 (= #0 #1)
 | | implementation = Differential %1 %2.() %0.(#0)
-| | demand for %0 = (#0)
-| | demand for %1 = (#1)
-| | demand for %2 = ()
+| | demand = (#0, #2)
 | Map true
 | Project (#0, #0, #2)
 
@@ -251,10 +248,9 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | Get materialize.public.t3 (u41)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#0)
+| Join %0 %1 (= #0 #1)
 | | implementation = Differential %1 %0.(#0)
-| | demand for %0 = (#0)
-| | demand for %1 = (#1)
+| | demand = (#0, #2)
 
 3 =
 | Get %2
@@ -269,18 +265,16 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | ArrangeBy (#0)
 
 6 =
-| Join %4 %5 (= %4.#0 %5.#0)
+| Join %4 %5 (= #0 #1)
 | | implementation = DeltaQuery %4 %5.(#0) | %5 %4.(#0)
-| | demand for %4 = (#0)
-| | demand for %5 = ()
+| | demand = (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 7 =
-| Join %3 %6 (= %3.#2 %6.#0)
+| Join %3 %6 (= #2 #3)
 | | implementation = Differential %3 %6.(#0)
-| | demand for %3 = (#0, #2)
-| | demand for %6 = ()
+| | demand = (#0, #2)
 | Map true
 | Project (#0, #0, #2)
 
@@ -312,10 +306,9 @@ SELECT age, ascii_num * 2 as result FROM (
 | Filter !(isnull(#0))
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#0)
+| Join %0 %1 (= #0 #2)
 | | implementation = Differential %1 %0.(#0)
-| | demand for %0 = (#1)
-| | demand for %1 = (#1)
+| | demand = (#1, #3)
 | Map replace(#1, "o", "i") substr(#4, 2, 1) ascii(#5) (#6 * 2)
 | Project (#3, #7)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -233,16 +233,15 @@ ORDER BY
 
 6 =
 | Get %5
-| ArrangeBy ()
 
 7 =
 | Get %5
 | Distinct group=(#0)
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 8 =
 | Get materialize.public.partsupp (u11)
-| ArrangeBy (#0, #3)
+| ArrangeBy (#0)
 
 9 =
 | Get materialize.public.supplier (u8)
@@ -257,8 +256,15 @@ ORDER BY
 | Filter (#1 = "EUROPE")
 
 12 =
-| Join %6 %7 %8 %9 %10 %11 (= #0 #28 #29 #37) (= #19 #32) (= #30 #34) (= #42 #44)
-| | implementation = Differential %11 %6.() %7.(#0) %8.(#0, #3) %9.(#0, #3) %10.()
+| Join %7 %8 %9 %10 %11 (= #0 #1 #9) (= #2 #6) (= #14 #16)
+| | implementation = Differential %11 %7.() %8.(#0) %9.(#0, #3) %10.()
+| | demand = (#0, #4)
+| Reduce group=(#0) min(#4)
+| ArrangeBy (#0, #1)
+
+13 =
+| Join %6 %12 (= #0 #28) (= #19 #29)
+| | implementation = Differential %6 %12.(#0, #1)
 | | demand = (#0, #2, #10, #11, #13..#15, #22)
 | Project (#14, #10, #22, #0, #2, #11, #13, #15)
 
@@ -752,8 +758,8 @@ ORDER BY
 | | implementation = DeltaQuery %0 %3.(#0) %1.(#1) %2.(#0) | %1 %0.(#0) %3.(#0) %2.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#1) %2.(#0)
 | | demand = (#0..#2, #4, #5, #7, #12, #22, #23, #25, #34)
 | Filter (#25 = "R") (#12 < 1994-01-01) (datetots(#12) < 1994-01-01 00:00:00) (#12 >= 1993-10-01)
-| Map (#22 * (100dec - #23))
-| Project (#0, #1, #37, #5, #34, #2, #4, #7)
+| Reduce group=(#0, #1, #5, #4, #34, #2, #7) sum((#22 * (100dec - #23)))
+| Project (#0, #1, #7, #2, #4, #5, #3, #6)
 
 EOF
 
@@ -909,7 +915,7 @@ ORDER BY
 2 =
 | Join %0 %1 (= #0 #9)
 | | implementation = DeltaQuery %0 %1.(#1) | %1 %0.(#0)
-| | demand = (#0, #8, #16)
+| | demand = (#0..#8, #16)
 | Filter !("^.*special.*requests.*$" ~(#16))
 
 3 =
@@ -917,8 +923,8 @@ ORDER BY
 
 4 =
 | Get %2
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7)
 | Negate
-| Project (#0..#7)
 
 5 =
 | Get materialize.public.customer (u15)
@@ -1113,7 +1119,7 @@ ORDER BY
 | Join %4 %5
 | | implementation = Differential %5 %4.()
 | | demand = (#0, #1)
-| Map (#0 != #1)
+| Reduce group=(#0) all((#0 != #1))
 
 7 =
 | Get %2
@@ -1121,8 +1127,7 @@ ORDER BY
 
 8 =
 | Get %6
-| Filter #8
-| Project (#0, #8)
+| Filter #1
 
 9 =
 | Get %6
@@ -1184,7 +1189,6 @@ WHERE
 
 3 =
 | Get %2
-| ArrangeBy (#1)
 
 4 =
 | Get %2
@@ -1199,14 +1203,15 @@ WHERE
 | Join %4 %5 (= #0 #2)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0, #5)
-| Map 1
-| Map (2dec * (((#5 * 10000000dec) / 100dec) * 10dec))
+| Reduce group=(#0) sum(#5) countall(null)
+| Map (2dec * (((#1 * 10000000dec) / (i64todec(#2) * 100dec)) * 10dec))
+| ArrangeBy (#0)
 
 7 =
 | Join %3 %6 (= #1 #25)
-| | implementation = Differential %6 %3.(#1)
-| | demand = (#4, #5, #43)
-| Filter ((#4 * 10000000dec) < #43)
+| | implementation = Differential %3 %6.(#0)
+| | demand = (#4, #5, #28)
+| Filter ((#4 * 10000000dec) < #28)
 | Reduce group=() sum(#5)
 
 8 =
@@ -1444,7 +1449,6 @@ ORDER BY
 
 3 =
 | Get %2
-| Distinct group=(#0)
 | ArrangeBy ()
 
 4 =
@@ -1453,14 +1457,14 @@ ORDER BY
 5 =
 | Join %3 %4
 | | implementation = Differential %4 %3.()
-| | demand = (#0..#3)
+| | demand = (#0, #11..#13)
 
 6 =
 | Get %5
 
 7 =
 | Get %5
-| Distinct group=(#1)
+| Distinct group=(#11)
 | ArrangeBy (#0)
 
 8 =
@@ -1468,53 +1472,48 @@ ORDER BY
 | ArrangeBy (#0)
 
 9 =
-| Join %7 %8 (= #0 #1)
-| | implementation = DeltaQuery %7 %8.(#0) | %8 %7.(#0)
-| | demand = (#0, #2)
-| Filter "^forest.*$" ~(#2)
-| Map (#0 = #1)
-| ArrangeBy (#0)
+| Join %6 %7 %8 (= #11 #16 #17)
+| | implementation = Differential %6 %7.(#0) %8.(#0)
+| | demand = (#0, #11..#13, #18)
+| Filter "^forest.*$" ~(#18)
+| Map true
 
 10 =
-| Join %6 %9 (= #1 #6)
-| | implementation = Differential %6 %9.(#0)
-| | demand = (#0..#3)
-
-11 =
 | Get %2
 
-12 =
-| Get %10
-| Filter (#0 = #2)
+11 =
+| Get %9
+| Filter (#0 = #12)
 
-13 =
-| Get %10
-| Distinct group=(#1, #2)
+12 =
+| Get %9
+| Distinct group=(#11, #12)
 | ArrangeBy (#0, #1)
 
-14 =
+13 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#1, #2)
 
-15 =
-| Join %13 %14 (= #0 #3) (= #1 #4)
-| | implementation = DeltaQuery %13 %14.(#1, #2) | %14 %13.(#0, #1)
+14 =
+| Join %12 %13 (= #0 #3) (= #1 #4)
+| | implementation = DeltaQuery %12 %13.(#1, #2) | %13 %12.(#0, #1)
 | | demand = (#0, #1, #6, #12)
 | Filter (datetots(#12) < 1996-01-01 00:00:00) (#12 >= 1995-01-01)
-| Map (5dec * #6)
+| Reduce group=(#0, #1) sum(#6)
+| Map (5dec * #2)
 | ArrangeBy (#0, #1)
 
-16 =
-| Join %12 %15 (= #1 #17) (= #2 #18)
-| | implementation = Differential %12 %15.(#0, #1)
-| | demand = (#0, #3, #35)
-| Filter ((i32todec(#3) * 1000dec) > #35)
+15 =
+| Join %11 %14 (= #11 #27) (= #12 #28)
+| | implementation = Differential %11 %14.(#0, #1)
+| | demand = (#0, #13, #30)
+| Filter ((i32todec(#13) * 1000dec) > #30)
 | Reduce group=(#0) any(true)
 | ArrangeBy (#0)
 
-17 =
-| Join %11 %16 (= #0 #11)
-| | implementation = Differential %11 %16.(#0)
+16 =
+| Join %10 %15 (= #0 #11)
+| | implementation = Differential %10 %15.(#0)
 | | demand = (#1, #2)
 | Project (#1, #2)
 
@@ -1587,7 +1586,6 @@ ORDER BY
 
 5 =
 | Get %4
-| ArrangeBy (#7, #0)
 
 6 =
 | Get %4
@@ -1602,10 +1600,12 @@ ORDER BY
 | | implementation = Differential %6 %7.(#0)
 | | demand = (#0, #1, #4)
 | Filter (#4 != #1)
+| Distinct group=(#0, #1)
+| ArrangeBy (#0, #1)
 
 9 =
 | Join %5 %8 (= #0 #37) (= #7 #36)
-| | implementation = Differential %8 %5.(#7, #0)
+| | implementation = Differential %5 %8.(#0, #1)
 | | demand = (#0, #1, #7)
 | Map true
 
@@ -1629,6 +1629,7 @@ ORDER BY
 | | implementation = Differential %12 %13.(#0)
 | | demand = (#0, #1, #4, #13, #14)
 | Filter (#4 != #1) (#14 > #13)
+| Distinct group=(#0, #1)
 | Map true
 | Negate
 | Project (#0, #1)
@@ -1640,7 +1641,7 @@ ORDER BY
 | Union %14 %15
 
 17 =
-| Join %11 %16 (= #0 #56) (= #7 #55)
+| Join %11 %16 (= #0 #40) (= #7 #39)
 | | implementation = Differential %16 %11.(#7, #0)
 | | demand = (#1)
 | Reduce group=(#1) countall(null)
@@ -1731,6 +1732,7 @@ ORDER BY
 | Join %4 %5 (= #0 #12)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0)
+| Distinct group=(#0)
 | Map true
 | Negate
 | Project (#0)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -226,13 +226,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 5 =
-| Join %0 %1 %2 %3 %4 (= %0.#0 %2.#0) (= %1.#0 %2.#1) (= %1.#3 %3.#0) (= %3.#2 %4.#0)
+| Join %0 %1 %2 %3 %4 (= #23 #25) (= #12 #21) (= #9 #17) (= #0 #16)
 | | implementation = DeltaQuery %0 %2.(#0) %1.(#0) %3.(#0) %4.(#0) | %1 %3.(#0) %4.(#0) %2.(#1) %0.(#0) | %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) | %3 %4.(#0) %1.(#3) %2.(#1) %0.(#0) | %4 %3.(#2) %1.(#3) %2.(#1) %0.(#0)
-| | demand for %0 = (#0, #2, #4, #5)
-| | demand for %1 = (#1, #2, #4..#6)
-| | demand for %2 = (#3)
-| | demand for %3 = (#1)
-| | demand for %4 = (#1)
+| | demand = (#0, #2, #4, #5, #10, #11, #13..#15, #19, #22, #26)
 | Filter "^.*BRASS$" ~(#4) (#5 = 15) (#26 = "EUROPE")
 
 6 =
@@ -241,41 +237,35 @@ ORDER BY
 7 =
 | Get %5
 | Distinct group=(#0)
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 8 =
 | Get materialize.public.partsupp (u11)
-| ArrangeBy (#0) (#1)
+| ArrangeBy (#0)
 
 9 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| ArrangeBy (#0, #3)
 
 10 =
 | Get materialize.public.nation (u1)
-| ArrangeBy (#0) (#2)
+| ArrangeBy ()
 
 11 =
 | Get materialize.public.region (u4)
-| ArrangeBy (#0)
+| Filter (#1 = "EUROPE")
 
 12 =
-| Join %7 %8 %9 %10 %11 (= %7.#0 %8.#0) (= %8.#1 %9.#0) (= %9.#3 %10.#0) (= %10.#2 %11.#0)
-| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0) | %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0) | %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0) | %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
-| | demand for %7 = (#0)
-| | demand for %8 = (#3)
-| | demand for %9 = ()
-| | demand for %10 = ()
-| | demand for %11 = (#1)
-| Filter (#18 = "EUROPE")
+| Join %7 %8 %9 %10 %11 (= #0 #1 #9) (= #2 #6) (= #14 #16)
+| | implementation = Differential %11 %7.() %8.(#0) %9.(#0, #3) %10.()
+| | demand = (#0, #4)
 | Reduce group=(#0) min(#4)
 | ArrangeBy (#0, #1)
 
 13 =
-| Join %6 %12 (= %6.#0 %12.#0) (= %6.#19 %12.#1)
+| Join %6 %12 (= #0 #28) (= #19 #29)
 | | implementation = Differential %6 %12.(#0, #1)
-| | demand for %6 = (#0, #2, #10, #11, #13..#15, #22)
-| | demand for %12 = ()
+| | demand = (#0, #2, #10, #11, #13..#15, #22)
 | Project (#14, #10, #22, #0, #2, #11, #13, #15)
 
 EOF
@@ -319,11 +309,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 3 =
-| Join %0 %1 %2 (= %0.#0 %1.#1) (= %1.#0 %2.#0)
+| Join %0 %1 %2 (= #8 #17) (= #0 #9)
 | | implementation = DeltaQuery %0 %1.(#1) %2.(#0) | %1 %0.(#0) %2.(#0) | %2 %1.(#0) %0.(#0)
-| | demand for %0 = (#6)
-| | demand for %1 = (#0, #4, #7)
-| | demand for %2 = (#5, #6, #10)
+| | demand = (#6, #8, #12, #15, #22, #23, #27)
 | Filter (#6 = "BUILDING") (#12 < 1995-03-15) (#27 > 1995-03-15)
 | Reduce group=(#8, #12, #15) sum((#22 * (100dec - #23)))
 | Project (#0, #3, #1, #2)
@@ -371,19 +359,17 @@ ORDER BY
 | ArrangeBy (#0)
 
 4 =
-| Join %2 %3 (= %2.#0 %3.#0)
+| Join %2 %3 (= #0 #9)
 | | implementation = DeltaQuery %2 %3.(#0) | %3 %2.(#0)
-| | demand for %2 = (#0)
-| | demand for %3 = (#11, #12)
+| | demand = (#0, #20, #21)
 | Filter (#20 < #21)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
 5 =
-| Join %1 %4 (= %1.#0 %4.#0)
+| Join %1 %4 (= #0 #9)
 | | implementation = Differential %1 %4.(#0)
-| | demand for %1 = (#5)
-| | demand for %4 = ()
+| | demand = (#5)
 | Reduce group=(#5) countall(null)
 
 EOF
@@ -440,14 +426,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 6 =
-| Join %0 %1 %2 %3 %4 %5 (= %0.#0 %1.#1) (= %0.#3 %3.#3 %4.#0) (= %1.#0 %2.#0) (= %2.#2 %3.#0) (= %4.#2 %5.#0)
+| Join %0 %1 %2 %3 %4 %5 (= #0 #9) (= #3 #36 #40) (= #8 #17) (= #19 #33) (= #42 #44)
 | | implementation = Differential %2 %1.(#0) %0.(#0) %3.(#0, #3) %4.(#0) %5.(#0)
-| | demand for %0 = ()
-| | demand for %1 = (#4)
-| | demand for %2 = (#5, #6)
-| | demand for %3 = ()
-| | demand for %4 = (#1)
-| | demand for %5 = (#1)
+| | demand = (#12, #22, #23, #41, #45)
 | Filter (#45 = "ASIA") (#12 < 1995-01-01) (#12 >= 1994-01-01)
 | Reduce group=(#41) sum((#22 * (100dec - #23)))
 
@@ -559,14 +540,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 6 =
-| Join %0 %1 %2 %3 %4 %5 (= %0.#0 %1.#2) (= %0.#3 %4.#0) (= %1.#0 %2.#0) (= %2.#1 %3.#0) (= %3.#3 %5.#0)
+| Join %0 %1 %2 %3 %4 %5 (= #35 #44) (= #24 #32) (= #7 #23) (= #3 #40) (= #0 #9)
 | | implementation = DeltaQuery %0 %4.(#0) %1.(#2) %2.(#0) %3.(#0) %5.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) %4.(#0) %5.(#0) | %2 %3.(#0) %5.(#0) %1.(#0) %0.(#0) %4.(#0) | %3 %5.(#0) %2.(#1) %1.(#0) %0.(#0) %4.(#0) | %4 %0.(#3) %1.(#2) %2.(#0) %3.(#0) %5.(#0) | %5 %3.(#3) %2.(#1) %1.(#0) %0.(#0) %4.(#0)
-| | demand for %0 = ()
-| | demand for %1 = (#5, #6, #10)
-| | demand for %2 = ()
-| | demand for %3 = ()
-| | demand for %4 = (#1)
-| | demand for %5 = (#1)
+| | demand = (#12, #13, #17, #41, #45)
 | Filter (((#41 = "FRANCE") && (#45 = "GERMANY")) || ((#41 = "GERMANY") && (#45 = "FRANCE"))) (#17 <= 1996-12-31) (#17 >= 1995-01-01)
 | Reduce group=(#41, #45, tsextractyear(datetots(#17))) sum((#12 * (100dec - #13)))
 
@@ -646,16 +622,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 8 =
-| Join %0 %1 %2 %3 %4 %5 %6 %7 (= %0.#0 %2.#1) (= %1.#0 %2.#2) (= %1.#3 %6.#0) (= %2.#0 %3.#0) (= %3.#1 %4.#0) (= %4.#3 %5.#0) (= %5.#2 %7.#0)
+| Join %0 %1 %2 %3 %4 %5 %6 %7 (= #51 #57) (= #44 #49) (= #33 #41) (= #16 #32) (= #12 #53) (= #9 #18) (= #0 #17)
 | | implementation = DeltaQuery %0 %2.(#1) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0) | %1 %6.(#0) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0) | %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0) | %3 %4.(#0) %5.(#0) %7.(#0) %2.(#0) %0.(#0) %1.(#0) %6.(#0) | %4 %5.(#0) %7.(#0) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0) | %5 %7.(#0) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0) | %6 %1.(#3) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0) | %7 %5.(#2) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
-| | demand for %0 = (#4)
-| | demand for %1 = ()
-| | demand for %2 = (#5, #6)
-| | demand for %3 = (#4)
-| | demand for %4 = ()
-| | demand for %5 = ()
-| | demand for %6 = (#1)
-| | demand for %7 = (#1)
+| | demand = (#4, #21, #22, #36, #54, #58)
 | Filter (#4 = "ECONOMY ANODIZED STEEL") (#58 = "AMERICA") (#36 <= 1996-12-31) (#36 >= 1995-01-01)
 | Reduce group=(tsextractyear(datetots(#36))) sum(if (#54 = "BRAZIL") then {(#21 * (100dec - #22))} else {0dec}) sum((#21 * (100dec - #22)))
 | Map (((#1 * 10000000dec) / #2) * 1000dec)
@@ -724,14 +693,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 6 =
-| Join %0 %1 %2 %3 %4 %5 (= %0.#0 %2.#1 %3.#0) (= %1.#0 %2.#2 %3.#1) (= %1.#3 %5.#0) (= %2.#0 %4.#0)
+| Join %0 %1 %2 %3 %4 %5 (= #9 #18 #33) (= #0 #17 #32) (= #16 #37) (= #12 #46)
 | | implementation = DeltaQuery %0 %2.(#1) %3.(#0, #1) %1.(#0) %4.(#0) %5.(#0) | %1 %5.(#0) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0) | %2 %3.(#0, #1) %0.(#0) %1.(#0) %4.(#0) %5.(#0) | %3 %0.(#0) %1.(#0) %5.(#0) %2.(#1, #2) %4.(#0) | %4 %2.(#0) %3.(#0, #1) %0.(#0) %1.(#0) %5.(#0) | %5 %1.(#3) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0)
-| | demand for %0 = (#1)
-| | demand for %1 = ()
-| | demand for %2 = (#4..#6)
-| | demand for %3 = (#3)
-| | demand for %4 = (#4)
-| | demand for %5 = (#1)
+| | demand = (#1, #20..#22, #35, #41, #47)
 | Filter "^green$" ~(#1)
 | Reduce group=(#47, tsextractyear(datetots(#41))) sum(((#21 * (100dec - #22)) - (#35 * #20)))
 
@@ -790,12 +754,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 4 =
-| Join %0 %1 %2 %3 (= %0.#0 %1.#1) (= %0.#3 %3.#0) (= %1.#0 %2.#0)
+| Join %0 %1 %2 %3 (= #8 #17) (= #3 #33) (= #0 #9)
 | | implementation = DeltaQuery %0 %3.(#0) %1.(#1) %2.(#0) | %1 %0.(#0) %3.(#0) %2.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#1) %2.(#0)
-| | demand for %0 = (#0..#2, #4, #5, #7)
-| | demand for %1 = (#4)
-| | demand for %2 = (#5, #6, #8)
-| | demand for %3 = (#1)
+| | demand = (#0..#2, #4, #5, #7, #12, #22, #23, #25, #34)
 | Filter (#25 = "R") (#12 < 1994-01-01) (datetots(#12) < 1994-01-01 00:00:00) (#12 >= 1993-10-01)
 | Reduce group=(#0, #1, #5, #4, #34, #2, #7) sum((#22 * (100dec - #23)))
 | Project (#0, #1, #7, #2, #4, #5, #3, #6)
@@ -846,11 +807,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 3 =
-| Join %0 %1 %2 (= %0.#1 %1.#0) (= %1.#3 %2.#0)
+| Join %0 %1 %2 (= #8 #12) (= #1 #5)
 | | implementation = DeltaQuery %0 %1.(#0) %2.(#0) | %1 %2.(#0) %0.(#1) | %2 %1.(#3) %0.(#1)
-| | demand for %0 = (#0, #2, #3)
-| | demand for %1 = ()
-| | demand for %2 = (#1)
+| | demand = (#0, #2, #3, #13)
 | Filter (#13 = "GERMANY")
 
 4 =
@@ -866,8 +825,7 @@ ORDER BY
 6 =
 | Join %4 %5
 | | implementation = Differential %4 %5.()
-| | demand for %4 = (#0, #1)
-| | demand for %5 = (#1)
+| | demand = (#0, #1, #3)
 | Filter ((#1 * 10000dec) > #3)
 | Project (#0, #1)
 
@@ -914,10 +872,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#0)
+| Join %0 %1 (= #0 #9)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
-| | demand for %0 = (#5)
-| | demand for %1 = (#10..#12, #14)
+| | demand = (#5, #19..#21, #23)
 | Filter ((#23 = "MAIL") || (#23 = "SHIP")) (#19 < #20) (#20 < #21) (datetots(#21) < 1995-01-01 00:00:00) (#21 >= 1994-01-01)
 | Reduce group=(#23) sum(if ((#5 = "1-URGENT") || (#5 = "2-HIGH")) then {1} else {0}) sum(if ((#5 != "1-URGENT") && (#5 != "2-HIGH")) then {1} else {0})
 
@@ -956,10 +913,9 @@ ORDER BY
 | ArrangeBy (#1)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#1)
+| Join %0 %1 (= #0 #9)
 | | implementation = DeltaQuery %0 %1.(#1) | %1 %0.(#0)
-| | demand for %0 = (#0..#7)
-| | demand for %1 = (#0, #8)
+| | demand = (#0..#8, #16)
 | Filter !("^.*special.*requests.*$" ~(#16))
 
 3 =
@@ -1010,10 +966,9 @@ WHERE
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#1 %1.#0)
+| Join %0 %1 (= #1 #16)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
-| | demand for %0 = (#5, #6, #10)
-| | demand for %1 = (#4)
+| | demand = (#5, #6, #10, #20)
 | Filter (datetots(#10) < 1996-02-01 00:00:00) (#10 >= 1996-01-01)
 | Reduce group=() sum(if "^PROMO.*$" ~(#20) then {(#5 * (100dec - #6))} else {0dec}) sum((#5 * (100dec - #6)))
 
@@ -1090,11 +1045,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 3 =
-| Join %0 %1 %2 (= %0.#0 %1.#0) (= %1.#1 %2.#0)
+| Join %0 %1 %2 (= #0 #7) (= #8 #9)
 | | implementation = Differential %1 %0.(#0) %2.(#0)
-| | demand for %0 = (#0..#2, #4)
-| | demand for %1 = (#1)
-| | demand for %2 = ()
+| | demand = (#0..#2, #4, #8)
 | Project (#0..#2, #4, #8)
 
 EOF
@@ -1145,10 +1098,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#0 %1.#0)
+| Join %0 %1 (= #0 #5)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
-| | demand for %0 = (#1)
-| | demand for %1 = (#3..#5)
+| | demand = (#1, #8..#10)
 | Filter !("^MEDIUM POLISHED.*$" ~(#9)) ((((((((#10 = 49) || (#10 = 14)) || (#10 = 23)) || (#10 = 45)) || (#10 = 19)) || (#10 = 3)) || (#10 = 36)) || (#10 = 9)) (#8 != "Brand#45")
 
 3 =
@@ -1166,8 +1118,7 @@ ORDER BY
 6 =
 | Join %4 %5
 | | implementation = Differential %5 %4.()
-| | demand for %4 = (#0)
-| | demand for %5 = (#0)
+| | demand = (#0, #1)
 | Reduce group=(#0) all((#0 != #1))
 
 7 =
@@ -1194,10 +1145,9 @@ ORDER BY
 | Union %8 %11
 
 13 =
-| Join %7 %12 (= %7.#1 %12.#0)
+| Join %7 %12 (= #1 #14)
 | | implementation = Differential %12 %7.(#1)
-| | demand for %7 = (#1, #8..#10)
-| | demand for %12 = ()
+| | demand = (#1, #8..#10)
 | Reduce group=(#8, #9, #10) count(distinct #1)
 
 EOF
@@ -1232,10 +1182,9 @@ WHERE
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#1 %1.#0)
+| Join %0 %1 (= #1 #16)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
-| | demand for %0 = (#1, #4, #5)
-| | demand for %1 = (#3, #6)
+| | demand = (#1, #4, #5, #19, #22)
 | Filter (#19 = "Brand#23") (#22 = "MED BOX")
 
 3 =
@@ -1251,19 +1200,17 @@ WHERE
 | ArrangeBy (#1)
 
 6 =
-| Join %4 %5 (= %4.#0 %5.#1)
+| Join %4 %5 (= #0 #2)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
-| | demand for %4 = (#0)
-| | demand for %5 = (#4)
+| | demand = (#0, #5)
 | Reduce group=(#0) sum(#5) countall(null)
 | Map (2dec * (((#1 * 10000000dec) / (i64todec(#2) * 100dec)) * 10dec))
 | ArrangeBy (#0)
 
 7 =
-| Join %3 %6 (= %3.#1 %6.#0)
+| Join %3 %6 (= #1 #25)
 | | implementation = Differential %3 %6.(#0)
-| | demand for %3 = (#4, #5)
-| | demand for %6 = (#3)
+| | demand = (#4, #5, #28)
 | Filter ((#4 * 10000000dec) < #28)
 | Reduce group=() sum(#5)
 
@@ -1338,11 +1285,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 3 =
-| Join %0 %1 %2 (= %0.#0 %1.#1) (= %1.#0 %2.#0)
+| Join %0 %1 %2 (= #8 #17) (= #0 #9)
 | | implementation = DeltaQuery %0 %1.(#1) %2.(#0) | %1 %0.(#0) %2.(#0) | %2 %1.(#0) %0.(#0)
-| | demand for %0 = (#0, #1)
-| | demand for %1 = (#0, #3, #4)
-| | demand for %2 = (#4)
+| | demand = (#0, #1, #8, #11, #12, #21)
 
 4 =
 | Get %3
@@ -1357,20 +1302,18 @@ ORDER BY
 | ArrangeBy (#0)
 
 7 =
-| Join %5 %6 (= %5.#0 %6.#0)
+| Join %5 %6 (= #0 #1)
 | | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
-| | demand for %5 = (#0)
-| | demand for %6 = (#4)
+| | demand = (#0, #5)
 | Reduce group=(#0, #0) sum(#5)
 | Filter (#2 > 30000dec)
 | Reduce group=(#0) any(true)
 | ArrangeBy (#0)
 
 8 =
-| Join %4 %7 (= %4.#8 %7.#0)
+| Join %4 %7 (= #8 #33)
 | | implementation = Differential %4 %7.(#0)
-| | demand for %4 = (#0, #1, #8, #11, #12, #21)
-| | demand for %7 = ()
+| | demand = (#0, #1, #8, #11, #12, #21)
 | Reduce group=(#1, #0, #8, #12, #11) sum(#21)
 
 EOF
@@ -1423,10 +1366,9 @@ WHERE
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#1 %1.#0)
+| Join %0 %1 (= #1 #16)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
-| | demand for %0 = (#4..#6, #13, #14)
-| | demand for %1 = (#3, #5, #6)
+| | demand = (#4..#6, #13, #14, #19, #21, #22)
 | Filter (((((((#19 = "Brand#12") && ((((#22 = "SM CASE") || (#22 = "SM BOX")) || (#22 = "SM PACK")) || (#22 = "SM PKG"))) && (#4 >= 100dec)) && (#4 <= 1100dec)) && (#21 <= 5)) || (((((#19 = "Brand#23") && ((((#22 = "MED BAG") || (#22 = "MED BOX")) || (#22 = "MED PKG")) || (#22 = "MED PACK"))) && (#4 >= 1000dec)) && (#4 <= 2000dec)) && (#21 <= 10))) || (((((#19 = "Brand#34") && ((((#22 = "LG CASE") || (#22 = "LG BOX")) || (#22 = "LG PACK")) || (#22 = "LG PKG"))) && (#4 >= 2000dec)) && (#4 <= 3000dec)) && (#21 <= 15))) ((#14 = "AIR") || (#14 = "AIR REG")) (#13 = "DELIVER IN PERSON") (#21 >= 1)
 | Reduce group=() sum((#5 * (100dec - #6)))
 
@@ -1500,14 +1442,14 @@ ORDER BY
 | ArrangeBy (#0)
 
 2 =
-| Join %0 %1 (= %0.#3 %1.#0)
+| Join %0 %1 (= #3 #7)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#3)
-| | demand for %0 = (#0..#2)
-| | demand for %1 = (#1)
+| | demand = (#0..#2, #8)
 | Filter (#8 = "CANADA")
 
 3 =
 | Get %2
+| Distinct group=(#0)
 | ArrangeBy ()
 
 4 =
@@ -1516,15 +1458,14 @@ ORDER BY
 5 =
 | Join %3 %4
 | | implementation = Differential %4 %3.()
-| | demand for %3 = (#0)
-| | demand for %4 = (#0..#2)
+| | demand = (#0..#3)
 
 6 =
 | Get %5
 
 7 =
 | Get %5
-| Distinct group=(#11)
+| Distinct group=(#1)
 | ArrangeBy (#0)
 
 8 =
@@ -1532,54 +1473,55 @@ ORDER BY
 | ArrangeBy (#0)
 
 9 =
-| Join %6 %7 %8 (= %6.#11 %7.#0 %8.#0)
-| | implementation = Differential %6 %7.(#0) %8.(#0)
-| | demand for %6 = (#0, #11..#13)
-| | demand for %7 = ()
-| | demand for %8 = (#1)
-| Filter "^forest.*$" ~(#18)
-| Map true
+| Join %7 %8 (= #0 #1)
+| | implementation = DeltaQuery %7 %8.(#0) | %8 %7.(#0)
+| | demand = (#0, #2)
+| Filter "^forest.*$" ~(#2)
+| Reduce group=(#0) any(true)
+| ArrangeBy (#0)
 
 10 =
-| Get %2
+| Join %6 %9 (= #1 #6)
+| | implementation = Differential %6 %9.(#0)
+| | demand = (#0..#3)
 
 11 =
-| Get %9
-| Filter (#0 = #12)
+| Get %2
 
 12 =
-| Get %9
-| Distinct group=(#11, #12)
-| ArrangeBy (#0, #1)
+| Get %10
+| Filter (#0 = #2)
 
 13 =
+| Get %10
+| Distinct group=(#1, #2)
+| ArrangeBy (#0, #1)
+
+14 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#1, #2)
 
-14 =
-| Join %12 %13 (= %12.#0 %13.#1) (= %12.#1 %13.#2)
-| | implementation = DeltaQuery %12 %13.(#1, #2) | %13 %12.(#0, #1)
-| | demand for %12 = (#0, #1)
-| | demand for %13 = (#4, #10)
+15 =
+| Join %13 %14 (= #0 #3) (= #1 #4)
+| | implementation = DeltaQuery %13 %14.(#1, #2) | %14 %13.(#0, #1)
+| | demand = (#0, #1, #6, #12)
 | Filter (datetots(#12) < 1996-01-01 00:00:00) (#12 >= 1995-01-01)
 | Reduce group=(#0, #1) sum(#6)
 | Map (5dec * #2)
 | ArrangeBy (#0, #1)
 
-15 =
-| Join %11 %14 (= %11.#11 %14.#0) (= %11.#12 %14.#1)
-| | implementation = Differential %11 %14.(#0, #1)
-| | demand for %11 = (#0, #13)
-| | demand for %14 = (#3)
-| Filter ((i32todec(#13) * 1000dec) > #30)
+16 =
+| Join %12 %15 (= #1 #8) (= #2 #9)
+| | implementation = Differential %12 %15.(#0, #1)
+| | demand = (#0, #3, #11)
+| Filter ((i32todec(#3) * 1000dec) > #11)
 | Reduce group=(#0) any(true)
 | ArrangeBy (#0)
 
-16 =
-| Join %10 %15 (= %10.#0 %15.#0)
-| | implementation = Differential %10 %15.(#0)
-| | demand for %10 = (#1, #2)
-| | demand for %15 = ()
+17 =
+| Join %11 %16 (= #0 #11)
+| | implementation = Differential %11 %16.(#0)
+| | demand = (#1, #2)
 | Project (#1, #2)
 
 EOF
@@ -1644,12 +1586,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 4 =
-| Join %0 %1 %2 %3 (= %0.#0 %1.#2) (= %0.#3 %3.#0) (= %1.#0 %2.#0)
+| Join %0 %1 %2 %3 (= #7 #23) (= #3 #32) (= #0 #9)
 | | implementation = DeltaQuery %0 %3.(#0) %1.(#2) %2.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#2) %2.(#0)
-| | demand for %0 = (#0, #1)
-| | demand for %1 = (#0, #11, #12)
-| | demand for %2 = (#2)
-| | demand for %3 = (#1)
+| | demand = (#0, #1, #7, #18, #19, #25, #33)
 | Filter (#25 = "F") (#33 = "SAUDI ARABIA") (#19 > #18)
 
 5 =
@@ -1664,19 +1603,17 @@ ORDER BY
 | ArrangeBy (#0)
 
 8 =
-| Join %6 %7 (= %6.#0 %7.#0)
+| Join %6 %7 (= #0 #2)
 | | implementation = Differential %6 %7.(#0)
-| | demand for %6 = (#0, #1)
-| | demand for %7 = (#2)
+| | demand = (#0, #1, #4)
 | Filter (#4 != #1)
 | Distinct group=(#0, #1)
 | ArrangeBy (#0, #1)
 
 9 =
-| Join %5 %8 (= %5.#0 %8.#1) (= %5.#7 %8.#0)
+| Join %5 %8 (= #0 #37) (= #7 #36)
 | | implementation = Differential %5 %8.(#0, #1)
-| | demand for %5 = (#0, #1, #7)
-| | demand for %8 = ()
+| | demand = (#0, #1, #7)
 | Map true
 
 10 =
@@ -1695,10 +1632,9 @@ ORDER BY
 | ArrangeBy (#0)
 
 14 =
-| Join %12 %13 (= %12.#0 %13.#0)
+| Join %12 %13 (= #0 #2)
 | | implementation = Differential %12 %13.(#0)
-| | demand for %12 = (#0, #1)
-| | demand for %13 = (#2, #11, #12)
+| | demand = (#0, #1, #4, #13, #14)
 | Filter (#4 != #1) (#14 > #13)
 | Distinct group=(#0, #1)
 | Map true
@@ -1712,10 +1648,9 @@ ORDER BY
 | Union %14 %15
 
 17 =
-| Join %11 %16 (= %11.#0 %16.#1) (= %11.#7 %16.#0)
+| Join %11 %16 (= #0 #40) (= #7 #39)
 | | implementation = Differential %16 %11.(#7, #0)
-| | demand for %11 = (#1)
-| | demand for %16 = ()
+| | demand = (#1)
 | Reduce group=(#1) countall(null)
 
 EOF
@@ -1785,8 +1720,7 @@ ORDER BY
 2 =
 | Join %0 %1
 | | implementation = Differential %0 %1.()
-| | demand for %0 = (#0, #4, #5)
-| | demand for %1 = (#2)
+| | demand = (#0, #4, #5, #10)
 | Filter ((#5 * 1000000dec) > #10)
 
 3 =
@@ -1802,10 +1736,9 @@ ORDER BY
 | ArrangeBy (#1)
 
 6 =
-| Join %4 %5 (= %4.#0 %5.#1)
+| Join %4 %5 (= #0 #12)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
-| | demand for %4 = (#0)
-| | demand for %5 = ()
+| | demand = (#0)
 | Distinct group=(#0)
 | Map true
 | Negate
@@ -1819,10 +1752,9 @@ ORDER BY
 | Union %6 %7
 
 9 =
-| Join %3 %8 (= %3.#0 %8.#0)
+| Join %3 %8 (= #0 #11)
 | | implementation = Differential %8 %3.(#0)
-| | demand for %3 = (#4, #5)
-| | demand for %8 = ()
+| | demand = (#4, #5)
 | Reduce group=(substr(#4, 1, 2)) countall(null) sum(#5)
 
 EOF

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -233,15 +233,16 @@ ORDER BY
 
 6 =
 | Get %5
+| ArrangeBy ()
 
 7 =
 | Get %5
 | Distinct group=(#0)
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 8 =
 | Get materialize.public.partsupp (u11)
-| ArrangeBy (#0)
+| ArrangeBy (#0, #3)
 
 9 =
 | Get materialize.public.supplier (u8)
@@ -256,15 +257,8 @@ ORDER BY
 | Filter (#1 = "EUROPE")
 
 12 =
-| Join %7 %8 %9 %10 %11 (= #0 #1 #9) (= #2 #6) (= #14 #16)
-| | implementation = Differential %11 %7.() %8.(#0) %9.(#0, #3) %10.()
-| | demand = (#0, #4)
-| Reduce group=(#0) min(#4)
-| ArrangeBy (#0, #1)
-
-13 =
-| Join %6 %12 (= #0 #28) (= #19 #29)
-| | implementation = Differential %6 %12.(#0, #1)
+| Join %6 %7 %8 %9 %10 %11 (= #0 #28 #29 #37) (= #19 #32) (= #30 #34) (= #42 #44)
+| | implementation = Differential %11 %6.() %7.(#0) %8.(#0, #3) %9.(#0, #3) %10.()
 | | demand = (#0, #2, #10, #11, #13..#15, #22)
 | Project (#14, #10, #22, #0, #2, #11, #13, #15)
 
@@ -758,8 +752,8 @@ ORDER BY
 | | implementation = DeltaQuery %0 %3.(#0) %1.(#1) %2.(#0) | %1 %0.(#0) %3.(#0) %2.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#1) %2.(#0)
 | | demand = (#0..#2, #4, #5, #7, #12, #22, #23, #25, #34)
 | Filter (#25 = "R") (#12 < 1994-01-01) (datetots(#12) < 1994-01-01 00:00:00) (#12 >= 1993-10-01)
-| Reduce group=(#0, #1, #5, #4, #34, #2, #7) sum((#22 * (100dec - #23)))
-| Project (#0, #1, #7, #2, #4, #5, #3, #6)
+| Map (#22 * (100dec - #23))
+| Project (#0, #1, #37, #5, #34, #2, #4, #7)
 
 EOF
 
@@ -915,7 +909,7 @@ ORDER BY
 2 =
 | Join %0 %1 (= #0 #9)
 | | implementation = DeltaQuery %0 %1.(#1) | %1 %0.(#0)
-| | demand = (#0..#8, #16)
+| | demand = (#0, #8, #16)
 | Filter !("^.*special.*requests.*$" ~(#16))
 
 3 =
@@ -923,8 +917,8 @@ ORDER BY
 
 4 =
 | Get %2
-| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7)
 | Negate
+| Project (#0..#7)
 
 5 =
 | Get materialize.public.customer (u15)
@@ -1119,7 +1113,7 @@ ORDER BY
 | Join %4 %5
 | | implementation = Differential %5 %4.()
 | | demand = (#0, #1)
-| Reduce group=(#0) all((#0 != #1))
+| Map (#0 != #1)
 
 7 =
 | Get %2
@@ -1127,7 +1121,8 @@ ORDER BY
 
 8 =
 | Get %6
-| Filter #1
+| Filter #8
+| Project (#0, #8)
 
 9 =
 | Get %6
@@ -1189,6 +1184,7 @@ WHERE
 
 3 =
 | Get %2
+| ArrangeBy (#1)
 
 4 =
 | Get %2
@@ -1203,15 +1199,14 @@ WHERE
 | Join %4 %5 (= #0 #2)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0, #5)
-| Reduce group=(#0) sum(#5) countall(null)
-| Map (2dec * (((#1 * 10000000dec) / (i64todec(#2) * 100dec)) * 10dec))
-| ArrangeBy (#0)
+| Map 1
+| Map (2dec * (((#5 * 10000000dec) / 100dec) * 10dec))
 
 7 =
 | Join %3 %6 (= #1 #25)
-| | implementation = Differential %3 %6.(#0)
-| | demand = (#4, #5, #28)
-| Filter ((#4 * 10000000dec) < #28)
+| | implementation = Differential %6 %3.(#1)
+| | demand = (#4, #5, #43)
+| Filter ((#4 * 10000000dec) < #43)
 | Reduce group=() sum(#5)
 
 8 =
@@ -1477,7 +1472,7 @@ ORDER BY
 | | implementation = DeltaQuery %7 %8.(#0) | %8 %7.(#0)
 | | demand = (#0, #2)
 | Filter "^forest.*$" ~(#2)
-| Reduce group=(#0) any(true)
+| Map (#0 = #1)
 | ArrangeBy (#0)
 
 10 =
@@ -1506,15 +1501,14 @@ ORDER BY
 | | implementation = DeltaQuery %13 %14.(#1, #2) | %14 %13.(#0, #1)
 | | demand = (#0, #1, #6, #12)
 | Filter (datetots(#12) < 1996-01-01 00:00:00) (#12 >= 1995-01-01)
-| Reduce group=(#0, #1) sum(#6)
-| Map (5dec * #2)
+| Map (5dec * #6)
 | ArrangeBy (#0, #1)
 
 16 =
-| Join %12 %15 (= #1 #8) (= #2 #9)
+| Join %12 %15 (= #1 #17) (= #2 #18)
 | | implementation = Differential %12 %15.(#0, #1)
-| | demand = (#0, #3, #11)
-| Filter ((i32todec(#3) * 1000dec) > #11)
+| | demand = (#0, #3, #35)
+| Filter ((i32todec(#3) * 1000dec) > #35)
 | Reduce group=(#0) any(true)
 | ArrangeBy (#0)
 
@@ -1593,6 +1587,7 @@ ORDER BY
 
 5 =
 | Get %4
+| ArrangeBy (#7, #0)
 
 6 =
 | Get %4
@@ -1607,12 +1602,10 @@ ORDER BY
 | | implementation = Differential %6 %7.(#0)
 | | demand = (#0, #1, #4)
 | Filter (#4 != #1)
-| Distinct group=(#0, #1)
-| ArrangeBy (#0, #1)
 
 9 =
 | Join %5 %8 (= #0 #37) (= #7 #36)
-| | implementation = Differential %5 %8.(#0, #1)
+| | implementation = Differential %8 %5.(#7, #0)
 | | demand = (#0, #1, #7)
 | Map true
 
@@ -1636,7 +1629,6 @@ ORDER BY
 | | implementation = Differential %12 %13.(#0)
 | | demand = (#0, #1, #4, #13, #14)
 | Filter (#4 != #1) (#14 > #13)
-| Distinct group=(#0, #1)
 | Map true
 | Negate
 | Project (#0, #1)
@@ -1648,7 +1640,7 @@ ORDER BY
 | Union %14 %15
 
 17 =
-| Join %11 %16 (= #0 #40) (= #7 #39)
+| Join %11 %16 (= #0 #56) (= #7 #55)
 | | implementation = Differential %16 %11.(#7, #0)
 | | demand = (#1)
 | Reduce group=(#1) countall(null)
@@ -1739,7 +1731,6 @@ ORDER BY
 | Join %4 %5 (= #0 #12)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0)
-| Distinct group=(#0)
 | Map true
 | Negate
 | Project (#0)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -237,28 +237,29 @@ ORDER BY
 7 =
 | Get %5
 | Distinct group=(#0)
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 8 =
 | Get materialize.public.partsupp (u11)
-| ArrangeBy (#0)
+| ArrangeBy (#0) (#1)
 
 9 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#0, #3)
+| ArrangeBy (#0) (#3)
 
 10 =
 | Get materialize.public.nation (u1)
-| ArrangeBy ()
+| ArrangeBy (#0) (#2)
 
 11 =
 | Get materialize.public.region (u4)
-| Filter (#1 = "EUROPE")
+| ArrangeBy (#0)
 
 12 =
-| Join %7 %8 %9 %10 %11 (= #0 #1 #9) (= #2 #6) (= #14 #16)
-| | implementation = Differential %11 %7.() %8.(#0) %9.(#0, #3) %10.()
-| | demand = (#0, #4)
+| Join %7 %8 %9 %10 %11 (= #0 #1) (= #2 #6) (= #9 #13) (= #15 #17)
+| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0) | %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0) | %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0) | %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
+| | demand = (#0, #4, #18)
+| Filter (#18 = "EUROPE")
 | Reduce group=(#0) min(#4)
 | ArrangeBy (#0, #1)
 


### PR DESCRIPTION
This is the beginning of a PR that means to allow general ScalarExprs in join keys, rather than just columns. There are several cases where this helps, most prominently when there is a single constant value to be joined with other values (e.g. a filter to implement as an indexed look-up). This shows up in @wangandi's work, but also in set intersection work, plausibly.

Anyhow, it also just seems like the right thing to do, and simplifies logic in many cases. In particular, it may obviate the need for `simplify.rs` which currently exists only to work around this limitation.