### PR TITLE
Fix SLT parser

### DIFF
--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -82,8 +82,13 @@ pub fn and<'a>(
     b_expr: &'a ScalarExpr,
 ) -> Result<Datum<'a>, EvalError> {
     match a_expr.eval(datums, env, temp_storage)? {
-        Datum::True => b_expr.eval(datums, env, temp_storage),
-        d => Ok(d),
+        Datum::False => Ok(Datum::False),
+        a => match (a, b_expr.eval(datums, env, temp_storage)?) {
+            (_, Datum::False) => Ok(Datum::False),
+            (Datum::Null, _) | (_, Datum::Null) => Ok(Datum::Null),
+            (Datum::True, Datum::True) => Ok(Datum::True),
+            _ => unreachable!(),
+        },
     }
 }
 
@@ -95,8 +100,13 @@ pub fn or<'a>(
     b_expr: &'a ScalarExpr,
 ) -> Result<Datum<'a>, EvalError> {
     match a_expr.eval(datums, env, temp_storage)? {
-        Datum::False => b_expr.eval(datums, env, temp_storage),
-        d => Ok(d),
+        Datum::True => Ok(Datum::True),
+        a => match (a, b_expr.eval(datums, env, temp_storage)?) {
+            (_, Datum::True) => Ok(Datum::True),
+            (Datum::Null, _) | (_, Datum::Null) => Ok(Datum::Null),
+            (Datum::False, Datum::False) => Ok(Datum::False),
+            _ => unreachable!(),
+        },
     }
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -296,7 +296,7 @@ impl Parser {
                 };
                 Ok(Expr::UnaryOp {
                     op,
-                    expr: Box::new(self.parse_subexpr(Self::PLUS_MINUS_PREC)?),
+                    expr: Box::new(self.parse_subexpr(45)?),
                 })
             }
             Token::Number(_) | Token::SingleQuotedString(_) | Token::HexStringLiteral(_) => {
@@ -797,7 +797,6 @@ impl Parser {
 
     const UNARY_NOT_PREC: u8 = 15;
     const BETWEEN_PREC: u8 = 20;
-    const PLUS_MINUS_PREC: u8 = 30;
 
     /// Get the precedence of the next token
     pub fn get_next_precedence(&self) -> Result<u8, ParserError> {
@@ -825,7 +824,7 @@ impl Parser {
                 Token::Eq | Token::Lt | Token::LtEq | Token::Neq | Token::Gt | Token::GtEq => {
                     Ok(20)
                 }
-                Token::Plus | Token::Minus => Ok(Self::PLUS_MINUS_PREC),
+                Token::Plus | Token::Minus => Ok(30),
                 Token::Mult | Token::Div | Token::Mod => Ok(40),
                 Token::DoubleColon => Ok(50),
                 // TODO(jamii) it's not clear what precedence postgres gives to json operators

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -625,6 +625,21 @@ fn parse_unary_math() {
 }
 
 #[test]
+fn parse_unary_math_precedence() {
+    assert_eq!(
+        verified_expr("+ a / b"),
+        Expr::BinaryOp {
+            left: Box::new(Expr::UnaryOp {
+                op: UnaryOperator::Plus,
+                expr: Box::new(Expr::Identifier(Ident::new("a"))),
+            }),
+            op: BinaryOperator::Divide,
+            right: Box::new(Expr::Identifier(Ident::new("b"))),
+        }
+    )
+}
+
+#[test]
 fn parse_is_null() {
     use self::Expr::*;
     let sql = "a IS NULL";

--- a/src/sqllogictest/parser.rs
+++ b/src/sqllogictest/parser.rs
@@ -46,14 +46,6 @@ fn parse_types(input: &str) -> Result<Vec<Type>, failure::Error> {
         .collect()
 }
 
-fn parse_sql<'a>(input: &mut &'a str) -> Result<&'a str, failure::Error> {
-    lazy_static! {
-        static ref QUERY_OUTPUT_REGEX: Regex =
-            Regex::new("(\r?\n----\r?\n)|(\r?\n\r?\n)|$").unwrap();
-    }
-    split_at(input, &QUERY_OUTPUT_REGEX)
-}
-
 lazy_static! {
     static ref WHITESPACE_REGEX: Regex = Regex::new(r"\s+").unwrap();
 }
@@ -61,10 +53,9 @@ lazy_static! {
 pub fn parse_record<'a>(
     mode: &mut Mode,
     input: &mut &'a str,
-) -> Result<Option<Record<'a>>, failure::Error> {
+) -> Result<Record<'a>, failure::Error> {
     if *input == "" {
-        // must have just been a bunch of comments
-        return Ok(None);
+        return Ok(Record::Halt);
     }
 
     lazy_static! {
@@ -79,9 +70,9 @@ pub fn parse_record<'a>(
 
     let mut words = first_line.split(' ').peekable();
     match words.next().unwrap() {
-        "statement" => Ok(Some(parse_statement(words, first_line, input)?)),
+        "statement" => parse_statement(words, first_line, input),
 
-        "query" => Ok(Some(parse_query(words, first_line, input, *mode)?)),
+        "query" => parse_query(words, first_line, input, *mode),
 
         "hash-threshold" => {
             let threshold = words
@@ -89,33 +80,35 @@ pub fn parse_record<'a>(
                 .ok_or_else(|| format_err!("missing threshold in: {}", first_line))?
                 .parse::<u64>()
                 .map_err(|err| format_err!("invalid threshold ({}) in: {}", err, first_line))?;
-            Ok(Some(Record::HashThreshold { threshold }))
+            Ok(Record::HashThreshold { threshold })
         }
 
         // we'll follow the postgresql version of all these tests
         "skipif" => {
             match words.next().unwrap() {
-                "postgresql" => Ok(None),
-                _ => {
-                    // query starts on the next line
+                "postgresql" => {
+                    // discard next record
+                    parse_record(mode, input)?;
                     parse_record(mode, input)
                 }
+                _ => parse_record(mode, input),
             }
         }
         "onlyif" => {
             match words.next().unwrap() {
-                "postgresql" => {
-                    // query starts on the next line
+                "postgresql" => parse_record(mode, input),
+                _ => {
+                    // discard next record
+                    parse_record(mode, input)?;
                     parse_record(mode, input)
                 }
-                _ => Ok(None),
             }
         }
 
-        "halt" => Ok(Some(Record::Halt)),
+        "halt" => Ok(Record::Halt),
 
         // this is some cockroach-specific thing, we don't care
-        "subtest" | "user" | "kv-batch-size" => Ok(None),
+        "subtest" | "user" | "kv-batch-size" => parse_record(mode, input),
 
         "mode" => {
             *mode = match words.next() {
@@ -151,7 +144,10 @@ fn parse_statement<'a>(
         Some("error") => expected_error = Some(parse_expected_error(first_line)),
         _ => bail!("invalid statement disposition: {}", first_line),
     };
-    let sql = parse_sql(input)?;
+    lazy_static! {
+        static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
+    }
+    let sql = split_at(input, &DOUBLE_LINE_REGEX)?;
     Ok(Record::Statement {
         expected_error,
         rows_affected,
@@ -167,7 +163,10 @@ fn parse_query<'a>(
 ) -> Result<Record<'a>, failure::Error> {
     if words.peek() == Some(&"error") {
         let error = parse_expected_error(first_line);
-        let sql = parse_sql(input)?;
+        lazy_static! {
+            static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
+        }
+        let sql = split_at(input, &DOUBLE_LINE_REGEX)?;
         return Ok(Record::Query {
             sql,
             output: Err(error),
@@ -207,15 +206,29 @@ fn parse_query<'a>(
     if multiline && (check_column_names || sort.yes()) {
         bail!("multiline option is incompatible with all other options");
     }
+    let label = words.next();
     lazy_static! {
         static ref LINE_REGEX: Regex = Regex::new("\r?(\n|$)").unwrap();
         static ref HASH_REGEX: Regex = Regex::new(r"(\S+) values hashing to (\S+)").unwrap();
+        static ref QUERY_OUTPUT_REGEX: Regex = Regex::new(r"\r?\n----").unwrap();
     }
-    let label = words.next();
-    let sql = parse_sql(input)?;
+    let sql = split_at(input, &QUERY_OUTPUT_REGEX)?;
+    lazy_static! {
+        static ref EOF_REGEX: Regex = Regex::new(r"(\n|\r\n)EOF(\n|\r\n)").unwrap();
+        static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
+    }
+    let mut output_str = split_at(
+        input,
+        if multiline {
+            &EOF_REGEX
+        } else {
+            &DOUBLE_LINE_REGEX
+        },
+    )?
+    .trim_start();
     let column_names = if check_column_names {
         Some(
-            split_at(input, &LINE_REGEX)?
+            split_at(&mut output_str, &LINE_REGEX)?
                 .split(' ')
                 .filter(|s| !s.is_empty())
                 .map(ColumnName::from)
@@ -223,18 +236,6 @@ fn parse_query<'a>(
         )
     } else {
         None
-    };
-    lazy_static! {
-        static ref EOF_REGEX: Regex = Regex::new(r"(\n|\r\n)EOF(\n|\r\n)").unwrap();
-        static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
-    }
-    let output_str = if multiline {
-        split_at(input, &EOF_REGEX)?
-    } else if input.starts_with('\n') || input.starts_with('\r') || input.starts_with('#') {
-        // QUERY_REGEX already ate a newline, so if there is one more left then the output must be empty
-        ""
-    } else {
-        split_at(input, &DOUBLE_LINE_REGEX)?
     };
     let output = match HASH_REGEX.captures(output_str) {
         Some(captures) => Output::Hashed {
@@ -244,9 +245,10 @@ fn parse_query<'a>(
         None => {
             if multiline {
                 Output::Values(vec![output_str.to_owned()])
+            } else if output_str.starts_with('\r') || output_str.starts_with('\n') {
+                Output::Values(vec![])
             } else {
-                let mut vals: Vec<String> =
-                    output_str.trim().lines().map(|s| s.to_owned()).collect();
+                let mut vals: Vec<String> = output_str.lines().map(|s| s.to_owned()).collect();
                 if let Mode::Cockroach = mode {
                     let mut rows: Vec<Vec<String>> = vec![];
                     for line in vals {
@@ -324,8 +326,8 @@ pub fn parse_records(mut input: &str) -> Result<Vec<Record>, failure::Error> {
     let mut records = vec![];
     loop {
         match parse_record(&mut mode, &mut input)? {
-            None | Some(Record::Halt) => break,
-            Some(record) => records.push(record),
+            Record::Halt => break,
+            record => records.push(record),
         }
     }
     Ok(records)

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -99,6 +99,26 @@ SELECT FALSE AND FALSE
 false
 
 query B
+SELECT TRUE AND NULL
+----
+NULL
+
+query B
+SELECT NULL AND TRUE
+----
+NULL
+
+query B
+SELECT FALSE AND null
+----
+false
+
+query B
+SELECT NULL AND FALSE
+----
+false
+
+query B
 SELECT TRUE OR FALSE
 ----
 true
@@ -112,6 +132,26 @@ query B
 SELECT FALSE OR FALSE
 ----
 false
+
+query B
+SELECT TRUE OR NULL
+----
+true
+
+query B
+SELECT NULL OR TRUE
+----
+true
+
+query B
+SELECT FALSE OR null
+----
+NULL
+
+query B
+SELECT NULL OR FALSE
+----
+NULL
 
 query B
 SELECT TRUE AND NOT TRUE

--- a/test/sqllogictest/cockroach/union.slt
+++ b/test/sqllogictest/cockroach/union.slt
@@ -257,7 +257,7 @@ CREATE TABLE b (a INTEGER PRIMARY KEY)
 
 query I
 SELECT * FROM a UNION ALL SELECT * FROM b
-
+----
 
 # Make sure that UNION ALL doesn't crash when its two children have different
 # post-processing stages.

--- a/test/sqllogictest/postgres-incompatibility.slt
+++ b/test/sqllogictest/postgres-incompatibility.slt
@@ -28,11 +28,6 @@ SELECT CASE 24 WHEN - - 89 + ( + ( + - 42 ) ) * + - 50 THEN NULL ELSE + 23 * - 4
 72865.000000000000
 
 query R
-SELECT DISTINCT + 49 - + 94 + + 97 / - 52 / - COALESCE ( - COUNT ( * ), ( - - 34 ) - + AVG ( 68 ), - + 57 + + 61 ) AS col1
-----
--46.800000000000
-
-query R
 SELECT ALL ( - COUNT ( * ) ) + + - COUNT ( * ) + 36 / COALESCE ( + CAST ( 76 AS INTEGER ), COUNT ( * ) - - + 21 * 44 * + COALESCE ( 61, - AVG ( 41 ) / - 34 ) + COALESCE ( 67, - ( 69 ), - 75 + 35 * + ( 78 * - 20 ) ) * + 36, 99 ) * + 65
 ----
 24.000000000000

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -21,22 +21,27 @@ CREATE TABLE t3 (a int)
 # This works in MySQL, but not PostgreSQL.
 query I
 SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t2.a
+----
 
 # As above, this works in MySQL, but not PostgreSQL.
 query I
 SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a LEFT JOIN t3 ON t2.a = t3.a GROUP BY t2.a
+----
 
 # Same as last query, but with associativity reversed.
 query I
 SELECT t1.a FROM t1 JOIN (t2 JOIN t3 ON t2.a = t3.a) ON t1.a = t2.a GROUP BY t3.a
+----
 
 # This works in PostgreSQL.
 query I
 SELECT t1.a FROM t1 NATURAL JOIN t2
+----
 
 # This works in PostgreSQL too.
 query I
 SELECT t2.a FROM t1 NATURAL JOIN t2
+----
 
 # Test sources with unnamed columns.
 


### PR DESCRIPTION
This is working towards fixing stuff I broke in https://github.com/MaterializeInc/materialize/pull/2212/, but also seems to have fixed some pre-existing parser bugs that were hiding legit test failures eg 

```
query I nosort
SELECT 1 FROM t1 WHERE '1' IN ( NULL, 1 )
----
1
1
1
```

```
jamie=> CREATE TABLE t1( x INTEGER, y TEXT );
CREATE TABLE
jamie=> INSERT INTO t1 VALUES(1,'true');
INSERT 0 1
jamie=> INSERT INTO t1 VALUES(0,'false');
INSERT 0 1
jamie=> INSERT INTO t1 VALUES(NULL,'NULL');
INSERT 0 1
jamie=> SELECT 1 FROM t1 WHERE 1 IN ( NULL, 1 );
 ?column? 
----------
(0 rows)
```
