### PR TITLE
mzimage: add spec convenience subcommand

### DIFF
--- a/misc/python/bin/mzimage.py
+++ b/misc/python/bin/mzimage.py
@@ -62,6 +62,12 @@ def main() -> int:
         help="fingerprint an image",
     )
 
+    add_image_subcommand(
+        "spec",
+        description="Compute the Docker Hub specification for an image.",
+        help="compute image spec",
+    )
+
     describe_parser = add_image_subcommand(
         "describe",
         description="Print information about an image.",
@@ -106,6 +112,8 @@ def main() -> int:
             deps.acquire()
         elif args.command == "fingerprint":
             print(rimage.fingerprint())
+        elif args.command == "spec":
+            print(rimage.spec())
         elif args.command == "describe":
             inputs = sorted(rimage.inputs(args.transitive))
             dependencies = sorted(rimage.list_dependencies(args.transitive))


### PR DESCRIPTION
Add a subcommand that prints out an image spec, like

    materialize/testdrive:mzbuild-U6WKRP7LGOLURBHYKVZK65KCY7MOXHZ4

so that folks don't need to manually construct one from the output of
`mzimage describe`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2771)
<!-- Reviewable:end -->
