### PR TITLE
docs: add materialize_logical_timestamp()

### DIFF
--- a/www/data/sql_funcs.json
+++ b/www/data/sql_funcs.json
@@ -160,6 +160,10 @@
                 "url": "extract"
             },
             {
+                "signature": "mz_logical_timestamp() -> numeric",
+                "description": "The logical time at which a query executes.<br/><br/>**NOTE**: Users cannot define views with queries containing `mz_logical_timestamp()`."
+            },
+            {
                 "signature": "now() -> timestamptz",
                 "description": "The `timestamptz` representing when the query was executed.<br/><br/>**NOTE**: Users cannot define views with queries containing `now()`."
             },


### PR DESCRIPTION
I struggle to understand a use case for end-users with this function, so I just added it the list of functions we support with minor detail. If either @frankmcsherry or @nacrooks can explain what someone might do with this, I'm glad to flesh this out with its own doc.

Fix #2289