### PR TITLE
sqllogictest: fix parser

### DIFF
--- a/src/sqllogictest/parser.rs
+++ b/src/sqllogictest/parser.rs
@@ -123,7 +123,7 @@ pub fn parse_record<'a>(
                 Some("standard") | Some("sqlite") => Mode::Standard,
                 other => bail!("unknown parse mode: {:?}", other),
             };
-            Ok(None)
+            parse_record(mode, input)
         }
 
         other => bail!("Unexpected start of record: {}", other),
@@ -167,7 +167,7 @@ fn parse_query<'a>(
 ) -> Result<Record<'a>, failure::Error> {
     if words.peek() == Some(&"error") {
         let error = parse_expected_error(first_line);
-        let sql = input;
+        let sql = parse_sql(input)?;
         return Ok(Record::Query {
             sql,
             output: Err(error),
@@ -230,7 +230,7 @@ fn parse_query<'a>(
     }
     let output_str = if multiline {
         split_at(input, &EOF_REGEX)?
-    } else if input.starts_with('\n') || input.starts_with('\r') {
+    } else if input.starts_with('\n') || input.starts_with('\r') || input.starts_with('#') {
         // QUERY_REGEX already ate a newline, so if there is one more left then the output must be empty
         ""
     } else {

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -110,32 +110,32 @@ CREATE TABLE date_trunc_timestamps (
 query T multiline
 EXPLAIN PLAN FOR SELECT date_trunc('day', ts) FROM date_trunc_timestamps
 ----
-Project {
-  outputs: [1],
-  Map {
-    scalars: [date_trunc_day #0],
-    Get { materialize.public.date_trunc_timestamps (u5) }
-  }
-}
+0 =
+| Get materialize.public.date_trunc_timestamps (u5)
+| Map date_trunc_day(#0)
+| Project (#1)
+
+EOF
 
 query T multiline
 EXPLAIN PLAN FOR SELECT date_trunc(field, ts) FROM date_trunc_fields, date_trunc_timestamps
 ----
-Project {
-  outputs: [2],
-  Map {
-    scalars: [#0 date_trunc #1],
-    Join {
-      variables: [],
-      implementation: DifferentialLinear,
-      Get { materialize.public.date_trunc_timestamps (u5) },
-      ArrangeBy {
-        keys: [[]],
-        Get { materialize.public.date_trunc_fields (u1) }
-      }
-    }
-  }
-}
+0 =
+| Get materialize.public.date_trunc_fields (u1)
+| ArrangeBy ()
+
+1 =
+| Get materialize.public.date_trunc_timestamps (u5)
+
+2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand for %0 = (#0)
+| | demand for %1 = (#0)
+| Map date_trunc(#0, #1)
+| Project (#2)
+
+EOF
 
 mode cockroach
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -196,95 +196,101 @@ mode standard
 query T multiline
 EXPLAIN PLAN FOR SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 ----
-Project {
-  outputs: [0],
-  Map {
-    scalars: [true],
-    Join {
-      variables: [],
-      implementation: DifferentialLinear,
-      Get { materialize.public.t1 (u37) },
-      ArrangeBy {
-        keys: [[]],
-        Distinct {
-          group_key: [],
-          Get { materialize.public.t2 (u39) }
-        }
-      }
-    }
-  }
-}
+0 =
+| Get materialize.public.t1 (u37)
+
+1 =
+| Get materialize.public.t2 (u39)
+| Distinct group=()
+| ArrangeBy ()
+
+2 =
+| Join %0 %1
+| | implementation = Differential %0 %1.()
+| | demand for %0 = (#0)
+| | demand for %1 = ()
+| Map true
+| Project (#0)
+
+EOF
 
 query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2)
 ----
-Project {
-  outputs: [0, 0, 2],
-  Map {
-    scalars: [true],
-    Join {
-      variables: [[(0, 0), (2, 0)]],
-      implementation: DifferentialLinear,
-      Get { materialize.public.t3 (u41) },
-      ArrangeBy {
-        keys: [[]],
-        Distinct {
-          group_key: [],
-          Get { materialize.public.t2 (u39) }
-        }
-      },
-      ArrangeBy { keys: [[#0]], Get { materialize.public.t1 (u37) } }
-    }
-  }
-}
+0 =
+| Get materialize.public.t1 (u37)
+| ArrangeBy (#0)
+
+1 =
+| Get materialize.public.t3 (u41)
+
+2 =
+| Get materialize.public.t2 (u39)
+| Distinct group=()
+| ArrangeBy ()
+
+3 =
+| Join %0 %1 %2 (= %0.#0 %1.#0)
+| | implementation = Differential %1 %2.() %0.(#0)
+| | demand for %0 = (#0)
+| | demand for %1 = (#1)
+| | demand for %2 = ()
+| Map true
+| Project (#0, #0, #2)
+
+EOF
 
 query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2 WHERE t3.b = t2.b)
 ----
-Let {
-  l0 = Join {
-    variables: [[(0, 0), (1, 0)]],
-    implementation: DifferentialLinear,
-    Get { materialize.public.t3 (u41) },
-    ArrangeBy { keys: [[#0]], Get { materialize.public.t1 (u37) } }
-  }
-} in
-Project {
-  outputs: [0, 0, 2],
-  Map {
-    scalars: [true],
-    Join {
-      variables: [[(0, 2), (1, 0)]],
-      implementation: DifferentialLinear,
-      Get { l0 },
-      ArrangeBy {
-        keys: [[#0]],
-        Distinct {
-          group_key: [#0],
-          Join {
-            variables: [[(0, 0), (1, 0)]],
-            implementation: DeltaQuery,
-            ArrangeBy {
-              keys: [[#0]],
-              Distinct { group_key: [#2], Get { l0 } }
-            },
-            ArrangeBy {
-              keys: [[#0]],
-              Get { materialize.public.t2 (u39) }
-            }
-          }
-        }
-      }
-    }
-  }
-}
+0 =
+| Get materialize.public.t1 (u37)
+| ArrangeBy (#0)
 
-mode cockroach
+1 =
+| Get materialize.public.t3 (u41)
+
+2 =
+| Join %0 %1 (= %0.#0 %1.#0)
+| | implementation = Differential %1 %0.(#0)
+| | demand for %0 = (#0)
+| | demand for %1 = (#1)
+
+3 =
+| Get %2
+
+4 =
+| Get %2
+| Distinct group=(#2)
+| ArrangeBy (#0)
+
+5 =
+| Get materialize.public.t2 (u39)
+| ArrangeBy (#0)
+
+6 =
+| Join %4 %5 (= %4.#0 %5.#0)
+| | implementation = DeltaQuery %4 %5.(#0) | %5 %4.(#0)
+| | demand for %4 = (#0)
+| | demand for %5 = ()
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+7 =
+| Join %3 %6 (= %3.#2 %6.#0)
+| | implementation = Differential %3 %6.(#0)
+| | demand for %3 = (#0, #2)
+| | demand for %6 = ()
+| Map true
+| Project (#0, #0, #2)
+
+EOF
+
 # Regression test for materialize#1158
 # The following subquery currently generates a plan with a map with
 # 4 scalars that refer to other scalars in the map. If query planning optimizes away
 # this particular case, replace with another query that generates such a plan
-query T
+query T multiline
 EXPLAIN PLAN FOR
 SELECT age, ascii_num * 2 as result FROM (
   SELECT age, ascii(letter) AS ascii_num FROM (
@@ -296,22 +302,26 @@ SELECT age, ascii_num * 2 as result FROM (
   )
 )
 ----
-Project {
-  outputs: [3, 7],
-  Map {
-    scalars: [
-      replace(#1, "o", "i"),
-      substr(#4, 2, 1),
-      ascii #5,
-      i32toi64 #6 * 2
-    ],
-    Join {
-      variables: [[(0, 0), (1, 0)]],
-      Filter { predicates: [!isnull #0], Get { likes (u3) } },
-      Filter { predicates: [!isnull #0], Get { age (u21) } }
-    }
-  }
-}
+0 =
+| Get materialize.public.likes (u3)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+1 =
+| Get materialize.public.age (u21)
+| Filter !(isnull(#0))
+
+2 =
+| Join %0 %1 (= %0.#0 %1.#0)
+| | implementation = Differential %1 %0.(#0)
+| | demand for %0 = (#1)
+| | demand for %1 = (#1)
+| Map replace(#1, "o", "i") substr(#4, 2, 1) ascii(#5) (#6 * 2)
+| Project (#3, #7)
+
+EOF
+
+mode cockroach
 
 query II rowsort
 SELECT age, ascii_num * 2 as result FROM (


### PR DESCRIPTION
The changes in #2212 broke parsing of most SLT files, but also hid the
fact that the parser was broken by incorrectly parsing any file that
began with a "mode" directive as empty.