### PR TITLE
Don't track quote styles with identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,7 @@ name = "sql-parser"
 version = "0.1.0"
 dependencies = [
  "failure",
+ "lazy_static",
  "log",
  "matches",
  "repr",

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -2291,18 +2291,12 @@ fn index_sql(
     use sql_parser::ast::{Expr, Ident, Statement, Value};
 
     Statement::CreateIndex {
-        name: Ident {
-            value: index_name,
-            quote_style: Some('"'),
-        },
+        name: Ident::new(index_name),
         on_name: sql::normalize::unresolve(view_name),
         key_parts: keys
             .iter()
             .map(|i| match view_desc.get_unambiguous_name(*i) {
-                Some(n) => Expr::Identifier(Ident {
-                    value: n.to_string(),
-                    quote_style: Some('"'),
-                }),
+                Some(n) => Expr::Identifier(Ident::new(n.to_string())),
                 _ => Expr::Value(Value::Number((i + 1).to_string())),
             })
             .collect(),

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 failure = "0.1.6"
 log = "0.4.5"
 repr = { path = "../repr" }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 matches = "0.1"

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -66,6 +66,8 @@ pub use self::query::{
 pub use self::value::{ExtractField, IntervalValue, Value};
 use std::path::PathBuf;
 
+use crate::keywords::is_reserved_keyword;
+
 struct DisplaySeparated<'a, T>
 where
     T: AstDisplay,
@@ -102,60 +104,75 @@ where
     DisplaySeparated { slice, sep: ", " }
 }
 
-/// An identifier, decomposed into its value or character data and the quote style.
+/// An identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Ident {
-    /// The value of the identifier without quotes.
-    pub value: String,
-    /// The starting quote if any. Valid quote characters are the single quote,
-    /// double quote, backtick, and opening square bracket.
-    pub quote_style: Option<char>,
-}
+pub struct Ident(String);
 
 impl Ident {
-    /// Create a new identifier with the given value and no quotes.
+    /// Create a new identifier with the given value.
     pub fn new<S>(value: S) -> Self
     where
         S: Into<String>,
     {
-        Ident {
-            value: value.into(),
-            quote_style: None,
-        }
+        Ident(value.into())
     }
 
-    /// Create a new quoted identifier with the given quote and value. This function
-    /// panics if the given quote is not a valid quote character.
-    pub fn with_quote<S>(quote: char, value: S) -> Self
+    /// Creates a new identifier with the normalized form of the given value. This should only be
+    /// used on identifiers read from SQL that were not quoted.
+    pub fn new_normalized<S>(value: S) -> Self
     where
         S: Into<String>,
     {
-        assert!(quote == '\'' || quote == '"' || quote == '`' || quote == '[');
-        Ident {
-            value: value.into(),
-            quote_style: Some(quote),
-        }
+        Ident(value.into().to_lowercase())
+    }
+
+    /// An identifier can be printed in bare mode if
+    ///  * it matches the regex [a-z_][a-z0-9_]* and
+    ///  * it is not a "reserved keyword."
+    pub fn can_be_printed_bare(&self) -> bool {
+        let mut chars = self.0.chars();
+        chars
+            .next()
+            .map(|ch| (ch >= 'a' && ch <= 'z') || (ch == '_'))
+            .unwrap_or(false)
+            && chars.all(|ch| (ch >= 'a' && ch <= 'z') || (ch == '_') || (ch >= '0' && ch <= '9'))
+            && !is_reserved_keyword(&self.0)
+    }
+
+    pub fn value(&self) -> String {
+        self.0.to_string()
+    }
+
+    pub fn as_str<'a>(&'a self) -> &'a str {
+        &self.0
     }
 }
 
 impl From<&str> for Ident {
     fn from(value: &str) -> Self {
-        Ident {
-            value: value.to_string(),
-            quote_style: None,
-        }
+        Ident(value.to_string())
     }
 }
 
+/// More-or-less a direct translation of the Postgres function for doing the same thing:
+///
+///   https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/ruleutils.c#L10730-L10812
+///
+/// Quotation is forced when printing in Stable mode.
 impl AstDisplay for Ident {
     fn fmt(&self, f: &mut AstFormatter) {
-        match self.quote_style {
-            Some(q) if q == '"' || q == '\'' || q == '`' => {
-                f.write_str(format!("{}{}{}", q, self.value, q))
+        if self.can_be_printed_bare() && !f.stable() {
+            f.write_str(&self.0);
+        } else {
+            f.write_str("\"");
+            for ch in self.0.chars() {
+                // Double up on double-quotes.
+                if ch == '"' {
+                    f.write_str("\"");
+                }
+                f.write_str(ch);
             }
-            Some(q) if q == '[' => f.write_str(format!("[{}]", self.value)),
-            None => f.write_str(&self.value),
-            _ => panic!("unexpected quote style"),
+            f.write_str("\"");
         }
     }
 }

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -1846,7 +1846,7 @@ mod tests {
 
         impl<'a> Visit<'a> for Visitor<'a> {
             fn visit_ident(&mut self, ident: &'a Ident) {
-                self.seen_idents.push(&ident.value);
+                self.seen_idents.push(ident.as_str());
             }
         }
 
@@ -1856,7 +1856,7 @@ mod tests {
 
         impl<'a> VisitMut<'a> for VisitorMut<'a> {
             fn visit_ident(&mut self, ident: &'a mut Ident) {
-                self.seen_idents.push(&ident.value);
+                self.seen_idents.push(ident.as_str());
             }
         }
 

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -18,6 +18,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
+use lazy_static::lazy_static;
+
 ///! This module defines
 /// 1) a list of constants for every keyword that
 /// can appear in [Word::keyword]:
@@ -518,3 +522,20 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[&str] = &[
     // Reserved only as a column alias in the `SELECT` clause:
     FROM,
 ];
+
+lazy_static! {
+    static ref RESERVED_KEYWORD_SET: HashSet<String> = {
+        let mut kw = HashSet::new();
+        for k in RESERVED_FOR_TABLE_ALIAS {
+            kw.insert((*k).to_string());
+        }
+        for k in RESERVED_FOR_COLUMN_ALIAS {
+            kw.insert((*k).to_string());
+        }
+        kw
+    };
+}
+
+pub fn is_reserved_keyword(s: &str) -> bool {
+    RESERVED_KEYWORD_SET.contains(&s.to_uppercase())
+}

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2228,10 +2228,9 @@ impl Parser {
         let modifier = self.parse_one_of_keywords(&["SESSION", "LOCAL"]);
         let mut variable = self.parse_identifier()?;
         let mut normal = self.consume_token(&Token::Eq) || self.parse_keyword("TO");
-        if !normal && variable.value.to_uppercase() == "TIME" {
+        if !normal && variable.as_str().to_uppercase() == "TIME" {
             self.expect_keyword("ZONE")?;
-            variable.value = "timezone".into();
-            variable.quote_style = None;
+            variable = Ident::new("timezone");
             normal = true;
         }
         if normal {
@@ -2246,7 +2245,7 @@ impl Parser {
                 variable,
                 value,
             })
-        } else if variable.value.to_uppercase() == "TRANSACTION" && modifier.is_none() {
+        } else if variable.as_str().to_uppercase() == "TRANSACTION" && modifier.is_none() {
             Ok(Statement::SetTransaction {
                 modes: self.parse_transaction_modes()?,
             })
@@ -2842,9 +2841,9 @@ impl Parser {
 
 impl Word {
     pub fn to_ident(&self) -> Ident {
-        Ident {
-            value: self.value.clone(),
-            quote_style: self.quote_style,
+        match self.quote_style {
+            Some(_) => Ident::new(&self.value),
+            None => Ident::new_normalized(&self.value),
         }
     }
 }

--- a/src/sql-parser/src/tokenizer.rs
+++ b/src/sql-parser/src/tokenizer.rs
@@ -364,6 +364,7 @@ impl Tokenizer {
                 }
                 // delimited (quoted) identifier
                 quote_start if self.is_delimited_identifier_start(quote_start) => {
+                    // TODO(justin): handle doubled-up quotes: "foo""bar" should be `foo"bar`.
                     chars.next(); // consume the opening quote
                     let quote_end = Word::matching_end_quote(quote_start);
                     let s = peeking_take_while(chars, |ch| ch != quote_end);

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -25,6 +25,7 @@ use std::fmt;
 use repr::datetime::DateTimeField;
 
 use matches::assert_matches;
+use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::*;
 use sql_parser::parser::*;
 
@@ -177,13 +178,10 @@ fn parse_no_table_name() {
 
 #[test]
 fn parse_delete_statement() {
-    let sql = "DELETE FROM \"table\"";
+    let sql = "DELETE FROM table";
     match verified_stmt(sql) {
         Statement::Delete { table_name, .. } => {
-            assert_eq!(
-                ObjectName(vec![Ident::with_quote('"', "table")]),
-                table_name
-            );
+            assert_eq!(ObjectName(vec![Ident::new("table")]), table_name);
         }
         _ => unreachable!(),
     }
@@ -300,7 +298,7 @@ fn parse_select_wildcard() {
 #[test]
 fn parse_count_wildcard() {
     verified_only_select(
-        "SELECT COUNT(Employee.*) FROM Order JOIN Employee ON Order.employee = Employee.id",
+        "SELECT count(employee.*) FROM \"order\" JOIN employee ON \"order\".employee = employee.id",
     );
 }
 
@@ -328,11 +326,11 @@ fn parse_column_aliases() {
 
 #[test]
 fn parse_concat_function() {
-    let sql = "SELECT CONCAT('CONCAT', ' ', 'function')";
+    let sql = "SELECT concat('CONCAT', ' ', 'function')";
     let _select = verified_only_select(sql);
-    let sql = "SELECT CONCAT(first_name, ' ', last_name) FROM customer";
+    let sql = "SELECT concat(first_name, ' ', last_name) FROM customer";
     let _select = verified_only_select(sql);
-    let sql = "SELECT CONCAT('Concat with ', NULL) AS result_string";
+    let sql = "SELECT concat('Concat with ', NULL) AS result_string";
     let _select = verified_only_select(sql);
     let sql = "SELECT first_name, concat('A', 3, 'chars') FROM customer";
     let _select = verified_only_select(sql);
@@ -365,11 +363,11 @@ Expected an identifier after AS, found: EOF"
 
 #[test]
 fn parse_select_count_wildcard() {
-    let sql = "SELECT COUNT(*) FROM customer";
+    let sql = "SELECT count(*) FROM customer";
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Function(Function {
-            name: ObjectName(vec![Ident::new("COUNT")]),
+            name: ObjectName(vec![Ident::new("count")]),
             args: vec![Expr::Wildcard],
             filter: None,
             over: None,
@@ -381,11 +379,11 @@ fn parse_select_count_wildcard() {
 
 #[test]
 fn parse_select_count_filter() {
-    let sql = "SELECT COUNT(*) FILTER (WHERE foo) FROM customer";
+    let sql = "SELECT count(*) FILTER (WHERE foo) FROM customer";
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Function(Function {
-            name: ObjectName(vec![Ident::new("COUNT")]),
+            name: ObjectName(vec![Ident::new("count")]),
             args: vec![Expr::Wildcard],
             filter: Some(Box::new(Expr::Identifier(Ident::new("foo")))),
             over: None,
@@ -397,11 +395,11 @@ fn parse_select_count_filter() {
 
 #[test]
 fn parse_select_count_distinct() {
-    let sql = "SELECT COUNT(DISTINCT + x) FROM customer";
+    let sql = "SELECT count(DISTINCT + x) FROM customer";
     let select = verified_only_select(sql);
     assert_eq!(
         &Expr::Function(Function {
-            name: ObjectName(vec![Ident::new("COUNT")]),
+            name: ObjectName(vec![Ident::new("count")]),
             args: vec![Expr::UnaryOp {
                 op: UnaryOperator::Plus,
                 expr: Box::new(Expr::Identifier(Ident::new("x")))
@@ -414,18 +412,18 @@ fn parse_select_count_distinct() {
     );
 
     one_statement_parses_to(
-        "SELECT COUNT(ALL + x) FROM customer",
-        "SELECT COUNT(+ x) FROM customer",
+        "SELECT count(ALL + x) FROM customer",
+        "SELECT count(+ x) FROM customer",
     );
 
-    let sql = "SELECT COUNT(ALL DISTINCT + x) FROM customer";
+    let sql = "SELECT count(ALL DISTINCT + x) FROM customer";
     let res = parse_sql_statements(sql);
     assert_eq!(
         ("\
 Parse error:
-SELECT COUNT(ALL DISTINCT + x) FROM customer
+SELECT count(ALL DISTINCT + x) FROM customer
              ^^^^^^^^^^^^
-Cannot specify both ALL and DISTINCT in function: COUNT"
+Cannot specify both ALL and DISTINCT in function: count"
             .to_string()),
         format!("{}", res.unwrap_err())
     );
@@ -972,12 +970,12 @@ fn parse_select_group_by() {
 
 #[test]
 fn parse_select_having() {
-    let sql = "SELECT foo FROM bar GROUP BY foo HAVING COUNT(*) > 1";
+    let sql = "SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1";
     let select = verified_only_select(sql);
     assert_eq!(
         Some(Expr::BinaryOp {
             left: Box::new(Expr::Function(Function {
-                name: ObjectName(vec![Ident::new("COUNT")]),
+                name: ObjectName(vec![Ident::new("count")]),
                 args: vec![Expr::Wildcard],
                 filter: None,
                 over: None,
@@ -1258,11 +1256,11 @@ fn parse_alter_table_constraints() {
         "CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) \
          REFERENCES public.address(address_id)",
     );
-    check_one("CONSTRAINT ck CHECK (rtrim(ltrim(REF_CODE)) <> '')");
+    check_one("CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> '')");
 
     check_one("PRIMARY KEY (foo, bar)");
     check_one("UNIQUE (id)");
-    check_one("FOREIGN KEY (foo, bar) REFERENCES AnotherTable(foo, bar)");
+    check_one("FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar)");
     check_one("CHECK (end_date > start_date OR end_date IS NULL)");
 
     fn check_one(constraint_text: &str) {
@@ -1354,7 +1352,7 @@ fn parse_window_functions() {
 
 #[test]
 fn parse_aggregate_with_group_by() {
-    let sql = "SELECT a, COUNT(1), MIN(b), MAX(b) FROM foo GROUP BY a";
+    let sql = "SELECT a, count(1), min(b), max(b) FROM foo GROUP BY a";
     let _ast = verified_only_select(sql);
     //TODO: assertions
 }
@@ -1661,9 +1659,9 @@ fn parse_simple_math_expr_minus() {
 
 #[test]
 fn parse_delimited_identifiers() {
-    // check that quoted identifiers in any position remain quoted after serialization
+    // check that identifiers requiring quotation are quoted
     let select = verified_only_select(
-        r#"SELECT "alias"."bar baz", "myfun"(), "simple id" AS "column alias" FROM "a table" AS "alias""#,
+        r#"SELECT alias."bar baz", myfun(), "simple id" AS "column alias" FROM "a table" AS alias"#,
     );
     // check FROM
     match only(select.from).relation {
@@ -1673,8 +1671,8 @@ fn parse_delimited_identifiers() {
             args,
             with_hints,
         } => {
-            assert_eq!(vec![Ident::with_quote('"', "a table")], name.0);
-            assert_eq!(Ident::with_quote('"', "alias"), alias.unwrap().name);
+            assert_eq!(vec![Ident::new("a table")], name.0);
+            assert_eq!(Ident::new("alias"), alias.unwrap().name);
             assert!(args.is_empty());
             assert!(with_hints.is_empty());
         }
@@ -1683,15 +1681,12 @@ fn parse_delimited_identifiers() {
     // check SELECT
     assert_eq!(3, select.projection.len());
     assert_eq!(
-        &Expr::CompoundIdentifier(vec![
-            Ident::with_quote('"', "alias"),
-            Ident::with_quote('"', "bar baz")
-        ]),
+        &Expr::CompoundIdentifier(vec![Ident::new("alias"), Ident::new("bar baz")]),
         expr_from_projection(&select.projection[0]),
     );
     assert_eq!(
         &Expr::Function(Function {
-            name: ObjectName(vec![Ident::with_quote('"', "myfun")]),
+            name: ObjectName(vec![Ident::new("myfun")]),
             args: vec![],
             filter: None,
             over: None,
@@ -1701,14 +1696,14 @@ fn parse_delimited_identifiers() {
     );
     match &select.projection[2] {
         SelectItem::ExprWithAlias { expr, alias } => {
-            assert_eq!(&Expr::Identifier(Ident::with_quote('"', "simple id")), expr);
-            assert_eq!(&Ident::with_quote('"', "column alias"), alias);
+            assert_eq!(&Expr::Identifier(Ident::new("simple id")), expr);
+            assert_eq!(&Ident::new("column alias"), alias);
         }
         _ => panic!("Expected ExprWithAlias"),
     }
 
-    verified_stmt(r#"CREATE TABLE "foo" ("bar" int)"#);
-    verified_stmt(r#"ALTER TABLE foo ADD CONSTRAINT "bar" PRIMARY KEY (baz)"#);
+    verified_stmt(r#"CREATE TABLE foo (bar int)"#);
+    verified_stmt(r#"ALTER TABLE foo ADD CONSTRAINT bar PRIMARY KEY (baz)"#);
     //TODO verified_stmt(r#"UPDATE foo SET "bar" = 5"#);
 }
 
@@ -2086,7 +2081,7 @@ fn parse_simple_case_expr() {
 
 #[test]
 fn parse_from_advanced() {
-    let sql = "SELECT * FROM fn(1, 2) AS foo, schema.bar AS bar WITH (NOLOCK)";
+    let sql = "SELECT * FROM fn(1, 2) AS foo, schema.bar AS bar WITH (nolock)";
     let _select = verified_only_select(sql);
 }
 
@@ -2578,7 +2573,10 @@ fn parse_union() {
     verified_stmt("WITH cte AS (SELECT 1 AS foo) (SELECT foo FROM cte ORDER BY 1 LIMIT 1)");
     verified_stmt("SELECT 1 UNION (SELECT 2 ORDER BY 1 LIMIT 1)");
     verified_stmt("SELECT 1 UNION SELECT 2 INTERSECT SELECT 3"); // Union[1, Intersect[2,3]]
-    verified_stmt("SELECT foo FROM tab UNION SELECT bar FROM TAB");
+    one_statement_parses_to(
+        "SELECT foo FROM tab UNION SELECT bar FROM TAB",
+        "SELECT foo FROM tab UNION SELECT bar FROM tab",
+    );
     verified_stmt("(SELECT * FROM new EXCEPT SELECT * FROM old) UNION ALL (SELECT * FROM old EXCEPT SELECT * FROM new) ORDER BY 1");
 }
 
@@ -4016,7 +4014,7 @@ fn lateral_derived() {
         let lateral_str = if lateral_in { "LATERAL " } else { "" };
         let sql = format!(
             "SELECT * FROM customer LEFT JOIN {}\
-             (SELECT * FROM order WHERE order.customer = customer.id LIMIT 3) AS order ON true",
+             (SELECT * FROM \"order\" WHERE \"order\".customer = customer.id LIMIT 3) AS \"order\" ON true",
             lateral_str
         );
         let select = verified_only_select(&sql);
@@ -4037,7 +4035,7 @@ fn lateral_derived() {
             assert_eq!(Ident::new("order"), alias.name);
             assert_eq!(
                 subquery.to_string(),
-                "SELECT * FROM order WHERE order.customer = customer.id LIMIT 3"
+                "SELECT * FROM \"order\" WHERE \"order\".customer = customer.id LIMIT 3"
             );
         } else {
             unreachable!()
@@ -4253,28 +4251,22 @@ fn parse_explain() {
         "EXPLAIN OPTIMIZED PLAN FOR SELECT 665",
     );
 
-    let ast = verified_stmt("EXPLAIN OPTIMIZED PLAN FOR VIEW FOO");
+    let ast = verified_stmt("EXPLAIN OPTIMIZED PLAN FOR VIEW foo");
     assert_eq!(
         ast,
         Statement::Explain {
             stage: ExplainStage::OptimizedPlan,
-            explainee: Explainee::View(ObjectName(vec![Ident {
-                value: "FOO".to_owned(),
-                quote_style: None
-            }])),
+            explainee: Explainee::View(ObjectName(vec![Ident::new("foo")])),
             options: ExplainOptions { typed: false },
         }
     );
 
-    let ast = verified_stmt("EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW FOO");
+    let ast = verified_stmt("EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo");
     assert_eq!(
         ast,
         Statement::Explain {
             stage: ExplainStage::OptimizedPlan,
-            explainee: Explainee::View(ObjectName(vec![Ident {
-                value: "FOO".to_owned(),
-                quote_style: None
-            }])),
+            explainee: Explainee::View(ObjectName(vec![Ident::new("foo")])),
             options: ExplainOptions { typed: true },
         }
     );
@@ -4416,7 +4408,7 @@ fn parse_create_table_with_defaults() {
                     ColumnDef {
                         name: "last_name".into(),
                         data_type: DataType::Varchar(Some(45)),
-                        collation: Some(ObjectName(vec![Ident::with_quote('"', "es_ES")])),
+                        collation: Some(ObjectName(vec![Ident::new("es_ES")])),
                         options: vec![ColumnOptionDef {
                             name: None,
                             option: ColumnOption::NotNull,
@@ -4642,13 +4634,13 @@ fn parse_set() {
         }
     );
 
-    let stmt = verified_stmt("SET a = DEFAULT");
+    let stmt = verified_stmt("SET a = default");
     assert_eq!(
         stmt,
         Statement::SetVariable {
             local: false,
             variable: "a".into(),
-            value: SetVariableValue::Ident("DEFAULT".into()),
+            value: SetVariableValue::Ident("default".into()),
         }
     );
 
@@ -4718,11 +4710,12 @@ fn parse_show() {
         }
     );
 
-    let stmt = verified_stmt("SHOW ALL");
+    // TODO(justin): parse "SHOW all" as its own thing so that we can format this without downcasing.
+    let stmt = verified_stmt("SHOW all");
     assert_eq!(
         stmt,
         Statement::ShowVariable {
-            variable: "ALL".into()
+            variable: "all".into()
         }
     )
 }
@@ -4841,6 +4834,35 @@ FROM bar+1 ORDER
 Expected end of statement, found: +"
             .to_string(),
     );
+}
+
+#[test]
+fn format_ident() {
+    let cases = vec![
+        ("foo", "foo", "\"foo\""),
+        ("_foo", "_foo", "\"_foo\""),
+        ("foo_bar", "foo_bar", "\"foo_bar\""),
+        ("foo1", "foo1", "\"foo1\""),
+        // Contains disallowed character.
+        ("Foo", "\"Foo\"", "\"Foo\""),
+        ("a b", "\"a b\"", "\"a b\""),
+        ("\"", "\"\"\"\"", "\"\"\"\""),
+        ("foo\"bar", "\"foo\"\"bar\"", "\"foo\"\"bar\""),
+        ("foo$bar", "\"foo$bar\"", "\"foo$bar\""),
+        // Digit at the beginning.
+        ("1foo", "\"1foo\"", "\"1foo\""),
+        // Non-reserved keyword.
+        ("floor", "floor", "\"floor\""),
+        // Reserved keyword.
+        ("order", "\"order\"", "\"order\""),
+        // Empty string allowed by Materialize but not PG.
+        // TODO(justin): disallow this!
+        ("", "\"\"", "\"\""),
+    ];
+    for (name, formatted, forced_quotation) in cases {
+        assert_eq!(formatted, format!("{}", Ident::new(name)));
+        assert_eq!(forced_quotation, Ident::new(name).to_ast_string_stable());
+    }
 }
 
 pub fn run_parser_method<F, T>(sql: &str, f: F) -> T

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -14,6 +14,7 @@ use failure::bail;
 use catalog::names::{DatabaseSpecifier, FullName, PartialName};
 use ore::collections::CollectionExt;
 use repr::ColumnName;
+use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::VisitMut;
 use sql_parser::ast::{
     Expr, Function, Ident, IfExistsBehavior, ObjectName, SqlOption, Statement, TableAlias, Value,
@@ -22,11 +23,7 @@ use sql_parser::ast::{
 use crate::statement::StatementContext;
 
 pub fn ident(ident: Ident) -> String {
-    if ident.quote_style.is_some() {
-        ident.value
-    } else {
-        ident.value.to_lowercase()
-    }
+    ident.as_str().into()
 }
 
 pub fn function_name(name: ObjectName) -> Result<String, failure::Error> {
@@ -71,10 +68,10 @@ pub fn with_options(options: &[SqlOption]) -> HashMap<String, Value> {
 pub fn unresolve(name: FullName) -> ObjectName {
     let mut out = vec![];
     if let DatabaseSpecifier::Name(n) = name.database {
-        out.push(Ident::with_quote('"', n));
+        out.push(Ident::new(n));
     }
-    out.push(Ident::with_quote('"', name.schema));
-    out.push(Ident::with_quote('"', name.item));
+    out.push(Ident::new(name.schema));
+    out.push(Ident::new(name.item));
     ObjectName(out)
 }
 
@@ -89,13 +86,6 @@ pub fn create_statement(
     scx: &StatementContext,
     mut stmt: Statement,
 ) -> Result<String, failure::Error> {
-    fn norm_ident(ident: &mut Ident) {
-        if ident.quote_style.is_none() {
-            ident.value = ident.value.to_lowercase();
-        }
-        ident.quote_style = Some('"');
-    };
-
     let allocate_name = |name: &ObjectName| -> Result<_, failure::Error> {
         Ok(unresolve(scx.allocate_name(object_name(name.clone())?)))
     };
@@ -150,10 +140,6 @@ pub fn create_statement(
                 Err(e) => self.err = Some(e),
             };
         }
-
-        fn visit_ident(&mut self, ident: &'ast mut Ident) {
-            norm_ident(ident);
-        }
     }
 
     // Think very hard before changing any of the branches in this match
@@ -169,7 +155,7 @@ pub fn create_statement(
     match &mut stmt {
         Statement::CreateSource {
             name,
-            col_names,
+            col_names: _,
             connector: _,
             with_options: _,
             format: _,
@@ -178,9 +164,6 @@ pub fn create_statement(
             materialized,
         } => {
             *name = allocate_name(name)?;
-            for c in col_names {
-                norm_ident(c);
-            }
             *if_not_exists = false;
             *materialized = false;
         }
@@ -199,16 +182,13 @@ pub fn create_statement(
 
         Statement::CreateView {
             name,
-            columns,
+            columns: _,
             query,
             materialized,
             if_exists,
             with_options: _,
         } => {
             *name = allocate_name(name)?;
-            for c in columns {
-                norm_ident(c);
-            }
             {
                 let mut normalizer = QueryNormalizer { scx, err: None };
                 normalizer.visit_query(query);
@@ -221,12 +201,11 @@ pub fn create_statement(
         }
 
         Statement::CreateIndex {
-            name,
+            name: _,
             on_name,
             key_parts,
             if_not_exists,
         } => {
-            norm_ident(name);
             *on_name = resolve_name(on_name)?;
             let mut normalizer = QueryNormalizer { scx, err: None };
             for key_part in key_parts {
@@ -241,5 +220,34 @@ pub fn create_statement(
         _ => unreachable!(),
     }
 
-    Ok(stmt.to_string())
+    Ok(stmt.to_ast_string_stable())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Session;
+    use catalog::{Catalog, PlanContext};
+    use sql_parser::parser::Parser;
+
+    #[test]
+    fn normalized_create() {
+        let scx = &StatementContext {
+            pcx: &PlanContext::default(),
+            session: &Session::default(),
+            catalog: &Catalog::dummy(),
+        };
+
+        let parsed = Parser::parse_sql("create materialized view foo as select 1 as bar".into())
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+
+        // Ensure that all identifiers are quoted.
+        assert_eq!(
+            r#"CREATE VIEW "materialize"."public"."foo" AS SELECT 1 AS "bar""#,
+            create_statement(scx, parsed).unwrap()
+        );
+    }
 }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -107,10 +107,7 @@ pub fn plan_show_where(
         let predicate = match &f {
             ShowStatementFilter::Like(s) => {
                 owned = Expr::BinaryOp {
-                    left: Box::new(Expr::Identifier(Ident::with_quote(
-                        '"',
-                        names[0].clone().unwrap(),
-                    ))),
+                    left: Box::new(Expr::Identifier(Ident::new(names[0].clone().unwrap()))),
                     op: BinaryOperator::Like,
                     right: Box::new(Expr::Value(Value::SingleQuotedString(s.into()))),
                 };

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -186,7 +186,7 @@ pub fn describe_statement(
             vec![],
         ),
         Statement::ShowVariable { variable, .. } => {
-            if variable.value == unicase::Ascii::new("ALL") {
+            if variable.as_str() == unicase::Ascii::new("ALL") {
                 (
                     Some(
                         RelationDesc::empty()
@@ -198,7 +198,7 @@ pub fn describe_statement(
                 )
             } else {
                 (
-                    Some(RelationDesc::empty().add_column(variable.value, ScalarType::String)),
+                    Some(RelationDesc::empty().add_column(variable.as_str(), ScalarType::String)),
                     vec![],
                 )
             }
@@ -317,16 +317,16 @@ fn handle_set_variable(
         value: match value {
             SetVariableValue::Literal(Value::SingleQuotedString(s)) => s,
             SetVariableValue::Literal(lit) => lit.to_string(),
-            SetVariableValue::Ident(ident) => ident.value,
+            SetVariableValue::Ident(ident) => ident.value(),
         },
     })
 }
 
 fn handle_show_variable(_: &StatementContext, variable: Ident) -> Result<Plan, failure::Error> {
-    if variable.value == unicase::Ascii::new("ALL") {
+    if variable.as_str() == unicase::Ascii::new("ALL") {
         Ok(Plan::ShowAllVariables)
     } else {
-        Ok(Plan::ShowVariable(variable.value))
+        Ok(Plan::ShowVariable(variable.to_string()))
     }
 }
 

--- a/test/sqllogictest/index.slt
+++ b/test/sqllogictest/index.slt
@@ -38,19 +38,19 @@ query TTTTBI colnames
 SHOW INDEX IN bar
 ----
 Source_or_view           Key_name                            Column_name  Expression     Null  Seq_in_index
-materialize.public.bar   materialize.public.bar_idx          NULL         substr("z",␠3) true  1
-materialize.public.bar   materialize.public.bar_primary_idx  z            NULL           false 1
+materialize.public.bar  materialize.public.bar_idx  NULL  substr(z,␠3)  true  1
+materialize.public.bar  materialize.public.bar_primary_idx  z  NULL  false  1
 
 query TTTTBI colnames
 SHOW INDEX FROM foo
 ----
-Source_or_view                     Key_name                            Column_name  Expression  Null   Seq_in_index
-materialize.public.foo   materialize.public.edge_columns     NULL         floor("c")  true   2
-materialize.public.foo   materialize.public.edge_columns     a            NULL        false  1
-materialize.public.foo   materialize.public.foo_idx          NULL         "a"␠+␠"c"   true   1
-materialize.public.foo   materialize.public.foo_primary_idx  a            NULL        false  1
-materialize.public.foo   materialize.public.foo_primary_idx  b            NULL        true   2
-materialize.public.foo   materialize.public.foo_primary_idx  c            NULL        true   3
+Source_or_view          Key_name                            Column_name  Expression  Null   Seq_in_index
+materialize.public.foo  materialize.public.edge_columns     NULL         floor(c)    true   2
+materialize.public.foo  materialize.public.edge_columns     a            NULL        false  1
+materialize.public.foo  materialize.public.foo_idx          NULL         a␠+␠c       true   1
+materialize.public.foo  materialize.public.foo_primary_idx  a            NULL        false  1
+materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
+materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3
 
 statement ok
 DROP INDEX foo_idx
@@ -63,7 +63,7 @@ materialize.public.foo  materialize.public.foo_primary_idx  a            NULL   
 materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3
 materialize.public.foo  materialize.public.edge_columns     a            NULL        false  1
-materialize.public.foo  materialize.public.edge_columns     NULL         floor("c")  true   2
+materialize.public.foo  materialize.public.edge_columns     NULL         floor(c)  true   2
 
 statement ok
 DROP INDEX edge_columns

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -150,7 +150,7 @@ catalog item 'materialize.public.i1' is an index and so cannot be depended upon
 > SHOW INDEX in v2a;
 Source_or_view           Key_name                             Column_name Expression     Null   Seq_in_index
 ------------------------------------------------------------------------------------------------------------
-materialize.public.v2a   materialize.public.i2                <null>      "\"x\" * 2"    false  1
+materialize.public.v2a   materialize.public.i2                <null>      "x * 2"    false  1
 materialize.public.v2a   materialize.public.v2a_primary_idx   x           <null>         false  1
 
 > SHOW INDEX in v2;
@@ -265,7 +265,7 @@ unknown catalog item 'i4'
 > SHOW INDEX in s3;
 Source_or_view          Key_name                              Column_name Expression     Null  Seq_in_index
 ----------------------------------------------------------------------------------------------------
-materialize.public.s3   materialize.public.j1                 <null>      "ascii(\"y\")" false 1
+materialize.public.s3   materialize.public.j1                 <null>      "ascii(y)" false 1
 materialize.public.s3   materialize.public.s3_primary_idx     x           <null>         false 1
 materialize.public.s3   materialize.public.s3_primary_idx     y           <null>         false 2
 
@@ -293,7 +293,7 @@ unknown catalog item 'j1'
 > SHOW INDEX in s4;
 Source_or_view          Key_name                              Column_name Expression  Null  Seq_in_index
 ----------------------------------------------------------------------------------------------------
-materialize.public.s4   materialize.public.j2                 <null>      "\"x\" + 2" false 1
+materialize.public.s4   materialize.public.j2                 <null>      "x + 2" false 1
 materialize.public.s4   materialize.public.s4_primary_idx     x           <null>      false 1
 materialize.public.s4   materialize.public.s4_primary_idx     y           <null>      false 2
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -73,7 +73,7 @@ data_view
 > SHOW CREATE VIEW test1
 View                      Create View
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.test1  "CREATE VIEW \"materialize\".\"public\".\"test1\" AS SELECT \"b\", sum(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
+materialize.public.test1  "CREATE VIEW \"materialize\".\"public\".\"test1\" AS SELECT \"b\", \"sum\"(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
 
 # Materialized view can be built on a not-materialized view.
 > CREATE MATERIALIZED VIEW test2 AS


### PR DESCRIPTION
This commit simplifies (in some ways) the parser's handling of
identifiers.

Previously, to determine if an identifier needed to be quoted when being
printed out, the parser would track if it was quoted when it was read
in. This worked, but was a little clunky. After this change, we always
store the identifier in its normalized form (i.e., if it was entered
without quotes, it gets normalized, and if it was entered with quotes,
it does not) and determine if it needs quoting only when it gets printed
out.

This leads to a small change in behaviour in some cases, as the
capitalization of identifiers is now stripped away when it is not
relevant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2667)
<!-- Reviewable:end -->
