### PR TITLE
testdrive: bump SQL timeout

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -38,7 +38,7 @@ mod kafka;
 mod kinesis;
 mod sql;
 
-const DEFAULT_SQL_TIMEOUT: Duration = Duration::from_millis(12700);
+const DEFAULT_SQL_TIMEOUT: Duration = Duration::from_millis(15875);
 
 /// User-settable configuration parameters.
 #[derive(Debug)]


### PR DESCRIPTION
Increase the default SQL timeout by a few seconds, to see if that makes
testdrive less flaky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2751)
<!-- Reviewable:end -->
