### PR TITLE
ci: probably fix slow-to-start postgres

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -13,6 +13,8 @@
 
 set -euo pipefail
 
+. misc/shlib/shlib.bash
+
 if [[ ! "${BUILDKITE-}" ]]; then
     sqllogictest() {
         cargo run --release --bin sqllogictest -- "$@"
@@ -20,7 +22,7 @@ if [[ ! "${BUILDKITE-}" ]]; then
 fi
 
 if [[ "${BUILDKITE-}" ]]; then
-    wait-for-it --timeout=30 postgres:5432
+    await_postgres -h postgres -p 5432
 fi
 
 export RUST_BACKTRACE=full

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -13,6 +13,8 @@
 
 set -euo pipefail
 
+. misc/shlib/shlib.bash
+
 if [[ ! "${BUILDKITE-}" ]]; then
     sqllogictest() {
         cargo run --release --bin sqllogictest -- "$@"
@@ -155,6 +157,7 @@ tests=(
 )
 
 if [[ "${BUILDKITE-}" ]]; then
-    wait-for-it postgres:5432
+    await_postgres -h postgres -p 5432
 fi
+
 sqllogictest -v "${tests[@]}"

--- a/misc/docker/ci-sqllogictest/Dockerfile
+++ b/misc/docker/ci-sqllogictest/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get -qy install wait-for-it
+RUN apt-get update && apt-get -qy install postgresql-client wait-for-it
 
 COPY sqllogictest /usr/local/bin
 

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -96,6 +96,24 @@ ci_status_report() {
     fi
 }
 
+# await_postgres [connection options]
+#
+# Waits for PostgreSQL to become ready. Accepts the same options as the
+# underlying pg_isready utility. Gives up after 30 tries, waiting 1s between
+# each try.
+#
+# Note that simply checking for the PostgreSQL port to start accepting
+# connections is insufficient, as PostgreSQL can start accepting connections
+# and immediately rejecting them with a "the database system is starting up"
+# fatal error.
+await_postgres() {
+    local i=0
+    until pg_isready "$@" || ((++i > 30)); do
+        echo "waiting 1s for postgres to become ready"
+        sleep 1
+    done
+}
+
 # mapfile_shim [array]
 #
 # A limited backport of the Bash 4.0 `mapfile` built-in. Reads lines from the


### PR DESCRIPTION
Apparently just waiting for the PostgreSQL port to have a listener bound
is insufficient, as PostgreSQL might yet reject the connection during
server startup. Check using the pg_isready utility, which presumably
does things properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2618)
<!-- Reviewable:end -->
