### PR TITLE
expr,sql: clarify like vs regex functions

### DIFF
--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -15,7 +15,6 @@ mod id;
 mod relation;
 mod scalar;
 
-pub mod like;
 pub mod pretty;
 pub mod transform;
 
@@ -24,5 +23,5 @@ pub use relation::func::{AggregateFunc, UnaryTableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::{AggregateExpr, ColumnOrder, IdGen, JoinImplementation, RelationExpr};
 pub use scalar::func::{BinaryFunc, DateTruncTo, NullaryFunc, UnaryFunc, VariadicFunc};
-pub use scalar::{EvalEnv, ScalarExpr};
+pub use scalar::{like_pattern, EvalEnv, ScalarExpr};
 pub use transform::OptimizedRelationExpr;

--- a/src/expr/scalar/like_pattern.rs
+++ b/src/expr/scalar/like_pattern.rs
@@ -9,10 +9,9 @@
 
 use regex::Regex;
 
-pub fn build_like_regex_from_string(like_string: &str) -> Result<Regex, failure::Error> {
-    // The goal is to build a regex that matches the same strings as the LIKE
-    // pattern.
-    //
+/// Builds a regular expression that matches the same strings as a SQL
+/// LIKE pattern.
+pub fn build_regex(pattern: &str) -> Result<Regex, failure::Error> {
     // LIKE patterns always cover the whole string, so we anchor the regex on
     // both sides. An underscore (`_`) in a LIKE pattern matches any single
     // character and a percent sign (`%`) matches any sequence of zero or more
@@ -32,7 +31,7 @@ pub fn build_like_regex_from_string(like_string: &str) -> Result<Regex, failure:
     // syntax eventually.
     let mut regex = String::from("^");
     let mut escape = false;
-    for c in like_string.chars() {
+    for c in pattern.chars() {
         match c {
             '\\' if !escape => escape = true,
             '_' if !escape => regex.push('.'),

--- a/src/sql/expr.rs
+++ b/src/sql/expr.rs
@@ -19,7 +19,6 @@ use repr::*;
 use crate::Params;
 
 // these happen to be unchanged at the moment, but there might be additions later
-pub use dataflow_expr::like;
 pub use dataflow_expr::{
     AggregateFunc, BinaryFunc, ColumnOrder, NullaryFunc, UnaryFunc, UnaryTableFunc, VariadicFunc,
 };

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -2697,7 +2697,7 @@ fn plan_like<'a>(
     }
 
     let mut expr = ScalarExpr::CallBinary {
-        func: BinaryFunc::MatchRegex,
+        func: BinaryFunc::MatchLikePattern,
         expr1: Box::new(lexpr),
         expr2: Box::new(rexpr),
     };

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -24,7 +24,7 @@ use dataflow_types::{
     FileSourceConnector, KafkaSinkConnector, KafkaSourceConnector, KinesisSourceConnector,
     PeekWhen, ProtobufEncoding, RowSetFinishing, SinkConnector, SourceConnector,
 };
-use expr::GlobalId;
+use expr::{like_pattern, GlobalId};
 use ore::collections::CollectionExt;
 use repr::strconv;
 use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowArena, ScalarType};
@@ -33,7 +33,6 @@ use sql_parser::ast::{
     SetVariableValue, ShowStatementFilter, Stage, Statement, Value,
 };
 
-use crate::expr::like::build_like_regex_from_string;
 use crate::query::QueryLifetime;
 use crate::{normalize, query, Index, Params, Plan, PlanSession, Sink, Source, View};
 use regex::Regex;
@@ -394,9 +393,9 @@ fn handle_show_objects(
         Ok(Plan::SendRows(rows))
     } else {
         let like_regex = match filter {
-            Some(ShowStatementFilter::Like(pattern)) => build_like_regex_from_string(&pattern)?,
+            Some(ShowStatementFilter::Like(pattern)) => like_pattern::build_regex(&pattern)?,
             Some(ShowStatementFilter::Where(_)) => bail!("SHOW ... WHERE is not supported"),
-            None => build_like_regex_from_string("%")?,
+            None => like_pattern::build_regex("%")?,
         };
 
         let empty_schema = BTreeMap::new();


### PR DESCRIPTION
These function names got a bit confused with the change to Row. Clarify
their names: the two-argument form matches a LIKE pattern, while the
one-argument form matches a regex.