### PR TITLE
sql: support naming columns in create source

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -389,26 +389,16 @@ impl DataEncoding {
                         .collect(),
                 )
             }
-            DataEncoding::Csv(CsvEncoding {
-                n_cols, col_names, ..
-            }) => {
-                let cols = match col_names {
-                    Some(col_names) => col_names
-                        .iter()
-                        .map(|v| (ColumnType::new(ScalarType::String), Some(v.to_string())))
-                        .collect(),
-                    None => (1..=*n_cols)
-                        .map(|i| {
-                            (
-                                ColumnType::new(ScalarType::String),
-                                Some(format!("column{}", i)),
-                            )
-                        })
-                        .collect(),
-                };
-
-                RelationDesc::from_cols(cols)
-            }
+            DataEncoding::Csv(CsvEncoding { n_cols, .. }) => RelationDesc::from_cols(
+                (1..=*n_cols)
+                    .map(|i| {
+                        (
+                            ColumnType::new(ScalarType::String),
+                            Some(format!("column{}", i)),
+                        )
+                    })
+                    .collect(),
+            ),
             DataEncoding::Text => RelationDesc::from_cols(vec![(
                 ColumnType::new(ScalarType::String),
                 Some("text".to_owned()),
@@ -432,7 +422,6 @@ pub struct AvroEncoding {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CsvEncoding {
     pub header_row: bool,
-    pub col_names: Option<Vec<String>>,
     pub n_cols: usize,
     pub delimiter: u8,
 }

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -755,6 +755,7 @@ pub enum Statement {
     /// `CREATE SOURCE`
     CreateSource {
         name: ObjectName,
+        col_names: Vec<Ident>,
         connector: Connector,
         with_options: Vec<SqlOption>,
         format: Option<Format>,
@@ -1013,6 +1014,7 @@ impl fmt::Display for Statement {
             }
             Statement::CreateSource {
                 name,
+                col_names,
                 connector,
                 with_options,
                 format,
@@ -1028,7 +1030,11 @@ impl fmt::Display for Statement {
                 if *if_not_exists {
                     write!(f, "IF NOT EXISTS ")?;
                 }
-                write!(f, "{} FROM {}", name, connector,)?;
+                write!(f, "{} ", name)?;
+                if !col_names.is_empty() {
+                    write!(f, "({}) ", display_comma_separated(col_names))?;
+                }
+                write!(f, "FROM {}", connector,)?;
                 if !with_options.is_empty() {
                     write!(f, " WITH ({})", display_comma_separated(with_options))?;
                 }

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -359,6 +359,7 @@ macro_rules! make_visitor {
             fn visit_create_source(
                 &mut self,
                 name: &'ast $($mut)* ObjectName,
+                col_names: &'ast $($mut)* [Ident],
                 connector: &'ast $($mut)* Connector,
                 with_options: &'ast $($mut)* [SqlOption],
                 format: Option<&'ast $($mut)* Format>,
@@ -366,7 +367,7 @@ macro_rules! make_visitor {
                 if_not_exists: bool,
                 materialized: bool,
             ) {
-                visit_create_source(self, name, connector, with_options, format, envelope, if_not_exists, materialized)
+                visit_create_source(self, name, col_names, connector, with_options, format, envelope, if_not_exists, materialized)
             }
 
             fn visit_connector(
@@ -675,13 +676,14 @@ macro_rules! make_visitor {
                 }
                 Statement::CreateSource {
                     name,
+                    col_names,
                     connector,
                     with_options,
                     format,
                     envelope,
                     if_not_exists,
                     materialized,
-                } => visitor.visit_create_source(name, connector, with_options, format.as_auto_ref(), envelope, *if_not_exists, *materialized),
+                } => visitor.visit_create_source(name, col_names, connector, with_options, format.as_auto_ref(), envelope, *if_not_exists, *materialized),
                 Statement::CreateSink {
                     name,
                     from,
@@ -1332,6 +1334,7 @@ macro_rules! make_visitor {
         pub fn visit_create_source<'ast, V: $name<'ast> + ?Sized>(
             visitor: &mut V,
             name: &'ast $($mut)* ObjectName,
+            col_names: &'ast $($mut)* [Ident],
             connector: &'ast $($mut)* Connector,
             with_options: &'ast $($mut)* [SqlOption],
             format: Option<&'ast $($mut)* Format>,
@@ -1340,6 +1343,9 @@ macro_rules! make_visitor {
             _materialized: bool,
         ) {
             visitor.visit_object_name(name);
+            for column in col_names {
+                visitor.visit_ident(column);
+            }
             visitor.visit_connector(connector);
             for option in with_options {
                 visitor.visit_option(option);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1258,6 +1258,7 @@ impl Parser {
         self.expect_keyword("SOURCE")?;
         let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_object_name()?;
+        let col_names = self.parse_parenthesized_column_list(Optional)?;
         self.expect_keyword("FROM")?;
         let connector = self.parse_connector()?;
         let with_options = self.parse_with_options()?;
@@ -1274,6 +1275,7 @@ impl Parser {
 
         Ok(Statement::CreateSource {
             name,
+            col_names,
             connector,
             with_options,
             format,

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -169,6 +169,7 @@ pub fn create_statement(
     match &mut stmt {
         Statement::CreateSource {
             name,
+            col_names,
             connector: _,
             with_options: _,
             format: _,
@@ -177,6 +178,9 @@ pub fn create_statement(
             materialized,
         } => {
             *name = allocate_name(name)?;
+            for c in col_names {
+                norm_ident(c);
+            }
             *if_not_exists = false;
             *materialized = false;
         }

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -872,6 +872,7 @@ fn handle_create_view(
 
 pub async fn purify_statement(mut stmt: Statement) -> Result<Statement, failure::Error> {
     if let Statement::CreateSource {
+        col_names,
         connector,
         format,
         with_options,
@@ -934,26 +935,25 @@ pub async fn purify_statement(mut stmt: Statement) -> Result<Statement, failure:
                     *schema = sql_parser::ast::Schema::Inline(buf);
                 }
             }
-            Some(Format::Csv { header_row, .. }) => {
-                if *header_row {
+            Some(Format::Csv {
+                header_row,
+                delimiter,
+                ..
+            }) => {
+                if *header_row && col_names.is_empty() {
                     match connector {
                         Connector::File { path } => {
-                            if !with_options_map.contains_key("col_names") {
-                                let path = path.clone();
-                                let f = tokio::fs::File::open(path).await?;
-                                let f = tokio::io::BufReader::new(f);
-                                let csv_header = f.lines().next_line().await?;
-                                match csv_header {
-                                    Some(csv_header) => {
-                                        with_options.push(sql_parser::ast::SqlOption {
-                                            name: sql_parser::ast::Ident::new("col_names"),
-                                            value: sql_parser::ast::Value::SingleQuotedString(
-                                                csv_header,
-                                            ),
-                                        });
-                                    }
-                                    None => bail!("CSV file expected header line, but is empty"),
+                            let path = path.clone();
+                            let f = tokio::fs::File::open(path).await?;
+                            let f = tokio::io::BufReader::new(f);
+                            let csv_header = f.lines().next_line().await?;
+                            match csv_header {
+                                Some(csv_header) => {
+                                    csv_header
+                                        .split(*delimiter as char)
+                                        .for_each(|v| col_names.push(Ident::from(v)));
                                 }
+                                None => bail!("CSV file expected header line, but is empty"),
                             }
                         }
                         _ => bail!("CSV format with headers only works with file connectors"),
@@ -970,6 +970,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
     match &stmt {
         Statement::CreateSource {
             name,
+            col_names,
             connector,
             with_options,
             format,
@@ -982,7 +983,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                 sql_parser::ast::Envelope::Debezium => dataflow_types::Envelope::Debezium,
             };
 
-            let get_encoding = |mut with_options: std::collections::HashMap<String, Value>| {
+            let get_encoding = || {
                 let format = format
                     .as_ref()
                     .ok_or_else(|| format_err!("Source format must be specified"))?;
@@ -1052,39 +1053,17 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         n_cols,
                         delimiter,
                     } => {
-                        let (col_names, n_cols) = match with_options.remove("col_names") {
-                            Some(Value::SingleQuotedString(s)) => {
-                                let col_names: Vec<String> =
-                                    s.split(*delimiter as char).map(|v| v.to_string()).collect();
-                                let n_cols_derived = col_names.len();
-                                // If user specified number of columns, ensure it matches the
-                                // number of names provided.
-                                if let Some(n_cols) = n_cols {
-                                    if *n_cols != n_cols_derived {
-                                        bail!(
-                                            "Provided names for {} columns, but specified {} columns \
-                                             when creating source",
-                                            n_cols_derived,
-                                            n_cols
-                                        )
-                                    }
-                                };
-                                (Some(col_names), n_cols_derived)
+                        let n_cols = if col_names.is_empty() {
+                            match n_cols {
+                                Some(n) => *n,
+                                None => bail!("Cannot determine number of columns in CSV source; specify using \
+                                CREATE SOURCE...FORMAT CSV WITH X COLUMNS")
                             }
-                            _ => {
-                                match n_cols {
-                                    Some(n_cols) => (None, *n_cols),
-                                    None => bail!(
-                                        "Cannot determine number of columns in CSV source; specify using \
-                                        CREATE SOURCE...FORMAT CSV WITH X COLUMNS"
-                                    )
-                                }
-                            },
+                        } else {
+                            col_names.len()
                         };
-
                         DataEncoding::Csv(CsvEncoding {
                             header_row: *header_row,
-                            col_names,
                             n_cols,
                             delimiter: match *delimiter as u32 {
                                 0..=127 => *delimiter as u8,
@@ -1118,7 +1097,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         topic: topic.clone(),
                         ssl_certificate_file,
                     });
-                    let encoding = get_encoding(with_options)?;
+                    let encoding = get_encoding()?;
                     (connector, encoding)
                 }
                 Connector::Kinesis { arn, .. } => {
@@ -1177,7 +1156,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         access_key,
                         secret_access_key,
                     });
-                    let encoding = get_encoding(with_options)?;
+                    let encoding = get_encoding()?;
                     (connector, encoding)
                 }
                 Connector::File { path, .. } => {
@@ -1190,7 +1169,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         path: path.clone().into(),
                         tail,
                     });
-                    let encoding = get_encoding(with_options)?;
+                    let encoding = get_encoding()?;
                     (connector, encoding)
                 }
                 Connector::AvroOcf { path, .. } => {
@@ -1219,6 +1198,21 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             };
 
             let mut desc = encoding.desc(envelope)?;
+
+            let typ = desc.typ();
+            if !col_names.is_empty() {
+                if col_names.len() != typ.column_types.len() {
+                    bail!(
+                        "SOURCE definition has {} columns, but expected {} columns",
+                        col_names.len(),
+                        typ.column_types.len()
+                    )
+                }
+                for (i, name) in col_names.iter().enumerate() {
+                    desc.set_name(i, Some(normalize::column_name(name.clone())));
+                }
+            }
+
             // TODO(benesch): the available metadata columns should not depend
             // on the format.
             match encoding {

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -32,3 +32,13 @@ data           mz_offset
 > select convert_from(data, 'utf8') FROM data
 ©1
 ©2
+
+> CREATE MATERIALIZED SOURCE data_named_col (named_col)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
+  FORMAT BYTES
+
+> SHOW COLUMNS FROM data_named_col
+Field      Nullable  Type
+--------------------------
+named_col       NO        bytea
+mz_offset  NO        int8

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -39,8 +39,8 @@ Rochester      NY        14618   2
 "bad,place\""  CA        92679   4
 
 # Static CSV with manual headers.
-> CREATE MATERIALIZED SOURCE static_csv_manual_header
-  FROM FILE '${testdrive.temp-dir}/static.csv' WITH (col_names='city_man,state_man,zip_man')
+> CREATE MATERIALIZED SOURCE static_csv_manual_header (city_man, state_man, zip_man)
+  FROM FILE '${testdrive.temp-dir}/static.csv'
   FORMAT CSV WITH HEADER
 
 > SELECT * FROM static_csv_manual_header

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -38,3 +38,25 @@ ip            ts                      path                                      
 search_kw
 ------------------
 helper+ins+hennaed
+
+> CREATE MATERIALIZED SOURCE regex_source_named_cols (ip, ts, path, search_kw, product_detail_id, code)
+  FROM FILE '${testdrive.temp-dir}/request.log'
+  FORMAT REGEX '(?P<foo1>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<foo2>[^]]+)\] "(?P<foo3>(?:GET /search/\?kw=(?P<foo4>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<foo5>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<foo6>\d{3}) -'
+
+> SHOW COLUMNS FROM regex_source_named_cols
+Field              Nullable  Type
+---------------------------------
+ip                 YES       text
+ts                 YES       text
+path               YES       text
+search_kw          YES       text
+product_detail_id  YES       text
+code               YES       text
+mz_line_no         NO        int8
+
+> SELECT * FROM regex_source_named_cols ORDER BY mz_line_no
+ip            ts                      path                                           search_kw           product_detail_id  code  mz_line_no
+--------------------------------------------------------------------------------------------------------------------------------------------
+123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
+8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3


### PR DESCRIPTION
To fix #2510, removed `col_names` from `WITH` options, and now support naming columns when creating sources, e.g. `CREATE SOURCE foo (bar, baz)` which names two columns `bar` and `baz`.

This works on all ad-hoc formatted sources, but does not work on either Protobuf or Avro, where we derive the column names.

Internally, this is accomplished by passing around a `Vec<Ident>` on the `CreateSource` statement representing the column names.
- Really this should be an `Option<Vec<Ident>>` but `parse_parenthesized_column_list` returns `Vec<Ident>` and all of the other statements using this function similarly accept their fate as potentially having empty vecs. I'd be glad to refactor `parse_parenthesized_column_list` to more properly express its optionality.

Fix #2510 