### PR TITLE
coord,sql: tail IDs, not catalog entries

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -637,7 +637,7 @@ where
                 session,
             ),
 
-            Plan::Tail(source) => tx.send(self.sequence_tail(conn_id, source), session),
+            Plan::Tail(id) => tx.send(self.sequence_tail(conn_id, id), session),
 
             Plan::SendRows(rows) => tx.send(Ok(send_immediate_rows(rows)), session),
 
@@ -1195,9 +1195,8 @@ where
     fn sequence_tail(
         &mut self,
         conn_id: u32,
-        source: catalog::CatalogEntry,
+        source_id: GlobalId,
     ) -> Result<ExecuteResponse, failure::Error> {
-        let source_id = source.id();
         let index_id = if let Some(Some((index_id, _))) = self
             .views
             .get(&source_id)

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -13,7 +13,7 @@
 
 use ::expr::GlobalId;
 use catalog::names::{DatabaseSpecifier, FullName};
-use catalog::{Catalog, CatalogEntry};
+use catalog::Catalog;
 use dataflow_types::{PeekWhen, RowSetFinishing, SinkConnectorBuilder, SourceConnector};
 use repr::{RelationDesc, Row, ScalarType};
 use sql_parser::parser::Parser as SqlParser;
@@ -103,7 +103,7 @@ pub enum Plan {
         finishing: RowSetFinishing,
         materialize: bool,
     },
-    Tail(CatalogEntry),
+    Tail(GlobalId),
     SendRows(Vec<Row>),
     ExplainPlan(::expr::RelationExpr, ExplainOptions),
     SendDiffs {

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -309,9 +309,8 @@ fn handle_tail(scx: &StatementContext, from: ObjectName) -> Result<Plan, failure
     let from = scx.resolve_name(from)?;
     let entry = scx.catalog.get(&from)?;
     match entry.item() {
-        CatalogItem::View(_) => Ok(Plan::Tail(entry.clone())),
-        CatalogItem::Source(_) => Ok(Plan::Tail(entry.clone())),
-        _ => bail!(
+        CatalogItem::Source(_) | CatalogItem::View(_) => Ok(Plan::Tail(entry.id())),
+        CatalogItem::Index(_) | CatalogItem::Sink(_) => bail!(
             "'{}' cannot be tailed because it is a {}",
             from,
             entry.item().type_string()


### PR DESCRIPTION
Returning a CatalogEntry in a sql::Plan is strange, since it could get
out of sync with the entry in the actual catalog. Since only the ID is
needed, I think it's cleaner and cheaper to pass around the GlobalId
instead.

Also make a match statement exhaustive while I'm in here, just to
future-proof the code. If we ever get a new type of tailable object,
it'll be harder to forget about it.