### PR TITLE
docs: consolidate conceptual docs around SQL components

### DIFF
--- a/doc/user/overview/architecture.md
+++ b/doc/user/overview/architecture.md
@@ -38,9 +38,9 @@ _Below: Zooming in on Materialize's internal structure in the above deployment._
 
 Right now, Materialize provides its interactive interface through `psql` running
 locally on a client machine; this uses the PostgreSQL wire protocol (`pgwire`)
-to communicate with `materialized`. _NOTE: We have a client called
+to communicate with `materialized`. We have a client called
 [`mzcli`](https://github.com/MaterializeInc/mzcli) that we recommend using, but
-it's just a modified wrapper around `pgcli`._
+it's just a modified wrapper around `pgcli`.
 
 Because this is a SQL shell, Materialize lets you interact with your node
 through SQL statements sent over `pgwire` to an internal `queue`, where they are
@@ -59,7 +59,7 @@ When Materialize receives a `CREATE SOURCE...` statement, it connects to some
 destination to read data. In the case of streaming sources, it attempts to
 connect to a Kafka stream, which it plumbs into its local instance of
 Differential. You can find more information about how that works in the
-**Kafka** section below.
+[Sources](#sources-ingesting-data) section.
 
 ### Reading data
 
@@ -152,8 +152,8 @@ Implicit in this design are a few key points:
 
 Check out:
 
-- [Get started](../../get-started)
-- [`CREATE SOURCE`](../../sql/create-source)
+- [API components](../api-components) to better understand Materialize's API
+- [Get started](../../get-started) to try out Materialize
 
 [1]:
 https://paper.dropbox.com/doc/Materialize-Product--AbHSqqXlN5YNKHiYEXm3EKyNAg-eMbfh2QTOCPrU7drExDCm

--- a/doc/user/overview/what-is-materialize.md
+++ b/doc/user/overview/what-is-materialize.md
@@ -102,3 +102,8 @@ In contrast, Materialize continually updates queries as data comes in, which mea
 ### Materialized views in relational databases
 
 To maintain materialized views, most RDBMSes occasionally re-run the view's underlying query. This results in a potential impact to the database's performance while updating the view, as well as data that is only infrequently up-to-date.
+
+## Learn more
+
+- [Architecture overview](../architecture-overview) to understand Materialize's internal architecture
+- [API overview](../api-components) to understand what Materialize's SQL API expresses

--- a/doc/user/sql/create-materialized-view.md
+++ b/doc/user/sql/create-materialized-view.md
@@ -14,13 +14,7 @@ feature.
 ## Conceptual framework
 
 `CREATE MATERIALIZED VIEW` computes and maintains the results of a `SELECT`
-query in memory. (For more information about materialized views, see [What is
-Materialize?](../../overview/what-is-materialize))
-
-This means that as data streams in from your sources, Materialize incrementally
-updates the results of the view's `SELECT` statement. Because these results are
-available in memory, you can get an answer to the query with incredibly low
-latency.
+query in memory. For more information, see [API Components: Materialized views](../../overview/api-components#materialized-views).
 
 ## Syntax
 
@@ -34,21 +28,6 @@ _view&lowbar;name_ | A name for the view.
 _select&lowbar;stmt_ | The [`SELECT` statement](../select) whose output you want to materialize and maintain.
 
 ## Details
-
-### Overview
-
-When creating a view, Materialize's internal Differential dataflow engine
-creates a persistent dataflow for the corresponding `SELECT` statement. All of
-the data that is available from the view's source's arrangements (which is
-similar to an index in the language of RDBMSes) is then used to create the first
-result set of the view.
-
-As data continues to stream in from Kafka, Differential passes the data to the
-appropriate dataflows, which are then responsible for making any necessary
-updates to maintain the views you've defined.
-
-When reading from a view (e.g. `SELECT * FROM some_view`), Materialize simply
-returns the current result set for the persisted dataflow.
 
 ### Memory
 

--- a/doc/user/sql/create-source.md
+++ b/doc/user/sql/create-source.md
@@ -14,60 +14,18 @@ with its data as if it were in a SQL table.
 ## Conceptual framework
 
 To provide data to Materialize, you must create "sources", which is a catchall
-term for a resource Materialize can read data from. For more detail about how
-sources work within the rest of Materialize, check out our [architecture
-overview](/docs/overview/architecture/).
-
-Sources consist of three distinct elements:
-
-Element | Purpose | Example
---------|---------|--------
-**Connector** | Provides actual bytes of data to Materialize | Kafka
-**Format** | The structure of the external source's bytes | Avro
-**Envelope** | How Materialize should handle the incoming data + additional formatting information | Append-only
-
-### Connectors
-
-Materialize can connect to the following types of sources:
-
-- Streaming sources like Kafka
-- File sources like `.csv` or unstructured log files
-
-### Formats
-
-Materialize can decode incoming bytes of data from several formats
-
-- Avro
-- Protobuf
-- Regex
-- CSV
-- Plain text
-- Raw bytes
-
-### Envelopes
-
-What Materialize actually does with the data it receives depends on the
-"envelope" your data provides:
-
-Envelope | Action
----------|-------
-**Append-only** | Inserts all received data; does not support updates or deletes.
-**Debezium** | Treats data as wrapped in a "diff envelope" which indicates whether the record is an insertion, deletion, or update. The Debezium envelope is only supported by sources published to Kafka by [Debezium].
-
-For more information about envelopes, see [Envelope details](#envelope-details).
+term for a resource Materialize can read data from. For more information, see [API Components: Sources](../../overview/api-components#sources).
 
 ## Syntax
 
 ### Create source
-
-`CREATE SOURCE` can be used to create streaming or file sources.
 
 {{< diagram "create-source.html" >}}
 
 Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
-**FROM** _connector&lowbar;spec_ | A specification of how to connect to the external resource providing the data. For more detail, see [Connector specifications](#connector-spec).
+**FROM** _connector&lowbar;spec_ | A specification of how to connect to the external resource providing the data. For more detail, see [Connector specifications](#connector-specifications).
 **FORMAT** _format&lowbar;spec_ | A description of the format of data in the source. For more detail, see [Format specifications](#format-spec).
 **ENVELOPE** _envelope_ | The envelope type.<br/><br/> &#8226; **NONE** implies that each record appends to the source. <br/><br/>&#8226; **DEBEZIUM** requires records have the [appropriate fields](#format-implications), which allow deletes, inserts, and updates. The Debezium envelope is only supported by sources published to Kafka by [Debezium].<br/><br/>For more information, see [Debezium envelope details](#debezium-envelope-details).
 
@@ -127,9 +85,15 @@ Field | Value
 _schema&lowbar;file&lowbar;path_ | The absolute path to a file containing the schema.
 _inline&lowbar;schema_ | A string representing the schema.
 
-## External source details
+## Connector details
 
-External sources provide the actual bytes of data to Materialize.
+Connectors let materialize get data from external sources, which provide the
+actual bytes of data for Materialize to process.
+
+Materialize can connect to the following types of sources:
+
+- Streaming sources like Kafka
+- File sources like `.csv` or unstructured log files
 
 ### Kafka source details
 
@@ -145,6 +109,17 @@ Materialize expects each source to use to one Kafka topic, which is&mdash;in
 - All data in file sources are treated as [`string`](../types/string).
 
 ## Format details
+
+The source's format describes the structure of its bytes.
+
+Materialize can decode incoming bytes of data from several formats:
+
+- Avro
+- Protobuf
+- Regex
+- CSV
+- Plain text
+- Raw bytes
 
 ### Avro format details
 
@@ -222,6 +197,11 @@ source without applying any formatting or decoding.
 ## Envelope details
 
 Envelopes determine whether an incoming record inserts new data, updates or deletes existing data, or both.
+
+Materialize supports the following types of envelopes:
+
+- Append-only, which only supports inserting new data
+- Debezium, which supports all CRUD operations
 
 ### Append-only envelope details
 

--- a/doc/user/sql/create-view.md
+++ b/doc/user/sql/create-view.md
@@ -16,15 +16,7 @@ VIEW`](../create-materialized-view).
 ## Conceptual framework
 
 `CREATE VIEW` simply stores the verbatim `SELECT` query, and provides a
-shorthand for performing the query.
-
-Note that you can only `SELECT` from non-materialized views if all of the views
-in their `FROM` clauses are themselves materialized or have transitive access to
-materialized views. For more information on this restriction, see [Selecting
-from non-materialized views](#selecting-from-non-materialized-views).
-
-If you plan on repeatedly reading from a view, we recommend using [materialized
-views](../create-materialized-view) instead.
+shorthand for performing the query. For more information, see [API Components: Sources](../../overview/api-components#non-materialized-views).
 
 ## Syntax
 


### PR DESCRIPTION
Previously, we didn't have a single source that helped users understand our API's fundamental nouns. Instead, one had to know which SQL API docs to review to create this understanding.

In this PR, I've consolidated the conceptual framework sections of the fundamental API components into a single doc.

@benesch @frankmcsherry grateful for a quick look over this to ensure I haven't introduced any mistruths in reformatting this information