### PR TITLE
Track Kinesis millis_behind_latest

### DIFF
--- a/demo/chbench/grafana/conf/dashboards/materialize.json
+++ b/demo/chbench/grafana/conf/dashboards/materialize.json
@@ -1360,12 +1360,100 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
+      "id": 47,
+      "legend": {
+        "avg": false,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mz_kinesis_shard_millis_behind_latest",
+          "legendFormat": "{{ stream_name }} {{ shard_id }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Time behind external source",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": null,
+          "logBase": 2,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "id": 30,
       "panels": [],
@@ -1383,7 +1471,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 68
       },
       "id": 24,
       "legend": {
@@ -1468,7 +1556,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 68
       },
       "id": 20,
       "legend": {
@@ -1560,7 +1648,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "id": 16,
       "legend": {
@@ -1646,7 +1734,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 76
       },
       "id": 35,
       "legend": {
@@ -1738,7 +1826,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -1795,7 +1883,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 84
       },
       "id": 18,
       "legend": {
@@ -1880,7 +1968,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 84
+        "y": 92
       },
       "id": 22,
       "legend": {

--- a/src/dataflow/decode/avro.rs
+++ b/src/dataflow/decode/avro.rs
@@ -9,10 +9,12 @@
 
 use log::error;
 
-use super::{DecoderState, PushSession, EVENTS_COUNTER};
+use super::{DecoderState, PushSession};
 use dataflow_types::{Diff, Timestamp};
 use interchange::avro::{Decoder, EnvelopeType};
 use repr::Row;
+
+use crate::metrics::EVENTS_COUNTER;
 
 pub struct AvroDecoderState {
     decoder: Decoder,

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -15,9 +15,10 @@ use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 
-use super::EVENTS_COUNTER;
 use dataflow_types::{Diff, Timestamp};
 use repr::{Datum, Row};
+
+use crate::metrics::EVENTS_COUNTER;
 
 pub fn csv<G>(
     stream: &Stream<G, (Vec<u8>, Option<i64>)>,

--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -7,11 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use lazy_static::lazy_static;
-
 use differential_dataflow::hashable::Hashable;
-use prometheus::{register_int_counter_vec, IntCounterVec};
-use prometheus_static_metric::make_static_metric;
 use timely::dataflow::{
     channels::pact::{Exchange, ParallelizationContract, Pipeline},
     channels::pushers::buffer::Session,
@@ -37,23 +33,6 @@ use interchange::avro::{extract_debezium_slow, extract_row, DiffPair};
 
 use log::error;
 use std::iter;
-
-make_static_metric! {
-    pub struct EventsRead: IntCounter {
-        "format" => { avro, csv, protobuf },
-        "status" => { success, error }
-    }
-}
-
-lazy_static! {
-    static ref EVENTS_COUNTER_INTERNAL: IntCounterVec = register_int_counter_vec!(
-        "mz_dataflow_events_read_total",
-        "Count of events we have read from the wire",
-        &["format", "status"]
-    )
-    .unwrap();
-    static ref EVENTS_COUNTER: EventsRead = EventsRead::from(&EVENTS_COUNTER_INTERNAL);
-}
 
 /// Take a Timely stream and convert it to a Differential stream, where each diff is "1"
 /// and each time is the current Timely timestamp.

--- a/src/dataflow/decode/protobuf.rs
+++ b/src/dataflow/decode/protobuf.rs
@@ -13,7 +13,8 @@ use dataflow_types::{Diff, Timestamp};
 use interchange::protobuf::{self, Decoder};
 use repr::Row;
 
-use super::{DecoderState, PushSession, EVENTS_COUNTER};
+use super::{DecoderState, PushSession};
+use crate::metrics::EVENTS_COUNTER;
 
 pub struct ProtobufDecoderState {
     decoder: Decoder,

--- a/src/dataflow/lib.rs
+++ b/src/dataflow/lib.rs
@@ -11,6 +11,7 @@
 
 mod arrangement;
 mod decode;
+mod metrics;
 mod operator;
 mod render;
 mod sink;

--- a/src/dataflow/metrics/mod.rs
+++ b/src/dataflow/metrics/mod.rs
@@ -14,7 +14,7 @@ use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {
     pub struct EventsRead: IntCounter {
-        "format" => { avro, bytes, csv, protobuf },
+        "format" => { avro, csv, protobuf, raw },
         "status" => { success, error }
     }
 }

--- a/src/dataflow/metrics/mod.rs
+++ b/src/dataflow/metrics/mod.rs
@@ -1,0 +1,30 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use lazy_static::lazy_static;
+
+use prometheus::{register_int_counter_vec, IntCounterVec};
+use prometheus_static_metric::make_static_metric;
+
+make_static_metric! {
+    pub struct EventsRead: IntCounter {
+        "format" => { avro, bytes, csv, protobuf },
+        "status" => { success, error }
+    }
+}
+
+lazy_static! {
+    static ref EVENTS_COUNTER_INTERNAL: IntCounterVec = register_int_counter_vec!(
+        "mz_dataflow_events_read_total",
+        "Count of events we have read from the wire",
+        &["format", "status"]
+    )
+    .unwrap();
+    pub static ref EVENTS_COUNTER: EventsRead = EventsRead::from(&EVENTS_COUNTER_INTERNAL);
+}

--- a/src/dataflow/source/kinesis.rs
+++ b/src/dataflow/source/kinesis.rs
@@ -173,7 +173,7 @@ where
                         events_success += 1;
                     }
                     downgrade_capability(cap, &name);
-                    EVENTS_COUNTER.bytes.success.inc_by(events_success);
+                    EVENTS_COUNTER.raw.success.inc_by(events_success);
                     BYTES_READ_COUNTER.inc_by(bytes_read);
 
                     if get_records_output.millis_behind_latest == Some(0)

--- a/src/dataflow/source/kinesis.rs
+++ b/src/dataflow/source/kinesis.rs
@@ -106,8 +106,9 @@ where
                         Ok(output) => {
                             shard_iterator = output.next_shard_iterator.clone();
                             if let Some(millis) = output.millis_behind_latest {
-                                let mut shard_metrics: IntGauge =
-                                    MILLIS_TRAILING_RAW.with_label_values(&[&shard_id]).set(millis);
+                                let shard_metrics: IntGauge =
+                                    MILLIS_BEHIND_LATEST.with_label_values(&[&shard_id]);
+                                shard_metrics.set(millis);
                             }
                             output
                         }

--- a/src/dataflow/source/kinesis.rs
+++ b/src/dataflow/source/kinesis.rs
@@ -36,7 +36,7 @@ lazy_static! {
     static ref MILLIS_BEHIND_LATEST: IntGaugeVec = register_int_gauge_vec!(
         "mz_kinesis_shard_millis_behind_latest",
         "How far the shard is behind the tip of the stream",
-        &["shard_id"]
+        &["stream_name", "shard_id"]
     )
     .expect("Can construct an intgauge for millis_behind_latest");
 }
@@ -106,8 +106,8 @@ where
                         Ok(output) => {
                             shard_iterator = output.next_shard_iterator.clone();
                             if let Some(millis) = output.millis_behind_latest {
-                                let shard_metrics: IntGauge =
-                                    MILLIS_BEHIND_LATEST.with_label_values(&[&shard_id]);
+                                let shard_metrics: IntGauge = MILLIS_BEHIND_LATEST
+                                    .with_label_values(&[&stream_name, &shard_id]);
                                 shard_metrics.set(millis);
                             }
                             output


### PR DESCRIPTION
Implements: https://github.com/MaterializeInc/materialize/issues/2616

### Background
Each time a Materialize Kinesis source reads from a Kinesis stream's shard, it's provided with an output payload that contains a `millis_behind_latest` field. This field indicates how far the shard is behind the tip of the stream, in milliseconds. 

### The Problem
We've just enhanced our Kinesis sources to be able to read from streams with multiple shards and streams that dynamically update their shards. Currently, we use a basic round-robin strategy to read from a new shard each time we activate the source. However, this is probably not the optimal way to read from a stream's shards: a stream may have "hot shards," etc. Additionally, the current implementation incurs a high network overhead on each activation. 

### The Solution
This PR aims to diagnose performance issues in Kinesis sources by pushing a map of `shard_id` -> `millis_behind_latest` to Grafana. That way, we can actively monitor this information to determine any performance bottlenecks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2688)
<!-- Reviewable:end -->
