### PR TITLE
Don't assume that Bintray usernames are of the form user@organization

### DIFF
--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -50,7 +50,9 @@ def main() -> None:
 
 def publish_deb(package: str, version: str) -> None:
     print(f"{package} v{version}")
-    bt = bintray.Client("materialize", user="ci", api_key=os.environ["BINTRAY_API_KEY"])
+    bt = bintray.Client(
+        "materialize", user="ci@materialize", api_key=os.environ["BINTRAY_API_KEY"]
+    )
     bt.repo("apt").package(package).publish_uploads(version)
 
 

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -79,7 +79,9 @@ def stage_deb(repo: mzbuild.Repository, package: str, version: str) -> None:
     )
     deb_size = deb_path.stat().st_size
 
-    bt = bintray.Client("materialize", user="ci", api_key=os.environ["BINTRAY_API_KEY"])
+    bt = bintray.Client(
+        "materialize", user="ci@materialize", api_key=os.environ["BINTRAY_API_KEY"]
+    )
     package = bt.repo("apt").package("materialized-unstable")
     try:
         print("Creating Bintray version...")

--- a/misc/python/materialize/bintray.py
+++ b/misc/python/materialize/bintray.py
@@ -134,7 +134,7 @@ class Client:
 
     def __init__(self, subject: str, user: str, api_key: str):
         self.session = Session()
-        self.session.auth = (f"{user}@{subject}", api_key)
+        self.session.auth = (f"{user}", api_key)
         self.subject = subject
 
     def repo(self, repo: str) -> RepoClient:


### PR DESCRIPTION
Unfortunately this pattern is only used for organizational sub-accounts. The account (i.e., mine) that created the organization is a "full" account not associated with the `materialize` namespace, so it doesn't have this pattern. Also it's probably possible to give permissions to random users from other organizations.

So for full flexibility, we shouldn't assume this in the Bintray client.

(In practice we will only ever run this on `ci@materialize` probably, but it's better to be more correct, and also, it was blocking me from testing things with my personal account)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2792)
<!-- Reviewable:end -->
