### PR TITLE
Require -w/--threads or MZ_THREADS

### DIFF
--- a/ci/test/catalog-compat/catcompatck
+++ b/ci/test/catalog-compat/catcompatck
@@ -41,7 +41,7 @@ expect_sql() {
 }
 
 launch_materialized() {
-    "materialized-$1" "$@" &
+    "materialized-$1" -w1 "$@" &
     materialized_pid=$?
     wait-for-it --timeout=30 -q localhost:6875
     run_sql "SELECT 1" > /dev/null

--- a/ci/test/testdrive.compose.yml
+++ b/ci/test/testdrive.compose.yml
@@ -31,7 +31,7 @@ services:
     depends_on: [kafka, zookeeper, schema-registry, materialized]
   materialized:
     image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
-    command: --logging-granularity=10ms --data-directory=/share/mzdata
+    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1
     volumes:
     - mzdata:/share/mzdata
     - tmp:/share/tmp

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -76,12 +76,7 @@ fn run() -> Result<(), failure::Error> {
         "historical detail maintained for arrangements (default 60s)",
         "DURATION/\"off\"",
     );
-    opts.optopt(
-        "w",
-        "threads",
-        "number of per-process worker threads (default 1)",
-        "N",
-    );
+    opts.optopt("w", "threads", "number of per-process worker threads", "N");
     opts.optopt(
         "p",
         "process",
@@ -151,7 +146,24 @@ fn run() -> Result<(), failure::Error> {
 
     let log_file = popts.opt_str("log-file");
     let max_increment_ts_size = popts.opt_get_default("batch-size", 10000_i64)?;
-    let threads = popts.opt_get_default("threads", 1)?;
+
+    let threads = match popts.opt_get::<usize>("threads")? {
+        Some(val) => val,
+        None => match env::var_os("MZ_THREADS") {
+            Some(val) => val.into_string().unwrap().parse()?,
+            None => 0,
+        },
+    };
+    if threads == 0 {
+        bail!(
+            "'--threads' must be specified and greater than 0\n\
+             hint: As a starting point, set the number of threads to half of the number of\n\
+             cores on your system. Then, further adjust based on your performance needs.\n\
+             hint: You may also set the environment variable MZ_THREADS to the desired number\n\
+             of threads."
+        );
+    }
+
     let process = popts.opt_get_default("process", 0)?;
     let processes = popts.opt_get_default("processes", 1)?;
     let address_file = popts.opt_str("address-file");


### PR DESCRIPTION
To educate users and make -w / --threads discoverable, we require that
the user specify the number of worker threads when running a release
binary.

This isn't a requirement for debug builds (--debug / MZ_DEV), because
performance is unlikely to be a primary consideration in that situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2447)
<!-- Reviewable:end -->
