### PR TITLE
repr: remove unused pretty dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,16 +2261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1891757f8427ce41706957fde1fec1b86aee3e335bd50320257705061507a24c"
-dependencies = [
- "arrayvec",
- "typed-arena",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,7 +2588,6 @@ dependencies = [
  "hex",
  "ordered-float",
  "ore",
- "pretty",
  "rand",
  "rand_chacha",
  "regex",
@@ -3646,12 +3635,6 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
-
-[[package]]
-name = "typed-arena"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -18,7 +18,6 @@ failure = "0.1.7"
 hex = "0.4.2"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
-pretty = "0.9.0"
 regex = "1.3.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Usage of pretty was removed in the EXPLAIN PLAN redesign (0be6866e).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2710)
<!-- Reviewable:end -->
