### PR TITLE
shlib: fix mapfile_shim on Bash 3

### DIFF
--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -121,11 +121,12 @@ await_postgres() {
 # the variable MAPFILE is used instead. Other options of `mapfile` are not
 # supported.
 mapfile_shim() {
-    local -n var=${1:-MAPFILE}
-    var=()
+    local val
+    val=()
     while IFS= read -r line; do
-        var+=("$line")
+        val+=("$line")
     done
+    declare -ag "${1:-MAPFILE}=($(printf "%q " "${val[@]}"))"
 }
 
 ########################################


### PR DESCRIPTION
This function, meant to shim a feature missing in Bash 4 for Bash 3, was
somehow still relying on features in Bash 4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2717)
<!-- Reviewable:end -->
