### PR TITLE
Make mz_perf_arrangement_records use a left join

### DIFF
--- a/src/dataflow-types/logging.rs
+++ b/src/dataflow-types/logging.rs
@@ -525,7 +525,7 @@ const VIEW_PERF_ARRANGEMENT_RECORDS: LogView = LogView {
     name: "mz_perf_arrangement_records",
     sql: "CREATE MATERIALIZED VIEW mz_perf_arrangement_records AS SELECT mas.worker, name, records, operator
 FROM mz_catalog.mz_arrangement_sizes mas
-JOIN mz_catalog.mz_dataflow_operators mdo ON mdo.id = mas.operator",
+LEFT JOIN mz_catalog.mz_dataflow_operators mdo ON mdo.id = mas.operator AND mdo.worker = mas.worker",
     id: GlobalId::System(47),
     index_id: GlobalId::System(48),
 };


### PR DESCRIPTION
Fixes #2040.

Might have missed somewhere, but I couldn't find another place where
this seemed appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2615)
<!-- Reviewable:end -->
