### PR TITLE
ci/www: remove deploy key

### DIFF
--- a/ci/www/changed.sh
+++ b/ci/www/changed.sh
@@ -18,7 +18,7 @@ cd "$(dirname "$0")/../.."
 if [[ "$BRANCH" = master ]]; then
     spec=HEAD^
 else
-    git fetch https://"$DEPLOY_KEY"@github.com/MaterializeInc/materialize.git master
+    git fetch https://github.com/MaterializeInc/materialize.git master
     spec=FETCH_HEAD...
 fi
 


### PR DESCRIPTION
Now that the repository is public, Netlify no longer needs a deploy key.
Remove it, so that Netlify doesn't think that our build contains
anything secret.