### PR TITLE
materialized: fix --dev flag behavior

### DIFF
--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -113,9 +113,9 @@ fn run() -> Result<(), failure::Error> {
         "PATH",
     );
     opts.optopt("", "symbiosis", "(internal use only)", "URL");
-    opts.optflag("", "no-prometheus", "Do not gather prometheus metrics");
+    opts.optflag("", "no-prometheus", "do not gather prometheus metrics");
     if cfg!(debug_assertions) {
-        opts.optflag("", "dev", "Allow running the dev (unoptimized) build");
+        opts.optflag("", "dev", "allow running this dev (unoptimized) build");
     }
 
     let popts = opts.parse(&args[1..])?;
@@ -159,8 +159,12 @@ fn run() -> Result<(), failure::Error> {
     let address_file = popts.opt_str("address-file");
     let gather_metrics = !popts.opt_present("no-prometheus");
 
-    if cfg!(debug_assertions) && popts.opt_present("dev") {
-        bail!("Cannot run dev build without '--dev'");
+    if cfg!(debug_assertions) && !popts.opt_present("dev") && !ore::env::is_var_truthy("MZ_DEV") {
+        bail!(
+            "refusing to run dev (unoptimized) binary without explicit opt-in\n\
+             hint: Pass the '--dev' option or set the MZ_DEV environment variable to opt in.\n\
+             hint: Or perhaps you meant to use a release binary?"
+        );
     }
 
     let logical_compaction_window = match popts

--- a/src/ore/env.rs
+++ b/src/ore/env.rs
@@ -1,0 +1,28 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Process environment utilities.
+
+use std::env;
+use std::ffi::OsStr;
+
+/// Reports whether the environment variable `key` is set to a truthy value in
+/// the current process's environment.
+///
+/// The empty string and the string "0" are considered false. All other values
+/// are considered true.
+pub fn is_var_truthy<K>(key: K) -> bool
+where
+    K: AsRef<OsStr>,
+{
+    match env::var_os(key) {
+        None => false,
+        Some(val) => val != "0" && val != "",
+    }
+}

--- a/src/ore/lib.rs
+++ b/src/ore/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod cast;
 pub mod collections;
+pub mod env;
 pub mod fmt;
 pub mod future;
 pub mod hash;


### PR DESCRIPTION
If we must have this --dev flag, it should at least have the desired
effect. Also introduce a MZ_DEV environment variable that can be used to
opt out of this behavior more permanently.

While I'm in here, fix up the consistency of error messages and option
descriptions. These should all start with lower case letters, per
longstanding Unix tradition.