### PR TITLE
expr,sql: replace EvalEnv with PlanContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "bincode",
+ "chrono",
  "dataflow-types",
  "expr",
  "failure",
@@ -3139,6 +3140,7 @@ dependencies = [
  "catalog",
  "chrono",
  "dataflow-types",
+ "expr",
  "failure",
  "log",
  "ore",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 [dependencies]
 backtrace = "0.3.43"
 bincode = { version = "1.2", optional = true }
+chrono = "0.4"
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 failure = "0.1.6"

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
-use expr::{EvalEnv, GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInstanceId};
+use expr::{GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInstanceId};
 use interchange::avro;
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use regex::Regex;
@@ -74,7 +74,6 @@ pub struct Update {
 pub struct BuildDesc {
     pub id: GlobalId,
     pub relation_expr: OptimizedRelationExpr,
-    pub eval_env: EvalEnv,
     /// is_some if building a view, none otherwise
     pub typ: Option<RelationType>,
 }
@@ -139,13 +138,11 @@ impl DataflowDesc {
         &mut self,
         id: GlobalId,
         expr: OptimizedRelationExpr,
-        eval_env: EvalEnv,
         typ: RelationType,
     ) {
         self.objects_to_build.push(BuildDesc {
             id,
             relation_expr: expr,
-            eval_env,
             typ: Some(typ),
         });
     }
@@ -156,7 +153,6 @@ impl DataflowDesc {
         on_id: GlobalId,
         on_type: RelationType,
         keys: Vec<ScalarExpr>,
-        eval_env: EvalEnv,
     ) {
         self.objects_to_build.push(BuildDesc {
             id,
@@ -164,7 +160,6 @@ impl DataflowDesc {
                 input: Box::new(RelationExpr::global_get(on_id, on_type)),
                 keys: vec![keys],
             }),
-            eval_env,
             typ: None,
         });
     }

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -25,7 +25,7 @@ use timely::worker::Worker as TimelyWorker;
 
 use dataflow_types::Timestamp;
 use dataflow_types::*;
-use expr::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr, SourceInstanceId};
+use expr::{GlobalId, Id, RelationExpr, ScalarExpr, SourceInstanceId};
 use repr::{Datum, RelationType, Row, RowArena};
 
 use self::context::{ArrangementFlavor, Context};
@@ -70,7 +70,6 @@ pub(crate) fn build_local_input<A: Allocate>(
                 .insert(get_expr.clone(), stream.as_collection());
             context.render_arranged(
                 &get_expr.clone().arrange_by(&[index.keys.clone()]),
-                &EvalEnv::default(),
                 region,
                 worker_index,
                 Some(&index_id.to_string()),
@@ -309,12 +308,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
 
             for object in dataflow.objects_to_build.clone() {
                 if let Some(typ) = object.typ {
-                    context.ensure_rendered(
-                        object.relation_expr.as_ref(),
-                        &object.eval_env,
-                        region,
-                        worker_index,
-                    );
+                    context.ensure_rendered(object.relation_expr.as_ref(), region, worker_index);
                     context.clone_from_to(
                         &object.relation_expr.as_ref(),
                         &RelationExpr::global_get(object.id, typ.clone()),
@@ -322,7 +316,6 @@ pub(crate) fn build_dataflow<A: Allocate>(
                 } else {
                     context.render_arranged(
                         &object.relation_expr.as_ref(),
-                        &object.eval_env,
                         region,
                         worker_index,
                         Some(&object.id.to_string()),
@@ -449,7 +442,6 @@ where
     pub fn ensure_rendered(
         &mut self,
         relation_expr: &RelationExpr,
-        env: &EvalEnv,
         scope: &mut G,
         worker_index: usize,
     ) {
@@ -492,15 +484,15 @@ where
                     if self.has_collection(&bind) {
                         panic!("Inappropriate to re-bind name: {:?}", bind);
                     } else {
-                        self.ensure_rendered(value, env, scope, worker_index);
+                        self.ensure_rendered(value, scope, worker_index);
                         self.clone_from_to(value, &bind);
-                        self.ensure_rendered(body, env, scope, worker_index);
+                        self.ensure_rendered(body, scope, worker_index);
                         self.clone_from_to(body, relation_expr);
                     }
                 }
 
                 RelationExpr::Project { input, outputs } => {
-                    self.ensure_rendered(input, env, scope, worker_index);
+                    self.ensure_rendered(input, scope, worker_index);
                     let outputs = outputs.clone();
                     let collection = self.collection(input).unwrap().map(move |row| {
                         let datums = row.unpack();
@@ -511,14 +503,13 @@ where
                 }
 
                 RelationExpr::Map { input, scalars } => {
-                    self.ensure_rendered(input, env, scope, worker_index);
-                    let env = env.clone();
+                    self.ensure_rendered(input, scope, worker_index);
                     let scalars = scalars.clone();
                     let collection = self.collection(input).unwrap().map(move |input_row| {
                         let mut datums = input_row.unpack();
                         let temp_storage = RowArena::new();
                         for scalar in &scalars {
-                            let datum = scalar.eval(&datums, &env, &temp_storage);
+                            let datum = scalar.eval(&datums, &temp_storage);
                             // Scalar is allowed to see the outputs of previous scalars.
                             // To avoid repeatedly unpacking input_row, we just push the outputs into datums so later scalars can see them.
                             // Note that this doesn't mutate input_row.
@@ -536,8 +527,7 @@ where
                     expr,
                     demand,
                 } => {
-                    self.ensure_rendered(input, env, scope, worker_index);
-                    let env = env.clone();
+                    self.ensure_rendered(input, scope, worker_index);
                     let func = func.clone();
                     let expr = expr.clone();
 
@@ -568,10 +558,8 @@ where
                         let datums = input_row.unpack();
                         let replace = replace.clone();
                         let temp_storage = RowArena::new();
-                        let expr = expr
-                            .eval(&datums, &env, &temp_storage)
-                            .unwrap_or(Datum::Null);
-                        let output_rows = func.eval(expr, &env, &temp_storage);
+                        let expr = expr.eval(&datums, &temp_storage).unwrap_or(Datum::Null);
+                        let output_rows = func.eval(expr, &temp_storage);
                         output_rows
                             .into_iter()
                             .map(move |output_row| {
@@ -604,31 +592,25 @@ where
                     let collection = if let RelationExpr::Join { implementation, .. } = &**input {
                         match implementation {
                             expr::JoinImplementation::Differential(_start, _order) => {
-                                self.render_join(input, predicates, env, scope, worker_index)
+                                self.render_join(input, predicates, scope, worker_index)
                             }
                             expr::JoinImplementation::DeltaQuery(_orders) => self
-                                .render_delta_join(
-                                    input,
-                                    predicates,
-                                    env,
-                                    scope,
-                                    worker_index,
-                                    |t| t.saturating_sub(1),
-                                ),
+                                .render_delta_join(input, predicates, scope, worker_index, |t| {
+                                    t.saturating_sub(1)
+                                }),
                             expr::JoinImplementation::Unimplemented => {
                                 panic!("Attempt to render unimplemented join");
                             }
                         }
                     } else {
-                        self.ensure_rendered(input, env, scope, worker_index);
-                        let env = env.clone();
+                        self.ensure_rendered(input, scope, worker_index);
                         let temp_storage = RowArena::new();
                         let predicates = predicates.clone();
                         self.collection(input).unwrap().filter(move |input_row| {
                             let datums = input_row.unpack();
                             predicates.iter().all(|predicate| {
                                 match predicate
-                                    .eval(&datums, &env, &temp_storage)
+                                    .eval(&datums, &temp_storage)
                                     .unwrap_or(Datum::Null)
                                 {
                                     Datum::True => true,
@@ -643,19 +625,14 @@ where
 
                 RelationExpr::Join { implementation, .. } => match implementation {
                     expr::JoinImplementation::Differential(_start, _order) => {
-                        let collection =
-                            self.render_join(relation_expr, &[], env, scope, worker_index);
+                        let collection = self.render_join(relation_expr, &[], scope, worker_index);
                         self.collections.insert(relation_expr.clone(), collection);
                     }
                     expr::JoinImplementation::DeltaQuery(_orders) => {
-                        let collection = self.render_delta_join(
-                            relation_expr,
-                            &[],
-                            env,
-                            scope,
-                            worker_index,
-                            |t| t.saturating_sub(1),
-                        );
+                        let collection =
+                            self.render_delta_join(relation_expr, &[], scope, worker_index, |t| {
+                                t.saturating_sub(1)
+                            });
                         self.collections.insert(relation_expr.clone(), collection);
                     }
                     expr::JoinImplementation::Unimplemented => {
@@ -664,26 +641,26 @@ where
                 },
 
                 RelationExpr::Reduce { .. } => {
-                    self.render_reduce(relation_expr, env, scope, worker_index);
+                    self.render_reduce(relation_expr, scope, worker_index);
                 }
 
                 RelationExpr::TopK { .. } => {
-                    self.render_topk(relation_expr, env, scope, worker_index);
+                    self.render_topk(relation_expr, scope, worker_index);
                 }
 
                 RelationExpr::Negate { input } => {
-                    self.ensure_rendered(input, env, scope, worker_index);
+                    self.ensure_rendered(input, scope, worker_index);
                     let collection = self.collection(input).unwrap().negate();
                     self.collections.insert(relation_expr.clone(), collection);
                 }
 
                 RelationExpr::Threshold { .. } => {
-                    self.render_threshold(relation_expr, env, scope, worker_index);
+                    self.render_threshold(relation_expr, scope, worker_index);
                 }
 
                 RelationExpr::Union { left, right } => {
-                    self.ensure_rendered(left, env, scope, worker_index);
-                    self.ensure_rendered(right, env, scope, worker_index);
+                    self.ensure_rendered(left, scope, worker_index);
+                    self.ensure_rendered(right, scope, worker_index);
 
                     let input1 = self.collection(left).unwrap();
                     let input2 = self.collection(right).unwrap();
@@ -693,7 +670,7 @@ where
                 }
 
                 RelationExpr::ArrangeBy { .. } => {
-                    self.render_arranged(relation_expr, env, scope, worker_index, None);
+                    self.render_arranged(relation_expr, scope, worker_index, None);
                 }
             };
         }
@@ -702,23 +679,21 @@ where
     fn render_arranged(
         &mut self,
         relation_expr: &RelationExpr,
-        env: &EvalEnv,
         scope: &mut G,
         worker_index: usize,
         id: Option<&str>,
     ) {
         if let RelationExpr::ArrangeBy { input, keys } = relation_expr {
             if keys.is_empty() {
-                self.ensure_rendered(input, env, scope, worker_index);
+                self.ensure_rendered(input, scope, worker_index);
                 let collection = self.collection(input).unwrap();
                 self.collections.insert(relation_expr.clone(), collection);
             }
             for key_set in keys {
                 if self.arrangement(&input, &key_set).is_none() {
-                    self.ensure_rendered(input, env, scope, worker_index);
+                    self.ensure_rendered(input, scope, worker_index);
                     let built = self.collection(input).unwrap();
                     let keys2 = key_set.clone();
-                    let env = env.clone();
                     let name = if let Some(id) = id {
                         format!("Arrange: {}", id)
                     } else {
@@ -728,9 +703,10 @@ where
                         .map(move |row| {
                             let datums = row.unpack();
                             let temp_storage = RowArena::new();
-                            let key_row = Row::pack(keys2.iter().map(|k| {
-                                k.eval(&datums, &env, &temp_storage).unwrap_or(Datum::Null)
-                            }));
+                            let key_row =
+                                Row::pack(keys2.iter().map(|k| {
+                                    k.eval(&datums, &temp_storage).unwrap_or(Datum::Null)
+                                }));
                             (key_row, row)
                         })
                         .arrange_named::<OrdValSpine<_, _, _, _>>(&name);
@@ -754,7 +730,6 @@ where
         &mut self,
         relation_expr: &RelationExpr,
         predicates: &[ScalarExpr],
-        env: &EvalEnv,
         scope: &mut G,
         worker_index: usize,
     ) -> Collection<G, Row> {
@@ -777,7 +752,7 @@ where
             }
 
             for input in inputs.iter() {
-                self.ensure_rendered(input, env, scope, worker_index);
+                self.ensure_rendered(input, scope, worker_index);
             }
 
             let types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
@@ -817,7 +792,6 @@ where
                 &source_columns,
                 &mut predicates,
                 &mut equivalences,
-                env,
             );
 
             for (input, next_keys) in order.iter() {
@@ -913,16 +887,15 @@ where
                     .collect();
 
                 // We exploit the demand information to restrict `prev` to its demanded columns.
-                let env_clone = env.clone();
                 let prev_keyed = joined
                     .map({
                         move |row| {
                             let datums = row.unpack();
                             let temp_storage = RowArena::new();
-                            let key = Row::pack(prev_keys.iter().map(|e| {
-                                e.eval(&datums, &env_clone, &temp_storage)
-                                    .unwrap_or(Datum::Null)
-                            }));
+                            let key =
+                                Row::pack(prev_keys.iter().map(|e| {
+                                    e.eval(&datums, &temp_storage).unwrap_or(Datum::Null)
+                                }));
                             let row = Row::pack(prev_vals.iter().map(|i| datums[*i]));
                             (key, row)
                         }
@@ -966,7 +939,6 @@ where
                     &source_columns,
                     &mut predicates,
                     &mut equivalences,
-                    env,
                 );
             }
 
@@ -1003,13 +975,7 @@ where
         }
     }
 
-    fn render_topk(
-        &mut self,
-        relation_expr: &RelationExpr,
-        env: &EvalEnv,
-        scope: &mut G,
-        worker_index: usize,
-    ) {
+    fn render_topk(&mut self, relation_expr: &RelationExpr, scope: &mut G, worker_index: usize) {
         if let RelationExpr::TopK {
             input,
             group_key,
@@ -1020,7 +986,7 @@ where
         {
             use differential_dataflow::operators::reduce::Reduce;
 
-            self.ensure_rendered(input, env, scope, worker_index);
+            self.ensure_rendered(input, scope, worker_index);
             let input = self.collection(input).unwrap();
 
             // To provide a robust incremental orderby-limit experience, we want to avoid grouping
@@ -1152,7 +1118,6 @@ where
     fn render_threshold(
         &mut self,
         relation_expr: &RelationExpr,
-        env: &EvalEnv,
         scope: &mut G,
         worker_index: usize,
     ) {
@@ -1163,7 +1128,7 @@ where
 
             // TODO: easier idioms for detecting, re-using, and stashing.
             if self.arrangement_columns(&input, &keys[..]).is_none() {
-                self.ensure_rendered(input, env, scope, worker_index);
+                self.ensure_rendered(input, scope, worker_index);
                 let built = self.collection(input).unwrap();
                 let keys2 = keys.clone();
                 let keyed = built

--- a/src/expr/lib.rs
+++ b/src/expr/lib.rs
@@ -26,5 +26,5 @@ pub use relation::{
     RowSetFinishing,
 };
 pub use scalar::func::{BinaryFunc, DateTruncTo, NullaryFunc, UnaryFunc, VariadicFunc};
-pub use scalar::{like_pattern, EvalEnv, EvalError, ScalarExpr};
+pub use scalar::{like_pattern, EvalError, ScalarExpr};
 pub use transform::OptimizedRelationExpr;

--- a/src/expr/relation/func.rs
+++ b/src/expr/relation/func.rs
@@ -18,8 +18,6 @@ use serde::{Deserialize, Serialize};
 use repr::decimal::Significand;
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
-use crate::EvalEnv;
-
 use std::iter;
 
 // TODO(jamii) be careful about overflow in sum/avg
@@ -447,7 +445,7 @@ pub enum AggregateFunc {
 }
 
 impl AggregateFunc {
-    pub fn eval<'a, I>(&self, datums: I, _env: &'a EvalEnv, temp_storage: &'a RowArena) -> Datum<'a>
+    pub fn eval<'a, I>(&self, datums: I, temp_storage: &'a RowArena) -> Datum<'a>
     where
         I: IntoIterator<Item = Datum<'a>>,
     {
@@ -676,12 +674,7 @@ pub enum UnaryTableFunc {
 }
 
 impl UnaryTableFunc {
-    pub fn eval<'a>(
-        &'a self,
-        datum: Datum<'a>,
-        _env: &'a EvalEnv,
-        _temp_storage: &'a RowArena,
-    ) -> Vec<Row> {
+    pub fn eval<'a>(&'a self, datum: Datum<'a>, _temp_storage: &'a RowArena) -> Vec<Row> {
         match self {
             UnaryTableFunc::JsonbEach => jsonb_each(datum),
             UnaryTableFunc::JsonbObjectKeys => jsonb_object_keys(datum),

--- a/src/expr/transform/binding.rs
+++ b/src/expr/transform/binding.rs
@@ -66,7 +66,7 @@ use indexmap::IndexMap;
 
 use repr::RelationType;
 
-use crate::{EvalEnv, GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
 
 // -----------------------------------------------------------------------------
 
@@ -223,7 +223,6 @@ impl super::Transform for Hoist {
         &self,
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         Hoist::hoist(expr);
         Ok(())
@@ -291,7 +290,6 @@ impl super::Transform for Unbind {
         &self,
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         Unbind::unbind(expr);
         Ok(())
@@ -472,7 +470,6 @@ impl super::Transform for Deduplicate {
         &self,
         expr: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         Deduplicate::deduplicate(expr);
         Ok(())

--- a/src/expr/transform/constant_join.rs
+++ b/src/expr/transform/constant_join.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct InsertConstantJoin;
@@ -22,7 +22,6 @@ impl super::Transform for InsertConstantJoin {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())
@@ -68,7 +67,6 @@ impl super::Transform for RemoveConstantJoin {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, RelationExpr, ScalarExpr};
 
 /// Drive demand from the root through operators.
 ///
@@ -26,7 +26,6 @@ impl crate::transform::Transform for Demand {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/empty_map.rs
+++ b/src/expr/transform/empty_map.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct EmptyMap;
@@ -19,7 +19,6 @@ impl super::Transform for EmptyMap {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/filter_lets.rs
+++ b/src/expr/transform/filter_lets.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
 
 /// Pushes common filter predicates on gets into the let binding.
 ///
@@ -26,7 +26,6 @@ impl super::Transform for FilterLets {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/fusion/filter.rs
+++ b/src/expr/transform/fusion/filter.rs
@@ -39,7 +39,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct Filter;
@@ -49,7 +49,6 @@ impl crate::transform::Transform for Filter {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), crate::transform::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/fusion/join.rs
+++ b/src/expr/transform/fusion/join.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct Join;
@@ -19,7 +19,6 @@ impl crate::transform::Transform for Join {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), crate::transform::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/fusion/map.rs
+++ b/src/expr/transform/fusion/map.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 use std::mem;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct Map;
@@ -20,7 +20,6 @@ impl crate::transform::Transform for Map {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), crate::transform::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/fusion/project.rs
+++ b/src/expr/transform/fusion/project.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct Project;
@@ -19,7 +19,6 @@ impl crate::transform::Transform for Project {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), crate::transform::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/inline_let.rs
+++ b/src/expr/transform/inline_let.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct InlineLet;
@@ -19,7 +19,6 @@ impl super::Transform for InlineLet {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/join_elision.rs
+++ b/src/expr/transform/join_elision.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 use repr::RelationType;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 /// Removes singleton constants from joins, and removes joins with
 /// single input relations.
@@ -23,7 +23,6 @@ impl super::Transform for JoinElision {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/join_implementation.rs
+++ b/src/expr/transform/join_implementation.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, RelationExpr, ScalarExpr};
 
 /// Determines the join implementation for join operators.
 ///
@@ -33,7 +33,6 @@ impl super::Transform for JoinImplementation {
         &self,
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation, indexes);
         Ok(())

--- a/src/expr/transform/join_order.rs
+++ b/src/expr/transform/join_order.rs
@@ -57,7 +57,6 @@ impl super::Transform for JoinOrder {
         &self,
         relation: &mut RelationExpr,
         arrangements: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation, arrangements);
         Ok(())

--- a/src/expr/transform/nonnull_requirements.rs
+++ b/src/expr/transform/nonnull_requirements.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr, UnaryTableFunc};
+use crate::{GlobalId, Id, RelationExpr, ScalarExpr, UnaryTableFunc};
 
 /// Drive non-null requirements to `RelationExpr::Constant` collections.
 ///
@@ -34,7 +34,6 @@ impl crate::transform::Transform for NonNullRequirements {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/nonnullable.rs
+++ b/src/expr/transform/nonnullable.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use repr::{ColumnType, Datum, RelationType, ScalarType};
 
 use crate::relation::AggregateExpr;
-use crate::{AggregateFunc, EvalEnv, GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
+use crate::{AggregateFunc, GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
 
 #[derive(Debug)]
 pub struct NonNullable;
@@ -22,7 +22,6 @@ impl super::Transform for NonNullable {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/predicate_pushdown.rs
+++ b/src/expr/transform/predicate_pushdown.rs
@@ -51,7 +51,7 @@ use std::collections::HashMap;
 
 use repr::{ColumnType, Datum, ScalarType};
 
-use crate::{AggregateFunc, EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{AggregateFunc, GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct PredicatePushdown;
@@ -61,7 +61,6 @@ impl super::Transform for PredicatePushdown {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/projection_extraction.rs
+++ b/src/expr/transform/projection_extraction.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 /// Extracts simple projections from the scalar expressions in a `Map` operator
 /// into a `Project`, so they can be subjected to other optimizations.
@@ -21,7 +21,6 @@ impl super::Transform for ProjectionExtraction {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/projection_lifting.rs
+++ b/src/expr/transform/projection_lifting.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, RelationExpr, ScalarExpr};
 
 /// Hoist projections wherever possible, in order to minimize structural limitations on transformations.
 /// Projections can be re-introduced in the physical planning stage.
@@ -21,7 +21,6 @@ impl crate::transform::Transform for ProjectionLifting {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/reduce_elision.rs
+++ b/src/expr/transform/reduce_elision.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 /// Removes `Reduce` when the input has (compatible) keys.
 ///
@@ -24,7 +24,6 @@ impl super::Transform for ReduceElision {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/reduction_pushdown.rs
+++ b/src/expr/transform/reduction_pushdown.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct ReductionPushdown;
@@ -19,21 +19,20 @@ impl super::Transform for ReductionPushdown {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        env: &EvalEnv,
     ) -> Result<(), super::TransformError> {
-        self.transform(relation, env);
+        self.transform(relation);
         Ok(())
     }
 }
 
 impl ReductionPushdown {
-    pub fn transform(&self, relation: &mut RelationExpr, env: &EvalEnv) {
+    pub fn transform(&self, relation: &mut RelationExpr) {
         relation.visit_mut(&mut |e| {
-            self.action(e, env);
+            self.action(e);
         });
     }
 
-    pub fn action(&self, relation: &mut RelationExpr, _env: &EvalEnv) {
+    pub fn action(&self, relation: &mut RelationExpr) {
         if let RelationExpr::Reduce {
             input,
             group_key,

--- a/src/expr/transform/redundant_join.rs
+++ b/src/expr/transform/redundant_join.rs
@@ -12,7 +12,6 @@
 #![allow(clippy::comparison_chain, clippy::filter_next)]
 use std::collections::HashMap;
 
-use crate::scalar::EvalEnv;
 use crate::{GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
@@ -23,15 +22,14 @@ impl super::Transform for RedundantJoin {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        env: &EvalEnv,
     ) -> Result<(), super::TransformError> {
-        self.transform(relation, env);
+        self.transform(relation);
         Ok(())
     }
 }
 
 impl RedundantJoin {
-    pub fn transform(&self, relation: &mut RelationExpr, _env: &EvalEnv) {
+    pub fn transform(&self, relation: &mut RelationExpr) {
         relation.visit_mut(&mut |e| {
             self.action(e);
         });

--- a/src/expr/transform/simplify.rs
+++ b/src/expr/transform/simplify.rs
@@ -73,7 +73,6 @@ impl super::Transform for SimplifyFilterPredicates {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/split_predicates.rs
+++ b/src/expr/transform/split_predicates.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{BinaryFunc, EvalEnv, GlobalId, RelationExpr, ScalarExpr};
+use crate::{BinaryFunc, GlobalId, RelationExpr, ScalarExpr};
 
 #[derive(Debug)]
 pub struct SplitPredicates;
@@ -19,7 +19,6 @@ impl super::Transform for SplitPredicates {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         relation.visit_mut(&mut |expr| {
             if let RelationExpr::Filter { predicates, .. } = expr {

--- a/src/expr/transform/topk_elision.rs
+++ b/src/expr/transform/topk_elision.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 
-use crate::{EvalEnv, GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, RelationExpr, ScalarExpr};
 
 /// Remove TopK operators with both an offset of zero and no limit.
 #[derive(Debug)]
@@ -20,7 +20,6 @@ impl crate::transform::Transform for TopKElision {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/update_let.rs
+++ b/src/expr/transform/update_let.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 
 use repr::RelationType;
 
-use crate::{EvalEnv, GlobalId, Id, IdGen, LocalId, RelationExpr, ScalarExpr};
+use crate::{GlobalId, Id, IdGen, LocalId, RelationExpr, ScalarExpr};
 
 /// Refreshes identifiers and types for local let bindings.
 ///
@@ -27,7 +27,6 @@ impl super::Transform for UpdateLet {
         &self,
         relation: &mut RelationExpr,
         _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation);
         Ok(())

--- a/src/expr/transform/use_indexes.rs
+++ b/src/expr/transform/use_indexes.rs
@@ -39,7 +39,6 @@ impl super::Transform for FilterEqualLiteral {
         &self,
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) -> Result<(), super::TransformError> {
         self.transform(relation, indexes);
         Ok(())
@@ -155,7 +154,6 @@ impl super::Transform for FilterLifting {
         &self,
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-        _: &EvalEnv,
     ) {
         self.transform(relation, indexes);
     }

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -13,7 +13,7 @@
 
 use ::expr::{GlobalId, RowSetFinishing};
 use catalog::names::{DatabaseSpecifier, FullName};
-use catalog::Catalog;
+use catalog::{Catalog, PlanContext};
 use dataflow_types::{PeekWhen, SinkConnectorBuilder, SourceConnector};
 use repr::{RelationDesc, Row, ScalarType};
 use sql_parser::parser::Parser as SqlParser;
@@ -192,12 +192,13 @@ pub async fn purify(stmt: Statement) -> Result<Statement, failure::Error> {
 /// `stmt` does does not depend on any external state. To purify a statement,
 /// use [`purify`].
 pub fn plan(
+    pcx: &PlanContext,
     catalog: &Catalog,
     session: &dyn PlanSession,
     stmt: Statement,
     params: &Params,
 ) -> Result<Plan, failure::Error> {
-    statement::handle_statement(catalog, session, stmt, params)
+    statement::handle_statement(pcx, catalog, session, stmt, params)
 }
 
 /// Determines the type of the rows that will be returned by `stmt` and the type

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1758,7 +1758,10 @@ fn plan_function<'a>(
                     bail!("{} does not take any arguments", ident);
                 }
                 match ecx.qcx.lifetime {
-                    QueryLifetime::OneShot => Ok(ScalarExpr::CallNullary(NullaryFunc::Now)),
+                    QueryLifetime::OneShot => Ok(ScalarExpr::literal(
+                        Datum::from(ecx.qcx.scx.pcx.wall_time),
+                        ColumnType::new(ScalarType::TimestampTz),
+                    )),
                     QueryLifetime::Static => bail!("{} cannot be used in static queries", ident),
                 }
             }

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -22,7 +22,7 @@ use rusoto_core::Region;
 use url::Url;
 
 use catalog::names::{DatabaseSpecifier, FullName, PartialName};
-use catalog::{Catalog, CatalogItem, SchemaType};
+use catalog::{Catalog, CatalogItem, PlanContext, SchemaType};
 use dataflow_types::{
     AvroEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding, DataEncoding, Envelope,
     ExternalSourceConnector, FileSourceConnector, KafkaSinkConnectorBuilder, KafkaSourceConnector,
@@ -50,7 +50,12 @@ pub fn describe_statement(
     session: &dyn PlanSession,
     stmt: Statement,
 ) -> Result<(Option<RelationDesc>, Vec<ScalarType>), failure::Error> {
-    let scx = &StatementContext { catalog, session };
+    let pcx = &PlanContext::default();
+    let scx = &StatementContext {
+        catalog,
+        session,
+        pcx,
+    };
     Ok(match stmt {
         Statement::CreateDatabase { .. }
         | Statement::CreateSchema { .. }
@@ -222,12 +227,17 @@ pub fn describe_statement(
 }
 
 pub fn handle_statement(
+    pcx: &PlanContext,
     catalog: &Catalog,
     session: &dyn PlanSession,
     stmt: Statement,
     params: &Params,
 ) -> Result<Plan, failure::Error> {
-    let scx = &StatementContext { catalog, session };
+    let scx = &StatementContext {
+        pcx,
+        catalog,
+        session,
+    };
     match stmt {
         Statement::Tail { name } => handle_tail(scx, name),
         Statement::StartTransaction { .. } => Ok(Plan::StartTransaction),
@@ -509,7 +519,7 @@ fn handle_show_indexes(
                 create_sql,
                 keys,
                 on,
-                eval_env: _,
+                ..
             }) => {
                 let key_sqls = match crate::parse(create_sql.to_owned())
                     .expect("create_sql cannot be invalid")
@@ -1505,7 +1515,7 @@ fn handle_explain(
     } else {
         false
     };
-    let (sql, query) = match explainee {
+    let (scx, sql, query) = match explainee {
         Explainee::View(name) => {
             let full_name = scx.resolve_name(name.clone())?;
             let entry = scx.catalog.get(&full_name)?;
@@ -1523,14 +1533,19 @@ fn handle_explain(
                 Statement::CreateView { query, .. } => query,
                 _ => panic!("Sql for existing view should parse as a view"),
             };
-            (view.create_sql.clone(), *query)
+            let scx = StatementContext {
+                pcx: &view.plan_cx,
+                catalog: scx.catalog,
+                session: scx.session,
+            };
+            (scx, view.create_sql.clone(), *query)
         }
-        Explainee::Query(query) => (query.to_string(), query),
+        Explainee::Query(query) => (scx.clone(), query.to_string(), query),
     };
     // Previouly we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
     // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
     let (mut sql_expr, _desc, finishing, _param_types) =
-        query::plan_root_query(scx, query, QueryLifetime::OneShot)?;
+        query::plan_root_query(&scx, query, QueryLifetime::OneShot)?;
     let finishing = if is_view {
         // views don't use a separate finishing
         sql_expr.finish(finishing);
@@ -1623,8 +1638,9 @@ fn object_type_as_plural_str(object_type: ObjectType) -> &'static str {
 }
 
 /// Immutable state that applies to the planning of an entire `Statement`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StatementContext<'a> {
+    pub pcx: &'a PlanContext,
     pub catalog: &'a Catalog,
     pub session: &'a dyn PlanSession,
 }

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 catalog = { path = "../catalog" }
 chrono = { version = "0.4", features = ["serde"] }
 dataflow-types = { path = "../dataflow-types" }
+expr = { path = "../expr" }
 failure = "0.1.7"
 log = "0.4.8"
 ore = { path = "../ore" }

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -35,7 +35,7 @@ use sql_parser::ast::{DataType, ObjectType, Statement};
 use tokio_postgres::types::FromSql;
 
 use catalog::names::FullName;
-use catalog::Catalog;
+use catalog::{Catalog, PlanContext};
 use repr::decimal::Significand;
 use repr::jsonb::Jsonb;
 use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
@@ -121,11 +121,16 @@ END $$;
 
     pub async fn execute(
         &mut self,
+        pcx: &PlanContext,
         catalog: &Catalog,
         session: &Session,
         stmt: &Statement,
     ) -> Result<Plan, failure::Error> {
-        let scx = StatementContext { catalog, session };
+        let scx = StatementContext {
+            pcx,
+            catalog,
+            session,
+        };
         Ok(match stmt {
             Statement::CreateTable {
                 name,


### PR DESCRIPTION
EvalEnv represented plan-local (or dataflow-local) state, like the
logical time chosen for the query's execution, or the wall time at which
the query was planned. It was intended to one day store information
from the session that planned the query, like the session timezone,
which impacts how e.g. timestamptzs are parsed and formatted.

Unfortunately the approach made cross-dataflow optimization hard. Two
plans will almost always have different wall times, and in the future
might have different timezones... but most plans don't actually
reference the wall time (or the timezone, in the future), and so it's
perfectly safe to share dataflow fragments across these dataflows, even
though their EvalEnvs differ.

Instead, we can inline the EvalEnv into the AST.

So

    ScalarExpr::CallNullary(NullaryFunc::Now)

becomes:

    ScalarExpr::Literal(<inlined now>).

If we had timezones,

    ScalarExpr::CallBinary(BinaryFunc::CastTimestampTzToString)

would become:

    ScalarExpr::CallBinary(BinaryFunc::CastTimestampTzToString(<inlined tz>))

Determining whether a dataflow fragment can be shared now reduces to the
problem of determining whether two RelationExprs are equivalent.

The EvalEnv becomes a catalog/sql/coord-only concern, now called
PlanContext. If the plan results in creating a new item, then the
PlanContext needs to be persisted alongside the item, but otherwise the
PlanContext is entirely handled by the process of planning the SQL
query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2606)
<!-- Reviewable:end -->
