### PR TITLE
ci/test: move security advisories check to dedicated job

### DIFF
--- a/ci/security/pipeline.yml
+++ b/ci/security/pipeline.yml
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Checks for security advisories in the Rust crate dependency graph.
+
+steps:
+  - command: cargo deny check advisories
+    timeout_in_minutes: 5
+    plugins:
+      - docker#v3.1.0:
+          image: materialize/ci-builder:1.42.0-20200327-102717
+          propagate-uid-gid: true
+          mount-ssh-agent: true
+          volumes:
+          - "$HOME/.cargo:/cargo"
+          environment:
+          - CARGO_HOME=/cargo

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -19,6 +19,6 @@ ci_init
 
 ci_try bin/lint
 ci_try cargo --locked fmt -- --check
-ci_try cargo --locked deny check
+ci_try cargo --locked deny check licenses bans sources
 
 ci_status_report


### PR DESCRIPTION
We don't want historical builds or PR builds failing just because a
security vulnerability was discovered in one of our dependencies. These
are serious, but not serious enough to warrant nondeterminism in our CI
pipeline.

Instead introduce a separate CI job whose only responsibility is to
check for these vulnerabilites in the Rust advisory database. That job
will be scheduled to run daily and post failures in Slack.