### PR TITLE
Allow multiple statements in one SQL query

### DIFF
--- a/src/coord/command.rs
+++ b/src/coord/command.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 use derivative::Derivative;
 
 use dataflow_types::{PeekResponse, Update};
-use sql::Session;
+use sql::{Session, Statement};
 
 /// The requests the client can make of a [`Coordinator`](crate::Coordinator).
 #[derive(Debug)]
@@ -24,13 +24,13 @@ pub enum Command {
         tx: futures::channel::oneshot::Sender<Response<Vec<StartupMessage>>>,
     },
 
-    /// Parse the specified SQL into a prepared statement.
+    /// Save the specified statement as a prepared statement.
     ///
     /// The prepared statement is saved in the connection's [`sql::Session`]
     /// under the specified name.
-    Parse {
+    Describe {
         name: String,
-        sql: String,
+        stmt: Option<Statement>,
         session: Session,
         tx: futures::channel::oneshot::Sender<Response<()>>,
     },

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -434,9 +434,8 @@ where
                 result: Err(err),
                 session,
             } => {
-                return self
-                    .error(session, SqlState::INTERNAL_ERROR, err.to_string())
-                    .await;
+                self.error(session, SqlState::INTERNAL_ERROR, err.to_string())
+                    .await
             }
         }
     }

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -1025,14 +1025,7 @@ where
     }
 
     async fn recv(&mut self) -> Result<Option<FrontendMessage>, comm::Error> {
-        let mut message = self.conn.try_next().await?;
-        if let Some(FrontendMessage::Query { sql }) = &message {
-            if sql == "brennan;" {
-                message = Some(FrontendMessage::Query {
-                    sql: "SELECT 1; SELECT 1;".into(),
-                });
-            }
-        }
+        let message = self.conn.try_next().await?;
         match &message {
             Some(message) => trace!("cid={} recv={:?}", self.conn_id, message),
             None => trace!("cid={} recv=<eof>", self.conn_id),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -726,51 +726,53 @@ impl State {
         &mut self,
         sql: &str,
     ) -> Result<(Option<RelationDesc>, ExecuteResponse), failure::Error> {
-        let statement_name = String::from("");
-        let portal_name = String::from("");
-
-        // Parse.
-        {
-            let (tx, rx) = futures::channel::oneshot::channel();
-            self.cmd_tx
-                .unbounded_send(coord::Command::Parse {
-                    name: statement_name.clone(),
-                    sql: sql.into(),
-                    session: mem::take(&mut self.session),
-                    tx,
-                })
-                .expect("futures channel should not fail");
-            let resp = block_on(rx).expect("futures channel should not fail");
-            resp.result?;
-            mem::replace(&mut self.session, resp.session);
-        }
-
-        // Bind.
-        let stmt = self
-            .session
-            .get_prepared_statement(&statement_name)
-            .expect("unnamed prepared statement missing");
-        let desc = stmt.desc().cloned();
-        let result_formats = vec![pgrepr::Format::Text; stmt.result_width()];
-        self.session
-            .set_portal(portal_name.clone(), statement_name, vec![], result_formats)?;
-
-        // Execute.
-        {
-            let (tx, rx) = futures::channel::oneshot::channel();
-            self.cmd_tx
-                .unbounded_send(coord::Command::Execute {
-                    portal_name,
-                    session: mem::take(&mut self.session),
-                    conn_id: self.conn_id,
-                    tx,
-                })
-                .expect("futures channel should not fail");
-            let resp = block_on(rx).expect("futures channel should not fail");
-            mem::replace(&mut self.session, resp.session);
-            Ok((desc, resp.result?))
-        }
+        todo!()
     }
+    //     let statement_name = String::from("");
+    //     let portal_name = String::from("");
+    //
+    //     // Parse.
+    //     {
+    //         let (tx, rx) = futures::channel::oneshot::channel();
+    //         self.cmd_tx
+    //             .unbounded_send(coord::Command::Parse {
+    //                 name: statement_name.clone(),
+    //                 sql: sql.into(),
+    //                 session: mem::take(&mut self.session),
+    //                 tx,
+    //             })
+    //             .expect("futures channel should not fail");
+    //         let resp = block_on(rx).expect("futures channel should not fail");
+    //         resp.result?;
+    //         mem::replace(&mut self.session, resp.session);
+    //     }
+    //
+    //     // Bind.
+    //     let stmt = self
+    //         .session
+    //         .get_prepared_statement(&statement_name)
+    //         .expect("unnamed prepared statement missing");
+    //     let desc = stmt.desc().cloned();
+    //     let result_formats = vec![pgrepr::Format::Text; stmt.result_width()];
+    //     self.session
+    //         .set_portal(portal_name.clone(), statement_name, vec![], result_formats)?;
+    //
+    //     // Execute.
+    //     {
+    //         let (tx, rx) = futures::channel::oneshot::channel();
+    //         self.cmd_tx
+    //             .unbounded_send(coord::Command::Execute {
+    //                 portal_name,
+    //                 session: mem::take(&mut self.session),
+    //                 conn_id: self.conn_id,
+    //                 tx,
+    //             })
+    //             .expect("futures channel should not fail");
+    //         let resp = block_on(rx).expect("futures channel should not fail");
+    //         mem::replace(&mut self.session, resp.session);
+    //         Ok((desc, resp.result?))
+    //     }
+    // }
 }
 
 fn print_record(record: &Record) {


### PR DESCRIPTION
I tested this locally and it seems to work. @benesch any suggestions on the best way to write an automated test? I considered changing TestDrive to accept multiple statements, but after a bit of digging it seems like the underlying `tokio-postgres` client wouldn't support that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2773)
<!-- Reviewable:end -->
