### PR TITLE
testdrive: retry when waiting for errors, too

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -293,7 +293,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
             Command::FailSql(mut sql) => {
                 sql.query = subst(&sql.query)?;
                 sql.expected_error = subst(&sql.expected_error)?;
-                Box::new(sql::build_fail_sql(sql).map_err(wrap_err)?)
+                Box::new(sql::build_fail_sql(sql, sql_timeout).map_err(wrap_err)?)
             }
         };
         out.push(PosAction {

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -12,6 +12,7 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::os::unix::ffi::OsStringExt;
 use std::path::{self, PathBuf};
+use std::time::Duration;
 
 use async_trait::async_trait;
 
@@ -145,7 +146,7 @@ impl Action for VerifyAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path = retry::retry(|| async {
+        let path = retry::retry_for(Duration::from_secs(8), |_| async {
             let row = state
                 .pgclient
                 .query_one(

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -81,7 +81,7 @@ impl Action for AddPartitionsAction {
             return Err(e.to_string());
         }
 
-        retry::retry(|| async {
+        retry::retry_for(Duration::from_secs(8), |_| async {
             let metadata = state
                 .kafka_producer
                 .client()

--- a/src/testdrive/src/action/kafka/create_topic.rs
+++ b/src/testdrive/src/action/kafka/create_topic.rs
@@ -174,7 +174,7 @@ impl Action for CreateTopicAction {
         // get automatically created with multiple partitions. (Since
         // multiple partitions have no ordering guarantees, this violates
         // many assumptions that our tests make.)
-        retry::retry(|| async {
+        retry::retry_for(Duration::from_secs(8), |_| async {
             let metadata = state
                 .kafka_producer
                 .client()

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -44,7 +44,7 @@ impl Action for VerifyAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
-        let topic: String = retry::retry(|| async {
+        let topic: String = retry::retry_for(Duration::from_secs(8), |_| async {
             let row = state
                 .pgclient
                 .query_one(

--- a/src/testdrive/src/action/kinesis/ingest.rs
+++ b/src/testdrive/src/action/kinesis/ingest.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use rand::distributions::Alphanumeric;
@@ -62,7 +64,7 @@ impl Action for IngestAction {
 
             // The Kinesis stream might not be immediately available,
             // be prepared to back off.
-            retry::retry(|| async {
+            retry::retry_for(Duration::from_secs(8), |_| async {
                 match state.kinesis_client.put_record(put_input.clone()).await {
                     Ok(_output) => Ok(()),
                     Err(RusotoError::Service(PutRecordError::ResourceNotFound(err))) => {

--- a/src/testdrive/src/action/kinesis/update_shards.rs
+++ b/src/testdrive/src/action/kinesis/update_shards.rs
@@ -57,7 +57,7 @@ impl Action for UpdateShardCountAction {
             .map_err(|e| format!("adding shards to stream {}: {}", &stream_name, e))?;
 
         // Verify the current shard count.
-        retry::retry_max_backoff(Duration::from_secs(30), || async {
+        retry::retry_for(Duration::from_secs(60), |_| async {
             // Wait for shards to stop updating.
             let description = state
                 .kinesis_client

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -8,15 +8,14 @@
 // by the Apache License, Version 2.0.
 
 use std::ascii;
-use std::cmp;
-use std::error::Error as _;
+use std::error::Error;
 use std::fmt::Write as _;
 use std::io::{self, Write};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use md5::{Digest, Md5};
 use serde_json::Value;
-use tokio::time::{self, Duration};
 use tokio_postgres::error::DbError;
 use tokio_postgres::row::Row;
 use tokio_postgres::types::{Json, Type};
@@ -28,6 +27,7 @@ use sql_parser::parser::Parser as SqlParser;
 
 use crate::action::{Action, State};
 use crate::parser::{FailSqlCommand, SqlCommand, SqlExpectedResult};
+use crate::util::retry;
 
 pub struct SqlAction {
     cmd: SqlCommand,
@@ -98,37 +98,32 @@ impl Action for SqlAction {
     async fn redo(&self, state: &mut State) -> Result<(), String> {
         let query = &self.cmd.query;
         print_query(&query);
-        let mut total_backoff = Duration::from_millis(0);
-        let mut backoff = cmp::min(Duration::from_millis(100), self.timeout);
-        loop {
-            match self.try_redo(&mut state.pgclient, &query).await {
+
+        let pgclient = &state.pgclient;
+        retry::retry_for(self.timeout, |retry_state| async move {
+            match self.try_redo(pgclient, &query).await {
                 Ok(()) => {
-                    if total_backoff > Duration::from_millis(0) {
+                    if retry_state.i != 0 {
                         println!();
                     }
                     println!("rows match; continuing");
-                    break;
+                    Ok(())
                 }
-                Err(err) => {
-                    if total_backoff == Duration::from_millis(0) {
-                        print!(
-                            "rows didn't match; sleeping to see if dataflow catches up {:?}",
-                            backoff
-                        );
-                        io::stdout().flush().unwrap();
-                    } else if total_backoff < self.timeout {
-                        backoff = cmp::min(backoff * 2, self.timeout - total_backoff);
+                Err(e) => {
+                    if retry_state.i == 0 {
+                        print!("rows didn't match; sleeping to see if dataflow catches up");
+                    }
+                    if let Some(backoff) = retry_state.next_backoff {
                         print!(" {:?}", backoff);
                         io::stdout().flush().unwrap();
                     } else {
                         println!();
-                        return Err(err);
                     }
+                    Err(e)
                 }
             }
-            time::delay_for(backoff).await;
-            total_backoff += backoff;
-        }
+        })
+        .await?;
 
         if let Some(data_dir) = &state.data_dir {
             match self.stmt {
@@ -180,11 +175,7 @@ impl SqlAction {
         }
     }
 
-    async fn try_redo(
-        &self,
-        pgclient: &mut tokio_postgres::Client,
-        query: &str,
-    ) -> Result<(), String> {
+    async fn try_redo(&self, pgclient: &tokio_postgres::Client, query: &str) -> Result<(), String> {
         let mut actual: Vec<_> = pgclient
             .query(query, &[])
             .await

--- a/src/testdrive/src/util/kinesis.rs
+++ b/src/testdrive/src/util/kinesis.rs
@@ -21,7 +21,7 @@ pub async fn wait_for_stream_shards(
     stream_name: String,
     target_shard_count: i64,
 ) -> Result<(), String> {
-    retry::retry_max_backoff(Duration::from_secs(30), || async {
+    retry::retry_for(Duration::from_secs(60), |_| async {
         let description = kinesis_client
             .describe_stream(DescribeStreamInput {
                 exclusive_start_shard_id: None,


### PR DESCRIPTION
Now that we have runtime errors, we potentially need to wait for a query
to enter an error state (e.g., for a bad datum to arrive from Kafka and
propagate through the dataflow). This should fix up some CI flakiness
we've been seeing lately.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2715)
<!-- Reviewable:end -->
