### PR TITLE
Update the `since` field of IndexState.

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1727,14 +1727,21 @@ where
                 // harmful. We should reconsider compaction policy with an eye
                 // towards minimizing unexpected screw-ups.
                 if let Some(compaction_latency_ms) = index_state.compaction_latency_ms {
-                    index_state.since.clear();
-                    for time in index_state.upper.frontier().iter() {
-                        index_state
-                            .since
-                            .insert(time.saturating_sub(compaction_latency_ms));
+                    // Decline to compact complete collections. This would have the
+                    // effect of making the collection unusable. Instead, we would
+                    // prefer to compact collections only when we believe it would
+                    // reduce the volume of the collection, but we don't have that
+                    // information here.
+                    if !index_state.upper.frontier().is_empty() {
+                        index_state.since.clear();
+                        for time in index_state.upper.frontier().iter() {
+                            index_state
+                                .since
+                                .insert(time.saturating_sub(compaction_latency_ms));
+                        }
+                        self.since_updates
+                            .push((name.clone(), index_state.since.elements().to_vec()));
                     }
-                    self.since_updates
-                        .push((name.clone(), index_state.since.elements().to_vec()));
                 }
             }
         }

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1727,12 +1727,14 @@ where
                 // harmful. We should reconsider compaction policy with an eye
                 // towards minimizing unexpected screw-ups.
                 if let Some(compaction_latency_ms) = index_state.compaction_latency_ms {
-                    let mut since = Antichain::new();
+                    index_state.since.clear();
                     for time in index_state.upper.frontier().iter() {
-                        since.insert(time.saturating_sub(compaction_latency_ms));
+                        index_state
+                            .since
+                            .insert(time.saturating_sub(compaction_latency_ms));
                     }
                     self.since_updates
-                        .push((name.clone(), since.elements().to_vec()));
+                        .push((name.clone(), index_state.since.elements().to_vec()));
                 }
             }
         }

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1885,7 +1885,6 @@ pub struct IndexState {
     /// The compaction frontier.
     /// All peeks in advance of this frontier will be correct,
     /// but peeks not in advance of this frontier may not be.
-    #[allow(dead_code)]
     since: Antichain<Timestamp>,
     /// Compaction delay.
     ///


### PR DESCRIPTION
This field was not previously being updated, which made validity tests against it vacuously true. This meant that races between compaction and upper frontiers could result in incorrect results. There should now be an error instead (the error has always existed, but the state on which it was based was not correct).