### PR TITLE
Make json-to-avro properly reorder fields in Testdrive

### DIFF
--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -61,13 +61,13 @@ $ kafka-verify format=avro sink=materialize.public.snk2
 {"before": null, "after": {"a": "goofus", "b": "gallant", "mz_line_no": 3}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3
-{"before": null, "after": {"c": "jackjill", "mz_line_no": 2}}
-{"before": null, "after": {"c": "goofusgallant", "mz_line_no": 3}}
+{"before": null, "after": {"c": "jackjill"}}
+{"before": null, "after": {"c": "goofusgallant"}}
 
 $ kafka-verify format=avro sink=materialize.public.snk4
-{"before": null, "after": {"c": "jackjill", "mz_line_no": 2}}
-{"before": null, "after": {"c": "goofusgallant", "mz_line_no": 3}}
+{"before": null, "after": {"c": "jackjill"}}
+{"before": null, "after": {"c": "goofusgallant"}}
 
 $ kafka-verify format=avro sink=materialize.public.snk5
-{"before": null, "after": {"c": "jackjill", "mz_line_no": 2}}
-{"before": null, "after": {"c": "goofusgallant", "mz_line_no": 3}}
+{"before": null, "after": {"c": "jackjill"}}
+{"before": null, "after": {"c": "goofusgallant"}}


### PR DESCRIPTION
Avro record values require that fields be listed in the order they appear in schemas, but users of Json, in general, expect to be able to write down object fields in whatever order they like without changing behavior.

`avro-rs` already had a utility class for creating records with the fields in the proper order; we extend it slightly for this use case.

While I'm here, fix some comments.

I have not bothered including a test, because this behavior is already exercised by an as-yet-unlanded testdrive test that Natacha has, so it'll naturally be tested once that goes in.