### PR TITLE
docs: type cleanup

### DIFF
--- a/doc/user/sql/types/boolean.md
+++ b/doc/user/sql/types/boolean.md
@@ -14,6 +14,7 @@ Detail | Info
 -------|------
 **Quick Syntax** | `TRUE` or `FALSE`
 **Size** | 1 byte
+**Aliases** | `bool`
 
 ## Syntax
 
@@ -25,11 +26,16 @@ Detail | Info
 
 #### From `boolean`
 
-You cannot cast `boolean` to any other type.
+You can [cast](../../functions/cast) `boolean` to:
+
+- [`text`](../text)
 
 #### To `boolean`
 
-You can cast [`int`](../int) to `boolean`.
+You can [cast](../../functions/cast) the following types to `boolean`:
+
+- [`int`](../int)
+- [`text`](../text)
 
 ## Examples
 

--- a/doc/user/sql/types/date.md
+++ b/doc/user/sql/types/date.md
@@ -34,13 +34,15 @@ _tz&lowbar;offset_ | _(NOP)_ The timezone's distance, in hours, from UTC.
 
 You can [cast](../../functions/cast) `date` to:
 
+- [`text`](../text)
 - [`timestamp`](../timestamp)
 - [`timestamptz`](../timestamp)
-- [`string`](../string)
 
 #### To `date`
 
-You cannot cast any other type to `date`.
+You can [cast](../../functions/cast) the following types to `date`:
+
+- [`text`](../text)
 
 ### Valid operations
 

--- a/doc/user/sql/types/float.md
+++ b/doc/user/sql/types/float.md
@@ -4,6 +4,11 @@ description: "Express signed, inexact numbers"
 menu:
   main:
     parent: 'sql-types'
+aliases:
+    - /docs/sql/types/real
+    - /docs/sql/types/double
+    - /docs/sql/types/double-precision
+    - /docs/sql/types/float64
 ---
 
 `real` and `double precision` data express a variable-precision, inexact number
@@ -12,7 +17,7 @@ with a floating decimal point.
 Type               | Aliases           | Size    | Range
 -------------------|-------------------|---------|------
 `real`             | `float4`          | 4 bytes | Approx. 1E-37 to 1E+37 with 6 decimal digits of precision
-`double precision` | `float`, `float8` | 8 bytes | Approx. 1E-307 to 1E+307 with 15 decimal digits of precision
+`double precision` | `float`, `float8`, `double` | 8 bytes | Approx. 1E-307 to 1E+307 with 15 decimal digits of precision
 
 ## Syntax
 
@@ -56,8 +61,8 @@ can be cast to and from one another.
 You can [cast](../../functions/cast) `real` or `double precision` to:
 
 - [`int`](../int)
-- [`decimal`](../float)
-- [`string`](../string)
+- [`numeric`](../numeric)
+- [`text`](../text)
 
 #### To `real` or `double precision`
 
@@ -65,7 +70,8 @@ You can [cast](../../functions/cast) the following types to `real` or `double
 precision`:
 
 - [`int`](../int)
-- [`decimal`](../float)
+- [`numeric`](../numeric)
+- [`text`](../text)
 
 ## Examples
 

--- a/doc/user/sql/types/integer.md
+++ b/doc/user/sql/types/integer.md
@@ -1,14 +1,14 @@
 ---
 title: "Integer Data Types"
 description: "Express signed integers"
-aliases:
-- /docs/sql/types/bigint
-- /docs/sql/types/int
-- /docs/sql/types/int4
-- /docs/sql/types/int8
 menu:
   main:
     parent: 'sql-types'
+aliases:
+  - /docs/sql/types/bigint
+  - /docs/sql/types/int
+  - /docs/sql/types/int4
+  - /docs/sql/types/int8
 ---
 
 `integer` and `bigint` data express signed integers.
@@ -34,16 +34,16 @@ all other integer types.
 You can [cast](../../functions/cast) `integer` or `bigint` to:
 
 - [`bool`](../boolean)
-- [`decimal`](../decimal)
-- [`float`](../float)
-- [`string`](../string)
+- [`numeric`](../numeric)
+- [`real`/`double`](../float)
+- [`text`](../text)
 
 #### To `int`
 
 You can [cast](../../functions/cast) the following types to `integer` or `bigint`:
 
-- [`decimal`](../decimal)
-- [`float`](../float)
+- [`numeric`](../numeric)
+- [`real`/`double`](../float)
 
 ## Examples
 

--- a/doc/user/sql/types/jsonb.md
+++ b/doc/user/sql/types/jsonb.md
@@ -4,14 +4,18 @@ description: "Expresses a JSON object"
 menu:
   main:
     parent: 'sql-types'
+aliases:
+  - /docs/sql/types/json
 ---
 
-`jsonb` data expresses a JavaScript Object Notation (JSON) object.
+`jsonb` data expresses a JavaScript Object Notation (JSON) object similar to PostgreSQL's implementation.
 
 Detail | Info
 -------|------
 **Quick Syntax** | `'{"1":2,"3":4}'::JSONB`
 **Size** | Variable
+
+Materialize does not yet support a type more similar to PostgreSQL's impplementation of `json`.
 
 ## Syntax
 
@@ -59,17 +63,17 @@ SELECT * FROM jsonb_object_keys('{"1":2,"3":4}'::JSONB);
 
 You can [cast](../../functions/cast) `jsonb` to:
 
-- [`string`](../string) (stringifies `jsonb`)
-- [`float`](../string)
 - [`bool`](../boolean)
+- [`real`/`double`](../float)
+- [`text`](../text) (stringifies `jsonb`)
 
 #### To `jsonb`
 
 You can [cast](../../functions/cast) the following types to `jsonb`:
 
-- [`string`](../string) (parses `jsonb`)
+- [`text`](../text) (parses `jsonb`)
 
-#### Notes about converting `jsonb` to `string`/`text`
+#### Notes about converting `jsonb` to `text`
 
 `jsonb` can have some odd-feeling corner cases when converting to or from `string` (also known as `text`).
 

--- a/doc/user/sql/types/numeric.md
+++ b/doc/user/sql/types/numeric.md
@@ -16,8 +16,7 @@ Detail | Info
 **Max precision** | 38
 **Max scale** | 38
 **Default** | 38 precision, 0 scale
-
-Materialize also accepts `decimal` as an alias for `numeric`.
+**Aliases** | `decimal`
 
 ## Syntax
 
@@ -51,15 +50,16 @@ _scale_ | The total number of fractional decimal digits to track, e.g. `.321` ha
 You can [cast](../../functions/cast) `numeric` to:
 
 - [`int`](../int)
-- [`float`](../float)
-- [`string`](../string)
+- [`real`/`double`](../float)
+- [`text`](../text)
 
 #### To `numeric`
 
 You can [cast](../../functions/cast) the following types to `numeric`:
 
 - [`int`](../int)
-- [`float`](../float)
+- [`real`/`double`](../float)
+- [`text`](../text)
 
 ## Examples
 

--- a/doc/user/sql/types/timestamp.md
+++ b/doc/user/sql/types/timestamp.md
@@ -1,11 +1,11 @@
 ---
 title: "Timestamp Data Types"
 description: "Expresses a date and time"
-aliases:
-    - /docs/sql/types/timestamptz
 menu:
   main:
     parent: 'sql-types'
+aliases:
+    - /docs/sql/types/timestamptz
 ---
 
 `timestamp` and `timestamp with time zone` data expresses a date and time in UTC.
@@ -45,8 +45,8 @@ _tz&lowbar;offset_ | The timezone's distance, in hours, from UTC.
 
 You can [cast](../../functions/cast) `timestamp` or `timestamptz` to:
 
-- [`text`](../text)
 - [`date`](../date)
+- [`text`](../text)
 - `timestamp`
 - `timestamptz`
 
@@ -54,8 +54,8 @@ You can [cast](../../functions/cast) `timestamp` or `timestamptz` to:
 
 You can [cast](../../functions/cast) the following types to `timestamp` or `timestamptz`:
 
-- [`text`](../text)
 - [`date`](../date)
+- [`text`](../text)
 - `timestamp`
 - `timestamptz`
 


### PR DESCRIPTION
A few inconsistencies in the type docs were bugging me, so I cleaned them up