### PR TITLE
expr: reduce coalesce expressions

### DIFF
--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -263,18 +263,27 @@ SELECT sqrt(1.23783::decimal(15, 5))
 ----
 1.11257
 
-# Test coalesce
+# Test coalesce.
 query I
-SELECT coalesce(NULL,1,NULL)
+SELECT coalesce(NULL, 1, NULL)
 ----
 1
 
 query R
-SELECT coalesce(NULL,1,NULL)
+SELECT coalesce(NULL, 1, NULL)
 ----
 1
 
 query T
-SELECT coalesce('hello','world', NULL)
+SELECT coalesce('hello', 'world', NULL)
 ----
 hello
+
+statement ok
+CREATE VIEW v AS SELECT 1 AS a
+
+# Coalesce should reduce away errors that statically can be shown not to occur.
+query T
+SELECT coalesce(1, 1 / 0, a) FROM v
+----
+1


### PR DESCRIPTION
We can apply a lot of smarts to reducing calls to the coalesce function.
If we can reduce away an error, that makes SLT happy, too.