### PR TITLE
coord,sql: make sink topic creation asynchronous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ name = "coord"
 version = "0.1.0"
 dependencies = [
  "catalog",
+ "ccsr",
  "chrono",
  "comm",
  "dataflow",
@@ -698,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "derivative"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b94d2eb97732ec84b4e25eaf37db890e317b80e921f168c82cb5282473f8151"
+checksum = "1eae4d76b7cefedd1b4f8cc24378b2fbd1ac1b66e3bbebe8e2192d3be81cb355"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3025,7 +3026,6 @@ dependencies = [
  "itertools 0.9.0",
  "ore",
  "pgrepr",
- "rdkafka",
  "regex",
  "repr",
  "rusoto_core",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 [dependencies]
 catalog = { path = "../catalog" }
 chrono = "0.4"
+ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }

--- a/src/coord/lib.rs
+++ b/src/coord/lib.rs
@@ -23,6 +23,7 @@
 mod command;
 mod coord;
 mod persistence;
+mod sink_connector;
 mod timestamp;
 mod util;
 

--- a/src/coord/lib.rs
+++ b/src/coord/lib.rs
@@ -24,6 +24,7 @@ mod command;
 mod coord;
 mod persistence;
 mod timestamp;
+mod util;
 
 pub use self::coord::{dump_catalog, Config, Coordinator};
 pub use self::timestamp::TimestampConfig;

--- a/src/coord/persistence.rs
+++ b/src/coord/persistence.rs
@@ -125,7 +125,7 @@ impl CatalogItemSerializer for SqlSerializer {
             Plan::CreateSink { sink, .. } => catalog::CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
                 from: sink.from,
-                connector: sink.connector,
+                connector: catalog::SinkConnectorState::Pending(sink.connector_builder),
             }),
             _ => bail!("catalog entry generated inappropriate plan"),
         })

--- a/src/coord/sink_connector.rs
+++ b/src/coord/sink_connector.rs
@@ -1,0 +1,74 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use failure::{bail, format_err, ResultExt};
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::config::ClientConfig;
+
+use dataflow_types::{
+    KafkaSinkConnector, KafkaSinkConnectorBuilder, SinkConnector, SinkConnectorBuilder,
+};
+use expr::GlobalId;
+use ore::collections::CollectionExt;
+
+pub async fn build(
+    builder: SinkConnectorBuilder,
+    id: GlobalId,
+) -> Result<SinkConnector, failure::Error> {
+    match builder {
+        SinkConnectorBuilder::Kafka(k) => build_kafka(k, id).await,
+    }
+}
+
+async fn build_kafka(
+    builder: KafkaSinkConnectorBuilder,
+    id: GlobalId,
+) -> Result<SinkConnector, failure::Error> {
+    let topic = format!("{}-{}-{}", builder.topic_prefix, id, builder.topic_suffix);
+
+    // Create Kafka topic with single partition.
+    let mut config = ClientConfig::new();
+    config.set("bootstrap.servers", &builder.broker_url.to_string());
+    let res = config
+        .create::<AdminClient<_>>()
+        .expect("creating admin kafka client failed")
+        .create_topics(
+            &[NewTopic::new(&topic, 1, TopicReplication::Fixed(1))],
+            &AdminOptions::new().request_timeout(Some(Duration::from_secs(5))),
+        )
+        .await
+        .with_context(|e| format!("error creating new topic {} for sink: {}", topic, e))?;
+    if res.len() != 1 {
+        bail!(
+            "error creating topic {} for sink: \
+             kafka topic creation returned {} results, but exactly one result was expected",
+            topic,
+            res.len()
+        );
+    }
+    res.into_element()
+        .map_err(|(_, e)| format_err!("error creating topic {} for sink: {}", topic, e))?;
+
+    // Publish value schema for the topic.
+    //
+    // TODO(benesch): do we need to delete the Kafka topic if publishing the
+    // schema fails?
+    let schema_id = ccsr::AsyncClient::new(builder.schema_registry_url)
+        .publish_schema(&format!("{}-value", topic), &builder.value_schema)
+        .await
+        .with_context(|e| format!("unable to publish schema to registry in kafka sink: {}", e))?;
+
+    Ok(SinkConnector::Kafka(KafkaSinkConnector {
+        schema_id,
+        topic,
+        url: builder.broker_url,
+    }))
+}

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -221,7 +221,7 @@ fn get_kafka_partitions(consumer: &BaseConsumer, topic: &str) -> Vec<i32> {
     partitions
 }
 
-pub struct Timestamper {
+pub(crate) struct Timestamper {
     // Current list of up to date sources that use a real time consistency model
     rt_sources: HashMap<SourceInstanceId, RtTimestampConsumer>,
 

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -221,7 +221,7 @@ fn get_kafka_partitions(consumer: &BaseConsumer, topic: &str) -> Vec<i32> {
     partitions
 }
 
-pub(crate) struct Timestamper {
+pub struct Timestamper {
     // Current list of up to date sources that use a real time consistency model
     rt_sources: HashMap<SourceInstanceId, RtTimestampConsumer>,
 

--- a/src/coord/util.rs
+++ b/src/coord/util.rs
@@ -13,21 +13,29 @@ use crate::command::Response;
 
 /// Handles responding to clients.
 pub struct ClientTransmitter<T> {
-    tx: futures::channel::oneshot::Sender<Response<T>>,
+    tx: Option<futures::channel::oneshot::Sender<Response<T>>>,
 }
 
 impl<T> ClientTransmitter<T> {
     /// Creates a new client transmitter.
     pub fn new(tx: futures::channel::oneshot::Sender<Response<T>>) -> ClientTransmitter<T> {
-        ClientTransmitter { tx }
+        ClientTransmitter { tx: Some(tx) }
     }
 
     /// Transmits `result` to the client, returning ownership of the session
     /// `session` as well.
-    pub fn send(self, result: Result<T, failure::Error>, session: Session) {
+    pub fn send(mut self, result: Result<T, failure::Error>, session: Session) {
         // We can safely ignore failure to send the message, as that simply
         // indicates that the client has disconnected and is no longer
         // interested in the response.
-        let _ = self.tx.send(Response { result, session });
+        let _ = self.tx.take().unwrap().send(Response { result, session });
+    }
+}
+
+impl<T> Drop for ClientTransmitter<T> {
+    fn drop(&mut self) {
+        if self.tx.is_some() {
+            panic!("client transmitter dropped without send")
+        }
     }
 }

--- a/src/coord/util.rs
+++ b/src/coord/util.rs
@@ -1,0 +1,33 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use sql::Session;
+
+use crate::command::Response;
+
+/// Handles responding to clients.
+pub struct ClientTransmitter<T> {
+    tx: futures::channel::oneshot::Sender<Response<T>>,
+}
+
+impl<T> ClientTransmitter<T> {
+    /// Creates a new client transmitter.
+    pub fn new(tx: futures::channel::oneshot::Sender<Response<T>>) -> ClientTransmitter<T> {
+        ClientTransmitter { tx }
+    }
+
+    /// Transmits `result` to the client, returning ownership of the session
+    /// `session` as well.
+    pub fn send(self, result: Result<T, failure::Error>, session: Session) {
+        // We can safely ignore failure to send the message, as that simply
+        // indicates that the client has disconnected and is no longer
+        // interested in the response.
+        let _ = self.tx.send(Response { result, session });
+    }
+}

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -552,6 +552,20 @@ pub struct TailSinkConnector {
     pub since: Timestamp,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SinkConnectorBuilder {
+    Kafka(KafkaSinkConnectorBuilder),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KafkaSinkConnectorBuilder {
+    pub broker_url: Url,
+    pub schema_registry_url: Url,
+    pub value_schema: String,
+    pub topic_prefix: String,
+    pub topic_suffix: String,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct IndexDesc {
     /// Identity of the collection the index is on.

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -23,7 +23,6 @@ interchange = { path = "../interchange" }
 itertools = "0.9"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored"] }
 regex = "1.3.5"
 repr = { path = "../repr" }
 rusoto_core = "0.43.0-beta.1"

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -14,7 +14,7 @@
 use ::expr::GlobalId;
 use catalog::names::{DatabaseSpecifier, FullName};
 use catalog::{Catalog, CatalogEntry};
-use dataflow_types::{PeekWhen, RowSetFinishing, SinkConnector, SourceConnector};
+use dataflow_types::{PeekWhen, RowSetFinishing, SinkConnectorBuilder, SourceConnector};
 use repr::{RelationDesc, Row, ScalarType};
 use sql_parser::parser::Parser as SqlParser;
 
@@ -131,7 +131,7 @@ pub struct Source {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    pub connector: SinkConnector,
+    pub connector_builder: SinkConnectorBuilder,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Just like sources need an asynchronous pre-planning step
("purification"), sinks need an asynchronous post-planning step. With
Kafka sinks, for example, we need to create the topic the sink will
write to.

Previously we'd do that by blocking the SQL planning thread, but that
has the usual performance caveats. This patch teaches the coordinator to
instead create the topic asynchronously. The plumbing is a real drag, as
we write a state machine by hand that's split across a few crates:

  * The SQL layer creates a "sink connector builder" that contains all
    the necessary pieces of state to actually build a sink connector.

  * The coordinator installs a temporary catalog item to reserve the
    name while the connector is built. Because we can't transactionally
    create a Kafka topic, we need to "lock" the name while we go create
    the Kafka topic, otherwise another session might claim the name.
    (We cannot fail for any reason after creating the Kafka topic or
    we'll leak the topic.)

  * The coordinator launches an asynchronous task to create the topic.

  * After the topic is created, the future resolves with the actual
    connector, and the coordinator updates the catalog with the actual
    connector.

  * The dataflow layer builds the sink using the connector.