### PR TITLE
coord: retry catalog op if SQLite database is locked

### DIFF
--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -33,7 +33,7 @@ regex = "1.3.4"
 rusoto_core = "0.43.0"
 rusoto_credential = "0.43.0"
 rusoto_kinesis = "0.43.0"
-rusqlite = { version = "0.20", features = ["bundled"] }
+rusqlite = { version = "0.20", features = ["bundled", "unlock_notify"] }
 serde = "1"
 serde_json = "1.0.41"
 sql = { path = "../sql" }


### PR DESCRIPTION
Database operations sometimes fail with a "database is locked" error in
CI due to the way testdrive validates the on-disk catalog state with its
own SQLite connection.

This commit enables rusqlite's unlock_notify feature, which
automatically retries SQLite operations that would return a "database is
locked" error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2718)
<!-- Reviewable:end -->
