### PR TITLE
Ensure sufficiently many parameters were provided

### DIFF
--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -504,6 +504,15 @@ where
         };
 
         let param_types = stmt.param_types();
+        if param_types.len() > raw_params.len() {
+            return self
+                .error(
+                    session,
+                    SqlState::PROTOCOL_VIOLATION,
+                    format!("there is no parameter ${}", raw_params.len() + 1),
+                )
+                .await;
+        }
         let param_formats = match pad_formats(param_formats, raw_params.len()) {
             Ok(param_formats) => param_formats,
             Err(msg) => return self.error(session, SqlState::PROTOCOL_VIOLATION, msg).await,


### PR DESCRIPTION
This PR is currently missing tests, and I'm not sure how to test it, since the Rust Postgres driver does this validation client side. Any suggestions?

Fixes #2591.

Previously, the following node program would crash Materialize:

```node
const { Client } = require('pg')
const client = new Client({
  host: 'localhost',
  port: 6875,
});

client.connect();

client.query({
  text: 'select $1::int + $2::int',
  values: [1],
}, (err, res) => {
  console.log(err);
  console.log(res);
  client.end()
});
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2593)
<!-- Reviewable:end -->
