### PR TITLE
WIP: Dataflow optimization

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1603,6 +1603,12 @@ where
         dataflow.add_index_export(*id, index.on, on_type, index.keys.clone());
         // TODO: should we still support creating multiple dataflows with a single command,
         // Or should it all be compacted into a single DataflowDesc with multiple exports?
+
+        // Optimize the dataflow. This performs inter-view optimizations,
+        // for example demand analysis that can allow sources to restrict
+        // the values they need to decode.
+        dataflow.optimize();
+
         broadcast(
             &mut self.broadcast_tx,
             SequencedCommand::CreateDataflows(vec![dataflow]),

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -635,8 +635,8 @@ impl DataflowDesc {
                 return desc.desc.typ().arity();
             }
         }
-        for (index_id, (_desc, typ)) in self.index_imports.iter() {
-            if index_id == id {
+        for (_index_id, (desc, typ)) in self.index_imports.iter() {
+            if &desc.on_id == id {
                 return typ.arity();
             }
         }
@@ -645,6 +645,6 @@ impl DataflowDesc {
                 return desc.relation_expr.as_ref().arity();
             }
         }
-        panic!("GlobalId {} not found in DataflowDesc", id);
+        panic!("GlobalId {} not found in DataflowDesc: {:?}", id, self);
     }
 }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
-use expr::{EvalEnv, GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInstanceId};
+use expr::{
+    EvalEnv, GlobalId, Id, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInstanceId,
+};
 use interchange::avro;
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use regex::Regex;
@@ -390,7 +392,7 @@ pub struct ProtobufEncoding {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SourceDesc {
     pub connector: SourceConnector,
-    /// Optionally, filtering and projection to apply.
+    /// Optionally, filtering and projection to optionally apply.
     pub operators: Option<LinearOperator>,
     pub desc: RelationDesc,
 }
@@ -537,20 +539,112 @@ pub struct IndexDesc {
     pub keys: Vec<ScalarExpr>,
 }
 
-/// In-place restrictions to make to streams of rows.
+/// In-place restrictions that can be made to rows.
 ///
-/// The intended behavior is to first restrict all rows by
-/// the predicates in `self.predicates` and the retain the
-/// columns identified by `self.projection`. This allows the
-/// predicates to reference columns that may then be dropped,
-/// but requires each implementation to reason about which
-/// columns must be extracted.
+/// These fields indicate *optional* information that may applied to
+/// streams of rows. Any row that does not satisfy all predicates may
+/// be discarded, and any column not listed in the projection may be
+/// replaced by a default value.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct LinearOperator {
-    /// Tests all of which must evaluate to `Datum::True` for the row to pass.
+    /// Rows that do not pass all predicates may be discarded.
     pub predicates: Vec<ScalarExpr>,
-    /// The sequence of source columns to extract.
+    /// Columns not present in `projection` may be replaced with
+    /// default values.
     pub projection: Vec<usize>,
     /// The environment required for `predicates`.
     pub eval_env: EvalEnv,
+}
+
+impl DataflowDesc {
+    /// Optimizes the implementation of each dataflow.
+    pub fn optimize(&mut self) {
+        // We are currently not clever enough to optimize around multiple evaluation environments.
+        // We may eventually be able to instantiate the bindings in the environment, but this is
+        // not yet possible to guarantee.
+        let mut environments = self
+            .objects_to_build
+            .iter()
+            .map(|o| o.eval_env.clone())
+            .collect::<Vec<_>>();
+        environments.dedup();
+        if environments.len() != 1 {
+            return;
+        }
+        let eval_env = environments.pop().unwrap();
+
+        // This method is currently limited in scope to propagating filtering and
+        // projection information, though it could certainly generalize beyond.
+
+        // 1. Propagate demand information from outputs back to sources.
+        let mut demand = HashMap::new();
+
+        // Demand all columns of inputs to sinks.
+        for (_id, sink) in self.sink_exports.iter() {
+            let input_id = sink.from.0;
+            demand
+                .entry(Id::Global(input_id))
+                .or_insert(HashSet::new())
+                .extend(0..self.arity_of(&input_id));
+        }
+
+        // Demand all columns of inputs to exported indexes.
+        for (_id, desc, _typ) in self.index_exports.iter() {
+            let input_id = desc.on_id;
+            demand
+                .entry(Id::Global(input_id))
+                .or_insert(HashSet::new())
+                .extend(0..self.arity_of(&input_id));
+        }
+
+        // Propagate demand information from outputs to inputs.
+        for build_desc in self.objects_to_build.iter_mut().rev() {
+            let transform = expr::transform::demand::Demand;
+            if let Some(columns) = demand.get(&Id::Global(build_desc.id)).clone() {
+                transform.action(
+                    build_desc.relation_expr.as_mut(),
+                    columns.clone(),
+                    &mut demand,
+                );
+            }
+        }
+
+        // Push demand information into the SourceDesc.
+        for (source_id, source_desc) in self.source_imports.iter_mut() {
+            if let Some(columns) = demand.get(&Id::Global(source_id.sid)).clone() {
+                // Install no-op demand information if none exists.
+                if source_desc.operators.is_none() {
+                    source_desc.operators = Some(LinearOperator {
+                        predicates: Vec::new(),
+                        projection: (0..source_desc.desc.typ().arity()).collect(),
+                        eval_env: eval_env.clone(),
+                    })
+                }
+                // Restrict required columns by those identified as demanded.
+                if let Some(operator) = &mut source_desc.operators {
+                    operator.projection.retain(|col| columns.contains(col));
+                }
+            }
+        }
+    }
+
+    /// The number of columns associated with an identifier in the dataflow.
+    fn arity_of(&self, id: &GlobalId) -> usize {
+        for (source, desc) in self.source_imports.iter() {
+            if &source.sid == id {
+                return desc.desc.typ().arity();
+            }
+        }
+        for (index_id, (_desc, typ)) in self.index_imports.iter() {
+            if index_id == id {
+                return typ.arity();
+            }
+        }
+        for desc in self.objects_to_build.iter() {
+            if &desc.id == id {
+                return desc.relation_expr.as_ref().arity();
+            }
+        }
+        panic!("GlobalId {} not found in DataflowDesc", id);
+    }
 }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -584,7 +584,7 @@ impl DataflowDesc {
             let input_id = sink.from.0;
             demand
                 .entry(Id::Global(input_id))
-                .or_insert(HashSet::new())
+                .or_insert_with(HashSet::new)
                 .extend(0..self.arity_of(&input_id));
         }
 
@@ -593,7 +593,7 @@ impl DataflowDesc {
             let input_id = desc.on_id;
             demand
                 .entry(Id::Global(input_id))
-                .or_insert(HashSet::new())
+                .or_insert_with(HashSet::new)
                 .extend(0..self.arity_of(&input_id));
         }
 

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -118,21 +118,21 @@ where
                                             session.give((
                                                 Row::pack(
                                                     (0..n_cols)
-                                                        .map(|i| {
-                                                            // Unsafety rationalized as 1. the input text is determined to be
-                                                            // valid utf8, and 2. the delimiter is ascii, which should make each
-                                                            // delimited region also utf8.
-                                                            Datum::String(unsafe {
-                                                                if demanded[i] {
+                                                        .map(|i|
+                                                            if demanded[i] {
+                                                                // Unsafety rationalized as 1. the input text is determined to be
+                                                                // valid utf8, and 2. the delimiter is ascii, which should make each
+                                                                // delimited region also utf8.
+                                                                Datum::String(unsafe {
                                                                     std::str::from_utf8_unchecked(
                                                                         &buffer
                                                                             [bounds[i]..bounds[i + 1]],
                                                                     )
-                                                                } else {
-                                                                    ""
-                                                                }
-                                                            })
-                                                        })
+                                                                })
+                                                            } else {
+                                                                Datum::Null
+                                                            }
+                                                        )
                                                         .chain(iter::once(
                                                             line_no.map(Datum::Int64).into(),
                                                         )),

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -9,6 +9,7 @@
 
 use std::iter;
 
+use dataflow_types::LinearOperator;
 use differential_dataflow::Hashable;
 use log::error;
 use timely::dataflow::channels::pact::Exchange;
@@ -24,10 +25,21 @@ pub fn csv<G>(
     header_row: bool,
     n_cols: usize,
     delimiter: u8,
+    operators: &mut Option<LinearOperator>,
 ) -> Stream<G, (Row, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    let operators = operators.take();
+    let demanded = (0..n_cols)
+        .map(move |c| {
+            operators
+                .as_ref()
+                .map(|o| o.projection.contains(&c))
+                .unwrap_or(true)
+        })
+        .collect::<Vec<_>>();
+
     // Delimiters must be single-byte utf8 to safely treat all matched fields as valid utf8.
     assert!(delimiter.is_ascii());
 
@@ -111,10 +123,14 @@ where
                                                             // valid utf8, and 2. the delimiter is ascii, which should make each
                                                             // delimited region also utf8.
                                                             Datum::String(unsafe {
-                                                                std::str::from_utf8_unchecked(
-                                                                    &buffer
-                                                                        [bounds[i]..bounds[i + 1]],
-                                                                )
+                                                                if demanded[i] {
+                                                                    std::str::from_utf8_unchecked(
+                                                                        &buffer
+                                                                            [bounds[i]..bounds[i + 1]],
+                                                                    )
+                                                                } else {
+                                                                    ""
+                                                                }
                                                             })
                                                         })
                                                         .chain(iter::once(

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -226,7 +226,6 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                     if c.tail {
                                         FileReadStyle::TailFollowFd
                                     } else {
-<<<<<<< HEAD
                                         FileReadStyle::ReadOnce
                                     }
                                 } else {
@@ -244,44 +243,16 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                 )
                             }
                             ExternalSourceConnector::AvroOcf(_) => unreachable!(),
-=======
-                                        FileReadStyle::None
-                                    };
-
-                                    let ctor = |file| {
-                                        futures::future::ok(
-                                            FramedRead::new(file, LinesCodec::new())
-                                                .map(|res| res.map(String::into_bytes)),
-                                        )
-                                    };
-                                    source::file(
-                                        src_id,
-                                        region,
-                                        format!("csv-{}", src_id),
-                                        c.path,
-                                        executor,
-                                        read_style,
-                                        ctor,
-                                    )
-                                }
-                                ExternalSourceConnector::AvroOcf(_) => unreachable!(),
-                            };
-                            // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
-                            // a hypothetical future avro_extract, protobuf_extract, etc.
-                            let stream = decode(
-                                &source,
-                                encoding,
-                                &dataflow.debug_name,
-                                &envelope,
-                                &mut src.operators,
-                            );
-
-                            (stream, capability)
->>>>>>> demonstrate CSV projection
                         };
                         // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
                         // a hypothetical future avro_extract, protobuf_extract, etc.
-                        let stream = decode(&source, encoding, &dataflow.debug_name, &envelope);
+                        let stream = decode(
+                            &source,
+                            encoding,
+                            &dataflow.debug_name,
+                            &envelope,
+                            &mut src.operators,
+                        );
 
                         (stream, capability)
                     };

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -128,7 +128,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                 unreachable!()
             };
             // Load declared sources into the rendering context.
-            for (source_number, (src_id, src)) in
+            for (source_number, (src_id, mut src)) in
                 dataflow.source_imports.clone().into_iter().enumerate()
             {
                 if let SourceConnector::External {
@@ -226,6 +226,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                     if c.tail {
                                         FileReadStyle::TailFollowFd
                                     } else {
+<<<<<<< HEAD
                                         FileReadStyle::ReadOnce
                                     }
                                 } else {
@@ -243,6 +244,40 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                 )
                             }
                             ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+=======
+                                        FileReadStyle::None
+                                    };
+
+                                    let ctor = |file| {
+                                        futures::future::ok(
+                                            FramedRead::new(file, LinesCodec::new())
+                                                .map(|res| res.map(String::into_bytes)),
+                                        )
+                                    };
+                                    source::file(
+                                        src_id,
+                                        region,
+                                        format!("csv-{}", src_id),
+                                        c.path,
+                                        executor,
+                                        read_style,
+                                        ctor,
+                                    )
+                                }
+                                ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+                            };
+                            // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
+                            // a hypothetical future avro_extract, protobuf_extract, etc.
+                            let stream = decode(
+                                &source,
+                                encoding,
+                                &dataflow.debug_name,
+                                &envelope,
+                                &mut src.operators,
+                            );
+
+                            (stream, capability)
+>>>>>>> demonstrate CSV projection
                         };
                         // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
                         // a hypothetical future avro_extract, protobuf_extract, etc.

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -47,7 +47,11 @@ impl Demand {
         );
     }
 
-    /// Columns be produced.
+    /// Propagates information about demanded columns.
+    ///
+    /// The input `columns` are indicated as demanded, and the input `gets`
+    /// should be populated with demand information for identifiers outside
+    /// the scope of `relation`.
     pub fn action(
         &self,
         relation: &mut RelationExpr,

--- a/src/repr/relation.rs
+++ b/src/repr/relation.rs
@@ -100,13 +100,18 @@ impl RelationType {
         }
     }
 
-    /// Adds a set of indices as keys for the colleciton.
+    /// Adds a set of indices as keys for the collection.
     pub fn add_keys(mut self, mut indices: Vec<usize>) -> Self {
         indices.sort();
         if !self.keys.contains(&indices) {
             self.keys.push(indices);
         }
         self
+    }
+
+    /// The number of columns in the relation type.
+    pub fn arity(&self) -> usize {
+        self.column_types.len()
     }
 }
 


### PR DESCRIPTION
This PR introduces inter-view dataflow optimization. Specifically, it currently propagates demand information from published sinks and indexes back through dataflows to sources. Source instantiation now consults this information and blanks out columns that are not demanded.

Still to do: determine feasibility of propagating filter expressions back to sources, demonstrate the use of these two in the CSV source.

cc: @wangandi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2598)
<!-- Reviewable:end -->
