### PR TITLE
expr: allow transformations to fail

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -207,11 +207,9 @@ where
                                 let eval_env = EvalEnv::default();
                                 let view = catalog::View {
                                     create_sql: view.create_sql,
-                                    expr: optimizer.optimize(
-                                        view.expr,
-                                        catalog.indexes(),
-                                        &eval_env,
-                                    ),
+                                    expr: optimizer
+                                        .optimize(view.expr, catalog.indexes(), &eval_env)
+                                        .expect("failed to optimize bootstrap sql"),
                                     eval_env,
                                     desc: view.desc,
                                 };
@@ -772,7 +770,7 @@ where
                     create_sql: view.create_sql,
                     expr: self
                         .optimizer
-                        .optimize(view.expr, self.catalog.indexes(), &eval_env),
+                        .optimize(view.expr, self.catalog.indexes(), &eval_env)?,
                     desc: view.desc,
                     eval_env,
                 };
@@ -932,9 +930,9 @@ where
                 // constant expression that originally contains a global get? Is
                 // there anything not containing a global get that cannot be
                 // optimized to a constant expression?
-                let mut source = self
-                    .optimizer
-                    .optimize(source, self.catalog.indexes(), &eval_env);
+                let mut source =
+                    self.optimizer
+                        .optimize(source, self.catalog.indexes(), &eval_env)?;
 
                 // If this optimizes to a constant expression, we can immediately return the result.
                 if let RelationExpr::Constant { rows, typ: _ } = source.as_ref() {
@@ -1113,7 +1111,7 @@ where
                 };
                 let relation_expr =
                     self.optimizer
-                        .optimize(relation_expr, self.catalog.indexes(), &eval_env);
+                        .optimize(relation_expr, self.catalog.indexes(), &eval_env)?;
                 let pretty = relation_expr.as_ref().pretty_humanized(&self.catalog);
                 let rows = vec![Row::pack(&[Datum::from(&*pretty)])];
                 Ok(send_immediate_rows(rows))

--- a/src/coord/persistence.rs
+++ b/src/coord/persistence.rs
@@ -107,7 +107,7 @@ impl CatalogItemSerializer for SqlSerializer {
                 };
                 catalog::CatalogItem::View(View {
                     create_sql: view.create_sql,
-                    expr: optimizer.optimize(view.expr, catalog.indexes(), &eval_env),
+                    expr: optimizer.optimize(view.expr, catalog.indexes(), &eval_env)?,
                     eval_env,
                     desc: view.desc,
                 })

--- a/src/expr/transform/binding.rs
+++ b/src/expr/transform/binding.rs
@@ -224,8 +224,9 @@ impl super::Transform for Hoist {
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         Hoist::hoist(expr);
+        Ok(())
     }
 }
 
@@ -291,8 +292,9 @@ impl super::Transform for Unbind {
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         Unbind::unbind(expr);
+        Ok(())
     }
 }
 
@@ -471,8 +473,9 @@ impl super::Transform for Deduplicate {
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         Deduplicate::deduplicate(expr);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/column_knowledge.rs
+++ b/src/expr/transform/column_knowledge.rs
@@ -24,15 +24,20 @@ impl super::Transform for ColumnKnowledge {
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         env: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         self.transform(expr, env)
     }
 }
 
 impl ColumnKnowledge {
     /// Transforms an expression through accumulated knowledge.
-    pub fn transform(&self, expr: &mut RelationExpr, env: &EvalEnv) {
+    pub fn transform(
+        &self,
+        expr: &mut RelationExpr,
+        env: &EvalEnv,
+    ) -> Result<(), super::TransformError> {
         ColumnKnowledge::harvest(expr, env, &mut HashMap::new());
+        Ok(())
     }
 
     /// Harvest per-column knowledge.

--- a/src/expr/transform/constant_join.rs
+++ b/src/expr/transform/constant_join.rs
@@ -23,8 +23,9 @@ impl super::Transform for InsertConstantJoin {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 
@@ -73,8 +74,9 @@ impl super::Transform for RemoveConstantJoin {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -27,8 +27,9 @@ impl crate::transform::Transform for Demand {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/empty_map.rs
+++ b/src/expr/transform/empty_map.rs
@@ -20,8 +20,9 @@ impl super::Transform for EmptyMap {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/filter_lets.rs
+++ b/src/expr/transform/filter_lets.rs
@@ -27,8 +27,9 @@ impl super::Transform for FilterLets {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/fusion/filter.rs
+++ b/src/expr/transform/fusion/filter.rs
@@ -50,8 +50,9 @@ impl crate::transform::Transform for Filter {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), crate::transform::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/fusion/join.rs
+++ b/src/expr/transform/fusion/join.rs
@@ -20,8 +20,9 @@ impl crate::transform::Transform for Join {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), crate::transform::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/fusion/map.rs
+++ b/src/expr/transform/fusion/map.rs
@@ -21,8 +21,9 @@ impl crate::transform::Transform for Map {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), crate::transform::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/fusion/project.rs
+++ b/src/expr/transform/fusion/project.rs
@@ -20,8 +20,9 @@ impl crate::transform::Transform for Project {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), crate::transform::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/inline_let.rs
+++ b/src/expr/transform/inline_let.rs
@@ -20,8 +20,9 @@ impl super::Transform for InlineLet {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/join_elision.rs
+++ b/src/expr/transform/join_elision.rs
@@ -24,8 +24,9 @@ impl super::Transform for JoinElision {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/join_implementation.rs
+++ b/src/expr/transform/join_implementation.rs
@@ -34,8 +34,9 @@ impl super::Transform for JoinImplementation {
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         self.transform(relation, indexes);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/join_order.rs
+++ b/src/expr/transform/join_order.rs
@@ -58,8 +58,9 @@ impl super::Transform for JoinOrder {
         relation: &mut RelationExpr,
         arrangements: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation, arrangements)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation, arrangements);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/nonnull_requirements.rs
+++ b/src/expr/transform/nonnull_requirements.rs
@@ -35,8 +35,9 @@ impl crate::transform::Transform for NonNullRequirements {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/nonnullable.rs
+++ b/src/expr/transform/nonnullable.rs
@@ -23,8 +23,9 @@ impl super::Transform for NonNullable {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/predicate_pushdown.rs
+++ b/src/expr/transform/predicate_pushdown.rs
@@ -62,8 +62,9 @@ impl super::Transform for PredicatePushdown {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/projection_extraction.rs
+++ b/src/expr/transform/projection_extraction.rs
@@ -22,8 +22,9 @@ impl super::Transform for ProjectionExtraction {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/projection_lifting.rs
+++ b/src/expr/transform/projection_lifting.rs
@@ -22,8 +22,9 @@ impl crate::transform::Transform for ProjectionLifting {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/reduce_elision.rs
+++ b/src/expr/transform/reduce_elision.rs
@@ -25,8 +25,9 @@ impl super::Transform for ReduceElision {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -25,8 +25,9 @@ impl super::Transform for FoldConstants {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         env: &EvalEnv,
-    ) {
-        self.transform(relation, env)
+    ) -> Result<(), crate::transform::TransformError> {
+        self.transform(relation, env);
+        Ok(())
     }
 }
 
@@ -378,8 +379,9 @@ pub mod demorgans {
             relation: &mut RelationExpr,
             _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
             _: &EvalEnv,
-        ) {
-            self.transform(relation)
+        ) -> Result<(), crate::transform::TransformError> {
+            self.transform(relation);
+            Ok(())
         }
     }
 
@@ -464,8 +466,9 @@ pub mod undistribute_and {
             relation: &mut RelationExpr,
             _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
             _: &EvalEnv,
-        ) {
-            self.transform(relation)
+        ) -> Result<(), crate::transform::TransformError> {
+            self.transform(relation);
+            Ok(())
         }
     }
 

--- a/src/expr/transform/reduction_pushdown.rs
+++ b/src/expr/transform/reduction_pushdown.rs
@@ -20,8 +20,9 @@ impl super::Transform for ReductionPushdown {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         env: &EvalEnv,
-    ) {
-        self.transform(relation, env)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation, env);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/redundant_join.rs
+++ b/src/expr/transform/redundant_join.rs
@@ -24,8 +24,9 @@ impl super::Transform for RedundantJoin {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         env: &EvalEnv,
-    ) {
-        self.transform(relation, env)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation, env);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/simplify.rs
+++ b/src/expr/transform/simplify.rs
@@ -74,8 +74,9 @@ impl super::Transform for SimplifyFilterPredicates {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/split_predicates.rs
+++ b/src/expr/transform/split_predicates.rs
@@ -20,7 +20,7 @@ impl super::Transform for SplitPredicates {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         relation.visit_mut(&mut |expr| {
             if let RelationExpr::Filter { predicates, .. } = expr {
                 let mut pending_predicates = predicates.drain(..).collect::<Vec<_>>();
@@ -39,5 +39,6 @@ impl super::Transform for SplitPredicates {
                 }
             }
         });
+        Ok(())
     }
 }

--- a/src/expr/transform/update_let.rs
+++ b/src/expr/transform/update_let.rs
@@ -28,8 +28,9 @@ impl super::Transform for UpdateLet {
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
-        self.transform(relation)
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
     }
 }
 

--- a/src/expr/transform/use_indexes.rs
+++ b/src/expr/transform/use_indexes.rs
@@ -40,8 +40,9 @@ impl super::Transform for FilterEqualLiteral {
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
         _: &EvalEnv,
-    ) {
+    ) -> Result<(), super::TransformError> {
         self.transform(relation, indexes);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This converts the non-converging fixpoint panic into a graceful error
(#1177). It also tees us up nicely for runtime errors (#489).

This PR is mostly extracted from #2234, which has already been approved.