### PR TITLE
ci/slt: use mzbuild for dependency management

### DIFF
--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - block: ":vertical_traffic_light: Go"
   - command: ci/slt/slt.sh
     timeout_in_minutes: 300
     artifact_paths: target/slt-summary.json

--- a/ci/test/pipeline.yml
+++ b/ci/test/pipeline.yml
@@ -109,17 +109,6 @@ steps:
           run: healthcheck
     if: $CHANGED_RUST
 
-  - id: full-sqllogictest
-    label: ":bulb: :bulb: Full SQL logic tests"
-    depends_on: build
-    trigger: sql-logic-tests
-    async: true
-    build:
-      commit: "$BUILDKITE_COMMIT"
-      branch: "$BUILDKITE_BRANCH"
-      env:
-        SQLLOGICTEST_IMAGE_ID: $BUILDKITE_BUILD_NUMBER
-
   - id: lang-js
     label: ":javascript: tests"
     depends_on: build


### PR DESCRIPTION
We no longer need to carefully manage the build dependencies of the full
SLT CI job. It will automatically download the correct version of the
SLT mzimage from Docker Hub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2674)
<!-- Reviewable:end -->
