### PR TITLE
ci/test: use bin/xcompile to invoke cargo deb

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -64,7 +64,7 @@ def stage_deb(repo: mzbuild.Repository, package: str, version: str) -> None:
     deb_path = repo.rd.xcargo_target_dir() / "debian" / "materialized.deb"
     spawn.runv(
         [
-            "cargo",
+            repo.rd.xcargo(),
             "deb",
             "--no-build",
             "--no-strip",


### PR DESCRIPTION
This ensures that it looks in target/x86_64-unknown-linux-gnu/release
for the binary instead of in target/release directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2760)
<!-- Reviewable:end -->
