### PR TITLE
interchange: rework avro encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,7 @@ dependencies = [
  "criterion",
  "failure",
  "futures",
+ "itertools",
  "log",
  "num-traits",
  "ordered-float",

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -22,6 +22,7 @@ failure = "0.1.7"
 futures = "0.3"
 log = "0.4.8"
 num-traits = "0.2.11" # don't want to upgrade to autocfg 1.0 until more things use it
+itertools = "0.8.0"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 protobuf = "2.8.1"

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -669,9 +669,6 @@ fn handle_create_sink(scx: &StatementContext, stmt: Statement) -> Result<Plan, f
     let from = scx.resolve_name(from)?;
     let catalog_entry = scx.catalog.get(&from)?;
 
-    // Validate that we can actually encode this stream as Avro.
-    let relation_desc = catalog_entry.desc()?.clone();
-    let _ = interchange::avro::encode_schema(&relation_desc)?;
     let topic_name = format!(
         "{}-{}-{}",
         topic,


### PR DESCRIPTION
Rework how Avro encoding works so that it is no longer fallible. Rather
than generating a schema and encoder separately, have the encoder
tightly manage the generation of the schema; then encoding can rely on
these tightly-managed properties of the generated schema.

As a side effect, this diff adds support for encoding all known
Materialize data types as Avro.

This could use quite a few more tests, but those will have to wait for a
future commit that re-enables testdrive testing of Avro sinks.

Fix #1517.