### PR TITLE
Support SHOW DATABASES { WHERE | LIKE }

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,7 @@ dependencies = [
  "futures",
  "interchange",
  "itertools 0.9.0",
+ "lazy_static",
  "log",
  "ore",
  "pgrepr",

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -21,6 +21,7 @@ failure = "0.1.7"
 futures = "0.3"
 interchange = { path = "../interchange" }
 itertools = "0.9"
+lazy_static = "1.4.0"
 log = "0.4.8"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -18,6 +18,7 @@ use std::time::UNIX_EPOCH;
 use aws_arn::{Resource, ARN};
 use failure::{bail, format_err, ResultExt};
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use rusoto_core::Region;
 use url::Url;
 
@@ -45,6 +46,11 @@ use crate::{normalize, query, Index, Params, Plan, PlanSession, Sink, Source, Vi
 use regex::Regex;
 
 use tokio::io::AsyncBufReadExt;
+
+lazy_static! {
+    static ref SHOW_DATABASES_DESC: RelationDesc =
+        { RelationDesc::empty().add_column("Database", ScalarType::String) };
+}
 
 pub fn describe_statement(
     catalog: &Catalog,
@@ -153,10 +159,7 @@ pub fn describe_statement(
             vec![],
         ),
 
-        Statement::ShowDatabases { .. } => (
-            Some(RelationDesc::empty().add_column("Database", ScalarType::String)),
-            vec![],
-        ),
+        Statement::ShowDatabases { .. } => (Some(SHOW_DATABASES_DESC.clone()), vec![]),
 
         Statement::ShowObjects {
             object_type,
@@ -347,15 +350,20 @@ fn handle_show_databases(
     scx: &StatementContext,
     filter: Option<&ShowStatementFilter>,
 ) -> Result<Plan, failure::Error> {
-    if filter.is_some() {
-        bail!("SHOW DATABASES {LIKE | WHERE} is not yet supported");
-    }
-    Ok(Plan::SendRows(
-        scx.catalog
-            .databases()
-            .map(|database| Row::pack(&[Datum::from(database)]))
-            .collect(),
-    ))
+    let rows = scx
+        .catalog
+        .databases()
+        .map(|database| vec![Datum::from(database)])
+        .collect();
+
+    let (r, finishing) = query::plan_show_where(scx, filter, rows, &SHOW_DATABASES_DESC)?;
+
+    Ok(Plan::Peek {
+        source: r.decorrelate()?,
+        when: PeekWhen::Immediately,
+        finishing,
+        materialize: true,
+    })
 }
 
 fn handle_show_objects(

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -1,0 +1,65 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query T
+SHOW DATABASES
+----
+materialize
+
+query T
+SHOW DATABASES LIKE 'foo'
+----
+
+query T
+SHOW DATABASES LIKE 'materialize'
+----
+materialize
+
+query T
+SHOW DATABASES WHERE "Database" LIKE 'mat%'
+----
+materialize
+
+query T
+SHOW DATABASES WHERE (SELECT true)
+----
+materialize
+
+statement error WHERE clause must have boolean type, not String
+SHOW DATABASES WHERE 'hello'
+----
+
+statement ok
+CREATE TABLE xyz (x int, y int, z int)
+----
+
+statement ok
+INSERT INTO xyz VALUES (1, 2, 3), (4, 5, 6)
+----
+
+query B
+SELECT (EXISTS (SELECT * FROM xyz))
+----
+true
+
+query T
+SHOW DATABASES WHERE (EXISTS (SELECT * FROM xyz))
+----
+materialize
+
+query T
+SHOW DATABASES WHERE (EXISTS (SELECT * FROM xyz WHERE x = 1))
+----
+materialize
+
+query T
+SHOW DATABASES WHERE (EXISTS (SELECT * FROM xyz WHERE x = 3))
+----


### PR DESCRIPTION
Relevant to #1529.

This is an initial spike at support `SHOW ... WHERE` that only supports
SHOW DATABASES. Remaining work after this involves:
* supporting SHOW VIEWS ... which I think is fundamentally the same but
  involves reogranizing some logic.
* supporting other SHOW variants, some of which have multiple columns
  (I'm not yet sure how they choose what column to use for `LIKE`).

This uses a different approach than the existing implementations of LIKE
which I think is a little more generalizable: rather than running the
predicate on each row as the plan is generated, it just shoves all the
rows into a constant relational expression and puts a filter on top and
lets the execution engine (or more likely, the optimizer) sort out the
details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2620)
<!-- Reviewable:end -->
