### PR TITLE
Parse and validate upsert envelope command.

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -186,7 +186,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                 read_style,
                                 ctor,
                             );
-                            (decode_avro_values(&source, envelope), capability)
+                            (decode_avro_values(&source, &envelope), capability)
                         } else {
                             let (source, capability) = match connector {
                                 ExternalSourceConnector::Kafka(c) => {
@@ -258,7 +258,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                             };
                             // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
                             // a hypothetical future avro_extract, protobuf_extract, etc.
-                            let stream = decode(&source, encoding, &dataflow.debug_name, envelope);
+                            let stream = decode(&source, encoding, &dataflow.debug_name, &envelope);
 
                             (stream, capability)
                         };
@@ -273,6 +273,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                 Some((Row::pack(datums.into_iter()), diff))
                             })
                         }
+                        Envelope::Upsert(_) => unreachable!("Upsert is not supported yet"),
                     };
 
                     // Introduce the stream by name, as an unarranged collection.

--- a/src/repr/relation.rs
+++ b/src/repr/relation.rs
@@ -184,10 +184,10 @@ impl RelationDesc {
 
     pub fn add_cols<I, N>(&mut self, cols: I)
     where
-        I: IntoIterator<Item = (ColumnType, Option<N>)>,
+        I: IntoIterator<Item = (Option<N>, ColumnType)>,
         N: Into<ColumnName>,
     {
-        for (typ, name) in cols.into_iter() {
+        for (name, typ) in cols.into_iter() {
             self.typ.column_types.push(typ);
             self.names.push(name.map(Into::into));
         }

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -586,10 +586,11 @@ pub enum Format {
     Text,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Envelope {
     None,
     Debezium,
+    Upsert(Option<Format>),
 }
 
 impl Default for Envelope {
@@ -600,14 +601,22 @@ impl Default for Envelope {
 
 impl fmt::Display for Envelope {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::None => "NONE", // this is unreachable as long as the default is None, but include it in case we ever change that
-                Self::Debezium => "DEBEZIUM",
+        match self {
+            Self::None => {
+                // this is unreachable as long as the default is None, but include it in case we ever change that
+                write!(f, "NONE")?;
             }
-        )
+            Self::Debezium => {
+                write!(f, "DEBEZIUM")?;
+            }
+            Self::Upsert(format) => {
+                write!(f, "UPSERT")?;
+                if let Some(format) = format {
+                    write!(f, " FORMAT {}", format)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -386,8 +386,10 @@ macro_rules! make_visitor {
 
             fn visit_source_envelope(
                 &mut self,
-                _envelope: &'ast $($mut)* Envelope,
-            ) { }
+                envelope: &'ast $($mut)* Envelope,
+            ) {
+                visit_source_envelope(self, envelope)
+            }
 
             fn visit_avro_schema(
                 &mut self,
@@ -1387,6 +1389,16 @@ macro_rules! make_visitor {
                     visitor.visit_schema(schema);
                 },
                 Regex(regex) => visitor.visit_literal_string(regex),
+            }
+        }
+
+        fn visit_source_envelope<'ast, V: $name<'ast> + ?Sized>(
+            visitor: &mut V,
+            envelope: &'ast $($mut)* Envelope,
+        ) {
+            use Envelope::*;
+            if let Upsert(Some(format)) = envelope {
+                visitor.visit_format(format);
             }
         }
 

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -465,6 +465,7 @@ define_keywords!(
     UNKNOWN,
     UNNEST,
     UPDATE,
+    UPSERT,
     UPPER,
     USER,
     USING,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1257,8 +1257,19 @@ impl Parser {
             Envelope::None
         } else if self.parse_keyword("DEBEZIUM") {
             Envelope::Debezium
+        } else if self.parse_keyword("UPSERT") {
+            let format = if self.parse_keyword("FORMAT") {
+                Some(self.parse_format()?)
+            } else {
+                None
+            };
+            Envelope::Upsert(format)
         } else {
-            return self.expected(self.peek_range(), "NONE or DEBEZIUM", self.peek_token());
+            return self.expected(
+                self.peek_range(),
+                "NONE, DEBEZIUM, or UPSERT",
+                self.peek_token(),
+            );
         };
         Ok(envelope)
     }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -3411,6 +3411,50 @@ fn parse_create_source_default_envelope() {
 }
 
 #[test]
+fn parse_create_source_upsert_envelope() {
+    let sql = "CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' \
+    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' \
+    ENVELOPE UPSERT";
+    match verified_stmt(sql) {
+        Statement::CreateSource { envelope, .. } => {
+            assert_eq!(Envelope::Upsert(None), envelope);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_source_upsert_envelope_format_avro() {
+    let sql = "CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' \
+    FORMAT AVRO USING SCHEMA 'string' \
+    ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'";
+    match verified_stmt(sql) {
+        Statement::CreateSource { envelope, .. } => {
+            assert_eq!(
+                Envelope::Upsert(Some(Format::Avro(AvroSchema::Schema(Schema::Inline(
+                    "long".into()
+                ))))),
+                envelope
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_source_upsert_envelope_format_text() {
+    let sql = "CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' \
+    FORMAT AVRO USING SCHEMA FILE 'path' \
+    ENVELOPE UPSERT FORMAT TEXT";
+    match verified_stmt(sql) {
+        Statement::CreateSource { envelope, .. } => {
+            assert_eq!(Envelope::Upsert(Some(Format::Text)), envelope);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
 fn parse_create_source_if_not_exists() {
     let sql = "CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES";
     match verified_stmt(sql) {

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -51,7 +51,7 @@ enum Encoder {
 }
 
 impl Encoder {
-    fn decode_into_buf(&self, row: &str, buf: &mut Vec<u8>) -> Result<(), String> {
+    fn encode_to_bytes(&self, row: &str, buf: &mut Vec<u8>) -> Result<(), String> {
         match self {
             Encoder::Avro { schema, schema_id } => {
                 let val = crate::format::avro::json_to_avro(
@@ -238,9 +238,9 @@ impl Action for IngestAction {
                 (None, row.clone())
             };
 
-            value_encoder.decode_into_buf(&val_row, &mut val_buf)?;
+            value_encoder.encode_to_bytes(&val_row, &mut val_buf)?;
             if let Some(key_encoder) = &key_encoder {
-                key_encoder.decode_into_buf(&key_row.unwrap(), &mut key_buf)?;
+                key_encoder.encode_to_bytes(&key_row.unwrap(), &mut key_buf)?;
             }
 
             let mut record: FutureRecord<_, _> = FutureRecord::to(&topic_name)


### PR DESCRIPTION
Carved out the sql-parsing and validation portion of #2493 

Note that currently, for the sake of flexibility, I allow support for keys involving arbitrary numbers of columns, but I could take that out if we do not think it is necessary/if we think there would be an improvement benefit from forbidding multi-column keys.

In `src/repr`, changed RelationDesc::add_cols to take IntoIterator<Item = (Option<N>, ColumnType)> instead of IntoIterator<Item = (ColumnType, Option<N>)> because I got annoyed at how it did not line up with the return value ofRelationDesc::iter, which is `Iterator<Item = (Option<&ColumnName>, &ColumnType)>`.

As mentioned in the comment of #1575, the upsert envelope syntax is `CREATE [MATERIALIZED] SOURCE yadda ... yadda ... ENVELOPE UPSERT [FORMAT {TEXT | AVRO USING SCHEMA yadda ... yadda}]`
