### PR TITLE
dataflow,sql: ensure kafka offset column is accounted for

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -481,7 +481,7 @@ pub enum ExternalSourceConnector {
 impl ExternalSourceConnector {
     pub fn metadata_columns(&self) -> Vec<(ColumnType, Option<String>)> {
         match self {
-            Self::Kafka(_) => vec![],
+            Self::Kafka(_) => vec![(ColumnType::new(ScalarType::Int64), Some("mz_offset".into()))],
             Self::File(_) => vec![(
                 ColumnType::new(ScalarType::Int64),
                 Some("mz_line_no".into()),

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -140,15 +140,13 @@ pub fn describe_statement(
                     let mut relation_desc = RelationDesc::empty()
                         .add_column(col_name, ScalarType::String)
                         .add_column("TYPE", ScalarType::String);
-                    if !materialized {
-                        if ObjectType::View == object_type {
-                            relation_desc = relation_desc
-                                .add_column("QUERYABLE", ScalarType::Bool)
-                                .add_column("MATERIALIZED", ScalarType::Bool);
-                        } else if ObjectType::Source == object_type {
-                            relation_desc =
-                                relation_desc.add_column("MATERIALIZED", ScalarType::Bool);
-                        }
+                    if ObjectType::View == object_type {
+                        relation_desc = relation_desc.add_column("QUERYABLE", ScalarType::Bool);
+                    }
+                    if !materialized &&
+                        (ObjectType::View == object_type || ObjectType::Source == object_type)
+                    {
+                        relation_desc = relation_desc.add_column("MATERIALIZED", ScalarType::Bool);
                     }
                     relation_desc
                 } else {

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1077,7 +1077,12 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             };
 
             let mut desc = encoding.desc(envelope)?;
-            desc.add_cols(external_connector.metadata_columns());
+            // TODO(benesch): the available metadata columns should not depend
+            // on the format.
+            match encoding {
+                DataEncoding::Avro { .. } | DataEncoding::Protobuf { .. } => (),
+                _ => desc.add_cols(external_connector.metadata_columns()),
+            }
 
             let if_not_exists = *if_not_exists;
             let materialized = *materialized;

--- a/src/testdrive/action/sql.rs
+++ b/src/testdrive/action/sql.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::ascii;
 use std::env;
 use std::error::Error as _;
 use std::fmt::Write as _;
@@ -264,6 +265,10 @@ fn decode_row(row: Row) -> Result<Vec<String>, String> {
             match *ty {
                 Type::BOOL => row.get::<_, Option<bool>>(i).map(|x| x.to_string()),
                 Type::CHAR | Type::TEXT => row.get::<_, Option<String>>(i),
+                Type::BYTEA => row.get::<_, Option<Vec<u8>>>(i).map(|x| {
+                    let s = x.into_iter().map(ascii::escape_default).flatten().collect();
+                    String::from_utf8(s).unwrap()
+                }),
                 Type::INT4 => row.get::<_, Option<i32>>(i).map(|x| x.to_string()),
                 Type::INT8 => row.get::<_, Option<i64>>(i).map(|x| x.to_string()),
                 Type::NUMERIC => row.get::<_, Option<Numeric>>(i).map(|x| x.to_string()),

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-ingest format=raw topic=bytes timestamp=1
+©1
+©2
+
+> CREATE MATERIALIZED SOURCE data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
+  FORMAT BYTES
+
+> SHOW COLUMNS FROM data
+Field      Nullable  Type
+--------------------------
+data       NO        bytea
+mz_offset  NO        int8
+
+> SELECT * FROM data
+data           mz_offset
+----
+"\\xc2\\xa91"  0
+"\\xc2\\xa92"  1

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -194,9 +194,9 @@ test1        USER true      false
 test2        USER false     false
 
 > SHOW FULL MATERIALIZED VIEWS
-VIEWS        TYPE
------------------
-names_view   USER
+VIEWS        TYPE  QUERYABLE
+----------------------------
+names_view   USER  true
 
 > SHOW FULL SOURCES FROM mz_catalog
 VIEWS                             TYPE   MATERIALIZED
@@ -247,10 +247,10 @@ test1        USER true      false
 test2        USER true      false
 
 > SHOW FULL MATERIALIZED VIEWS
-VIEWS        TYPE
------------------
-names_view   USER
-plurals_view USER
+VIEWS        TYPE  QUERYABLE
+----------------------------
+names_view   USER  true
+plurals_view USER  true
 
 > SHOW MATERIALIZED VIEWS
 VIEWS
@@ -275,9 +275,9 @@ test1        USER false     false
 test2        USER false     false
 
 > SHOW FULL MATERIALIZED VIEWS
-VIEWS        TYPE
------------------
-plurals_view USER
+VIEWS        TYPE  QUERYABLE
+----------------------------
+plurals_view USER  true
 
 > SHOW MATERIALIZED VIEWS
 VIEWS


### PR DESCRIPTION
Raw Kafka sources were not properly reporting their mz_offset column.
The situation is weird because Avro and Protobuf formats do not
propagate this column, while regex and CSV formats do. Just hack around
the issue for now, and add additional tests to decrease the probability
of the type descriptor skewing from the actual result set in the future.

This issue was discovered by @JLDLaughlin while working on #2259.