### PR TITLE
dc.sh: support stopping a service that has been run multiple times

### DIFF
--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -310,7 +310,9 @@ dc_stop() {
         run_cmd=$(dc_is_run_cmd "$1")
         is_up=$(dc_is_running "$1")
         if [[ -n $run_cmd ]]; then
-            runv docker stop "$run_cmd"
+            while read -r run_cmd; do
+                runv docker stop "$run_cmd"
+            done <<<"$run_cmd"
             return
         elif [[ -n $is_up ]]; then
             runv ./mzcompose --mz-quiet stop "$1"


### PR DESCRIPTION
if you:

    $ dcsh run -d peeker
    $ dcsh run -d peeker

that will result in two peekers running. Before now dc.sh would choke on that, with this
change it stops them all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2778)
<!-- Reviewable:end -->
