### PR TITLE
Simplify timestamps

### DIFF
--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -345,6 +345,11 @@ fn downgrade_capability(
                                    to Kafka sources."
                 ),
             };
+            if pid as usize > partition_metadata.len() {
+                partition_metadata.extend(
+                    iter::repeat((start_offset, 0)).take(pid as usize - partition_metadata.len()),
+                );
+            }
             let last_offset = partition_metadata[pid as usize].0;
             // Check whether timestamps can be closed on this partition
             while let Some((partition_count, ts, offset)) = entries.first() {

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -66,6 +66,7 @@ impl<'a> From<&BorrowedMessage<'a>> for MessageParts {
 
 // Refresh our metadata from Kafka, which is necessary in order to start receiving messages
 // for new partitions. Return whether the check succeeded and returned expectedly many partitions.
+#[must_use]
 fn refresh_kafka_metadata(
     consumer: &mut BaseConsumer<GlueConsumerContext>,
     expected_partitions: usize,
@@ -409,6 +410,7 @@ fn find_matching_timestamp(
 ///
 /// Returns true if we learned about a new partition and Kafka metadata needs to be refreshed.
 #[allow(clippy::too_many_arguments)]
+#[must_use]
 fn downgrade_capability(
     id: &SourceInstanceId,
     cap: &mut Capability<Timestamp>,

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -8,9 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
-use std::convert::TryFrom;
-use std::iter::FromIterator;
 use std::sync::Mutex;
 use std::time::Duration;
 

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -353,7 +353,7 @@ fn downgrade_capability(
             if pid as usize >= partition_metadata.len() {
                 partition_metadata.extend(
                     iter::repeat((start_offset, *min_open_ts))
-                        .take(pid as usize - partition_metadata.len()),
+                        .take(1 + pid as usize - partition_metadata.len()),
                 );
             }
             let last_offset = partition_metadata[pid as usize].0;
@@ -369,7 +369,7 @@ fn downgrade_capability(
                     // entries before we continue.
                     partition_metadata.extend(
                         iter::repeat((start_offset, *min_open_ts))
-                            .take(*partition_count as usize - partition_metadata.len()),
+                            .take(1 + *partition_count as usize - partition_metadata.len()),
                     );
                 }
                 if last_offset == *offset {

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -256,6 +256,7 @@ where
                             &activator,
                         ) {
                             needs_refresh = true;
+                            buffer = Some(message);
                             return SourceStatus::Alive;
                         }
                     }


### PR DESCRIPTION
This simplifies timestamp handling in kafka.rs in a few ways:

* Replaces a few `HashMap`s of per-partition metadata with one vector.
* Doesn't spin in a tight loop asking Kafka for partitions. Instead, if we learn from timestamping code, or from receiving a message, that there are new partitions we didn't know about, just fill in the correct default values for the metadata. We *do* need to refresh the consumer's metadata if we discover a new partition, but that case is so rare that it should be fine to sleep between tries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2766)
<!-- Reviewable:end -->
