### PR TITLE
Testdrive can create log-compacted topics with plain string keys.

### DIFF
--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -318,7 +318,12 @@ impl<'a> Iterator for LineReader<'a> {
         while let Some((i, c)) = chars.next() {
             if c == '\n' {
                 self.src_line += 1;
-                if fold_newlines && i + 3 < self.inner.len() && &self.inner[i + 1..i + 3] == "  " {
+                if fold_newlines
+                    && i + 3 < self.inner.len()
+                    && self.inner.is_char_boundary(i + 1)
+                    && self.inner.is_char_boundary(i + 3)
+                    && &self.inner[i + 1..i + 3] == "  "
+                {
                     // Chomp the newline and one space. This ensures a SQL query
                     // that is split over two lines does not become invalid.
                     chars.next();

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -10,8 +10,8 @@
 $ kafka-create-topic topic=bytes
 
 $ kafka-ingest format=bytes topic=bytes timestamp=1
-©1
-©2
+"©1"
+"©2"
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -7,10 +7,16 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# IMPORTANT: compacted kafka logs are produced using the same syntax as
-# kafka-avro-console-producer.
+# TODO: after taking up the arrange_from_upsert operator, the results of selecting
+# from the streams should change.
 
-$ set keyschema={"type": "string"}
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
 
 $ set schema=[
     "null",
@@ -24,9 +30,34 @@ $ set schema=[
     }
   ]
 
-$ kafka-create-topic topic=test1
+$ kafka-create-topic topic=avroavro
 
-$ kafka-ingest format=avro topic=test1 key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+{"key": "bird1"} {"f1":"goose", "f2": 1}
+{"key": "birdmore"} {"f1":"geese", "f2": 2}
+{"key": "mammal1"} {"f1": "moose", "f2": 1}
+{"key": "bird1"} null
+{"key": "birdmore"} {"f1":"geese", "f2": 56}
+{"key": "mammalmore"} {"f1": "moose", "f2": 42}
+{"key": "mammal1"} null
+
+#> CREATE MATERIALIZED SOURCE avroavro
+#  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+#  ENVELOPE UPSERT
+
+#> SELECT * from avroavro
+#key           f1       f2
+#-------------------------
+#bird1         goose    1
+#birdmore      geese    2
+#mammal1       moose    1
+#birdmore      geese    56
+#mammalmore    moose    42
+
+$ kafka-create-topic topic=textavro
+
+$ kafka-ingest format=avro topic=textavro key-format=bytes schema=${schema} publish=true timestamp=1
 "bird1" {"f1":"goose", "f2": 1}
 "birdmore" {"f1":"geese", "f2": 2}
 "mammal1" {"f1": "moose", "f2": 1}
@@ -35,5 +66,16 @@ $ kafka-ingest format=avro topic=test1 key-schema=${keyschema} schema=${schema} 
 "mammalmore" {"f1": "moose", "f2": 42}
 "mammal1" null
 
-# TODO: create source in this format. then query to make sure upsert works
-# TODO: test key1: null for deletion. test deletion in the middle of a row
+#> CREATE MATERIALIZED SOURCE textavro
+#  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+#  ENVELOPE UPSERT FORMAT TEXT
+
+#> select * from textavro
+#key           f1       f2
+#-------------------------
+#bird1         goose    1
+#birdmore      geese    2
+#mammal1       moose    1
+#birdmore      geese    56
+#mammalmore    moose    42

--- a/test/testdrive/timestamps-multi.td
+++ b/test/testdrive/timestamps-multi.td
@@ -32,7 +32,7 @@ $ set schema={
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-dummy,1,0,0,0
+"dummy,1,0,0,0"
 
 $ kafka-create-topic topic=data partitions=2
 
@@ -76,13 +76,13 @@ At least one input has no complete timestamps yet.
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data2-${testdrive.seed},2,0,1,0
+"testdrive-data2-${testdrive.seed},2,0,1,0"
 
 ! SELECT * FROM view_empty;
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data2-${testdrive.seed},2,1,1,0
+"testdrive-data2-${testdrive.seed},2,1,1,0"
 
 > SELECT * FROM view_empty;
 b sum
@@ -91,13 +91,13 @@ b sum
 
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},2,0,1,1
+"testdrive-data-${testdrive.seed},2,0,1,1"
 
 ! SELECT * FROM view_byo;
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},2,1,1,1
+"testdrive-data-${testdrive.seed},2,1,1,1"
 
 > SELECT * FROM view_byo
 b  sum
@@ -105,7 +105,7 @@ b  sum
 1  4
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},2,0,2,2
+"testdrive-data-${testdrive.seed},2,0,2,2"
 
 $ kafka-ingest partition=0 format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 2, "b": 1}}
@@ -119,7 +119,7 @@ b  sum
 1  4
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},2,1,2,2
+"testdrive-data-${testdrive.seed},2,1,2,2"
 
 > SELECT * FROM view_byo
 b  sum
@@ -128,7 +128,7 @@ b  sum
 2  1
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},2,1,3,5
+"testdrive-data-${testdrive.seed},2,1,3,5"
 
 $ kafka-ingest partition=1 format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 1, "b": 3}}
@@ -143,8 +143,8 @@ b  sum
 
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},2,1,4,5
-testdrive-data-${testdrive.seed},2,0,4,2
+"testdrive-data-${testdrive.seed},2,1,4,5"
+"testdrive-data-${testdrive.seed},2,0,4,2"
 
 > SELECT * FROM view_byo
 b  sum
@@ -161,8 +161,8 @@ b  sum
 3  3
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},3,1,5,6
-testdrive-data-${testdrive.seed},3,0,5,3
+"testdrive-data-${testdrive.seed},3,1,5,6"
+"testdrive-data-${testdrive.seed},3,0,5,3"
 
 $ kafka-add-partitions topic=data total-partitions=3
 
@@ -198,7 +198,7 @@ b  sum
 3  3
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},3,2,5,1
+"testdrive-data-${testdrive.seed},3,2,5,1"
 
 > SELECT * FROM view_byo
 b  sum
@@ -225,9 +225,9 @@ $ kafka-ingest partition=3 format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 1, "b": 11}}
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},3,1,6,7
-testdrive-data-${testdrive.seed},3,0,6,4
-testdrive-data-${testdrive.seed},3,2,6,2
+"testdrive-data-${testdrive.seed},3,1,6,7"
+"testdrive-data-${testdrive.seed},3,0,6,4"
+"testdrive-data-${testdrive.seed},3,2,6,2"
 
 > SELECT * FROM view_byo
 b  sum
@@ -240,7 +240,7 @@ b  sum
 7  1
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},4,3,7,1
+"testdrive-data-${testdrive.seed},4,3,7,1"
 
 > SELECT * FROM view_byo
 b  sum

--- a/test/testdrive/timestamps.td
+++ b/test/testdrive/timestamps.td
@@ -32,7 +32,7 @@ $ set schema={
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-dummy,1,0,0,0
+"dummy,1,0,0,0"
 
 $ kafka-create-topic topic=data
 
@@ -92,8 +92,8 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-testdrive-data-${testdrive.seed},1,0,1,1
-testdrive-data2-${testdrive.seed},1,0,1,4
+"testdrive-data-${testdrive.seed},1,0,1,1"
+"testdrive-data2-${testdrive.seed},1,0,1,4"
 
 > SELECT * FROM view_byo
 b  sum
@@ -107,7 +107,7 @@ b  sum
 2  1
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=2
-testdrive-data-${testdrive.seed},1,0,2,4
+"testdrive-data-${testdrive.seed},1,0,2,4"
 
 > SELECT * FROM view2_byo
 b  sum
@@ -119,7 +119,7 @@ b  sum
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=2
-testdrive-data3-${testdrive.seed},1,0,10,0
+"testdrive-data3-${testdrive.seed},1,0,10,0"
 
 > SELECT * FROM view_empty
 a a


### PR DESCRIPTION
Carved out the testdrive portion from #2493. 

Due to a prospect request, we want to support plain-string keys for log-compacted kafka topics in addition to avro keys.

Manually verified using kafka-avro-console-consumer that correct log-compacted kafka topics were produced.