### PR TITLE
Enable decoding of key-value input/creating upsert envelope sources.

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -349,6 +349,18 @@ impl DataEncoding {
         );
         Ok(full_desc)
     }
+
+    pub fn op_name(&self) -> &str {
+        match self {
+            DataEncoding::Bytes => "Bytes",
+            DataEncoding::AvroOcf { .. } => "AvroOcf",
+            DataEncoding::Avro(_) => "Avro",
+            DataEncoding::Protobuf(_) => "Protobuf",
+            DataEncoding::Regex { .. } => "Regex",
+            DataEncoding::Csv(_) => "Csv",
+            DataEncoding::Text => "Text",
+        }
+    }
 }
 
 /// Encoding in Avro format.

--- a/src/dataflow/decode/avro.rs
+++ b/src/dataflow/decode/avro.rs
@@ -7,62 +7,112 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use differential_dataflow::Hashable;
 use log::error;
-use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::Operator;
-use timely::dataflow::{Scope, Stream};
-use url::Url;
 
-use super::EVENTS_COUNTER;
-use dataflow_types::{Diff, Timestamp};
+use super::{DecoderState, PushSession, EVENTS_COUNTER};
+use dataflow_types::Timestamp;
+use interchange::avro::{Decoder, EnvelopeType};
 use repr::Row;
 
-pub fn avro<G>(
-    stream: &Stream<G, (Vec<u8>, Option<i64>)>,
-    raw_schema: &str,
-    schema_registry: Option<Url>,
-    is_debezium: bool,
-) -> Stream<G, (Row, Timestamp, Diff)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    stream.unary(
-        Exchange::new(|x: &(Vec<u8>, _)| x.0.hashed()),
-        "AvroDecode",
-        move |_, _| {
-            let mut decoder =
-                interchange::avro::Decoder::new(raw_schema, schema_registry, is_debezium);
-            move |input, output| {
-                let mut events_success = 0;
-                let mut events_error = 0;
-                input.for_each(|cap, data| {
-                    let mut session = output.session(&cap);
-                    for (payload, _) in data.iter() {
-                        match decoder.decode(payload) {
-                            Ok(diff_pair) => {
-                                events_success += 1;
-                                if let Some(before) = diff_pair.before {
-                                    session.give((before, *cap.time(), 1));
-                                }
-                                if let Some(after) = diff_pair.after {
-                                    session.give((after, *cap.time(), 1));
-                                }
-                            }
-                            Err(err) => {
-                                events_error += 1;
-                                error!("avro deserialization error: {}", err)
-                            }
-                        }
-                    }
-                });
-                if events_success > 0 {
-                    EVENTS_COUNTER.avro.success.inc_by(events_success);
-                }
-                if events_error > 0 {
-                    EVENTS_COUNTER.avro.error.inc_by(events_error);
+pub struct AvroDecoderState {
+    decoder: Decoder,
+    events_success: i64,
+    events_error: i64,
+}
+
+impl AvroDecoderState {
+    pub fn new(
+        reader_schema: &str,
+        schema_registry_url: Option<url::Url>,
+        envelope: EnvelopeType,
+    ) -> Self {
+        AvroDecoderState {
+            decoder: Decoder::new(reader_schema, schema_registry_url, envelope),
+            events_success: 0,
+            events_error: 0,
+        }
+    }
+}
+
+impl DecoderState for AvroDecoderState {
+    /// Reset number of success and failures with decoding
+    fn reset_event_count(&mut self) {
+        self.events_success = 0;
+        self.events_error = 0;
+    }
+
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
+        match self.decoder.decode(bytes) {
+            Ok(diff_pair) => {
+                if let Some(after) = diff_pair.after {
+                    self.events_success += 1;
+                    Ok(after)
+                } else {
+                    self.events_error += 1;
+                    Err("no avro key found for record".to_string())
                 }
             }
-        },
-    )
+            Err(err) => {
+                self.events_error += 1;
+                Err(format!("avro deserialization error: {}", err))
+            }
+        }
+    }
+
+    /// give a session a key-value pair
+    fn give_key_value<'a>(
+        &mut self,
+        key: Row,
+        bytes: &[u8],
+        _: &Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        time: Timestamp,
+    ) {
+        let result = self.decoder.decode(bytes);
+        match result {
+            Ok(diff_pair) => {
+                self.events_success += 1;
+                session.give(((key, diff_pair.after), time, 1));
+            }
+            Err(err) => {
+                self.events_error += 1;
+                error!("avro deserialization error: {}", err)
+            }
+        }
+    }
+
+    /// give a session a plain value
+    fn give_value<'a>(
+        &mut self,
+        bytes: &[u8],
+        _: &Option<i64>,
+        session: &mut PushSession<'a, Row>,
+        time: Timestamp,
+    ) {
+        match self.decoder.decode(bytes) {
+            Ok(diff_pair) => {
+                self.events_success += 1;
+                if let Some(before) = diff_pair.before {
+                    session.give((before, time, 1));
+                }
+                if let Some(after) = diff_pair.after {
+                    session.give((after, time, 1));
+                }
+            }
+            Err(err) => {
+                self.events_error += 1;
+                error!("avro deserialization error: {}", err)
+            }
+        }
+    }
+
+    /// Register number of success and failures with decoding
+    fn log_error_count(&self) {
+        if self.events_success > 0 {
+            EVENTS_COUNTER.avro.success.inc_by(self.events_success);
+        }
+        if self.events_error > 0 {
+            EVENTS_COUNTER.avro.error.inc_by(self.events_error);
+        }
+    }
 }

--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -352,15 +352,6 @@ where
     })
 }
 
-pub fn drop_key<G>(
-    stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
-) -> Stream<G, (Vec<u8>, Option<i64>)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    stream.map(|((_key, payload), aux_num)| (payload, aux_num))
-}
-
 fn decode_values_inner<G, V>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,
     mut value_decoder_state: V,

--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -13,30 +13,30 @@ use differential_dataflow::hashable::Hashable;
 use prometheus::{register_int_counter_vec, IntCounterVec};
 use prometheus_static_metric::make_static_metric;
 use timely::dataflow::{
-    channels::pact::Exchange,
+    channels::pact::{Exchange, ParallelizationContract, Pipeline},
+    channels::pushers::buffer::Session,
+    channels::pushers::Counter as PushCounter,
+    channels::pushers::Tee,
     operators::{map::Map, Operator},
     Scope, Stream,
 };
 
 use dataflow_types::{DataEncoding, Diff, Envelope, Timestamp};
 use repr::Datum;
-use repr::Row;
+use repr::{Row, RowPacker};
 
 mod avro;
 mod csv;
 mod protobuf;
 mod regex;
 
-use self::avro::avro;
 use self::csv::csv;
 use self::regex::regex as regex_fn;
 use ::avro::types::Value;
 use interchange::avro::{extract_debezium_slow, extract_row, DiffPair};
 
 use log::error;
-use protobuf::protobuf;
 use std::iter;
-use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline};
 
 make_static_metric! {
     pub struct EventsRead: IntCounter {
@@ -118,6 +118,303 @@ where
     })
 }
 
+pub type PushSession<'a, R> = Session<
+    'a,
+    Timestamp,
+    (R, Timestamp, Diff),
+    PushCounter<Timestamp, (R, Timestamp, Diff), Tee<Timestamp, (R, Timestamp, Diff)>>,
+>;
+
+pub trait DecoderState {
+    /// Reset number of success and failures with decoding
+    fn reset_event_count(&mut self);
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String>;
+    /// give a session a key-value pair
+    fn give_key_value<'a>(
+        &mut self,
+        key: Row,
+        bytes: &[u8],
+        aux_num: &Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        time: Timestamp,
+    );
+    /// give a session a plain value
+    fn give_value<'a>(
+        &mut self,
+        bytes: &[u8],
+        aux_num: &Option<i64>,
+        session: &mut PushSession<'a, Row>,
+        time: Timestamp,
+    );
+    /// Register number of success and failures with decoding
+    fn log_error_count(&self);
+}
+
+fn pack_with_line_no(datum: Datum, line_no: &Option<i64>) -> Row {
+    Row::pack(iter::once(datum).chain(line_no.map(Datum::from)))
+}
+
+pub struct BytesDecoderState;
+
+impl DecoderState for BytesDecoderState {
+    fn reset_event_count(&mut self) {}
+
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
+        let mut result = RowPacker::new();
+        result.push(Datum::from(bytes));
+        Ok(result.finish())
+    }
+
+    /// give a session a key-value pair
+    fn give_key_value<'a>(
+        &mut self,
+        key: Row,
+        bytes: &[u8],
+        line_no: &Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        time: Timestamp,
+    ) {
+        session.give((
+            (key, Some(pack_with_line_no(Datum::from(bytes), line_no))),
+            time,
+            1,
+        ));
+    }
+
+    /// give a session a plain value
+    fn give_value<'a>(
+        &mut self,
+        bytes: &[u8],
+        line_no: &Option<i64>,
+        session: &mut PushSession<'a, Row>,
+        time: Timestamp,
+    ) {
+        session.give((pack_with_line_no(Datum::from(bytes), line_no), time, 1));
+    }
+
+    /// Register number of success and failures with decoding
+    fn log_error_count(&self) {}
+}
+
+pub struct TextDecoderState;
+
+impl DecoderState for TextDecoderState {
+    fn reset_event_count(&mut self) {}
+
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
+        let mut result = RowPacker::new();
+        result.push(Datum::from(std::str::from_utf8(&bytes).ok()));
+        Ok(result.finish())
+    }
+
+    /// give a session a key-value pair
+    fn give_key_value<'a>(
+        &mut self,
+        key: Row,
+        bytes: &[u8],
+        line_no: &Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        time: Timestamp,
+    ) {
+        session.give((
+            (
+                key,
+                Some(pack_with_line_no(
+                    Datum::from(std::str::from_utf8(bytes).ok()),
+                    line_no,
+                )),
+            ),
+            time,
+            1,
+        ));
+    }
+
+    /// give a session a plain value
+    fn give_value<'a>(
+        &mut self,
+        bytes: &[u8],
+        line_no: &Option<i64>,
+        session: &mut PushSession<'a, Row>,
+        time: Timestamp,
+    ) {
+        session.give((
+            pack_with_line_no(Datum::from(std::str::from_utf8(bytes).ok()), line_no),
+            time,
+            1,
+        ));
+    }
+
+    /// Register number of success and failures with decoding
+    fn log_error_count(&self) {}
+}
+
+fn decode_kafka_upsert_inner<G, K: 'static, V: 'static>(
+    stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
+    mut key_decoder_state: K,
+    mut value_decoder_state: V,
+    op_name: &str,
+) -> Stream<G, ((Row, Option<Row>), Timestamp, Diff)>
+where
+    G: Scope<Timestamp = Timestamp>,
+    K: DecoderState,
+    V: DecoderState,
+{
+    stream.unary(
+        Exchange::new(|x: &((Vec<u8>, _), _)| (x.0).0.hashed()),
+        &op_name,
+        move |_, _| {
+            move |input, output| {
+                input.for_each(|cap, data| {
+                    let mut session = output.session(&cap);
+                    for ((key, payload), aux_num) in data.iter() {
+                        match key_decoder_state.decode_key(key) {
+                            Ok(key) => {
+                                value_decoder_state.give_key_value(
+                                    key,
+                                    payload,
+                                    aux_num,
+                                    &mut session,
+                                    *cap.time(),
+                                );
+                            }
+                            Err(err) => {
+                                error!("{}", err);
+                            }
+                        }
+                    }
+                });
+                key_decoder_state.log_error_count();
+                value_decoder_state.log_error_count();
+            }
+        },
+    )
+}
+
+pub fn decode_kafka_upsert<G>(
+    stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
+    value_encoding: DataEncoding,
+    key_encoding: DataEncoding,
+) -> Stream<G, ((Row, Option<Row>), Timestamp, Diff)>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let op_name = format!(
+        "{}-{}Decode",
+        key_encoding.op_name(),
+        value_encoding.op_name()
+    );
+    match (key_encoding, value_encoding) {
+        (DataEncoding::Text, DataEncoding::Avro(val_enc)) => decode_kafka_upsert_inner(
+            stream,
+            TextDecoderState,
+            avro::AvroDecoderState::new(
+                &val_enc.value_schema,
+                val_enc.schema_registry_url,
+                interchange::avro::EnvelopeType::Upsert,
+            ),
+            &op_name,
+        ),
+        (DataEncoding::Avro(key_enc), DataEncoding::Avro(val_enc)) => decode_kafka_upsert_inner(
+            stream,
+            avro::AvroDecoderState::new(
+                &key_enc.value_schema,
+                key_enc.schema_registry_url,
+                interchange::avro::EnvelopeType::None,
+            ),
+            avro::AvroDecoderState::new(
+                &val_enc.value_schema,
+                val_enc.schema_registry_url,
+                interchange::avro::EnvelopeType::Upsert,
+            ),
+            &op_name,
+        ),
+        _ => unreachable!(),
+    }
+}
+
+fn decode_kafka_inner<G, V: 'static>(
+    stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
+    mut value_decoder_state: V,
+    op_name: &str,
+) -> Stream<G, (Row, Timestamp, Diff)>
+where
+    G: Scope<Timestamp = Timestamp>,
+    V: DecoderState,
+{
+    stream.unary(
+        Exchange::new(|x: &((_, Vec<u8>), _)| (x.0).1.hashed()),
+        &op_name,
+        move |_, _| {
+            move |input, output| {
+                value_decoder_state.reset_event_count();
+                input.for_each(|cap, data| {
+                    let mut session = output.session(&cap);
+                    for ((_, payload), aux_num) in data.iter() {
+                        value_decoder_state.give_value(payload, aux_num, &mut session, *cap.time());
+                    }
+                });
+                value_decoder_state.log_error_count();
+            }
+        },
+    )
+}
+
+pub fn decode_kafka<G>(
+    stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
+    encoding: DataEncoding,
+    envelope: &Envelope,
+) -> Stream<G, (Row, Timestamp, Diff)>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let op_name = format!("{}Decode", encoding.op_name());
+    match encoding {
+        DataEncoding::Avro(enc) => decode_kafka_inner(
+            stream,
+            avro::AvroDecoderState::new(
+                &enc.value_schema,
+                enc.schema_registry_url,
+                envelope.get_avro_envelope_type(),
+            ),
+            &op_name,
+        ),
+        DataEncoding::Protobuf(enc) => decode_kafka_inner(
+            stream,
+            protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
+            &op_name,
+        ),
+        DataEncoding::Bytes => decode_kafka_inner(stream, BytesDecoderState, &op_name),
+        _ => unreachable!(),
+    }
+}
+
+fn decode_inner<G, V: 'static>(
+    stream: &Stream<G, (Vec<u8>, Option<i64>)>,
+    mut value_decoder_state: V,
+    op_name: &str,
+) -> Stream<G, (Row, Timestamp, Diff)>
+where
+    G: Scope<Timestamp = Timestamp>,
+    V: DecoderState,
+{
+    stream.unary(
+        Exchange::new(|x: &(Vec<u8>, _)| (x.0.hashed())),
+        &op_name,
+        move |_, _| {
+            move |input, output| {
+                value_decoder_state.reset_event_count();
+                input.for_each(|cap, data| {
+                    let mut session = output.session(&cap);
+                    for (payload, aux_num) in data.iter() {
+                        value_decoder_state.give_value(payload, aux_num, &mut session, *cap.time());
+                    }
+                });
+                value_decoder_state.log_error_count();
+            }
+        },
+    )
+}
+
 pub fn decode<G>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,
     encoding: DataEncoding,
@@ -127,16 +424,23 @@ pub fn decode<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    let op_name = format!("{}Decode", encoding.op_name());
+
     match (encoding, envelope) {
-        (_, Envelope::Upsert(_)) => unreachable!("Upsert-envelope not implemented yet."),
+        (_, Envelope::Upsert(_)) => {
+            unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")
+        }
         (DataEncoding::Csv(enc), Envelope::None) => {
             csv(stream, enc.header_row, enc.n_cols, enc.delimiter)
         }
-        (DataEncoding::Avro(enc), envelope) => avro(
+        (DataEncoding::Avro(enc), envelope) => decode_inner(
             stream,
-            &enc.value_schema,
-            enc.schema_registry_url,
-            envelope.get_avro_envelope_type() == interchange::avro::EnvelopeType::Debezium,
+            avro::AvroDecoderState::new(
+                &enc.value_schema,
+                enc.schema_registry_url,
+                envelope.get_avro_envelope_type(),
+            ),
+            &op_name,
         ),
         (DataEncoding::AvroOcf { .. }, _) => {
             unreachable!("Internal error: Cannot decode Avro OCF separately from reading")
@@ -145,37 +449,12 @@ where
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
         (DataEncoding::Regex { regex }, Envelope::None) => regex_fn(stream, regex, name),
-        (DataEncoding::Protobuf(enc), Envelope::None) => {
-            protobuf(stream, &enc.descriptors, &enc.message_name)
-        }
-        (DataEncoding::Bytes, Envelope::None) => pass_through(
+        (DataEncoding::Protobuf(enc), Envelope::None) => decode_inner(
             stream,
-            "RawBytes",
-            Exchange::new(|payload: &(Vec<u8>, Option<i64>)| payload.0.hashed()),
-        )
-        .map(|((payload, line_no), r, d)| {
-            (
-                Row::pack(
-                    iter::once(Datum::from(payload.as_slice())).chain(line_no.map(Datum::from)),
-                ),
-                r,
-                d,
-            )
-        }),
-        (DataEncoding::Text, Envelope::None) => pass_through(
-            stream,
-            "Text",
-            Exchange::new(|payload: &(Vec<u8>, Option<i64>)| payload.0.hashed()),
-        )
-        .map(|((payload, line_no), r, d)| {
-            (
-                Row::pack(
-                    iter::once(Datum::from(std::str::from_utf8(&payload).ok()))
-                        .chain(line_no.map(Datum::from)),
-                ),
-                r,
-                d,
-            )
-        }),
+            protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
+            &op_name,
+        ),
+        (DataEncoding::Bytes, Envelope::None) => decode_inner(stream, BytesDecoderState, &op_name),
+        (DataEncoding::Text, Envelope::None) => decode_inner(stream, TextDecoderState, &op_name),
     }
 }

--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -118,12 +118,8 @@ where
     })
 }
 
-pub type PushSession<'a, R> = Session<
-    'a,
-    Timestamp,
-    (R, Timestamp, Diff),
-    PushCounter<Timestamp, (R, Timestamp, Diff), Tee<Timestamp, (R, Timestamp, Diff)>>,
->;
+pub type PushSession<'a, R> =
+    Session<'a, Timestamp, R, PushCounter<Timestamp, R, Tee<Timestamp, R>>>;
 
 pub trait DecoderState {
     /// Reset number of success and failures with decoding
@@ -134,76 +130,44 @@ pub trait DecoderState {
         &mut self,
         key: Row,
         bytes: &[u8],
-        aux_num: &Option<i64>,
-        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        aux_num: Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>, Timestamp)>,
         time: Timestamp,
     );
     /// give a session a plain value
     fn give_value<'a>(
         &mut self,
         bytes: &[u8],
-        aux_num: &Option<i64>,
-        session: &mut PushSession<'a, Row>,
+        aux_num: Option<i64>,
+        session: &mut PushSession<'a, (Row, Timestamp, Diff)>,
         time: Timestamp,
     );
     /// Register number of success and failures with decoding
     fn log_error_count(&self);
 }
 
-fn pack_with_line_no(datum: Datum, line_no: &Option<i64>) -> Row {
+fn pack_with_line_no(datum: Datum, line_no: Option<i64>) -> Row {
     Row::pack(iter::once(datum).chain(line_no.map(Datum::from)))
 }
 
-pub struct BytesDecoderState;
-
-impl DecoderState for BytesDecoderState {
-    fn reset_event_count(&mut self) {}
-
-    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
-        let mut result = RowPacker::new();
-        result.push(Datum::from(bytes));
-        Ok(result.finish())
-    }
-
-    /// give a session a key-value pair
-    fn give_key_value<'a>(
-        &mut self,
-        key: Row,
-        bytes: &[u8],
-        line_no: &Option<i64>,
-        session: &mut PushSession<'a, (Row, Option<Row>)>,
-        time: Timestamp,
-    ) {
-        session.give((
-            (key, Some(pack_with_line_no(Datum::from(bytes), line_no))),
-            time,
-            1,
-        ));
-    }
-
-    /// give a session a plain value
-    fn give_value<'a>(
-        &mut self,
-        bytes: &[u8],
-        line_no: &Option<i64>,
-        session: &mut PushSession<'a, Row>,
-        time: Timestamp,
-    ) {
-        session.give((pack_with_line_no(Datum::from(bytes), line_no), time, 1));
-    }
-
-    /// Register number of success and failures with decoding
-    fn log_error_count(&self) {}
+fn bytes_to_datum(bytes: &[u8]) -> Datum {
+    Datum::from(bytes)
 }
 
-pub struct TextDecoderState;
+fn text_to_datum(bytes: &[u8]) -> Datum {
+    Datum::from(std::str::from_utf8(bytes).ok())
+}
 
-impl DecoderState for TextDecoderState {
+struct OffsetDecoderState<F: Fn(&[u8]) -> Datum> {
+    datum_func: F,
+}
+
+impl<F: Fn(&[u8]) -> Datum> DecoderState for OffsetDecoderState<F> {
     fn reset_event_count(&mut self) {}
 
     fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
         let mut result = RowPacker::new();
-        result.push(Datum::from(std::str::from_utf8(&bytes).ok()));
+        result.push((self.datum_func)(bytes));
         Ok(result.finish())
     }
 
@@ -212,20 +176,14 @@ impl DecoderState for TextDecoderState {
         &mut self,
         key: Row,
         bytes: &[u8],
-        line_no: &Option<i64>,
-        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        line_no: Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>, Timestamp)>,
         time: Timestamp,
     ) {
         session.give((
-            (
-                key,
-                Some(pack_with_line_no(
-                    Datum::from(std::str::from_utf8(bytes).ok()),
-                    line_no,
-                )),
-            ),
+            key,
+            Some(pack_with_line_no((self.datum_func)(bytes), line_no)),
             time,
-            1,
         ));
     }
 
@@ -233,12 +191,12 @@ impl DecoderState for TextDecoderState {
     fn give_value<'a>(
         &mut self,
         bytes: &[u8],
-        line_no: &Option<i64>,
-        session: &mut PushSession<'a, Row>,
+        line_no: Option<i64>,
+        session: &mut PushSession<'a, (Row, Timestamp, Diff)>,
         time: Timestamp,
     ) {
         session.give((
-            pack_with_line_no(Datum::from(std::str::from_utf8(bytes).ok()), line_no),
+            pack_with_line_no((self.datum_func)(bytes), line_no),
             time,
             1,
         ));
@@ -248,16 +206,16 @@ impl DecoderState for TextDecoderState {
     fn log_error_count(&self) {}
 }
 
-fn decode_kafka_upsert_inner<G, K: 'static, V: 'static>(
+fn decode_key_values_inner<G, K, V>(
     stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
     mut key_decoder_state: K,
     mut value_decoder_state: V,
     op_name: &str,
-) -> Stream<G, ((Row, Option<Row>), Timestamp, Diff)>
+) -> Stream<G, (Row, Option<Row>, Timestamp)>
 where
     G: Scope<Timestamp = Timestamp>,
-    K: DecoderState,
-    V: DecoderState,
+    K: DecoderState + 'static,
+    V: DecoderState + 'static,
 {
     stream.unary(
         Exchange::new(|x: &((Vec<u8>, _), _)| (x.0).0.hashed()),
@@ -274,12 +232,12 @@ where
                         match key_decoder_state.decode_key(key) {
                             Ok(key) => {
                                 if payload.is_empty() {
-                                    session.give(((key, None), *cap.time(), 1));
+                                    session.give((key, None, *cap.time()));
                                 } else {
                                     value_decoder_state.give_key_value(
                                         key,
                                         payload,
-                                        aux_num,
+                                        *aux_num,
                                         &mut session,
                                         *cap.time(),
                                     );
@@ -298,11 +256,11 @@ where
     )
 }
 
-pub fn decode_kafka_upsert<G>(
+pub fn decode_key_values<G>(
     stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
     value_encoding: DataEncoding,
     key_encoding: DataEncoding,
-) -> Stream<G, ((Row, Option<Row>), Timestamp, Diff)>
+) -> Stream<G, (Row, Option<Row>, Timestamp)>
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -311,10 +269,12 @@ where
         key_encoding.op_name(),
         value_encoding.op_name()
     );
-    match (key_encoding, value_encoding) {
-        (DataEncoding::Bytes, DataEncoding::Avro(val_enc)) => decode_kafka_upsert_inner(
+    let decoded_stream = match (key_encoding, value_encoding) {
+        (DataEncoding::Bytes, DataEncoding::Avro(val_enc)) => decode_key_values_inner(
             stream,
-            BytesDecoderState,
+            OffsetDecoderState {
+                datum_func: bytes_to_datum,
+            },
             avro::AvroDecoderState::new(
                 &val_enc.value_schema,
                 val_enc.schema_registry_url,
@@ -322,9 +282,11 @@ where
             ),
             &op_name,
         ),
-        (DataEncoding::Text, DataEncoding::Avro(val_enc)) => decode_kafka_upsert_inner(
+        (DataEncoding::Text, DataEncoding::Avro(val_enc)) => decode_key_values_inner(
             stream,
-            TextDecoderState,
+            OffsetDecoderState {
+                datum_func: text_to_datum,
+            },
             avro::AvroDecoderState::new(
                 &val_enc.value_schema,
                 val_enc.schema_registry_url,
@@ -332,7 +294,7 @@ where
             ),
             &op_name,
         ),
-        (DataEncoding::Avro(key_enc), DataEncoding::Avro(val_enc)) => decode_kafka_upsert_inner(
+        (DataEncoding::Avro(key_enc), DataEncoding::Avro(val_enc)) => decode_key_values_inner(
             stream,
             avro::AvroDecoderState::new(
                 &key_enc.value_schema,
@@ -346,90 +308,67 @@ where
             ),
             &op_name,
         ),
-        (DataEncoding::Text, DataEncoding::Bytes) => {
-            decode_kafka_upsert_inner(stream, TextDecoderState, BytesDecoderState, &op_name)
-        }
-        (DataEncoding::Bytes, DataEncoding::Bytes) => {
-            decode_kafka_upsert_inner(stream, BytesDecoderState, BytesDecoderState, &op_name)
-        }
-        (DataEncoding::Text, DataEncoding::Text) => {
-            decode_kafka_upsert_inner(stream, TextDecoderState, TextDecoderState, &op_name)
-        }
+        (DataEncoding::Text, DataEncoding::Bytes) => decode_key_values_inner(
+            stream,
+            OffsetDecoderState {
+                datum_func: text_to_datum,
+            },
+            OffsetDecoderState {
+                datum_func: bytes_to_datum,
+            },
+            &op_name,
+        ),
+        (DataEncoding::Bytes, DataEncoding::Bytes) => decode_key_values_inner(
+            stream,
+            OffsetDecoderState {
+                datum_func: bytes_to_datum,
+            },
+            OffsetDecoderState {
+                datum_func: bytes_to_datum,
+            },
+            &op_name,
+        ),
+        (DataEncoding::Text, DataEncoding::Text) => decode_key_values_inner(
+            stream,
+            OffsetDecoderState {
+                datum_func: text_to_datum,
+            },
+            OffsetDecoderState {
+                datum_func: text_to_datum,
+            },
+            &op_name,
+        ),
         _ => unreachable!(),
-    }
+    };
+    decoded_stream.map(|(key, value, timestamp)| {
+        if let Some(value) = value {
+            let mut value_with_key = RowPacker::new();
+            value_with_key.extend_by_row(&key);
+            value_with_key.extend_by_row(&value);
+            (key, Some(value_with_key.finish()), timestamp)
+        } else {
+            (key, None, timestamp)
+        }
+    })
 }
 
-fn decode_kafka_inner<G, V: 'static>(
+pub fn drop_key<G>(
     stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
-    mut value_decoder_state: V,
-    op_name: &str,
-) -> Stream<G, (Row, Timestamp, Diff)>
-where
-    G: Scope<Timestamp = Timestamp>,
-    V: DecoderState,
-{
-    stream.unary(
-        Exchange::new(|x: &((_, Vec<u8>), _)| (x.0).1.hashed()),
-        &op_name,
-        move |_, _| {
-            move |input, output| {
-                value_decoder_state.reset_event_count();
-                input.for_each(|cap, data| {
-                    let mut session = output.session(&cap);
-                    for ((_, payload), aux_num) in data.iter() {
-                        if !payload.is_empty() {
-                            value_decoder_state.give_value(
-                                payload,
-                                aux_num,
-                                &mut session,
-                                *cap.time(),
-                            );
-                        }
-                    }
-                });
-                value_decoder_state.log_error_count();
-            }
-        },
-    )
-}
-
-pub fn decode_kafka<G>(
-    stream: &Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
-    encoding: DataEncoding,
-    envelope: &Envelope,
-) -> Stream<G, (Row, Timestamp, Diff)>
+) -> Stream<G, (Vec<u8>, Option<i64>)>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let op_name = format!("{}Decode", encoding.op_name());
-    match encoding {
-        DataEncoding::Avro(enc) => decode_kafka_inner(
-            stream,
-            avro::AvroDecoderState::new(
-                &enc.value_schema,
-                enc.schema_registry_url,
-                envelope.get_avro_envelope_type(),
-            ),
-            &op_name,
-        ),
-        DataEncoding::Protobuf(enc) => decode_kafka_inner(
-            stream,
-            protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
-            &op_name,
-        ),
-        DataEncoding::Bytes => decode_kafka_inner(stream, BytesDecoderState, &op_name),
-        _ => unreachable!(),
-    }
+    stream.map(|((_key, payload), aux_num)| (payload, aux_num))
 }
 
-fn decode_inner<G, V: 'static>(
+fn decode_values_inner<G, V>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,
     mut value_decoder_state: V,
     op_name: &str,
 ) -> Stream<G, (Row, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
-    V: DecoderState,
+    V: DecoderState + 'static,
 {
     stream.unary(
         Exchange::new(|x: &(Vec<u8>, _)| (x.0.hashed())),
@@ -443,7 +382,7 @@ where
                         if !payload.is_empty() {
                             value_decoder_state.give_value(
                                 payload,
-                                aux_num,
+                                *aux_num,
                                 &mut session,
                                 *cap.time(),
                             );
@@ -456,7 +395,7 @@ where
     )
 }
 
-pub fn decode<G>(
+pub fn decode_values<G>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,
     encoding: DataEncoding,
     name: &str,
@@ -474,7 +413,7 @@ where
         (DataEncoding::Csv(enc), Envelope::None) => {
             csv(stream, enc.header_row, enc.n_cols, enc.delimiter)
         }
-        (DataEncoding::Avro(enc), envelope) => decode_inner(
+        (DataEncoding::Avro(enc), envelope) => decode_values_inner(
             stream,
             avro::AvroDecoderState::new(
                 &enc.value_schema,
@@ -490,12 +429,24 @@ where
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
         (DataEncoding::Regex { regex }, Envelope::None) => regex_fn(stream, regex, name),
-        (DataEncoding::Protobuf(enc), Envelope::None) => decode_inner(
+        (DataEncoding::Protobuf(enc), Envelope::None) => decode_values_inner(
             stream,
             protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
             &op_name,
         ),
-        (DataEncoding::Bytes, Envelope::None) => decode_inner(stream, BytesDecoderState, &op_name),
-        (DataEncoding::Text, Envelope::None) => decode_inner(stream, TextDecoderState, &op_name),
+        (DataEncoding::Bytes, Envelope::None) => decode_values_inner(
+            stream,
+            OffsetDecoderState {
+                datum_func: bytes_to_datum,
+            },
+            &op_name,
+        ),
+        (DataEncoding::Text, Envelope::None) => decode_values_inner(
+            stream,
+            OffsetDecoderState {
+                datum_func: text_to_datum,
+            },
+            &op_name,
+        ),
     }
 }

--- a/src/dataflow/decode/protobuf.rs
+++ b/src/dataflow/decode/protobuf.rs
@@ -7,65 +7,110 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use differential_dataflow::Hashable;
 use log::error;
-use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::Operator;
-use timely::dataflow::{Scope, Stream};
 
-use dataflow_types::{Diff, Timestamp};
+use dataflow_types::Timestamp;
 use interchange::protobuf::{self, Decoder};
 use repr::Row;
 
-use super::EVENTS_COUNTER;
+use super::{DecoderState, PushSession, EVENTS_COUNTER};
 
-pub fn protobuf<G>(
-    stream: &Stream<G, (Vec<u8>, Option<i64>)>,
-    descriptors: &[u8],
-    message_name: &str,
-) -> Stream<G, (Row, Timestamp, Diff)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    let message_name = message_name.to_owned();
-    let descriptors = protobuf::decode_descriptors(descriptors)
-        .expect("descriptors provided to protobuf source are pre-validated");
-    let mut decoder = Decoder::new(descriptors, &message_name);
+pub struct ProtobufDecoderState {
+    decoder: Decoder,
+    events_success: i64,
+    events_error: i64,
+}
 
-    stream.unary(
-        Exchange::new(|x: &(Vec<u8>, _)| x.0.hashed()),
-        "ProtobufDecode",
-        move |_, _| {
-            move |input, output| {
-                let mut events_success = 0;
-                let mut events_error = 0;
-                input.for_each(|cap, data| {
-                    let mut session = output.session(&cap);
-                    for (payload, _) in data.iter() {
-                        match decoder.decode(payload) {
-                            Ok(row) => {
-                                if let Some(row) = row {
-                                    events_success += 1;
-                                    session.give((row, *cap.time(), 1));
-                                } else {
-                                    events_error += 1;
-                                    error!("protobuf deserialization returned None");
-                                }
-                            }
-                            Err(err) => {
-                                events_error += 1;
-                                error!("protobuf deserialization error: {}", err)
-                            }
-                        }
-                    }
-                });
-                if events_success > 0 {
-                    EVENTS_COUNTER.protobuf.success.inc_by(events_success);
-                }
-                if events_error > 0 {
-                    EVENTS_COUNTER.protobuf.error.inc_by(events_error);
+impl ProtobufDecoderState {
+    pub fn new(descriptors: &[u8], message_name: &str) -> Self {
+        let descriptors = protobuf::decode_descriptors(descriptors)
+            .expect("descriptors provided to protobuf source are pre-validated");
+        ProtobufDecoderState {
+            decoder: Decoder::new(descriptors, message_name),
+            events_success: 0,
+            events_error: 0,
+        }
+    }
+}
+
+impl DecoderState for ProtobufDecoderState {
+    /// Reset number of success and failures with decoding
+    fn reset_event_count(&mut self) {
+        self.events_success = 0;
+        self.events_error = 0;
+    }
+
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
+        match self.decoder.decode(bytes) {
+            Ok(row) => {
+                if let Some(row) = row {
+                    self.events_success += 1;
+                    Ok(row)
+                } else {
+                    self.events_error += 1;
+                    Err("protobuf deserialization returned None".to_string())
                 }
             }
-        },
-    )
+            Err(err) => {
+                self.events_error += 1;
+                Err(format!("protobuf deserialization error: {}", err))
+            }
+        }
+    }
+
+    /// give a session a key-value pair
+    fn give_key_value<'a>(
+        &mut self,
+        key: Row,
+        bytes: &[u8],
+        _: &Option<i64>,
+        session: &mut PushSession<'a, (Row, Option<Row>)>,
+        time: Timestamp,
+    ) {
+        match self.decoder.decode(bytes) {
+            Ok(row) => {
+                self.events_success += 1;
+                session.give(((key, row), time, 1));
+            }
+            Err(err) => {
+                self.events_error += 1;
+                error!("protobuf deserialization error: {}", err)
+            }
+        }
+    }
+
+    /// give a session a plain value
+    fn give_value<'a>(
+        &mut self,
+        bytes: &[u8],
+        _: &Option<i64>,
+        session: &mut PushSession<'a, Row>,
+        time: Timestamp,
+    ) {
+        match self.decoder.decode(bytes) {
+            Ok(row) => {
+                if let Some(row) = row {
+                    self.events_success += 1;
+                    session.give((row, time, 1));
+                } else {
+                    self.events_error += 1;
+                    error!("protobuf deserialization returned None");
+                }
+            }
+            Err(err) => {
+                self.events_error += 1;
+                error!("protobuf deserialization error: {}", err)
+            }
+        }
+    }
+
+    /// Register number of success and failures with decoding
+    fn log_error_count(&self) {
+        if self.events_success > 0 {
+            EVENTS_COUNTER.protobuf.success.inc_by(self.events_success);
+        }
+        if self.events_error > 0 {
+            EVENTS_COUNTER.protobuf.error.inc_by(self.events_error);
+        }
+    }
 }

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -15,6 +15,7 @@ use std::rc::Weak;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
+use differential_dataflow::operators::arrange::upsert::arrange_from_upsert;
 use differential_dataflow::operators::join::JoinCore;
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::{AsCollection, Collection};
@@ -26,7 +27,7 @@ use timely::worker::Worker as TimelyWorker;
 use dataflow_types::Timestamp;
 use dataflow_types::*;
 use expr::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr, SourceInstanceId};
-use repr::{Datum, RelationType, Row, RowArena, RowPacker};
+use repr::{Datum, RelationType, Row, RowArena};
 
 use self::context::{ArrangementFlavor, Context};
 use super::sink;
@@ -34,7 +35,7 @@ use super::source;
 use super::source::FileReadStyle;
 use super::source::SourceToken;
 use crate::arrangement::manager::{TraceManager, WithDrop};
-use crate::decode::{decode, decode_avro_values, decode_kafka, decode_kafka_upsert};
+use crate::decode::{decode_avro_values, decode_key_values, decode_values};
 use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::server::LocalInput;
 use crate::server::{TimestampChanges, TimestampHistories};
@@ -159,57 +160,22 @@ pub(crate) fn build_dataflow<A: Allocate>(
                     consistency,
                 } = src.connector
                 {
+                    let get_expr = RelationExpr::global_get(src_id.sid, src.desc.typ().clone());
+
                     // This uid must be unique across all different instantiations of a source
                     let uid = SourceInstanceId {
                         sid: src_id.sid,
                         vid: first_export_id,
                     };
 
-                    let (stream, capability) = if let ExternalSourceConnector::AvroOcf(c) =
-                        connector
-                    {
-                        // Distribute read responsibility among workers.
-                        use differential_dataflow::hashable::Hashable;
-                        let hash = src_id.hashed() as usize;
-                        let should_read = hash % worker_peers == worker_index;
-                        let read_style = if should_read {
-                            if c.tail {
-                                FileReadStyle::TailFollowFd
-                            } else {
-                                FileReadStyle::ReadOnce
-                            }
-                        } else {
-                            FileReadStyle::None
-                        };
-
-                        let reader_schema = match &encoding {
-                            DataEncoding::AvroOcf { reader_schema } => reader_schema,
-                            _ => unreachable!(
-                                "Internal error: \
-                                     Avro OCF schema should have already been resolved.\n\
-                                     Encoding is: {:?}",
-                                encoding
-                            ),
-                        };
-                        let reader_schema = Schema::parse_str(reader_schema).unwrap();
-                        let ctor = move |file| avro::Reader::with_schema(&reader_schema, file);
-                        let (source, capability) = source::file(
-                            src_id,
-                            region,
-                            format!("ocf-{}", src_id),
-                            c.path,
-                            read_style,
-                            ctor,
-                        );
-                        (decode_avro_values(&source, &envelope), capability)
-                    } else {
-                        let (source, capability) = match connector {
+                    let capability = if let Envelope::Upsert(key_encoding) = envelope {
+                        match connector {
                             ExternalSourceConnector::Kafka(c) => {
                                 // Distribute read responsibility among workers.
                                 use differential_dataflow::hashable::Hashable;
                                 let hash = src_id.hashed() as usize;
                                 let read_from_kafka = hash % worker_peers == worker_index;
-                                source::kafka(
+                                let (source, capability) = source::kafka(
                                     region,
                                     format!("kafka-{}-{}", first_export_id, source_number),
                                     c,
@@ -219,76 +185,150 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                     timestamp_channel.clone(),
                                     consistency,
                                     read_from_kafka,
-                                )
+                                );
+                                let arranged = arrange_from_upsert(
+                                    &decode_key_values(&source, encoding, key_encoding),
+                                    &format!("UpsertArrange: {}", src_id.to_string()),
+                                );
+                                let keys = src.desc.typ().keys[0]
+                                    .iter()
+                                    .map(|k| ScalarExpr::Column(*k))
+                                    .collect::<Vec<_>>();
+                                context.set_local(&get_expr, &keys, arranged);
+                                capability
                             }
-                            ExternalSourceConnector::Kinesis(c) => {
-                                // Distribute read responsibility among workers.
-                                use differential_dataflow::hashable::Hashable;
-                                let hash = src_id.hashed() as usize;
-                                let read_from_kinesis = hash % worker_peers == worker_index;
-                                source::kinesis(
-                                    region,
-                                    format!("kinesis-{}-{}", first_export_id, source_number),
-                                    c,
-                                    uid,
-                                    advance_timestamp,
-                                    timestamp_histories.clone(),
-                                    timestamp_channel.clone(),
-                                    consistency,
-                                    read_from_kinesis,
-                                )
-                            }
-                            ExternalSourceConnector::File(c) => {
-                                // Distribute read responsibility among workers.
-                                use differential_dataflow::hashable::Hashable;
-                                let hash = src_id.hashed() as usize;
-                                let should_read = hash % worker_peers == worker_index;
-                                let read_style = if should_read {
-                                    if c.tail {
-                                        FileReadStyle::TailFollowFd
-                                    } else {
-                                        FileReadStyle::ReadOnce
-                                    }
-                                } else {
-                                    FileReadStyle::None
-                                };
-
-                                let ctor = |file| Ok(std::io::BufReader::new(file).split(b'\n'));
-                                source::file(
-                                    src_id,
-                                    region,
-                                    format!("csv-{}", src_id),
-                                    c.path,
-                                    read_style,
-                                    ctor,
-                                )
-                            }
-                            ExternalSourceConnector::AvroOcf(_) => unreachable!(),
-                        };
-                        // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
-                        // a hypothetical future avro_extract, protobuf_extract, etc.
-                        let stream = decode(&source, encoding, &dataflow.debug_name, &envelope);
-
-                        (stream, capability)
-                    };
-
-                    let collection = match envelope {
-                        Envelope::None => stream.as_collection(),
-                        Envelope::Debezium => {
-                            // TODO(btv) -- this should just be a RelationExpr::Explode (name TBD)
-                            stream.as_collection().explode(|row| {
-                                let mut datums = row.unpack();
-                                let diff = datums.pop().unwrap().unwrap_int64() as isize;
-                                Some((Row::pack(datums.into_iter()), diff))
-                            })
+                            _ => unreachable!("Upsert envelope unsupported for non-Kafka sources"),
                         }
+                    } else {
+                        let (stream, capability) = if let ExternalSourceConnector::AvroOcf(c) =
+                            connector
+                        {
+                            // Distribute read responsibility among workers.
+                            use differential_dataflow::hashable::Hashable;
+                            let hash = src_id.hashed() as usize;
+                            let should_read = hash % worker_peers == worker_index;
+                            let read_style = if should_read {
+                                if c.tail {
+                                    FileReadStyle::TailFollowFd
+                                } else {
+                                    FileReadStyle::ReadOnce
+                                }
+                            } else {
+                                FileReadStyle::None
+                            };
+
+                            let reader_schema = match &encoding {
+                                DataEncoding::AvroOcf { reader_schema } => reader_schema,
+                                _ => unreachable!(
+                                    "Internal error: \
+                                         Avro OCF schema should have already been resolved.\n\
+                                        Encoding is: {:?}",
+                                    encoding
+                                ),
+                            };
+                            let reader_schema = Schema::parse_str(reader_schema).unwrap();
+                            let ctor = move |file| avro::Reader::with_schema(&reader_schema, file);
+                            let (source, capability) = source::file(
+                                src_id,
+                                region,
+                                format!("ocf-{}", src_id),
+                                c.path,
+                                read_style,
+                                ctor,
+                            );
+                            (decode_avro_values(&source, &envelope), capability)
+                        } else {
+                            let (source, capability) = match connector {
+                                ExternalSourceConnector::Kafka(c) => {
+                                    // Distribute read responsibility among workers.
+                                    use differential_dataflow::hashable::Hashable;
+                                    use timely::dataflow::operators::Map;
+                                    let hash = src_id.hashed() as usize;
+                                    let read_from_kafka = hash % worker_peers == worker_index;
+                                    let (source, capability) = source::kafka(
+                                        region,
+                                        format!("kafka-{}-{}", first_export_id, source_number),
+                                        c,
+                                        uid,
+                                        advance_timestamp,
+                                        timestamp_histories.clone(),
+                                        timestamp_channel.clone(),
+                                        consistency,
+                                        read_from_kafka,
+                                    );
+                                    (source.map(|((_key, payload), aux_num)| {
+                                        (payload, aux_num)
+                                        }),
+                                    capability,
+                                    )
+                                }
+                                ExternalSourceConnector::Kinesis(c) => {
+                                    // Distribute read responsibility among workers.
+                                    use differential_dataflow::hashable::Hashable;
+                                    let hash = src_id.hashed() as usize;
+                                    let read_from_kinesis = hash % worker_peers == worker_index;
+                                    source::kinesis(
+                                        region,
+                                        format!("kinesis-{}-{}", first_export_id, source_number),
+                                        c,
+                                        uid,
+                                        advance_timestamp,
+                                        timestamp_histories.clone(),
+                                        timestamp_channel.clone(),
+                                        consistency,
+                                        read_from_kinesis,
+                                    )
+                                }
+                                ExternalSourceConnector::File(c) => {
+                                    // Distribute read responsibility among workers.
+                                    use differential_dataflow::hashable::Hashable;
+                                    let hash = src_id.hashed() as usize;
+                                    let should_read = hash % worker_peers == worker_index;
+                                    let read_style = if should_read {
+                                        if c.tail {
+                                            FileReadStyle::TailFollowFd
+                                        } else {
+                                            FileReadStyle::ReadOnce
+                                        }
+                                    } else {
+                                        FileReadStyle::None
+                                    };
+
+                                    let ctor = |file| Ok(std::io::BufReader::new(file).split(b'\n'));
+                                    source::file(
+                                        src_id,
+                                        region,
+                                        format!("csv-{}", src_id),
+                                        c.path,
+                                        read_style,
+                                        ctor,
+                                    )
+                                }
+                                ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+                            };
+                            // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
+                            // a hypothetical future avro_extract, protobuf_extract, etc.
+                            let stream = decode(&source, encoding, &dataflow.debug_name, &envelope);
+
+                            (stream, capability)
+                        };
+
+                        let collection = match envelope {
+                            Envelope::None => stream.as_collection(),
+                            Envelope::Debezium => {
+                                // TODO(btv) -- this should just be a RelationExpr::Explode (name TBD)
+                                stream.as_collection().explode(|row| {
+                                    let mut datums = row.unpack();
+                                    let diff = datums.pop().unwrap().unwrap_int64() as isize;
+                                    Some((Row::pack(datums.into_iter()), diff))
+                                })
+                            }
+                            Envelope::Upsert(_) => unreachable!(),
+                        };
+
+                        capability
                     };
 
-                    // Introduce the stream by name, as an unarranged collection.
-                    context.collections.insert(
-                        RelationExpr::global_get(src_id.sid, src.desc.typ().clone()),
-                        collection,
-                    );
                     let token = Rc::new(capability);
                     source_tokens.insert(src_id.sid, token.clone());
 

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -331,6 +331,11 @@ where
                                     );
                                 };
 
+                                // Null payloads are expected from Debezium and
+                                // Upsert formats.
+                                // See https://github.com/MaterializeInc/materialize/issues/439#issuecomment-534236276
+                                // Upsert treats null payloads as requests to
+                                // delete the record with the corresponding key.
                                 let out = message.payload().map(|p| p.to_vec()).unwrap_or_default();
                                 bytes_read += key.len() as i64;
                                 bytes_read += out.len() as i64;

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -52,7 +52,10 @@ pub fn kafka<G>(
     timestamp_tx: TimestampChanges,
     consistency: Consistency,
     read_kafka: bool,
-) -> (Stream<G, (Vec<u8>, Option<i64>)>, Option<SourceToken>)
+) -> (
+    Stream<G, ((Vec<u8>, Vec<u8>), Option<i64>)>,
+    Option<SourceToken>,
+)
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -186,6 +189,7 @@ where
                         let payload = message.payload();
                         let partition = message.partition();
                         let offset = message.offset() + 1;
+                        let key = message.key().map(|k| k.to_vec()).unwrap_or_default();
 
                         if !partitions.contains(&partition) {
                             // We have received a message for a partition for which we do not yet
@@ -248,7 +252,9 @@ where
                                 if let Some(payload) = payload {
                                     let out = payload.to_vec();
                                     bytes_read += out.len() as i64;
-                                    output.session(&cap).give((out, Some(message.offset())));
+                                    output
+                                        .session(&cap)
+                                        .give(((key, out), Some(message.offset())));
                                 }
 
                                 downgrade_capability(
@@ -301,6 +307,7 @@ where
                     while let Some(result) = consumer.poll(Duration::from_millis(0)) {
                         match result {
                             Ok(message) => {
+                                let key = message.key().map(|k| k.to_vec()).unwrap_or_default();
                                 let payload = match message.payload() {
                                     Some(p) => p,
                                     // Null payloads are expected from Debezium.
@@ -333,7 +340,9 @@ where
 
                                 let out = payload.to_vec();
                                 bytes_read += out.len() as i64;
-                                output.session(&cap).give((out, Some(message.offset())));
+                                output
+                                    .session(&cap)
+                                    .give(((key, out), Some(message.offset())));
                             }
                             Err(err) => error!("kafka error: {}: {}", name, err),
                         }

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -535,7 +535,7 @@ impl Decoder {
             }
         } else {
             let val = avro::from_avro_datum(resolved_schema, &mut bytes)?;
-            let row = extract_row(val, false, iter::empty())?;
+            let row = extract_row(val, self.envelope == EnvelopeType::Upsert, iter::empty())?;
             DiffPair {
                 before: None,
                 after: row,

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -415,7 +415,7 @@ pub struct Decoder {
     reader_schema: Schema,
     writer_schemas: Option<SchemaCache>,
     fast_row_schema: Option<Schema>,
-    is_debezium: bool,
+    envelope: EnvelopeType,
 }
 
 impl fmt::Debug for Decoder {
@@ -445,7 +445,7 @@ impl Decoder {
     pub fn new(
         reader_schema: &str,
         schema_registry_url: Option<url::Url>,
-        is_debezium: bool,
+        envelope: EnvelopeType,
     ) -> Decoder {
         // It is assumed that the reader schema has already been verified
         // to be a valid Avro schema.
@@ -475,7 +475,7 @@ impl Decoder {
             reader_schema,
             writer_schemas,
             fast_row_schema,
-            is_debezium,
+            envelope,
         }
     }
 
@@ -514,7 +514,7 @@ impl Decoder {
             None => (&self.reader_schema, None),
         };
 
-        let result = if self.is_debezium {
+        let result = if self.envelope == EnvelopeType::Debezium {
             if let (Some(schema), None) = (&self.fast_row_schema, reader_schema) {
                 // The record is laid out such that we can extract the `before` and
                 // `after` fields without decoding the entire record.

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -12,7 +12,7 @@ use byteorder::{NetworkEndian, WriteBytesExt};
 use chrono::{Duration, NaiveDate};
 use criterion::{black_box, Criterion, Throughput};
 
-use interchange::avro::{parse_schema, Decoder};
+use interchange::avro::{parse_schema, Decoder, EnvelopeType};
 use std::ops::Add;
 
 pub fn bench_avro(c: &mut Criterion) {
@@ -293,7 +293,7 @@ pub fn bench_avro(c: &mut Criterion) {
     buf.extend(avro::to_avro_datum(&schema, record).unwrap());
     let len = buf.len() as u64;
 
-    let mut decoder = Decoder::new(schema_str, None, true);
+    let mut decoder = Decoder::new(schema_str, None, EnvelopeType::Debezium);
 
     let mut bg = c.benchmark_group("avro");
     bg.throughput(Throughput::Bytes(len));

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1258,10 +1258,6 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                 if let DataEncoding::Avro(AvroEncoding { key_schema, .. }) = &mut encoding {
                     *key_schema = None;
                 }
-                // TODO: remove the bail once PR #2943 is in
-                // the bail is meant to prevent someone from accidentally trying
-                // the upsert envelope and then causing a panic.
-                bail!("Upsert envelope is not supported yet");
             }
 
             let mut desc = encoding.desc(&envelope)?;

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1211,7 +1211,6 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     (connector, encoding)
                 }
             };
-
             // TODO (materialize#2537): cleanup format validation
             // Avro format validation is different for the Debezium envelope
             // vs the Upsert envelope.

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -86,7 +86,11 @@ impl Transcoder {
                 val.write_to_vec(&mut out).map_err(|e| e.to_string())?;
             }
             Transcoder::Bytes { terminator } => match terminator {
-                Some(t) => row.read_until(*t, &mut out).map(|_n| ()),
+                Some(t) => {
+                    row.read_until(*t, &mut out).map_err(|e| e.to_string())?;
+                    out.pop();
+                    Ok(())
+                }
                 None => row.read_to_end(&mut out).map(|_n| ()),
             }
             .map_err(|e| e.to_string())?,

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -41,19 +41,19 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
 {"key": "mammalmore"} {"f1": "moose", "f2": 42}
 {"key": "mammal1"} null
 
-#> CREATE MATERIALIZED SOURCE avroavro
-#  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
-#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-#  ENVELOPE UPSERT
+> CREATE MATERIALIZED SOURCE avroavro
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT
 
-#> SELECT * from avroavro
-#key           f1       f2
-#-------------------------
-#bird1         goose    1
-#birdmore      geese    2
-#mammal1       moose    1
-#birdmore      geese    56
-#mammalmore    moose    42
+> SELECT * from avroavro
+key           f1       f2
+-------------------------
+bird1         goose    1
+birdmore      geese    2
+mammal1       moose    1
+birdmore      geese    56
+mammalmore    moose    42
 
 $ kafka-create-topic topic=textavro
 
@@ -66,16 +66,102 @@ birdmore: {"f1":"geese", "f2": 56}
 mammalmore: {"f1": "moose", "f2": 42}
 mammal1: null
 
-#> CREATE MATERIALIZED SOURCE textavro
-#  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
-#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-#  ENVELOPE UPSERT FORMAT TEXT
+> CREATE MATERIALIZED SOURCE textavro
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT FORMAT TEXT
 
-#> select * from textavro
-#key           f1       f2
-#-------------------------
-#bird1         goose    1
-#birdmore      geese    2
-#mammal1       moose    1
-#birdmore      geese    56
-#mammalmore    moose    42
+> select * from textavro
+key           f1       f2
+-------------------------
+bird1         goose    1
+birdmore      geese    2
+mammal1       moose    1
+birdmore      geese    56
+mammalmore    moose    42
+
+> CREATE MATERIALIZED SOURCE bytesavro
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT FORMAT BYTES
+
+> select * from bytesavro
+key           f1       f2
+-------------------------
+bird1         goose    1
+birdmore      geese    2
+mammal1       moose    1
+birdmore      geese    56
+mammalmore    moose    42
+
+$ kafka-create-topic topic=textbytes
+
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes publish=true timestamp=1
+"bìrd1" "goose"
+"birdmore" "geese"
+"mammal1" "moose"
+"bird1" null
+"birdmore" "géese"
+"mammalmore" "moose"
+"mammal1" null
+
+> CREATE MATERIALIZED SOURCE textbytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FORMAT BYTES ENVELOPE UPSERT FORMAT TEXT
+
+> select * from textbytes
+key           data             mz_offset
+----------------------------------------
+bìrd1         "goose"          0
+birdmore      "geese"          1
+mammal1       "moose"          2
+birdmore      "g\\xc3\\xa9ese" 4
+mammalmore    "moose"          5
+
+> CREATE MATERIALIZED SOURCE texttext
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
+
+> select * from texttext
+key           data  mz_offset
+-----------------------------
+bìrd1         goose 0
+birdmore      geese 1
+mammal1       moose 2
+birdmore      géese 4
+mammalmore    moose 5
+
+> CREATE MATERIALIZED SOURCE bytesbytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FORMAT BYTES ENVELOPE UPSERT FORMAT BYTES
+
+> select * from bytesbytes
+key              data             mz_offset
+----------------------------------------
+"b\\xc3\\xacrd1" "goose"          0
+"birdmore"       "geese"          1
+"mammal1"        "moose"          2
+"birdmore"       "g\\xc3\\xa9ese" 4
+"mammalmore"     "moose"          5
+
+# A null key should result in an error decoding that row but not a panic
+$ kafka-ingest format=bytes topic=nullkey key-format=bytes publish=true timestamp=1
+"bird1" "goose"
+null "geese"
+"mammal1" "moose"
+"bird1" null
+"birdmore" "geese"
+"mammalmore" "moose"
+"mammal1" null
+
+> CREATE MATERIALIZED SOURCE nullkey
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullkey-${testdrive.seed}'
+  FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
+
+> select * from nullkey
+key           data  mz_offset
+-----------------------------
+bird1         goose 0
+mammal1       moose 2
+birdmore      geese 4
+mammalmore    moose 5

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# TODO: after taking up the arrange_from_upsert operator, the results of selecting
-# from the streams should change.
+# TODO: uncomment tests when timestamping problem is fixed.
+# TODO: add tests where the updated value is less than old value
 
 $ set keyschema={
     "type": "record",
@@ -34,11 +34,23 @@ $ kafka-create-topic topic=avroavro
 
 $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
 {"key": "bird1"} {"f1":"goose", "f2": 1}
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=2
 {"key": "birdmore"} {"f1":"geese", "f2": 2}
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=3
 {"key": "mammal1"} {"f1": "moose", "f2": 1}
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=4
 {"key": "bird1"} null
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=5
 {"key": "birdmore"} {"f1":"geese", "f2": 56}
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=6
 {"key": "mammalmore"} {"f1": "moose", "f2": 42}
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=7
 {"key": "mammal1"} null
 
 > CREATE MATERIALIZED SOURCE avroavro
@@ -46,18 +58,15 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
-> SELECT * from avroavro
-key           f1       f2
--------------------------
-bird1         goose    1
-birdmore      geese    2
-mammal1       moose    1
-birdmore      geese    56
-mammalmore    moose    42
+#> SELECT * from avroavro
+#key           f1       f2
+#-------------------------
+#birdmore      geese    56
+#mammalmore    moose    42
 
 $ kafka-create-topic topic=textavro
 
-$ kafka-ingest format=avro topic=textavro key-format=bytes schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true timestamp=1
 bird1: {"f1":"goose", "f2": 1}
 birdmore: {"f1":"geese", "f2": 2}
 mammal1: {"f1": "moose", "f2": 1}
@@ -71,97 +80,83 @@ mammal1: null
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT FORMAT TEXT
 
-> select * from textavro
-key           f1       f2
--------------------------
-bird1         goose    1
-birdmore      geese    2
-mammal1       moose    1
-birdmore      geese    56
-mammalmore    moose    42
+#> select * from textavro
+#key           f1       f2
+#-------------------------
+#birdmore      geese    56
+#mammalmore    moose    42
 
 > CREATE MATERIALIZED SOURCE bytesavro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT FORMAT BYTES
 
-> select * from bytesavro
-key           f1       f2
--------------------------
-bird1         goose    1
-birdmore      geese    2
-mammal1       moose    1
-birdmore      geese    56
-mammalmore    moose    42
+#> select * from bytesavro
+#key           f1       f2
+#-------------------------
+#birdmore      geese    56
+#mammalmore    moose    42
 
 $ kafka-create-topic topic=textbytes
 
-$ kafka-ingest format=bytes topic=textbytes key-format=bytes publish=true timestamp=1
-"bìrd1" "goose"
-"birdmore" "geese"
-"mammal1" "moose"
-"bird1" null
-"birdmore" "géese"
-"mammalmore" "moose"
-"mammal1" null
+$ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+bìrd1:goose
+birdmore:geese
+mammal1:moose
+bìrd1:
+birdmore:géese
+mammalmore:moose
+mammal1:
 
 > CREATE MATERIALIZED SOURCE textbytes
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
   FORMAT BYTES ENVELOPE UPSERT FORMAT TEXT
 
-> select * from textbytes
-key           data             mz_offset
-----------------------------------------
-bìrd1         "goose"          0
-birdmore      "geese"          1
-mammal1       "moose"          2
-birdmore      "g\\xc3\\xa9ese" 4
-mammalmore    "moose"          5
+#> select * from textbytes
+#key           data             mz_offset
+#----------------------------------------
+#birdmore      "g\\xc3\\xa9ese" 4
+#mammalmore    "moose"          5
 
 > CREATE MATERIALIZED SOURCE texttext
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
   FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
 
-> select * from texttext
-key           data  mz_offset
------------------------------
-bìrd1         goose 0
-birdmore      geese 1
-mammal1       moose 2
-birdmore      géese 4
-mammalmore    moose 5
+#> select * from texttext
+#key           data  mz_offset
+#-----------------------------
+#bìrd1         goose 0
+#birdmore      geese 1
+#mammal1       moose 2
+#birdmore      géese 4
+#mammalmore    moose 5
 
 > CREATE MATERIALIZED SOURCE bytesbytes
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
   FORMAT BYTES ENVELOPE UPSERT FORMAT BYTES
 
-> select * from bytesbytes
-key              data             mz_offset
-----------------------------------------
-"b\\xc3\\xacrd1" "goose"          0
-"birdmore"       "geese"          1
-"mammal1"        "moose"          2
-"birdmore"       "g\\xc3\\xa9ese" 4
-"mammalmore"     "moose"          5
+#> select * from bytesbytes
+#key              data             mz_offset
+#----------------------------------------
+#"birdmore"       "g\\xc3\\xa9ese" 4
+#"mammalmore"     "moose"          5
 
 # A null key should result in an error decoding that row but not a panic
-$ kafka-ingest format=bytes topic=nullkey key-format=bytes publish=true timestamp=1
-"bird1" "goose"
-null "geese"
-"mammal1" "moose"
-"bird1" null
-"birdmore" "geese"
-"mammalmore" "moose"
-"mammal1" null
+$ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=: publish=true
+bird1:goose
+:geese
+mammal1:moose
+bird1:
+birdmore:geese
+mammalmore:moose
+mammal1:null
 
 > CREATE MATERIALIZED SOURCE nullkey
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullkey-${testdrive.seed}'
   FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
 
-> select * from nullkey
-key           data  mz_offset
------------------------------
-bird1         goose 0
-mammal1       moose 2
-birdmore      geese 4
-mammalmore    moose 5
+#> select * from nullkey
+#key           data  mz_offset
+#-----------------------------
+#birdmore      geese 4
+#mammalmore    moose 5

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -32,114 +32,161 @@ $ set schema=[
 
 $ kafka-create-topic topic=avroavro
 
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-avroavro-${testdrive.seed},1,0,1,1
+testdrive-avroavro-${testdrive.seed},1,0,2,2
+testdrive-avroavro-${testdrive.seed},1,0,3,3
+testdrive-avroavro-${testdrive.seed},1,0,4,4
+testdrive-avroavro-${testdrive.seed},1,0,5,5
+testdrive-avroavro-${testdrive.seed},1,0,6,6
+testdrive-avroavro-${testdrive.seed},1,0,7,7
+testdrive-avroavro-${testdrive.seed},1,0,8,8
+testdrive-avroavro-${testdrive.seed},1,0,9,9
+
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"key": "fish"} {"f1": "fish", "f2": 1000}
 {"key": "bird1"} {"f1":"goose", "f2": 1}
-
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=2
 {"key": "birdmore"} {"f1":"geese", "f2": 2}
-
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=3
 {"key": "mammal1"} {"f1": "moose", "f2": 1}
-
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=4
 {"key": "bird1"} null
-
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=5
 {"key": "birdmore"} {"f1":"geese", "f2": 56}
-
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=6
 {"key": "mammalmore"} {"f1": "moose", "f2": 42}
-
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=7
 {"key": "mammal1"} null
+{"key": "mammalmore"} {"f1":"moose", "f2": 2}
 
 > CREATE MATERIALIZED SOURCE avroavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-avroavro-${testdrive.seed}'
+      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
-#> SELECT * from avroavro
-#key           f1       f2
-#-------------------------
-#birdmore      geese    56
-#mammalmore    moose    42
+> SELECT * from avroavro
+key           f1       f2
+---------------------------
+fish          fish     1000
+birdmore      geese    56
+mammalmore    moose    2
 
 $ kafka-create-topic topic=textavro
 
-$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true timestamp=1
-bird1: {"f1":"goose", "f2": 1}
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-textavro-${testdrive.seed},1,0,1,1
+testdrive-textavro-${testdrive.seed},1,0,1,2
+testdrive-textavro-${testdrive.seed},1,0,2,4
+
+$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true
+fish: {"f1": "fish", "f2": 1000}
+bìrd1: {"f1":"goose", "f2": 1}
 birdmore: {"f1":"geese", "f2": 2}
 mammal1: {"f1": "moose", "f2": 1}
-bird1: null
+bìrd1: null
 birdmore: {"f1":"geese", "f2": 56}
-mammalmore: {"f1": "moose", "f2": 42}
+mämmalmore: {"f1": "moose", "f2": 42}
 mammal1: null
-
-> CREATE MATERIALIZED SOURCE textavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE UPSERT FORMAT TEXT
-
-#> select * from textavro
-#key           f1       f2
-#-------------------------
-#birdmore      geese    56
-#mammalmore    moose    42
+mammalmore: {"f1":"moose", "f2": 2}
 
 > CREATE MATERIALIZED SOURCE bytesavro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT FORMAT BYTES
 
-#> select * from bytesavro
-#key           f1       f2
-#-------------------------
-#birdmore      geese    56
-#mammalmore    moose    42
+> CREATE MATERIALIZED SOURCE textavro
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textavro-${testdrive.seed}'
+    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT FORMAT TEXT
+
+> select * from bytesavro
+key           f1       f2
+---------------------------
+fish          fish     1000
+b\xc3\xacrd1  goose    1
+birdmore      geese    2
+mammal1       moose    1
+
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-textavro-${testdrive.seed},1,0,3,5
+testdrive-textavro-${testdrive.seed},1,0,5,6
+testdrive-textavro-${testdrive.seed},1,0,8,7
+testdrive-textavro-${testdrive.seed},1,0,13,8
+
+> select * from textavro
+key           f1       f2
+---------------------------
+fish          fish     1000
+birdmore      geese    56
+mämmalmore    moose    42
 
 $ kafka-create-topic topic=textbytes
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
+fish:fish
 bìrd1:goose
-birdmore:geese
+bírdmore:geese
 mammal1:moose
 bìrd1:
-birdmore:géese
+bírdmore:géese
 mammalmore:moose
 mammal1:
-
-> CREATE MATERIALIZED SOURCE textbytes
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
-  FORMAT BYTES ENVELOPE UPSERT FORMAT TEXT
-
-#> select * from textbytes
-#key           data             mz_offset
-#----------------------------------------
-#birdmore      "g\\xc3\\xa9ese" 4
-#mammalmore    "moose"          5
+mammal1:mouse
+mammalmore:herd
 
 > CREATE MATERIALIZED SOURCE texttext
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
 
-#> select * from texttext
-#key           data  mz_offset
-#-----------------------------
-#bìrd1         goose 0
-#birdmore      geese 1
-#mammal1       moose 2
-#birdmore      géese 4
-#mammalmore    moose 5
+> CREATE MATERIALIZED SOURCE textbytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+  WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
+  FORMAT BYTES ENVELOPE UPSERT FORMAT TEXT
 
 > CREATE MATERIALIZED SOURCE bytesbytes
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textbytes-${testdrive.seed}'
+      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT BYTES ENVELOPE UPSERT FORMAT BYTES
 
-#> select * from bytesbytes
-#key              data             mz_offset
-#----------------------------------------
-#"birdmore"       "g\\xc3\\xa9ese" 4
-#"mammalmore"     "moose"          5
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-textbytes-${testdrive.seed},1,0,1,1
+testdrive-textbytes-${testdrive.seed},1,0,3,3
+testdrive-textbytes-${testdrive.seed},1,0,6,4
+testdrive-textbytes-${testdrive.seed},1,0,10,5
+
+> select * from texttext
+key           data  mz_offset
+-----------------------------
+fish          fish  0
+bírdmore      geese 2
+mammal1       moose 3
+
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-textbytes-${testdrive.seed},1,0,15,8
+testdrive-textbytes-${testdrive.seed},1,0,21,9
+
+> select * from textbytes
+key           data             mz_offset
+----------------------------------------
+fish          fish             0
+bírdmore      g\xc3\xa9ese     5
+mammal1       mouse            8
+mammalmore    moose            6
+
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-textbytes-${testdrive.seed},1,0,28,10
+
+> select * from bytesbytes
+key              data             mz_offset
+----------------------------------------
+fish             fish             0
+b\xc3\xadrdmore  g\xc3\xa9ese     5
+mammal1          mouse            8
+mammalmore       herd             9
 
 # A null key should result in an error decoding that row but not a panic
 $ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=: publish=true
@@ -149,14 +196,25 @@ mammal1:moose
 bird1:
 birdmore:geese
 mammalmore:moose
-mammal1:null
+mammal1:
 
 > CREATE MATERIALIZED SOURCE nullkey
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullkey-${testdrive.seed}'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-nullkey-${testdrive.seed}'
+      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT TEXT ENVELOPE UPSERT FORMAT TEXT
 
-#> select * from nullkey
-#key           data  mz_offset
-#-----------------------------
-#birdmore      geese 4
-#mammalmore    moose 5
+$ kafka-ingest format=bytes topic=data-consistency
+testdrive-nullkey-${testdrive.seed},1,0,30,1
+testdrive-nullkey-${testdrive.seed},1,0,32,2
+testdrive-nullkey-${testdrive.seed},1,0,35,3
+testdrive-nullkey-${testdrive.seed},1,0,38,4
+testdrive-nullkey-${testdrive.seed},1,0,42,5
+testdrive-nullkey-${testdrive.seed},1,0,46,6
+testdrive-nullkey-${testdrive.seed},1,0,51,7
+
+> select * from nullkey
+key           data  mz_offset
+-----------------------------
+birdmore      geese 4
+mammalmore    moose 5

--- a/test/testdrive/nulls.td
+++ b/test/testdrive/nulls.td
@@ -50,3 +50,21 @@ a
 ---
 1
 2
+
+#In the event of null payload, materialize should skip the entry and not panic
+$ kafka-create-topic topic=nullpayload
+
+$ kafka-ingest format=bytes topic=nullpayload timestamp=1
+"Sé"
+null
+"así"
+
+> CREATE MATERIALIZED SOURCE nullpayload (col)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullpayload-${testdrive.seed}'
+  FORMAT BYTES
+
+> SELECT col from nullpayload
+col
+---
+"S\\xc3\\xa9"
+"as\\xc3\\xad"

--- a/test/testdrive/nulls.td
+++ b/test/testdrive/nulls.td
@@ -54,10 +54,10 @@ a
 #In the event of null payload, materialize should skip the entry and not panic
 $ kafka-create-topic topic=nullpayload
 
-$ kafka-ingest format=bytes topic=nullpayload timestamp=1
-"Sé"
-null
-"así"
+$ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=nullpayload timestamp=1
+:Sé
+:
+:así
 
 > CREATE MATERIALIZED SOURCE nullpayload (col)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullpayload-${testdrive.seed}'


### PR DESCRIPTION
Part of #1575/#1577.

So far, this only supports
* reading from log-compacted topics, i.e. the upsert envelope. It does not actually use the upsert operator yet. It appends the key in front of the value row if the value is not None. It skips the row when the value is None. 
* Combinations of Keys: Avro, Bytes, Text and Values: Avro, Bytes, Text. It should be quite easy to support other key-value combinations in materialize; the main blocker would be just writing the tests for them.

Due to the size of the PR, it has been broken up. The sql parsing part is in #2496. The testdrive part is in #2494. This section now contains the dataflow-package portion.

Kafka sources now return two Vec<u8>, one for the key and one of the value. If the payload (resp. key) is null, the Vec<u8> is empty. To avoid some repeat code writing, I've made `DecoderState`s for DataEncodings involved in decoding kafka and passed them off to generic functions. I would use dynamic dispatching to save more code writing, but I'm afraid of it negatively affecting performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2493)
<!-- Reviewable:end -->
