### PR TITLE
sqllogictest: clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,7 +3068,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "md5",
- "ordered-float",
  "ore",
  "pgrepr",
  "regex",
@@ -3076,9 +3075,7 @@ dependencies = [
  "serde_json",
  "sql",
  "sql-parser",
- "timely",
  "tokio",
- "uuid",
  "walkdir",
 ]
 

--- a/bin/check
+++ b/bin/check
@@ -19,6 +19,15 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 source misc/shlib/shlib.bash
 
+extra_lints=(
+    # All compiler warnings should be considered errors.
+    warnings
+
+    # Wildcard dependencies are, by definition, incorrect. It is impossible
+    # to be compatible with all future breaking changes in a crate.
+    clippy::wildcard_dependencies
+)
+
 # Add lints to this list freely, but please add a comment with justification
 # along with the lint. The goal is to ever-so-slightly increase the barrier to
 # turning off a lint.
@@ -167,4 +176,6 @@ disabled_lints=(
 # and the inputs to this script are trusted.
 
 # shellcheck disable=SC2046
-run cargo clippy --all-targets -- -D warnings $(printf -- "-A %s " "${disabled_lints[@]}")
+run cargo clippy --all-targets -- \
+    $(printf -- "-D %s " "${extra_lints[@]}") \
+    $(printf -- "-A %s " "${disabled_lints[@]}")

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -24,8 +24,7 @@ futures = "0.3"
 getopts = "0.2"
 itertools = "0.8.2"
 lazy_static = "1"
-md5 = "*"
-ordered-float = "*"
+md5 = "0.7.0"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 regex = "1"
@@ -33,7 +32,5 @@ repr = { path = "../repr" }
 serde_json = "1"
 sql = { path = "../sql" }
 sql-parser = { path = "../sql-parser" }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 tokio = "0.2"
-uuid = "0.8"
 walkdir = "2"


### PR DESCRIPTION
Several of its declared dependencies were unused. Also avoid wildcard
dependencies, for the reasons stated in the patch.