### PR TITLE
Run chbench for 60 seconds in CI

### DIFF
--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -118,6 +118,7 @@ steps:
     depends_on: build
     command: demo/chbench/dc.sh ci
     timeout_in_minutes: 30
+    plugins:
       - MaterializeInc/uid#master: ~
     if: $CHANGED_RUST
 

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -113,6 +113,14 @@ steps:
           run: billing-demo
     if: $CHANGED_RUST
 
+  - id: chbench-demo
+    label: "chbench sanity check"
+    depends_on: build
+    command: demo/chbench/dc.sh ci
+    timeout_in_minutes: 30
+      - MaterializeInc/uid#master: ~
+    if: $CHANGED_RUST
+
   - id: catalog-compat
     label: ":book: catalog compatibility check"
     depends_on: build

--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -326,7 +326,7 @@ dc_check_query() {
 dc_ensure_stays_up() {
     local container=$1
     local seconds="${2-5}"
-    echo -n "ensuring $container is staying up "
+    echo -n "ensuring $container is staying up for $seconds seconds: "
     for i in $(seq 1 "$seconds"); do
         sleep 1
         if [[ -z $(dc_is_running "$container") ]]; then

--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -301,14 +301,16 @@ dc_is_running() {
 
 dc_run_query() {
     local query=$1
+    # shellcheck disable=SC2059
     (printf "$query\n" | docker-compose run cli psql -q -h materialized -p 6875 -d materialize) || true
 }
 
 dc_check_query() {
     local query=$1
     local timeout=$2
-    for i in $(seq 0 $timeout); do
-        local result=$(dc_run_query "$query")
+    for i in $(seq 0 "$timeout"); do
+        local result
+        result=$(dc_run_query "$query")
         if [[ -z $result ]]; then
             sleep 1
         else

--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -93,6 +93,7 @@ main() {
             local glob="${1:?restore requires an argument}" && shift
             dc_prom_restore "$glob"
             ;;
+        ci) ci;;
         *) usage ;;
     esac
 }
@@ -298,11 +299,33 @@ dc_is_running() {
     ( dc_chbench_containers | grep -E "chbench_${1}" ) || true
 }
 
+dc_run_query() {
+    local query=$1
+    (printf "$query\n" | docker-compose run cli psql -q -h materialized -p 6875 -d materialize) || true
+}
+
+dc_check_query() {
+    local query=$1
+    local timeout=$2
+    for i in $(seq 0 $timeout); do
+        local result=$(dc_run_query "$query")
+        if [[ -z $result ]]; then
+            sleep 1
+        else
+            printf %s "$result"
+            return
+        fi
+    done
+    uw "query failed after $timeout attempts: $query"
+    exit 1
+}
+
+
 dc_ensure_stays_up() {
     local container=$1
     local seconds="${2-5}"
     echo -n "ensuring $container is staying up "
-    for i in $(seq "$seconds" 1); do
+    for i in $(seq 1 "$seconds"); do
         sleep 1
         if [[ -z $(dc_is_running "$container") ]]; then
             echo
@@ -369,6 +392,26 @@ drop_kafka_topics() {
     dc_stop materialized peeker
     runv docker exec -it chbench_kafka_1 kafka-topics --delete --bootstrap-server localhost:9092 --topic "mysql.tpcch.*" || true
     dc_up materialized
+}
+
+ci() {
+    bring_up_source_data
+    drop_kafka_topics
+    export MZ_IMG=materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
+    export PEEKER_IMG=materialize/ci-peeker:${BUILDKITE_BUILD_NUMBER}
+    dc_run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
+    dc_run -d chbench run \
+        --dsn=mysql --gen-dir=/var/lib/mysql-files \
+        --analytic-threads=0 --transactional-threads=1 --run-seconds=432000 \
+        -l /dev/stdout --config-file-path=/etc/chbenchmark/mz-default.cfg \
+        --mz-url=postgresql://materialized:6875/materialize?sslmode=disable
+    dc_ensure_stays_up chbench 60
+    dc_logs chbench
+    dc_run -d peeker \
+         --queries q01
+    dc_ensure_stays_up peeker
+    dc_status
+    dc_check_query "\\pset format unaligned\nselect count(*) from q01" 20
 }
 
 # Long-running load test

--- a/demo/chbench/docker-compose.yml
+++ b/demo/chbench/docker-compose.yml
@@ -24,7 +24,7 @@ x-port-mappings:
 version: '3.7'
 services:
   materialized:
-    image: materialize/materialized:latest
+    image: ${MZ_IMG:-materialize/materialized:latest}
     ports:
      - *materialized
     init: true
@@ -139,6 +139,8 @@ services:
   inspect:
     image: ubuntu:bionic
     command: "true"
+    volumes:
+      - chbench-gen:/gen
 
   # Metabase
   # We need to ~manually add our `metabase-materialize-driver` to /plugins
@@ -210,7 +212,7 @@ services:
       - ./prometheus-sql-exporter/mysql/tpcch.collector.yml:/config/tpcch.collector.yml
   peeker:
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
-    image: materialize/peeker:latest
+    image: ${PEEKER_IMG:-materialize/peeker:latest}
     init: true
     # run peeker using 'dc.sh run peeker' to adjust which queries are peeked,
     # and see /src/peeker/config.toml for a list of queries


### PR DESCRIPTION
Attempt to avoid people making changes to materialized that breaks chbench.

This causes the CI test pipeline to run chbench for 60 seconds and check that a basic query (`select count(*) from q01`) finishes.

It also fixes a bug in `dc_ensure_stays_up` that was causing it to essentially do nothing.