### PR TITLE
Expose Kafka configs for kerberized clusters

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -517,6 +517,7 @@ pub struct KafkaSourceConnector {
     pub url: Url,
     pub topic: String,
     pub ssl_certificate_file: Option<PathBuf>,
+    pub client_config: Option<Vec<(String, String)>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -60,6 +60,7 @@ where
         url,
         topic,
         ssl_certificate_file,
+        client_config,
     } = connector.clone();
 
     let ts = if read_kafka {
@@ -100,6 +101,12 @@ where
                 path.to_str()
                     .expect("Converting ssl certificate file path failed"),
             );
+        }
+
+        if let Some(client_config) = client_config {
+            for c in client_config.iter() {
+                config.set(&c.0, &c.1);
+            }
         }
 
         let mut consumer: Option<BaseConsumer<GlueConsumerContext>> = if read_kafka {


### PR DESCRIPTION
An MVP for the request in #2303, which lets users set the following setting in the `WITH (option_list)` section of `CREATE SOURCE`, including the following settings:

- `security.protocol`
- `sasl.mechanisms`
- `sasl.kerberos.service.name`
- `sasl.kerberos.kinit.cmd`
- `sasl.kerberos.min.time.before.relogin`

I haven't yet investigated what we need for keytab support, as mentioned in the original request, but wanted to see if this lets the client progress sufficiently far.

### Testing?

I'm unable to find a good place to write unit tests for this function. I also don't have a Kafka cluster set up with Kerberos to run integration tests. Any suggestions?

### Docs

Will lands docs after code reivew.