### PR TITLE
Fixing issues with multi-partition Kafka streams

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -682,16 +682,19 @@ where
                 let mut timestamps = self.ts_histories.borrow_mut();
                 if let Some(entries) = timestamps.get_mut(&id) {
                     let ts = entries.entry(pid).or_insert_with(Vec::new);
-                    // TODO (brennan) - I'm not sure if this can fail, but
-                    // keep it commented out for now until #2735 is fixed and we're sure there
-                    // is no weirdness going on with offsets.
-                    //
-                    // assert!(
-                    //     offset >= last_offset,
-                    //     "offset should not go backwards, but {} < {}",
-                    //     offset,
-                    //     last_offset
-                    // );
+                    let (_, last_ts, last_offset) = ts.last().unwrap_or(&(0, 0, 0));
+                    assert!(
+                        offset >= *last_offset,
+                        "offset should not go backwards, but {} < {}",
+                        offset,
+                        last_offset
+                    );
+                    assert!(
+                        timestamp > *last_ts,
+                        "timestamp should move forwards, but {} <= {}",
+                        timestamp,
+                        last_ts
+                    );
                     ts.push((partition_count, timestamp, offset));
                     let source = self
                         .ts_source_mapping

--- a/src/dataflow/source/file.rs
+++ b/src/dataflow/source/file.rs
@@ -371,10 +371,11 @@ where
                             activator.activate();
                             return SourceStatus::Alive;
                         }
-                        Some(_) => {
+                        Some(ts) => {
                             last_processed_offset = current_msg_offset;
+                            let ts_cap = cap.delayed(&ts);
                             output
-                                .session(&cap)
+                                .session(&ts_cap)
                                 .give((message, Some(last_processed_offset)));
 
                             downgrade_capability(

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -306,13 +306,14 @@ where
                             activator.activate();
                             return SourceStatus::Alive;
                         }
-                        Some(_) => {
+                        Some(ts) => {
                             let key = message.key.unwrap_or_default();
                             let out = message.payload.unwrap_or_default();
                             partition_metadata[partition as usize].0 = offset;
                             bytes_read += key.len() as i64;
                             bytes_read += out.len() as i64;
-                            output.session(&cap).give((key, (out, Some(offset - 1))));
+                            let ts_cap = cap.delayed(&ts);
+                            output.session(&ts_cap).give((key, (out, Some(offset - 1))));
 
                             KAFKA_PARTITION_OFFSET_INGESTED
                                 .with_label_values(&[
@@ -465,6 +466,11 @@ fn downgrade_capability(
                     "Internal error! Timestamping offset went below start: {} < {}. Materialize will now crash.",
                     offset, start_offset
                 );
+
+                assert!(
+                    *ts > 0,
+                    "Internal error! Received a zero-timestamp. Materialize will crash now."
+                );
                 if *partition_count as usize > partition_metadata.len() {
                     // A new partition has been added, we need to update the appropriate
                     // entries before we continue.
@@ -474,6 +480,11 @@ fn downgrade_capability(
                     );
                     needs_md_refresh = true;
                 }
+                // This assertion makes sure that if we ever fast-forwarded the empty stream
+                // (any message of the form "PID,TS,0"), we have correctly removed the (_,_,0) entry
+                // even if data has subsequently been added to the stream
+                assert!(*offset != 0 || last_offset == 0);
+
                 if last_offset == *offset {
                     // We have now seen all messages corresponding to this timestamp for this
                     // partition. We

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=1minute
 
 $ set keyschema={
     "type": "record",

--- a/test/testdrive/timestamps-file.td
+++ b/test/testdrive/timestamps-file.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=1minute
+
 $ file-append path=data-consistency.csv
 dummy,1,0,0,0
 

--- a/test/testdrive/timestamps-kafka-avro-multi-tmp.td
+++ b/test/testdrive/timestamps-kafka-avro-multi-tmp.td
@@ -239,7 +239,9 @@ $ kafka-ingest partition=3 format=avro topic=data schema=${schema} timestamp=1
 {"a": 1, "b": 11}
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 7, "offset": 1}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 1, "timestamp": 6, "offset": 7}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 0, "timestamp": 6, "offset": 4}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 2, "timestamp": 6, "offset": 2}
 
 > SELECT * FROM view_byo
 b  sum
@@ -252,9 +254,25 @@ b  sum
 7  1
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 7, "offset": 7}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 7, "offset": 4}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4, "partition_id": 2, "timestamp": 7, "offset": 2}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 7, "offset": 1}
+
+> SELECT * FROM view_byo
+b  sum
+------
+1  6
+2  1
+3  3
+5  1
+6  1
+7  1
+8  1
+9  1
+10 1
+
+$ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 1, "timestamp": 7, "offset": 7}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 0, "timestamp": 7, "offset": 4}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 2, "timestamp": 7, "offset": 2}
 
 > SELECT * FROM view_byo
 b  sum

--- a/test/testdrive/timestamps-ocf.td
+++ b/test/testdrive/timestamps-ocf.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-sql-timeout duration=1minute
+
 $ set consistency={
      "name": "materialize.byo.consistency",
      "type": "record",


### PR DESCRIPTION
This PR fixes

1) a liveness issue in RT consistency in the presence of multiple partitions (#2735)
2) a liveness issue in BYO consistency (causing us to downgrade the capability only after 60 seconds)
3) a safety issue in BYO consistency (causing us to show a message at a timestamp that was not yet closed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2743)
<!-- Reviewable:end -->
