### PR TITLE
testdrive: rework kafka ingestion transcoding

### DIFF
--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -7,19 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
+use std::io::{BufRead, Read};
 
-use avro::Schema;
 use byteorder::{NetworkEndian, WriteBytesExt};
 use futures::executor::block_on;
 use futures::future::{self, TryFutureExt};
 use futures::stream::{FuturesUnordered, TryStreamExt};
 use rdkafka::producer::FutureRecord;
-use serde_json::{Deserializer, Value};
+use serde::de::DeserializeOwned;
 
 use crate::action::{Action, State};
-use crate::format::protobuf;
-use crate::format::protobuf::native::{Batch, Struct};
+use crate::format::avro::{self, Schema};
+use crate::format::protobuf::{self, ToMessage};
 use crate::parser::BuiltinCommand;
 
 pub struct IngestAction {
@@ -34,59 +33,65 @@ pub struct IngestAction {
 
 enum Format {
     Avro { schema: String },
-    Proto { message: String },
-    Bytes,
+    Protobuf { message: protobuf::MessageType },
+    Bytes { terminator: Option<u8> },
 }
 
-enum Encoder {
-    Avro {
-        schema: Schema,
-        schema_id: i32,
-    },
-    Proto {
-        parser: &'static dyn Fn(&str) -> Result<protobuf::DynMessage, failure::Error>,
-        validator: &'static dyn Fn(&[u8]) -> Result<Box<dyn fmt::Debug>, failure::Error>,
-    },
-    Bytes,
+enum Transcoder {
+    Avro { schema: Schema, schema_id: i32 },
+    Protobuf { message: protobuf::MessageType },
+    Bytes { terminator: Option<u8> },
 }
 
-impl Encoder {
-    fn encode_to_bytes(&self, row: &str, buf: &mut Vec<u8>) -> Result<(), String> {
+impl Transcoder {
+    fn decode_json<R, T>(row: R) -> Result<T, String>
+    where
+        R: Read,
+        T: DeserializeOwned,
+    {
+        let deserializer = serde_json::Deserializer::from_reader(row);
+        match deserializer.into_iter().next() {
+            None => Err("line ended without json datum".into()),
+            Some(r) => r.map_err(|e| format!("parsing json: {}", e.to_string())),
+        }
+    }
+
+    fn transcode<R>(&self, mut row: R) -> Result<Vec<u8>, String>
+    where
+        R: BufRead,
+    {
+        let mut out = vec![];
         match self {
-            Encoder::Avro { schema, schema_id } => {
-                let val = crate::format::avro::json_to_avro(
-                    &serde_json::from_str(row)
-                        .map_err(|e| format!("parsing avro datum: {}", e.to_string()))?,
-                    schema.top_node(),
-                )?;
+            Transcoder::Avro { schema, schema_id } => {
+                let val = Self::decode_json(row)?;
+                let val = crate::format::avro::json_to_avro(&val, schema.top_node())?;
                 // The first byte is a magic byte (0) that indicates the Confluent
                 // serialization format version, and the next four bytes are a
                 // 32-bit schema ID.
                 //
                 // https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format
-                buf.write_u8(0).unwrap();
-                buf.write_i32::<NetworkEndian>(*schema_id).unwrap();
-                buf.extend(avro::to_avro_datum(&schema, val).map_err(|e| e.to_string())?);
+                out.write_u8(0).unwrap();
+                out.write_i32::<NetworkEndian>(*schema_id).unwrap();
+                out.extend(avro::to_avro_datum(&schema, val).map_err(|e| e.to_string())?);
             }
-            Encoder::Proto { parser, validator } => {
-                let msg =
-                    parser(row).map_err(|e| format!("converting row to type {} -> {}", row, e))?;
-                *buf = msg
-                    .write_to_bytes()
-                    .map_err(|e| format!("writing protobuf message for {}: {}", row, e))?;
-                // There are a variety of `write_*` methods on `Message` that don't
-                // seem to automatically do the right thing. This should always
-                // succeed, otherwise there is no chance for the server.
-                let _parsed = validator(&buf)
-                    .map_err(|e| format!("error validating proto row={}\nerror={}", row, e))?;
+            Transcoder::Protobuf { message } => {
+                let val: protobuf::DynMessage = match message {
+                    protobuf::MessageType::Batch => {
+                        Self::decode_json::<_, protobuf::native::Batch>(row)?.to_message()
+                    }
+                    protobuf::MessageType::Struct => {
+                        Self::decode_json::<_, protobuf::native::Struct>(row)?.to_message()
+                    }
+                };
+                val.write_to_vec(&mut out).map_err(|e| e.to_string())?;
             }
-            Encoder::Bytes => {
-                let json_string: serde_json::Value = serde_json::from_str(row)
-                    .map_err(|e| format!("parsing json string datum: {}", e.to_string()))?;
-                *buf = json_string.as_str().unwrap().as_bytes().to_vec();
+            Transcoder::Bytes { terminator } => match terminator {
+                Some(t) => row.read_until(*t, &mut out).map(|_n| ()),
+                None => row.read_to_end(&mut out).map(|_n| ()),
             }
+            .map_err(|e| e.to_string())?,
         }
-        Ok(())
+        Ok(out)
     }
 }
 
@@ -94,33 +99,31 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, String> {
     let topic_prefix = format!("testdrive-{}", cmd.args.string("topic")?);
     let partition = cmd.args.opt_parse::<i32>("partition")?.unwrap_or(0);
     let format = match cmd.args.string("format")?.as_str() {
-        "avro" => {
-            let schema = cmd.args.string("schema")?;
-            Format::Avro { schema }
-        }
-        "protobuf" => {
-            let message = cmd.args.string("message")?;
-            Format::Proto { message }
-        }
-        "bytes" => Format::Bytes,
-        f => return Err(format!("unknown message format: {}", f)),
+        "avro" => Format::Avro {
+            schema: cmd.args.string("schema")?,
+        },
+        "protobuf" => Format::Protobuf {
+            message: cmd.args.parse("message")?,
+        },
+        "bytes" => Format::Bytes { terminator: None },
+        f => return Err(format!("unknown format: {}", f)),
     };
-    let key_format = cmd.args.opt_string("key-format");
-    let key_schema = cmd.args.opt_string("key-schema");
-    let key_format = match (key_format.map(|s| s.to_lowercase()).as_deref(), key_schema) {
-        (Some("avro"), Some(key_schema)) => Some(Format::Avro { schema: key_schema }),
-        (None, Some(key_schema)) => Some(Format::Avro { schema: key_schema }),
-        (Some("bytes"), None) => Some(Format::Bytes),
-        (None, None) => None,
-        (Some(format_name), Some(_)) => {
-            return Err(format!(
-                "Cannot specify key-schema for key-format {}",
-                format_name
-            ));
-        }
-        (Some(format_name), None) => {
-            return Err(format!("unknown key-format {}", format_name));
-        }
+    let key_format = match cmd.args.opt_string("key-format").as_deref() {
+        Some("avro") => Some(Format::Avro {
+            schema: cmd.args.string("key-schema")?,
+        }),
+        Some("protobuf") => Some(Format::Protobuf {
+            message: cmd.args.parse("key-message")?,
+        }),
+        Some("bytes") => Some(Format::Bytes {
+            terminator: match cmd.args.opt_parse::<char>("key-terminator")? {
+                Some(c) if c.is_ascii() => Some(c as u8),
+                Some(_) => return Err("key terminator must be single ASCII character".into()),
+                None => Some(b':'),
+            },
+        }),
+        Some(f) => return Err(format!("unknown key format: {}", f)),
+        None => None,
     };
     let timestamp = cmd.args.opt_parse("timestamp")?;
     let publish = cmd.args.opt_bool("publish")?;
@@ -169,8 +172,8 @@ impl Action for IngestAction {
 
     fn redo(&self, state: &mut State) -> Result<(), String> {
         let topic_name = format!("{}-{}", self.topic_prefix, state.seed);
-        let mut make_encoder = |format: &Format, typ| match *format {
-            Format::Avro { ref schema } => {
+        let mut make_transcoder = |format: &Format, typ| match format {
+            Format::Avro { schema } => {
                 let schema_id = if self.publish {
                     let ccsr_subject = format!("{}-{}", topic_name, typ);
                     let schema_id = state.tokio_runtime.block_on(
@@ -185,70 +188,33 @@ impl Action for IngestAction {
                 };
                 let schema = interchange::avro::parse_schema(&schema)
                     .map_err(|e| format!("parsing avro schema: {}", e))?;
-                Ok(Encoder::Avro { schema, schema_id })
+                Ok::<_, String>(Transcoder::Avro { schema, schema_id })
             }
-            Format::Proto { ref message } => match message.as_str() {
-                ".Struct" => Ok(Encoder::Proto {
-                    parser: &protobuf::json_to_protobuf::<Struct>,
-                    validator: &protobuf::decode::<Struct>,
-                }),
-                ".Batch" => Ok(Encoder::Proto {
-                    parser: &protobuf::json_to_protobuf::<Batch>,
-                    validator: &protobuf::decode::<Batch>,
-                }),
-                _ => Err(format!("unknown testdrive protobuf message: {}", message)),
-            },
-            Format::Bytes => Ok(Encoder::Bytes),
+            Format::Protobuf { message } => Ok(Transcoder::Protobuf { message: *message }),
+            Format::Bytes { terminator } => Ok(Transcoder::Bytes {
+                terminator: *terminator,
+            }),
         };
-        let value_encoder = make_encoder(&self.format, "value")?;
-        let key_encoder = match &self.key_format {
+        let value_transcoder = make_transcoder(&self.format, "value")?;
+        let key_transcoder = match &self.key_format {
             None => None,
-            Some(f) => Some(make_encoder(f, "key")?),
+            Some(f) => Some(make_transcoder(f, "key")?),
         };
 
         let futs = FuturesUnordered::new();
         for row in &self.rows {
-            let mut val_buf = Vec::new();
-            let mut key_buf = Vec::new();
-            let (key_row, val_row) = if key_encoder.is_some() {
-                let mut tokens = Deserializer::from_str(&row).into_iter::<Value>();
-                let key_row = tokens.next();
-                let val_row = tokens.next();
-
-                if tokens.next().is_some() || key_row.is_none() || val_row.is_none() {
-                    return Err(format!(
-                        "invalid row: {}; testdrive expects two json objects",
-                        row
-                    ));
-                }
-
-                (
-                    Some(
-                        key_row
-                            .unwrap()
-                            .map_err(|e| format!("parsing avro datum: {}", e.to_string()))?
-                            .to_string(),
-                    ),
-                    val_row
-                        .unwrap()
-                        .map_err(|e| format!("parsing avro datum: {}", e.to_string()))?
-                        .to_string(),
-                )
-            } else {
-                (None, row.clone())
+            let mut row = row.as_bytes();
+            let key = match &key_transcoder {
+                None => None,
+                Some(kt) => Some(kt.transcode(&mut row)?),
             };
-
-            value_encoder.encode_to_bytes(&val_row, &mut val_buf)?;
-            if let Some(key_encoder) = &key_encoder {
-                key_encoder.encode_to_bytes(&key_row.unwrap(), &mut key_buf)?;
-            }
+            let value = value_transcoder.transcode(&mut row)?;
 
             let mut record: FutureRecord<_, _> = FutureRecord::to(&topic_name)
-                .payload(&val_buf)
+                .payload(&value)
                 .partition(self.partition);
-
-            if self.key_format.is_some() {
-                record = record.key(&key_buf);
+            if let Some(key) = &key {
+                record = record.key(key);
             }
             if let Some(timestamp) = self.timestamp {
                 record = record.timestamp(timestamp);

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -64,7 +64,7 @@ impl Transcoder {
         match self {
             Transcoder::Avro { schema, schema_id } => {
                 let val = Self::decode_json(row)?;
-                let val = crate::format::avro::json_to_avro(&val, schema.top_node())?;
+                let val = avro::from_json(&val, schema.top_node())?;
                 // The first byte is a magic byte (0) that indicates the Confluent
                 // serialization format version, and the next four bytes are a
                 // 32-bit schema ID.
@@ -186,7 +186,7 @@ impl Action for IngestAction {
                 } else {
                     1
                 };
-                let schema = interchange::avro::parse_schema(&schema)
+                let schema = avro::parse_schema(&schema)
                     .map_err(|e| format!("parsing avro schema: {}", e))?;
                 Ok::<_, String>(Transcoder::Avro { schema, schema_id })
             }

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -68,12 +68,12 @@ impl Action for VerifyAction {
         config.set("auto.offset.reset", "earliest");
         config.set("group.id", "materialize-testdrive");
 
-        let schema = interchange::avro::parse_schema(&schema)
-            .map_err(|e| format!("parsing avro schema: {}", e))?;
+        let schema =
+            avro::parse_schema(&schema).map_err(|e| format!("parsing avro schema: {}", e))?;
         let mut converted_expected_messages = Vec::new();
         for expected in &self.expected_messages {
             converted_expected_messages.push(
-                crate::format::avro::json_to_avro(
+                avro::from_json(
                     &serde_json::from_str(expected)
                         .map_err(|e| format!("parsing avro datum: {}", e.to_string()))?,
                     schema.top_node(),

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -22,54 +22,55 @@ use std::num::TryFromIntError;
 
 use serde_json::Value as JsonValue;
 
-use avro::schema::{SchemaNode, SchemaPiece};
-use avro::types::{DecimalValue, ToAvro, Value as AvroValue};
+// Re-export components from the various other Avro libraries, so that other
+// testdrive modules can import just this one.
 
-pub use avro::{to_avro_datum, Schema};
+pub use avro::schema::{Schema, SchemaNode, SchemaPiece};
+pub use avro::types::{DecimalValue, ToAvro, Value};
+pub use avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
+pub use interchange::avro::parse_schema;
 
 // This function is derived from code in the avro_rs project. Update the license
 // header on this file accordingly if you move it to a new home.
-pub fn json_to_avro(json: &JsonValue, schema: SchemaNode) -> Result<AvroValue, String> {
+pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> {
     match (json, schema.inner) {
-        (JsonValue::Null, SchemaPiece::Null) => Ok(AvroValue::Null),
-        (JsonValue::Bool(b), SchemaPiece::Boolean) => Ok(AvroValue::Boolean(*b)),
-        (JsonValue::Number(ref n), SchemaPiece::Int) => Ok(AvroValue::Int(
+        (JsonValue::Null, SchemaPiece::Null) => Ok(Value::Null),
+        (JsonValue::Bool(b), SchemaPiece::Boolean) => Ok(Value::Boolean(*b)),
+        (JsonValue::Number(ref n), SchemaPiece::Int) => Ok(Value::Int(
             n.as_i64()
                 .unwrap()
                 .try_into()
                 .map_err(|e: TryFromIntError| e.to_string())?,
         )),
-        (JsonValue::Number(ref n), SchemaPiece::Long) => Ok(AvroValue::Long(n.as_i64().unwrap())),
+        (JsonValue::Number(ref n), SchemaPiece::Long) => Ok(Value::Long(n.as_i64().unwrap())),
         (JsonValue::Number(ref n), SchemaPiece::Float) => {
-            Ok(AvroValue::Float(n.as_f64().unwrap() as f32))
+            Ok(Value::Float(n.as_f64().unwrap() as f32))
         }
-        (JsonValue::Number(ref n), SchemaPiece::Double) => {
-            Ok(AvroValue::Double(n.as_f64().unwrap()))
-        }
-        (JsonValue::Number(ref n), SchemaPiece::Date) => Ok(AvroValue::Date(
+        (JsonValue::Number(ref n), SchemaPiece::Double) => Ok(Value::Double(n.as_f64().unwrap())),
+        (JsonValue::Number(ref n), SchemaPiece::Date) => Ok(Value::Date(
             chrono::NaiveDate::from_ymd(1970, 1, 1) + chrono::Duration::days(n.as_i64().unwrap()),
         )),
         (JsonValue::Number(ref n), SchemaPiece::TimestampMilli) => {
             let ts = n.as_i64().unwrap();
-            Ok(AvroValue::Timestamp(chrono::NaiveDateTime::from_timestamp(
+            Ok(Value::Timestamp(chrono::NaiveDateTime::from_timestamp(
                 ts / 1_000,
                 ts as u32 % 1_000,
             )))
         }
         (JsonValue::Number(ref n), SchemaPiece::TimestampMicro) => {
             let ts = n.as_i64().unwrap();
-            Ok(AvroValue::Timestamp(chrono::NaiveDateTime::from_timestamp(
+            Ok(Value::Timestamp(chrono::NaiveDateTime::from_timestamp(
                 ts / 1_000_000,
                 ts as u32 % 1_000_000,
             )))
         }
-        (JsonValue::Array(items), SchemaPiece::Array(inner)) => Ok(AvroValue::Array(
+        (JsonValue::Array(items), SchemaPiece::Array(inner)) => Ok(Value::Array(
             items
                 .iter()
-                .map(|x| json_to_avro(x, schema.step(&**inner)))
+                .map(|x| from_json(x, schema.step(&**inner)))
                 .collect::<Result<_, _>>()?,
         )),
-        (JsonValue::String(s), SchemaPiece::String) => Ok(AvroValue::String(s.clone())),
+        (JsonValue::String(s), SchemaPiece::String) => Ok(Value::String(s.clone())),
         (
             JsonValue::Array(items),
             SchemaPiece::Decimal {
@@ -84,7 +85,7 @@ pub fn json_to_avro(json: &JsonValue, schema: SchemaNode) -> Result<AvroValue, S
                 Some(bytes) => bytes,
                 None => return Err("decimal was not represented by byte array".into()),
             };
-            Ok(AvroValue::Decimal(DecimalValue {
+            Ok(Value::Decimal(DecimalValue {
                 unscaled: bytes,
                 precision: *precision,
                 scale: *scale,
@@ -92,7 +93,7 @@ pub fn json_to_avro(json: &JsonValue, schema: SchemaNode) -> Result<AvroValue, S
         }
         (JsonValue::String(s), SchemaPiece::Json) => {
             let j = serde_json::from_str(s).map_err(|e| e.to_string())?;
-            Ok(AvroValue::Json(j))
+            Ok(Value::Json(j))
         }
         (JsonValue::Object(items), SchemaPiece::Record { .. }) => {
             let mut builder = avro::types::Record::new(schema)
@@ -101,7 +102,7 @@ pub fn json_to_avro(json: &JsonValue, schema: SchemaNode) -> Result<AvroValue, S
                 let field = builder
                     .field_by_name(key)
                     .ok_or_else(|| format!("No such key in record: {}", key))?;
-                let val = json_to_avro(val, schema.step(&field.schema))?;
+                let val = from_json(val, schema.step(&field.schema))?;
                 builder.put(key, val);
             }
             Ok(builder.avro())
@@ -110,8 +111,8 @@ pub fn json_to_avro(json: &JsonValue, schema: SchemaNode) -> Result<AvroValue, S
             let variants = us.variants();
             let mut last_err = format!("Union schema {:?} did not match {:?}", variants, val);
             for (i, variant) in variants.iter().enumerate() {
-                match json_to_avro(val, schema.step(variant)) {
-                    Ok(avro) => return Ok(AvroValue::Union(i, Box::new(avro))),
+                match from_json(val, schema.step(variant)) {
+                    Ok(avro) => return Ok(Value::Union(i, Box::new(avro))),
                     Err(msg) => last_err = msg,
                 }
             }
@@ -124,12 +125,12 @@ pub fn json_to_avro(json: &JsonValue, schema: SchemaNode) -> Result<AvroValue, S
     }
 }
 
-/// Computes the multiset difference between two slices of [`AvroValue`]s, i.e.,
+/// Computes the multiset difference between two slices of [`Value`]s, i.e.,
 /// `lhs - rhs`.
 ///
-/// Required because `AvroValue` does not implement `Hash`, `Eq`, or `Ord`, and
-/// so using a standard multiset type to perform the difference is not possible.
-pub fn multiset_difference<'a>(lhs: &'a [AvroValue], rhs: &'a [AvroValue]) -> Vec<AvroValue> {
+/// Required because `Value` does not implement `Hash`, `Eq`, or `Ord`, and so
+/// using a standard multiset type to perform the difference is not possible.
+pub fn multiset_difference<'a>(lhs: &'a [Value], rhs: &'a [Value]) -> Vec<Value> {
     let mut diff = lhs.to_vec();
     for r in rhs {
         if let Some(i) = diff.iter().position(|l| l == r) {
@@ -145,8 +146,8 @@ mod tests {
 
     #[test]
     fn test_multiset_difference() {
-        const ONE: AvroValue = AvroValue::Int(1);
-        const TWO: AvroValue = AvroValue::Int(2);
+        const ONE: Value = Value::Int(1);
+        const TWO: Value = Value::Int(2);
         for (lhs, rhs, expected) in &[
             (&[][..], &[][..], &[][..]),
             (&[ONE], &[], &[ONE]),

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -20,10 +20,12 @@
 use std::convert::{TryFrom, TryInto};
 use std::num::TryFromIntError;
 
+use serde_json::Value as JsonValue;
+
 use avro::schema::{SchemaNode, SchemaPiece};
 use avro::types::{DecimalValue, ToAvro, Value as AvroValue};
 
-use serde_json::Value as JsonValue;
+pub use avro::{to_avro_datum, Schema};
 
 // This function is derived from code in the avro_rs project. Update the license
 // header on this file accordingly if you move it to a new home.

--- a/src/testdrive/src/format/protobuf/native.rs
+++ b/src/testdrive/src/format/protobuf/native.rs
@@ -15,7 +15,7 @@ use protobuf::RepeatedField;
 use serde::Deserialize;
 
 use crate::format::protobuf::gen::{billing, simple};
-use crate::format::protobuf::{DbgMsg, DynMessage, FromMessage, ToMessage};
+use crate::format::protobuf::{DbgMsg, DynMessage, ToMessage};
 
 // Billing demo
 
@@ -23,10 +23,6 @@ impl ToMessage for Batch {
     fn to_message(self) -> DynMessage {
         Box::new(billing::Batch::from(self))
     }
-}
-
-impl FromMessage for Batch {
-    type MessageType = billing::Batch;
 }
 
 impl DbgMsg for billing::Batch {}
@@ -155,10 +151,6 @@ impl ToMessage for Struct {
     fn to_message(self) -> DynMessage {
         Box::new(simple::Struct::from(self))
     }
-}
-
-impl FromMessage for Struct {
-    type MessageType = simple::Struct;
 }
 
 impl DbgMsg for simple::Struct {}

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -122,7 +122,7 @@ $ set valid-key-schema={
 
 $ kafka-create-topic topic=missing-data
 
-$ kafka-ingest format=avro topic=missing-data schema=${schema-v1} key-schema=${key-schema-missing}
+$ kafka-ingest format=avro key-format=avro topic=missing-data schema=${schema-v1} key-schema=${key-schema-missing}
   publish=true timestamp=1
 {"b": 42} {"before": null, "after": {"a": 1}}
 
@@ -134,8 +134,8 @@ Value schema missing primary key column: b
 
 $ kafka-create-topic topic=mismatched-data
 
-$ kafka-ingest format=avro topic=mismatched-data schema=${schema-v1} key-schema=${key-schema-wrong-type}
-  publish=true timestamp=3
+$ kafka-ingest topic=mismatched-data publish=true timestamp=3
+  format=avro schema=${schema-v1} key-format=avro key-schema=${key-schema-wrong-type}
 {"a": 1} {"before": null, "after": {"a": 1}}
 
 ! CREATE SOURCE data_v3
@@ -144,8 +144,8 @@ $ kafka-ingest format=avro topic=mismatched-data schema=${schema-v1} key-schema=
   ENVELOPE DEBEZIUM
 key and value column types do not match
 
-$ kafka-ingest format=avro topic=data schema=${schema-v1} key-schema=${valid-key-schema}
-  publish=true timestamp=5
+$ kafka-ingest topic=data publish=true timestamp=5
+  format=avro schema=${schema-v1} key-format=avro key-schema=${valid-key-schema}
 {"a": 1} {"before": null, "after": {"a": 1}}
 
 > CREATE MATERIALIZED SOURCE data_v3

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -10,8 +10,8 @@
 $ kafka-create-topic topic=bytes
 
 $ kafka-ingest format=bytes topic=bytes timestamp=1
-"©1"
-"©2"
+©1
+©2
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -58,13 +58,13 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
 $ kafka-create-topic topic=textavro
 
 $ kafka-ingest format=avro topic=textavro key-format=bytes schema=${schema} publish=true timestamp=1
-"bird1" {"f1":"goose", "f2": 1}
-"birdmore" {"f1":"geese", "f2": 2}
-"mammal1" {"f1": "moose", "f2": 1}
-"bird1" null
-"birdmore" {"f1":"geese", "f2": 56}
-"mammalmore" {"f1": "moose", "f2": 42}
-"mammal1" null
+bird1: {"f1":"goose", "f2": 1}
+birdmore: {"f1":"geese", "f2": 2}
+mammal1: {"f1": "moose", "f2": 1}
+bird1: null
+birdmore: {"f1":"geese", "f2": 56}
+mammalmore: {"f1": "moose", "f2": 42}
+mammal1: null
 
 #> CREATE MATERIALIZED SOURCE textavro
 #  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'

--- a/test/testdrive/proto-billing.td
+++ b/test/testdrive/proto-billing.td
@@ -15,12 +15,12 @@
 
 $ kafka-create-topic topic=messages
 
-$ kafka-ingest format=protobuf topic=messages message=.Batch timestamp=1
+$ kafka-ingest format=protobuf topic=messages message=batch timestamp=1
 {"id": "1", "interval_start": "2020-01-01_00:00:00", "interval_end": "2020-01-01_00:00:09", "records": []}
 {"id": "2", "interval_start": "2020-01-01_00:00:10", "interval_end": "2020-01-01_00:00:19", "records": [{"interval_start": "2020-01-01_00:00:10", "interval_end": "2020-01-01_00:00:15", "meter": "user", "value": 25, "measurements": [{"resource": "Cpu", "measured_value": 5}, {"resource": "Mem", "measured_value": 128}]}, {"interval_start": "2020-01-01_00:00:16", "interval_end": "2020-01-01_00:00:19", "meter": "user", "value": 125, "measurements": [{"resource": "Cpu", "measured_value": 13}, {"resource": "Mem", "measured_value": 256}]}]}
 
 # TODO: default values for enums, strings, bytes do not work right now
-$ kafka-ingest format=protobuf topic=messages message=.Batch timestamp=10
+$ kafka-ingest format=protobuf topic=messages message=batch timestamp=10
 {"id": "0", "interval_start": "0", "interval_end": "0", "records": []}
 
 > SHOW COLUMNS FROM billing

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -21,7 +21,7 @@
 
 $ kafka-create-topic topic=messages
 
-$ kafka-ingest format=protobuf topic=messages message=.Struct timestamp=1
+$ kafka-ingest format=protobuf topic=messages message=struct timestamp=1
 {"int": 1, "bad_int": 1, "bin": "One", "st": "my-string"}
 {"int": 2, "bad_int": 2, "bin": "One", "st": "something-valid"}
 

--- a/test/testdrive/timestamps-multi.td
+++ b/test/testdrive/timestamps-multi.td
@@ -32,7 +32,7 @@ $ set schema={
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"dummy,1,0,0,0"
+dummy,1,0,0,0
 
 $ kafka-create-topic topic=data partitions=2
 
@@ -76,13 +76,13 @@ At least one input has no complete timestamps yet.
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data2-${testdrive.seed},2,0,1,0"
+testdrive-data2-${testdrive.seed},2,0,1,0
 
 ! SELECT * FROM view_empty;
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data2-${testdrive.seed},2,1,1,0"
+testdrive-data2-${testdrive.seed},2,1,1,0
 
 > SELECT * FROM view_empty;
 b sum
@@ -91,13 +91,13 @@ b sum
 
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},2,0,1,1"
+testdrive-data-${testdrive.seed},2,0,1,1
 
 ! SELECT * FROM view_byo;
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},2,1,1,1"
+testdrive-data-${testdrive.seed},2,1,1,1
 
 > SELECT * FROM view_byo
 b  sum
@@ -105,7 +105,7 @@ b  sum
 1  4
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},2,0,2,2"
+testdrive-data-${testdrive.seed},2,0,2,2
 
 $ kafka-ingest partition=0 format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 2, "b": 1}}
@@ -119,7 +119,7 @@ b  sum
 1  4
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},2,1,2,2"
+testdrive-data-${testdrive.seed},2,1,2,2
 
 > SELECT * FROM view_byo
 b  sum
@@ -128,7 +128,7 @@ b  sum
 2  1
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},2,1,3,5"
+testdrive-data-${testdrive.seed},2,1,3,5
 
 $ kafka-ingest partition=1 format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 1, "b": 3}}
@@ -143,8 +143,8 @@ b  sum
 
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},2,1,4,5"
-"testdrive-data-${testdrive.seed},2,0,4,2"
+testdrive-data-${testdrive.seed},2,1,4,5
+testdrive-data-${testdrive.seed},2,0,4,2
 
 > SELECT * FROM view_byo
 b  sum
@@ -161,8 +161,8 @@ b  sum
 3  3
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},3,1,5,6"
-"testdrive-data-${testdrive.seed},3,0,5,3"
+testdrive-data-${testdrive.seed},3,1,5,6
+testdrive-data-${testdrive.seed},3,0,5,3
 
 $ kafka-add-partitions topic=data total-partitions=3
 
@@ -198,7 +198,7 @@ b  sum
 3  3
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},3,2,5,1"
+testdrive-data-${testdrive.seed},3,2,5,1
 
 > SELECT * FROM view_byo
 b  sum
@@ -225,9 +225,9 @@ $ kafka-ingest partition=3 format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 1, "b": 11}}
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},3,1,6,7"
-"testdrive-data-${testdrive.seed},3,0,6,4"
-"testdrive-data-${testdrive.seed},3,2,6,2"
+testdrive-data-${testdrive.seed},3,1,6,7
+testdrive-data-${testdrive.seed},3,0,6,4
+testdrive-data-${testdrive.seed},3,2,6,2
 
 > SELECT * FROM view_byo
 b  sum
@@ -240,7 +240,7 @@ b  sum
 7  1
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},4,3,7,1"
+testdrive-data-${testdrive.seed},4,3,7,1
 
 > SELECT * FROM view_byo
 b  sum

--- a/test/testdrive/timestamps.td
+++ b/test/testdrive/timestamps.td
@@ -32,7 +32,7 @@ $ set schema={
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"dummy,1,0,0,0"
+dummy,1,0,0,0
 
 $ kafka-create-topic topic=data
 
@@ -92,8 +92,8 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=1
-"testdrive-data-${testdrive.seed},1,0,1,1"
-"testdrive-data2-${testdrive.seed},1,0,1,4"
+testdrive-data-${testdrive.seed},1,0,1,1
+testdrive-data2-${testdrive.seed},1,0,1,4
 
 > SELECT * FROM view_byo
 b  sum
@@ -107,7 +107,7 @@ b  sum
 2  1
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=2
-"testdrive-data-${testdrive.seed},1,0,2,4"
+testdrive-data-${testdrive.seed},1,0,2,4
 
 > SELECT * FROM view2_byo
 b  sum
@@ -119,7 +119,7 @@ b  sum
 At least one input has no complete timestamps yet.
 
 $ kafka-ingest format=bytes topic=data-consistency timestamp=2
-"testdrive-data3-${testdrive.seed},1,0,10,0"
+testdrive-data3-${testdrive.seed},1,0,10,0
 
 > SELECT * FROM view_empty
 a a


### PR DESCRIPTION
Testdrive now supports ingesting records with both keys and values into
Kafka. Since `kafka-ingest` expects one line per Kafka record, that line
needs to contain both the key and value. This is easy enough when the
key or value format is Avro/Protobuf, as testdrive expects Avro/Protobuf
input in JSON, and JSON is self delimiting. A line like

    {"a": 1}  null

is easily separated into the key JSON ({"a": 1) and the value JSON
(null).

The bytes format is challenging, though, as the nature of an
unstructured format like bytes means that there is no one universal
separator that can be used to separate the key and value. Presently
testdrive requires that bytes input be a JSON-formatted string, but this
is unnecessarily limiting, as not all bytes input is representable as a
JSON string.

Instead, adopt the approach that kafka-console-producer uses of allowing
a configurable separator between key and value. By default the separator
is a `:` character, as in

    key: value

but it can be configured via the `key-terminator` option:

    $ kafka-ingest key-format=bytes key-terminator=$
    key$ value

Also rename the encoder to "transcoder" to capture the confusion that
Andi and I had about whether it was a decoder or encoder: it's actually
both.