### PR TITLE
testdrive: rework AWS state for localstack edge router

### DIFF
--- a/ci/test/testdrive.compose.yml
+++ b/ci/test/testdrive.compose.yml
@@ -17,7 +17,7 @@ services:
       && wait-for-it --timeout=30 materialized:6875
       && testdrive
       --kafka-addr=kafka:9092
-      --kinesis-region=us-east-2
+      --aws-region=us-east-2
       --schema-registry-url=http://schema-registry:8081
       --materialized-url=postgres://ignored@materialized:6875
       --validate-catalog=/share/mzdata

--- a/doc/developer/testing.md
+++ b/doc/developer/testing.md
@@ -244,6 +244,8 @@ $ pip install localstack
 $ START_WEB=false SERVICES=kinesis localstack start
 ```
 
+You will need localstack v0.11 or later.
+
 Like the [Unit Tests](#unitintegration-tests), in order to run testdrive, you should have Zookeeper, Kafka, and Confluent Schema Registry running. Testdrive is more flexible than the unit tests, though, in that you are allowed to run them at non-default locations.
 
 To run a testdrive script, you'll need two terminal windows open. In the

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -18,9 +18,9 @@ use self::parser::LineReader;
 mod action;
 mod format;
 mod parser;
-mod util;
 
 pub mod error;
+pub mod util;
 
 pub use self::action::Config;
 

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -9,10 +9,13 @@
 
 use std::env;
 use std::process;
+use std::time::Duration;
 
 use getopts::Options;
+use tokio::runtime::Runtime;
 
 use testdrive::error::{Error, ResultExt};
+use testdrive::util;
 use testdrive::Config;
 
 fn main() {
@@ -32,10 +35,11 @@ fn run() -> Result<(), Error> {
     opts.optopt("", "schema-registry-url", "schema registry URL", "URL");
     opts.optopt(
         "",
-        "kinesis-region",
-        "optional custom kinesis region",
+        "aws-region",
+        "a named AWS region to target for AWS API requests",
         "custom",
     );
+    opts.optopt("", "aws-endpoint", "custom AWS endpoint", "URL");
     opts.optopt(
         "",
         "materialized-url",
@@ -76,8 +80,27 @@ fn run() -> Result<(), Error> {
             hints: vec![],
         })?;
     }
-    if let Some(region) = opts.opt_str("kinesis-region") {
-        config.kinesis_region = region;
+    if let (Ok(Some(region)), None) = (opts.opt_get("aws-region"), opts.opt_str("aws-endpoint")) {
+        // Standard AWS region without a custom endpoint. Try to find actual AWS
+        // credentials.
+        let mut runtime = Runtime::new().unwrap();
+        let (account, credentials) =
+            runtime.block_on(util::aws::account_details(Duration::from_secs(5)))?;
+        config.aws_region = region;
+        config.aws_account = account;
+        config.aws_credentials = credentials;
+    } else {
+        // Either a non-standard AWS region, a custom endpoint, or both. Assume
+        // dummy authentication, and just use the default dummy credentials in
+        // the default config.
+        config.aws_region = rusoto_core::Region::Custom {
+            name: opts
+                .opt_str("aws-region")
+                .unwrap_or_else(|| "localstack".into()),
+            endpoint: opts
+                .opt_str("aws-endpoint")
+                .unwrap_or_else(|| "http://localhost:4566".into()),
+        };
     }
     if let Some(url) = opts.opt_str("materialized-url") {
         config.materialized_pgconfig = url.parse().map_err(|e| Error::General {
@@ -86,6 +109,7 @@ fn run() -> Result<(), Error> {
             hints: vec![],
         })?;
     }
+
     if let Some(path) = opts.opt_str("validate-catalog") {
         config.materialized_catalog_path = Some(path.into());
     }

--- a/src/testdrive/src/util.rs
+++ b/src/testdrive/src/util.rs
@@ -7,4 +7,5 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub mod aws;
 pub mod postgres;

--- a/src/testdrive/src/util/aws.rs
+++ b/src/testdrive/src/util/aws.rs
@@ -1,0 +1,52 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use rusoto_core::Region;
+use rusoto_credential::{AwsCredentials, ChainProvider, ProvideAwsCredentials};
+use rusoto_sts::{GetCallerIdentityRequest, Sts, StsClient};
+
+use crate::error::Error;
+
+/// Fetches AWS credentials and the corresponding account number by consulting
+/// several known sources.
+///
+/// For details about where AWS credentials can be stored, see Rusoto's
+/// [`ChainProvider`] documentation.
+pub async fn account_details(timeout: Duration) -> Result<(String, AwsCredentials), Error> {
+    let mut provider = ChainProvider::new();
+    provider.set_timeout(timeout);
+    let credentials = provider.credentials().await.map_err(|e| Error::General {
+        ctx: "retrieving AWS credentials".into(),
+        cause: Some(Box::new(e)),
+        hints: vec![],
+    })?;
+    let sts_client = StsClient::new(Region::default());
+    let get_identity = sts_client.get_caller_identity(GetCallerIdentityRequest {});
+    let account = tokio::time::timeout(timeout, get_identity)
+        .await
+        .map_err(|_: tokio::time::Elapsed| Error::General {
+            ctx: "timeout while retrieving AWS account number from STS".into(),
+            cause: None,
+            hints: vec![],
+        })?
+        .map_err(|e| Error::General {
+            ctx: "retrieving AWS account ID".into(),
+            cause: Some(Box::new(e)),
+            hints: vec![],
+        })?
+        .account
+        .ok_or_else(|| Error::General {
+            ctx: "AWS did not return account ID".into(),
+            cause: None,
+            hints: vec![],
+        })?;
+    Ok((account, credentials))
+}

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -20,7 +20,7 @@ here's a test string
   WITH (access_key = '${testdrive.aws-access-key}',
         secret_access_key = '${testdrive.aws-secret-access-key}',
         token = '${testdrive.aws-token}',
-        endpoint = '${testdrive.kinesis-endpoint}')
+        endpoint = '${testdrive.aws-endpoint}')
   FORMAT BYTES;
 
 > CREATE MATERIALIZED VIEW f_view


### PR DESCRIPTION
The latest version of localstack (v0.11) includes an edge router which
exposes all AWS services on the same port (4566 by default). This makes
our lives much easier, as testdrive doesn't need to track the Kinesis
endpoint separately from the endpoint for other services.

This patch does a few things:

  - Introduces --aws-region and --aws-endpoint options to configure
    the AWS region and endpoint that testdrive targets. These replace
    the --kinesis-region option.

    By default, these target a localstack region running at
    http://localhost:4566, which is correct for development
    environments.

    To test against real AWS, specify --aws-region=us-east-2 or another
    standard region of your choosing.

    To test against a localstack running on a nonstandard host or port,
    specify e.g. --aws-endpoint=http://host:1234.

  - Only fetches credentials when running against real AWS, and does so
    with a short timeout (5s). This prevents testdrive from blocking
    silently for 30s if AWS credentials are not present on the machine.

  - Adjusts action::State to carry around more strongly-typed
    AWS information, in an effort to reduce the number of fields.