### PR TITLE
mzbuild: `git clean` with `-d` flag

### DIFF
--- a/misc/python/mzbuild.py
+++ b/misc/python/mzbuild.py
@@ -95,7 +95,7 @@ def chmod_x(path: Path) -> None:
 
 class PreImage:
     def run(self, root: Path, path: Path) -> None:
-        runv(["git", "clean", "-ffX", path])
+        runv(["git", "clean", "-ffdX", path])
 
     def depends(self, root: Path, path: Path) -> List[bytes]:
         pass


### PR DESCRIPTION
In newer versions of git the `-d` flag is redundant, because we've
specified an explicit path to clean, but in old versions of Git, like
the one we have in the CI builder, the `-d` flag needs to be passed
explicitly to get `git clean` to remove ignored directories. [[0]]

This was causing mzbuild failures in CI, where the ci-cargo-test image
could have build directories lying around from the last job to run on
the agent.

[0]: https://github.com/git/git/commit/e86bbcf987faad8e487beb814351a404fa80957f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2672)
<!-- Reviewable:end -->
