### PR TITLE
Threshold should only produce positive updates

### DIFF
--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -130,7 +130,7 @@ impl FoldConstants {
             }
             RelationExpr::Threshold { input } => {
                 if let RelationExpr::Constant { rows, .. } = &mut **input {
-                    rows.retain(|(_, diff| *diff > 0);
+                    rows.retain(|(_, diff)| *diff > 0);
                     *relation = input.take_dangerous();
                 }
             }

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -130,11 +130,7 @@ impl FoldConstants {
             }
             RelationExpr::Threshold { input } => {
                 if let RelationExpr::Constant { rows, .. } = &mut **input {
-                    for (_, diff) in rows {
-                        if *diff < 0 {
-                            *diff = 0;
-                        }
-                    }
+                    rows.retain(|(_, diff| *diff > 0);
                     *relation = input.take_dangerous();
                 }
             }


### PR DESCRIPTION
Threshold would set negative diffs to zero, but that confused other parts of the system. Specifically (for future ref) differential's `consolidate` method, which we used, doesn't seem to expect zero diffs and does not proactively filter out those that it does not create.

Fixes #2464