### PR TITLE
deps: bump to latest base64 and tokio-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+
+[[package]]
 name = "billing-demo"
 version = "0.1.0"
 dependencies = [
@@ -238,7 +244,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.0",
+ "generic-array",
 ]
 
 [[package]]
@@ -408,7 +414,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-serde",
- "tokio-util",
+ "tokio-util 0.3.1",
  "uuid",
 ]
 
@@ -596,7 +602,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array 0.12.0",
+ "generic-array",
  "subtle",
 ]
 
@@ -656,7 +662,7 @@ dependencies = [
  "serde_json",
  "timely",
  "tokio",
- "tokio-util",
+ "tokio-util 0.3.1",
  "url",
  "uuid",
 ]
@@ -725,15 +731,26 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.0",
+ "generic-array",
 ]
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
  "libc",
  "redox_users",
  "winapi 0.3.8",
@@ -1146,18 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 dependencies = [
  "typenum",
 ]
@@ -1199,7 +1207,7 @@ dependencies = [
  "log",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.2.0",
 ]
 
 [[package]]
@@ -1353,7 +1361,7 @@ name = "interchange"
 version = "0.1.0"
 dependencies = [
  "avro",
- "base64",
+ "base64 0.12.0",
  "byteorder",
  "ccsr",
  "chrono",
@@ -2085,7 +2093,7 @@ dependencies = [
  "repr",
  "sql",
  "tokio",
- "tokio-util",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -2128,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0af6cbca0e6e3ce8692ee19fb8d734b641899e07b68eb73e9bbbd32f1703991"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
@@ -2158,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47cb5f148a31d981d6a5f88f82c6fcc9b5aeb1b6c626d56568f9e007308acfbf"
+checksum = "18741b59a558e4dfdb9c968e8126dccbefd6a16bf54e3bc5668d420b4c4ed71b"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2172,15 +2180,14 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30f0e172ae0fb0653dbf777ad10a74b8e58d6de95a892f2e1d3e94a9df9a844"
+checksum = "3f611afe4d1407ebe7f3ced1ffc66f730fac1b1c13085e230a8cdcb921e97710"
 dependencies = [
- "base64",
+ "base64 0.12.0",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "generic-array 0.13.2",
  "hmac",
  "md5",
  "memchr",
@@ -2590,7 +2597,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2638,12 +2645,12 @@ dependencies = [
 
 [[package]]
 name = "rusoto_core"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492ae34e8ba20e0521e028e19fc90a5650c2668b622b2220986de811bfe44f1e"
+checksum = "3a8d624cb48fcaca612329e4dd544380aa329ef338e83d3a90f5b7897e631971"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.12.0",
  "bytes",
  "futures",
  "hmac",
@@ -2667,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_credential"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c981690595b685c0df4c8f695cbe2e3ed4cd7269bcbcf1e5db2e8e5afc043cfb"
+checksum = "ba3e7cdf483d7198d9bca7414746d3ba656239e89e467b715d0571912f0b492f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2687,9 +2694,9 @@ dependencies = [
 
 [[package]]
 name = "rusoto_kinesis"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2918e2eb0b9f724a019fafa1dcbc6f8ed0c0c3732ef9f8dedbe4de7f9b8b5ab0"
+checksum = "3819b13e35a4fbb3885edbafe8c16ee864232404d3948b55778f67e47be4e778"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2701,11 +2708,11 @@ dependencies = [
 
 [[package]]
 name = "rusoto_signature"
-version = "0.43.0-beta.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1692e8e8c4e1edfa5269fe12ca5806504dcac485ca337e386e201fe6fdd22d5"
+checksum = "62940a2bd479900a1bf8935b8f254d3e19368ac3ac4570eb4bd48eb46551a1b7"
 dependencies = [
- "base64",
+ "base64 0.12.0",
  "bytes",
  "futures",
  "hex",
@@ -2745,7 +2752,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 dependencies = [
- "base64",
+ "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
@@ -3420,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4794270a16f0095a02a752e6cbe9618ef440397af5eb409fa9eb826650ccbdb"
+checksum = "524da2f17264514c854ac770177bdb810f0db7e706ae69f143d6e6828e3c4fe3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -3437,7 +3444,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "tokio",
- "tokio-util",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -3469,6 +3476,20 @@ name = "tokio-util"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ dependencies = [
  "digest",
  "failure",
  "futures",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "libflate",
  "log",
@@ -307,7 +307,7 @@ dependencies = [
  "dataflow-types",
  "expr",
  "failure",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "log",
  "ore",
@@ -453,7 +453,7 @@ dependencies = [
  "expr",
  "failure",
  "futures",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "ore",
  "pgrepr",
@@ -519,7 +519,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.8.2",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -540,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.8.2",
 ]
 
 [[package]]
@@ -638,7 +638,7 @@ dependencies = [
  "failure",
  "futures",
  "interchange",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "log",
  "notify",
@@ -1360,7 +1360,7 @@ dependencies = [
  "criterion",
  "failure",
  "futures",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "num-traits",
  "ordered-float",
@@ -1391,6 +1391,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -1569,7 +1578,7 @@ dependencies = [
  "futures",
  "getopts",
  "hyper",
- "itertools",
+ "itertools 0.9.0",
  "jemallocator",
  "lazy_static",
  "log",
@@ -2065,7 +2074,7 @@ dependencies = [
  "expr",
  "failure",
  "futures",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "log",
  "ordered-float",
@@ -3004,7 +3013,7 @@ dependencies = [
  "failure",
  "futures",
  "interchange",
- "itertools",
+ "itertools 0.9.0",
  "ore",
  "pgrepr",
  "regex",
@@ -3041,7 +3050,7 @@ dependencies = [
  "failure",
  "futures",
  "getopts",
- "itertools",
+ "itertools 0.9.0",
  "lazy_static",
  "md-5",
  "ore",

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,9 @@ skip = [
     # Do not add to this list without good reason! Duplicate dependencies slow
     # down compilation and bloat the binary.
 
+    # Awaiting https://github.com/bheisler/criterion.rs/pull/398.
+    { name = "itertools", version = "0.8.0" },
+
     # Waiting on https://github.com/RustCrypto/utils/pull/39 and releases for
     # https://github.com/RustCrypto/traits.
     { name = "generic-array", version = "0.12.0" },

--- a/deny.toml
+++ b/deny.toml
@@ -7,9 +7,13 @@ skip = [
     # Awaiting https://github.com/bheisler/criterion.rs/pull/398.
     { name = "itertools", version = "0.8.0" },
 
-    # Waiting on https://github.com/RustCrypto/utils/pull/39 and releases for
-    # https://github.com/RustCrypto/traits.
-    { name = "generic-array", version = "0.12.0" },
+    # Awaiting:
+    #   - reqwest 0.13.5 (https://github.com/seanmonstar/reqwest/releases)
+    #   - redox-users (https://gitlab.redox-os.org/redox-os/users/-/merge_requests/34)
+    { name = "base64", version = "0.11.0" },
+
+    # Awaiting h2 0.2.4 (https://github.com/hyperium/h2/releases).
+    { name = "tokio-util", version = "0.2" },
 
     # Waiting on mio 0.7: https://github.com/tokio-rs/tokio/issues/1190.
     { name = "miow", version = "0.2.1" },

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -21,7 +21,7 @@ chrono = { version = "0.4" }
 digest = "0.8"
 failure = "0.1.7"
 futures = "0.3"
-itertools = "0.8"
+itertools = "0.9"
 libflate = "0.1"
 log = "0.4.8"
 rand = "0.7.3"

--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -26,7 +26,7 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 structopt = "0.3.11"
 thiserror = "1.0.13"
 tokio = { version = "0.2.13", features = ["full"] }
-tokio-postgres = "0.5.1"
+tokio-postgres = "0.5.2"
 url = "2.1.1"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -16,7 +16,7 @@ expr = { path = "../expr" }
 failure = "0.1.6"
 lazy_static = "1.4.0"
 log = "0.4.8"
-itertools = "0.8.2"
+itertools = "0.9"
 ore = { path = "../ore" }
 rand = "0.7.3"
 regex = "1"

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -19,7 +19,7 @@ rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "0.2", features = ["dns", "macros", "rt-threaded", "stream", "time", "uds"] }
 tokio-serde = { version = "0.6.1", features = ["bincode"] }
-tokio-util = { version = "0.2", features = ["codec"] }
+tokio-util = { version = "0.3.1", features = ["codec"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -18,7 +18,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 expr = { path = "../expr" }
 failure = "0.1.5"
 futures = "0.3"
-itertools = "0.8"
+itertools = "0.9"
 log = "0.4"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -25,9 +25,9 @@ pgrepr = { path = "../pgrepr" }
 repr = { path = "../repr" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build"] }
 regex = "1.3.4"
-rusoto_core = "0.43.0-beta.1"
-rusoto_credential = "0.43.0-beta.1"
-rusoto_kinesis = "0.43.0-beta.1"
+rusoto_core = "0.43.0"
+rusoto_credential = "0.43.0"
+rusoto_kinesis = "0.43.0"
 rusqlite = { version = "0.20", features = ["bundled"] }
 serde = "1"
 serde_json = "1.0.41"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -21,7 +21,7 @@ expr = { path = "../expr" }
 failure = "0.1"
 futures = "0.3"
 interchange = { path = "../interchange" }
-itertools = "0.8"
+itertools = "0.9"
 lazy_static = "1.4"
 log = "0.4"
 notify = "4.0"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -33,12 +33,12 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 regex = "1.3.5"
 repr = { path = "../repr" }
 rusoto_core = "0.43.0-beta.1"
-rusoto_credential = "0.43.0-beta.1"
-rusoto_kinesis = "0.43.0-beta.1"
+rusoto_credential = "0.43.0"
+rusoto_kinesis = "0.43.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.48"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 tokio = { version = "0.2", features = ["blocking", "fs", "rt-threaded"] }
-tokio-util = { version = "0.2", features = ["codec"] }
+tokio-util = { version = "0.3", features = ["codec"] }
 url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -34,7 +34,7 @@ serde-value = "0.6.0"
 serde_json = "1.0.48"
 sha2 = "0.8"
 url = "2.1.1"
-base64 = "0.11.0"
+base64 = "0.12.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -22,7 +22,7 @@ failure = "0.1.7"
 futures = "0.3"
 log = "0.4.8"
 num-traits = "0.2.11" # don't want to upgrade to autocfg 1.0 until more things use it
-itertools = "0.8.0"
+itertools = "0.9.0"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 protobuf = "2.8.1"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -49,7 +49,7 @@ fallible-iterator = "0.2.0"
 itertools = "0.9"
 postgres = { version = "0.17", features = ["with-chrono-0_4"] }
 serde_json = "1"
-tokio-postgres = { version = "0.5", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.5.2", features = ["with-chrono-0_4"] }
 
 [package.metadata.deb]
 depends = "$auto, systemd"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -46,7 +46,7 @@ tracing-subscriber = "0.2.3"
 [dev-dependencies]
 chrono = "0.4"
 fallible-iterator = "0.2.0"
-itertools = "0.8.2"
+itertools = "0.9"
 postgres = { version = "0.17", features = ["with-chrono-0_4"] }
 serde_json = "1"
 tokio-postgres = { version = "0.5", features = ["with-chrono-0_4"] }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -18,7 +18,7 @@ dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.7"
 futures = "0.3"
-itertools = "0.8.2"
+itertools = "0.9"
 lazy_static = "1.4.0"
 log = "0.4.8"
 ordered-float = { version = "1.0.2", features = ["serde"] }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -29,4 +29,4 @@ rand = "0.7"
 repr = { path = "../repr" }
 sql = { path = "../sql" }
 tokio = "0.2"
-tokio-util = { version = "0.2", features = ["codec"] }
+tokio-util = { version = "0.3", features = ["codec"] }

--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -122,8 +122,7 @@ impl Default for Codec {
     }
 }
 
-impl Encoder for Codec {
-    type Item = BackendMessage;
+impl Encoder<BackendMessage> for Codec {
     type Error = io::Error;
 
     fn encode(&mut self, msg: BackendMessage, dst: &mut BytesMut) -> Result<(), io::Error> {

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -20,7 +20,7 @@ expr = { path = "../expr" }
 failure = "0.1.7"
 futures = "0.3"
 interchange = { path = "../interchange" }
-itertools = "0.8"
+itertools = "0.9"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 regex = "1.3.5"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -15,7 +15,7 @@ expr = { path = "../expr" }
 failure = "0.1.7"
 futures = "0.3"
 getopts = "0.2"
-itertools = "0.8.2"
+itertools = "0.9"
 lazy_static = "1"
 md-5 = "0.8"
 ore = { path = "../ore" }

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.8"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 tokio = "0.2"
-tokio-postgres = { version = "0.5.1", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.5.2", features = ["with-chrono-0_4", "with-serde_json-1"] }
 repr = { path = "../repr" }
 serde_json = "1.0"
 sql = { path = "../sql" }


### PR DESCRIPTION
These need to be updated together to avoid duplicate dependencies.