### PR TITLE
dataflow: thread runtime errors through rendering

### DIFF
--- a/src/dataflow/arrangement/manager.rs
+++ b/src/dataflow/arrangement/manager.rs
@@ -9,31 +9,30 @@
 
 //! Management of arrangements across dataflows.
 
-use differential_dataflow::operators::arrange::TraceAgent;
+use std::any::Any;
 use std::collections::HashMap;
+use std::rc::Rc;
+
+use differential_dataflow::operators::arrange::TraceAgent;
+use differential_dataflow::trace::implementations::ord::{OrdKeyBatch, OrdValBatch};
+use differential_dataflow::trace::implementations::spine_fueled_neu::Spine;
+use differential_dataflow::trace::TraceReader;
 
 use dataflow_types::{Diff, Timestamp};
-use expr::GlobalId;
+use expr::{EvalError, GlobalId};
 use repr::Row;
 
-use differential_dataflow::trace::implementations::ord::OrdValBatch;
-use differential_dataflow::trace::implementations::spine_fueled_neu::Spine;
-use std::rc::Rc;
+pub type OrdKeySpine<K, T, R, O = usize> = Spine<K, (), T, R, Rc<OrdKeyBatch<K, T, R, O>>>;
 pub type OrdValSpine<K, V, T, R, O = usize> = Spine<K, V, T, R, Rc<OrdValBatch<K, V, T, R, O>>>;
-
-#[allow(dead_code)]
-pub type KeysValsSpine = OrdValSpine<Row, Row, Timestamp, Diff>;
+pub type TraceKeyHandle<K, T, R> = TraceAgent<OrdKeySpine<K, T, R>>;
 pub type TraceValHandle<K, V, T, R> = TraceAgent<OrdValSpine<K, V, T, R>>;
 pub type KeysValsHandle = TraceValHandle<Row, Row, Timestamp, Diff>;
+pub type ErrsHandle = TraceKeyHandle<EvalError, Timestamp, Diff>;
 
-/// A map from collection names to cached arrangements.
-///
-/// A `TraceManager` stores maps from global identifiers to various arranged
-/// representations of a collection. These arrangements can either be unkeyed,
-/// or keyed by some expression.
+/// A `TraceManager` stores maps from global identifiers to the primary arranged
+/// representation of that collection.
 pub struct TraceManager {
-    /// A map from global identifiers to maintained traces.
-    pub traces: HashMap<GlobalId, WithDrop<KeysValsHandle>>,
+    pub traces: HashMap<GlobalId, TraceBundle>,
 }
 
 impl Default for TraceManager {
@@ -54,10 +53,11 @@ impl TraceManager {
     /// be able to remove this code.
     pub fn maintenance(&mut self) {
         let mut antichain = timely::progress::frontier::Antichain::new();
-        for handle in self.traces.values_mut() {
-            use differential_dataflow::trace::TraceReader;
-            handle.read_upper(&mut antichain);
-            handle.distinguish_since(antichain.elements());
+        for bundle in self.traces.values_mut() {
+            bundle.oks.read_upper(&mut antichain);
+            bundle.oks.distinguish_since(antichain.elements());
+            bundle.errs.read_upper(&mut antichain);
+            bundle.errs.distinguish_since(antichain.elements());
         }
     }
 
@@ -68,87 +68,83 @@ impl TraceManager {
     /// not in advance of `frontier`. Users should take care to only rely on
     /// accumulations at times in advance of `frontier`.
     pub fn allow_compaction(&mut self, id: GlobalId, frontier: &[Timestamp]) {
-        use differential_dataflow::trace::TraceReader;
-        if let Some(val) = self.traces.get_mut(&id) {
-            val.advance_by(frontier);
+        if let Some(bundle) = self.traces.get_mut(&id) {
+            bundle.oks.advance_by(frontier);
+            bundle.errs.advance_by(frontier);
         }
     }
 
-    /// Returns a copy of a by_key arrangement, should it exist.
-    #[allow(dead_code)]
-    pub fn get(&self, id: &GlobalId) -> Option<&WithDrop<KeysValsHandle>> {
+    /// Returns a reference to the trace for `id`, should it exist.
+    pub fn get(&self, id: &GlobalId) -> Option<&TraceBundle> {
         self.traces.get(&id)
     }
 
-    /// Returns a copy of a by_key arrangement, should it exist.
-    #[allow(dead_code)]
-    pub fn get_mut(&mut self, id: &GlobalId) -> Option<&mut WithDrop<KeysValsHandle>> {
+    /// Returns a mutable reference to the trace for `id`, should it
+    /// exist.
+    pub fn get_mut(&mut self, id: &GlobalId) -> Option<&mut TraceBundle> {
         self.traces.get_mut(&id)
     }
 
-    /// Binds a by_keys arrangement.
-    #[allow(dead_code)]
-    pub fn set(&mut self, id: GlobalId, trace: WithDrop<KeysValsHandle>) {
-        //Currently it is assumed that the first arrangement for a collection is the one
-        //keyed by the primary keys
+    /// Binds the arrangement for `id` to `trace`.
+    pub fn set(&mut self, id: GlobalId, trace: TraceBundle) {
         self.traces.insert(id, trace);
     }
 
-    /// Removes a trace
+    /// Removes the trace for `id`.
     pub fn del_trace(&mut self, id: &GlobalId) -> bool {
         self.traces.remove(&id).is_some()
     }
 
-    /// Removes all remnants of all named traces.
+    /// Removes all managed traces.
     pub fn del_all_traces(&mut self) {
         self.traces.clear();
     }
 }
 
-/// A thin wrapper containing an associated item to drop.
-///
-/// This type is used for controlled shutdown of dataflows as handles are dropped.
-/// The associated `to_drop` will be dropped with the element, and can be observed
-/// by other bits of clean-up code.
+/// Bundles together traces for the successful computations (`oks`), the
+/// failed computations (`errs`), and additional tokens that should share
+/// the lifetime of the bundled traces (`to_drop`).
 #[derive(Clone)]
-pub struct WithDrop<T> {
-    element: T,
-    to_drop: Option<std::rc::Rc<Box<dyn std::any::Any>>>,
+pub struct TraceBundle {
+    oks: KeysValsHandle,
+    errs: ErrsHandle,
+    to_drop: Option<Rc<Box<dyn Any>>>,
 }
 
-impl<T> WithDrop<T> {
-    /// Creates a new wrapper with an item to drop.
-    pub fn new<S: std::any::Any>(element: T, to_drop: S) -> Self {
-        Self {
-            element,
-            to_drop: Some(std::rc::Rc::new(Box::new(to_drop))),
-        }
-    }
-
-    /// Read access to the drop token, so that others can clone it.
-    pub fn to_drop(&self) -> &Option<std::rc::Rc<Box<dyn std::any::Any>>> {
-        &self.to_drop
-    }
-}
-
-impl<T> From<T> for WithDrop<T> {
-    fn from(element: T) -> Self {
-        Self {
-            element,
+impl TraceBundle {
+    /// Constructs a new trace bundle out of an `oks` trace and `errs` trace.
+    pub fn new(oks: KeysValsHandle, errs: ErrsHandle) -> TraceBundle {
+        TraceBundle {
+            oks,
+            errs,
             to_drop: None,
         }
     }
-}
 
-impl<T> std::ops::Deref for WithDrop<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.element
+    /// Adds tokens to be dropped when the trace bundle is dropped.
+    pub fn with_drop<T>(self, to_drop: T) -> TraceBundle
+    where
+        T: 'static,
+    {
+        TraceBundle {
+            oks: self.oks,
+            errs: self.errs,
+            to_drop: Some(Rc::new(Box::new(to_drop))),
+        }
     }
-}
 
-impl<T> std::ops::DerefMut for WithDrop<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.element
+    /// Returns a mutable reference to the `oks` trace.
+    pub fn oks_mut(&mut self) -> &mut KeysValsHandle {
+        &mut self.oks
+    }
+
+    /// Returns a mutable reference to the `errs` trace.
+    pub fn errs_mut(&mut self) -> &mut ErrsHandle {
+        &mut self.errs
+    }
+
+    /// Returns a reference to the `to_drop` tokens.
+    pub fn to_drop(&self) -> &Option<Rc<Box<dyn Any>>> {
+        &self.to_drop
     }
 }

--- a/src/dataflow/lib.rs
+++ b/src/dataflow/lib.rs
@@ -11,6 +11,7 @@
 
 mod arrangement;
 mod decode;
+mod operator;
 mod render;
 mod sink;
 mod source;

--- a/src/dataflow/operator.rs
+++ b/src/dataflow/operator.rs
@@ -1,0 +1,309 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::AsCollection;
+use differential_dataflow::Collection;
+use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline};
+use timely::dataflow::channels::pushers::Tee;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::operators::generic::{operator, InputHandle, OperatorInfo, OutputHandle};
+use timely::dataflow::operators::Capability;
+use timely::dataflow::{Scope, Stream};
+use timely::Data;
+
+/// Extension methods for timely [`Stream`]s.
+pub trait StreamExt<G, D1>
+where
+    D1: Data,
+    G: Scope,
+{
+    /// Like `timely::dataflow::operators::generic::operator::Operator::unary`,
+    /// but the logic function can handle failures.
+    ///
+    /// Creates a new dataflow operator that partitions its input stream by a
+    /// parallelization strategy `pact` and repeatedly invokes `logic`, the
+    /// function returned by the function passed as `constructor`. The `logic`
+    /// function can read to the input stream and write to either of two output
+    /// streams, where the first output stream represents successful
+    /// computations and the second output stream represents failed
+    /// computations.
+    fn unary_fallible<D2, E, B, L, P>(
+        &self,
+        pact: P,
+        name: &str,
+        constructor: B,
+    ) -> (Stream<G, D2>, Stream<G, E>)
+    where
+        D2: Data,
+        E: Data,
+        B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
+        L: FnMut(
+                &mut InputHandle<G::Timestamp, D1, P::Puller>,
+                &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>,
+                &mut OutputHandle<G::Timestamp, E, Tee<G::Timestamp, E>>,
+            ) + 'static,
+        P: ParallelizationContract<G::Timestamp, D1>;
+
+    /// Like [`timely::dataflow::operators::map::Map::map`], but `logic`
+    /// is allowed to fail. The first returned stream will contain the
+    /// successful applications of `logic`, while the second returned stream
+    /// will contain the failed applications.
+    fn map_fallible<D2, E, L>(&self, logic: L) -> (Stream<G, D2>, Stream<G, E>)
+    where
+        D2: Data,
+        E: Data,
+        L: FnMut(D1) -> Result<D2, E> + 'static;
+
+    /// Like [`timely::dataflow::operators::map::Map::flat_map`], but `logic`
+    /// is allowed to fail. The first returned stream will contain the
+    /// successful applications of `logic`, while the second returned stream
+    /// will contain the failed applications.
+    fn flat_map_fallible<D2, E, I, L>(&self, logic: L) -> (Stream<G, D2>, Stream<G, E>)
+    where
+        D2: Data,
+        E: Data,
+        I: IntoIterator<Item = Result<D2, E>>,
+        L: FnMut(D1) -> I + 'static;
+
+    /// Like [`timely::dataflow::operators::map::Map::filter`], but `logic`
+    /// is allowed to fail. The first returned stream will contain the
+    /// elements where `logic` returned `Ok(true)`, and the second returned
+    /// stream will contain the errors for elements where `logic` failed.
+    /// Elements for which `logic` returned `Ok(false)` are not present in
+    /// either stream.
+    fn filter_fallible<E, L>(&self, logic: L) -> (Stream<G, D1>, Stream<G, E>)
+    where
+        E: Data,
+        L: FnMut(&D1) -> Result<bool, E> + 'static;
+}
+
+/// Extension methods for differential [`Collection`]s.
+pub trait CollectionExt<G, D1, R>
+where
+    G: Scope,
+    R: Semigroup,
+{
+    /// Creates a new empty collection in `scope`.
+    fn empty(scope: &G) -> Collection<G, D1, R>;
+
+    /// Like [`Collection::map`], but `logic` is allowed to fail. The first
+    /// returned collection will contain successful applications of `logic`,
+    /// while the second returned collection will contain the failed
+    /// applications.
+    fn map_fallible<D2, E, L>(&self, logic: L) -> (Collection<G, D2, R>, Collection<G, E, R>)
+    where
+        D2: Data,
+        E: Data,
+        L: FnMut(D1) -> Result<D2, E> + 'static;
+
+    /// Like [`Collection::flat_map`], but `logic` is allowed to fail. The first
+    /// returned collection will contain the successful applications of `logic`,
+    /// while the second returned collection will contain the failed
+    /// applications.
+    fn flat_map_fallible<D2, E, I, L>(
+        &self,
+        logic: L,
+    ) -> (Collection<G, D2, R>, Collection<G, E, R>)
+    where
+        D2: Data,
+        E: Data,
+        I: IntoIterator<Item = Result<D2, E>>,
+        L: FnMut(D1) -> I + 'static;
+
+    /// Like [`Collection::filter`], but `logic` is allowed to fail. The first
+    /// returned collection will contain the elements where `logic` returned
+    /// `Ok(true)`, and the second returned collection will contain the errors
+    /// for elements where `logic` failed. Elements for which `logic` returned
+    /// `Ok(false)` are not present in either collection.
+    fn filter_fallible<E, L>(&self, logic: L) -> (Collection<G, D1, R>, Collection<G, E, R>)
+    where
+        E: Data,
+        L: FnMut(&D1) -> Result<bool, E> + 'static;
+}
+
+impl<G, D1> StreamExt<G, D1> for Stream<G, D1>
+where
+    D1: Data,
+    G: Scope,
+{
+    fn unary_fallible<D2, E, B, L, P>(
+        &self,
+        pact: P,
+        name: &str,
+        constructor: B,
+    ) -> (Stream<G, D2>, Stream<G, E>)
+    where
+        D2: Data,
+        E: Data,
+        B: FnOnce(Capability<G::Timestamp>, OperatorInfo) -> L,
+        L: FnMut(
+                &mut InputHandle<G::Timestamp, D1, P::Puller>,
+                &mut OutputHandle<G::Timestamp, D2, Tee<G::Timestamp, D2>>,
+                &mut OutputHandle<G::Timestamp, E, Tee<G::Timestamp, E>>,
+            ) + 'static,
+        P: ParallelizationContract<G::Timestamp, D1>,
+    {
+        let mut builder = OperatorBuilder::new(name.into(), self.scope());
+        builder.set_notify(false);
+
+        let operator_info = builder.operator_info();
+
+        let mut input = builder.new_input(self, pact);
+        let (mut ok_output, ok_stream) = builder.new_output();
+        let (mut err_output, err_stream) = builder.new_output();
+
+        builder.build(move |mut capabilities| {
+            // `capabilities` should be a single-element vector.
+            let capability = capabilities.pop().unwrap();
+            let mut logic = constructor(capability, operator_info);
+            move |_frontiers| {
+                let mut ok_output_handle = ok_output.activate();
+                let mut err_output_handle = err_output.activate();
+                logic(&mut input, &mut ok_output_handle, &mut err_output_handle);
+            }
+        });
+
+        (ok_stream, err_stream)
+    }
+
+    fn map_fallible<D2, E, L>(&self, mut logic: L) -> (Stream<G, D2>, Stream<G, E>)
+    where
+        D2: Data,
+        E: Data,
+        L: FnMut(D1) -> Result<D2, E> + 'static,
+    {
+        let mut storage = Vec::new();
+        self.unary_fallible(Pipeline, "MapFallible", move |_, _| {
+            move |input, ok_output, err_output| {
+                input.for_each(|time, data| {
+                    let mut ok_session = ok_output.session(&time);
+                    let mut err_session = err_output.session(&time);
+                    data.swap(&mut storage);
+                    for d1 in storage.drain(..) {
+                        match logic(d1) {
+                            Ok(d2) => ok_session.give(d2),
+                            Err(e) => err_session.give(e),
+                        }
+                    }
+                })
+            }
+        })
+    }
+
+    fn flat_map_fallible<D2, E, I, L>(&self, mut logic: L) -> (Stream<G, D2>, Stream<G, E>)
+    where
+        D2: Data,
+        E: Data,
+        I: IntoIterator<Item = Result<D2, E>>,
+        L: FnMut(D1) -> I + 'static,
+    {
+        let mut storage = Vec::new();
+        self.unary_fallible(Pipeline, "FlatMapFallible", move |_, _| {
+            move |input, ok_output, err_output| {
+                input.for_each(|time, data| {
+                    let mut ok_session = ok_output.session(&time);
+                    let mut err_session = err_output.session(&time);
+                    data.swap(&mut storage);
+                    for r in storage.drain(..).flat_map(|d1| logic(d1)) {
+                        match r {
+                            Ok(d2) => ok_session.give(d2),
+                            Err(e) => err_session.give(e),
+                        }
+                    }
+                })
+            }
+        })
+    }
+
+    fn filter_fallible<E, L>(&self, mut logic: L) -> (Stream<G, D1>, Stream<G, E>)
+    where
+        E: Data,
+        L: FnMut(&D1) -> Result<bool, E> + 'static,
+    {
+        let mut storage = Vec::new();
+        self.unary_fallible(Pipeline, "FilterFallible", move |_, _| {
+            move |input, ok_output, err_output| {
+                input.for_each(|time, data| {
+                    let mut ok_session = ok_output.session(&time);
+                    let mut err_session = err_output.session(&time);
+                    data.swap(&mut storage);
+                    storage.retain(|d1| match logic(d1) {
+                        Ok(retain) => retain,
+                        Err(e) => {
+                            err_session.give(e);
+                            false
+                        }
+                    });
+                    if !storage.is_empty() {
+                        ok_session.give_vec(&mut storage);
+                    }
+                })
+            }
+        })
+    }
+}
+
+impl<G, D1, R> CollectionExt<G, D1, R> for Collection<G, D1, R>
+where
+    G: Scope,
+    G::Timestamp: Data,
+    D1: Data,
+    R: Semigroup,
+{
+    fn empty(scope: &G) -> Collection<G, D1, R> {
+        operator::empty(scope).as_collection()
+    }
+
+    fn map_fallible<D2, E, L>(&self, mut logic: L) -> (Collection<G, D2, R>, Collection<G, E, R>)
+    where
+        D2: Data,
+        E: Data,
+        L: FnMut(D1) -> Result<D2, E> + 'static,
+    {
+        let (ok_stream, err_stream) = self.inner.map_fallible(move |(d1, t, r)| match logic(d1) {
+            Ok(d2) => Ok((d2, t, r)),
+            Err(e) => Err((e, t, r)),
+        });
+        (ok_stream.as_collection(), err_stream.as_collection())
+    }
+
+    fn flat_map_fallible<D2, E, I, L>(
+        &self,
+        mut logic: L,
+    ) -> (Collection<G, D2, R>, Collection<G, E, R>)
+    where
+        D2: Data,
+        E: Data,
+        I: IntoIterator<Item = Result<D2, E>>,
+        L: FnMut(D1) -> I + 'static,
+    {
+        let (ok_stream, err_stream) = self.inner.flat_map_fallible(move |(d1, t, r)| {
+            logic(d1).into_iter().map(move |res| match res {
+                Ok(d2) => Ok((d2, t.clone(), r.clone())),
+                Err(e) => Err((e, t.clone(), r.clone())),
+            })
+        });
+        (ok_stream.as_collection(), err_stream.as_collection())
+    }
+
+    fn filter_fallible<E, L>(&self, mut logic: L) -> (Collection<G, D1, R>, Collection<G, E, R>)
+    where
+        E: Data,
+        L: FnMut(&D1) -> Result<bool, E> + 'static,
+    {
+        let (ok_stream, err_stream) =
+            self.inner
+                .filter_fallible(move |(d1, t, r)| match logic(d1) {
+                    Ok(retain) => Ok(retain),
+                    Err(e) => Err((e, t.clone(), r.clone())),
+                });
+        (ok_stream.as_collection(), err_stream.as_collection())
+    }
+}

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -9,8 +9,6 @@
 
 //! An interactive dataflow server.
 
-use differential_dataflow::trace::cursor::Cursor;
-use differential_dataflow::trace::TraceReader;
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -20,41 +18,42 @@ use std::rc::Rc;
 use std::rc::Weak;
 use std::sync::Mutex;
 
+use differential_dataflow::operators::arrange::arrangement::Arrange;
+use differential_dataflow::trace::cursor::Cursor;
+use differential_dataflow::trace::TraceReader;
+use differential_dataflow::Collection;
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::executor::block_on;
+use futures::future::TryFutureExt;
+use futures::sink::{Sink, SinkExt};
 use lazy_static::lazy_static;
+use prometheus::{register_int_gauge_vec, IntGauge, IntGaugeVec};
+use serde::{Deserialize, Serialize};
 use timely::communication::allocator::generic::GenericBuilder;
 use timely::communication::allocator::zero_copy::initialize::initialize_networking_from_sockets;
 use timely::communication::initialize::WorkerGuards;
 use timely::communication::Allocate;
 use timely::dataflow::operators::unordered_input::UnorderedHandle;
 use timely::dataflow::operators::ActivateCapability;
+use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::progress::ChangeBatch;
 use timely::worker::Worker as TimelyWorker;
 
-use futures::channel::mpsc::UnboundedReceiver;
-use futures::executor::block_on;
-use futures::future::TryFutureExt;
-use futures::sink::{Sink, SinkExt};
-use prometheus::{register_int_gauge_vec, IntGauge, IntGaugeVec};
-use serde::{Deserialize, Serialize};
-
-use super::render;
-use crate::arrangement::{
-    manager::{KeysValsHandle, WithDrop},
-    TraceManager,
-};
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
     Consistency, DataflowDesc, Diff, ExternalSourceConnector, IndexDesc, PeekResponse, Timestamp,
     Update,
 };
-use expr::{GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
+use expr::{EvalError, GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
 use ore::future::channel::mpsc::ReceiverExt;
 use repr::{Datum, RelationType, Row, RowArena};
 
+use super::render;
+use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
 use crate::logging::materialized::MaterializedEvent;
-
+use crate::operator::CollectionExt;
 use crate::source::SourceToken;
 
 lazy_static! {
@@ -350,19 +349,28 @@ where
                     move |time, data| m_logger.publish_batch(time, data),
                 );
 
+            let errs = self.inner.dataflow::<Timestamp, _, _>(|scope| {
+                Collection::<_, EvalError, isize>::empty(scope)
+                    .arrange()
+                    .trace
+            });
+
             // Install traces as maintained indexes
             for (log, (_, trace)) in t_traces {
-                self.traces.set(log.index_id(), WithDrop::from(trace));
+                self.traces
+                    .set(log.index_id(), TraceBundle::new(trace, errs.clone()));
                 self.reported_frontiers
                     .insert(log.index_id(), Antichain::from_elem(0));
             }
             for (log, (_, trace)) in d_traces {
-                self.traces.set(log.index_id(), WithDrop::from(trace));
+                self.traces
+                    .set(log.index_id(), TraceBundle::new(trace, errs.clone()));
                 self.reported_frontiers
                     .insert(log.index_id(), Antichain::from_elem(0));
             }
             for (log, (_, trace)) in m_traces {
-                self.traces.set(log.index_id(), WithDrop::from(trace));
+                self.traces
+                    .set(log.index_id(), TraceBundle::new(trace, errs.clone()));
                 self.reported_frontiers
                     .insert(log.index_id(), Antichain::from_elem(0));
             }
@@ -461,9 +469,9 @@ where
             let mut progress = Vec::new();
             let ids = self.traces.traces.keys().cloned().collect::<Vec<_>>();
             for id in ids {
-                if let Some(trace) = self.traces.get(&id) {
+                if let Some(traces) = self.traces.get_mut(&id) {
                     // Read the upper frontier and compare to what we've reported.
-                    trace.clone().read_upper(&mut upper);
+                    traces.oks_mut().read_upper(&mut upper);
                     let lower = self
                         .reported_frontiers
                         .get_mut(&id)
@@ -552,9 +560,11 @@ where
                 filter,
             } => {
                 // Acquire a copy of the trace suitable for fulfilling the peek.
-                let mut trace = self.traces.get(&id).unwrap().clone();
-                trace.advance_by(&[timestamp]);
-                trace.distinguish_since(&[]);
+                let mut trace_bundle = self.traces.get(&id).unwrap().clone();
+                trace_bundle.oks_mut().advance_by(&[timestamp]);
+                trace_bundle.errs_mut().advance_by(&[timestamp]);
+                trace_bundle.oks_mut().distinguish_since(&[]);
+                trace_bundle.errs_mut().distinguish_since(&[]);
                 // Prepare a description of the peek work to do.
                 let mut peek = PendingPeek {
                     id,
@@ -562,7 +572,7 @@ where
                     tx,
                     timestamp,
                     finishing,
-                    trace,
+                    trace_bundle,
                     project,
                     filter,
                 };
@@ -753,7 +763,7 @@ struct PendingPeek {
     project: Option<Vec<usize>>,
     filter: Vec<expr::ScalarExpr>,
     /// The data from which the trace derives.
-    trace: WithDrop<KeysValsHandle>,
+    trace_bundle: TraceBundle,
 }
 
 impl PendingPeek {
@@ -775,25 +785,49 @@ impl PendingPeek {
     /// not the case that `upper` is less or equal to that timestamp,
     /// and so the result cannot further evolve.
     fn seek_fulfillment(&mut self, upper: &mut Antichain<Timestamp>) -> bool {
-        self.trace.read_upper(upper);
-        if !upper.less_equal(&self.timestamp) {
-            let response = match self.collect_finished_data() {
-                Ok(rows) => PeekResponse::Rows(rows),
-                Err(text) => PeekResponse::Error(text),
-            };
-
-            let mut tx = block_on(self.tx.connect()).unwrap();
-            block_on(tx.send(response)).unwrap();
-
-            true
-        } else {
-            false
+        self.trace_bundle.oks_mut().read_upper(upper);
+        if upper.less_equal(&self.timestamp) {
+            return false;
         }
+        self.trace_bundle.errs_mut().read_upper(upper);
+        if upper.less_equal(&self.timestamp) {
+            return false;
+        }
+        let response = match self.collect_finished_data() {
+            Ok(rows) => PeekResponse::Rows(rows),
+            Err(text) => PeekResponse::Error(text),
+        };
+        let mut tx = block_on(self.tx.connect()).unwrap();
+        block_on(tx.send(response)).unwrap();
+        true
     }
 
     /// Collects data for a known-complete peek.
     fn collect_finished_data(&mut self) -> Result<Vec<Row>, String> {
-        let (mut cursor, storage) = self.trace.cursor();
+        // Check if there exist any errors and, if so, return whatever one we
+        // find first.
+        let (mut cursor, storage) = self.trace_bundle.errs_mut().cursor();
+        while cursor.key_valid(&storage) {
+            let mut copies = 0;
+            cursor.map_times(&storage, |time, diff| {
+                if time.less_equal(&self.timestamp) {
+                    copies += diff;
+                }
+            });
+            if copies < 0 {
+                return Err(format!(
+                    "Negative multiplicity: {} for {}",
+                    copies,
+                    cursor.key(&storage),
+                ));
+            }
+            if copies > 0 {
+                return Err(cursor.key(&storage).to_string());
+            }
+            cursor.step_key(&storage);
+        }
+
+        let (mut cursor, storage) = self.trace_bundle.oks_mut().cursor();
         let mut results = Vec::new();
 
         // We can limit the record enumeration if i. there is a limit set,
@@ -810,26 +844,30 @@ impl PendingPeek {
                 let datums = row.unpack();
                 // Before (expensively) determining how many copies of a row
                 // we have, let's eliminate rows that we don't care about.
-                if self.filter.iter().all(|predicate| {
-                    let temp_storage = RowArena::new();
-                    predicate
+                let mut retain = true;
+                let temp_storage = RowArena::new();
+                for predicate in &self.filter {
+                    let d = predicate
                         .eval(&datums, &temp_storage)
-                        .unwrap_or(Datum::Null)
-                        == Datum::True
-                }) {
+                        .map_err(|e| e.to_string())?;
+                    if d != Datum::True {
+                        retain = false;
+                        break;
+                    }
+                }
+                if retain {
                     // Differential dataflow represents collections with binary counts,
                     // but our output representation is unary (as many rows as reported
                     // by the count). We should determine this count, and especially if
                     // it is non-zero, before producing any output data.
                     let mut copies = 0;
                     cursor.map_times(&storage, |time, diff| {
-                        use timely::order::PartialOrder;
                         if time.less_equal(&self.timestamp) {
                             copies += diff;
                         }
                     });
                     if copies < 0 {
-                        return Result::Err(format!(
+                        return Err(format!(
                             "Negative multiplicity: {} for {:?}",
                             copies,
                             row.unpack(),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -35,7 +35,7 @@ use std::path::Path;
 use std::str;
 use std::thread;
 
-use failure::{bail, ResultExt};
+use failure::{bail, format_err, ResultExt};
 use futures::executor::block_on;
 use itertools::izip;
 use lazy_static::lazy_static;
@@ -43,6 +43,7 @@ use md5::{Digest, Md5};
 use regex::Regex;
 
 use coord::ExecuteResponse;
+use dataflow_types::PeekResponse;
 use ore::option::OptionExt;
 use ore::thread::{JoinHandleExt, JoinOnDropHandle};
 use repr::jsonb::Jsonb;
@@ -537,11 +538,18 @@ impl State {
         }
 
         // send plan, read response
-        let (desc, rows_rx) = match self.run_sql(sql) {
-            Ok((desc, ExecuteResponse::SendingRows(rx))) => (
-                desc.expect("RelationDesc missing for query that returns rows"),
-                rx,
-            ),
+        let (desc, rows) = match self.run_sql(sql) {
+            Ok((desc, ExecuteResponse::SendingRows(rx))) => {
+                let desc = desc.expect("RelationDesc missing for query that returns rows");
+                let rows = match block_on(rx)? {
+                    PeekResponse::Rows(rows) => Ok(rows),
+                    PeekResponse::Error(e) => Err(format_err!("{}", e)),
+                    PeekResponse::Canceled => {
+                        panic!("sqllogictest query cannot possibly be canceled")
+                    }
+                };
+                (desc, rows)
+            }
             Ok(other) => {
                 return Ok(Outcome::PlanFailure {
                     error: failure::format_err!(
@@ -550,6 +558,11 @@ impl State {
                     ),
                 });
             }
+            Err(e) => (RelationDesc::empty(), Err(e)),
+        };
+
+        let raw_output = match rows {
+            Ok(rows) => rows,
             Err(error) => {
                 return match output {
                     Ok(_) => {
@@ -571,9 +584,6 @@ impl State {
                 };
             }
         };
-
-        // get actual output
-        let raw_output = block_on(rows_rx)?.unwrap_rows();
 
         // unpack expected output
         let QueryOutput {

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -235,7 +235,7 @@ ORDER BY ol_number
 | Get materialize.public.orderline (u19)
 | Filter (datetots(#6) > 2007-01-02 00:00:00)
 | Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) countall(null)
-| Map (((i32todec(#1) * 10000000dec) / i64todec(#3)) / 10dec), (((#2 * 10000000dec) / (i64todec(#4) * 100dec)) * 10dec)
+| Map (((i32todec(#1) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec), (((#2 * 10000000dec) / (i64todec(if (#4 = 0) then {null} else {#4}) * 100dec)) * 10dec)
 | Project (#0..#2, #6, #7, #5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#5)
@@ -1145,7 +1145,7 @@ AND ol_quantity < t.a
 | | demand = (#0, #4, #12)
 | Filter "^.*b$" ~(#4)
 | Reduce group=(#0) sum(#12) count(#12)
-| Map (((i32todec(#1) * 10000000dec) / i64todec(#2)) / 10dec)
+| Map (((i32todec(#1) * 10000000dec) / i64todec(if (#2 = 0) then {null} else {#2})) / 10dec)
 | ArrangeBy (#0)
 
 %4 =
@@ -1489,7 +1489,7 @@ ORDER BY substr(c_state, 1, 1)
 | Get materialize.public.customer (u6)
 | Filter (((((((substr(#11, 1, 1) = "1") || (substr(#11, 1, 1) = "2")) || (substr(#11, 1, 1) = "3")) || (substr(#11, 1, 1) = "4")) || (substr(#11, 1, 1) = "5")) || (substr(#11, 1, 1) = "6")) || (substr(#11, 1, 1) = "7")), (#16 > 0dec)
 | Reduce group=() sum(#16) count(#16)
-| Map (((#0 * 10000000dec) / (i64todec(#1) * 100dec)) * 10dec)
+| Map (((#0 * 10000000dec) / (i64todec(if (#1 = 0) then {null} else {#1}) * 100dec)) * 10dec)
 | ArrangeBy ()
 
 %2 =

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -102,7 +102,7 @@ CREATE TABLE date_trunc_fields (
 )
 
 statement ok
-INSERT INTO date_trunc_fields VALUES ('day'), ('DaY'), ('month'), ('MoNTH'), ('bad')
+INSERT INTO date_trunc_fields VALUES ('day'), ('DaY'), ('month'), ('MoNTH')
 
 query T rowsort
 SELECT date_trunc(field, TIMESTAMP '2019-11-26 15:56:46.241150') FROM date_trunc_fields
@@ -111,7 +111,12 @@ SELECT date_trunc(field, TIMESTAMP '2019-11-26 15:56:46.241150') FROM date_trunc
 2019-11-26 00:00:00
 2019-11-01 00:00:00
 2019-11-01 00:00:00
-NULL
+
+statement ok
+INSERT INTO date_trunc_fields VALUES ('bad')
+
+query error unknown units 'bad'
+SELECT date_trunc(field, TIMESTAMP '2019-11-26 15:56:46.241150') FROM date_trunc_fields
 
 mode standard
 
@@ -124,7 +129,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT date_trunc('day', ts) FROM date_trunc_timestamps
 ----
 %0 =
-| Get materialize.public.date_trunc_timestamps (u5)
+| Get materialize.public.date_trunc_timestamps (u7)
 | Map date_trunc_day_ts(#0)
 | Project (#1)
 
@@ -138,7 +143,7 @@ EXPLAIN PLAN FOR SELECT date_trunc(field, ts) FROM date_trunc_fields, date_trunc
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.date_trunc_timestamps (u5)
+| Get materialize.public.date_trunc_timestamps (u7)
 
 %2 =
 | Join %0 %1

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -162,7 +162,7 @@ ORDER BY
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
 | Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) countall(null) countall(null) sum(#6) countall(null) countall(null)
-| Map (((#2 * 10000000dec) / (i64todec(#6) * 100dec)) * 10dec), (((#3 * 10000000dec) / (i64todec(#7) * 100dec)) * 10dec), (((#8 * 10000000dec) / (i64todec(#9) * 100dec)) * 10dec)
+| Map (((#2 * 10000000dec) / (i64todec(if (#6 = 0) then {null} else {#6}) * 100dec)) * 10dec), (((#3 * 10000000dec) / (i64todec(if (#7 = 0) then {null} else {#7}) * 100dec)) * 10dec), (((#8 * 10000000dec) / (i64todec(if (#9 = 0) then {null} else {#9}) * 100dec)) * 10dec)
 | Project (#0..#5, #11..#13, #10)
 
 Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0..#9)
@@ -1233,7 +1233,7 @@ WHERE
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0, #5)
 | Reduce group=(#0) sum(#5) countall(null)
-| Map (2dec * (((#1 * 10000000dec) / (i64todec(#2) * 100dec)) * 10dec))
+| Map (2dec * (((#1 * 10000000dec) / (i64todec(if (#2 = 0) then {null} else {#2}) * 100dec)) * 10dec))
 | ArrangeBy (#0)
 
 %7 =
@@ -1742,7 +1742,7 @@ ORDER BY
 | Get materialize.public.customer (u15)
 | Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17")), (#5 > 0dec)
 | Reduce group=() sum(#5) countall(null)
-| Map (((#0 * 10000000dec) / (i64todec(#1) * 100dec)) * 10dec)
+| Map (((#0 * 10000000dec) / (i64todec(if (#1 = 0) then {null} else {#1}) * 100dec)) * 10dec)
 | ArrangeBy ()
 
 %2 =

--- a/test/testdrive/runtime-errors.td
+++ b/test/testdrive/runtime-errors.td
@@ -1,0 +1,74 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "id", "type": "string"},
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+{"before": null, "after": {"id": "valid1", "a": 2, "b": 1}}
+{"before": null, "after": {"id": "valid2", "a": 17, "b": 5}}
+
+> CREATE SOURCE data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED VIEW multiply AS SELECT id, a * b AS product FROM data
+
+> CREATE MATERIALIZED VIEW divide AS SELECT id, a / b AS quotient FROM data
+
+> CREATE MATERIALIZED VIEW both AS
+  SELECT * FROM multiply NATURAL JOIN divide
+
+> SELECT * FROM both
+valid1  2   2
+valid2  85  3
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
+{"before": null, "after": {"id": "bad1", "a": 7, "b": 0}}
+
+> SELECT * FROM multiply
+valid1  2
+valid2  85
+bad1    0
+
+! SELECT * FROM divide
+division by zero
+
+! SELECT * FROM both
+division by zero
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=3
+{"before": {"id": "bad1", "a": 7, "b": 0}, "after": null}
+
+> SELECT * FROM both
+valid1  2   2
+valid2  85  3


### PR DESCRIPTION
Dataflow graphs are now built with two parallel trees of computation:
the oks tree and the errs tree. At any point where computation can fail,
errors can be injected into the errs tree. For example:

```
    oks1  errs1       oks2  errs2
      |     |           |     |
      |     |           |     |
   project  |           |     |
      |     |           |     |
      |     |           |     |
     map    |           |     |
      |\    |           |     |
      | \   |           |     |
      |  \  |           |     |
      |   \ |           |     |
      |    \|           |     |
   project  +           +     +
      |     |          /     /
      |     |         /     /
    join ------------+     /
      |     |             /
      |     | +----------+
      |     |/
     oks   errs
```

The project operation cannot fail, so errors from errs1 are propagated
directly. Map operators are fallible and so can inject additional errors
into the stream. Join operators combine the errors from each of their
inputs.

Completing a peek now involves checking the errs stream. The presence of
even a single error indicates that the computation is in an error state,
and we simply choose whatever error sorts first to return to the client.

If the error-causing data is later removed from the oks stream, the
computation will naturally remove the errors from the errs stream, and
peeking the computation will no longer return an error.

Future improvements include:

  * Allowing sources to produce errors. In this patch, all sources are
    forced to have a permanently empty error stream.

  * Allowing users to view the error stream directly. At the moment, if
    a stream has multiple errors, there is no way to see any error but
    the first.

Fix #489.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2441)
<!-- Reviewable:end -->
