### PR TITLE
Adding support for Debezium-style transactional guarantees.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 name = "coord"
 version = "0.1.0"
 dependencies = [
+ "avro",
  "catalog",
  "ccsr",
  "chrono",
@@ -461,7 +462,9 @@ dependencies = [
  "expr",
  "failure",
  "futures",
+ "interchange",
  "itertools 0.9.0",
+ "lazy_static",
  "log",
  "ore",
  "pgrepr",

--- a/bin/check
+++ b/bin/check
@@ -177,6 +177,10 @@ disabled_lints=(
     # implementation is too strict -- it disallows anything containing an `Arc` or `Rc`,
     # for example.
     clippy::mutable_key_type
+
+    # Upstream description: https://rust-lang.github.io/rust-clippy/master/index.html#naive_bytecount
+    # Clippy unnecessarily forces use of the bytecount crates for counting bytes
+    clippy::naive-bytecount
 )
 
 # NOTE(benesch): we ignore some ShellCheck complaints about sloppy word

--- a/demo/trx/connectr/Dockerfile
+++ b/demo/trx/connectr/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM confluentinc/cp-enterprise-kafka:5.3.0
+
+# https://github.com/confluentinc/cp-docker-images/issues/764
+RUN sed -i s,https://s3-us-west-2.amazonaws.com/staging-confluent-packages-5.3.0/deb/5.3,https://packages.confluent.io/deb/5.3, /etc/apt/sources.list
+
+RUN apt-get update && apt-get -qy install curl
+
+RUN curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /usr/local/bin/wait-for-it \
+    && chmod +x /usr/local/bin/wait-for-it
+
+COPY docker-entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/demo/trx/connectr/docker-entrypoint.sh
+++ b/demo/trx/connectr/docker-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -euo pipefail
+
+wait-for-it --timeout=60 connect:8083
+
+topics=(
+    dbserver1.inventory.foo
+)
+
+echo "${topics[@]}" | xargs -n1 -P8 kafka-topics --bootstrap-server kafka:9092 --create --partitions 1 --replication-factor 1 --topic
+
+curl -H 'Content-Type: application/json'  connect:8083/connectors --data '{
+  "name": "psql-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "provide.transaction.metadata": "true",
+    "database.hostname": "postgres",
+    "database.port": "5432",
+    "database.user": "postgres",
+    "database.password": "postgres",
+    "database.dbname": "postgres",
+    "database.server.name": "dbserver1",
+    "database.history.kafka.bootstrap.servers": "kafka:9092",
+    "include.schema.changes": "true",
+    "database.history.kafka.topic": "psql-history",
+    "time.precision.mode": "connect"
+   }
+}'

--- a/demo/trx/docker-compose.yaml
+++ b/demo/trx/docker-compose.yaml
@@ -1,0 +1,155 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# Map from host-port:internal port
+#
+# This mostly just shows all the ports that are available to the host system, if you want
+# to change these you must restart the docker-compose cluster.
+x-port-mappings:
+  - &kafka 9092:9092
+  - &materialized 6875:6875
+  - &mysql 3306:3306
+  - &control-center 9021:9021
+  - &grafana 3000:3000
+  - &metabase 3030:3000
+  - &prometheus 9090:9090
+
+version: '3.7'
+services:
+  zookeeper:
+    image: debezium/zookeeper:1.1
+    ports:
+     - 2181:2181
+     - 2888:2888
+     - 3888:3888
+  kafka:
+    image: debezium/kafka:1.1
+    ports:
+     - 9092:9092
+    links:
+     - zookeeper
+    environment:
+     - ZOOKEEPER_CONNECT=zookeeper:2181
+  postgres:
+    image: debezium/example-postgres:1.1
+    volumes:
+     - ./scripts:/docker-entrypoint-initdb.d
+    ports:
+     - 5432:5432
+    environment:
+     - POSTGRES_USER=postgres
+     - POSTGRES_PASSWORD=postgres
+  materialized:
+    image: materialize/materialized:latest
+    ports:
+     - 6875:6875
+    command: -w1
+    init: true
+    environment:
+      # you can for example add `pgwire=trace` or change `info` to `debug` to get more verbose logs
+      - MZ_LOG=pgwire=debug,info
+      # We want this to eventually count up to the size of the largest batch in an
+      # arrangement. This number represents a tradeoff between proactive merging (which
+      # takes time) and low latency.
+      #
+      # 1000 was chosen by fair dice roll
+      - DIFFERENTIAL_EAGER_MERGE=1000
+  connect:
+    image: debezium/connect:1.1
+    ports:
+     - 8083:8083
+    links:
+     - kafka
+     - postgres
+    environment:
+     - BOOTSTRAP_SERVERS=kafka:9092
+     - GROUP_ID=1
+     - CONFIG_STORAGE_TOPIC=my_connect_configs
+     - OFFSET_STORAGE_TOPIC=my_connect_offsets
+     - STATUS_STORAGE_TOPIC=my_connect_statuses
+     - POSTGRES_USER=postgres
+     - POSTGRES_PASSWORD=postgres
+     - KEY_CONVERTER=io.confluent.connect.avro.AvroConverter
+     - VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter
+     - CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+     - CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081
+    depends_on: [kafka, schema-registry]
+  schema-registry:
+    build: schema-registry
+    environment:
+     - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
+     - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+     - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081,http://localhost:8081
+     - SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_METHODS=GET,POST,PUT,OPTIONS
+     - SCHEMA_REGISTRY_ACCeSS_CONTROL_ALLOW_ORIGIN=*
+    depends_on: [zookeeper, kafka]
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:5.3.0
+    restart: always
+    depends_on: [zookeeper, kafka, connect]
+    ports:
+      - 9021:9021
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka:9092"
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION: 1
+      CONTROL_CENTER_COMMAND_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_METRICS_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_METRICS_TOPIC_PARTITIONS: 1
+      CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS: 1
+      CONTROL_CENTER_CONNECT_CLUSTER: "http://connect:8083"
+      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE: "true"
+  cli:
+    image: materialize/cli
+    init: true
+    # if you run the terminal with a dark background uncomment these lines
+    # environment:
+    #   MZCLI_PROMPT: DARK_MODE
+    depends_on:
+      - materialized
+  inspect:
+    image: ubuntu:bionic
+    command: "true"
+  schema-registry:
+    build: schema-registry
+    environment:
+     - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
+     - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+     - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081,http://localhost:8081
+    depends_on: [zookeeper, kafka]
+  connectr:
+    build: connectr
+    depends_on: [schema-registry, control-center]
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:5.3.0
+    restart: always
+    depends_on: [zookeeper, kafka, connect]
+    ports:
+      - 9021:9021
+    environment:
+      CONTROL_CENTER_BOOTSTRAP_SERVERS: "kafka:9092"
+      CONTROL_CENTER_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      CONTROL_CENTER_REPLICATION_FACTOR: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION: 1
+      CONTROL_CENTER_COMMAND_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_METRICS_TOPIC_REPLICATION: 1
+      CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS: 1
+      CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS: 1
+      CONTROL_CENTER_METRICS_TOPIC_PARTITIONS: 1
+      CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS: 1
+      CONTROL_CENTER_CONNECT_CLUSTER: "http://connect:8083"
+      CONTROL_CENTER_SCHEMA_REGISTRY_URL: "http://schema-registry:8081"
+      CONTROL_CENTER_DEPRECATED_VIEWS_ENABLE: "true"

--- a/demo/trx/mzcli/Dockerfile
+++ b/demo/trx/mzcli/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM ubuntu:bionic
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+COPY mzcli-mtrlz.zip /tmp
+
+RUN apt-get update \
+    && apt-get upgrade -qy \
+    && apt-get install -qy less postgresql-client \
+    && apt-get install -qy --no-install-recommends \
+        build-essential \
+        libpq-dev \
+        python3-minimal \
+        python3-dev \
+        python3-pip \
+        python3-setuptools \
+        python3-wheel \
+        python3-setuptools \
+    && pip3 install psycopg2-binary \
+    && pip3 install /tmp/mzcli-mtrlz.zip \
+    && apt-get remove --purge -qy \
+        build-essential \
+        libpq-dev \
+    && apt-get autoremove -qy \
+    ;
+
+COPY watch-sql /usr/local/bin/watch-sql
+
+CMD ["mzcli", "host=materialized port=6875 dbname=materialize"]

--- a/demo/trx/schema-registry/Dockerfile
+++ b/demo/trx/schema-registry/Dockerfile
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM confluentinc/cp-schema-registry
+
+RUN apt-get update -q && apt-get install -qy jq

--- a/demo/trx/scripts/init.sql
+++ b/demo/trx/scripts/init.sql
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+CREATE SCHEMA inventory;
+
+grant create on schema inventory to postgres;
+
+CREATE TABLE inventory.foo (a int, b int, primary key (a));

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 path = "lib.rs"
 
 [dependencies]
+avro = { path = "../avro" }
 catalog = { path = "../catalog" }
 chrono = "0.4"
 ccsr = { path = "../ccsr" }
@@ -20,7 +21,9 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 expr = { path = "../expr" }
 failure = "0.1.5"
 futures = "0.3"
+interchange = { path = "../interchange" }
 itertools = "0.9"
+lazy_static = "1.4"
 log = "0.4"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -409,7 +409,7 @@ fn identify_consistency_format(msgs: &[Vec<u8>]) -> ConsistencyFormatting {
         || block_on(Reader::with_schema(&DEBEZIUM_TRX_SCHEMA_VALUE, &msg[..])).is_ok()
     {
         ConsistencyFormatting::DebeziumOcf
-    } else if msg.iter().filter(|b| **b == b',').count() == 5 {
+    } else if msg.iter().filter(|b| **b == b',').count() == 4 {
         ConsistencyFormatting::Raw
     } else {
         ConsistencyFormatting::Unknown

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -9,11 +9,17 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::panic;
 use std::str;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use avro::schema::Schema;
+use avro::types::Value;
+use avro::Reader;
+
+use lazy_static::lazy_static;
 use log::{error, info};
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::message::Message;
@@ -33,6 +39,73 @@ use expr::{PartitionId, SourceInstanceId};
 use crate::coord;
 
 use itertools::Itertools;
+
+lazy_static! {
+    static ref DEBEZIUM_TRX_SCHEMA_KEY: Schema = {
+        Schema::parse_str(
+            r#"    {
+    "name": "io.debezium.connector.common.TransactionMetadataKey",
+    "type": "record",
+    "fields": [
+        {
+            "name": "id",
+            "type": "string"
+        }
+    ]
+}"#,
+        )
+        .unwrap()
+    };
+    static ref DEBEZIUM_TRX_SCHEMA_VALUE: Schema = {
+        Schema::parse_str(
+            r#"    {
+    "name": "io.debezium.connector.common.TransactionMetadataValue",
+    "type": "record",
+    "fields": [
+        {
+            "name": "id",
+            "type": "string"
+        },
+        {
+            "name": "status",
+            "type": "string"
+        },
+        {
+            "name": "event_count",
+            "type": [
+                "long",
+                "null"
+            ]
+        },
+        {
+            "name": "data_collections",
+            "type": [
+                {
+                    "type": "array",
+                    "items": {
+                        "name": "data",
+                        "type": "record",
+                        "fields": [
+                            {
+                                "name": "event_count",
+                                "type": "long"
+                            },
+                            {
+                                "name": "data_collection",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "null"
+            ]
+        }
+    ]
+}"#,
+        )
+        .unwrap()
+    };
+}
 
 pub struct TimestampConfig {
     pub frequency: Duration,
@@ -62,13 +135,37 @@ enum RtTimestampConnector {
 /// Timestamp consumer: wrapper around source consumers that stores necessary information
 /// about topics and offset for byo consistency
 struct ByoTimestampConsumer {
+    // Source Connector
     connector: ByoTimestampConnector,
+    // The name of the source with which this connector is associated
     source_name: String,
+    // The format of the connector
+    envelope: ConsistencyFormatting,
+    // The last timestamp assigned per partition
     last_partition_ts: HashMap<i32, u64>,
+    // The max assigned timestamp. Should be max(last_partition_ts)
     last_ts: u64,
+    // The max offset for which a timestamp has been assigned
+    last_offset: i64,
+    // The total number of partitions for the data topic
     current_partition_count: i32,
 }
 
+/// Supported format/envelope pairs for consistency topic decoding
+/// TODO(natacha): this should be removed
+enum ConsistencyFormatting {
+    // The formatting of this consistency source is currently unknown
+    Unknown,
+    // The formatting of this consistency source follows the
+    // SourceName,PartitionCount,PartitionId,TS,Offset
+    Raw,
+    // The formatting of this consistency source follows the
+    // Debezium Kafka format
+    DebeziumKafka,
+    // The formatting of this consistency source follows the
+    // Debezium format (OCF + Avro)
+    DebeziumOcf,
+}
 enum ByoTimestampConnector {
     Kafka(ByoKafkaConnector),
     File(ByoFileConnector),
@@ -127,6 +224,8 @@ fn byo_query_source(consumer: &mut ByoTimestampConsumer, max_increment_size: i64
     messages
 }
 
+// TODO(Natacha): this function is currently only applicable to Kafka sources
+// Should be made more generic
 fn byo_extract_ts_update(
     consumer: &ByoTimestampConsumer,
     messages: Vec<Vec<u8>>,
@@ -242,6 +341,79 @@ pub struct Timestamper {
 
     // Max increment size
     max_increment_size: i64,
+}
+
+/// A debezium record contains a set of update counts for each topic that the transaction
+/// updated. This function extracts the set of (topic, update_count) as a vector.
+fn parse_debezium(record: Vec<(String, Value)>) -> Vec<(String, i64)> {
+    let mut result = vec![];
+    for (key, value) in record {
+        if key == "data_collections" {
+            if let Value::Union(_, value) = value {
+                if let Value::Array(items) = *value {
+                    for v in items {
+                        if let Value::Record(item) = v {
+                            let mut value: String = String::new();
+                            let mut write_count = 0;
+                            for (k, v) in item {
+                                if k == "data_collection" {
+                                    if let Value::String(data) = v {
+                                        value = data;
+                                    } else {
+                                        panic!("Incorrect AVRO format. String expected");
+                                    }
+                                } else if k == "event_count" {
+                                    if let Value::Long(e) = v {
+                                        write_count = e;
+                                    } else {
+                                        panic!("Incorrect AVRO format. Long expected");
+                                    }
+                                }
+                            }
+                            result.push((value, write_count))
+                        } else {
+                            error!("Incorrect AVRO format. Record expected");
+                        }
+                    }
+                }
+            } else {
+                error!(
+                    "Incorrect AVRO format. Union of Null/Array expected {:?}",
+                    value
+                );
+            }
+        }
+    }
+    result
+}
+
+/// Determines what format does a given consistency source abide to
+/// TODO(Natacha): this information should be included as metadata
+/// This function tries to decode to all known formats. If a decoding
+/// is successful, it assumes that all subsequent messages of that stream
+/// will have been encoded using the same formatting/envelope
+fn identify_consistency_format(msgs: &[Vec<u8>]) -> ConsistencyFormatting {
+    use avro::from_avro_datum;
+    use futures::executor::block_on;
+
+    let msg = match msgs.first() {
+        Some(msg) => msg,
+        None => return ConsistencyFormatting::Unknown,
+    };
+
+    if block_on(from_avro_datum(&DEBEZIUM_TRX_SCHEMA_KEY, &mut &msg[5..])).is_ok()
+        || block_on(from_avro_datum(&DEBEZIUM_TRX_SCHEMA_VALUE, &mut &msg[5..])).is_ok()
+    {
+        ConsistencyFormatting::DebeziumKafka
+    } else if block_on(Reader::with_schema(&DEBEZIUM_TRX_SCHEMA_KEY, &msg[..])).is_ok()
+        || block_on(Reader::with_schema(&DEBEZIUM_TRX_SCHEMA_VALUE, &msg[..])).is_ok()
+    {
+        ConsistencyFormatting::DebeziumOcf
+    } else if msg.iter().filter(|b| **b == b',').count() == 5 {
+        ConsistencyFormatting::Raw
+    } else {
+        ConsistencyFormatting::Unknown
+    }
 }
 
 impl Timestamper {
@@ -376,26 +548,34 @@ impl Timestamper {
     /// A new timestamp should be:
     /// 1) strictly greater than the last timestamp
     /// This is necessary to guarantee that this timestamp *could not have been closed yet*
+    ///
+    /// Supports two envelopes: None and Debezium. Currently compatible with Debezium format 1.1
     fn update_byo_timestamp(&mut self) {
         for (id, byo_consumer) in &mut self.byo_sources {
             // Get the next set of messages from the Consistency topic
             let messages = byo_query_source(byo_consumer, self.max_increment_size);
-            // Notify coordinator of updates
-            for (partition_count, partition, timestamp, offset) in
-                byo_extract_ts_update(byo_consumer, messages)
-            {
-                let last_p_ts = match byo_consumer.last_partition_ts.get(&partition) {
-                    Some(ts) => *ts,
-                    None => 0,
-                };
-                if timestamp == 0
-                    || timestamp == std::u64::MAX
-                    || timestamp < byo_consumer.last_ts
-                    || timestamp <= last_p_ts
-                    || (partition_count > byo_consumer.current_partition_count
-                        && timestamp == byo_consumer.last_ts)
-                {
-                    error!("The timestamp assignment rules have been violated. The rules are as follows:\n\
+            // TODO(Natacha): move from automatic detection of source format to explicit formatting
+            // information
+            if let ConsistencyFormatting::Unknown = byo_consumer.envelope {
+                byo_consumer.envelope = identify_consistency_format(&messages);
+            }
+            match byo_consumer.envelope {
+                ConsistencyFormatting::Raw => {
+                    for (partition_count, partition, timestamp, offset) in
+                        byo_extract_ts_update(byo_consumer, messages)
+                    {
+                        let last_p_ts = match byo_consumer.last_partition_ts.get(&partition) {
+                            Some(ts) => *ts,
+                            None => 0,
+                        };
+                        if timestamp == 0
+                            || timestamp == std::u64::MAX
+                            || timestamp < byo_consumer.last_ts
+                            || timestamp <= last_p_ts
+                            || (partition_count > byo_consumer.current_partition_count
+                                && timestamp == byo_consumer.last_ts)
+                        {
+                            error!("The timestamp assignment rules have been violated. The rules are as follows:\n\
                      1) A timestamp should be greater than 0\n\
                      2) The timestamp should be strictly smaller than u64::MAX\n\
                      2) If no new partition is added, a new timestamp should be:\n \
@@ -403,46 +583,103 @@ impl Timestamper {
                         - greater or equal to all the timestamps that have been assigned across all partitions\n \
                         If a new partition is added, a new timestamp should be:\n  \
                         - strictly greater than the last timestamp\n");
-                } else {
-                    match byo_consumer.connector {
-                        ByoTimestampConnector::Kafka(_) => {
-                            if byo_consumer.current_partition_count < partition_count {
-                                // A new partition has been added. Partitions always gets added with
-                                // newPartitionId = previousLastPartitionId + 1 and start from 0.
-                                // So this new partition will have ID "partition_count - 1"
-                                // We ensure that the first messages in this partition will always have
-                                // timestamps > the last closed timestamp. We need to explicitly close
-                                // out all prior timestamps. To achieve this, we send an additional
-                                // timestamp message to the coord/worker
+                        } else {
+                            match byo_consumer.connector {
+                                ByoTimestampConnector::Kafka(_) => {
+                                    if byo_consumer.current_partition_count < partition_count {
+                                        // A new partition has been added. Partitions always gets added with
+                                        // newPartitionId = previousLastPartitionId + 1 and start from 0.
+                                        // So this new partition will have ID "partition_count - 1"
+                                        // We ensure that the first messages in this partition will always have
+                                        // timestamps > the last closed timestamp. We need to explicitly close
+                                        // out all prior timestamps. To achieve this, we send an additional
+                                        // timestamp message to the coord/worker
+                                        self.tx
+                                            .unbounded_send(
+                                                coord::Message::AdvanceSourceTimestamp {
+                                                    id: *id,
+                                                    partition_count, // The new partition count
+                                                    pid: PartitionId::Kafka(partition_count - 1), // the ID of the new partition
+                                                    timestamp: byo_consumer.last_ts,
+                                                    offset: 0, // An offset of 0 will "fast-forward" the stream, it denotes
+                                                               // the empty interval
+                                                },
+                                            )
+                                            .expect("Failed to send update to coordinator");
+                                    }
+                                    byo_consumer.current_partition_count = partition_count;
+                                    byo_consumer.last_ts = timestamp;
+                                    byo_consumer.last_partition_ts.insert(partition, timestamp);
+                                    self.tx
+                                        .unbounded_send(coord::Message::AdvanceSourceTimestamp {
+                                            id: *id,
+                                            partition_count,
+                                            pid: PartitionId::Kafka(partition),
+                                            timestamp,
+                                            offset,
+                                        })
+                                        .expect("Failed to send update to coordinator");
+                                }
+                                _ => {
+                                    error!(
+                                        "BYO consistency is not supported for this source type."
+                                    );
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                ConsistencyFormatting::DebeziumKafka => {
+                    for msg in messages {
+                        // The first 5 bytes are reserved for the schema id/schema registry information
+                        let mut bytes = &msg[5..];
+                        let res = futures::executor::block_on(avro::from_avro_datum(
+                            &DEBEZIUM_TRX_SCHEMA_VALUE,
+                            &mut bytes,
+                        ));
+                        let results = match res {
+                            Ok(record) => {
+                                if let Value::Record(record) = record {
+                                    parse_debezium(record)
+                                } else {
+                                    error!("Incorrect Avro format. Expected Record");
+                                    vec![]
+                                }
+                            }
+                            Err(_) => {
+                                // This message was a key message. We can safely ignore it
+                                vec![]
+                            }
+                        };
+                        //TODO(natacha): this is (potentially)
+                        // inefficient every customer processes the same
+                        // consistency topic.
+                        for (topic, count) in results {
+                            if byo_consumer.source_name == topic {
+                                // TODO(natacha): consistency topic for Debezium currently supports only one partition
+                                byo_consumer.last_offset += count;
+                                byo_consumer.last_ts += 1;
                                 self.tx
                                     .unbounded_send(coord::Message::AdvanceSourceTimestamp {
                                         id: *id,
-                                        partition_count, // The new partition count
-                                        pid: PartitionId::Kafka(partition_count - 1), // the ID of the new partition
+                                        partition_count: 1,
+                                        pid: PartitionId::Kafka(0),
                                         timestamp: byo_consumer.last_ts,
-                                        offset: 0, // An offset of 0 will "fast-forward" the stream, it denotes
-                                                   // the empty interval
+                                        offset: byo_consumer.last_offset,
                                     })
                                     .expect("Failed to send update to coordinator");
                             }
-                            byo_consumer.current_partition_count = partition_count;
-                            byo_consumer.last_ts = timestamp;
-                            byo_consumer.last_partition_ts.insert(partition, timestamp);
-                            self.tx
-                                .unbounded_send(coord::Message::AdvanceSourceTimestamp {
-                                    id: *id,
-                                    partition_count,
-                                    pid: PartitionId::Kafka(partition),
-                                    timestamp,
-                                    offset,
-                                })
-                                .expect("Failed to send update to coordinator");
-                        }
-                        _ => {
-                            error!("BYO consistency is not supported for this source type.");
-                            return;
                         }
                     }
+                }
+                ConsistencyFormatting::DebeziumOcf => {
+                    error!("Avro OCF sources are not currently supported");
+                }
+                ConsistencyFormatting::Unknown => {
+                    // Could not identify the source formatting. This could
+                    // either be because there were no messages, or because
+                    // they were formatted incorrectly
                 }
             }
         }
@@ -549,9 +786,11 @@ impl Timestamper {
                     kc,
                     timestamp_topic,
                 )),
+                envelope: ConsistencyFormatting::Unknown,
                 last_partition_ts: HashMap::new(),
                 last_ts: 0,
                 current_partition_count: 0,
+                last_offset: 0,
             },
             ExternalSourceConnector::File(fc) | ExternalSourceConnector::AvroOcf(fc) => {
                 error!("File sources are unsupported for timestamping");
@@ -562,9 +801,11 @@ impl Timestamper {
                         fc,
                         timestamp_topic,
                     )),
+                    envelope: ConsistencyFormatting::Unknown,
                     last_partition_ts: HashMap::new(),
                     last_ts: 0,
                     current_partition_count: 0,
+                    last_offset: 0,
                 }
             }
             ExternalSourceConnector::Kinesis(kinc) => {
@@ -576,9 +817,11 @@ impl Timestamper {
                         kinc,
                         timestamp_topic,
                     )),
+                    envelope: ConsistencyFormatting::Unknown,
                     last_partition_ts: HashMap::new(),
                     last_ts: 0,
                     current_partition_count: 0,
+                    last_offset: 0,
                 }
             }
         }

--- a/test/testdrive/transactions_debezium_kafka.td
+++ b/test/testdrive/transactions_debezium_kafka.td
@@ -1,0 +1,195 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ set trxschemakey={
+      "name": "io.debezium.connector.common.TransactionMetadataKey",
+      "type": "record",
+      "fields": [
+          {
+              "name": "id",
+              "type": "string"
+          }
+      ]
+  }
+
+
+$ set trxschema={
+      "name": "io.debezium.connector.common.TransactionMetadataValue",
+      "type": "record",
+      "fields": [
+        {
+              "name": "id",
+              "type": "string"
+         },
+         {
+              "name": "status",
+              "type": "string"
+         },
+          {
+              "name": "event_count",
+              "type": [
+                  "long",
+                  "null"
+              ]
+          },
+          {
+              "name": "data_collections",
+              "type": [
+                  {
+                      "type": "array",
+                      "items": {
+                          "name": "data",
+                          "type": "record",
+                          "fields": [
+                              {
+                                  "name": "event_count",
+                                  "type": "long"
+                              },
+                              {
+                                  "name": "data_collection",
+                                  "type": "string"
+                              }
+                          ]
+                      }
+                  },
+                  "null"
+              ]
+          }
+      ]
+  }
+
+$ kafka-create-topic topic=consistency
+
+$ kafka-create-topic topic=foo
+
+$ kafka-create-topic topic=bar
+
+$ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
+{"before": null, "after": {"a": 1, "b": 1}}
+{"before": null, "after": {"a": 2, "b": 2}}
+
+$ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
+{"before": null, "after": {"a": 10, "b": 1}}
+
+> CREATE MATERIALIZED SOURCE data_foo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
+    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE data_bar
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bar-${testdrive.seed}'
+    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+
+> CREATE MATERIALIZED VIEW foo AS SELECT b, sum(a) FROM data_foo GROUP BY b
+
+> CREATE MATERIALIZED VIEW bar AS SELECT b, sum(a) FROM data_bar GROUP BY b
+
+> CREATE MATERIALIZED VIEW join AS SELECT * FROM foo JOIN bar USING (b);
+
+! SELECT * FROM bar;
+At least one input has no complete timestamps yet.
+
+! SELECT * FROM foo;
+At least one input has no complete timestamps yet.
+
+! SELECT * FROM join ;
+At least one input has no complete timestamps yet.
+
+$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschemakey}
+{"id": "1"}
+
+$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
+{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
+{"status":"END","id":"1","event_count":0,"data_collections":[]}
+{"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
+{"status":"END","id":"2","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}
+
+> SELECT * FROM foo;
+b  sum
+------
+1  1
+2  2
+
+> SELECT * FROM bar;
+b  sum
+------
+1  10
+
+> SELECT * FROM join;
+a  a  b
+------
+1  1  10
+
+$ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
+{"before": null, "after": {"a": 3, "b": 3}}
+
+$ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
+{"before": null, "after": {"a": 30, "b": 3}}
+
+$ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
+{"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
+{"status":"END","id":"3","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}
+
+> SELECT * FROM foo;
+b  sum
+------
+1  1
+2  2
+
+> SELECT * FROM bar;
+b  sum
+------
+1  10
+3  30
+
+> SELECT * FROM join;
+a  a  b
+------
+1  1  10
+
+$ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
+{"before": null, "after": {"a": 4, "b": 4}}
+
+> SELECT * FROM foo;
+b  sum
+------
+1  1
+2  2
+3  3
+4  4
+
+> SELECT * FROM join;
+a  a  b
+------
+1  1  10
+3  3  30


### PR DESCRIPTION
This PR does three things:

1) it adds support for understanding and converting the Debezium produced transaction metadata topic (for Postgres only, starting from version 1.1. Support for MySQL will be added in v1.3).  The transaction metadata topic outputs the following pairs:

```
{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
{"status":"END","id":"1","event_count":0,"data_collections":[]}
{"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
{"status":"END","id":"2","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "foo"},{"event_count": 1, "data_collection": "bar"}]}
```

The code parses this Avro source and converts it into Materialize timestamp messages.

2) it adds code to automatically "detect" the encoding type of the consistency topic (currently, there can be three: a manually generated comma separated topic, the Avro + Schema Registry Debezium consistency format, and the Avro + OCF consistency format generated by tb (we do not currently support this last one - it is blocked on timestamping file sources). This automatic detection is only supposed to be temporary. Consistency sources are becoming complex enough that we will have to add metadata on source encoding/formatting. 

3) It adds a demo (Postgres + Debezium + Materialize) setup to run the above experiment end-to-end. Running this experiment is currently blocked on a Debezium bug: https://issues.redhat.com/browse/DBZ-1915

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2534)
<!-- Reviewable:end -->
