### PR TITLE
More clearly indicate state of malformed reduce input

### DIFF
--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -231,7 +231,7 @@ where
                 // because we don't know that the aggregation method is not sensitive
                 // to the number of records.
                 let iter = source.iter().flat_map(|(v, w)| {
-                    std::iter::repeat(v.iter().next().unwrap()).take(*w as usize)
+                    std::iter::repeat(v.iter().next().unwrap()).take(std::cmp::max(0, *w) as usize)
                 });
                 let mut packer = RowPacker::new();
                 if prepend_key {
@@ -429,7 +429,10 @@ where
                 // We ignore the count here under the belief that it cannot affect
                 // hierarchical aggregations; should that belief be incorrect, we
                 // should certainly revise this implementation.
-                let iter = source.iter().map(|(val, _cnt)| val.iter().next().unwrap());
+                let iter = source
+                    .iter()
+                    .filter(|(_val, cnt)| cnt > &0)
+                    .map(|(val, _cnt)| val.iter().next().unwrap());
                 target.push((Row::pack(Some(aggr.eval(iter, &RowArena::new()))), 1));
             }
         })

--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -145,11 +145,13 @@ where
                             // that the key doesn't exist (the others could be phantoms due to
                             // negative input records); we could just suppress the output in that
                             // case, rather than panic, though we surely want to see what is up.
+                            // XXX: This panic reports user-supplied data!
                             panic!(
-                                "ReduceCollation found unexpected indexes:\n\tExpected:\t{:?}\n\tFound:\t{:?}\n\tFor:\t{:?}",
+                                "ReduceCollation found unexpected indexes:\n\tExpected:\t{:?}\n\tFound:\t{:?}\n\tFor:\t{:?}\n\tKey:{:?}",
                                 (0..aggregates_len).collect::<Vec<_>>(),
                                 input.iter().map(|((p,_),_)| p).collect::<Vec<_>>(),
                                 aggregates_clone,
+                                key,
                             );
                         }
                         let mut result = RowPacker::new();


### PR DESCRIPTION
We are seeing `Reduce` panics in the wild, where the intended number of contributions to each key is not found. This PR more clearly complains, and also highlights one possible source of this error (if we have negative records in the input, some accumulations may zero out and vanish, whereas others remain with surprising tallies; re-aligning their results would panic).

There is an important discussion point about how much program data is legit to produce as output here. It would probably be helpful to produce the offending key in the `panic`, for example, but this is potentially sensitive data and just jamming that in to logs is not something to be done casually. This PR does not do that. This PR *does* do report integer accumulations in an `error!()`, and we should perhaps discuss that (counts, but also sums).

For a clearer example of the weird case with negative records, imagine our input change stream was exactly (yes, it accumulates to a collection with negative counts; I agree it shouldn't):

    ((frank, mcsherry), t, -1)
    ((frank, zappa), t, +1)

and we wanted to do both a `count(*)` and maybe a `count(*) filter (where val == zappa)`. The first aggregation will project out the data and say "nothing to see here; don't even mention `frank`". The second aggregation will come back with a `(frank, 1)` aggregation and be confused that it didn't find the first `count(*)` it was expecting. 

This failure is slightly robustified against in the PR by suppressing aggregate output when the net number of records participating isn't positive (anything that nets zero, or negative, doesn't produce an aggregate even if it looks like there is good data). In this case we log an error instead, and we should be vigilant about having folks check their logs for this sort of error as it implies that something is awry with either their input or our pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2622)
<!-- Reviewable:end -->
