### PR TITLE
ci-builder: fix SSH agent forwarding

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -87,6 +87,7 @@ case "$cmd" in
                 --volume "/var/run/docker.sock:/var/run/docker.sock"
                 --volume "$HOME/.cargo:/cargo"
                 --volume "$HOME/.docker/config.json:/docker/config.json"
+                --env "SSH_AUTH_SOCK=/tmp/ssh-agent.sock"
                 --env "CARGO_HOME=/cargo"
                 --env "DOCKER_CONFIG=/docker"
                 --user "$(id -u):$(stat -c %g /var/run/docker.sock)"


### PR DESCRIPTION
We were forgetting to set the environment variable to point at the
forwarded SSH agent socket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2676)
<!-- Reviewable:end -->
