### PR TITLE
Add script to delete materialized-unstable binaries older than 14 days.

### DIFF
--- a/ci/cleanup/bintray.py
+++ b/ci/cleanup/bintray.py
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize import bintray
+import dateutil.parser
+import os
+from typing import List, Dict
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def get_old_versions(bt: bintray.Client) -> List[str]:
+    pc = bt.repo("apt").package("materialized-unstable")
+    version_strs = json.loads(pc.get_metadata().content)["versions"]
+    versions = (json.loads(pc.get_version(v).content) for v in version_strs)
+
+    def is_old(v: Dict[str, str]) -> bool:
+        return datetime.now(tz=timezone.utc) - dateutil.parser.parse(
+            v["created"]
+        ) > timedelta(days=14)
+
+    old_versions = [
+        v["name"] for v in versions if dateutil.parser.parse(v["created"]) if is_old(v)
+    ]
+    return old_versions
+
+
+def main() -> None:
+    bt = bintray.Client(
+        "materialize", user="ci@materialize", api_key=os.environ["BINTRAY_API_KEY"]
+    )
+    old_versions = get_old_versions(bt)
+    pc = bt.repo("apt").package("materialized-unstable")
+    print(f"Will delete {len(old_versions)} old versions")
+    for v in old_versions:
+        print(f"Deleting version {v}")
+        pc.delete_version(v)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Cleans up old binaries
+
+steps:
+  - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.bintray
+    timeout_in_minutes: 10

--- a/misc/python/materialize/bintray.py
+++ b/misc/python/materialize/bintray.py
@@ -56,6 +56,12 @@ class PackageClient:
             res.raise_for_status()
         return res
 
+    def delete_version(self, version: str) -> Response:
+        url = f"{API_BASE}/packages/{self.subject}/{self.repo}/{self.package}/versions/{version}"
+        res = self.session.delete(url)
+        res.raise_for_status()
+        return res
+
     def debian_upload(
         self,
         version: str,
@@ -110,6 +116,12 @@ class PackageClient:
     def get_metadata(self) -> Response:
         url = f"{API_BASE}/packages/{self.subject}/{self.repo}/{self.package}"
         res = self.session.get(url)
+        return res
+
+    def get_version(self, version: str) -> Response:
+        url = f"{API_BASE}/packages/{self.subject}/{self.repo}/{self.package}/versions/{version}"
+        res = self.session.get(url)
+        res.raise_for_status()
         return res
 
 

--- a/misc/python/requirements-ci.txt
+++ b/misc/python/requirements-ci.txt
@@ -1,3 +1,4 @@
 awscli==1.18.43
 humanize==2.3.0
 requests==2.23.0
+python-dateutil==2.8.1

--- a/misc/python/requirements-ci.txt
+++ b/misc/python/requirements-ci.txt
@@ -1,4 +1,3 @@
 awscli==1.18.43
 humanize==2.3.0
 requests==2.23.0
-python-dateutil==2.8.1


### PR DESCRIPTION
Once this lands, we can set up Buildkite to run it daily, as we do for the security check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2794)
<!-- Reviewable:end -->
