### PR TITLE
doc: de-emphasize PostgreSQL compatiblitiy

### DIFF
--- a/doc/user/_index.md
+++ b/doc/user/_index.md
@@ -8,7 +8,7 @@ weight: 1
 
 Materialize is a streaming data warehouse. Materialize accepts input data from a
 variety of streaming sources (e.g. Kafka) and files (e.g. CSVs), and lets you
-query them using the PostgreSQL dialect of SQL.
+query them using SQL.
 
 ## What does Materialize do?
 

--- a/doc/user/connect/cli.md
+++ b/doc/user/connect/cli.md
@@ -1,12 +1,13 @@
 ---
 title: "CLI Connections"
-description: "You can connect to Materialize from your favorite shell using Postgres-compatible tools, like psql or pgcli."
+description: "You can connect to Materialize from your favorite shell using compatible tools, like mzcli or psql."
 menu:
   main:
     parent: "connections"
 ---
 
-You can connect to a running `materialized` process from your favorite shell using Postgres-compatible tools.
+You can connect to a running `materialized` process from your favorite shell
+using a compatible command-line client.
 
 ### Connection details
 
@@ -20,9 +21,17 @@ Detail | Info
 
 Tool | Description | Install
 -----|-------------|--------
-`mzcli` | Materialize adaptation of `pgcli` | [GitHub](https://github.com/MaterializeInc/mzcli#quick-start)
-`psql` | Vanilla PostgreSQL CLI tool. Useful for executing queries from scripts using `-c`. | `libpq` or `postgresql-client`
-`pgcli` | CLI tool with auto-completion & syntax highlighting | [`pgcli` documentation](https://www.pgcli.com/install)
+`mzcli` | Materialize-specific CLI | [GitHub](https://github.com/MaterializeInc/mzcli#quick-start)
+`psql` | Vanilla PostgreSQL CLI tool | `postgresql` or `postgresql-client`
+
+{{< warning >}}
+Not all features of `psql` are supported by Materialize.
+{{< /warning >}}
+
+Other tools built for PostgreSQL can often be made to work with Materialize with
+minor modifications, but are unlikely to work out of the box.
+[File a GitHub issue](https://github.com/MaterializeInc/materialize/issues/new?labels=C-feature&template=feature.md)
+if there is a PostgreSQL tool you would like us to consider supporting.
 
 ## Examples
 
@@ -42,5 +51,5 @@ You could use any of the following formats to connect to `materialized` with `ps
 psql postgres://<host>:6875/materialize
 psql -h <host> -p 6875 materialize
 psql -h <host> -p 6875 -d materialize
-psql host=<host>,port=6875,dbname=materialize
+psql host=<host> port=6875 dbname=materialize
 ```

--- a/doc/user/demos/microservice.md
+++ b/doc/user/demos/microservice.md
@@ -446,7 +446,7 @@ In a future iteration, we'll make this demo more interactive.
 Now that our deployment is running (and looks like the diagram shown above), we
 can see that Materialize is ingesting the `protobuf` data and normalizing it.
 
-1. Launch `psql` (or any Postgres CLI client), connecting to `materialize`:
+1. Launch `psql` (or any Materialize CLI client), connecting to `materialize`:
 
     ```shell
     psql -h localhost -p 6875 -d materialize

--- a/doc/user/get-started.md
+++ b/doc/user/get-started.md
@@ -16,7 +16,7 @@ To help you get started with Materialize, we'll:
 To complete this demo, you need:
 
 - Command line and network access.
-- A [PostgreSQL-compatible CLI](../connect/cli/). If you have PostgreSQL installed `psql` works.
+- A [Materialize-compatible CLI](../connect/cli/). If you have Materialize installed `psql` works.
 
 We also highly recommend checking out [What is Materialize?](../overview/what-is-materialize)
 
@@ -32,7 +32,7 @@ We also highly recommend checking out [What is Materialize?](../overview/what-is
 
     This starts the daemon listening on port 6875 using 1 worker.
 
-1. Connect to `materialized` through your PostgreSQL CLI, e.g.:
+1. Connect to `materialized` through your Materialize CLI, e.g.:
 
     ```shell
     psql -h localhost -p 6875 materialize
@@ -44,7 +44,7 @@ Materialize offers ANSI Standard SQL, but is not simply a relational database. I
 
 To get started, though, we'll begin with a simple version that doesn't require connecting to an external data source.
 
-1. From your PostgreSQL CLI, create a materialized view that contains actual data we can work with.
+1. From your Materialize CLI, create a materialized view that contains actual data we can work with.
 
     ```sql
     CREATE MATERIALIZED VIEW pseudo_source AS


### PR DESCRIPTION
We are decidedly not compatible with pgcli, so strike that from the
docs. Also tone down the language about PostgreSQL compatibility to cut
ourselves some slack.

Fix #2763.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2768)
<!-- Reviewable:end -->
