### PR TITLE
sql: support the FILTER aggregate clause

### DIFF
--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -1314,6 +1314,8 @@ impl fmt::Display for Assignment {
 pub struct Function {
     pub name: ObjectName,
     pub args: Vec<Expr>,
+    // aggregate functions may specify e.g. `COUNT(DISTINCT X) FILTER (WHERE ...)`
+    pub filter: Option<Box<Expr>>,
     pub over: Option<WindowSpec>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,
@@ -1328,6 +1330,9 @@ impl fmt::Display for Function {
             if self.distinct { "DISTINCT " } else { "" },
             display_comma_separated(&self.args),
         )?;
+        if let Some(filter) = &self.filter {
+            write!(f, " FILTER (WHERE {})", filter)?;
+        }
         if let Some(o) = &self.over {
             write!(f, " OVER ({})", o)?;
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -354,6 +354,15 @@ impl Parser {
             );
         }
         let args = self.parse_optional_args()?;
+        let filter = if self.parse_keyword("FILTER") {
+            self.expect_token(&Token::LParen)?;
+            self.expect_keyword("WHERE")?;
+            let expr = self.parse_expr()?;
+            self.expect_token(&Token::RParen)?;
+            Some(Box::new(expr))
+        } else {
+            None
+        };
         let over = if self.parse_keyword("OVER") {
             // TBD: support window names (`OVER mywin`) in place of inline specification
             self.expect_token(&Token::LParen)?;
@@ -388,6 +397,7 @@ impl Parser {
         Ok(Expr::Function(Function {
             name,
             args,
+            filter,
             over,
             distinct,
         }))

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -371,6 +371,23 @@ fn parse_select_count_wildcard() {
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("COUNT")]),
             args: vec![Expr::Wildcard],
+            filter: None,
+            over: None,
+            distinct: false,
+        }),
+        expr_from_projection(only(&select.projection))
+    );
+}
+
+#[test]
+fn parse_select_count_filter() {
+    let sql = "SELECT COUNT(*) FILTER (WHERE foo) FROM customer";
+    let select = verified_only_select(sql);
+    assert_eq!(
+        &Expr::Function(Function {
+            name: ObjectName(vec![Ident::new("COUNT")]),
+            args: vec![Expr::Wildcard],
+            filter: Some(Box::new(Expr::Identifier(Ident::new("foo")))),
             over: None,
             distinct: false,
         }),
@@ -389,6 +406,7 @@ fn parse_select_count_distinct() {
                 op: UnaryOperator::Plus,
                 expr: Box::new(Expr::Identifier(Ident::new("x")))
             }],
+            filter: None,
             over: None,
             distinct: true,
         }),
@@ -961,8 +979,9 @@ fn parse_select_having() {
             left: Box::new(Expr::Function(Function {
                 name: ObjectName(vec![Ident::new("COUNT")]),
                 args: vec![Expr::Wildcard],
+                filter: None,
                 over: None,
-                distinct: false
+                distinct: false,
             })),
             op: BinaryOperator::Gt,
             right: Box::new(Expr::Value(number("1")))
@@ -1294,6 +1313,7 @@ fn parse_scalar_function_in_projection() {
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("sqrt")]),
             args: vec![Expr::Identifier(Ident::new("id"))],
+            filter: None,
             over: None,
             distinct: false,
         }),
@@ -1317,6 +1337,7 @@ fn parse_window_functions() {
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::new("row_number")]),
             args: vec![],
+            filter: None,
             over: Some(WindowSpec {
                 partition_by: vec![],
                 order_by: vec![OrderByExpr {
@@ -1672,6 +1693,7 @@ fn parse_delimited_identifiers() {
         &Expr::Function(Function {
             name: ObjectName(vec![Ident::with_quote('"', "myfun")]),
             args: vec![],
+            filter: None,
             over: None,
             distinct: false,
         }),

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -84,3 +84,67 @@ query RRRRRR
 SELECT variance(a), var_samp(a), var_pop(a), stddev(a), stddev_samp(a), stddev_pop(a) FROM t2
 ----
 0.9166666666666666  0.9166666666666666  0.6875  0.9574271077563381  0.9574271077563381  0.82915619758885
+
+# TODO(benesch): these filter tests are copied from cockroach/aggregate.slt;
+# remove them from here when we can run that file in its entirely.
+
+statement ok
+CREATE TABLE filter_test (
+  k INT,
+  v INT,
+  mark BOOL
+)
+
+statement OK
+INSERT INTO filter_test VALUES
+(1, 2, false),
+(3, 4, true),
+(5, NULL, true),
+(6, 2, true),
+(7, 2, true),
+(8, 4, true),
+(NULL, 4, true)
+
+# FILTER should eliminate some results.
+query II rowsort
+SELECT v, count(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
+----
+2 2
+4 1
+NULL 0
+
+# Test multiple filters
+query IBIII rowsort
+SELECT v, mark, count(*) FILTER (WHERE k > 5), count(*), max(k) FILTER (WHERE k < 8) FROM filter_test GROUP BY v, mark
+----
+2 false 0 1 1
+2 true 2 2 7
+4 true 1 3 3
+NULL true 0 1 5
+
+query error FILTER specified but abs\(\) is not an aggregate function
+SELECT abs(1) FILTER (WHERE false)
+
+query error syntax error at or near "filter"
+SELECT column1 FILTER (WHERE column1 = 1) FROM (VALUES (1))
+
+query error aggregate functions are not allowed in FILTER
+SELECT v, count(*) FILTER (WHERE count(*) > 5) FROM filter_test GROUP BY v
+
+# These filter tests are Materialize-specific.
+
+# Test avg, which needs to propgate the filter through its implementation.
+query IR rowsort
+SELECT v, avg(k) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
+----
+2 6.500000
+4 8.000000
+NULL NULL
+
+# Similarly for variance and stddev.
+query IRR rowsort
+SELECT v, variance(k) FILTER (WHERE k > 5), stddev(k) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
+----
+2     0.500000000000  0.707106781186
+4     NULL            NULL
+NULL  NULL            NULL


### PR DESCRIPTION
FILTER allows filtering rows out of an aggregate function on a
per-invocation basis. The approach taken is to rewrite an expression of
the form

    agg(input) FILTER (condition)

as:

    agg(CASE WHEN condition THEN input ELSE NULL)

A bit of special care is required with count(*), which is described
within the patch.

Fix #2504.