### PR TITLE
Fix Kinesis source bug

### DIFF
--- a/src/dataflow/source/kinesis.rs
+++ b/src/dataflow/source/kinesis.rs
@@ -158,16 +158,14 @@ where
                     output.session(&cap).give((data, None))
                 }
 
-                if let Some(millis) = get_records_output.millis_behind_latest {
-                    if millis == 0 {
-                        // This activation does the following:
-                        //      1. Ensures we poll Kinesis more often than the eviction timeout (5 minutes)
-                        //      2. Proactively and frequently reactivates this source, since we don't have a
-                        //         smarter solution atm.
-                        // todo@jldlaughlin: Improve Kinesis source activation #2195
-                        activator.activate_after(get_reactivation_duration(timer));
-                        return SourceStatus::Alive;
-                    }
+                if let Some(0) = get_records_output.millis_behind_latest {
+                    // This activation does the following:
+                    //      1. Ensures we poll Kinesis more often than the eviction timeout (5 minutes)
+                    //      2. Proactively and frequently reactivates this source, since we don't have a
+                    //         smarter solution atm.
+                    // todo@jldlaughlin: Improve Kinesis source activation #2195
+                    activator.activate_after(get_reactivation_duration(timer));
+                    return SourceStatus::Alive;
                 }
 
                 if timer.elapsed().as_millis() > 10 {


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/2265

### The Embarrassing Problem
`GetRecords` returns a response that contains `millis_behind_latest` and `records`. `millis_behind_latest` indicates the number of milliseconds the get request/consumer is behind the tip of the stream. In the prior implementation of this code, I was mistakenly breaking on `millis_behind_latest == 0` **before** grabbing any records off of the response -- effectively dropping those records on the floor. 

tldr; I did this to myself.

Tested this locally by continuously pushing test records to my AWS Kinesis stream and having them show up in my materialized view of the Kinesis source. More testing to come: https://github.com/MaterializeInc/materialize/issues/2196, https://github.com/MaterializeInc/materialize/issues/2197, https://github.com/MaterializeInc/materialize/issues/2202.