### PR TITLE
ci: upgrade to latest version of docker-compose plugin

### DIFF
--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -14,7 +14,7 @@ steps:
     artifact_paths: target/slt-summary.json
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/slt/docker-compose.yml
           run: sqllogictest
   - wait

--- a/ci/test/cargo-test.compose.yml
+++ b/ci/test/cargo-test.compose.yml
@@ -11,7 +11,7 @@ version: '3'
 services:
   app:
     image: materialize/ci-cargo-test:${BUILDKITE_BUILD_NUMBER}
-    command: ["wait-for-it", "schema-registry:8081", "--", "run-tests"]
+    command: ["wait-for-it", "kafka:9092", "schema-registry:8081", "--", "run-tests"]
     volumes:
     - ../../:/workdir
     environment:

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -55,7 +55,7 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/test/cargo-test.compose.yml
           run: app
     if: $CHANGED_RUST
@@ -83,7 +83,7 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/test/testdrive.compose.yml
           run: testdrive
     if: $CHANGED_RUST || $CHANGED_TESTDRIVE
@@ -97,7 +97,7 @@ steps:
       SQLLOGICTEST_IMAGE_ID: $BUILDKITE_BUILD_NUMBER
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/slt/docker-compose.yml
           run: sqllogictest
     if: $CHANGED_RUST || $CHANGED_SLT
@@ -108,7 +108,7 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/test/streaming-demo.compose.yml
           run: billing-demo
     if: $CHANGED_RUST
@@ -128,7 +128,7 @@ steps:
     timeout_in_minutes: 30
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/test/catalog-compat.compose.yml
           run: catalog-compat
     if: $CHANGED_RUST
@@ -139,7 +139,7 @@ steps:
     timeout_in_minutes: 10
     plugins:
       - MaterializeInc/uid#master: ~
-      - docker-compose#v3.0.3:
+      - docker-compose#v3.3.0:
           config: ci/test/metabase-demo.compose.yml
           run: healthcheck
     if: $CHANGED_RUST

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -154,4 +154,7 @@ tests=(
     # test/sqllogictest/cockroach/zero.slt
 )
 
+if [[ "$BUILDKITE" ]]; then
+    wait-for-it postgres:5432
+fi
 sqllogictest -v "${tests[@]}"

--- a/ci/test/testdrive.compose.yml
+++ b/ci/test/testdrive.compose.yml
@@ -12,7 +12,7 @@ services:
   testdrive:
     image: materialize/ci-testdrive:${BUILDKITE_BUILD_NUMBER}
     command: >-
-      bash -c "wait-for-it schema-registry:8081 materialized:6875 --
+      bash -c "wait-for-it kafka:9092 schema-registry:8081 materialized:6875 --
       testdrive
       --kafka-addr=kafka:9092
       --schema-registry-url=http://schema-registry:8081


### PR DESCRIPTION
This will upload all container logs when a failure occurs, which should
make debugging the sporadic testdrive Kafka fetch error easier.