### PR TITLE
Support TAIL ... AS OF ...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
+ "timely",
  "url",
  "uuid",
 ]

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -652,7 +652,11 @@ where
                 session,
             ),
 
-            Plan::Tail(id) => tx.send(self.sequence_tail(conn_id, id), session),
+            Plan::Tail {
+                id,
+                ts,
+                with_snapshot,
+            } => tx.send(self.sequence_tail(conn_id, id, with_snapshot, ts), session),
 
             Plan::SendRows(rows) => tx.send(Ok(send_immediate_rows(rows)), session),
 
@@ -1165,7 +1169,7 @@ where
                 };
                 let index_name = format!("temp-index-on-{}", view_id);
                 let mut dataflow = DataflowDesc::new(view_name.to_string());
-                dataflow.as_of(Some(vec![timestamp.clone()]));
+                dataflow.as_of(Antichain::from_elem(timestamp));
                 let view = catalog::View {
                     create_sql: "<none>".into(),
                     plan_cx: PlanContext::default(),
@@ -1228,21 +1232,31 @@ where
         &mut self,
         conn_id: u32,
         source_id: GlobalId,
+        with_snapshot: bool,
+        ts: Option<Timestamp>,
     ) -> Result<ExecuteResponse, failure::Error> {
         // Determine the frontier of updates to tail *from*.
         // Updates greater or equal to this frontier will be produced.
-        let since = if let Some(Some((index_id, _))) = self
+        let frontier = if let Some(ts) = ts {
+            // If a timestamp was explicitly requested, use that.
+            Antichain::from_elem(self.determine_timestamp(
+                &RelationExpr::Get {
+                    id: Id::Global(source_id),
+                    // TODO(justin): find a way to avoid synthesizing an arbitrary relation type.
+                    typ: RelationType::empty(),
+                },
+                PeekWhen::AtTimestamp(ts),
+            )?)
+        } else if let Some(Some((index_id, _))) = self
             .views
             .get(&source_id)
             .map(|view_state| &view_state.default_idx)
         {
             self.upper_of(index_id)
                 .expect("name missing at coordinator")
-                .get(0)
-                .copied()
-                .unwrap_or(Timestamp::max_value())
+                .to_owned()
         } else {
-            0 as Timestamp
+            Antichain::from_elem(0)
         };
 
         let sink_name = format!(
@@ -1254,11 +1268,17 @@ where
         let sink_id = self.catalog.allocate_id()?;
         self.active_tails.insert(conn_id, sink_id);
         let (tx, rx) = self.switchboard.mpsc_limited(self.num_timely_workers);
+
         self.create_sink_dataflow(
             sink_name,
             sink_id,
             source_id,
-            SinkConnector::Tail(TailSinkConnector { tx, since }),
+            SinkConnector::Tail(TailSinkConnector {
+                tx,
+                frontier: frontier.clone(),
+                strict: !with_snapshot,
+            }),
+            frontier,
         );
         Ok(ExecuteResponse::Tailing { rx })
     }
@@ -1651,7 +1671,14 @@ where
             .expect("replacing a sink cannot fail");
 
         // Create the sink dataflow.
-        self.create_sink_dataflow(name.to_string(), id, sink.from, connector)
+        // TODO(justin): this should be picking a more reasonable frontier, see #2803.
+        self.create_sink_dataflow(
+            name.to_string(),
+            id,
+            sink.from,
+            connector,
+            Antichain::from_elem(0),
+        )
     }
 
     fn create_sink_dataflow(
@@ -1660,6 +1687,7 @@ where
         id: GlobalId,
         from: GlobalId,
         connector: SinkConnector,
+        as_of: Antichain<Timestamp>,
     ) {
         #[allow(clippy::single_match)]
         match &connector {
@@ -1686,6 +1714,7 @@ where
             _ => (),
         }
         let mut dataflow = DataflowDesc::new(name);
+        dataflow.as_of(as_of);
         self.import_source_or_view(&id, &from, &mut dataflow);
         let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
         dataflow.add_sink_export(id, from, from_type, connector);
@@ -1884,15 +1913,19 @@ where
         let mut uses_ids = Vec::new();
         source.global_uses(&mut uses_ids);
 
+        let need_to_determine = when == PeekWhen::Immediately;
+
         uses_ids.sort();
         uses_ids.dedup();
-        if uses_ids.iter().any(|id| {
-            if let Some(view_state) = self.views.get(id) {
-                !view_state.queryable
-            } else {
-                true
-            }
-        }) {
+        if need_to_determine
+            && uses_ids.iter().any(|id| {
+                if let Some(view_state) = self.views.get(id) {
+                    !view_state.queryable
+                } else {
+                    true
+                }
+            })
+        {
             bail!("Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources");
         }
         uses_ids = uses_ids
@@ -1958,10 +1991,7 @@ where
         if since.less_equal(&timestamp) {
             Ok(timestamp)
         } else {
-            bail!(
-                "Latest available timestamp ({}) is not valid for all inputs",
-                timestamp
-            );
+            bail!("Timestamp ({}) is not valid for all inputs", timestamp);
         }
     }
 

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -18,6 +18,7 @@ repr = { path = "../repr" }
 rusoto_core = "0.43.0-beta.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_regex = "0.4.0"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 url = { version = "2.1.1", features = ["serde"] }
 uuid = { version = "0.8", features = ["serde", "v4"] }
 

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -1050,6 +1050,8 @@ pub enum Statement {
     /// `TAIL`
     Tail {
         name: ObjectName,
+        with_snapshot: bool,
+        as_of: Option<Expr>,
     },
     /// `EXPLAIN [ DATAFLOW | PLAN ] FOR`
     Explain {
@@ -1473,9 +1475,20 @@ impl AstDisplay for Statement {
                     f.write_str(" AND CHAIN");
                 }
             }
-            Statement::Tail { name } => {
+            Statement::Tail {
+                name,
+                with_snapshot,
+                as_of,
+            } => {
                 f.write_str("TAIL ");
                 f.write_node(&name);
+                if *with_snapshot {
+                    f.write_str(" WITH SNAPSHOT");
+                }
+                if let Some(as_of) = as_of {
+                    f.write_str(" AS OF ");
+                    f.write_node(as_of);
+                }
             }
             Statement::Explain {
                 stage,

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -409,6 +409,7 @@ define_keywords!(
     SINK,
     SINKS,
     SMALLINT,
+    SNAPSHOT,
     SOME,
     SOURCE,
     SOURCES,

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -3821,8 +3821,50 @@ fn parse_drop_index() {
 fn parse_tail() {
     let sql = "TAIL foo.bar";
     match verified_stmt(sql) {
-        Statement::Tail { name } => {
+        Statement::Tail { name, .. } => {
             assert_eq!("foo.bar", name.to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "TAIL foo.bar AS OF 123";
+    match verified_stmt(sql) {
+        Statement::Tail {
+            name,
+            with_snapshot,
+            as_of,
+        } => {
+            assert_eq!("foo.bar", name.to_string());
+            assert_eq!(false, with_snapshot);
+            assert_eq!("123", as_of.unwrap().to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "TAIL foo.bar AS OF now()";
+    match verified_stmt(sql) {
+        Statement::Tail {
+            name,
+            with_snapshot,
+            as_of,
+        } => {
+            assert_eq!("foo.bar", name.to_string());
+            assert_eq!(false, with_snapshot);
+            assert_eq!("now()", as_of.unwrap().to_string());
+        }
+        _ => unreachable!(),
+    }
+
+    let sql = "TAIL foo.bar WITH SNAPSHOT AS OF now()";
+    match verified_stmt(sql) {
+        Statement::Tail {
+            name,
+            with_snapshot,
+            as_of,
+        } => {
+            assert_eq!("foo.bar", name.to_string());
+            assert_eq!(true, with_snapshot);
+            assert_eq!("now()", as_of.unwrap().to_string());
         }
         _ => unreachable!(),
     }

--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -14,7 +14,7 @@
 use ::expr::{GlobalId, RowSetFinishing};
 use catalog::names::{DatabaseSpecifier, FullName};
 use catalog::{Catalog, PlanContext};
-use dataflow_types::{PeekWhen, SinkConnectorBuilder, SourceConnector};
+use dataflow_types::{PeekWhen, SinkConnectorBuilder, SourceConnector, Timestamp};
 use repr::{RelationDesc, Row, ScalarType};
 use sql_parser::parser::Parser as SqlParser;
 
@@ -106,7 +106,11 @@ pub enum Plan {
         finishing: RowSetFinishing,
         materialize: bool,
     },
-    Tail(GlobalId),
+    Tail {
+        id: GlobalId,
+        with_snapshot: bool,
+        ts: Option<Timestamp>,
+    },
     SendRows(Vec<Row>),
     ExplainPlan {
         sql: String,

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -39,8 +39,11 @@ use uuid::Uuid;
 
 use ::expr::{DateTruncTo, Id, RowSetFinishing};
 use catalog::names::PartialName;
+use dataflow_types::Timestamp;
 use repr::decimal::{Decimal, MAX_DECIMAL_PRECISION};
-use repr::{strconv, ColumnName, ColumnType, Datum, RelationDesc, RelationType, ScalarType};
+use repr::{
+    strconv, ColumnName, ColumnType, Datum, RelationDesc, RelationType, RowArena, ScalarType,
+};
 
 use super::expr::{
     AggregateExpr, AggregateFunc, BinaryFunc, ColumnOrder, ColumnRef, JoinKind, NullaryFunc,
@@ -150,6 +153,41 @@ pub fn plan_show_where(
             project: (0..num_cols).collect(),
         },
     ))
+}
+
+/// Evaluates an expression in the AS OF position of a TAIL statement.
+pub fn eval_as_of<'a>(scx: &'a StatementContext, expr: Expr) -> Result<Timestamp, failure::Error> {
+    let scope = Scope::from_source(
+        None,
+        iter::empty::<Option<ColumnName>>(),
+        Some(Scope::empty(None)),
+    );
+    let desc = RelationDesc::empty();
+    let qcx = &QueryContext::root(scx, QueryLifetime::OneShot);
+    let ecx = &ExprContext {
+        qcx: &qcx,
+        name: "AS OF",
+        scope: &scope,
+        relation_type: &desc.typ(),
+        allow_aggregates: false,
+        allow_subqueries: false,
+    };
+
+    let ex = plan_expr(ecx, &expr, None)?.lower_uncorrelated();
+    let temp_storage = &RowArena::new();
+    let evaled = ex.eval(&[], temp_storage)?;
+
+    Ok(match ex.typ(desc.typ()).scalar_type {
+        ScalarType::Decimal(_, 0) => evaled.unwrap_decimal().as_i128().try_into()?,
+        ScalarType::Decimal(_, _) => {
+            bail!("decimal with fractional component is not a valid timestamp")
+        }
+        ScalarType::Int32 => evaled.unwrap_int32().try_into()?,
+        ScalarType::Int64 => evaled.unwrap_int64().try_into()?,
+        ScalarType::TimestampTz => evaled.unwrap_timestamptz().timestamp().try_into()?,
+        ScalarType::Timestamp => evaled.unwrap_timestamp().timestamp().try_into()?,
+        _ => bail!("can't use {} as a timestamp for AS OF", ex.typ(desc.typ())),
+    })
 }
 
 pub fn plan_index_exprs<'a>(


### PR DESCRIPTION
Closes #2721.

This commit permits the inclusion of an AS OF argument to TAIL, which
causes TAIL to emit updates from that timestamp onwards.

Not sure how to test this more extensively, tips appreciated if you've got em!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2762)
<!-- Reviewable:end -->
