### PR TITLE
sql: accept SET TIME ZONE UTC

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2190,8 +2190,15 @@ impl Parser {
 
     pub fn parse_set(&mut self) -> Result<Statement, ParserError> {
         let modifier = self.parse_one_of_keywords(&["SESSION", "LOCAL"]);
-        let variable = self.parse_identifier()?;
-        if self.consume_token(&Token::Eq) || self.parse_keyword("TO") {
+        let mut variable = self.parse_identifier()?;
+        let mut normal = self.consume_token(&Token::Eq) || self.parse_keyword("TO");
+        if !normal && variable.value.to_uppercase() == "TIME" {
+            self.expect_keyword("ZONE")?;
+            variable.value = "timezone".into();
+            variable.quote_style = None;
+            normal = true;
+        }
+        if normal {
             let token = self.peek_token();
             let value = match (self.parse_value(), token) {
                 (Ok(value), _) => SetVariableValue::Literal(value),
@@ -2203,7 +2210,7 @@ impl Parser {
                 variable,
                 value,
             })
-        } else if variable.value == "TRANSACTION" && modifier.is_none() {
+        } else if variable.value.to_uppercase() == "TRANSACTION" && modifier.is_none() {
             Ok(Statement::SetTransaction {
                 modes: self.parse_transaction_modes()?,
             })

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -4384,8 +4384,20 @@ fn parse_set() {
         }
     );
 
+    let stmt = one_statement_parses_to("SET TIME ZONE utc", "SET timezone = utc");
+    assert_eq!(
+        stmt,
+        Statement::SetVariable {
+            local: false,
+            variable: "timezone".into(),
+            value: SetVariableValue::Ident("utc".into()),
+        }
+    );
+
     one_statement_parses_to("SET a TO b", "SET a = b");
     one_statement_parses_to("SET SESSION a = b", "SET a = b");
+    one_statement_parses_to("SET tiMe ZoNE 7", "SET timezone = 7");
+    one_statement_parses_to("SET LOCAL tiMe ZoNE 7", "SET LOCAL timezone = 7");
 
     assert_eq!(
         parse_sql_statements("SET").unwrap_err().to_string(),

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test (lack of) timezone support.
+
+statement ok
+SET TIME ZONE UTC
+
+statement ok
+SET TIME ZONE 'UTC'
+
+statement ok
+SET TIME ZONE 'uTc'
+
+statement ok
+SET TimeZone = 'uTc'
+
+statement error parameter TimeZone can only be set to UTC
+SET TIME ZONE bad

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -16,6 +16,7 @@ DateStyle           "ISO, MDY"                        "Sets the display format f
 search_path         "mz_catalog, pg_catalog, public"  "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
 server_version      9.5.0                             "Shows the server version (PostgreSQL)."
 sql_safe_updates    false                             "Prohibits SQL statements that may be overly destructive (CockroachDB)."
+TimeZone            UTC                               "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 
 > SHOW client_encoding
 UTF8


### PR DESCRIPTION
This is a small step towards allowing clients to configure their time
zone. Most clients want to use UTC, and some will issue a SET TIME ZONE
UTC command regardless of whether the connection is already using UTC.
Just accept that declaration, so we work with those clients, but error
if clients try to select a different time zone.

Fix #2393.