### PR TITLE
Kerberized kafka login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,6 +787,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 
 [[package]]
+name = "duct"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1607fa68d55be208e83bcfbcfffbc1ec65c9fbcf9eb1a5d548dc3ac0100743b0"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +1994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d06355a7090ce852965b2d08e11426c315438462638c6d721448d0b47aa22"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,6 +2528,7 @@ dependencies = [
  "num_enum",
  "openssl-sys",
  "pkg-config",
+ "sasl2-sys",
 ]
 
 [[package]]
@@ -2816,6 +2839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sasl2-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "499fb6d600f2afd0941d9342997beb19d1580c4dd5d28251758db6a162e7091e"
+dependencies = [
+ "cc",
+ "duct",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +2999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cebcf3a403e4deafaf34dc882c4a1b6a648b43e5670aa2e4bb985914eaeb2d2"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3036,8 +3081,10 @@ dependencies = [
  "futures",
  "interchange",
  "itertools 0.9.0",
+ "log",
  "ore",
  "pgrepr",
+ "rdkafka",
  "regex",
  "repr",
  "rusoto_core",

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -725,13 +725,8 @@ impl Timestamper {
             .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &kc.url.to_string());
 
-        if let Some(path) = kc.ssl_certificate_file {
-            config.set("security.protocol", "ssl");
-            config.set(
-                "ssl.ca.location",
-                path.to_str()
-                    .expect("Converting ssl certificate file path failed"),
-            );
+        for (k, v) in &kc.config_options {
+            config.set(k, v);
         }
 
         let k_consumer: BaseConsumer = config.create().expect("Failed to create Kakfa consumer");
@@ -861,14 +856,8 @@ impl Timestamper {
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &kc.url.to_string());
-
-        if let Some(path) = kc.ssl_certificate_file {
-            config.set("security.protocol", "ssl");
-            config.set(
-                "ssl.ca.location",
-                path.to_str()
-                    .expect("Converting ssl certificate file path failed"),
-            );
+        for (k, v) in &kc.config_options {
+            config.set(k, v);
         }
 
         let k_consumer: BaseConsumer = config.create().expect("Failed to create Kakfa consumer");

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -459,7 +459,9 @@ pub enum Consistency {
 pub struct KafkaSourceConnector {
     pub url: Url,
     pub topic: String,
-    pub ssl_certificate_file: Option<PathBuf>,
+    // Represents options specified by user when creating the source, e.g.
+    // security settings.
+    pub config_options: Vec<(String, String)>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -29,7 +29,7 @@ ore = { path = "../ore" }
 pdqselect = "0.1.0"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prometheus-static-metric = { git = "https://github.com/MaterializeInc/rust-prometheus.git" }
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored"] }
 regex = "1.3.6"
 repr = { path = "../repr" }
 rusoto_core = "0.43.0-beta.1"

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -59,7 +59,7 @@ where
     let KafkaSourceConnector {
         url,
         topic,
-        ssl_certificate_file,
+        config_options,
     } = connector.clone();
 
     let ts = if read_kafka {
@@ -90,16 +90,8 @@ where
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &url.to_string());
-
-        if let Some(path) = ssl_certificate_file {
-            // See https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka
-            // for more details on this librdkafka option
-            config.set("security.protocol", "ssl");
-            config.set(
-                "ssl.ca.location",
-                path.to_str()
-                    .expect("Converting ssl certificate file path failed"),
-            );
+        for (k, v) in &config_options {
+            config.set(k, v);
         }
 
         let mut consumer: Option<BaseConsumer<GlueConsumerContext>> = if read_kafka {

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -21,8 +21,10 @@ failure = "0.1.7"
 futures = "0.3"
 interchange = { path = "../interchange" }
 itertools = "0.9"
+log = "0.4.8"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored"] }
 regex = "1.3.6"
 repr = { path = "../repr" }
 rusoto_core = "0.43.0-beta.1"

--- a/src/sql/kafka_util.rs
+++ b/src/sql/kafka_util.rs
@@ -1,0 +1,232 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Provides parsing and convenience functions for working with Kafka from the `sql` package.
+
+use std::collections::HashMap;
+use std::fs::metadata;
+use std::sync::{Arc, Mutex};
+
+use failure::bail;
+use log::{debug, error, info, warn};
+use rdkafka::consumer::BaseConsumer;
+use rdkafka::ClientConfig;
+use sql_parser::ast::Value;
+
+/// Parse the `with_options` from a `CREATE SOURCE` statement to determine
+/// Kafka security strategy.
+///
+/// # Arguments
+///
+/// - `with_options` should be the `with_options` field of
+///   `sql_parser::ast::Statement::CreateSource`.
+///
+/// # Errors
+///
+/// If the user specified...
+///
+/// - Incompatible options
+/// - Invalid values for known options
+pub fn extract_security_options(
+    mut with_options: &mut HashMap<String, Value>,
+) -> Result<Vec<(String, String)>, failure::Error> {
+    let security_protocol = match with_options.remove("security_protocol") {
+        None => None,
+        Some(Value::SingleQuotedString(p)) => Some(p),
+        Some(_) => bail!("ssl_certificate_file must be a string"),
+    };
+
+    let ssl_certificate_file = match with_options.remove("ssl_certificate_file") {
+        None => None,
+        Some(Value::SingleQuotedString(p)) => {
+            if metadata(&p).is_err() {
+                bail!(
+                    "Invalid WITH options: ssl_certificate_file='{}', file does not exist",
+                    p
+                )
+            }
+            Some(p)
+        }
+        Some(_) => bail!("ssl_certificate_file must be a string"),
+    };
+
+    let options: Vec<(String, String)> = match (security_protocol.as_deref(), ssl_certificate_file)
+    {
+        (None, None) => Vec::new(),
+        (Some("sasl_plaintext"), None) => sasl_plaintext_kerberos_settings(&mut with_options)?,
+        (Some("ssl"), Some(path)) | (None, Some(path)) => vec![
+            // See https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka
+            // for more details on this librdkafka option
+            ("security.protocol".to_string(), "ssl".to_string()),
+            ("ssl.ca.location".to_string(), path),
+        ],
+        (Some(invalid_protocol), Some(path)) => bail!(
+            "Invalid WITH options: security_protocol='{}', ssl_certificate_file='{}'",
+            invalid_protocol,
+            path
+        ),
+        (Some(invalid_protocol), None) => bail!(
+            "Invalid WITH options: security_protocol='{}'",
+            invalid_protocol
+        ),
+    };
+
+    Ok(options)
+}
+
+/// Return a list of key-value pairs to authenticate `rdkafka` to connect to a
+/// Kerberized Kafka cluster. You can find more detail about these settings in
+/// [librdkafka's
+/// documentation](https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka).
+///
+/// # Arguments
+///
+/// - `with_options` should be the `with_options` field of
+///   `sql_parser::ast::Statement::CreateSource`, where the user has passed in
+///   their options to connect to the Kerberized Kafka cluster.
+///
+/// # Errors
+///
+/// - If any of the values in `with_options` are not
+///   `sql_parser::ast::Value::SingleQuotedString`.
+///
+fn sasl_plaintext_kerberos_settings(
+    with_options: &mut HashMap<String, Value>,
+) -> Result<Vec<(String, String)>, failure::Error> {
+    let mut specified_options: Vec<(String, String)> = vec![(
+        "security.protocol".to_string(),
+        "sasl_plaintext".to_string(),
+    )];
+
+    // Represents valid `with_option` keys to connect to Kerberized Kafka
+    // cluster through SASL based on
+    // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.
+    // Currently all of these keys can be converted to their respective
+    // client config settings by replacing underscores with dots.
+    //
+    // Each option's default value are determined by `librdkafka`, and any
+    // missing-but-necessary options are surfaced by `librdkafka` either
+    // erroring or logging an error.
+    let allowed_settings = vec![
+        "sasl_kerberos_keytab",
+        "sasl_kerberos_kinit_cmd",
+        "sasl_kerberos_min_time_before_relogin",
+        "sasl_kerberos_principal",
+        "sasl_kerberos_service_name",
+        "sasl_mechanisms",
+    ];
+    for setting in allowed_settings {
+        match with_options.remove(&setting.to_string()) {
+            Some(Value::SingleQuotedString(v)) => {
+                specified_options.push((setting.replace("_", "."), v));
+            }
+            Some(_) => bail!("{}'s value must be a single-quoted string", setting),
+            None => {}
+        };
+    }
+
+    Ok(specified_options)
+}
+
+/// Create a new
+/// [`rdkafka::ClientConfig`](https://docs.rs/rdkafka/latest/rdkafka/config/struct.ClientConfig.html)
+/// with the provided `options,` and test its ability to create an
+/// [`rdkafka::consumer::BaseConsumer`](https://docs.rs/rdkafka/latest/rdkafka/consumer/base_consumer/struct.BaseConsumer.html).
+///
+/// # Arguments
+///
+/// - `options` should be slice of tuples with the structure `(setting name,
+///   value)`. You can find valid setting names in [`librdkafka`'s
+///   documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+///
+///   `extract_security_options`' output is viable for input.
+///
+/// # Errors
+///
+/// - `librdkafka` cannot create a BaseConsumer using the provided `options`. For
+///   example, when using Kerberos auth, and the named principal does not exist.
+pub fn test_config(options: &[(String, String)]) -> Result<(), failure::Error> {
+    let mut config = ClientConfig::new();
+    for (k, v) in options {
+        config.set(k, v);
+    }
+
+    match config.create_with_context(RDKafkaErrCheckContext::default()) {
+        Ok(consumer) => {
+            let consumer: BaseConsumer<RDKafkaErrCheckContext> = consumer;
+            if let Ok(err_string) = consumer.context().error.lock() {
+                if !err_string.is_empty() {
+                    bail!("librdkafka: {}", *err_string)
+                }
+            };
+        }
+        Err(e) => {
+            match e {
+                rdkafka::error::KafkaError::ClientCreation(s) => {
+                    // Rewrite error message to provide Materialize-specific guidance.
+                    if s == "Invalid sasl.kerberos.kinit.cmd value: Property \
+            not available: \"sasl.kerberos.keytab\""
+                    {
+                        bail!(
+                            "Can't seem to find local keytab cache. You must \
+                    provide explicit sasl_kerberos_keytab or \
+                    sasl_kerberos_kinit_cmd option."
+                        )
+                    } else {
+                        // Pass existing error back up.
+                        bail!(rdkafka::error::KafkaError::ClientCreation(s))
+                    }
+                }
+                _ => bail!(e),
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Gets error strings from `rdkafka` when creating test consumers.
+#[derive(Clone, Default)]
+struct RDKafkaErrCheckContext {
+    pub error: Arc<Mutex<String>>,
+}
+
+impl rdkafka::consumer::ConsumerContext for RDKafkaErrCheckContext {}
+
+impl rdkafka::client::ClientContext for RDKafkaErrCheckContext {
+    // `librdkafka` doesn't seem to propagate all Kerberos errors up the stack,
+    // but does log them, so we are currently relying on the `log` callback for
+    // error handling in situations we're aware of, e.g. cannot log into
+    // Kerberos.
+    fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
+        use rdkafka::config::RDKafkaLogLevel::*;
+        match level {
+            Emerg | Alert | Critical | Error => {
+                let mut err_string = self.error.lock().expect("lock poisoned");
+                // Do not allow logging to overwrite other values if
+                // present.
+                if err_string.is_empty() {
+                    *err_string = log_message.to_string();
+                }
+                error!(target: "librdkafka", "{} {}", fac, log_message)
+            }
+            Warning => warn!(target: "librdkafka", "{} {}", fac, log_message),
+            Notice => info!(target: "librdkafka", "{} {}", fac, log_message),
+            Info => info!(target: "librdkafka", "{} {}", fac, log_message),
+            Debug => debug!(target: "librdkafka", "{} {}", fac, log_message),
+        }
+    }
+    // Refer to the comment on the `log` callback.
+    fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
+        let mut err_string = self.error.lock().expect("lock poisoned");
+        // Allow error to overwrite value irrespective of other conditions
+        // (i.e. logging).
+        *err_string = reason.to_string();
+        error!("librdkafka: {}: {}", error, reason);
+    }
+}

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -27,6 +27,7 @@ pub mod normalize;
 
 mod explain;
 mod expr;
+mod kafka_util;
 mod query;
 mod scope;
 mod session;

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -39,6 +39,7 @@ use sql_parser::ast::{
     Statement, Value,
 };
 
+use crate::kafka_util;
 use crate::query::QueryLifetime;
 use crate::{normalize, query, Index, Params, Plan, PlanSession, Sink, Source, View};
 use regex::Regex;
@@ -954,8 +955,15 @@ pub async fn purify_statement(mut stmt: Statement) -> Result<Statement, failure:
         let with_options_map = normalize::with_options(with_options);
 
         match connector {
-            Connector::Kafka { broker, .. } if !broker.contains(':') => {
-                *broker += ":9092";
+            Connector::Kafka { broker, .. } => {
+                if !broker.contains(':') {
+                    *broker += ":9092";
+                }
+
+                // Verify that the provided security options are valid and then test them.
+                let specified_options =
+                    kafka_util::extract_security_options(&mut with_options_map.clone())?;
+                kafka_util::test_config(&specified_options)?;
             }
             Connector::AvroOcf { path, .. } => {
                 let path = path.clone();
@@ -1090,11 +1098,8 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             let mut consistency = Consistency::RealTime;
             let (external_connector, mut encoding) = match connector {
                 Connector::Kafka { broker, topic, .. } => {
-                    let ssl_certificate_file = match with_options.remove("ssl_certificate_file") {
-                        None => None,
-                        Some(Value::SingleQuotedString(p)) => Some(p.into()),
-                        Some(_) => bail!("ssl_certificate_file must be a string"),
-                    };
+                    let config_options = kafka_util::extract_security_options(&mut with_options)?;
+
                     consistency = match with_options.remove("consistency") {
                         None => Consistency::RealTime,
                         Some(Value::SingleQuotedString(topic)) => Consistency::BringYourOwn(topic),
@@ -1104,7 +1109,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     let connector = ExternalSourceConnector::Kafka(KafkaSourceConnector {
                         url: broker.parse()?,
                         topic: topic.clone(),
-                        ssl_certificate_file,
+                        config_options,
                     });
                     let encoding = get_encoding(format)?;
                     (connector, encoding)


### PR DESCRIPTION
- We only have anecdotal integration tests from the client. I'd like to extend this to something more meaningful in the future, but I haven't yet set up Kerberos successfully.
- When `rdkafka` cannot log into Kerberos, it logs errors but doesn't actually throw them (in my lived experience of [this code](https://github.com/edenhill/librdkafka/blob/479d1c04dbb80123f78f9a9a7237dabaaf223af2/src/rdkafka_sasl_cyrus.c#L199)). This means that the `error` callback doesn't actually do anything in the case I'm checking for, and I'm instead relying on the `log` callback for error handling. Seems bad but ¯\_(ツ)_/¯

@benesch Can you PTAL and let me know what you think? I'm also glad to go through whatever hoops we need for the time being to get this to compile in CI--haven't had time to dig in yet, but if you have time, I'd love a primer. If not, ok!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2586)
<!-- Reviewable:end -->
