### PR TITLE
testdrive: ditch serde_json preserve_order feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,6 @@ version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
 dependencies = [
- "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -37,7 +37,7 @@ rusoto_kinesis = "0.43.0-beta.1"
 rusoto_sts = "0.43.0-beta.1"
 serde = "1.0.105"
 serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }
-serde_json = { version = "1.0.51", features = ["preserve_order"] }
+serde_json = "1.0.51"
 sql-parser = { path = "../sql-parser" }
 tempfile = "3.1"
 termcolor = "1.1.0"


### PR DESCRIPTION
This was made unnecessary with #2539, since we no longer depend upon
(non-standard) JSON field ordering when converting JSON datums to Avro
datums.