### PR TITLE
Don't tell people to make a debug build

### DIFF
--- a/doc/user/install.md
+++ b/doc/user/install.md
@@ -65,7 +65,7 @@ release.
 git clone https://github.com/MaterializeInc/materialize.git
 cd materialize
 git checkout {{< version >}}
-cargo build
+cargo build --release
 ```
 
 ## Run the binary


### PR DESCRIPTION
If people want their builds to be faster, they will almost certainly figure out that they can remove `--release` from these instructions, but I think it's better for something with somewhat working performance to be the documented default. (I can discard this if people disagree!)