### PR TITLE
bin/check: re-enable clippy::redundant-closure link

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -131,26 +131,6 @@ disabled_lints=(
     # when the for loop is clearer.
     clippy::needless_range_loop
 
-    # Upstream description: https://rust-lang.github.io/rust-clippy/master/#redundant_closure
-    #
-    # clippy::redundant_closure prohibits using closures when the closure
-    # delegates to a function that could be called directly. For example, it
-    # would require that
-    #
-    #     collection.iter().map(|item| item.to_string())
-    #
-    # be rewritten as:
-    #
-    #     collection.iter().map(ToString::to_string)
-    #
-    # This lint is needlessly nitpicky. The author may be maintaining a
-    # consistent style with the surrounding code by introducing the closure,
-    # especially when closures of various arities are in close proximity,
-    # as only closures of zero or one arguments can be rewritten to delegate
-    # to the inner function directly. Besides, the needless closure will be
-    # trivially optimized away by LLVM.
-    clippy::redundant_closure
-
     # Upstream description: https://rust-lang.github.io/rust-clippy/master/#type_complexity
     #
     # clippy::type_complexity disallows types that are excessively nested.

--- a/src/billing-demo/src/main.rs
+++ b/src/billing-demo/src/main.rs
@@ -87,7 +87,7 @@ async fn create_kafka_messages(config: KafkaConfig) -> Result<()> {
     let mut k_client = kafka_client::KafkaClient::new(&config.url, &config.group_id)?;
 
     let mut buf = vec![];
-    let mut interval = config.message_sleep.map(|dur| tokio::time::interval(dur));
+    let mut interval = config.message_sleep.map(tokio::time::interval);
     let mut total_size = 0;
     for i in 0..config.message_count {
         if let Some(int) = interval.as_mut() {

--- a/src/catalog/lib.rs
+++ b/src/catalog/lib.rs
@@ -487,7 +487,7 @@ impl Catalog {
         if let CatalogItem::Index(index) = entry.item() {
             self.indexes
                 .entry(index.on)
-                .or_insert_with(|| Vec::new())
+                .or_insert_with(Vec::new)
                 .push(index.keys.clone());
         }
         self.get_schemas_mut(&entry.name.database)

--- a/src/comm/protocol.rs
+++ b/src/comm/protocol.rs
@@ -232,10 +232,7 @@ where
 {
     /// Attempts to retrieve an existing connection that is connected to `addr`.
     fn get(&mut self, addr: C::Addr) -> Option<Framed<C>> {
-        self.0
-            .entry(addr)
-            .or_insert_with(|| VecDeque::new())
-            .pop_front()
+        self.0.entry(addr).or_insert_with(VecDeque::new).pop_front()
     }
 
     /// Returns a framed connection to the pool so that it can be reused.
@@ -244,7 +241,7 @@ where
             Ok(addr) => self
                 .0
                 .entry(addr)
-                .or_insert_with(|| VecDeque::new())
+                .or_insert_with(VecDeque::new)
                 .push_back(conn),
             Err(e) => {
                 // An error while calling `peer_addr` typically indicates that

--- a/src/comm/switchboard.rs
+++ b/src/comm/switchboard.rs
@@ -182,7 +182,7 @@ where
                     futures.push(Box::pin(
                         TryConnectFuture::new(addr.clone(), timeout)
                             .and_then(move |conn| protocol::send_rendezvous_handshake(conn, id))
-                            .map_ok(|conn| Some(conn)),
+                            .map_ok(Some),
                     ));
                 }
             }

--- a/src/dataflow-bin/bin/dataflow-logview.rs
+++ b/src/dataflow-bin/bin/dataflow-logview.rs
@@ -102,7 +102,7 @@ fn main() {
             .enumerate()
             .filter(|(i, _)| *i % peers == index)
             .map(move |(_, s)| s.take().unwrap())
-            .map(|r| EventReader::<Duration, (Duration, WorkerIdentifier, TimelyEvent), _>::new(r))
+            .map(EventReader::<Duration, (Duration, WorkerIdentifier, TimelyEvent), _>::new)
             .collect::<Vec<_>>();
         worker.dataflow::<Duration, _, _>(|scope| {
             replayers

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -120,7 +120,7 @@ impl DataflowDesc {
     pub fn add_dependency(&mut self, view_id: GlobalId, dependent_id: GlobalId) {
         self.dependent_objects
             .entry(view_id)
-            .or_insert_with(|| Vec::new())
+            .or_insert_with(Vec::new)
             .push(dependent_id);
     }
 

--- a/src/dataflow/logging/timely.rs
+++ b/src/dataflow/logging/timely.rs
@@ -112,7 +112,7 @@ pub fn construct<A: Allocate>(
                                 // version when the host dataflow is dropped.
                                 channels_data
                                     .entry((event.scope_addr[0], worker))
-                                    .or_insert_with(|| Vec::new())
+                                    .or_insert_with(Vec::new)
                                     .push(event.clone());
 
                                 // Present channel description.

--- a/src/dataflow/render/context.rs
+++ b/src/dataflow/render/context.rs
@@ -198,7 +198,7 @@ where
     ) {
         self.local
             .entry(relation_expr.clone())
-            .or_insert_with(|| BTreeMap::new())
+            .or_insert_with(BTreeMap::new)
             .insert(keys.to_vec(), arranged);
     }
 
@@ -226,7 +226,7 @@ where
     ) {
         self.trace
             .entry(relation_expr.clone())
-            .or_insert_with(|| BTreeMap::new())
+            .or_insert_with(BTreeMap::new)
             .insert(keys.to_vec(), (gid, arranged.0, arranged.1));
     }
 

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -200,10 +200,7 @@ where
     let log_fn = Box::new(|_| None);
     let (builders, guard) = initialize_networking_from_sockets(sockets, process, threads, log_fn)
         .map_err(|err| format!("failed to initialize networking: {}", err))?;
-    let builders = builders
-        .into_iter()
-        .map(|x| GenericBuilder::ZeroCopy(x))
-        .collect();
+    let builders = builders.into_iter().map(GenericBuilder::ZeroCopy).collect();
 
     timely::execute::execute_from(builders, Box::new(guard), move |timely_worker| {
         executor.enter(|| {

--- a/src/expr/relation/mod.rs
+++ b/src/expr/relation/mod.rs
@@ -578,10 +578,7 @@ impl RelationExpr {
     pub fn reduce(self, group_key: Vec<usize>, aggregates: Vec<AggregateExpr>) -> Self {
         RelationExpr::Reduce {
             input: Box::new(self),
-            group_key: group_key
-                .into_iter()
-                .map(|c| ScalarExpr::Column(c))
-                .collect(),
+            group_key: group_key.into_iter().map(ScalarExpr::Column).collect(),
             aggregates,
         }
     }

--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -59,9 +59,7 @@ impl Demand {
                 // Nothing clever to do with constants, that I can think of.
             }
             RelationExpr::Get { id, .. } => {
-                gets.entry(*id)
-                    .or_insert_with(|| HashSet::new())
-                    .extend(columns);
+                gets.entry(*id).or_insert_with(HashSet::new).extend(columns);
             }
             RelationExpr::Let { id, value, body } => {
                 // Let harvests any requirements of get from its body,

--- a/src/expr/transform/join_implementation.rs
+++ b/src/expr/transform/join_implementation.rs
@@ -67,9 +67,7 @@ impl JoinImplementation {
                 RelationExpr::Reduce { group_key, .. } => {
                     arranged.insert(
                         Id::Local(*id),
-                        vec![(0..group_key.len())
-                            .map(|c| ScalarExpr::Column(c))
-                            .collect()],
+                        vec![(0..group_key.len()).map(ScalarExpr::Column).collect()],
                     );
                 }
                 _ => {}
@@ -136,11 +134,8 @@ impl JoinImplementation {
                     }
                     RelationExpr::Reduce { group_key, .. } => {
                         // The first `keys.len()` columns form an arrangement key.
-                        available_arrangements[index].push(
-                            (0..group_key.len())
-                                .map(|c| ScalarExpr::Column(c))
-                                .collect(),
-                        );
+                        available_arrangements[index]
+                            .push((0..group_key.len()).map(ScalarExpr::Column).collect());
                     }
                     _ => {}
                 }

--- a/src/expr/transform/nonnull_requirements.rs
+++ b/src/expr/transform/nonnull_requirements.rs
@@ -57,7 +57,7 @@ impl NonNullRequirements {
                 columns.iter().all(|c| datums[*c] != repr::Datum::Null)
             }),
             RelationExpr::Get { id, .. } => {
-                gets.entry(*id).or_insert_with(|| Vec::new()).push(columns);
+                gets.entry(*id).or_insert_with(Vec::new).push(columns);
             }
             RelationExpr::Let { id, value, body } => {
                 // Let harvests any non-null requirements from its body,

--- a/src/expr/transform/reduction.rs
+++ b/src/expr/transform/reduction.rs
@@ -78,7 +78,7 @@ impl FoldConstants {
                                     .eval(&datums, &temp_storage)?]))
                             })
                             .collect::<Result<Vec<_>, _>>()?;
-                        let entry = groups.entry(key).or_insert_with(|| Vec::new());
+                        let entry = groups.entry(key).or_insert_with(Vec::new);
                         for _ in 0..*diff {
                             entry.push(val.clone());
                         }

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -272,7 +272,7 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
         })
         .collect::<Result<_, io::Error>>()?;
 
-    let logging_config = config.logging_granularity.map(|d| LoggingConfig::new(d));
+    let logging_config = config.logging_granularity.map(LoggingConfig::new);
 
     // Initialize command queue and sql planner, but only on the primary.
     let coord_thread = if is_primary {

--- a/src/peeker/args.rs
+++ b/src/peeker/args.rs
@@ -101,7 +101,7 @@ fn load_config(config_path: Option<String>, cli_queries: Option<String>) -> Resu
     // load and parse th toml
     let config_file = config_path
         .as_ref()
-        .map(|config_file| std::fs::read_to_string(config_file))
+        .map(std::fs::read_to_string)
         .unwrap_or_else(|| Ok(DEFAULT_CONFIG.to_string()));
     let conf = match &config_file {
         Ok(contents) => toml::from_str::<RawConfig>(&contents).map_err(|e| {
@@ -236,7 +236,7 @@ impl TryFrom<RawConfig> for Config {
             .groups
             .into_iter()
             .map(|g| QueryGroup::from_group_config(g, &queries_by_name))
-            .chain(queries.iter().cloned().map(|q| Ok(q)))
+            .chain(queries.iter().cloned().map(Ok))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Config {

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -18,18 +18,12 @@ fn bench_sort_datums(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
 }
 
 fn bench_sort_row(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
-    let rows = rows
-        .into_iter()
-        .map(|row| Row::pack(row))
-        .collect::<Vec<_>>();
+    let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(|| rows.clone(), |mut rows| rows.sort())
 }
 
 fn bench_sort_iter(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
-    let rows = rows
-        .into_iter()
-        .map(|row| Row::pack(row))
-        .collect::<Vec<_>>();
+    let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(
         || rows.clone(),
         |mut rows| {
@@ -47,10 +41,7 @@ fn bench_sort_iter(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
 }
 
 fn bench_sort_unpack(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
-    let rows = rows
-        .into_iter()
-        .map(|row| Row::pack(row))
-        .collect::<Vec<_>>();
+    let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(
         || rows.clone(),
         |mut rows| {
@@ -61,10 +52,7 @@ fn bench_sort_unpack(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
 
 fn bench_sort_unpacked(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
     let arity = rows[0].len();
-    let rows = rows
-        .into_iter()
-        .map(|row| Row::pack(row))
-        .collect::<Vec<_>>();
+    let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(
         || rows.clone(),
         |rows| {
@@ -74,19 +62,13 @@ fn bench_sort_unpacked(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
             }
             let mut slices = unpacked.chunks(arity).collect::<Vec<_>>();
             slices.sort();
-            slices
-                .into_iter()
-                .map(|slice| Row::pack(slice))
-                .collect::<Vec<_>>()
+            slices.into_iter().map(Row::pack).collect::<Vec<_>>()
         },
     )
 }
 
 fn bench_filter_unpacked(filter: Datum, rows: Vec<Vec<Datum>>, b: &mut Bencher) {
-    let rows = rows
-        .into_iter()
-        .map(|row| Row::pack(row))
-        .collect::<Vec<_>>();
+    let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(
         || rows.clone(),
         |mut rows| rows.retain(|row| row.unpack()[0] == filter),
@@ -95,10 +77,7 @@ fn bench_filter_unpacked(filter: Datum, rows: Vec<Vec<Datum>>, b: &mut Bencher) 
 
 fn bench_filter_packed(filter: Datum, rows: Vec<Vec<Datum>>, b: &mut Bencher) {
     let filter = Row::pack(&[filter]);
-    let rows = rows
-        .into_iter()
-        .map(|row| Row::pack(row))
-        .collect::<Vec<_>>();
+    let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(
         || rows.clone(),
         |mut rows| rows.retain(|row| row.unpack()[0] == filter.unpack_first()),
@@ -106,7 +85,7 @@ fn bench_filter_packed(filter: Datum, rows: Vec<Vec<Datum>>, b: &mut Bencher) {
 }
 
 fn bench_pack_pack(rows: Vec<Vec<Datum>>, b: &mut Bencher) {
-    b.iter(|| rows.iter().map(|row| Row::pack(row)).collect::<Vec<_>>())
+    b.iter(|| rows.iter().map(Row::pack).collect::<Vec<_>>())
 }
 
 fn seeded_rng() -> rand_chacha::ChaChaRng {

--- a/src/repr/row.rs
+++ b/src/repr/row.rs
@@ -1100,7 +1100,7 @@ mod tests {
     #[test]
     fn test_dict_errors() -> Result<(), Box<dyn std::error::Error>> {
         let packer = RowPacker::new();
-        let packer = packer.try_push_dict_with(|packer| Ok(packer))?;
+        let packer = packer.try_push_dict_with(Ok)?;
         let _ = packer.finish();
 
         assert!(RowPacker::new()

--- a/src/repr/scalar/jsonb.rs
+++ b/src/repr/scalar/jsonb.rs
@@ -68,7 +68,7 @@ impl Jsonb {
                     }
                 }
                 Datum::String(s) => Value::String(s.to_owned()),
-                Datum::List(list) => Value::Array(list.iter().map(|e| inner(e)).collect()),
+                Datum::List(list) => Value::Array(list.iter().map(inner).collect()),
                 Datum::Dict(dict) => {
                     Value::Object(dict.iter().map(|(k, v)| (k.to_owned(), inner(v))).collect())
                 }

--- a/src/sql/expr.rs
+++ b/src/sql/expr.rs
@@ -666,7 +666,7 @@ impl RelationExpr {
 
     /// Constructs a constant collection from specific rows and schema.
     pub fn constant(rows: Vec<Vec<Datum>>, typ: RelationType) -> Self {
-        let rows = rows.into_iter().map(|row| Row::pack(row)).collect();
+        let rows = rows.into_iter().map(Row::pack).collect();
         RelationExpr::Constant { rows, typ }
     }
 }

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -357,7 +357,7 @@ fn push_column(
             row.push(string.as_deref().into());
         }
         DataType::SmallInt => {
-            let i = get_column_inner::<i16>(postgres_row, i, nullable)?.map(|i| i32::from(i));
+            let i = get_column_inner::<i16>(postgres_row, i, nullable)?.map(i32::from);
             row.push(i.into());
         }
         DataType::Int => {
@@ -370,7 +370,7 @@ fn push_column(
         }
         DataType::Float(p) => {
             if p.unwrap_or(53) <= 24 {
-                let f = get_column_inner::<f32>(postgres_row, i, nullable)?.map(|f| f64::from(f));
+                let f = get_column_inner::<f32>(postgres_row, i, nullable)?.map(f64::from);
                 row.push(f.into());
             } else {
                 let f = get_column_inner::<f64>(postgres_row, i, nullable)?;
@@ -378,7 +378,7 @@ fn push_column(
             }
         }
         DataType::Real => {
-            let f = get_column_inner::<f32>(postgres_row, i, nullable)?.map(|f| f64::from(f));
+            let f = get_column_inner::<f32>(postgres_row, i, nullable)?.map(f64::from);
             row.push(f.into());
         }
         DataType::Double => {


### PR DESCRIPTION
I'm told avoiding unnecessary closures means LLVM has less work to do,
which means compile times will be faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2681)
<!-- Reviewable:end -->
