### PR TITLE
Improve RelationType passed to scalar reduction.

### DIFF
--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -300,3 +300,17 @@ query T
 SELECT coalesce(1, 1 / 0, a) FROM v
 ----
 1
+
+# Tests issue #2355, that type information for Maps are correctly constructed
+# before being passed to expressions for optimization.
+statement ok
+CREATE VIEW bytes AS SELECT null::bytea AS data
+
+query T
+SELECT
+    COALESCE(data::jsonb->>'field1', data::jsonb->>'field2')
+FROM (
+    SELECT CONVERT_FROM(data, 'utf8') AS data FROM bytes
+)
+----
+NULL


### PR DESCRIPTION
Scalar reduction in Map was previously using the input RelationType, which would not reflect columns added by other expressions in the Map. Column references to them would then panic.

fixes #2355