### PR TITLE
Print panic stack trace to log file.

### DIFF
--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -114,7 +114,7 @@ same file. Most of the time, we use `mode cockroach`. The times when we use
 
     In `mode cockroach`, if your expected column name or row entry contains a
     space, to have the space not treated as a column delimiter, replace the
-    space with the symbol ␠, which is U+2040, the Unicode "SYMBOL FOR SPACE".
+    space with the symbol ␠, which is U+2420, the Unicode "SYMBOL FOR SPACE".
     Example:
     ```
     query TT colnames

--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -20,6 +20,9 @@ For information about available versions, see our [Versions page](../versions).
   round `x` to the `y`th digit after the decimal. (Default 0).
 - Support addition and subtraction between [`interval`]s.
 
+- In the event of a crash, materialize now prints the stack trace to the log
+  file as well as the terminal.
+
 <span id="v0.1.2"></span>
 ## 0.1.1 &rarr; 0.1.2
 

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -257,7 +257,7 @@ fn handle_panic(panic_info: &PanicInfo) {
 
     let backtrace = Backtrace::new();
 
-    eprintln!(
+    let crash_message = format!(
         r#"materialized encountered an internal error and crashed.
 
 We rely on bug reports to diagnose and fix these errors. Please
@@ -271,6 +271,10 @@ message: {}
         thr_name, msg, backtrace
     );
 
+    if LOG_FILE.get().is_some() {
+        log::error!("{}", crash_message);
+    }
+    eprintln!("{}", crash_message);
     process::exit(1);
 }
 


### PR DESCRIPTION
Resolves #2251 

Also corrects the unicode number of "SYMBOL FOR SPACE" in sqllogictest docs.