### PR TITLE
testdrive: properly async-ify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.22"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df72488e87761e772f14ae0c2480396810e51b2c2ade912f97f0f7e5b95e3c"
+checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1164,6 +1164,7 @@ dependencies = [
  "rand",
  "sqllogictest",
  "testdrive",
+ "tokio",
  "walkdir",
 ]
 
@@ -2507,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.23.1"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#3968f91faeb6d6169a82b7e51a5f73fc8698b7f1"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#5a5f284b9d5cbe8ad2d44f268f51aa91a3a87614"
 dependencies = [
  "futures",
  "libc",
@@ -2521,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.3.1"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#3968f91faeb6d6169a82b7e51a5f73fc8698b7f1"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#5a5f284b9d5cbe8ad2d44f268f51aa91a3a87614"
 dependencies = [
  "cmake",
  "libc",
@@ -2640,15 +2641,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "retry"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789e7aad247a37b785401b4d82bbad03212bb516fe7c0c2cc42f37bccb00b9b2"
-dependencies = [
- "rand",
 ]
 
 [[package]]
@@ -3282,6 +3274,7 @@ name = "testdrive"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "async-trait",
  "atty",
  "avro",
  "byteorder",
@@ -3299,7 +3292,6 @@ dependencies = [
  "ore",
  "parse_duration",
  "pgrepr",
- "postgres",
  "predicates",
  "protobuf",
  "protoc",
@@ -3309,7 +3301,6 @@ dependencies = [
  "regex",
  "repr",
  "reqwest",
- "retry",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kinesis",
@@ -3321,6 +3312,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "tokio",
+ "tokio-postgres",
  "url",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -25,4 +25,5 @@ libfuzzer-sys = "0.3"
 rand = { version = "0.7.3", features = ["small_rng"] }
 sqllogictest = { path = "../src/sqllogictest" }
 testdrive = { path = "../src/testdrive" }
+tokio = "0.2"
 walkdir = "2"

--- a/fuzz/fuzz_targets/fuzz_testdrive.rs
+++ b/fuzz/fuzz_targets/fuzz_testdrive.rs
@@ -10,12 +10,19 @@
 #![cfg_attr(not(test), no_main)]
 
 use libfuzzer_sys::fuzz_target;
+use tokio::runtime::Runtime;
 
 use testdrive::error::Error;
+use testdrive::Config;
 
 fuzz_target!(|data: &[u8]| {
+    let mut runtime = Runtime::new().unwrap();
     if let Ok(string) = std::str::from_utf8(data) {
-        match testdrive::run_string(&testdrive::Config::default(), "<fuzzer>", &string) {
+        match runtime.block_on(testdrive::run_string(
+            &Config::default(),
+            "<fuzzer>",
+            &string,
+        )) {
             Ok(()) | Err(Error::Input { .. }) | Err(Error::Usage { .. }) => {}
             Err(error @ Error::General { .. }) => panic!("{}", error),
         }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-trait = "0.1.30"
 atty = "0.2"
 avro = { path = "../avro" }
 byteorder = "1.3"
@@ -23,7 +24,7 @@ md-5 = "0.8"
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }
-postgres = { version = "0.17", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.5.3", features = ["with-chrono-0_4", "with-serde_json-1"] }
 protobuf = "2.8"
 protoc = "2.8.0"
 rand = "0.7.3"
@@ -31,7 +32,6 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 regex = "1"
 repr = { path = "../repr" }
 reqwest = { version = "0.10.4", features = ["native-tls-vendored"] }
-retry = "1.0"
 rusoto_core = "0.43.0-beta.1"
 rusoto_credential = "0.43.0-beta.1"
 rusoto_kinesis = "0.43.0-beta.1"

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -7,11 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::thread;
 use std::time::Duration;
 
-use futures::executor::block_on;
-use futures::future::TryFutureExt;
+use async_trait::async_trait;
 use rdkafka::admin::NewPartitions;
 
 use ore::cast::CastFrom;
@@ -19,6 +17,7 @@ use ore::collections::CollectionExt;
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
+use crate::util::retry;
 
 pub struct AddPartitionsAction {
     topic_prefix: String,
@@ -36,12 +35,13 @@ pub fn build_add_partitions(mut cmd: BuiltinCommand) -> Result<AddPartitionsActi
     })
 }
 
+#[async_trait]
 impl Action for AddPartitionsAction {
-    fn undo(&self, _: &mut State) -> Result<(), String> {
+    async fn undo(&self, _: &mut State) -> Result<(), String> {
         Ok(())
     }
 
-    fn redo(&self, state: &mut State) -> Result<(), String> {
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
         let topic_name = format!("{}-{}", self.topic_prefix, state.seed);
         println!(
             "Raising partition count of Kafka topic {} to {}",
@@ -66,12 +66,11 @@ impl Action for AddPartitionsAction {
         }
 
         let partitions = NewPartitions::new(&topic_name, usize::cast_from(self.partitions));
-        let res = block_on(
-            state
-                .kafka_admin
-                .create_partitions(&[partitions], &state.kafka_admin_opts)
-                .map_err(|e| e.to_string()),
-        )?;
+        let res = state
+            .kafka_admin
+            .create_partitions(&[partitions], &state.kafka_admin_opts)
+            .await
+            .map_err(|e| e.to_string())?;
         if res.len() != 1 {
             return Err(format!(
                 "kafka partition addition returned {} results, but exactly one result was expected",
@@ -82,37 +81,27 @@ impl Action for AddPartitionsAction {
             return Err(e.to_string());
         }
 
-        let mut i = 0;
-        loop {
-            let res = (|| {
-                let metadata = state
-                    .kafka_producer
-                    .client()
-                    .fetch_metadata(Some(&topic_name), Some(Duration::from_secs(1)))
-                    .map_err(|e| e.to_string())?;
-                if metadata.topics().len() != 1 {
-                    return Err("metadata fetch returned no topics".to_string());
-                }
-                let topic = metadata.topics().into_element();
-                if topic.partitions().len() as i32 != self.partitions {
-                    return Err(format!(
-                        "topic {} has {} partitions when exactly {} was expected",
-                        topic_name,
-                        topic.partitions().len(),
-                        self.partitions,
-                    ));
-                }
-                Ok(())
-            })();
-            match res {
-                Ok(()) => break,
-                Err(e) if i == 6 => return Err(e),
-                _ => {
-                    thread::sleep(Duration::from_millis(100 * 2_u64.pow(i)));
-                    i += 1;
-                }
+        retry::retry(|| async {
+            let metadata = state
+                .kafka_producer
+                .client()
+                .fetch_metadata(Some(&topic_name), Some(Duration::from_secs(1)))
+                .map_err(|e| e.to_string())?;
+            if metadata.topics().len() != 1 {
+                return Err("metadata fetch returned no topics".to_string());
             }
-        }
+            let topic = metadata.topics().into_element();
+            if topic.partitions().len() as i32 != self.partitions {
+                return Err(format!(
+                    "topic {} has {} partitions when exactly {} was expected",
+                    topic_name,
+                    topic.partitions().len(),
+                    self.partitions,
+                ));
+            }
+            Ok(())
+        })
+        .await?;
 
         state.kafka_topics.insert(topic_name, self.partitions);
         Ok(())

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -47,7 +47,7 @@ pub enum Error {
     },
     General {
         ctx: String,
-        cause: Option<Box<dyn StdError>>,
+        cause: Option<Box<dyn StdError + Send>>,
         hints: Vec<String>,
     },
     Usage {
@@ -218,7 +218,7 @@ pub trait ResultExt<T, E> {
 
 impl<T, E> ResultExt<T, E> for Result<T, E>
 where
-    E: 'static + StdError,
+    E: 'static + StdError + Send,
 {
     fn err_ctx(self, ctx: String) -> Result<T, Error>
     where

--- a/src/testdrive/src/util.rs
+++ b/src/testdrive/src/util.rs
@@ -9,3 +9,4 @@
 
 pub mod aws;
 pub mod postgres;
+pub mod retry;

--- a/src/testdrive/src/util/postgres.rs
+++ b/src/testdrive/src/util/postgres.rs
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use postgres::Config;
+use tokio_postgres::config::Host;
+use tokio_postgres::Config;
 use url::Url;
 
 use crate::error::Error;
@@ -21,8 +22,8 @@ pub fn config_url(config: &Config) -> Result<Url, Error> {
 
     let host = match config.get_hosts() {
         [] => "localhost".into(),
-        [postgres::config::Host::Tcp(host)] => host.clone(),
-        [postgres::config::Host::Unix(path)] => path.display().to_string(),
+        [Host::Tcp(host)] => host.clone(),
+        [Host::Unix(path)] => path.display().to_string(),
         _ => {
             return Err(Error::General {
                 ctx: "materialized URL cannot contain multiple hosts".into(),

--- a/src/testdrive/src/util/retry.rs
+++ b/src/testdrive/src/util/retry.rs
@@ -1,0 +1,32 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::future::Future;
+
+use tokio::time::{self, Duration};
+
+/// Retries a fallible operation `f` with suitable defaults for a network
+/// service.
+pub async fn retry<F, U, T>(mut f: F) -> Result<T, String>
+where
+    F: FnMut() -> U,
+    U: Future<Output = Result<T, String>>,
+{
+    let mut i = 0;
+    let mut backoff = Duration::from_millis(200);
+    loop {
+        match f().await {
+            Ok(t) => return Ok(t),
+            Err(e) if i > 5 => return Err(e),
+            Err(_) => i += 1,
+        }
+        time::delay_for(backoff).await;
+        backoff *= 2;
+    }
+}


### PR DESCRIPTION
Make testdrive use the async/await sugar, rather than manually
constructing futures and driving them around with a Tokio runtime.  We
don't actually care about or unlock the performance benefits of
async/await--this is test code, and not performance sensitive--but
because testdrive uses so many async components, using async/await is
far more ergonomic.

Hopefully this makes folks a lot less confused about how to use async
components in testdrive.

Note that the Avro OCF writer does not have an async library, and
presumably won't be the only testdrive dependency with no async support,
so a sync compatibility shim is provided for the actions that need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2621)
<!-- Reviewable:end -->
