### PR TITLE
Support placeholders in EXPLAIN

### DIFF
--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -61,6 +61,9 @@ fn test_bind_params() -> Result<(), Box<dyn Error>> {
         .collect();
     assert_eq!(rows, &[-41]);
 
+    // Just ensure it does not panic (see #2498).
+    client.query("EXPLAIN PLAN FOR SELECT $1::int", &[&42_i32])?;
+
     Ok(())
 }
 

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -71,7 +71,7 @@ pub fn describe_statement(
                     ExplainStage::Sql => "Sql",
                     ExplainStage::RawPlan => "Raw Plan",
                     ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
-                    ExplainStage::OptimizedPlan{..} => "Optimized Plan",
+                    ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
                 },
                 ScalarType::String,
             )),
@@ -160,8 +160,8 @@ pub fn describe_statement(
                     if ObjectType::View == object_type {
                         relation_desc = relation_desc.add_column("QUERYABLE", ScalarType::Bool);
                     }
-                    if !materialized &&
-                        (ObjectType::View == object_type || ObjectType::Source == object_type)
+                    if !materialized
+                        && (ObjectType::View == object_type || ObjectType::Source == object_type)
                     {
                         relation_desc = relation_desc.add_column("MATERIALIZED", ScalarType::Bool);
                     }
@@ -206,7 +206,10 @@ pub fn describe_statement(
                 query::plan_root_query(scx, *query, QueryLifetime::OneShot)?;
             (Some(desc), param_types)
         }
-        Statement::CreateTable { .. } => bail!("CREATE TABLE statements are not supported. Try CREATE SOURCE or CREATE [MATERIALIZED] VIEW instead."),
+        Statement::CreateTable { .. } => bail!(
+            "CREATE TABLE statements are not supported. \
+             Try CREATE SOURCE or CREATE [MATERIALIZED] VIEW instead."
+        ),
         _ => bail!("unsupported SQL statement: {:?}", stmt),
     })
 }


### PR DESCRIPTION
The first commit just changes a file to allow rustfmt to process it and rustfmts it (thanks for the pointer @quodlibetor).

Fixes #2498.

Two halves to changing this: first, we have to pass through the param
types of a query to also be the types of its corresponding EXPLAIN, and
second, we have to make sure we bind any params when EXPLAINing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2589)
<!-- Reviewable:end -->
