### PR TITLE
repr: use postgres's float input and output formats

### DIFF
--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -13,6 +13,14 @@ This page details changes between versions of Materialize, including:
 
 For information about available versions, see our [Versions page](../versions).
 
+<span id="v0.1.4"></span>
+## 0.1.3 &rarr; 0.1.4 (unreleased)
+
+- Make formatting and parsing for `real` and `double precision` numbers more
+  consistent with PostgreSQL. The strings `NaN`, and `[+-]Infinity` are
+  accepted as input, to select the special not-a-number and infinity states
+  of floating-point numbers.
+
 <span id="v0.1.3"></span>
 ## 0.1.2 &rarr; 0.1.3 (unreleased)
 

--- a/doc/user/sql/types/float.md
+++ b/doc/user/sql/types/float.md
@@ -22,7 +22,29 @@ Type               | Aliases           | Size    | Range
 
 - Materialize assumes untyped numeric literals containing decimal points are [`decimal`](../decimal); to use `float`, you must explicitly cast them as we've done below.
 
-## Details
+### Special values
+
+Floating-point numbers have three special values, as specified in IEEE 754:
+
+Value       | Aliases                    | Represents
+------------|----------------------------|-----------
+`NaN`       |                            | Not a number
+`Infinity`  | `Inf`, `+Infinity`, `+Inf` | Positive infinity
+`-Infinity` | `-Inf`                     | Negative infinity
+
+To input these special values, write them as a string and cast that string to
+the desired floating-point type. For example:
+
+```sql
+SELECT 'NaN'::real AS nan
+```
+```nofmt
+ nan
+-----
+ NaN
+```
+
+The strings are recognized case insensitively.
 
 ### Valid casts
 

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query TTTTT
+SELECT 'Inf'::float::text, 'Infinity'::float::text, 'inFinIty'::float::text, '+inf'::float::text, '+infinity'::float::text
+----
+Infinity  Infinity  Infinity  Infinity  Infinity
+
+query TTT
+SELECT '-Inf'::float::text, '-Infinity'::float::text, '-inFinIty'::float::text
+----
+-Infinity  -Infinity  -Infinity
+
+query TTT
+SELECT 'NaN'::float::text, 'nan'::float::text, 'nAN'::float::text
+----
+NaN  NaN  NaN
+
+query TTTTT
+SELECT 'Inf'::double precision::text, 'Infinity'::double precision::text, 'inFinIty'::double precision::text, '+inf'::double precision::text, '+infinity'::double precision::text
+----
+Infinity  Infinity  Infinity  Infinity  Infinity
+
+query TTT
+SELECT '-Inf'::double precision::text, '-Infinity'::double precision::text, '-inFinIty'::double precision::text
+----
+-Infinity  -Infinity  -Infinity
+
+query TTT
+SELECT 'NaN'::double precision::text, 'nan'::double precision::text, 'nAN'::double precision::text
+----
+NaN  NaN  NaN


### PR DESCRIPTION
@sploiselle certainly feel free to review the whole thing, but cc'd you for the docs review!

Fix #1553.