### PR TITLE
ci/test: use separate wait-for-it commands

### DIFF
--- a/ci/test/cargo-test.compose.yml
+++ b/ci/test/cargo-test.compose.yml
@@ -11,7 +11,7 @@ version: '3'
 services:
   app:
     image: materialize/ci-cargo-test:${BUILDKITE_BUILD_NUMBER}
-    command: ["wait-for-it", "kafka:9092", "schema-registry:8081", "--", "run-tests"]
+    command: ["wait-for-it", "kafka:9092", "--", "wait-for-it", "schema-registry:8081", "--", "run-tests"]
     volumes:
     - ../../:/workdir
     environment:

--- a/ci/test/streaming-demo.compose.yml
+++ b/ci/test/streaming-demo.compose.yml
@@ -14,7 +14,7 @@ services:
     entrypoint: /bin/bash
     volumes:
       - db-data:/share/billing-demo/data
-    command: -c "wait-for-it materialized:6875 kafka:9092 --
+    command: -c "wait-for-it materialized:6875 -- wait-for-it kafka:9092 --
       billing-demo --message-count 1000 --materialized-host materialized
       --kafka-host kafka --csv-file-name /share/billing-demo/data/prices.csv"
     environment:

--- a/ci/test/testdrive.compose.yml
+++ b/ci/test/testdrive.compose.yml
@@ -12,8 +12,10 @@ services:
   testdrive:
     image: materialize/ci-testdrive:${BUILDKITE_BUILD_NUMBER}
     command: >-
-      bash -c "wait-for-it kafka:9092 schema-registry:8081 materialized:6875 --
-      testdrive
+      bash -c "wait-for-it kafka:9092
+      && wait-for-it schema-registry:8081
+      && wait-for-it materialized:6875
+      && testdrive
       --kafka-addr=kafka:9092
       --schema-registry-url=http://schema-registry:8081
       --materialized-url=postgres://ignored@materialized:6875


### PR DESCRIPTION
Requesting to wait for multiple services is silently ignored.