### PR TITLE
testdrive: hoist option parsing into binary crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,6 +3268,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -42,6 +42,7 @@ sql-parser = { path = "../sql-parser" }
 tempfile = "3.1"
 termcolor = "1.1.0"
 tokio = "0.2"
+url = "2.1.0"
 
 [build-dependencies]
 protoc-rust = "2.12"

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -18,6 +18,7 @@ use self::parser::LineReader;
 mod action;
 mod format;
 mod parser;
+mod util;
 
 pub mod error;
 

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -65,13 +65,30 @@ fn run() -> Result<(), Error> {
         });
     }
 
-    let config = Config {
-        kafka_addr: opts.opt_str("kafka-addr"),
-        schema_registry_url: opts.opt_str("schema-registry-url"),
-        kinesis_region: opts.opt_str("kinesis-region"),
-        materialized_url: opts.opt_str("materialized-url"),
-        materialized_catalog_path: opts.opt_str("validate-catalog"),
-    };
+    let mut config = Config::default();
+    if let Some(addr) = opts.opt_str("kafka-addr") {
+        config.kafka_addr = addr;
+    }
+    if let Some(url) = opts.opt_str("schema-registry-url") {
+        config.schema_registry_url = url.parse().map_err(|e| Error::General {
+            ctx: "parsing schema registry url".into(),
+            cause: Some(Box::new(e)),
+            hints: vec![],
+        })?;
+    }
+    if let Some(region) = opts.opt_str("kinesis-region") {
+        config.kinesis_region = region;
+    }
+    if let Some(url) = opts.opt_str("materialized-url") {
+        config.materialized_pgconfig = url.parse().map_err(|e| Error::General {
+            ctx: "parsing materialized url".into(),
+            cause: Some(Box::new(e)),
+            hints: vec![],
+        })?;
+    }
+    if let Some(path) = opts.opt_str("validate-catalog") {
+        config.materialized_catalog_path = Some(path.into());
+    }
 
     if opts.free.is_empty() {
         testdrive::run_stdin(&config)

--- a/src/testdrive/src/util.rs
+++ b/src/testdrive/src/util.rs
@@ -1,0 +1,10 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod postgres;

--- a/src/testdrive/src/util/postgres.rs
+++ b/src/testdrive/src/util/postgres.rs
@@ -1,0 +1,59 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use postgres::Config;
+use url::Url;
+
+use crate::error::Error;
+
+/// Constructs a URL from PostgreSQL configuration parameters.
+///
+/// Returns an error if the set of configuration parameters is not representable
+/// as a URL, e.g., if there are multiple hosts.
+pub fn config_url(config: &Config) -> Result<Url, Error> {
+    let mut url = Url::parse("postgresql://").unwrap();
+
+    let host = match config.get_hosts() {
+        [] => "localhost".into(),
+        [postgres::config::Host::Tcp(host)] => host.clone(),
+        [postgres::config::Host::Unix(path)] => path.display().to_string(),
+        _ => {
+            return Err(Error::General {
+                ctx: "materialized URL cannot contain multiple hosts".into(),
+                cause: None,
+                hints: vec![],
+            })
+        }
+    };
+    url.set_host(Some(&host)).map_err(|e| Error::General {
+        ctx: "parsing materialized host".into(),
+        cause: Some(Box::new(e)),
+        hints: vec![],
+    })?;
+
+    url.set_port(Some(match config.get_ports() {
+        [] => 5432,
+        [port] => *port,
+        _ => {
+            return Err(Error::General {
+                ctx: "materialized URL cannot contain multiple ports".into(),
+                cause: None,
+                hints: vec![],
+            })
+        }
+    }))
+    .expect("known to be valid to set port");
+
+    if let Some(user) = config.get_user() {
+        url.set_username(user)
+            .expect("known to be valid to set username");
+    }
+
+    Ok(url)
+}


### PR DESCRIPTION
Make testdrive::Config require real Rust types, like `Url`s and
`postgres::Config`s, and move the requisite string parsing into the
binary crate. This makes the Rust API of testdrive a bit nicer, and will
allow the testdrive CLI options to not match exactly with the
testdrive::Config fields, which will become important in a future
commit.