### PR TITLE
expr: use dedicated error type

### DIFF
--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -23,5 +23,5 @@ pub use relation::func::{AggregateFunc, UnaryTableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::{AggregateExpr, ColumnOrder, IdGen, JoinImplementation, RelationExpr};
 pub use scalar::func::{BinaryFunc, DateTruncTo, NullaryFunc, UnaryFunc, VariadicFunc};
-pub use scalar::{like_pattern, EvalEnv, ScalarExpr};
+pub use scalar::{like_pattern, EvalEnv, EvalError, ScalarExpr};
 pub use transform::OptimizedRelationExpr;

--- a/src/expr/scalar/like_pattern.rs
+++ b/src/expr/scalar/like_pattern.rs
@@ -9,9 +9,11 @@
 
 use regex::Regex;
 
+use crate::scalar::EvalError;
+
 /// Builds a regular expression that matches the same strings as a SQL
 /// LIKE pattern.
-pub fn build_regex(pattern: &str) -> Result<Regex, failure::Error> {
+pub fn build_regex(pattern: &str) -> Result<Regex, EvalError> {
     // LIKE patterns always cover the whole string, so we anchor the regex on
     // both sides. An underscore (`_`) in a LIKE pattern matches any single
     // character and a percent sign (`%`) matches any sequence of zero or more
@@ -47,8 +49,8 @@ pub fn build_regex(pattern: &str) -> Result<Regex, failure::Error> {
     }
     regex.push('$');
     if escape {
-        failure::bail!("unterminated escape sequence in LIKE")
+        Err(EvalError::UnterminatedLikeEscapeSequence)
     } else {
-        Ok(Regex::new(&regex)?)
+        Ok(Regex::new(&regex).expect("regex constructed to be valid"))
     }
 }

--- a/src/expr/scalar/mod.rs
+++ b/src/expr/scalar/mod.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
+use std::fmt;
 use std::mem;
 
 use chrono::{DateTime, Utc};
@@ -497,6 +498,45 @@ pub struct EvalEnv {
     pub logical_time: Option<u64>,
     pub wall_time: Option<DateTime<Utc>>,
 }
+
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub enum EvalError {
+    DivisionByZero,
+    NumericFieldOverflow,
+    IntegerOutOfRange,
+    InvalidEncodingName(String),
+    InvalidByteSequence {
+        byte_sequence: String,
+        encoding_name: String,
+    },
+    UnknownUnits(String),
+    UnterminatedLikeEscapeSequence,
+}
+
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            EvalError::DivisionByZero => f.write_str("division by zero"),
+            EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
+            EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
+            EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
+            EvalError::InvalidByteSequence {
+                byte_sequence,
+                encoding_name,
+            } => write!(
+                f,
+                "invalid byte sequence '{}' for encoding '{}'",
+                byte_sequence, encoding_name
+            ),
+            EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
+            EvalError::UnterminatedLikeEscapeSequence => {
+                f.write_str("unterminated escape sequence in LIKE")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EvalError {}
 
 #[cfg(test)]
 mod tests {

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -80,7 +80,7 @@ SELECT date_trunc('millennium', TIMESTAMP '2019-11-26 15:56:46.241150')
 ----
 2001-01-01 00:00:00
 
-query error invalid date_trunc precision: bad
+query error unknown units 'bad'
 SELECT date_trunc('bad', TIMESTAMP '2019-11-26 15:56:46.241150')
 
 statement ok


### PR DESCRIPTION
failure::Error isn't cloneable, which means it can't be stored in an
expr AST.