### PR TITLE
WIP Compact keys inside the kafka source.

### DIFF
--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1281,16 +1281,12 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             };
 
             if let dataflow_types::Envelope::Upsert(_) = envelope {
-                if let Consistency::BringYourOwn(_) = consistency {
-                    match &mut encoding {
-                        DataEncoding::Avro(AvroEncoding { key_schema, .. }) => {
-                            *key_schema = None;
-                        }
-                        DataEncoding::Bytes | DataEncoding::Text => {}
-                        _ => bail!("Upsert envelope is not yet supported for this format."),
+                match &mut encoding {
+                    DataEncoding::Avro(AvroEncoding { key_schema, .. }) => {
+                        *key_schema = None;
                     }
-                } else {
-                    bail!("Upsert envelope is only supported for BYO consistency.")
+                    DataEncoding::Bytes | DataEncoding::Text => {}
+                    _ => bail!("Upsert envelope is not yet supported for this format."),
                 }
             }
 


### PR DESCRIPTION
Posting this as WIP PR that way we can see if I am missing some optimization or have misunderstood some aspect of the desired operator.

Modified source::kafka.rs such that it returns, for any given key and timestamp, the record with the max offset. Records are stored in `max_offset_row` until it is time to downgrade the capability because the record cannot be given to the session unless we are sure that a record with the same timestamp but greater offset will not appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2646)
<!-- Reviewable:end -->
