### PR TITLE
mzcompose: Don't crash on bootstrap if no venv exists

### DIFF
--- a/misc/python/bin/activate.py
+++ b/misc/python/bin/activate.py
@@ -71,7 +71,7 @@ def activate_venv(py_dir: Path, dev: bool = False) -> Path:
     # have a working virtualenv. Instead we use the presence of the
     # `stamp_path`, as that indicates the virtualenv was once working enough to
     # have dependencies installed into it.
-    if subprocess.run([python, "-c", ""]).returncode != 0:
+    if not venv_dir.exists() or subprocess.run([python, "-c", ""]).returncode != 0:
         print("==> Initializing virtualenv in {}".format(venv_dir))
         venv.create(py_dir / "venv", with_pip=True, clear=True)
 


### PR DESCRIPTION
subprocess.run will throw an exception if the thing it's trying to run doesn't exist at
all, even if check=False.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2689)
<!-- Reviewable:end -->
