### PR TITLE
Support more SHOW ... WHERE

### DIFF
--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -252,8 +252,8 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
             &[
                 ("@1".into(), 1),
                 ("@2".into(), 2),
+                ("@4".into(), 4),
                 ("c".into(), 3),
-                ("@4".into(), 4)
             ],
         );
         assert_eq!(

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -142,7 +142,12 @@ pub fn plan_show_where(
     Ok((
         row_expr,
         RowSetFinishing {
-            order_by: vec![],
+            order_by: (0..num_cols)
+                .map(|c| ColumnOrder {
+                    column: c,
+                    desc: false,
+                })
+                .collect(),
             limit: None,
             offset: 0,
             project: (0..num_cols).collect(),

--- a/test/sqllogictest/index.slt
+++ b/test/sqllogictest/index.slt
@@ -38,19 +38,19 @@ query TTTTBI colnames
 SHOW INDEX IN bar
 ----
 Source_or_view           Key_name                            Column_name  Expression     Null  Seq_in_index
-materialize.public.bar   materialize.public.bar_primary_idx  z            NULL           false 1
 materialize.public.bar   materialize.public.bar_idx          NULL         substr("z",␠3) true  1
+materialize.public.bar   materialize.public.bar_primary_idx  z            NULL           false 1
 
 query TTTTBI colnames
 SHOW INDEX FROM foo
 ----
 Source_or_view                     Key_name                            Column_name  Expression  Null   Seq_in_index
+materialize.public.foo   materialize.public.edge_columns     NULL         floor("c")  true   2
+materialize.public.foo   materialize.public.edge_columns     a            NULL        false  1
+materialize.public.foo   materialize.public.foo_idx          NULL         "a"␠+␠"c"   true   1
 materialize.public.foo   materialize.public.foo_primary_idx  a            NULL        false  1
 materialize.public.foo   materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo   materialize.public.foo_primary_idx  c            NULL        true   3
-materialize.public.foo   materialize.public.foo_idx          NULL         "a"␠+␠"c"   true   1
-materialize.public.foo   materialize.public.edge_columns     a            NULL        false  1
-materialize.public.foo   materialize.public.edge_columns     NULL         floor("c")  true   2
 
 statement ok
 DROP INDEX foo_idx

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -45,10 +45,7 @@ statement ok
 INSERT INTO xyz VALUES (1, 2, 3), (4, 5, 6)
 ----
 
-query B
-SELECT (EXISTS (SELECT * FROM xyz))
-----
-true
+# SHOW DATABASES
 
 query T
 SHOW DATABASES WHERE (EXISTS (SELECT * FROM xyz))
@@ -63,3 +60,139 @@ materialize
 query T
 SHOW DATABASES WHERE (EXISTS (SELECT * FROM xyz WHERE x = 3))
 ----
+
+statement ok
+CREATE MATERIALIZED VIEW v AS SELECT 1 AS a, 2 AS b, 3 AS c
+----
+
+statement ok
+CREATE INDEX idx1 ON v (b)
+----
+
+# SHOW INDEXES
+
+query TTTTTT colnames
+SHOW INDEXES FROM v
+----
+Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+materialize.public.v  materialize.public.idx1  b           NULL       false 1
+
+query TTTTTT colnames
+SHOW INDEXES FROM v WHERE "Column_name" = 'b'
+----
+Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+materialize.public.v  materialize.public.idx1  b           NULL       false 1
+
+query TTTTTT colnames
+SHOW INDEXES FROM v WHERE "Column_name" = 'c'
+----
+Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+
+# Reference a different column
+
+query TTTTTT colnames
+SHOW INDEXES FROM v WHERE "Key_name" = 'materialize.public.idx1'
+----
+Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+materialize.public.v  materialize.public.idx1  b           NULL       false 1
+
+# TODO(justin): not handled in parser yet:
+#   SHOW INDEXES FROM v LIKE '%v'
+
+query TTT colnames
+SHOW COLUMNS FROM v
+----
+Field Nullable Type
+a     NO       int4
+b     NO       int4
+c     NO       int4
+
+query TTT
+SHOW COLUMNS FROM v LIKE 'b'
+----
+b  NO  int4
+
+query TTT
+SHOW COLUMNS FROM v WHERE "Nullable" = 'NO'
+----
+a  NO  int4
+b  NO  int4
+c  NO  int4
+
+# SHOW SCHEMAS
+
+query T colnames
+SHOW SCHEMAS
+----
+SCHEMAS
+public
+
+query T
+SHOW SCHEMAS LIKE 'public'
+----
+public
+
+query T
+SHOW SCHEMAS LIKE 'private'
+----
+
+query T
+SHOW SCHEMAS WHERE "SCHEMAS" = 'public'
+----
+public
+
+# SHOW VIEWS/SOURCES
+
+statement ok
+CREATE MATERIALIZED VIEW u AS SELECT 1 AS x, 2 AS y
+
+query T
+SHOW VIEWS
+----
+u
+v
+
+query TTBB colnames
+SHOW FULL VIEWS
+----
+VIEWS TYPE QUERYABLE MATERIALIZED
+u     USER true      true
+v     USER true      true
+
+query T
+SHOW VIEWS LIKE '%u'
+----
+u
+
+statement error not supported
+SHOW VIEWS WHERE "VIEWS" = 'u'
+
+query T
+SHOW SOURCES
+----
+xyz
+
+statement error not supported
+SHOW SOURCES WHERE "SOURCES" = 'u'
+
+# SHOW OBJECTS
+
+query T colnames
+SHOW TABLES
+----
+TABLES
+xyz
+
+query T
+SHOW TABLES LIKE 'xyz'
+----
+xyz
+
+query T
+SHOW TABLES LIKE 'abc'
+----
+
+query T
+SHOW TABLES WHERE "TABLES" = 'xyz'
+----
+xyz


### PR DESCRIPTION
Fixes #1529.

The only remaining unsupported case is SHOW VIEWS/SOURCES, because we
don't plumb down the needed info via the catalog.

I got rid of some ordering stuff, I can add it back in the form of a
RowSetFinishing, but it doesn't seem to have been tested so I'm not sure
it was actually important.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2649)
<!-- Reviewable:end -->
