### PR TITLE
Fixing testdrive failure on file sources

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -682,20 +682,6 @@ where
                 let mut timestamps = self.ts_histories.borrow_mut();
                 if let Some(entries) = timestamps.get_mut(&id) {
                     let ts = entries.entry(pid).or_insert_with(Vec::new);
-                    let last_offset = if let Some(offs) = ts.last() {
-                        // timestamp.rs takes care to ensure that the timestamp value is
-                        // strictly increasing -- see `rt_generate_next_timestamp`.
-                        let last_timestamp = offs.1;
-                        assert!(
-                            timestamp > last_timestamp,
-                            "timestamp should advance, but {} <= {}",
-                            timestamp,
-                            last_timestamp
-                        );
-                        offs.2
-                    } else {
-                        0
-                    };
                     // TODO (brennan) - I'm not sure if this can fail, but
                     // keep it commented out for now until #2735 is fixed and we're sure there
                     // is no weirdness going on with offsets.
@@ -707,17 +693,15 @@ where
                     //     last_offset
                     // );
                     ts.push((partition_count, timestamp, offset));
-                    if last_offset == offset {
-                        // We only activate the source if the offset is the same as the last
-                        // offset as new data already triggers the source's activation
-                        let source = self
-                            .ts_source_mapping
-                            .get(&id)
-                            .expect("Id should be present");
-                        if let Some(source) = source.upgrade() {
-                            if let Some(token) = &*source {
-                                token.activate();
-                            }
+                    // We only activate the source if the offset is the same as the last
+                    // offset as new data already triggers the source's activation
+                    let source = self
+                        .ts_source_mapping
+                        .get(&id)
+                        .expect("Id should be present");
+                    if let Some(source) = source.upgrade() {
+                        if let Some(token) = &*source {
+                            token.activate();
                         }
                     }
                 }

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -693,8 +693,6 @@ where
                     //     last_offset
                     // );
                     ts.push((partition_count, timestamp, offset));
-                    // We only activate the source if the offset is the same as the last
-                    // offset as new data already triggers the source's activation
                     let source = self
                         .ts_source_mapping
                         .get(&id)

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -73,6 +73,12 @@ fn run() -> Result<(), failure::Error> {
     );
     opts.optopt(
         "",
+        "persist-ts",
+        "persists consistency information locally and recovers from local store",
+        "true/false",
+    );
+    opts.optopt(
+        "",
         "logical-compaction-window",
         "historical detail maintained for arrangements (default 60s)",
         "DURATION/\"off\"",
@@ -146,6 +152,7 @@ fn run() -> Result<(), failure::Error> {
 
     let log_file = popts.opt_str("log-file");
     let max_increment_ts_size = popts.opt_get_default("batch-size", 10000_i64)?;
+    let persist_ts = popts.opt_get_default("persist-ts", false)?;
 
     let threads = match popts.opt_get::<usize>("threads")? {
         Some(val) => val,
@@ -236,6 +243,7 @@ fn run() -> Result<(), failure::Error> {
         logging_granularity,
         timestamp_frequency,
         max_increment_ts_size,
+        persist_ts,
         logical_compaction_window,
         threads,
         process,

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -89,6 +89,9 @@ pub struct Config {
     pub timestamp_frequency: Duration,
     /// The maximum size of a timestamp batch.
     pub max_increment_ts_size: i64,
+    /// If set to true, records RT consistency information to the SQL lite store
+    /// and attempts to recover that information on startup
+    pub persist_ts: bool,
     /// The historical window in which distinctions are maintained for arrangements.
     ///
     /// As arrangements accept new timestamps they may optionally collapse prior
@@ -285,6 +288,7 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
             timestamp: coord::TimestampConfig {
                 frequency: config.timestamp_frequency,
                 max_size: config.max_increment_ts_size,
+                persist_ts: config.persist_ts,
             },
             logical_compaction_window: config.logical_compaction_window,
             executor: &executor,

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -45,6 +45,7 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
         timestamp_frequency: Duration::from_millis(10),
         logical_compaction_window: None,
         max_increment_ts_size: 1000,
+        persist_ts: false,
         threads: 1,
         process: 0,
         addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -407,6 +407,7 @@ impl State {
             timestamp: TimestampConfig {
                 frequency: Duration::from_millis(10),
                 max_size: 10000,
+                persist_ts: false,
             },
             logical_compaction_window: None,
         })?;

--- a/test/testdrive/timestamps-file.td
+++ b/test/testdrive/timestamps-file.td
@@ -35,18 +35,17 @@ a,b
 
 > CREATE MATERIALIZED VIEW view_byo2 AS SELECT * FROM data_byo2
 
-> CREATE MATERIALIZED SOURCE data_byo3 FROM FILE '${testdrive.temp-dir}/data2.csv'
-    WITH (consistency = '${testdrive.temp-dir}/data-consistency.csv')
-    FORMAT CSV WITH HEADER
-
-
 ! SELECT * FROM view_byo;
 At least one input has no complete timestamps yet.
 
 $ file-append path=data-consistency.csv
- ${testdrive.temp-dir}/data.csv,1,0,1,2
- ${testdrive.temp-dir}/data2.csv,1,0,1,2
- ${testdrive.temp-dir}/data2.csv,1,0,2,5
+\${testdrive.temp-dir}/data.csv,1,0,1,2
+\${testdrive.temp-dir}/data2.csv,1,0,1,2
+\${testdrive.temp-dir}/data2.csv,1,0,2,5
+
+> CREATE MATERIALIZED SOURCE data_byo3 FROM FILE '${testdrive.temp-dir}/data2.csv'
+    WITH (consistency = '${testdrive.temp-dir}/data-consistency.csv')
+    FORMAT CSV WITH HEADER
 
 > SELECT * FROM view_byo
 a   b   mz_line_no
@@ -79,7 +78,7 @@ a   b   mz_line_no
 2   2  3
 
 $ file-append path=data-consistency.csv
- ${testdrive.temp-dir}/data.csv,1,0,2,5
+\${testdrive.temp-dir}/data.csv,1,0,2,5
 
 
 > SELECT * FROM view_byo


### PR DESCRIPTION
This PR makes two changes

1) it makes persistency of timestamps an optional parameter (persist-ts) and defaults it to false given that we currently do not use this feature anywhere. This is unnecessary overhead.

2) it ensures that all new timestamp messages cause sources to be activated (this was responsible for the timestamp-file.td error)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2765)
<!-- Reviewable:end -->
