### PR TITLE
Update release documents

### DIFF
--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -22,7 +22,9 @@ For information about available versions, see our [Versions page](../versions).
   of floating-point numbers.
 
 <span id="v0.1.3"></span>
-## 0.1.2 &rarr; 0.1.3 (unreleased)
+## 0.1.2 &rarr; 0.1.3 
+
+- Support Amazon Kinesis Data Stream sources
 
 - Support the number functions `round(x: N)` and `round(x: N, y: N)`, which
   round `x` to the `y`th digit after the decimal. (Default 0).

--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -22,7 +22,7 @@ For information about available versions, see our [Versions page](../versions).
   of floating-point numbers.
 
 <span id="v0.1.3"></span>
-## 0.1.2 &rarr; 0.1.3 
+## 0.1.2 &rarr; 0.1.3
 
 - Support Amazon Kinesis Data Stream sources
 

--- a/www/config.toml
+++ b/www/config.toml
@@ -9,6 +9,7 @@ disableKinds = ["home"]
   # Keep the releases in reverse order of their release date. The first release
   # in the list is assumed to be the most recent.
   versions = [
+      { name = "v0.1.3", date = "17 March 2020" },
       { name = "v0.1.2", date = "04 March 2020" },
       { name = "v0.1.1", date = "22 February 2020" },
       { name = "v0.1.0", date = "13 February 2020" }


### PR DESCRIPTION
This PR:
- Adds Kinesis support to the `v0.1.3` release notes
- Adds `v0.1.3` to the list of Materialize releases