### PR TITLE
Allow verbosely printing Kafka statistics with a WITH option

### DIFF
--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -17,11 +17,11 @@ use std::time::Duration;
 use crate::server::{TimestampChanges, TimestampHistories};
 use dataflow_types::{Consistency, ExternalSourceConnector, KafkaSourceConnector, Timestamp};
 use lazy_static::lazy_static;
-use log::{error, warn};
+use log::{error, info, warn};
 use prometheus::{register_int_counter, IntCounter};
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::Offset::Offset;
-use rdkafka::{ClientConfig, ClientContext};
+use rdkafka::{ClientConfig, ClientContext, Statistics};
 use rdkafka::{Message, Timestamp as KafkaTimestamp};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
@@ -531,7 +531,11 @@ fn downgrade_capability(
 /// when the message queue switches from nonempty to empty.
 struct GlueConsumerContext(Mutex<SyncActivator>);
 
-impl ClientContext for GlueConsumerContext {}
+impl ClientContext for GlueConsumerContext {
+    fn stats(&self, statistics: Statistics) {
+        info!("Client stats: {:#?}", statistics);
+    }
+}
 
 impl ConsumerContext for GlueConsumerContext {
     fn message_queue_nonempty_callback(&self) {

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -182,7 +182,6 @@ where
                         let partition = message.partition();
                         let offset = message.offset() + 1;
                         let key = message.key().map(|k| k.to_vec()).unwrap_or_default();
-
                         if !partitions.contains(&partition) {
                             // We have received a message for a partition for which we do not yet
                             // have any metadata. Buffer the message and wait until we get the

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1123,14 +1123,17 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         "verbose_stats_ms must be a number between 0 and 86400000";
                     let verbose_stats_ms = match with_options.remove("verbose_stats_ms") {
                         None => 0,
-                        Some(Value::Number(n)) => match n.try_into::<i32>() {
-                            Ok(n @ 0...86400000) => n,
+                        Some(Value::Number(n)) => match n.parse::<i32>() {
+                            Ok(n @ 0..=86400000) => n,
                             _ => bail!(verbose_stats_err),
                         },
                         Some(_) => bail!(verbose_stats_err),
                     };
 
-                    config_options.push(("statistics.interval.ms".into(), verbose_stats_ms.into()));
+                    config_options.push((
+                        "statistics.interval.ms".to_string(),
+                        verbose_stats_ms.to_string(),
+                    ));
 
                     let connector = ExternalSourceConnector::Kafka(KafkaSourceConnector {
                         url: broker.parse()?,

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1124,7 +1124,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     let verbose_stats_ms = match with_options.remove("verbose_stats_ms") {
                         None => 0,
                         Some(Value::Number(n)) => match n.parse::<i32>() {
-                            Ok(n @ 0..=86400000) => n,
+                            Ok(n @ 0..=86_400_000) => n,
                             _ => bail!(verbose_stats_err),
                         },
                         Some(_) => bail!(verbose_stats_err),


### PR DESCRIPTION
Creating a source with `verbose_stats_ms = <N>` will now cause a bunch of Kafka statistics to be pretty-printed to the log every N milliseconds. Mostly intended to be useful to us for debugging, so I haven't added it to docs/release notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2650)
<!-- Reviewable:end -->
