### PR TITLE
ci/test: increase wait-for-it timeout

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -20,7 +20,7 @@ if [[ ! "${BUILDKITE-}" ]]; then
 fi
 
 if [[ "${BUILDKITE-}" ]]; then
-    wait-for-it postgres:5432
+    wait-for-it --timeout=30 postgres:5432
 fi
 
 export RUST_BACKTRACE=full

--- a/ci/test/cargo-test.compose.yml
+++ b/ci/test/cargo-test.compose.yml
@@ -11,7 +11,16 @@ version: '3'
 services:
   app:
     image: materialize/ci-cargo-test:${BUILDKITE_BUILD_NUMBER}
-    command: ["wait-for-it", "kafka:9092", "--", "wait-for-it", "schema-registry:8081", "--", "run-tests"]
+    command:
+    - "wait-for-it"
+    - "--timeout=30"
+    - "kafka:9092"
+    - "--"
+    - "wait-for-it"
+    - "--timeout=30"
+    - "schema-registry:8081"
+    - "--"
+    - "run-tests"
     volumes:
     - ../../:/workdir
     environment:

--- a/ci/test/catalog-compat/catcompatck
+++ b/ci/test/catalog-compat/catcompatck
@@ -43,11 +43,11 @@ expect_sql() {
 launch_materialized() {
     "materialized-$1" "$@" &
     materialized_pid=$?
-    wait-for-it -q localhost:6875
+    wait-for-it --timeout=30 -q localhost:6875
     run_sql "SELECT 1" > /dev/null
 }
 
-wait-for-it kafka:9092
+wait-for-it --timeout=30 kafka:9092
 
 say "launching materialized-golden"
 launch_materialized golden

--- a/ci/test/streaming-demo.compose.yml
+++ b/ci/test/streaming-demo.compose.yml
@@ -14,7 +14,7 @@ services:
     entrypoint: /bin/bash
     volumes:
       - db-data:/share/billing-demo/data
-    command: -c "wait-for-it materialized:6875 -- wait-for-it kafka:9092 --
+    command: -c "wait-for-it --timeout=30 materialized:6875 -- wait-for-it --timeout=30 kafka:9092 --
       billing-demo --message-count 1000 --materialized-host materialized
       --kafka-host kafka --csv-file-name /share/billing-demo/data/prices.csv"
     environment:

--- a/ci/test/testdrive.compose.yml
+++ b/ci/test/testdrive.compose.yml
@@ -12,9 +12,9 @@ services:
   testdrive:
     image: materialize/ci-testdrive:${BUILDKITE_BUILD_NUMBER}
     command: >-
-      bash -c "wait-for-it kafka:9092
-      && wait-for-it schema-registry:8081
-      && wait-for-it materialized:6875
+      bash -c "wait-for-it --timeout=30 kafka:9092
+      && wait-for-it --timeout=30 schema-registry:8081
+      && wait-for-it --timeout=30 materialized:6875
       && testdrive
       --kafka-addr=kafka:9092
       --schema-registry-url=http://schema-registry:8081


### PR DESCRIPTION
Reports have surfaced where more than 15s are required for services to
come online.

Fix #2419.