### PR TITLE
expr: fix bugs and simplify ScalarExpr::reduce

### DIFF
--- a/src/expr/scalar/mod.rs
+++ b/src/expr/scalar/mod.rs
@@ -70,6 +70,10 @@ impl ScalarExpr {
         ScalarExpr::Literal(row, typ)
     }
 
+    pub fn literal_null(typ: ColumnType) -> Self {
+        ScalarExpr::literal(Datum::Null, typ)
+    }
+
     pub fn call_unary(self, func: UnaryFunc) -> Self {
         ScalarExpr::CallUnary {
             func,
@@ -214,6 +218,13 @@ impl ScalarExpr {
         }
     }
 
+    pub fn as_literal_str(&self) -> Option<&str> {
+        match self.as_literal() {
+            Some(Datum::String(s)) => Some(s),
+            _ => None,
+        }
+    }
+
     pub fn is_literal_true(&self) -> bool {
         Some(Datum::True) == self.as_literal()
     }
@@ -247,7 +258,6 @@ impl ScalarExpr {
     /// assert_eq!(test, expr_t);
     /// ```
     pub fn reduce(&mut self, relation_type: &RelationType, env: &EvalEnv) {
-        let null = |typ| ScalarExpr::literal(Datum::Null, typ);
         let temp_storage = &RowArena::new();
         let eval = |e: &ScalarExpr| {
             ScalarExpr::literal(e.eval(&[], env, temp_storage), e.typ(&relation_type))
@@ -268,42 +278,36 @@ impl ScalarExpr {
                 } else if (expr1.is_literal_null() || expr2.is_literal_null())
                     && func.propagates_nulls()
                 {
-                    *e = null(e.typ(relation_type));
+                    *e = ScalarExpr::literal_null(e.typ(relation_type));
                 } else if *func == BinaryFunc::MatchLikePattern && expr2.is_literal() {
                     // We can at least precompile the regex.
-                    *e = match expr2.eval(&[], env, temp_storage) {
-                        Datum::String(string) => match like_pattern::build_regex(&string) {
-                            Ok(regex) => {
-                                expr1.take().call_unary(UnaryFunc::MatchRegex(Regex(regex)))
-                            }
-                            Err(_) => null(e.typ(&relation_type)),
-                        },
-                        _ => unreachable!(),
+                    let pattern = expr2.as_literal_str().unwrap();
+                    *e = match like_pattern::build_regex(&pattern) {
+                        Ok(regex) => expr1.take().call_unary(UnaryFunc::MatchRegex(Regex(regex))),
+                        Err(_) => ScalarExpr::literal_null(e.typ(&relation_type)),
                     };
                 } else if *func == BinaryFunc::DateTrunc && expr1.is_literal() {
-                    *e = match expr1.eval(&[], env, &temp_storage) {
-                        Datum::String(s) => match s.parse::<DateTruncTo>() {
-                            Ok(to) => ScalarExpr::CallUnary {
-                                func: UnaryFunc::DateTrunc(to),
-                                expr: Box::new(expr2.take()),
-                            },
-                            Err(_) => null(e.typ(&relation_type)),
+                    let units = expr1.as_literal_str().unwrap();
+                    *e = match units.parse::<DateTruncTo>() {
+                        Ok(to) => ScalarExpr::CallUnary {
+                            func: UnaryFunc::DateTrunc(to),
+                            expr: Box::new(expr2.take()),
                         },
-                        _ => unreachable!(),
+                        Err(_) => ScalarExpr::literal_null(e.typ(&relation_type)),
                     }
                 } else if *func == BinaryFunc::And && (expr1.is_literal() || expr2.is_literal()) {
                     // If we are here, not both inputs are literals.
                     if expr1.is_literal_false() || expr2.is_literal_true() {
-                        *e = (**expr1).clone();
+                        *e = expr1.take();
                     } else if expr2.is_literal_false() || expr1.is_literal_true() {
-                        *e = (**expr2).clone();
+                        *e = expr2.take();
                     }
                 } else if *func == BinaryFunc::Or && (expr1.is_literal() || expr2.is_literal()) {
                     // If we are here, not both inputs are literals.
                     if expr1.is_literal_true() || expr2.is_literal_false() {
-                        *e = (**expr1).clone();
+                        *e = expr1.take();
                     } else if expr2.is_literal_true() || expr1.is_literal_false() {
-                        *e = (**expr2).clone();
+                        *e = expr2.take();
                     }
                 }
             }
@@ -311,19 +315,15 @@ impl ScalarExpr {
                 if exprs.iter().all(|e| e.is_literal()) {
                     *e = eval(e);
                 } else if func.propagates_nulls() && exprs.iter().any(|e| e.is_literal_null()) {
-                    *e = null(e.typ(&relation_type));
+                    *e = ScalarExpr::literal_null(e.typ(&relation_type));
                 }
             }
-            ScalarExpr::If { cond, then, els } => {
-                if cond.is_literal() {
-                    match cond.eval(&[], env, &temp_storage) {
-                        Datum::True if then.is_literal() => *e = eval(then),
-                        Datum::False | Datum::Null if els.is_literal() => *e = eval(els),
-                        Datum::True | Datum::False | Datum::Null => (),
-                        _ => unreachable!(),
-                    }
-                }
-            }
+            ScalarExpr::If { cond, then, els } => match cond.as_literal() {
+                Some(Datum::True) => *e = then.take(),
+                Some(Datum::False) | Some(Datum::Null) => *e = els.take(),
+                Some(_) => unreachable!(),
+                None => (),
+            },
         });
     }
 

--- a/src/expr/transform/column_knowledge.rs
+++ b/src/expr/transform/column_knowledge.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 
 use repr::Datum;
-use repr::{ColumnType, ScalarType};
+use repr::{ColumnType, RelationType, ScalarType};
 
 use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
 
@@ -96,7 +96,7 @@ impl ColumnKnowledge {
             RelationExpr::Map { input, scalars } => {
                 let mut input_knowledge = ColumnKnowledge::harvest(input, env, knowledge);
                 for scalar in scalars.iter_mut() {
-                    let know = optimize(scalar, env, &input_knowledge[..]);
+                    let know = optimize(scalar, &input.typ(), env, &input_knowledge[..]);
                     input_knowledge.push(know);
                 }
                 input_knowledge
@@ -108,7 +108,7 @@ impl ColumnKnowledge {
                 demand: _,
             } => {
                 let mut input_knowledge = ColumnKnowledge::harvest(input, env, knowledge);
-                optimize(expr, env, &input_knowledge[..]);
+                optimize(expr, &input.typ(), env, &input_knowledge[..]);
                 let func_typ = func.output_type(&expr.typ(&input.typ()));
                 input_knowledge.extend(func_typ.column_types.into_iter().map(|typ| {
                     DatumKnowledge {
@@ -121,7 +121,7 @@ impl ColumnKnowledge {
             RelationExpr::Filter { input, predicates } => {
                 let input_knowledge = ColumnKnowledge::harvest(input, env, knowledge);
                 for predicate in predicates.iter_mut() {
-                    optimize(predicate, env, &input_knowledge[..]);
+                    optimize(predicate, &input.typ(), env, &input_knowledge[..]);
                 }
                 // If any predicate tests a column for equality, truth, or is_null, we learn stuff.
                 // I guess we implement that later on.
@@ -157,7 +157,7 @@ impl ColumnKnowledge {
                 let input_knowledge = ColumnKnowledge::harvest(input, env, knowledge);
                 let mut output = group_key
                     .iter_mut()
-                    .map(|k| optimize(k, env, &input_knowledge[..]))
+                    .map(|k| optimize(k, &input.typ(), env, &input_knowledge[..]))
                     .collect::<Vec<_>>();
                 for _aggregate in aggregates {
                     // This could be improved.
@@ -212,6 +212,7 @@ impl DatumKnowledge {
 /// Attempts to optimize
 pub fn optimize(
     expr: &mut ScalarExpr,
+    input_type: &RelationType,
     env: &EvalEnv,
     column_knowledge: &[DatumKnowledge],
 ) -> DatumKnowledge {
@@ -228,20 +229,20 @@ pub fn optimize(
             nullable: row.unpack_first() == Datum::Null,
         },
         ScalarExpr::CallNullary(_) => {
-            expr.reduce(env);
-            optimize(expr, env, column_knowledge)
+            expr.reduce(input_type, env);
+            optimize(expr, input_type, env, column_knowledge)
         }
         ScalarExpr::CallUnary { func, expr: inner } => {
-            let knowledge = optimize(inner, env, column_knowledge);
+            let knowledge = optimize(inner, input_type, env, column_knowledge);
             if knowledge.value.is_some() {
-                expr.reduce(env);
-                optimize(expr, env, column_knowledge)
+                expr.reduce(input_type, env);
+                optimize(expr, input_type, env, column_knowledge)
             } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
                 *expr = ScalarExpr::Literal(
                     repr::Row::pack(Some(Datum::False)),
                     ColumnType::new(ScalarType::Bool).nullable(false),
                 );
-                optimize(expr, env, column_knowledge)
+                optimize(expr, input_type, env, column_knowledge)
             } else {
                 DatumKnowledge {
                     value: None,
@@ -254,11 +255,11 @@ pub fn optimize(
             expr1,
             expr2,
         } => {
-            let knowledge1 = optimize(expr1, env, column_knowledge);
-            let knowledge2 = optimize(expr2, env, column_knowledge);
+            let knowledge1 = optimize(expr1, input_type, env, column_knowledge);
+            let knowledge2 = optimize(expr2, input_type, env, column_knowledge);
             if knowledge1.value.is_some() && knowledge2.value.is_some() {
-                expr.reduce(env);
-                optimize(expr, env, column_knowledge)
+                expr.reduce(input_type, env);
+                optimize(expr, input_type, env, column_knowledge)
             } else {
                 DatumKnowledge {
                     value: None,
@@ -269,12 +270,12 @@ pub fn optimize(
         ScalarExpr::CallVariadic { func: _, exprs } => {
             let mut knows = Vec::new();
             for expr in exprs.iter_mut() {
-                knows.push(optimize(expr, env, column_knowledge));
+                knows.push(optimize(expr, input_type, env, column_knowledge));
             }
 
             if knows.iter().all(|k| k.value.is_some()) {
-                expr.reduce(env);
-                optimize(expr, env, column_knowledge)
+                expr.reduce(input_type, env);
+                optimize(expr, input_type, env, column_knowledge)
             } else {
                 DatumKnowledge {
                     value: None,
@@ -283,13 +284,13 @@ pub fn optimize(
             }
         }
         ScalarExpr::If { cond, then, els } => {
-            if let Some((value, _typ)) = optimize(cond, env, column_knowledge).value {
+            if let Some((value, _typ)) = optimize(cond, input_type, env, column_knowledge).value {
                 match value.unpack_first() {
                     Datum::True => *expr = (**then).clone(),
                     Datum::False | Datum::Null => *expr = (**els).clone(),
                     d => panic!("IF condition evaluated to non-boolean datum {:?}", d),
                 }
-                optimize(expr, env, column_knowledge)
+                optimize(expr, input_type, env, column_knowledge)
             } else {
                 DatumKnowledge {
                     value: None,

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -48,7 +48,7 @@ impl FoldConstants {
                 aggregates,
             } => {
                 for aggregate in aggregates.iter_mut() {
-                    aggregate.expr.reduce(env);
+                    aggregate.expr.reduce(&input.typ(), env);
                 }
                 if let RelationExpr::Constant { rows, .. } = &**input {
                     // Build a map from `group_key` to `Vec<Vec<an, ..., a1>>)`,
@@ -130,7 +130,7 @@ impl FoldConstants {
             }
             RelationExpr::Map { input, scalars } => {
                 for scalar in scalars.iter_mut() {
-                    scalar.reduce(env);
+                    scalar.reduce(&input.typ(), env);
                 }
 
                 if let RelationExpr::Constant { rows, .. } = &**input {
@@ -158,7 +158,7 @@ impl FoldConstants {
                 expr,
                 demand: _,
             } => {
-                expr.reduce(env);
+                expr.reduce(&input.typ(), env);
 
                 if let RelationExpr::Constant { rows, .. } = &**input {
                     let new_rows = rows
@@ -190,7 +190,7 @@ impl FoldConstants {
             }
             RelationExpr::Filter { input, predicates } => {
                 for predicate in predicates.iter_mut() {
-                    predicate.reduce(env);
+                    predicate.reduce(&input.typ(), env);
                 }
                 predicates.retain(|p| !p.is_literal_true());
 


### PR DESCRIPTION
The simplifications here have the nice side effect of making it easier to plumb evaluation errors through reduce (#2234)—once evaluation can error, reduce has to be preserve those errors as it simplifies things.