### PR TITLE
Add a pgcode module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,6 +2081,7 @@ dependencies = [
  "ordered-float",
  "ore",
  "pgrepr",
+ "postgres",
  "prometheus",
  "rand",
  "repr",

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -30,3 +30,4 @@ repr = { path = "../repr" }
 sql = { path = "../sql" }
 tokio = "0.2"
 tokio-util = { version = "0.3", features = ["codec"] }
+postgres = "0.17.2"

--- a/src/pgwire/codec.rs
+++ b/src/pgwire/codec.rs
@@ -19,6 +19,7 @@ use std::str;
 
 use byteorder::{ByteOrder, NetworkEndian};
 use bytes::{Buf, BufMut, BytesMut};
+use postgres::error::SqlState;
 use prometheus::{register_int_counter, IntCounter};
 use tokio::io;
 use tokio_util::codec::{Decoder, Encoder};
@@ -93,7 +94,7 @@ impl Codec {
     fn encode_error_notice_response(
         dst: &mut BytesMut,
         severity: &'static str,
-        code: &'static str,
+        code: SqlState,
         message: String,
         detail: Option<String>,
         hint: Option<String>,
@@ -101,7 +102,7 @@ impl Codec {
         dst.put_u8(b'S');
         dst.put_string(severity);
         dst.put_u8(b'C');
-        dst.put_string(code);
+        dst.put_string(code.code());
         dst.put_u8(b'M');
         dst.put_string(&message);
         if let Some(detail) = &detail {

--- a/src/pgwire/message.rs
+++ b/src/pgwire/message.rs
@@ -10,6 +10,7 @@
 use std::sync::Arc;
 
 use bytes::BytesMut;
+use postgres::error::SqlState;
 
 use dataflow_types::Update;
 use repr::{ColumnName, RelationDesc, RelationType, ScalarType};
@@ -265,14 +266,14 @@ pub enum BackendMessage {
     CloseComplete,
     NoticeResponse {
         severity: NoticeSeverity,
-        code: &'static str,
+        code: SqlState,
         message: String,
         detail: Option<String>,
         hint: Option<String>,
     },
     ErrorResponse {
         severity: ErrorSeverity,
-        code: &'static str,
+        code: SqlState,
         message: String,
         detail: Option<String>,
     },


### PR DESCRIPTION
Rather than have all the pgerror codes inline in the error conditions,
this pulls them all into a single file with the names given to them by
Postgres.

This file should probably pulled to a more accessible location at some
point, since many aspects of the SQL language in Postgres have specific
error codes they return.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2595)
<!-- Reviewable:end -->
