### PR TITLE
testdrive: harden sink verification

### DIFF
--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -11,10 +11,11 @@ use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io::{Cursor, Write};
 use std::os::unix::ffi::OsStringExt;
-use std::path;
+use std::path::{self, PathBuf};
 
+use futures::future::TryFutureExt;
+use futures::stream::TryStreamExt;
 use retry::delay::Fibonacci;
-use tokio::stream::StreamExt;
 
 use crate::action::{Action, State};
 use crate::format::avro::{self, Codec, Reader, Writer};
@@ -146,67 +147,39 @@ impl Action for VerifyAction {
     }
 
     fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path: String = retry::retry(Fibonacci::from_millis(100).take(5), || {
+        let path = retry::retry(Fibonacci::from_millis(100).take(5), || {
             let row = state
                 .pgclient
                 .query_one(
                     "SELECT path FROM mz_catalog_names NATURAL JOIN mz_avro_ocf_sinks \
-                 WHERE name = $1",
+                     WHERE name = $1",
                     &[&self.sink],
                 )
                 .map_err(|e| format!("querying materialize: {}", e.to_string()))?;
             let bytes: Vec<u8> = row.get("path");
-            let os_string: OsString = OsStringExt::from_vec(bytes);
-            Ok::<_, String>(
-                os_string
-                    .into_string()
-                    .map_err(|_| "cannot convert path to string".to_string())?,
-            )
+            Ok::<_, String>(PathBuf::from(OsString::from_vec(bytes)))
         })
         .map_err(|e| format!("retrieving path: {:?}", e))?;
 
-        println!("Verifying results in file {}", path);
+        println!("Verifying results in file {}", path.display());
 
-        // Get the rows from this file
-        let sink_file = state
-            .tokio_runtime
-            .block_on(tokio::fs::File::open(&path))
-            .map_err(|e| format!("reading sink file {}: {}", path, e))?;
-        let reader = state
-            .tokio_runtime
-            .block_on(Reader::new(sink_file))
-            .map_err(|e| format!("parsing avro values from file: {}", e))?;
-        let schema = reader.writer_schema().clone();
-        let actual_messages: Vec<_> = state
-            .tokio_runtime
-            .block_on(reader.into_stream().collect::<Vec<_>>())
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| format!("converting to rust objects: {}", e))?;
+        // Get the rows from this file.
+        let (schema, actual) = state.tokio_runtime.block_on(async {
+            let file = tokio::fs::File::open(&path)
+                .map_err(|e| format!("reading sink file {}: {}", path.display(), e))
+                .await?;
+            let reader = Reader::new(file)
+                .map_err(|e| format!("creating avro reader: {}", e))
+                .await?;
+            let schema = reader.writer_schema().clone();
+            let messages: Vec<_> = reader
+                .into_stream()
+                .try_collect()
+                .map_err(|e| format!("reading avro values from file: {}", e))
+                .await?;
+            Ok::<_, String>((schema, messages))
+        })?;
 
-        let mut converted_expected_messages = Vec::new();
-        for expected in &self.expected {
-            converted_expected_messages.push(
-                avro::from_json(
-                    &serde_json::from_str(expected)
-                        .map_err(|e| format!("parsing avro datum: {}", e.to_string()))?,
-                    schema.top_node(),
-                )
-                .unwrap(),
-            );
-        }
-
-        let missing_values =
-            avro::multiset_difference(&converted_expected_messages, &actual_messages);
-        let additional_values =
-            avro::multiset_difference(&actual_messages, &converted_expected_messages);
-        if !missing_values.is_empty() || !additional_values.is_empty() {
-            return Err(format!(
-                "Mismatched Kafka sink rows. Missing: {:#?}, Unexpected: {:#?}",
-                missing_values, additional_values
-            ));
-        }
-
-        Ok(())
+        avro::validate_sink(&schema, &self.expected, &actual)
     }
 }

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -7,13 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
 use byteorder::{BigEndian, ByteOrder};
-use futures::executor::block_on;
-use futures::stream::StreamExt;
+use futures::future::TryFutureExt;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::message::Message;
 use retry::delay::Fibonacci;
+use tokio::stream::StreamExt;
 
 use crate::action::{Action, State};
 use crate::format::avro;
@@ -70,74 +72,61 @@ impl Action for VerifyAction {
 
         let schema =
             avro::parse_schema(&schema).map_err(|e| format!("parsing avro schema: {}", e))?;
-        let mut converted_expected_messages = Vec::new();
-        for expected in &self.expected_messages {
-            converted_expected_messages.push(
-                avro::from_json(
-                    &serde_json::from_str(expected)
-                        .map_err(|e| format!("parsing avro datum: {}", e.to_string()))?,
-                    schema.top_node(),
-                )
-                .unwrap(),
-            );
-        }
+        let schema = &schema;
+
         let consumer: StreamConsumer = config
             .create()
             .map_err(|e| format!("creating kafka consumer: {}", e))?;
         consumer.subscribe(&[&topic]).map_err(|e| e.to_string())?;
-        let mut message_stream = consumer.start();
-        let mut actual_messages = Vec::new();
-        for _i in 0..converted_expected_messages.len() {
-            let output = block_on(message_stream.next());
-            match output {
-                Some(result) => match result {
-                    Ok(m) => match m.payload() {
-                        Some(mut bytes) => {
-                            if bytes.len() < 5 {
-                                return Err(format!(
-                                        "avro datum is too few bytes: expected at least 5 bytes, got {}",
-                                        bytes.len()
-                                    ));
-                            }
-                            let magic = bytes[0];
-                            let _schema_id = BigEndian::read_i32(&bytes[1..5]);
-                            bytes = &bytes[5..];
 
-                            if magic != 0 {
-                                return Err(format!(
-                                    "wrong avro serialization magic: expected 0, got {}",
-                                    bytes[0]
-                                ));
-                            }
-                            actual_messages.push(
-                                block_on(::avro::from_avro_datum(&schema, &mut bytes))
-                                    .map_err(|e| format!("from_avro_datum: {}", e.to_string()))?,
-                            );
-                        }
-                        None => {
-                            return Err(String::from("No bytes found in Kafka message payload."))
-                        }
-                    },
-                    Err(e) => return Err(e.to_string()),
-                },
-                None => return Err(format!("No Kafka messages found for topic {}", &topic,)),
+        let actual_messages = state.tokio_runtime.block_on(async move {
+            // Wait up to 10 seconds for each message.
+            let mut message_stream = consumer
+                .start()
+                .take(self.expected_messages.len())
+                .timeout(Duration::from_secs(15));
+
+            let mut out = vec![];
+
+            // Collect all messages that arrive without timing out. If we trip
+            // the timeout, suppress the error and return what we have. This
+            // is nicer than returning "timeout expired", as the user will
+            // instead get an error message about the expected messages that
+            // were missing.
+            while let Some(Ok(message)) = message_stream.next().await {
+                let message = message.map_err(|e| e.to_string())?;
+
+                let mut bytes = match message.payload() {
+                    None => return Err("empty message payload".into()),
+                    Some(bytes) => bytes,
+                };
+
+                if bytes.len() < 5 {
+                    return Err(format!(
+                        "avro datum is too few bytes: expected at least 5 bytes, got {}",
+                        bytes.len()
+                    ));
+                }
+                let magic = bytes[0];
+                let _schema_id = BigEndian::read_i32(&bytes[1..5]);
+                bytes = &bytes[5..];
+
+                if magic != 0 {
+                    return Err(format!(
+                        "wrong avro serialization magic: expected 0, got {}",
+                        bytes[0]
+                    ));
+                }
+
+                let datum = avro::from_avro_datum(schema, &mut bytes)
+                    .map_err(|e| format!("from_avro_datum: {}", e.to_string()))
+                    .await?;
+                out.push(datum);
             }
-        }
-        // NB: We can't compare messages as they come in because
-        // Kafka sinks do not currently support ordering.
-        // TODO@jldlaughlin: update this once we have Kafka ordering guarantees
-        let missing_values =
-            avro::multiset_difference(&converted_expected_messages, &actual_messages);
-        let additional_values =
-            avro::multiset_difference(&actual_messages, &converted_expected_messages);
 
-        if !missing_values.is_empty() || !additional_values.is_empty() {
-            return Err(format!(
-                "Mismatched Kafka sink rows. Missing: {:#?}, Unexpected: {:#?}",
-                missing_values, additional_values
-            ));
-        }
+            Ok(out)
+        })?;
 
-        Ok(())
+        avro::validate_sink(schema, &self.expected_messages, &actual_messages)
     }
 }

--- a/test/testdrive/avro-sinks.td
+++ b/test/testdrive/avro-sinks.td
@@ -17,9 +17,9 @@
 
 $ kafka-verify format=avro sink=materialize.public.data_sink
 {"before": null, "after": {"a": 1, "b": 1}}
+{"before": null, "after": {"a": 1, "b": 2}}
 {"before": null, "after": {"a": 2, "b": 1}}
 {"before": null, "after": {"a": 3, "b": 1}}
-{"before": null, "after": {"a": 1, "b": 2}}
 
 > CREATE VIEW datetime_data (date, ts, ts_tz) AS VALUES
   (DATE '2000-01-01', TIMESTAMP '2000-01-01 10:10:10.111', TIMESTAMPTZ '2000-01-01 10:10:10.111+02'),


### PR DESCRIPTION
We guarantee order for sinks now, so we should test that. Turns out
the fix in #2551 was unnecessary.

Also includes a few assorted cleanups that I noticed, most notably
timing out in 15 seconds if we're unable to read the expected number of
messages from Kafka, rather than waiting around forever.

Note that this builds on #2549, so ignore all but the last commit. I'll rebase once #2549 lands. I.e., **just look at this commit:** <https://github.com/MaterializeInc/materialize/pull/2552/commits/db689f932ccaa143fa496ed5225e6aa23e8248ba>