### PR TITLE
dataflow: handle exports of aliased imported traces

### DIFF
--- a/src/dataflow/render/delta_join.rs
+++ b/src/dataflow/render/delta_join.rs
@@ -185,7 +185,7 @@ where
                                                 build_lookup(update_stream, local, prev_key)
                                             }
                                         }
-                                        ArrangementFlavor::Trace(trace) => {
+                                        ArrangementFlavor::Trace(_gid, trace) => {
                                             if other > &relation {
                                                 let trace = trace
                                                     .enter_at(

--- a/test/testdrive/github-2276.td
+++ b/test/testdrive/github-2276.td
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/2276.
+#
+# Verifies that a deep stack of dependencies can be properly created.
+
+> CREATE MATERIALIZED VIEW test1 AS SELECT 1;
+
+> CREATE MATERIALIZED VIEW test2 AS SELECT * FROM test1;
+
+> CREATE MATERIALIZED VIEW test3 AS SELECT * FROM test2;
+
+> CREATE MATERIALIZED VIEW test4 AS SELECT * FROM test3;
+
+> CREATE MATERIALIZED VIEW test5 AS SELECT * FROM test4;
+
+> SELECT * FROM test1
+1
+
+> SELECT * FROM test2
+1
+
+> SELECT * FROM test3
+1
+
+> SELECT * FROM test4
+1
+
+> SELECT * FROM test5
+1


### PR DESCRIPTION
Consider the following views that stack one on top of the other:

    CREATE MATERIALIZED VIEW test1 AS SELECT 1;
    CREATE MATERIALIZED VIEW test2 AS SELECT * FROM test1;
    CREATE MATERIALIZED VIEW test3 AS SELECT * FROM test2;
    CREATE MATERIALIZED VIEW test4 AS SELECT * FROM test3;

Rendering test3 involves importing the arrangement for test2's primary
index, then rexporting the arrangement as test3's primary index. The
previous logic for this would get confused because test3's primary index
was marked as an imported arrangement but did not appear in the list of
imported arrangements, as the import list mentions test2, not test3,
(because the test2/test3 aliasing has not been established at import
time). Put more succinctly: the index export code was not properly
accounting for aliasing of imported arrangements.

As mentioned in #2276, failed index exports are suppressed, and so
building test3 does not result in an error, even though it fails to
export the necessary index. Building test4 attempts to import this
nonexistent index, and crashes. Astute readers might notice that test2's
purpose is rather unclear--shouldn't this all happen one view
earlier?--but test1 is a constant view and so builds an arrangement on
the empty key [], while test2 wants an arrangement on [#0] and so has to
build that arrangement itself [0], and thus avoids directly exporting an
arrangement that it imported.

This commit tracks the provenance of imported arrangements (i.e., their
global IDs) in the local context, so that the correct external
arrangement can be selected when exporting external arrangements.

Fix #1985.
Fix #2276.

[0]: https://github.com/MaterializeInc/materialize/issues/1985#issuecomment-597982599