### PR TITLE
Adds the --logical-compaction-window command line argument.

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -2048,8 +2048,12 @@ fn index_sql(
     .to_string()
 }
 
+/// Testdrive uses this method to check that the in-memory state of the catalog matches
+/// the state if you were to load a new materialized instance from that catalog.
 pub fn dump_catalog(data_directory: &Path) -> Result<String, failure::Error> {
     let (switchboard, runtime) = comm::Switchboard::local()?;
+    // The configuration does not have any requirements other than pointing at the data
+    // directory specified as an argument to the method.
     let coord = Coordinator::new(Config {
         switchboard,
         num_timely_workers: 1,

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -2048,8 +2048,10 @@ fn index_sql(
     .to_string()
 }
 
-/// Testdrive uses this method to check that the in-memory state of the catalog matches
-/// the state if you were to load a new materialized instance from that catalog.
+/// Loads the catalog stored at `data_directory` and returns its serialized state.
+///
+/// There are no guarantees about the format of the serialized state, except that
+/// the serialized state for two identical catalogs will compare identically.
 pub fn dump_catalog(data_directory: &Path) -> Result<String, failure::Error> {
     let (switchboard, runtime) = comm::Switchboard::local()?;
     // The configuration does not have any requirements other than pointing at the data

--- a/src/coord/tests/noblock.rs
+++ b/src/coord/tests/noblock.rs
@@ -36,6 +36,7 @@ fn no_block() {
         data_directory: None,
         executor: &executor,
         timestamp: None,
+        logical_compaction_window: None,
     })
     .unwrap();
 

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -71,6 +71,12 @@ fn run() -> Result<(), failure::Error> {
         "SIZE",
     );
     opts.optopt(
+        "",
+        "logical-compaction-window",
+        "historical detail maintained for arrangements (default 60s)",
+        "DURATION/\"off\"",
+    );
+    opts.optopt(
         "w",
         "threads",
         "number of per-process worker threads (default 1)",
@@ -150,6 +156,16 @@ fn run() -> Result<(), failure::Error> {
     let address_file = popts.opt_str("address-file");
     let gather_metrics = !popts.opt_present("no-prometheus");
 
+    let logical_compaction_window = match popts
+        .opt_str("logical-compaction-window")
+        .as_ref()
+        .map(|x| x.as_str())
+    {
+        None => Some(parse_duration::parse("60s")?),
+        Some("off") => None,
+        Some(d) => Some(parse_duration::parse(&d)?),
+    };
+
     if process >= processes {
         bail!("process ID {} is not between 0 and {}", process, processes);
     }
@@ -201,6 +217,7 @@ fn run() -> Result<(), failure::Error> {
         logging_granularity,
         timestamp_frequency,
         max_increment_ts_size,
+        logical_compaction_window,
         threads,
         process,
         addresses,

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -43,6 +43,7 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
     let server = Server(materialized::serve(materialized::Config {
         logging_granularity: config.logging_granularity,
         timestamp_frequency: None,
+        logical_compaction_window: None,
         max_increment_ts_size: 1000,
         threads: 1,
         process: 0,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -394,6 +394,7 @@ impl State {
             data_directory: None,
             executor: &executor,
             timestamp: None,
+            logical_compaction_window: None,
         })?;
 
         let coord_thread = thread::spawn(move || coord.serve(cmd_rx)).join_on_drop();


### PR DESCRIPTION
This command line argument allows the user to set the default logical compaction window. This argument controls how aggressively materialized will compact historical distinctions, which trades off flexibility of execution against a lean memory footprint: more memory used means more options available. The possible values are any time, or the string "off" which will disable logical compaction.

Quick testing reveals that with the default setting arrangement sizes can be large
```
materialize=> select * from mz_arrangement_sizes order by records desc limit 10;
 operator | worker | records | batches 
----------+--------+---------+---------
      789 |      0 | 1226755 |       2
...
```
with smaller (1s) setting they are smaller 
```
materialize=> select * from mz_arrangement_sizes order by records desc limit 10;
 operator | worker | records | batches 
----------+--------+---------+---------
      789 |      0 |   30452 |       5
...
```
and with a zero setting (0s, not "off" which is the opposite) they are smaller still
```
materialize=> select * from mz_arrangement_sizes order by records desc limit 10;
 operator | worker | records | batches 
----------+--------+---------+---------
     1028 |      0 |    1585 |       2
     1030 |      0 |    1585 |       2
     1036 |      0 |    1585 |       2
      789 |      0 |    1585 |       2
      810 |      0 |    1585 |       2
      812 |      0 |    1585 |       2
      818 |      0 |    1585 |       2
      820 |      0 |    1585 |       2
      826 |      0 |    1585 |       2
      828 |      0 |    1585 |       2
(10 rows)
```
Note that operator `789` doesn't appear in the list (it is there, just off the screen with the identical record count).