### PR TITLE
Add testdrive support for log-compacted kafka topics.

### DIFF
--- a/src/testdrive/tests/cli.rs
+++ b/src/testdrive/tests/cli.rs
@@ -75,7 +75,7 @@ fn test_cmd_arg_missing_value() {
 }
 
 #[test]
-fn test_cmd_arg_bad_nesting_close() {
+fn test_cmd_arg_bad_nesting_brace_close() {
     cmd()
         .write_stdin("$ cmd arg={}}")
         .assert()
@@ -90,7 +90,7 @@ fn test_cmd_arg_bad_nesting_close() {
 }
 
 #[test]
-fn test_cmd_arg_bad_nesting_open() {
+fn test_cmd_arg_bad_nesting_brace_open() {
     cmd()
         .write_stdin("$ cmd arg={{one} two three")
         .assert()
@@ -100,6 +100,66 @@ fn test_cmd_arg_bad_nesting_open() {
      |
    1 | $ cmd arg={{one} two three
      |                          ^
+"#,
+        );
+}
+
+#[test]
+fn test_cmd_arg_bad_nesting_bracket_close() {
+    cmd()
+        .write_stdin("$ cmd arg=[{} things ] more]")
+        .assert()
+        .failure()
+        .stderr(
+            r#"<stdin>:1:28: error: command argument has unbalanced close bracket
+     |
+   1 | $ cmd arg=[{} things ] more]
+     |                            ^
+"#,
+        );
+}
+
+#[test]
+fn test_cmd_arg_bad_nesting_bracket_open() {
+    cmd()
+        .write_stdin("$ cmd arg=[{one} two three")
+        .assert()
+        .failure()
+        .stderr(
+            r#"<stdin>:1:26: error: command argument has unterminated open bracket
+     |
+   1 | $ cmd arg=[{one} two three
+     |                          ^
+"#,
+        );
+}
+
+#[test]
+fn test_cmd_arg_bad_nesting_intersect1() {
+    cmd()
+        .write_stdin("$ cmd arg=[{one]} two three")
+        .assert()
+        .failure()
+        .stderr(
+            r#"<stdin>:1:16: error: command argument has unterminated open brace
+     |
+   1 | $ cmd arg=[{one]} two three
+     |                ^
+"#,
+        );
+}
+
+#[test]
+fn test_cmd_arg_bad_nesting_intersect2() {
+    cmd()
+        .write_stdin("$ cmd arg=[{one {} two} [ three}]")
+        .assert()
+        .failure()
+        .stderr(
+            r#"<stdin>:1:32: error: command argument has unterminated open bracket
+     |
+   1 | $ cmd arg=[{one {} two} [ three}]
+     |                                ^
 "#,
         );
 }

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: compacted kafka logs are produced using the same syntax as
+# kafka-avro-console-producer.
+
+$ set keyschema={"type": "string"}
+
+$ set schema=[
+    "null",
+    {
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+  ]
+
+$ kafka-create-topic topic=test1
+
+$ kafka-ingest format=avro topic=test1 key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+"bird1" {"f1":"goose", "f2": 1}
+"birdmore" {"f1":"geese", "f2": 2}
+"mammal1" {"f1": "moose", "f2": 1}
+"bird1" null
+"birdmore" {"f1":"geese", "f2": 56}
+"mammalmore" {"f1": "moose", "f2": 42}
+"mammal1" null
+
+# TODO: create source in this format. then query to make sure upsert works
+# TODO: test key1: null for deletion. test deletion in the middle of a row

--- a/test/testdrive/registry.td
+++ b/test/testdrive/registry.td
@@ -128,11 +128,11 @@ $ kafka-create-topic topic=missing-data
 
 $ kafka-ingest format=avro topic=missing-data schema=${schema-v1} key-schema=${key-schema-missing}
   publish=true timestamp=1
-{"before": null, "after": {"a": 1}}
+{"b": 42} {"before": null, "after": {"a": 1}}
 
 $ kafka-ingest format=avro topic=missing-data schema=${schema-v1} key-schema=${key-schema-missing}
   publish=true timestamp=2
-{"before": null, "after": null}
+{"b": 42} {"before": null, "after": null}
 
 ! CREATE SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-missing-data-${testdrive.seed}'
@@ -144,11 +144,11 @@ $ kafka-create-topic topic=mismatched-data
 
 $ kafka-ingest format=avro topic=mismatched-data schema=${schema-v1} key-schema=${key-schema-wrong-type}
   publish=true timestamp=3
-{"before": null, "after": {"a": 1}}
+{"a": 1} {"before": null, "after": {"a": 1}}
 
 $ kafka-ingest format=avro topic=mismatched-data schema=${schema-v1} key-schema=${key-schema-wrong-type}
   publish=true timestamp=4
-{"before": null, "after": null}
+{"a": 0} {"before": null, "after": null}
 
 ! CREATE SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mismatched-data-${testdrive.seed}'
@@ -158,11 +158,11 @@ key and value column types do not match
 
 $ kafka-ingest format=avro topic=data schema=${schema-v1} key-schema=${valid-key-schema}
   publish=true timestamp=5
-{"before": null, "after": {"a": 1}}
+{"a": 1} {"before": null, "after": {"a": 1}}
 
 $ kafka-ingest format=avro topic=data schema=${schema-v1} key-schema=${valid-key-schema}
   publish=true timestamp=6
-{"before": null, "after": null}
+{"a": 0} {"before": null, "after": null}
 
 > CREATE MATERIALIZED SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'

--- a/test/testdrive/registry.td
+++ b/test/testdrive/registry.td
@@ -64,9 +64,6 @@ $ kafka-create-topic topic=data
 $ kafka-ingest format=avro topic=data schema=${schema-v1} publish=true timestamp=1
 {"before": null, "after": {"a": 1}}
 
-$ kafka-ingest format=avro topic=data schema=${schema-v1} publish=true timestamp=2
-{"before": null, "after": null}
-
 > CREATE MATERIALIZED SOURCE data_v1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -79,9 +76,6 @@ a
 
 $ kafka-ingest format=avro topic=data schema=${schema-v2} publish=true timestamp=3
 {"before": null, "after": {"a": 2, "b": -1}}
-
-$ kafka-ingest format=avro topic=data schema=${schema-v2} publish=true timestamp=4
-{"before": null, "after": null}
 
 > CREATE MATERIALIZED SOURCE data_v2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -130,10 +124,6 @@ $ kafka-ingest format=avro topic=missing-data schema=${schema-v1} key-schema=${k
   publish=true timestamp=1
 {"b": 42} {"before": null, "after": {"a": 1}}
 
-$ kafka-ingest format=avro topic=missing-data schema=${schema-v1} key-schema=${key-schema-missing}
-  publish=true timestamp=2
-{"b": 42} {"before": null, "after": null}
-
 ! CREATE SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-missing-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -146,10 +136,6 @@ $ kafka-ingest format=avro topic=mismatched-data schema=${schema-v1} key-schema=
   publish=true timestamp=3
 {"a": 1} {"before": null, "after": {"a": 1}}
 
-$ kafka-ingest format=avro topic=mismatched-data schema=${schema-v1} key-schema=${key-schema-wrong-type}
-  publish=true timestamp=4
-{"a": 0} {"before": null, "after": null}
-
 ! CREATE SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mismatched-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -159,10 +145,6 @@ key and value column types do not match
 $ kafka-ingest format=avro topic=data schema=${schema-v1} key-schema=${valid-key-schema}
   publish=true timestamp=5
 {"a": 1} {"before": null, "after": {"a": 1}}
-
-$ kafka-ingest format=avro topic=data schema=${schema-v1} key-schema=${valid-key-schema}
-  publish=true timestamp=6
-{"a": 0} {"before": null, "after": null}
 
 > CREATE MATERIALIZED SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'


### PR DESCRIPTION
Part of preparations to test the upcoming implementation for #1575.

kafka-avro-console-producer expects key-value records to be entered by having the key and value on the same line but separated by a tab. However, VSCode keeps converting every tab I type to spaces, so instead of using tab as the key separator, I am using ␉ (U2409 - SYMBOL FOR HORIZONTAL TABULATION) instead.

Added an argument to kafka-ingest called `compaction` (default false). When `compaction` is true and key-schema exists, it expects a key for each record. When compaction is false, it supports the debezium format, where we can make a key-schema to specify to materialize the primary key of a record, but no keys are pushed into kafka. 

To properly support log-compaction, testdrive needs to be able to support schema which are ["null", {"type": "record", ...}]. Extended the parser to be able to nested brackets in addition to braces.

Manually that tested that the kafka topic produced in compaction-kafka.td is in proper log-compacted format using the commands:
```
kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic testdrive-test1-${testdrive-seed} \
  --property print.key=false --from-beginning

kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic testdrive-test1-${testdrive-seed} \
  --property print.key=true --from-beginning
```