### PR TITLE
Modify billing demo to generate reproducible record sets

### DIFF
--- a/src/billing-demo/src/config.rs
+++ b/src/billing-demo/src/config.rs
@@ -67,7 +67,8 @@ pub struct Args {
     #[structopt(long)]
     pub seed: Option<u64>,
 
-    /// A date to start generating records from. Default is a week before now
+    /// A date to start generating records from. Default is a week before now.
+    /// The input time format should be "%Y-%m-%dT%H:%M:%S"
     #[structopt(long, parse(try_from_str = parse_utc_datetime_from_str))]
     pub start_time: Option<DateTime<Utc>>,
 }

--- a/src/billing-demo/src/mz_client.rs
+++ b/src/billing-demo/src/mz_client.rs
@@ -86,10 +86,15 @@ impl MzClient {
         file_name: &str,
         source_name: &str,
         num_clients: u32,
+        seed: Option<u64>,
     ) -> Result<()> {
         let mut writer = Writer::from_path(file_name)?;
         use rand::SeedableRng;
-        let rng = &mut rand::rngs::StdRng::from_seed(rand::random());
+        let rng = &mut if let Some(seed) = seed {
+            rand::rngs::StdRng::seed_from_u64(seed)
+        } else {
+            rand::rngs::StdRng::from_seed(rand::random())
+        };
 
         for i in 1..num_clients {
             writer.write_record(&[

--- a/src/billing-demo/src/randomizer.rs
+++ b/src/billing-demo/src/randomizer.rs
@@ -30,9 +30,10 @@ pub struct RecordState {
 }
 
 impl RecordState {
-    pub fn new() -> RecordState {
+    pub fn new(last_time: Option<DateTime<Utc>>) -> RecordState {
         RecordState {
-            last_time: Utc::now() - chrono::Duration::seconds(60 * 60 * 24 * 7),
+            last_time: last_time
+                .unwrap_or(Utc::now() - chrono::Duration::seconds(60 * 60 * 24 * 7)),
         }
     }
 }


### PR DESCRIPTION
For Chaos Testing (#1130)
Add two new arguments to billing demo:
--seed A seed to start the RNG from.
--start-time A time that records should begin from.

Manually tested that the arguments act as described.

FYI: My next step is to modify testdrive to be like sqllogictest and verify large numbers of rows by hashing the result and comparing the hashes.