### PR TITLE
mzbuild: restore fingerprinting of cargo inputs

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -180,7 +180,7 @@ class CargoBuild(PreImage):
                 ]
             )
 
-    def depends(self, root: Path, path: Path) -> List[bytes]:
+    def inputs(self, root: Path, path: Path) -> List[bytes]:
         # TODO(benesch): this should be much smarter about computing the Rust
         # files that actually contribute to this binary target.
         return super().inputs(root, path) + git_ls_files(
@@ -253,7 +253,7 @@ class CargoTest(PreImage):
         )
         shutil.copytree(root / "misc" / "shlib", path / "shlib")
 
-    def depends(self, root: Path, path: Path) -> List[bytes]:
+    def inputs(self, root: Path, path: Path) -> List[bytes]:
         # TODO(benesch): this should be much smarter about computing the Rust
         # files that actually contribute to this binary target.
         return super().inputs(root, path) + git_ls_files(


### PR DESCRIPTION
This was the result of a bad refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2713)
<!-- Reviewable:end -->
