### PR TITLE
Support custom regions for Kinesis sources

### DIFF
--- a/doc/user/sql/create-source/kinesis-source.md
+++ b/doc/user/sql/create-source/kinesis-source.md
@@ -38,6 +38,7 @@ Field | Value | Description
 ------|-------|------------
 `access_key` | `text` | _(Required)_ A valid [access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) to the Kinesis stream.
 `secret_access_key` | `text` | _(Required)_ A valid [secret access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) to the Kinesis stream.
+`endpoint` | `text` | _(Optional)_ If the stream exists in a custom AWS region, a valid endpoint for the stream must be provided.
 
 For details about the IAM account whose details you provide, see [Kinesis source
 details](#kinesis-source-details).
@@ -87,7 +88,7 @@ Materialize.
 CREATE SOURCE kinesis_source
 FROM KINESIS ARN ...
 WITH (access_key=...,
-             secret_access_key=...)
+      secret_access_key=...)
 FORMAT BYES;
 ```
 

--- a/doc/user/sql/create-source/kinesis-source.md
+++ b/doc/user/sql/create-source/kinesis-source.md
@@ -38,7 +38,7 @@ Field | Value | Description
 ------|-------|------------
 `access_key` | `text` | _(Required)_ A valid [access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) to the Kinesis stream.
 `secret_access_key` | `text` | _(Required)_ A valid [secret access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) to the Kinesis stream.
-`endpoint` | `text` | _(Optional)_ If the stream exists in a custom AWS region, a valid endpoint for the stream must be provided.
+`endpoint` | `text` | If the stream exists in a custom AWS region, the hostname for the Kinesis endpoint.
 
 For details about the IAM account whose details you provide, see [Kinesis source
 details](#kinesis-source-details).
@@ -107,6 +107,20 @@ FROM (
     SELECT CONVERT_FROM(data, 'utf8') AS data
     FROM kinesis_source
 )
+```
+
+It's also possible to create a Kinesis source from a Kinesis stream in a
+custom AWS region. To do that, create a source as you normally would
+(the custom region will be contained in your stream's ARN) and provide
+an endpoint from your stream:
+```sql
+
+CREATE SOURCE kinesis_source
+FROM KINESIS ARN ...
+WITH (access_key = ...,
+      secret_access_key = ...,
+      endpoint = ...)
+FORMAT BYTES;
 ```
 
 ## Related pages

--- a/doc/user/sql/create-source/kinesis-source.md
+++ b/doc/user/sql/create-source/kinesis-source.md
@@ -38,7 +38,6 @@ Field | Value | Description
 ------|-------|------------
 `access_key` | `text` | _(Required)_ A valid [access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) to the Kinesis stream.
 `secret_access_key` | `text` | _(Required)_ A valid [secret access key](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html) to the Kinesis stream.
-`endpoint` | `text` | If the stream exists in a custom AWS region, the hostname for the Kinesis endpoint.
 
 For details about the IAM account whose details you provide, see [Kinesis source
 details](#kinesis-source-details).
@@ -107,20 +106,6 @@ FROM (
     SELECT CONVERT_FROM(data, 'utf8') AS data
     FROM kinesis_source
 )
-```
-
-It's also possible to create a Kinesis source from a Kinesis stream in a
-custom AWS region. To do that, create a source as you normally would
-(the custom region will be contained in your stream's ARN) and provide
-an endpoint from your stream:
-```sql
-
-CREATE SOURCE kinesis_source
-FROM KINESIS ARN ...
-WITH (access_key = ...,
-      secret_access_key = ...,
-      endpoint = ...)
-FORMAT BYTES;
 ```
 
 ## Related pages

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1177,7 +1177,23 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     let region: Region = match arn.region {
                         Some(region) => match region.parse() {
                             Ok(region) => region,
-                            Err(e) => bail!("Unable to parse AWS region: {}", e),
+                            Err(e) => {
+                                // Region's fromstr doesn't support parsing custom regions.
+                                // If a Kinesis stream's ARN indicates it exists in a custom
+                                // region, support it iff a valid endpoint for the stream
+                                // is also provided.
+                                match with_options.remove("endpoint") {
+                                    Some(Value::SingleQuotedString(endpoint)) => Region::Custom {
+                                        name: region,
+                                        endpoint,
+                                    },
+                                    _ => bail!(
+                                        "Unable to parse AWS region: {}. If providing a custom \
+                                         region, an `endpoint` option must also be provided",
+                                        e
+                                    ),
+                                }
+                            }
                         },
                         None => bail!("Provided ARN does not include an AWS region"),
                     };

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -226,3 +226,19 @@ a
   FORMAT BYTES;
 
 > DROP SOURCE f
+
+# This tests Materialize's logic around custom AWS regions
+! CREATE SOURCE custom_source
+  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
+  WITH (access_key = 'fake_access_key', secret_access_key = 'fake_secret_access_key')
+  FORMAT BYTES;
+If providing a custom region, an `endpoint` option must also be provided
+
+> CREATE SOURCE custom_source
+  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
+  WITH (access_key = 'fake_access_key',
+        secret_access_key = 'fake_secret_access_key',
+        endpoint = 'fake_endpoint')
+  FORMAT BYTES;
+
+> DROP SOURCE custom_source

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -217,28 +217,3 @@ a
 > CREATE MATERIALIZED VIEW IF NOT EXISTS test1 AS SELECT 42 AS a
 
 > DROP VIEW test1
-
-# todo@jldlaughlin: Add a MATERIALIZED VIEW on top of this
-# source and drop it. Depends on #2103.
-> CREATE SOURCE f
-  FROM KINESIS ARN 'arn:aws:kinesis:us-east-2::stream/fake-stream'
-  WITH (access_key = 'fake_access_key', secret_access_key = 'fake_secret_access_key')
-  FORMAT BYTES;
-
-> DROP SOURCE f
-
-# This tests Materialize's logic around custom AWS regions
-! CREATE SOURCE custom_source
-  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
-  WITH (access_key = 'fake_access_key', secret_access_key = 'fake_secret_access_key')
-  FORMAT BYTES;
-If providing a custom region, an `endpoint` option must also be provided
-
-> CREATE SOURCE custom_source
-  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
-  WITH (access_key = 'fake_access_key',
-        secret_access_key = 'fake_secret_access_key',
-        endpoint = 'fake_endpoint')
-  FORMAT BYTES;
-
-> DROP SOURCE custom_source

--- a/test/testdrive/kinesis-sources.td
+++ b/test/testdrive/kinesis-sources.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Test Kinesis source functionality
+
+# todo@jldlaughlin: Add a MATERIALIZED VIEW on top of this
+# source and drop it. Depends on #2103.
+> CREATE SOURCE f
+  FROM KINESIS ARN 'arn:aws:kinesis:us-east-2::stream/fake-stream'
+  WITH (access_key = 'fake_access_key', secret_access_key = 'fake_secret_access_key')
+  FORMAT BYTES;
+
+> DROP SOURCE f
+
+# This tests Materialize's logic around custom AWS regions
+! CREATE SOURCE custom_source
+  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
+  WITH (access_key = 'fake_access_key', secret_access_key = 'fake_secret_access_key')
+  FORMAT BYTES;
+If providing a custom region, an `endpoint` option must also be provided
+
+> CREATE SOURCE custom_source
+  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
+  WITH (access_key = 'fake_access_key',
+        secret_access_key = 'fake_secret_access_key',
+        endpoint = 'fake_endpoint')
+  FORMAT BYTES;


### PR DESCRIPTION
### Background
We want to test our Kinesis sources programmatically. Although it might make sense to allow CI tests to hit the actual AWS Kinesis service (creating and deleting real streams), tests local to the developer (like testdrive) should hit a version of Kinesis running on localhost instead.

### The Problem
Unfortunately, rerouting requests from the real AWS APIs to localhost isn't so easy! Materialize communicates with AWS Kinesis APIs via [Rusoto](https://github.com/rusoto/rusoto) -- an AWS SDK for Rust. Rusoto automatically generates the hostname for requests based on the AWS service type (ex: `kinesis` functions alway map to the real AWS Kinesis endpoint). 

To bypass this automatic mapping, we can simply create test streams in custom regions like the following:
```
Region::Custom {
    name: [custom region name],
    endpoint: [endpoint of localstack's Kinesis]
}
```
(trick found [here](https://github.com/rusoto/rusoto/issues/996#issuecomment-370165867) thanks to @benesch!)

Although providing a custom region works to connect to localhost, Materialize currently doesn't support creating Kinesis sources existing in custom regions. We rely on Rusoto's `Region` fromstr to parse valid regions, but their implementation currently doesn't recognize custom options.

### The Solution
This PR expands Kinesis source support to allow custom regions if and only if an `endpoint` option is also provided.


