### PR TITLE
sql: support CSVs with headers

### DIFF
--- a/doc/user/known-limitations.md
+++ b/doc/user/known-limitations.md
@@ -75,8 +75,7 @@ tag](https://github.com/MaterializeInc/materialize/issues?q=is%3Aopen+is%3Aissue
 
 ### File sources
 
-- CSV files with header rows are not supported
-  ([#1982](https://github.com/MaterializeInc/materialize/issues/1982))
+None right now!
 
 ### Regex formatting
 
@@ -111,6 +110,8 @@ specified version.
 
 Fixed in | Known limitation
 --------------|-----------------
+[v0.2.0] | CSV files with header rows are not supported ([#1982](https://github.com/MaterializeInc/materialize/issues/1982))
 [v0.1.3] | Intervals do not support addition or subtraction with other intervals ([#1682](https://github.com/MaterializeInc/materialize/issues/1682))
 
+[v0.2.0]: ../release-notes/#v0.2.0
 [v0.1.3]: ../release-notes/#v0.1.3

--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -13,13 +13,15 @@ This page details changes between versions of Materialize, including:
 
 For information about available versions, see our [Versions page](../versions).
 
-<span id="v0.1.4"></span>
-## 0.1.3 &rarr; 0.1.4 (unreleased)
+<span id="v0.2.0"></span>
+## 0.1.3 &rarr; v0.2.0 (unreleased)
 
 - Make formatting and parsing for `real` and `double precision` numbers more
   consistent with PostgreSQL. The strings `NaN`, and `[+-]Infinity` are
   accepted as input, to select the special not-a-number and infinity states
   of floating-point numbers.
+- Support CSV files with headers (`CREATE SOURCE...FORMAT CSV WITH HEADER`).
+- Support naming columns when creating CSV sources.
 
 <span id="v0.1.3"></span>
 ## 0.1.2 &rarr; 0.1.3

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -21,6 +21,7 @@ use repr::{Datum, Row};
 
 pub fn csv<G>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,
+    header_row: bool,
     n_cols: usize,
     delimiter: u8,
 ) -> Stream<G, (Row, Timestamp, Diff)>
@@ -60,6 +61,9 @@ where
                             csv_reader.reset();
                             if let Some(line_no) = line_no {
                                 csv_reader.set_line(*line_no as u64);
+                                if header_row && *line_no == 1 {
+                                    continue;
+                                }
                             }
 
                             let mut input = line.as_slice();

--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -126,7 +126,9 @@ where
     G: Scope<Timestamp = Timestamp>,
 {
     match (encoding, envelope) {
-        (DataEncoding::Csv(enc), Envelope::None) => csv(stream, enc.n_cols, enc.delimiter),
+        (DataEncoding::Csv(enc), Envelope::None) => {
+            csv(stream, enc.header_row, enc.n_cols, enc.delimiter)
+        }
         (DataEncoding::Avro(enc), envelope) => avro(
             stream,
             &enc.value_schema,

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -573,7 +573,8 @@ pub enum Format {
     },
     Regex(String),
     Csv {
-        n_cols: usize,
+        header_row: bool,
+        n_cols: Option<usize>,
         delimiter: char,
     },
     Json,
@@ -620,10 +621,18 @@ impl fmt::Display for Format {
                 schema
             ),
             Self::Regex(regex) => write!(f, "REGEX '{}'", value::escape_single_quote_string(regex)),
-            Self::Csv { n_cols, delimiter } => write!(
-                f,
-                "CSV WITH {} COLUMNS{}",
+            Self::Csv {
+                header_row,
                 n_cols,
+                delimiter,
+            } => write!(
+                f,
+                "CSV WITH {}{}",
+                if *header_row {
+                    "HEADER".to_owned()
+                } else {
+                    format!("{} COLUMNS", n_cols.unwrap())
+                },
                 if *delimiter == ',' {
                     "".to_owned()
                 } else {

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -224,6 +224,7 @@ define_keywords!(
     GROUPS,
     HAVING,
     HEADER,
+    HEADERS,
     HOLD,
     HOUR,
     HOURS,


### PR DESCRIPTION
- Support CSV headers with new syntax:

    ```
    CREATE SOURCE ...
    FROM FILE '...'
    FORMAT CSV WITH HEADER;
    ```

    This:

    - Extracts first line from CSV, and uses those values as the source's 
    column names 
    - Skips adding the first line to the source

    I also types `WITH HEADERS` a few times, so added that as valid syntax.

- Add `WITH` option to let users name CSV source column names, even without
header, with new syntax::

    ```
    CREATE SOURCE ...
    FROM FILE '...'
    WITH (col_names='col_foo,col_bar')
    FORMAT CSV WITH 2 COLUMNS;
    ```

    This takes precedence over deriving the column names from the CSV header, if
    provided.

    Note that despite this being a `WITH` option on file sources, it does not
    apply to any non-CSV formatted file sources. If this format looks good, it
    could be easily added to other formats/encodings.

Note: I wasn't sure if this would make it into v0.2.0, so added a section for v0.2.1--if I can get this in tomorrow, glad to change the release notes.

Fix #1982 