### PR TITLE
docs: add option to name columns in create source

### DIFF
--- a/doc/user/sql/create-source/avro-source.md
+++ b/doc/user/sql/create-source/avro-source.md
@@ -28,6 +28,7 @@ Sources](../../../overview/api-components#sources).
 Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
+_col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
 **KAFKA BROKER** _host_ | The Kafka broker's host name.
 **FORMAT ...** _url_ | The URL of the Confluent schema registry to get schema information from.
 **FORMAT ...** _schema&lowbar;file&lowbar;path_ | The absolute path to a file containing the schema.
@@ -69,7 +70,8 @@ records' old and new values; this is roughly equivalent to the notion of Change
 Data Capture, or CDC. Materialize can use the data in this diff envelope to
 process data as representing inserts, updates, or deletes.
 
-This envelope is called the Debezium envelope because it's been developed to explicitly work with [Debezium].
+This envelope is called the Debezium envelope because it's been developed to
+explicitly work with [Debezium].
 
 To use the Debezium envelope with Materialize, you must configure Debezium with
 your database.

--- a/doc/user/sql/create-source/csv-source.md
+++ b/doc/user/sql/create-source/csv-source.md
@@ -27,6 +27,7 @@ Sources](../../../overview/api-components#sources).
 Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
+_col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
 **FILE** _path_ | The absolute path to the file you want to use as the source.
 **WITH (** _option&lowbar;list_ **)** | Options affecting source creation. For more detail, see [`WITH` options](#with-options).
 **HEADER** | Treat the first line of the CSV file as a header. See [CSV format details](#csv-format-details).
@@ -40,11 +41,11 @@ The following options are valid within the `WITH` clause.
 Field | Value | Description
 ------|-------|------------
 `tail` | `bool` | Continually check the file for new content; as new content arrives, process it using other `WITH` options.
-`col_names` | `text` | Name the source's columns using `text`, which should delimit each column name by the same _char_ as the file (i.e. the same _char_ as **DELIMITED BY** _char_). For an example, see [Creating a source from a dynamic CSV](#creating-a-source-from-a-dynamic-csv).
 
 ## Details
 
-This document assumes you're using a locally available file to load CSV data into Materialize.
+This document assumes you're using a locally available file to load CSV data
+into Materialize.
 
 ### File source details
 
@@ -52,7 +53,8 @@ This document assumes you're using a locally available file to load CSV data int
     ```sql
     CREATE SOURCE server_source FROM FILE '/Users/sean/server.log'...
     ```
-- All data in file sources are treated as [`text`](../../types/text), but can be converted to other types using [views](../../create-materialized-view).
+- All data in file sources are treated as [`text`](../../types/text), but can be
+  converted to other types using [views](../../create-materialized-view).
 
 ### CSV format details
 
@@ -64,8 +66,8 @@ Method | Outcome
 **HEADER** | Materialize reads the first line of the file to determine:<br/><br/>&bull; The number of columns in the file<br/><br/>&bull; The name of each column<br/><br/>The first line of the file is not ingested as data.
 _n_ **COLUMNS** | &bull; Materialize treats the file as if it has _n_ columns.<br/><br/>&bull; Columns are named `column1`, `column2`...`columnN`.
 
-- You can override these naming conventions using the [`col_names`
-  option](#with-options).
+- You can override these naming conventions by explicitly naming columns using
+  the _col&lowbar;name_ option in `CREATE SOURCE`.
 - All rows without the number of columns determined by the format are dropped,
   and Materialize logs an error.
 
@@ -96,9 +98,9 @@ This creates a source that...
 ### Creating a source from a dynamic CSV
 
 ```sql
-CREATE SOURCE dynamic_wo_header
+CREATE SOURCE dynamic_wo_header (col_foo, col_bar, col_baz)
 FROM FILE '[path to .csv]'
-WITH (tail = true, col_names='col_foo,col_bar,col_baz')
+WITH (tail = true)
 FORMAT CSV WITH 3 COLUMNS;
 ```
 

--- a/doc/user/sql/create-source/kinesis-source.md
+++ b/doc/user/sql/create-source/kinesis-source.md
@@ -27,6 +27,7 @@ Sources](../../../overview/api-components#sources).
 Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
+_col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
 **KINESIS ARN** _arn_ | The [AWS ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) of the Kinesis Data Stream.
 **WITH (** _option&lowbar;list_ **)** | Options affecting source creation. For more detail, see [`WITH` options](#with-options).
 

--- a/doc/user/sql/create-source/protobuf-source.md
+++ b/doc/user/sql/create-source/protobuf-source.md
@@ -28,6 +28,7 @@ Sources](../../../overview/api-components#sources).
 Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
+_col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
 **KAFKA BROKER** _host_ | The Kafka broker's host name.
 _message&lowbar;name_ | The top-level Protobuf message name, in the format `<package>.<message name>`. For example, `billing.Batch`. For more detail, see [Top-level message](#top-level-message).
 _schema&lowbar;file&lowbar;path_ | The absolute path to a file containing the [`FileDescriptorSet`](#filedescriptorset).
@@ -52,7 +53,8 @@ Protobuf-formatted external sources require:
 
 #### `FileDescriptorSet`
 
-The `FileDescriptorSet` encodes the Protobuf messages' schema, which Materialize needs to decode incoming Protobuf data.
+The `FileDescriptorSet` encodes the Protobuf messages' schema, which Materialize
+needs to decode incoming Protobuf data.
 
 You can generate the `FileDescriptorSet` with `protoc`, e.g.
 
@@ -62,7 +64,9 @@ protoc --include_imports --descriptor_set_out=SCHEMA billing.proto
 
 #### Top-level message
 
-Materialize needs to know which message from your `FileDescriptorSet` is the top-level message to decode, along with its package name, in the following format:
+Materialize needs to know which message from your `FileDescriptorSet` is the
+top-level message to decode, along with its package name, in the following
+format:
 
 ```shell
 <package name>.<top-level message>
@@ -87,7 +91,8 @@ Materialize.
 
 ## Example
 
-Assuming you've already generated a [`FileDescriptorSet`](#filedescriptorset) named `SCHEMA`:
+Assuming you've already generated a [`FileDescriptorSet`](#filedescriptorset)
+named `SCHEMA`:
 
 ```sql
 CREATE SOURCE batches

--- a/doc/user/sql/create-source/text-source.md
+++ b/doc/user/sql/create-source/text-source.md
@@ -41,7 +41,8 @@ the **TEXT** formatting option.
 Field | Use
 ------|-----
 _src&lowbar;name_ | The name for the source, which is used as its table name within SQL.
-_path_ | The absolute path to the file you want to use as the source.
+_col&lowbar;name_ | Override default column name with the provided [identifier](../../identifiers). If used, a _col&lowbar;name_ must be provided for each column in the created source.
+**FILE** _path_ | The absolute path to the file you want to use as the source.
 **WITH (** _option&lowbar;list_ **)** | Options affecting source creation. For more detail, see [`WITH` options](#with-options).
 **REGEX** _regex_ | Format the source's data as a string, applying _regex_, whose capture groups define the columns of the relation. For more detail, see [Regex format details](#regex-format-details).
 **TEXT** | Format the source's data as ASCII-encoded text.
@@ -137,7 +138,8 @@ This creates a source that...
 - Discards the second group, i.e. `(?:[0-9a-f]{4} ){8}`.
 - Materialize dynamically checks for new entries.
 
-Using the above example, the source would generate data that looks similar to this:
+Using the above example, the source would generate data that looks similar to
+this:
 
 ```nofmt
  offset  |     decoded

--- a/www/layouts/partials/sql-grammar/bnf/create-source-avro.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source-avro.bnf
@@ -1,5 +1,6 @@
 create_source ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ')')?
   'FROM' 'KAFKA BROKER' host 'TOPIC' topic
   'FORMAT' ('CONFLUENT SCHEMA REGISTRY' url |
     'SCHEMA' ('FILE' schema_file_path | inline_schema))

--- a/www/layouts/partials/sql-grammar/bnf/create-source-csv.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source-csv.bnf
@@ -1,5 +1,6 @@
 create_source ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ')')?
   'FROM' 'FILE' path ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'CSV WITH' ( 'HEADER' | n 'COLUMNS')
   ('DELIMITED BY' char)?

--- a/www/layouts/partials/sql-grammar/bnf/create-source-kinesis.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source-kinesis.bnf
@@ -1,4 +1,5 @@
 create_source_kinesis ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ')')?
   'FROM' 'KINESIS ARN' arn ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' 'BYTES'

--- a/www/layouts/partials/sql-grammar/bnf/create-source-protobuf.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source-protobuf.bnf
@@ -1,5 +1,6 @@
 create_source ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ')')?
   'FROM' 'KAFKA BROKER' host 'TOPIC' topic?
   'FORMAT' 'PROTOBUF MESSAGE' message_name
   'USING SCHEMA' ('FILE' schema_file_path | inline_schema)

--- a/www/layouts/partials/sql-grammar/bnf/create-source-text.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source-text.bnf
@@ -1,5 +1,6 @@
 create_source_misc ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ')')?
   'FROM' 'FILE' path ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
   'FORMAT' (
     'REGEX' regex |

--- a/www/layouts/partials/sql-grammar/bnf/create-source.bnf
+++ b/www/layouts/partials/sql-grammar/bnf/create-source.bnf
@@ -1,5 +1,6 @@
 create_source ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )* ')')?
   'FROM' connector_spec
   'FORMAT' format_spec
   ('ENVELOPE' ('NONE'|'DEBEZIUM'))?

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source-avro.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source-avro.html
@@ -1,4 +1,4 @@
-<svg width="549" height="419" data-bnfhash="12d83168971c7fb9f37e5508e5d57900">
+<svg width="591" height="545" data-bnfhash="db254480c0ecf996c75ef6812e611488">
   <polygon points="9 17 1 13 1 21"></polygon>
   <polygon points="17 17 9 13 9 21"></polygon>
   <rect x="31" y="3" width="132" height="32" rx="10"></rect>
@@ -10,55 +10,65 @@
   <rect x="365" y="3" width="82" height="32"></rect>
   <rect x="363" y="1" width="82" height="32" class="nonterminal"></rect>
   <text class="nonterminal" x="373" y="21">src_name</text>
-  <rect x="467" y="3" width="60" height="32" rx="10"></rect>
-  <rect x="465" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="475" y="21">FROM</text>
-  <rect x="55" y="101" width="124" height="32" rx="10"></rect>
-  <rect x="53" y="99" width="124" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="63" y="119">KAFKA BROKER</text>
-  <rect x="199" y="101" width="48" height="32"></rect>
-  <rect x="197" y="99" width="48" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="207" y="119">host</text>
-  <rect x="267" y="101" width="64" height="32" rx="10"></rect>
-  <rect x="265" y="99" width="64" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="275" y="119">TOPIC</text>
-  <rect x="351" y="101" width="50" height="32"></rect>
-  <rect x="349" y="99" width="50" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="359" y="119">topic</text>
-  <rect x="421" y="101" width="76" height="32" rx="10"></rect>
-  <rect x="419" y="99" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="429" y="119">FORMAT</text>
-  <rect x="107" y="167" width="236" height="32" rx="10"></rect>
-  <rect x="105" y="165" width="236" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="115" y="185">CONFLUENT SCHEMA REGISTRY</text>
-  <rect x="363" y="167" width="36" height="32"></rect>
-  <rect x="361" y="165" width="36" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="371" y="185">url</text>
-  <rect x="107" y="211" width="76" height="32" rx="10"></rect>
-  <rect x="105" y="209" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="115" y="229">SCHEMA</text>
-  <rect x="223" y="211" width="50" height="32" rx="10"></rect>
-  <rect x="221" y="209" width="50" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="231" y="229">FILE</text>
-  <rect x="293" y="211" width="132" height="32"></rect>
-  <rect x="291" y="209" width="132" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="301" y="229">schema_file_path</text>
-  <rect x="223" y="255" width="110" height="32"></rect>
-  <rect x="221" y="253" width="110" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="231" y="273">inline_schema</text>
-  <rect x="259" y="341" width="92" height="32" rx="10"></rect>
-  <rect x="257" y="339" width="92" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="267" y="359">ENVELOPE</text>
-  <rect x="391" y="341" width="58" height="32" rx="10"></rect>
-  <rect x="389" y="339" width="58" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="399" y="359">NONE</text>
-  <rect x="391" y="385" width="90" height="32" rx="10"></rect>
-  <rect x="389" y="383" width="90" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="399" y="403">DEBEZIUM</text>
-  <path class="line"
-    d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-516 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m124 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m236 0 h10 m0 0 h10 m36 0 h10 m0 0 h46 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m76 0 h10 m20 0 h10 m50 0 h10 m0 0 h10 m132 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m110 0 h10 m0 0 h92 m42 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-270 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m92 0 h10 m20 0 h10 m58 0 h10 m0 0 h32 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m43 -76 h-3">
-  </path>
-  <polygon points="539 323 547 319 547 327"></polygon>
-  <polygon points="539 323 531 319 531 327"></polygon>
+  <rect x="45" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="43" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="53" y="163">(</text>
+  <rect x="111" y="145" width="80" height="32"></rect>
+  <rect x="109" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="119" y="163">col_name</text>
+  <rect x="111" y="101" width="24" height="32" rx="10"></rect>
+  <rect x="109" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="119" y="119">,</text>
+  <rect x="231" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="229" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="239" y="163">)</text>
+  <rect x="297" y="145" width="60" height="32" rx="10"></rect>
+  <rect x="295" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="305" y="163">FROM</text>
+  <rect x="377" y="145" width="124" height="32" rx="10"></rect>
+  <rect x="375" y="143" width="124" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="385" y="163">KAFKA BROKER</text>
+  <rect x="521" y="145" width="48" height="32"></rect>
+  <rect x="519" y="143" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="529" y="163">host</text>
+  <rect x="182" y="227" width="64" height="32" rx="10"></rect>
+  <rect x="180" y="225" width="64" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="190" y="245">TOPIC</text>
+  <rect x="266" y="227" width="50" height="32"></rect>
+  <rect x="264" y="225" width="50" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="274" y="245">topic</text>
+  <rect x="336" y="227" width="76" height="32" rx="10"></rect>
+  <rect x="334" y="225" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="344" y="245">FORMAT</text>
+  <rect x="128" y="293" width="236" height="32" rx="10"></rect>
+  <rect x="126" y="291" width="236" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="136" y="311">CONFLUENT SCHEMA REGISTRY</text>
+  <rect x="384" y="293" width="36" height="32"></rect>
+  <rect x="382" y="291" width="36" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="392" y="311">url</text>
+  <rect x="128" y="337" width="76" height="32" rx="10"></rect>
+  <rect x="126" y="335" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="136" y="355">SCHEMA</text>
+  <rect x="244" y="337" width="50" height="32" rx="10"></rect>
+  <rect x="242" y="335" width="50" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="252" y="355">FILE</text>
+  <rect x="314" y="337" width="132" height="32"></rect>
+  <rect x="312" y="335" width="132" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="322" y="355">schema_file_path</text>
+  <rect x="244" y="381" width="110" height="32"></rect>
+  <rect x="242" y="379" width="110" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="252" y="399">inline_schema</text>
+  <rect x="301" y="467" width="92" height="32" rx="10"></rect>
+  <rect x="299" y="465" width="92" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="309" y="485">ENVELOPE</text>
+  <rect x="433" y="467" width="58" height="32" rx="10"></rect>
+  <rect x="431" y="465" width="58" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="441" y="485">NONE</text>
+  <rect x="433" y="511" width="90" height="32" rx="10"></rect>
+  <rect x="431" y="509" width="90" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="441" y="529">DEBEZIUM</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-466 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m20 -34 h10 m60 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-431 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m64 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-348 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m236 0 h10 m0 0 h10 m36 0 h10 m0 0 h46 m-378 0 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v24 m378 0 v-24 m-378 24 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m76 0 h10 m20 0 h10 m50 0 h10 m0 0 h10 m132 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m110 0 h10 m0 0 h92 m42 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-249 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m92 0 h10 m20 0 h10 m58 0 h10 m0 0 h32 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m43 -76 h-3"></path>
+  <polygon points="581 449 589 445 589 453"></polygon>
+  <polygon points="581 449 573 445 573 453"></polygon>
 </svg>
 <!-- generated by Railroad Diagram Generator https://www.bottlecaps.de/rr/ui -->

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source-csv.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source-csv.html
@@ -1,68 +1,80 @@
-<svg width="619" height="305" data-bnfhash="cb94ce24fccd0bec7f3d1a4a73dbf171">
-  <polygon points="9 17 1 13 1 21"></polygon>
-  <polygon points="17 17 9 13 9 21"></polygon>
-  <rect x="31" y="3" width="132" height="32" rx="10"></rect>
-  <rect x="29" y="1" width="132" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="39" y="21">CREATE SOURCE</text>
-  <rect x="203" y="35" width="122" height="32" rx="10"></rect>
-  <rect x="201" y="33" width="122" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="211" y="53">IF NOT EXISTS</text>
-  <rect x="365" y="3" width="82" height="32"></rect>
-  <rect x="363" y="1" width="82" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="373" y="21">src_name</text>
-  <rect x="467" y="3" width="60" height="32" rx="10"></rect>
-  <rect x="465" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="475" y="21">FROM</text>
-  <rect x="547" y="3" width="50" height="32" rx="10"></rect>
-  <rect x="545" y="1" width="50" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="555" y="21">FILE</text>
-  <rect x="27" y="145" width="48" height="32"></rect>
-  <rect x="25" y="143" width="48" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="35" y="163">path</text>
-  <rect x="115" y="145" width="58" height="32" rx="10"></rect>
-  <rect x="113" y="143" width="58" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="123" y="163">WITH</text>
-  <rect x="193" y="145" width="26" height="32" rx="10"></rect>
-  <rect x="191" y="143" width="26" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="201" y="163">(</text>
-  <rect x="259" y="145" width="46" height="32"></rect>
-  <rect x="257" y="143" width="46" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="267" y="163">field</text>
-  <rect x="325" y="145" width="30" height="32" rx="10"></rect>
-  <rect x="323" y="143" width="30" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="333" y="163">=</text>
-  <rect x="375" y="145" width="38" height="32"></rect>
-  <rect x="373" y="143" width="38" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="383" y="163">val</text>
-  <rect x="259" y="101" width="24" height="32" rx="10"></rect>
-  <rect x="257" y="99" width="24" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="267" y="119">,</text>
-  <rect x="453" y="145" width="26" height="32" rx="10"></rect>
-  <rect x="451" y="143" width="26" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="461" y="163">)</text>
-  <rect x="519" y="145" width="76" height="32" rx="10"></rect>
-  <rect x="517" y="143" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="527" y="163">FORMAT</text>
-  <rect x="61" y="227" width="90" height="32" rx="10"></rect>
-  <rect x="59" y="225" width="90" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="69" y="245">CSV WITH</text>
-  <rect x="191" y="227" width="74" height="32" rx="10"></rect>
-  <rect x="189" y="225" width="74" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="199" y="245">HEADER</text>
-  <rect x="191" y="271" width="28" height="32"></rect>
-  <rect x="189" y="269" width="28" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="199" y="289">n</text>
-  <rect x="239" y="271" width="88" height="32" rx="10"></rect>
-  <rect x="237" y="269" width="88" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="247" y="289">COLUMNS</text>
-  <rect x="387" y="259" width="118" height="32" rx="10"></rect>
-  <rect x="385" y="257" width="118" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="395" y="277">DELIMITED BY</text>
-  <rect x="525" y="259" width="46" height="32"></rect>
-  <rect x="523" y="257" width="46" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="533" y="277">char</text>
-  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m50 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-614 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m20 -34 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-578 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m20 0 h10 m74 0 h10 m0 0 h62 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m28 0 h10 m0 0 h10 m88 0 h10 m40 -44 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m118 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"></path>
-  <polygon points="609 241 617 237 617 245"></polygon>
-  <polygon points="609 241 601 237 601 245"></polygon>
+<svg width="583" height="431" data-bnfhash="f408020c386676a23cbb77043bf58eb9">
+  <polygon points="11 17 3 13 3 21"></polygon>
+  <polygon points="19 17 11 13 11 21"></polygon>
+  <rect x="33" y="3" width="132" height="32" rx="10"></rect>
+  <rect x="31" y="1" width="132" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="41" y="21">CREATE SOURCE</text>
+  <rect x="205" y="35" width="122" height="32" rx="10"></rect>
+  <rect x="203" y="33" width="122" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="213" y="53">IF NOT EXISTS</text>
+  <rect x="367" y="3" width="82" height="32"></rect>
+  <rect x="365" y="1" width="82" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="375" y="21">src_name</text>
+  <rect x="79" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="77" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="87" y="163">(</text>
+  <rect x="145" y="145" width="80" height="32"></rect>
+  <rect x="143" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="153" y="163">col_name</text>
+  <rect x="145" y="101" width="24" height="32" rx="10"></rect>
+  <rect x="143" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="153" y="119">,</text>
+  <rect x="265" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="263" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="273" y="163">)</text>
+  <rect x="331" y="145" width="60" height="32" rx="10"></rect>
+  <rect x="329" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="339" y="163">FROM</text>
+  <rect x="411" y="145" width="50" height="32" rx="10"></rect>
+  <rect x="409" y="143" width="50" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="419" y="163">FILE</text>
+  <rect x="481" y="145" width="48" height="32"></rect>
+  <rect x="479" y="143" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="489" y="163">path</text>
+  <rect x="64" y="271" width="58" height="32" rx="10"></rect>
+  <rect x="62" y="269" width="58" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="72" y="289">WITH</text>
+  <rect x="142" y="271" width="26" height="32" rx="10"></rect>
+  <rect x="140" y="269" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="150" y="289">(</text>
+  <rect x="208" y="271" width="46" height="32"></rect>
+  <rect x="206" y="269" width="46" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="216" y="289">field</text>
+  <rect x="274" y="271" width="30" height="32" rx="10"></rect>
+  <rect x="272" y="269" width="30" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="282" y="289">=</text>
+  <rect x="324" y="271" width="38" height="32"></rect>
+  <rect x="322" y="269" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="332" y="289">val</text>
+  <rect x="208" y="227" width="24" height="32" rx="10"></rect>
+  <rect x="206" y="225" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="216" y="245">,</text>
+  <rect x="402" y="271" width="26" height="32" rx="10"></rect>
+  <rect x="400" y="269" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="410" y="289">)</text>
+  <rect x="468" y="271" width="76" height="32" rx="10"></rect>
+  <rect x="466" y="269" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="476" y="289">FORMAT</text>
+  <rect x="25" y="353" width="90" height="32" rx="10"></rect>
+  <rect x="23" y="351" width="90" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="33" y="371">CSV WITH</text>
+  <rect x="155" y="353" width="74" height="32" rx="10"></rect>
+  <rect x="153" y="351" width="74" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="163" y="371">HEADER</text>
+  <rect x="155" y="397" width="28" height="32"></rect>
+  <rect x="153" y="395" width="28" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="163" y="415">n</text>
+  <rect x="203" y="397" width="88" height="32" rx="10"></rect>
+  <rect x="201" y="395" width="88" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="211" y="415">COLUMNS</text>
+  <rect x="351" y="385" width="118" height="32" rx="10"></rect>
+  <rect x="349" y="383" width="118" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="359" y="403">DELIMITED BY</text>
+  <rect x="489" y="385" width="46" height="32"></rect>
+  <rect x="487" y="383" width="46" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="497" y="403">char</text>
+  <path class="line" d="m19 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-434 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m20 -34 h10 m60 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-529 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m20 -34 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-563 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m20 0 h10 m74 0 h10 m0 0 h62 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m28 0 h10 m0 0 h10 m88 0 h10 m40 -44 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m118 0 h10 m0 0 h10 m46 0 h10 m23 -32 h-3"></path>
+  <polygon points="573 367 581 363 581 371"></polygon>
+  <polygon points="573 367 565 363 565 371"></polygon>
 </svg>
 <!-- generated by Railroad Diagram Generator https://www.bottlecaps.de/rr/ui -->

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source-kinesis.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source-kinesis.html
@@ -1,4 +1,4 @@
-<svg width="549" height="327" data-bnfhash="4d8d9f0e1181b0f4c70446130f493105">
+<svg width="569" height="387" data-bnfhash="faa4c70042a12d523cfff3be7b0e2f3b">
   <polygon points="9 17 1 13 1 21"></polygon>
   <polygon points="17 17 9 13 9 21"></polygon>
   <rect x="31" y="3" width="132" height="32" rx="10"></rect>
@@ -10,44 +10,56 @@
   <rect x="365" y="3" width="82" height="32"></rect>
   <rect x="363" y="1" width="82" height="32" class="nonterminal"></rect>
   <text class="nonterminal" x="373" y="21">src_name</text>
-  <rect x="467" y="3" width="60" height="32" rx="10"></rect>
-  <rect x="465" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="475" y="21">FROM</text>
-  <rect x="191" y="101" width="110" height="32" rx="10"></rect>
-  <rect x="189" y="99" width="110" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="199" y="119">KINESIS ARN</text>
-  <rect x="321" y="101" width="40" height="32"></rect>
-  <rect x="319" y="99" width="40" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="329" y="119">arn</text>
-  <rect x="46" y="211" width="58" height="32" rx="10"></rect>
-  <rect x="44" y="209" width="58" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="54" y="229">WITH</text>
-  <rect x="124" y="211" width="26" height="32" rx="10"></rect>
-  <rect x="122" y="209" width="26" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="132" y="229">(</text>
-  <rect x="190" y="211" width="46" height="32"></rect>
-  <rect x="188" y="209" width="46" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="198" y="229">field</text>
-  <rect x="256" y="211" width="30" height="32" rx="10"></rect>
-  <rect x="254" y="209" width="30" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="264" y="229">=</text>
-  <rect x="306" y="211" width="38" height="32"></rect>
-  <rect x="304" y="209" width="38" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="314" y="229">val</text>
-  <rect x="190" y="167" width="24" height="32" rx="10"></rect>
-  <rect x="188" y="165" width="24" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="198" y="185">,</text>
-  <rect x="384" y="211" width="26" height="32" rx="10"></rect>
-  <rect x="382" y="209" width="26" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="392" y="229">)</text>
-  <rect x="450" y="211" width="76" height="32" rx="10"></rect>
-  <rect x="448" y="209" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="458" y="229">FORMAT</text>
-  <rect x="459" y="293" width="62" height="32" rx="10"></rect>
-  <rect x="457" y="291" width="62" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="467" y="311">BYTES</text>
-  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-380 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m110 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-379 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m20 -34 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-111 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m62 0 h10 m3 0 h-3"></path>
-  <polygon points="539 307 547 303 547 311"></polygon>
-  <polygon points="539 307 531 303 531 311"></polygon>
+  <rect x="45" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="43" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="53" y="163">(</text>
+  <rect x="111" y="145" width="80" height="32"></rect>
+  <rect x="109" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="119" y="163">col_name</text>
+  <rect x="111" y="101" width="24" height="32" rx="10"></rect>
+  <rect x="109" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="119" y="119">,</text>
+  <rect x="231" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="229" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="239" y="163">)</text>
+  <rect x="297" y="145" width="60" height="32" rx="10"></rect>
+  <rect x="295" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="305" y="163">FROM</text>
+  <rect x="377" y="145" width="110" height="32" rx="10"></rect>
+  <rect x="375" y="143" width="110" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="385" y="163">KINESIS ARN</text>
+  <rect x="507" y="145" width="40" height="32"></rect>
+  <rect x="505" y="143" width="40" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="515" y="163">arn</text>
+  <rect x="56" y="271" width="58" height="32" rx="10"></rect>
+  <rect x="54" y="269" width="58" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="64" y="289">WITH</text>
+  <rect x="134" y="271" width="26" height="32" rx="10"></rect>
+  <rect x="132" y="269" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="142" y="289">(</text>
+  <rect x="200" y="271" width="46" height="32"></rect>
+  <rect x="198" y="269" width="46" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="208" y="289">field</text>
+  <rect x="266" y="271" width="30" height="32" rx="10"></rect>
+  <rect x="264" y="269" width="30" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="274" y="289">=</text>
+  <rect x="316" y="271" width="38" height="32"></rect>
+  <rect x="314" y="269" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="324" y="289">val</text>
+  <rect x="200" y="227" width="24" height="32" rx="10"></rect>
+  <rect x="198" y="225" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="208" y="245">,</text>
+  <rect x="394" y="271" width="26" height="32" rx="10"></rect>
+  <rect x="392" y="269" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="402" y="289">)</text>
+  <rect x="460" y="271" width="76" height="32" rx="10"></rect>
+  <rect x="458" y="269" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="468" y="289">FORMAT</text>
+  <rect x="479" y="353" width="62" height="32" rx="10"></rect>
+  <rect x="477" y="351" width="62" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="487" y="371">BYTES</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-466 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m20 -34 h10 m60 0 h10 m0 0 h10 m110 0 h10 m0 0 h10 m40 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-555 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m20 -34 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-101 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m62 0 h10 m3 0 h-3"></path>
+  <polygon points="559 367 567 363 567 371"></polygon>
+  <polygon points="559 367 551 363 551 371"></polygon>
 </svg>
 <!-- generated by Railroad Diagram Generator https://www.bottlecaps.de/rr/ui -->

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source-protobuf.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source-protobuf.html
@@ -1,4 +1,4 @@
-<svg width="549" height="343" data-bnfhash="b6173220ef68ab14892446ff0917c69c">
+<svg width="591" height="403" data-bnfhash="27cc79eb2fd2922280cc0668a52141f6">
   <polygon points="9 17 1 13 1 21"></polygon>
   <polygon points="17 17 9 13 9 21"></polygon>
   <rect x="31" y="3" width="132" height="32" rx="10"></rect>
@@ -10,44 +10,56 @@
   <rect x="365" y="3" width="82" height="32"></rect>
   <rect x="363" y="1" width="82" height="32" class="nonterminal"></rect>
   <text class="nonterminal" x="373" y="21">src_name</text>
-  <rect x="467" y="3" width="60" height="32" rx="10"></rect>
-  <rect x="465" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="475" y="21">FROM</text>
-  <rect x="35" y="101" width="124" height="32" rx="10"></rect>
-  <rect x="33" y="99" width="124" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="43" y="119">KAFKA BROKER</text>
-  <rect x="179" y="101" width="48" height="32"></rect>
-  <rect x="177" y="99" width="48" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="187" y="119">host</text>
-  <rect x="247" y="101" width="64" height="32" rx="10"></rect>
-  <rect x="245" y="99" width="64" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="255" y="119">TOPIC</text>
-  <rect x="351" y="133" width="50" height="32"></rect>
-  <rect x="349" y="131" width="50" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="359" y="151">topic</text>
-  <rect x="441" y="101" width="76" height="32" rx="10"></rect>
-  <rect x="439" y="99" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="449" y="119">FORMAT</text>
-  <rect x="51" y="199" width="164" height="32" rx="10"></rect>
-  <rect x="49" y="197" width="164" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="59" y="217">PROTOBUF MESSAGE</text>
-  <rect x="235" y="199" width="120" height="32"></rect>
-  <rect x="233" y="197" width="120" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="243" y="217">message_name</text>
-  <rect x="375" y="199" width="126" height="32" rx="10"></rect>
-  <rect x="373" y="197" width="126" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="383" y="217">USING SCHEMA</text>
-  <rect x="299" y="265" width="50" height="32" rx="10"></rect>
-  <rect x="297" y="263" width="50" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="307" y="283">FILE</text>
-  <rect x="369" y="265" width="132" height="32"></rect>
-  <rect x="367" y="263" width="132" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="377" y="283">schema_file_path</text>
-  <rect x="299" y="309" width="110" height="32"></rect>
-  <rect x="297" y="307" width="110" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="307" y="327">inline_schema</text>
-  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-536 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m124 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m20 -32 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-510 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m164 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-266 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m50 0 h10 m0 0 h10 m132 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m110 0 h10 m0 0 h92 m23 -44 h-3"></path>
-  <polygon points="539 279 547 275 547 283"></polygon>
-  <polygon points="539 279 531 275 531 283"></polygon>
+  <rect x="45" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="43" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="53" y="163">(</text>
+  <rect x="111" y="145" width="80" height="32"></rect>
+  <rect x="109" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="119" y="163">col_name</text>
+  <rect x="111" y="101" width="24" height="32" rx="10"></rect>
+  <rect x="109" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="119" y="119">,</text>
+  <rect x="231" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="229" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="239" y="163">)</text>
+  <rect x="297" y="145" width="60" height="32" rx="10"></rect>
+  <rect x="295" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="305" y="163">FROM</text>
+  <rect x="377" y="145" width="124" height="32" rx="10"></rect>
+  <rect x="375" y="143" width="124" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="385" y="163">KAFKA BROKER</text>
+  <rect x="521" y="145" width="48" height="32"></rect>
+  <rect x="519" y="143" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="529" y="163">host</text>
+  <rect x="70" y="227" width="64" height="32" rx="10"></rect>
+  <rect x="68" y="225" width="64" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="78" y="245">TOPIC</text>
+  <rect x="174" y="259" width="50" height="32"></rect>
+  <rect x="172" y="257" width="50" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="182" y="277">topic</text>
+  <rect x="264" y="227" width="76" height="32" rx="10"></rect>
+  <rect x="262" y="225" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="272" y="245">FORMAT</text>
+  <rect x="360" y="227" width="164" height="32" rx="10"></rect>
+  <rect x="358" y="225" width="164" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="368" y="245">PROTOBUF MESSAGE</text>
+  <rect x="35" y="325" width="120" height="32"></rect>
+  <rect x="33" y="323" width="120" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="43" y="343">message_name</text>
+  <rect x="175" y="325" width="126" height="32" rx="10"></rect>
+  <rect x="173" y="323" width="126" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="183" y="343">USING SCHEMA</text>
+  <rect x="341" y="325" width="50" height="32" rx="10"></rect>
+  <rect x="339" y="323" width="50" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="349" y="343">FILE</text>
+  <rect x="411" y="325" width="132" height="32"></rect>
+  <rect x="409" y="323" width="132" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="419" y="343">schema_file_path</text>
+  <rect x="341" y="369" width="110" height="32"></rect>
+  <rect x="339" y="367" width="110" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="349" y="387">inline_schema</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-466 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m20 -34 h10 m60 0 h10 m0 0 h10 m124 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-543 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m64 0 h10 m20 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m20 -32 h10 m76 0 h10 m0 0 h10 m164 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-533 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m120 0 h10 m0 0 h10 m126 0 h10 m20 0 h10 m50 0 h10 m0 0 h10 m132 0 h10 m-242 0 h20 m222 0 h20 m-262 0 q10 0 10 10 m242 0 q0 -10 10 -10 m-252 10 v24 m242 0 v-24 m-242 24 q0 10 10 10 m222 0 q10 0 10 -10 m-232 10 h10 m110 0 h10 m0 0 h92 m23 -44 h-3"></path>
+  <polygon points="581 339 589 335 589 343"></polygon>
+  <polygon points="581 339 573 335 573 343"></polygon>
 </svg>
 <!-- generated by Railroad Diagram Generator https://www.bottlecaps.de/rr/ui -->

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source-text.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source-text.html
@@ -1,4 +1,4 @@
-<svg width="619" height="349" data-bnfhash="a1a4e9961c7aa13d3ca5fd9cb8503f52">
+<svg width="547" height="475" data-bnfhash="ea7b55f8e1f673215763cc14c9445c00">
   <polygon points="9 17 1 13 1 21"></polygon>
   <polygon points="17 17 9 13 9 21"></polygon>
   <rect x="31" y="3" width="132" height="32" rx="10"></rect>
@@ -10,53 +10,65 @@
   <rect x="365" y="3" width="82" height="32"></rect>
   <rect x="363" y="1" width="82" height="32" class="nonterminal"></rect>
   <text class="nonterminal" x="373" y="21">src_name</text>
-  <rect x="467" y="3" width="60" height="32" rx="10"></rect>
-  <rect x="465" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="475" y="21">FROM</text>
-  <rect x="547" y="3" width="50" height="32" rx="10"></rect>
-  <rect x="545" y="1" width="50" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="555" y="21">FILE</text>
-  <rect x="27" y="145" width="48" height="32"></rect>
-  <rect x="25" y="143" width="48" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="35" y="163">path</text>
-  <rect x="115" y="145" width="58" height="32" rx="10"></rect>
-  <rect x="113" y="143" width="58" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="123" y="163">WITH</text>
-  <rect x="193" y="145" width="26" height="32" rx="10"></rect>
-  <rect x="191" y="143" width="26" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="201" y="163">(</text>
-  <rect x="259" y="145" width="46" height="32"></rect>
-  <rect x="257" y="143" width="46" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="267" y="163">field</text>
-  <rect x="325" y="145" width="30" height="32" rx="10"></rect>
-  <rect x="323" y="143" width="30" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="333" y="163">=</text>
-  <rect x="375" y="145" width="38" height="32"></rect>
-  <rect x="373" y="143" width="38" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="383" y="163">val</text>
-  <rect x="259" y="101" width="24" height="32" rx="10"></rect>
-  <rect x="257" y="99" width="24" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="267" y="119">,</text>
-  <rect x="453" y="145" width="26" height="32" rx="10"></rect>
-  <rect x="451" y="143" width="26" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="461" y="163">)</text>
-  <rect x="519" y="145" width="76" height="32" rx="10"></rect>
-  <rect x="517" y="143" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="527" y="163">FORMAT</text>
-  <rect x="431" y="227" width="64" height="32" rx="10"></rect>
-  <rect x="429" y="225" width="64" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="439" y="245">REGEX</text>
-  <rect x="515" y="227" width="56" height="32"></rect>
-  <rect x="513" y="225" width="56" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="523" y="245">regex</text>
-  <rect x="431" y="271" width="54" height="32" rx="10"></rect>
-  <rect x="429" y="269" width="54" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="439" y="289">TEXT</text>
-  <rect x="431" y="315" width="62" height="32" rx="10"></rect>
-  <rect x="429" y="313" width="62" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="439" y="333">BYTES</text>
-  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m50 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-614 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m20 -34 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-228 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m64 0 h10 m0 0 h10 m56 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m62 0 h10 m0 0 h78 m23 -88 h-3"></path>
-  <polygon points="609 241 617 237 617 245"></polygon>
-  <polygon points="609 241 601 237 601 245"></polygon>
+  <rect x="60" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="58" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="68" y="163">(</text>
+  <rect x="126" y="145" width="80" height="32"></rect>
+  <rect x="124" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="134" y="163">col_name</text>
+  <rect x="126" y="101" width="24" height="32" rx="10"></rect>
+  <rect x="124" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="134" y="119">,</text>
+  <rect x="246" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="244" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="254" y="163">)</text>
+  <rect x="312" y="145" width="60" height="32" rx="10"></rect>
+  <rect x="310" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="320" y="163">FROM</text>
+  <rect x="392" y="145" width="50" height="32" rx="10"></rect>
+  <rect x="390" y="143" width="50" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="400" y="163">FILE</text>
+  <rect x="462" y="145" width="48" height="32"></rect>
+  <rect x="460" y="143" width="48" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="470" y="163">path</text>
+  <rect x="45" y="271" width="58" height="32" rx="10"></rect>
+  <rect x="43" y="269" width="58" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="53" y="289">WITH</text>
+  <rect x="123" y="271" width="26" height="32" rx="10"></rect>
+  <rect x="121" y="269" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="131" y="289">(</text>
+  <rect x="189" y="271" width="46" height="32"></rect>
+  <rect x="187" y="269" width="46" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="197" y="289">field</text>
+  <rect x="255" y="271" width="30" height="32" rx="10"></rect>
+  <rect x="253" y="269" width="30" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="263" y="289">=</text>
+  <rect x="305" y="271" width="38" height="32"></rect>
+  <rect x="303" y="269" width="38" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="313" y="289">val</text>
+  <rect x="189" y="227" width="24" height="32" rx="10"></rect>
+  <rect x="187" y="225" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="197" y="245">,</text>
+  <rect x="383" y="271" width="26" height="32" rx="10"></rect>
+  <rect x="381" y="269" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="391" y="289">)</text>
+  <rect x="449" y="271" width="76" height="32" rx="10"></rect>
+  <rect x="447" y="269" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="457" y="289">FORMAT</text>
+  <rect x="359" y="353" width="64" height="32" rx="10"></rect>
+  <rect x="357" y="351" width="64" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="367" y="371">REGEX</text>
+  <rect x="443" y="353" width="56" height="32"></rect>
+  <rect x="441" y="351" width="56" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="451" y="371">regex</text>
+  <rect x="359" y="397" width="54" height="32" rx="10"></rect>
+  <rect x="357" y="395" width="54" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="367" y="415">TEXT</text>
+  <rect x="359" y="441" width="62" height="32" rx="10"></rect>
+  <rect x="357" y="439" width="62" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="367" y="459">BYTES</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-451 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m20 -34 h10 m60 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m48 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-529 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m30 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m20 -34 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-230 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m64 0 h10 m0 0 h10 m56 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m62 0 h10 m0 0 h78 m23 -88 h-3"></path>
+  <polygon points="537 367 545 363 545 371"></polygon>
+  <polygon points="537 367 529 363 529 371"></polygon>
 </svg>
 <!-- generated by Railroad Diagram Generator https://www.bottlecaps.de/rr/ui -->

--- a/www/layouts/partials/sql-grammar/rr-diagrams/create-source.html
+++ b/www/layouts/partials/sql-grammar/rr-diagrams/create-source.html
@@ -1,4 +1,4 @@
-<svg width="549" height="265" data-bnfhash="eb52a4ed737b45158bcc338e6905ab83">
+<svg width="615" height="337" data-bnfhash="1a450120dcb1875fd2a444700b6ffad8">
   <polygon points="9 17 1 13 1 21"></polygon>
   <polygon points="17 17 9 13 9 21"></polygon>
   <rect x="31" y="3" width="132" height="32" rx="10"></rect>
@@ -10,29 +10,41 @@
   <rect x="365" y="3" width="82" height="32"></rect>
   <rect x="363" y="1" width="82" height="32" class="nonterminal"></rect>
   <text class="nonterminal" x="373" y="21">src_name</text>
-  <rect x="467" y="3" width="60" height="32" rx="10"></rect>
-  <rect x="465" y="1" width="60" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="475" y="21">FROM</text>
-  <rect x="109" y="101" width="120" height="32"></rect>
-  <rect x="107" y="99" width="120" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="117" y="119">connector_spec</text>
-  <rect x="249" y="101" width="76" height="32" rx="10"></rect>
-  <rect x="247" y="99" width="76" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="257" y="119">FORMAT</text>
-  <rect x="345" y="101" width="98" height="32"></rect>
-  <rect x="343" y="99" width="98" height="32" class="nonterminal"></rect>
-  <text class="nonterminal" x="353" y="119">format_spec</text>
-  <rect x="259" y="187" width="92" height="32" rx="10"></rect>
-  <rect x="257" y="185" width="92" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="267" y="205">ENVELOPE</text>
-  <rect x="391" y="187" width="58" height="32" rx="10"></rect>
-  <rect x="389" y="185" width="58" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="399" y="205">NONE</text>
-  <rect x="391" y="231" width="90" height="32" rx="10"></rect>
-  <rect x="389" y="229" width="90" height="32" class="terminal" rx="10"></rect>
-  <text class="terminal" x="399" y="249">DEBEZIUM</text>
-  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-462 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m120 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m98 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-248 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m92 0 h10 m20 0 h10 m58 0 h10 m0 0 h32 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m43 -76 h-3"></path>
-  <polygon points="539 169 547 165 547 173"></polygon>
-  <polygon points="539 169 531 165 531 173"></polygon>
+  <rect x="45" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="43" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="53" y="163">(</text>
+  <rect x="111" y="145" width="80" height="32"></rect>
+  <rect x="109" y="143" width="80" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="119" y="163">col_name</text>
+  <rect x="111" y="101" width="24" height="32" rx="10"></rect>
+  <rect x="109" y="99" width="24" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="119" y="119">,</text>
+  <rect x="231" y="145" width="26" height="32" rx="10"></rect>
+  <rect x="229" y="143" width="26" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="239" y="163">)</text>
+  <rect x="297" y="145" width="60" height="32" rx="10"></rect>
+  <rect x="295" y="143" width="60" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="305" y="163">FROM</text>
+  <rect x="377" y="145" width="120" height="32"></rect>
+  <rect x="375" y="143" width="120" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="385" y="163">connector_spec</text>
+  <rect x="517" y="145" width="76" height="32" rx="10"></rect>
+  <rect x="515" y="143" width="76" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="525" y="163">FORMAT</text>
+  <rect x="187" y="227" width="98" height="32"></rect>
+  <rect x="185" y="225" width="98" height="32" class="nonterminal"></rect>
+  <text class="nonterminal" x="195" y="245">format_spec</text>
+  <rect x="325" y="259" width="92" height="32" rx="10"></rect>
+  <rect x="323" y="257" width="92" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="333" y="277">ENVELOPE</text>
+  <rect x="457" y="259" width="58" height="32" rx="10"></rect>
+  <rect x="455" y="257" width="58" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="465" y="277">NONE</text>
+  <rect x="457" y="303" width="90" height="32" rx="10"></rect>
+  <rect x="455" y="301" width="90" height="32" class="terminal" rx="10"></rect>
+  <text class="terminal" x="465" y="321">DEBEZIUM</text>
+  <path class="line" d="m17 17 h2 m0 0 h10 m132 0 h10 m20 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m122 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-466 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m26 0 h10 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v14 m252 0 v-14 m-252 14 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m0 0 h222 m20 -34 h10 m60 0 h10 m0 0 h10 m120 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-450 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m98 0 h10 m20 0 h10 m0 0 h252 m-282 0 h20 m262 0 h20 m-302 0 q10 0 10 10 m282 0 q0 -10 10 -10 m-292 10 v12 m282 0 v-12 m-282 12 q0 10 10 10 m262 0 q10 0 10 -10 m-272 10 h10 m92 0 h10 m20 0 h10 m58 0 h10 m0 0 h32 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m43 -76 h-3"></path>
+  <polygon points="605 241 613 237 613 245"></polygon>
+  <polygon points="605 241 597 237 597 245"></polygon>
 </svg>
 <!-- generated by Railroad Diagram Generator https://www.bottlecaps.de/rr/ui -->


### PR DESCRIPTION
Documents #2530 and reformats docs to adhere to width guidelines