### PR TITLE
ci/deploy: bump macOS timeout

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -36,6 +36,6 @@ steps:
   - command: ci/deploy/macos.sh
     agents:
       queue: mac
-    timeout_in_minutes: 15
+    timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/macos


### PR DESCRIPTION
15m is still too short for a clean build, e.g., when we bump the Rust version.