### PR TITLE
Include debug symbols in .deb packages.

### DIFF
--- a/ci/test/build.sh
+++ b/ci/test/build.sh
@@ -104,7 +104,7 @@ if [[ "$BUILDKITE_BRANCH" = master ]]; then
     ci_collapsed_heading "Building .deb package"
     # shellcheck disable=SC2016
     # TODO (brennan) - fix this version number
-    docker_run 'cargo-deb --deb-version 0.1.0-$(git rev-list HEAD | wc -l)-$(git rev-parse HEAD) -p materialized -o target/debian/materialized.deb'
+    docker_run 'cargo-deb --no-strip --deb-version 0.1.0-$(git rev-list HEAD | wc -l)-$(git rev-parse HEAD) -p materialized -o target/debian/materialized.deb'
     aws s3 cp \
         --acl=public-read \
         target/debian/materialized.deb \

--- a/doc/developer/release-checklist.md
+++ b/doc/developer/release-checklist.md
@@ -119,7 +119,7 @@ production readiness.
     must not include the `v` prefix.
 
     ```shell
-    bin/ci-builder run stable cargo-deb -p materialized --deb-version <VERSION-NO-V>
+    bin/ci-builder run stable cargo-deb --no-strip -p materialized --deb-version <VERSION-NO-V>
     ```
 
     Upload the resulting `.deb` file to [GemFury](https://fury.io) by dragging-


### PR DESCRIPTION
We estimate that on Bintray this will cost us <= $50/mo, assuming we purge unstable files that are more than a month old. The improved crash reports it will enable seem clearly worth it.