### PR TITLE
sql: add support for 'epoch' shorthand

### DIFF
--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -832,3 +832,20 @@ query T
 SELECT '2007-02-01 15:04:05+06'::timestamptz;
 ----
 2007-02-01 09:04:05+00
+
+# Test special date-timme inputs from Postgres
+
+query T
+SELECT 'epoch'::timestamp
+----
+1970-01-01 00:00:00
+
+query T
+SELECT 'epoch'::timestamptz
+----
+1970-01-01 00:00:00+00
+
+query T
+SELECT 'epoch'::date
+----
+1970-01-01


### PR DESCRIPTION
@quodlibetor I wanted to add something more obviously extensible here, but Clippy was mad about it, so I went with a janky `if`. Once we get infinity support in chronotope, I'll implement the infinity keyword, as well.

Fix #1805