### PR TITLE
Introduce AstDisplay

### DIFF
--- a/src/sql-parser/src/ast/data_type.rs
+++ b/src/sql-parser/src/ast/data_type.rs
@@ -18,7 +18,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
+use crate::ast::display::{AstDisplay, AstFormatter};
 
 /// SQL data types
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -77,55 +77,79 @@ pub enum DataType {
     Jsonb,
 }
 
-impl fmt::Display for DataType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl AstDisplay for DataType {
+    fn fmt(&self, f: &mut AstFormatter) {
         match self {
             DataType::Char(size) => format_type_with_optional_length(f, "char", size),
             DataType::Varchar(size) => {
                 format_type_with_optional_length(f, "character varying", size)
             }
-            DataType::Uuid => write!(f, "uuid"),
-            DataType::Clob(size) => write!(f, "clob({})", size),
-            DataType::Binary(size) => write!(f, "binary({})", size),
-            DataType::Varbinary(size) => write!(f, "varbinary({})", size),
-            DataType::Blob(size) => write!(f, "blob({})", size),
+            DataType::Uuid => f.write_str("uuid"),
+            DataType::Clob(size) => {
+                f.write_str("clob(");
+                f.write_str(size);
+                f.write_str(")");
+            }
+            DataType::Binary(size) => {
+                f.write_str("binary(");
+                f.write_str(size);
+                f.write_str(")");
+            }
+            DataType::Varbinary(size) => {
+                f.write_str("varbinary(");
+                f.write_str(size);
+                f.write_str(")");
+            }
+            DataType::Blob(size) => {
+                f.write_str("blob(");
+                f.write_str(size);
+                f.write_str(")");
+            }
             DataType::Decimal(precision, scale) => {
                 if let Some(scale) = scale {
-                    write!(f, "numeric({},{})", precision.unwrap(), scale)
+                    f.write_str("numeric(");
+                    f.write_str(precision.unwrap());
+                    f.write_str(",");
+                    f.write_str(scale);
+                    f.write_str(")");
                 } else {
                     format_type_with_optional_length(f, "numeric", precision)
                 }
             }
             DataType::Float(size) => format_type_with_optional_length(f, "float", size),
-            DataType::SmallInt => write!(f, "smallint"),
-            DataType::Int => write!(f, "int"),
-            DataType::BigInt => write!(f, "bigint"),
-            DataType::Real => write!(f, "real"),
-            DataType::Double => write!(f, "double"),
-            DataType::Boolean => write!(f, "boolean"),
-            DataType::Date => write!(f, "date"),
-            DataType::Time => write!(f, "time"),
-            DataType::TimeTz => write!(f, "time with time zone"),
-            DataType::Timestamp => write!(f, "timestamp"),
-            DataType::TimestampTz => write!(f, "timestamp with time zone"),
-            DataType::Interval => write!(f, "interval"),
-            DataType::Regclass => write!(f, "regclass"),
-            DataType::Text => write!(f, "text"),
-            DataType::Bytea => write!(f, "bytea"),
-            DataType::Array(ty) => write!(f, "{}[]", ty),
-            DataType::Jsonb => write!(f, "jsonb"),
+            DataType::SmallInt => f.write_str("smallint"),
+            DataType::Int => f.write_str("int"),
+            DataType::BigInt => f.write_str("bigint"),
+            DataType::Real => f.write_str("real"),
+            DataType::Double => f.write_str("double"),
+            DataType::Boolean => f.write_str("boolean"),
+            DataType::Date => f.write_str("date"),
+            DataType::Time => f.write_str("time"),
+            DataType::TimeTz => f.write_str("time with time zone"),
+            DataType::Timestamp => f.write_str("timestamp"),
+            DataType::TimestampTz => f.write_str("timestamp with time zone"),
+            DataType::Interval => f.write_str("interval"),
+            DataType::Regclass => f.write_str("regclass"),
+            DataType::Text => f.write_str("text"),
+            DataType::Bytea => f.write_str("bytea"),
+            DataType::Array(ty) => {
+                f.write_node(&ty);
+                f.write_str("[]")
+            }
+            DataType::Jsonb => f.write_str("jsonb"),
         }
     }
 }
 
 fn format_type_with_optional_length(
-    f: &mut fmt::Formatter,
+    f: &mut AstFormatter,
     sql_type: &'static str,
     len: &Option<u64>,
-) -> fmt::Result {
-    write!(f, "{}", sql_type)?;
+) {
+    f.write_str(sql_type);
     if let Some(len) = len {
-        write!(f, "({})", len)?;
+        f.write_str("(");
+        f.write_str(len);
+        f.write_str(")");
     }
-    Ok(())
 }

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 sqlparser-rs contributors. All rights reserved.
+// Copyright Materialize, Inc. All rights reserved.
+//
+// This file is derived from the sqlparser-rs project, available at
+// https://github.com/andygrove/sqlparser-rs. It was incorporated
+// directly into Materialize on December 21, 2019.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+#[derive(Debug)]
+pub struct AstFormatter {
+    // TODO(justin): add a "formatting mode" field when we have different contexts to print ASTs
+    // in.
+    buf: String,
+}
+
+impl AstFormatter {
+    pub fn write_node<T: AstDisplay>(&mut self, s: &T) {
+        s.fmt(self);
+    }
+
+    // TODO(justin): make this only accept a &str so that we don't accidentally pass an AstDisplay
+    // to it.
+    pub fn write_str<T: fmt::Display>(&mut self, s: T) {
+        self.buf.push_str(&s.to_string());
+    }
+}
+
+// AstDisplay is an alternative to fmt::Display to be used for formatting ASTs. It permits
+// configuration global to a printing of a given AST.
+pub trait AstDisplay {
+    fn fmt(&self, f: &mut AstFormatter);
+
+    fn to_ast_string(&self) -> String {
+        let mut f = AstFormatter { buf: String::new() };
+        self.fmt(&mut f);
+        f.buf
+    }
+}
+
+// Derive a fmt::Display implementation for types implementing AstDisplay.
+macro_rules! impl_display {
+    ($name:ident) => {
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str(self.to_ast_string().as_str())
+            }
+        }
+    };
+}
+
+impl<T: AstDisplay> AstDisplay for &Box<T> {
+    fn fmt(&self, f: &mut AstFormatter) {
+        (*self).fmt(f);
+    }
+}
+
+impl<T: AstDisplay> AstDisplay for Box<T> {
+    fn fmt(&self, f: &mut AstFormatter) {
+        (**self).fmt(f);
+    }
+}

--- a/src/sql-parser/src/ast/value.rs
+++ b/src/sql-parser/src/ast/value.rs
@@ -23,6 +23,7 @@ use std::fmt;
 use repr::datetime::DateTimeField;
 
 mod datetime;
+use crate::ast::display::{AstDisplay, AstFormatter};
 pub use datetime::{ExtractField, IntervalValue};
 
 #[derive(Debug)]
@@ -69,85 +70,123 @@ pub enum Value {
     Array(Vec<Value>),
 }
 
-impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl AstDisplay for Value {
+    fn fmt(&self, f: &mut AstFormatter) {
         match self {
-            Value::Number(v) => write!(f, "{}", v),
-            Value::SingleQuotedString(v) => write!(f, "'{}'", escape_single_quote_string(v)),
-            Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
-            Value::Boolean(v) => write!(f, "{}", v),
-            Value::Date(v) => write!(f, "DATE '{}'", escape_single_quote_string(v)),
-            Value::Time(v) => write!(f, "TIME '{}'", escape_single_quote_string(v)),
-            Value::Timestamp(v) => write!(f, "TIMESTAMP '{}'", escape_single_quote_string(v)),
-            Value::TimestampTz(v) => write!(
-                f,
-                "TIMESTAMP WITH TIME ZONE '{}'",
-                escape_single_quote_string(v)
-            ),
+            Value::Number(v) => f.write_str(v),
+            Value::SingleQuotedString(v) => {
+                f.write_str("'");
+                f.write_node(&escape_single_quote_string(v));
+                f.write_str("'");
+            }
+            Value::HexStringLiteral(v) => {
+                f.write_str("X'");
+                f.write_str(v);
+                f.write_str("'");
+            }
+            Value::Boolean(v) => f.write_str(v),
+            Value::Date(v) => {
+                f.write_str("DATE '");
+                f.write_node(&escape_single_quote_string(v));
+                f.write_str("'");
+            }
+            Value::Time(v) => {
+                f.write_str("TIME '");
+                f.write_node(&escape_single_quote_string(v));
+                f.write_str("'");
+            }
+            Value::Timestamp(v) => {
+                f.write_str("TIMESTAMP '");
+                f.write_node(&escape_single_quote_string(v));
+                f.write_str("'");
+            }
+            Value::TimestampTz(v) => {
+                f.write_str("TIMESTAMP WITH TIME ZONE '");
+                f.write_node(&escape_single_quote_string(v));
+                f.write_str("'");
+            }
             Value::Interval(IntervalValue {
                 value,
                 precision_high: _,
                 precision_low: _,
                 fsec_max_precision: Some(fsec_max_precision),
-            }) => write!(
-                f,
-                "INTERVAL '{}' SECOND ({})",
-                escape_single_quote_string(value),
-                fsec_max_precision
-            ),
+            }) => {
+                f.write_str("INTERVAL '");
+                f.write_node(&escape_single_quote_string(value));
+                f.write_str("' SECOND (");
+                f.write_str(fsec_max_precision);
+                f.write_str(")");
+            }
             Value::Interval(IntervalValue {
                 value,
                 precision_high,
                 precision_low,
                 fsec_max_precision,
             }) => {
-                write!(f, "INTERVAL '{}'", escape_single_quote_string(value),)?;
+                f.write_str("INTERVAL '");
+                f.write_node(&escape_single_quote_string(value));
+                f.write_str("'");
                 match (precision_high, precision_low, fsec_max_precision) {
                     (DateTimeField::Year, DateTimeField::Second, None) => {}
                     (DateTimeField::Year, DateTimeField::Second, Some(ns)) => {
-                        write!(f, " SECOND({})", ns)?;
+                        f.write_str(" SECOND(");
+                        f.write_str(ns);
+                        f.write_str(")");
                     }
                     (DateTimeField::Year, low, None) => {
-                        write!(f, " {}", low)?;
+                        f.write_str(" ");
+                        f.write_str(low);
                     }
                     (high, low, None) => {
-                        write!(f, " {} TO {}", high, low)?;
+                        f.write_str(" ");
+                        f.write_str(high);
+                        f.write_str(" TO ");
+                        f.write_str(low);
                     }
                     (high, low, Some(ns)) => {
-                        write!(f, " {} TO {}({})", high, low, ns)?;
+                        f.write_str(" ");
+                        f.write_str(high);
+                        f.write_str(" TO ");
+                        f.write_str(low);
+                        f.write_str("(");
+                        f.write_str(ns);
+                        f.write_str(")");
                     }
                 }
-                Ok(())
             }
-            Value::Null => write!(f, "NULL"),
+            Value::Null => f.write_str("NULL"),
             Value::Array(array) => {
                 let mut values = array.iter().peekable();
-                write!(f, "ARRAY[")?;
+                f.write_str("ARRAY[");
                 while let Some(value) = values.next() {
-                    write!(f, "{}", value)?;
+                    f.write_node(value);
                     if values.peek().is_some() {
-                        write!(f, ", ")?;
+                        f.write_str(", ");
                     }
                 }
-                write!(f, "]")?;
-                Ok(())
+                f.write_str("]");
             }
         }
     }
 }
+impl_display!(Value);
 
 pub struct EscapeSingleQuoteString<'a>(&'a str);
 
-impl<'a> fmt::Display for EscapeSingleQuoteString<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl<'a> AstDisplay for EscapeSingleQuoteString<'a> {
+    fn fmt(&self, f: &mut AstFormatter) {
         for c in self.0.chars() {
             if c == '\'' {
-                write!(f, "\'\'")?;
+                f.write_str("\'\'");
             } else {
-                write!(f, "{}", c)?;
+                f.write_str(c);
             }
         }
-        Ok(())
+    }
+}
+impl<'a> fmt::Display for EscapeSingleQuoteString<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.to_ast_string())
     }
 }
 

--- a/src/sql-parser/src/ast/value/datetime.rs
+++ b/src/sql-parser/src/ast/value/datetime.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use repr::datetime::DateTimeField;
 
 use super::ValueError;
+use crate::ast::display::{AstDisplay, AstFormatter};
 
 /// An intermediate value for Intervals, which tracks all data from
 /// the user, as well as the computed ParsedDateTime.
@@ -87,8 +88,8 @@ pub enum ExtractField {
     Epoch,
 }
 
-impl fmt::Display for ExtractField {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl AstDisplay for ExtractField {
+    fn fmt(&self, f: &mut AstFormatter) {
         match self {
             ExtractField::Millenium => f.write_str("MILLENIUM"),
             ExtractField::Century => f.write_str("CENTURY"),
@@ -115,6 +116,7 @@ impl fmt::Display for ExtractField {
         }
     }
 }
+impl_display!(ExtractField);
 
 use std::str::FromStr;
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -347,10 +347,7 @@ impl Parser {
             return parser_err!(
                 self,
                 all_range.start..distinct_range.end,
-                format!(
-                    "Cannot specify both ALL and DISTINCT in function: {}",
-                    name.to_string(),
-                )
+                format!("Cannot specify both ALL and DISTINCT in function: {}", name)
             );
         }
         let args = self.parse_optional_args()?;

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -403,10 +403,7 @@ fn plan_set_expr(qcx: &QueryContext, q: &SetExpr) -> Result<(RelationExpr, Scope
                 }
                 types = if let Some(types) = types {
                     if types.len() != value_exprs.len() {
-                        bail!(
-                            "VALUES expression has varying number of columns: {}",
-                            q.to_string()
-                        );
+                        bail!("VALUES expression has varying number of columns: {}", q);
                     }
                     Some(
                         types
@@ -3107,9 +3104,7 @@ fn sql_value_to_datum<'a>(l: &'a Value) -> Result<(Datum<'a>, ScalarType), failu
             }
         }
         Value::SingleQuotedString(s) => (Datum::String(s), ScalarType::String),
-        Value::HexStringLiteral(_) => {
-            bail!("x'' string literals are not supported: {}", l.to_string())
-        }
+        Value::HexStringLiteral(_) => bail!("x'' string literals are not supported: {}", l),
         Value::Boolean(b) => match b {
             false => (Datum::False, ScalarType::Bool),
             true => (Datum::True, ScalarType::Bool),
@@ -3131,7 +3126,7 @@ fn sql_value_to_datum<'a>(l: &'a Value) -> Result<(Datum<'a>, ScalarType), failu
             (Datum::Interval(i), ScalarType::Interval)
         }
         Value::Null => (Datum::Null, ScalarType::Unknown),
-        Value::Array(_) => bail!("ARRAY literals are not supported: {}", l.to_string()),
+        Value::Array(_) => bail!("ARRAY literals are not supported: {}", l),
     })
 }
 

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -66,28 +66,28 @@ impl Action for SqlAction {
             Statement::CreateSchema { name, .. } => {
                 self.try_drop(
                     &mut state.pgclient,
-                    &format!("DROP SCHEMA IF EXISTS {} CASCADE", name.to_string()),
+                    &format!("DROP SCHEMA IF EXISTS {} CASCADE", name),
                 )
                 .await
             }
             Statement::CreateSource { name, .. } => {
                 self.try_drop(
                     &mut state.pgclient,
-                    &format!("DROP SOURCE IF EXISTS {} CASCADE", name.to_string()),
+                    &format!("DROP SOURCE IF EXISTS {} CASCADE", name),
                 )
                 .await
             }
             Statement::CreateView { name, .. } => {
                 self.try_drop(
                     &mut state.pgclient,
-                    &format!("DROP VIEW IF EXISTS {} CASCADE", name.to_string()),
+                    &format!("DROP VIEW IF EXISTS {} CASCADE", name),
                 )
                 .await
             }
             Statement::CreateTable { name, .. } => {
                 self.try_drop(
                     &mut state.pgclient,
-                    &format!("DROP TABLE IF EXISTS {} CASCADE", name.to_string()),
+                    &format!("DROP TABLE IF EXISTS {} CASCADE", name),
                 )
                 .await
             }


### PR DESCRIPTION
This commit introduces a new trait for formatting ASTs that is distinct
from fmt::Display. The main difference is that it is orchestrated by a
Formatter we control, and can thus be configured to print the entire
tree in specific ways. It comes with the unfortunate ergonomic downside
of no longer being able to use the format!/write! macro. Suggestions for
how to improve the ergonomics here are welcome!

This is specifically to enable #2667, but I foresee being able to
configure the formatting of an AST to be useful in the future as we use
them for more things (in the past we used this kind of infrastructure
for things like forcing full-qualification of names).

This was a bit more complicated Rust-wise than some of my other changes so I probably did some wacky stuff 🙈 in particular it feels like I'm doing a lot of unnecessary copying, but I'm not sure if that matters or if there's an easy way to fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2714)
<!-- Reviewable:end -->
