### PR TITLE
expr: propagate errors but not types in reduction

### DIFF
--- a/test/sqllogictest/decimal.slt
+++ b/test/sqllogictest/decimal.slt
@@ -329,3 +329,13 @@ SELECT ..123
 
 statement error
 SELECT .1.23
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/2293.
+#
+# Verifies that errors propagate through decimal arithmetic properly.
+
+statement ok
+CREATE VIEW github_2293 AS SELECT 1 AS a
+
+query error division by zero
+SELECT 1::decimal(38,0) / 0 / a + 1 FROM github_2293;


### PR DESCRIPTION
When reducing an expression, propagating an error input to a function is
correct, but we must remember to install the function's output type, not
propagate its input type.

Fix #2293.