### PR TITLE
Support default codecs in avro ocf files

### DIFF
--- a/src/avro/reader.rs
+++ b/src/avro/reader.rs
@@ -121,22 +121,20 @@ impl<R: AsyncRead + Unpin + Send> Block<R> {
 
             self.codec = meta
                 .get("avro.codec")
-                .ok_or_else(|| DecodeError::new("unable to parse codec: 'avro.codec' missing"))
-                .and_then(|codec| {
-                    if let Value::Bytes(ref bytes) = *codec {
-                        from_utf8(bytes.as_ref())
-                            .map_err(|e| DecodeError::new(format!("unable to decode codec: {}", e)))
-                    } else {
-                        Err(DecodeError::new(format!(
-                            "unable to parse codec: expected bytes, got: {:?}",
-                            codec
-                        )))
-                    }
+                .map(|val| match val {
+                    Value::Bytes(ref bytes) => from_utf8(bytes.as_ref())
+                        .map_err(|e| DecodeError::new(format!("unable to decode codec: {}", e)))
+                        .and_then(|codec| {
+                            Codec::from_str(codec).map_err(|_| {
+                                DecodeError::new(format!("unrecognized codec '{}'", codec))
+                            })
+                        }),
+                    codec => Err(DecodeError::new(format!(
+                        "unable to parse codec: expected bytes, got: {:?}",
+                        codec
+                    ))),
                 })
-                .and_then(|codec| {
-                    Codec::from_str(codec)
-                        .map_err(|_| DecodeError::new(format!("unrecognized codec '{}'", codec)))
-                })?;
+                .unwrap_or(Ok(Codec::Null))?;
         } else {
             return Err(DecodeError::new("no metadata in header").into());
         }

--- a/test/testdrive/avro-ocf.td
+++ b/test/testdrive/avro-ocf.td
@@ -16,7 +16,7 @@ $ set writer-schema={
     ]
   }
 
-$ avro-ocf-write path=data.ocf schema=${writer-schema}
+$ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
 {"a": 1, "b": 2}
 {"a": 3, "b": 4}
 
@@ -30,6 +30,26 @@ a  b  mz_obj_no
 3  4  2
 
 > SHOW COLUMNS FROM basic
+Field      Nullable  Type
+-------------------------
+a          NO        int8
+b          NO        int4
+mz_obj_no  NO        int8
+
+$ avro-ocf-write path=data-no-codec.ocf schema=${writer-schema}
+{"a": 1, "b": 2}
+{"a": 3, "b": 4}
+
+> CREATE MATERIALIZED SOURCE basic_no_codec
+  FROM AVRO OCF '${testdrive.temp-dir}/data-no-codec.ocf'
+
+> SELECT * FROM basic_no_codec
+a  b  mz_obj_no
+---------------
+1  2  1
+3  4  2
+
+> SHOW COLUMNS FROM basic_no_codec
 Field      Nullable  Type
 -------------------------
 a          NO        int8


### PR DESCRIPTION
From the docs:

> avro.codec ... If codec is absent, it is assumed to be “null”.

https://avro.apache.org/docs/current/spec.html#Object+Container+Files