### PR TITLE
Pass client.id to librdkafka

### DIFF
--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1137,11 +1137,17 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         },
                         Some(_) => bail!(verbose_stats_err),
                     };
-
                     config_options.push((
                         "statistics.interval.ms".to_string(),
                         verbose_stats_ms.to_string(),
                     ));
+
+                    let kafka_client_id = match with_options.remove("kafka_client_id") {
+                        None => "materialized".to_string(),
+                        Some(Value::SingleQuotedString(s)) => s,
+                        Some(_) => bail!("kafka_client_id must be a string"),
+                    };
+                    config_options.push(("client.id".to_string(), kafka_client_id));
 
                     let connector = ExternalSourceConnector::Kafka(KafkaSourceConnector {
                         url: broker.parse()?,


### PR DESCRIPTION
This is necessary if people want to throttle requests from Materialize in Kafka.

The default client.id is `materialized`. It can be optionally configured per-source with a `WITH` option (`kafka_client_id`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2666)
<!-- Reviewable:end -->
