### PR TITLE
Remove Gemfury deb deploy

### DIFF
--- a/ci/deploy/deb.sh
+++ b/ci/deploy/deb.sh
@@ -14,19 +14,11 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-the_deb="s3://downloads.mtrlz.dev/materialized-$MATERIALIZED_IMAGE_ID-x86_64.deb"
-echo "Downloading deb from s3: $the_deb"
-aws s3 cp \
-    "$the_deb" \
-    ./materialized.deb
-
-curl -F package=@materialized.deb https://"$FURY_APT_PUSH_SECRET"@push.fury.io/materialize
-
 # Publish version that was already uploaded to Bintray
 # in ci/test/build.sh
-COMMIT_INDEX=$(git rev-list HEAD | wc -l)
-COMMIT_HASH=$(git rev-parse HEAD)
-upload="https://api.bintray.com/content/materialize/apt/materialized-unstable/dev-$COMMIT_INDEX-$COMMIT_HASH/publish"
+commit_index=$(git rev-list HEAD | wc -l)
+commit_hash=$(git rev-parse HEAD)
+upload="https://api.bintray.com/content/materialize/apt/materialized-unstable/dev-$commit_index-$commit_hash/publish"
 echo "Marking release public in bintray: $upload"
 
 curl -f -X POST -u ci@materialize:"$BINTRAY_API_KEY" "$upload"


### PR DESCRIPTION
We are no longer uploading these to s3, so deploys are failing.

We are no longer using Gemfury, so it's safe to get rid of.

Also fix shell variable capitalization convention.