### PR TITLE
deps: bump sasl2-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "sasl2-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "499fb6d600f2afd0941d9342997beb19d1580c4dd5d28251758db6a162e7091e"
+checksum = "0e99bf4f6a2db74a9d780ef085cde69f3aecb37834e95ae15881e8c82a0c880b"
 dependencies = [
  "cc",
  "duct",


### PR DESCRIPTION
The latest version avoids depending on nroff, which is not available in
CI. (Unclear why the failure only happened occasionally; probably a bug
in the sasl2-sys build system.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2645)
<!-- Reviewable:end -->
