### PR TITLE
Use timestamp zero for tails of unmaterialized sources/views

### DIFF
--- a/doc/user/sql/tail.md
+++ b/doc/user/sql/tail.md
@@ -1,13 +1,16 @@
 ---
 title: "TAIL"
-description: "`TAIL` streams updates that occur to a materialized view."
+description: "`TAIL` continually reports updates that occur to a source or view."
 menu:
     main:
         parent: "sql"
 ---
 
-`TAIL` streams updates that occur to a materialized view. This data only
-represents updates that occur after running the `TAIL` command.
+`TAIL` continually reports updates that occur to a source or view.
+For materialized sources or views this data only represents updates that occur after running the `TAIL` command.
+For non-materialized sources or views, all updates are presented.
+
+Tail will continue to run until cancelled, or until all updates the tailed item could undergo have been presented. The latter case may happen with static views (e.g. `SELECT true`), files without the `tail = true` modifier, or other settings in which a collection can cease to experience updates.
 
 ## Syntax
 
@@ -15,7 +18,7 @@ represents updates that occur after running the `TAIL` command.
 
 Field | Use
 ------|-----
-_object&lowbar;name_ | The item you want to tail; the item must be materialized (i.e. [materialized view](../create-materialized-view) or [materialized source](../create-source))
+_object&lowbar;name_ | The item you want to tail
 
 ## Details
 

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1211,14 +1211,20 @@ where
         conn_id: u32,
         source_id: GlobalId,
     ) -> Result<ExecuteResponse, failure::Error> {
-        let index_id = if let Some(Some((index_id, _))) = self
+        // Determine the frontier of updates to tail *from*.
+        // Updates greater or equal to this frontier will be produced.
+        let since = if let Some(Some((index_id, _))) = self
             .views
             .get(&source_id)
             .map(|view_state| &view_state.default_idx)
         {
-            index_id
+            self.upper_of(index_id)
+                .expect("name missing at coordinator")
+                .get(0)
+                .copied()
+                .unwrap_or(Timestamp::max_value())
         } else {
-            bail!("Cannot tail a view that has not been materialized.")
+            0 as Timestamp
         };
 
         let sink_name = format!(
@@ -1230,12 +1236,6 @@ where
         let sink_id = self.catalog.allocate_id()?;
         self.active_tails.insert(conn_id, sink_id);
         let (tx, rx) = self.switchboard.mpsc_limited(self.num_timely_workers);
-        let since = self
-            .upper_of(index_id)
-            .expect("name missing at coordinator")
-            .get(0)
-            .copied()
-            .unwrap_or(Timestamp::max_value());
         self.create_sink_dataflow(
             sink_name,
             sink_id,

--- a/src/dataflow/sink/tail.rs
+++ b/src/dataflow/sink/tail.rs
@@ -31,7 +31,7 @@ pub fn tail<G>(
         input.for_each(|_, rows| {
             let mut results: Vec<Update> = Vec::new();
             for (row, time, diff) in rows.iter() {
-                if connector.since.less_than(time) {
+                if connector.since.less_equal(time) {
                     results.push(Update {
                         row: row.clone(),
                         timestamp: *time,


### PR DESCRIPTION
This PR changes the behavior on TAIL requests for collections that are not materialized. Previously, we would error as we could not determine a time to tail *from*. Now, we use zero as the time.

This PR isn't ready to land, for reasons including it isn't clear that we want to do this (probably fine), and there aren't any tests yet (will have to skill up on the right way to test TAIL; I'm sure there are examples I can read!).

fixes #2519