### PR TITLE
remove flush-tables from chbench container

### DIFF
--- a/demo/chbench/chbench/Dockerfile
+++ b/demo/chbench/chbench/Dockerfile
@@ -58,7 +58,6 @@ RUN apt-get update && apt-get install -qy curl gnupg2 \
         cmake \
         confluent-schema-registry \
         curl \
-        jq \
         libconfig++-dev \
         libpqxx-dev \
         locales \
@@ -68,7 +67,6 @@ RUN apt-get update && apt-get install -qy curl gnupg2 \
     && apt-get autoremove -y \
     ;
 
-COPY ./flush-tables /usr/local/bin/flush-tables
 COPY ./mz-default.cfg /etc/chbenchmark/mz-default.cfg
 
 ENTRYPOINT ["chBenchmark"]

--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -544,7 +544,7 @@ demo_load() {
     dc_run chbench gen --warehouses=1 --config-file-path=/etc/chbenchmark/mz-default.cfg
     dc_run -d chbench run \
         --dsn=mysql --gen-dir=/var/lib/mysql-files \
-        --peek-conns=0 --flush-every=30 \
+        --peek-conns=0 \
         --analytic-threads=0 --transactional-threads=1 --run-seconds=864000 \
         --min-delay=0.0 --max-delay=0.0 -l /dev/stdout \
         --config-file-path=/etc/chbenchmark/mz-default.cfg \


### PR DESCRIPTION
It should no longer be needed with any of our consistency models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2790)
<!-- Reviewable:end -->
