### PR TITLE
Refactor i32 partition ids to PartitionId enum

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -42,7 +42,8 @@ use dataflow_types::{
 };
 use expr::transform::Optimizer;
 use expr::{
-    EvalEnv, GlobalId, Id, IdHumanizer, RelationExpr, RowSetFinishing, ScalarExpr, SourceInstanceId,
+    EvalEnv, GlobalId, Id, IdHumanizer, PartitionId, RelationExpr, RowSetFinishing, ScalarExpr,
+    SourceInstanceId,
 };
 use ore::collections::CollectionExt;
 use ore::thread::JoinHandleExt;
@@ -61,7 +62,7 @@ pub enum Message {
     AdvanceSourceTimestamp {
         id: SourceInstanceId,
         partition_count: i32,
-        pid: i32,
+        pid: PartitionId,
         timestamp: u64,
         offset: i64,
     },

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -663,8 +663,7 @@ impl Timestamper {
                 let pcount: SqlVal<i32> = row.get(0)?;
                 let pid: SqlVal<PartitionId> = match row.get(1) {
                     Ok(val) => val,
-                    Err(err) => {
-                        error!("Reading from timestamps and expected type PartitionId, found other: {}", err);
+                    Err(_err) => {
                         // Historically, pid was an i32 value. If the found value is not of type
                         // PartitionId, try to read an i32.
                         let pid: SqlVal<i32> = row.get(1)?;

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -48,7 +48,7 @@ use dataflow_types::{
     Consistency, DataflowDesc, Diff, ExternalSourceConnector, IndexDesc, PeekResponse, Timestamp,
     Update,
 };
-use expr::{EvalEnv, GlobalId, RowSetFinishing, SourceInstanceId};
+use expr::{EvalEnv, GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
 use ore::future::channel::mpsc::ReceiverExt;
 use repr::{Datum, RelationType, Row, RowArena};
 
@@ -139,7 +139,7 @@ pub enum SequencedCommand {
     AdvanceSourceTimestamp {
         id: SourceInstanceId,
         partition_count: i32,
-        pid: i32,
+        pid: PartitionId,
         timestamp: Timestamp,
         offset: i64,
     },
@@ -237,8 +237,9 @@ where
     })
 }
 
+/// Todo: write what this is.
 pub type TimestampHistories =
-    Rc<RefCell<HashMap<SourceInstanceId, HashMap<i32, Vec<(i32, Timestamp, i64)>>>>>;
+    Rc<RefCell<HashMap<SourceInstanceId, HashMap<PartitionId, Vec<(i32, Timestamp, i64)>>>>>;
 pub type TimestampChanges = Rc<
     RefCell<
         Vec<(
@@ -686,7 +687,7 @@ where
                     let ts = match entries.get_mut(&pid) {
                         Some(ts) => ts,
                         None => {
-                            entries.insert(pid, vec![]);
+                            entries.insert(pid.clone(), vec![]);
                             entries.get_mut(&pid).unwrap()
                         }
                     };

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -117,6 +117,38 @@ impl fmt::Display for SourceInstanceId {
     }
 }
 
+/// Unique identifier for each part of a whole source.
+///     Kafka -> partition
+///     Kinesis -> shard
+#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
+pub enum PartitionId {
+    Kafka(i32),
+    Kinesis(String),
+}
+
+impl std::cmp::PartialEq for PartitionId {
+    fn eq(&self, other: &Self) -> bool {
+        use PartitionId::*;
+
+        match (&self, &other) {
+            (&Kafka(a), &Kafka(b)) => a == b,
+            (&Kinesis(a), &Kinesis(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl std::hash::Hash for PartitionId {
+    fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
+        use PartitionId::*;
+
+        match &self {
+            Kafka(pid) => pid.hash(hasher),
+            Kinesis(pid) => pid.clone().hash(hasher),
+        }
+    }
+}
+
 /// Humanizer that provides no additional information.
 #[derive(Debug)]
 pub struct DummyHumanizer;

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -120,33 +120,10 @@ impl fmt::Display for SourceInstanceId {
 /// Unique identifier for each part of a whole source.
 ///     Kafka -> partition
 ///     Kinesis -> shard
-#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum PartitionId {
     Kafka(i32),
     Kinesis(String),
-}
-
-impl std::cmp::PartialEq for PartitionId {
-    fn eq(&self, other: &Self) -> bool {
-        use PartitionId::*;
-
-        match (&self, &other) {
-            (&Kafka(a), &Kafka(b)) => a == b,
-            (&Kinesis(a), &Kinesis(b)) => a == b,
-            _ => false,
-        }
-    }
-}
-
-impl std::hash::Hash for PartitionId {
-    fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
-        use PartitionId::*;
-
-        match &self {
-            Kafka(pid) => pid.hash(hasher),
-            Kinesis(pid) => pid.clone().hash(hasher),
-        }
-    }
 }
 
 /// Humanizer that provides no additional information.

--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -18,7 +18,7 @@ mod scalar;
 pub mod explain;
 pub mod transform;
 
-pub use id::{DummyHumanizer, GlobalId, Id, IdHumanizer, LocalId, SourceInstanceId};
+pub use id::{DummyHumanizer, GlobalId, Id, IdHumanizer, LocalId, PartitionId, SourceInstanceId};
 pub use relation::func::{AggregateFunc, UnaryTableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::{


### PR DESCRIPTION
### Background
In order to read multiple partitions or shards from a source, we need to keep track of the source's unique partition or shard ids. Support for reading from multiple partitions was originally built for Kafka, where unique partition ids are represented by an `i32` value. 

### The Problem
Kinesis shards are uniquely identified by a [String value](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_Shard.html#Streams-Type-Shard-ShardId), not an integer. We need to expand our representation of partition ids in the code in order to represent this new use case.

### The Solution
Create a new `PartitionId` enum that supports both `i32` values (for Kafka) and String values (for Kinesis). As a bonus, this change will make our `timestamps` code more extensible for new sources moving forward.

NOTE: An implication of this change is that we will silently migrate from storing `i32` values as blogs in the `timestamps` table to serialized `PartitionId` values. I put in a small piece of code that should make this backwards compatible. 