### PR TITLE
avro: relicense under MIT and add original copyright notice

### DIFF
--- a/src/avro/benches_/serde.rs
+++ b/src/avro/benches_/serde.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 #![feature(test)]
 extern crate test;

--- a/src/avro/benches_/serde_json.rs
+++ b/src/avro/benches_/serde_json.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Benchmarks for comparing `avro-rs` to `serde_json`. These benchmarks are meant to be
 //! comparable to those found in `benches/serde.rs`.

--- a/src/avro/benches_/single.rs
+++ b/src/avro/benches_/single.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 #![feature(test)]
 extern crate test;

--- a/src/avro/codec.rs
+++ b/src/avro/codec.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Logic for all supported compression codecs in Avro.
 use std::io::{Read, Write};

--- a/src/avro/decode.rs
+++ b/src/avro/decode.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 use std::collections::HashMap;
 use std::mem::transmute;

--- a/src/avro/encode.rs
+++ b/src/avro/encode.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 use std::convert::TryInto;
 use std::mem::transmute;

--- a/src/avro/examples/benchmark.rs
+++ b/src/avro/examples/benchmark.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 use std::time::{Duration, Instant};
 

--- a/src/avro/lib.rs
+++ b/src/avro/lib.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! # avro
 //! **[Apache Avro](https://avro.apache.org/)** is a data serialization system which provides rich

--- a/src/avro/reader.rs
+++ b/src/avro/reader.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Logic handling reading from Avro format at user level.
 use std::io::{ErrorKind, Read};

--- a/src/avro/schema.rs
+++ b/src/avro/schema.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Logic for parsing and interacting with schemas in Avro format.
 use std::borrow::Cow;

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Port of https://github.com/apache/avro/blob/master/lang/py/test/test_io.py
 use std::io::Cursor;

--- a/src/avro/types.rs
+++ b/src/avro/types.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Logic handling the intermediate representation of Avro values.
 use std::collections::HashMap;

--- a/src/avro/util.rs
+++ b/src/avro/util.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 use std::i64;
 use std::sync::Once;

--- a/src/avro/writer.rs
+++ b/src/avro/writer.rs
@@ -1,11 +1,13 @@
+// Copyright 2018 Flavien Raynaud.
 // Copyright Materialize, Inc. All rights reserved.
 //
-// Use of this software is governed by the Business Source License
-// included in the LICENSE file.
+// This file is derived from the avro-rs project, available at
+// https://github.com/flavray/avro-rs. It was incorporated
+// directly into Materialize on March 3, 2020.
 //
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0.
+// This file is subject to the terms of the MIT license, a copy
+// of which can be found in the LICENSE file at the root of this
+// repository.
 
 //! Logic handling writing in Avro format at user level.
 use std::collections::HashMap;


### PR DESCRIPTION
In the spirit of open source, relicense our additions to the Rust Avro
library under the original license, MIT, but add notes to the headers
about their source.

Closes #2657.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2663)
<!-- Reviewable:end -->
