### PR TITLE
Don't attempt to add a line number, which doesn't make sense, to Debezium records

### DIFF
--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -24,7 +24,7 @@ use url::Url;
 use catalog::names::{DatabaseSpecifier, FullName, PartialName};
 use catalog::{Catalog, CatalogItem, SchemaType};
 use dataflow_types::{
-    AvroEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding, DataEncoding,
+    AvroEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding, DataEncoding, Envelope,
     ExternalSourceConnector, FileSourceConnector, KafkaSinkConnectorBuilder, KafkaSourceConnector,
     KinesisSourceConnector, PeekWhen, ProtobufEncoding, SinkConnectorBuilder, SourceConnector,
 };
@@ -1273,8 +1273,13 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
 
             // TODO(benesch): the available metadata columns should not depend
             // on the format.
-            match encoding {
-                DataEncoding::Avro { .. } | DataEncoding::Protobuf { .. } => (),
+            //
+            // TODO(brennan): They should not depend on the envelope either. Figure out a way to
+            // make all of this more tasteful.
+            match (&encoding, &envelope) {
+                (DataEncoding::Avro { .. }, _)
+                | (DataEncoding::Protobuf { .. }, _)
+                | (_, Envelope::Debezium) => (),
                 _ => desc.add_cols(external_connector.metadata_columns()),
             }
 


### PR DESCRIPTION
Before this fix, Avro OCF files with the Debezium envelope cause Materialize to panic because the source is declaring a record number column, which can't actually exist in Debezium format.

Sticking every edge case in this one random place is not very good design, the handling of metadata columns should be refactored. But I will do that after 0.2 is cut. I just want to fix the panic right now in the easiest way possible so it doesn't go out in 0.2.