### PR TITLE
testdrive: disable automatic topic creation

### DIFF
--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -57,6 +57,8 @@ $ set consistency={
 
 $ kafka-create-topic topic=avroavro
 
+$ kafka-create-topic topic=data-consistency
+
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
 {"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 1}
 {"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 2, "offset": 2}
@@ -218,6 +220,8 @@ fish             fish             0
 b\xc3\xadrdmore  g\xc3\xa9ese     5
 mammal1          mouse            8
 mammalmore       herd             9
+
+$ kafka-create-topic topic=nullkey
 
 # A null key should result in an error decoding that row but not a panic
 $ kafka-ingest format=bytes topic=nullkey key-format=bytes key-terminator=: publish=true

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -49,6 +49,7 @@ services:
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
     - KAFKA_ADVERTISED_HOST_NAME=kafka
+    - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
   schema-registry:
     image: confluentinc/cp-schema-registry:5.2.1
     environment:

--- a/test/testdrive/timestamps-kafka-avro.td
+++ b/test/testdrive/timestamps-kafka-avro.td
@@ -43,6 +43,8 @@ $ set schema={
     ]
   }
 
+$ kafka-create-topic topic=data-consistency
+
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
 {"source": "dummy", "partition_count": 1, "partition_id": 0, "timestamp": 0, "offset": 0}
 


### PR DESCRIPTION
Testdrive and Materialize often race to create the same topic. We want
testdrive to win, as it issues actual create topic requests with
specific partition counts, while Materialize is accidentally creating
the topic via Kafka's auto-topic creation feature. Auto-topic creation
is usually disabled in production, so it's actually more realistic to
test with it off, anyway.

This is a likely cause of one the flakes described in #2753.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2761)
<!-- Reviewable:end -->
