### PR TITLE
billing-demo: properly set exit code

### DIFF
--- a/ci/test/streaming-demo.compose.yml
+++ b/ci/test/streaming-demo.compose.yml
@@ -23,12 +23,12 @@ services:
     environment:
     - RUST_LOG=billing-demo=debug,info
     user: $BUILDKITE_AGENT_UID:$BUILDKITE_AGENT_GID
-    depends_on: [kafka, zookeeper, materialized]
+    depends_on: [kafka, zookeeper, materialized, schema-registry]
   materialized:
     image: materialize/ci-materialized:${BUILDKITE_BUILD_NUMBER}
     volumes:
       - db-data:/share/billing-demo/data
-    command: --logging-granularity=10ms
+    command: --logging-granularity=10ms -w1
     depends_on: [kafka]
   zookeeper:
     image: zookeeper:3.4.13

--- a/src/billing-demo/src/main.rs
+++ b/src/billing-demo/src/main.rs
@@ -19,6 +19,7 @@
 #![deny(missing_debug_implementations, missing_docs)]
 
 use std::error::Error as _;
+use std::process;
 
 use protobuf::Message;
 use structopt::StructOpt;
@@ -44,6 +45,7 @@ async fn main() {
             println!("    caused by: {}", e);
             err = e.source();
         }
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
The billing-demo test in CI would always exit successfully, even if the
test failed, because the billing-demo binary would not exit with a
failing code on error.

/cc @ruchirK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2653)
<!-- Reviewable:end -->
