### PR TITLE
Use GPG instead of `trusted=yes` in Apt instructions

### DIFF
--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -30,11 +30,14 @@ curl -L https://downloads.mtrlz.dev/materialized-{{< version >}}-x86_64-apple-da
 
 ## Linux installation
 
-### apt
+### apt (Ubuntu, Debian, or variants)
 
 ```shell
-echo "deb [trusted=yes] https://packages.materialize.io/apt/ /" > /etc/apt/sources.list.d/materialize.list
-apt update
+# Add the signing key for the Materialize apt repository
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+# Add and update the repository
+apt-add-repository 'deb http://packages.materialize.io/apt/ /'
+# Install materialized
 apt install materialized
 ```
 

--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -37,6 +37,7 @@ curl -L https://downloads.mtrlz.dev/materialized-{{< version >}}-x86_64-apple-da
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
 # Add and update the repository
 apt-add-repository 'deb http://packages.materialize.io/apt/ /'
+apt update
 # Install materialized
 apt install materialized
 ```


### PR DESCRIPTION
The normal way to distribute apt binaries is by signing them with GPG and distributing over http, not by distributing over https. We were using https before because it was easier to set up in GemFrog, but let's change the docs now that we are on Bintray and GPG signing works (as long as the user imports Bintray's GPG key first).

The old way will still work, so people who followed the old instructions don't need to change anything. But documenting the more standard way makes us look more professional / less sketch.