### PR TITLE
publish Bintray package in deploy step

### DIFF
--- a/ci/deploy/deb.sh
+++ b/ci/deploy/deb.sh
@@ -24,4 +24,4 @@ curl -F package=@materialized.deb https://"$FURY_APT_PUSH_SECRET"@push.fury.io/m
 # in ci/test/build.sh
 COMMIT_INDEX=$(git rev-list HEAD | wc -l)
 COMMIT_HASH=$(git rev-parse HEAD)
-curl -f -X POST https://api.bintray.com/content/materialize/materialized/materialized-unstable/dev-$COMMIT_INDEX-$COMMIT_HASH/publish
+curl -f -X POST "https://api.bintray.com/content/materialize/materialized/materialized-unstable/dev-$COMMIT_INDEX-$COMMIT_HASH/publish"

--- a/ci/deploy/deb.sh
+++ b/ci/deploy/deb.sh
@@ -19,3 +19,9 @@ aws s3 cp \
     ./materialized.deb
 
 curl -F package=@materialized.deb https://"$FURY_APT_PUSH_SECRET"@push.fury.io/materialize
+
+# Publish version that was already uploaded to Bintray
+# in ci/test/build.sh
+COMMIT_INDEX=$(git rev-list HEAD | wc -l)
+COMMIT_HASH=$(git rev-parse HEAD)
+curl -f -X POST https://api.bintray.com/content/materialize/materialized/materialized-unstable/dev-$COMMIT_INDEX-$COMMIT_HASH/publish


### PR DESCRIPTION
Bintray package was already pushed in build.sh; this will publish it.

Unpublished versions will automatically be removed after a few days, so we don't need to do any manual garbage collection for commits where, for whatever reason, the build step runs on master but the deploy never does.