### PR TITLE
expr: avoid matching on datum type

### DIFF
--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -125,7 +125,7 @@ EXPLAIN PLAN FOR SELECT date_trunc('day', ts) FROM date_trunc_timestamps
 ----
 0 =
 | Get materialize.public.date_trunc_timestamps (u5)
-| Map date_truncts_day(#0)
+| Map date_trunc_day_ts(#0)
 | Project (#1)
 
 EOF


### PR DESCRIPTION
As a rule, expr functions should never match on the datum type, because
that information can be statically determined via the type system.
Convert a bunch of datum type switches to generic code using the
TimestampLike trait.