### PR TITLE
Test-drive support for randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,7 +2573,11 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.3.1"
+<<<<<<< HEAD
 source = "git+https://github.com/fede1024/rust-rdkafka.git#7059333050c0b51ab7a1ebb024d9abaf7634d0c3"
+=======
+source = "git+https://github.com/fede1024/rust-rdkafka.git#c414a780f47fbfc9fa783cf47d0f09759f504edc"
+>>>>>>> Adding support for random_sleep statement
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,11 +2573,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.3.1"
-<<<<<<< HEAD
 source = "git+https://github.com/fede1024/rust-rdkafka.git#7059333050c0b51ab7a1ebb024d9abaf7634d0c3"
-=======
-source = "git+https://github.com/fede1024/rust-rdkafka.git#c414a780f47fbfc9fa783cf47d0f09759f504edc"
->>>>>>> Adding support for random_sleep statement
 dependencies = [
  "cmake",
  "libc",

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -39,7 +39,6 @@ mod kinesis;
 mod sleep;
 mod sql;
 
-
 const DEFAULT_SQL_TIMEOUT: Duration = Duration::from_millis(12700);
 
 /// User-settable configuration parameters.
@@ -340,9 +339,11 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                         }
                         continue;
                     }
-                    "random_sleep" => {
-                        Box::new(sleep::build_sleep(builtin).map_err(wrap_err)?)
+                    "set-execution-count" => {
+                        // Skip, has already been handled
+                        continue;
                     }
+                    "random-sleep" => Box::new(sleep::build_sleep(builtin).map_err(wrap_err)?),
                     "set" => {
                         vars.extend(builtin.args);
                         continue;

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -36,7 +36,9 @@ mod avro_ocf;
 mod file;
 mod kafka;
 mod kinesis;
+mod sleep;
 mod sql;
+
 
 const DEFAULT_SQL_TIMEOUT: Duration = Duration::from_millis(12700);
 
@@ -337,6 +339,9 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                                 .map_err(|e| wrap_err(e.to_string()))?;
                         }
                         continue;
+                    }
+                    "random_sleep" => {
+                        Box::new(sleep::build_sleep(builtin).map_err(wrap_err)?)
                     }
                     "set" => {
                         vars.extend(builtin.args);

--- a/src/testdrive/src/action/sleep.rs
+++ b/src/testdrive/src/action/sleep.rs
@@ -1,0 +1,40 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use rdkafka::util::duration_to_millis;
+use rand::Rng;
+
+use crate::action::{State, SyncAction};
+use crate::parser::BuiltinCommand;
+
+pub struct SleepAction {
+    time: Duration
+}
+
+pub fn build_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
+    let arg= cmd.args.string("duration").map_err(|e| e.to_string())?;
+    let time = parse_duration::parse(&arg).map_err(|e| e.to_string())?;
+    Ok(SleepAction{time})
+}
+
+impl SyncAction for SleepAction {
+    fn undo(&self, _: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    fn redo(&self, _: &mut State) -> Result<(), String> {
+        let mut rng = rand::thread_rng();
+        let sleep= Duration::from_millis(rng.gen_range(0,duration_to_millis(self.time)));
+        println!("Sleeping for {:?}", sleep);
+        std::thread::sleep(sleep);
+        Ok(())
+    }
+}

--- a/src/testdrive/src/action/sleep.rs
+++ b/src/testdrive/src/action/sleep.rs
@@ -9,20 +9,20 @@
 
 use std::time::Duration;
 
-use rdkafka::util::duration_to_millis;
 use rand::Rng;
+use rdkafka::util::duration_to_millis;
 
 use crate::action::{State, SyncAction};
 use crate::parser::BuiltinCommand;
 
 pub struct SleepAction {
-    time: Duration
+    time: Duration,
 }
 
 pub fn build_sleep(mut cmd: BuiltinCommand) -> Result<SleepAction, String> {
-    let arg= cmd.args.string("duration").map_err(|e| e.to_string())?;
+    let arg = cmd.args.string("duration")?;
     let time = parse_duration::parse(&arg).map_err(|e| e.to_string())?;
-    Ok(SleepAction{time})
+    Ok(SleepAction { time })
 }
 
 impl SyncAction for SleepAction {
@@ -32,7 +32,7 @@ impl SyncAction for SleepAction {
 
     fn redo(&self, _: &mut State) -> Result<(), String> {
         let mut rng = rand::thread_rng();
-        let sleep= Duration::from_millis(rng.gen_range(0,duration_to_millis(self.time)));
+        let sleep = Duration::from_millis(rng.gen_range(0, duration_to_millis(self.time)));
         println!("Sleeping for {:?}", sleep);
         std::thread::sleep(sleep);
         Ok(())

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -56,30 +56,52 @@ pub async fn run_string(config: &Config, filename: &str, contents: &str) -> Resu
 }
 
 async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> Result<(), Error> {
-    let cmds = parser::parse(line_reader)?;
     // TODO(benesch): consider sharing state between files, to avoid
     // reconnections for every file. For now it's nice to not open any
     // connections until after parsing.
-    let (mut state, state_cleanup) = action::create_state(config).await?;
-    state.reset_materialized().await?;
-    // The `tokio::spawn` allows using `block_in_place` to run sync code within
-    // the spawned task. The spawn will one day not be necessary.
-    // See: https://github.com/tokio-rs/tokio/issues/1838.
-    tokio::spawn(async move {
-        let actions = action::build(cmds, &state)?;
-        for a in actions.iter().rev() {
-            let undo = a.action.undo(&mut state);
-            undo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
+    let cmds = parser::parse(line_reader)?;
+    let mut cmds_exec = cmds.clone();
+    // Extract number of executions
+    let mut execution_count = 1;
+    if let Some(command) = cmds_exec.iter_mut().find(|el| {
+        if let parser::Command::Builtin(c) = &el.command {
+            if c.name == "set-execution-count" {
+                return true;
+            }
         }
-        for a in &actions {
-            let redo = a.action.redo(&mut state);
-            redo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
+        false
+    }) {
+        if let parser::Command::Builtin(c) = &mut command.command {
+            let count = c.args.string("count").unwrap_or_default();
+            execution_count = count.parse::<u32>().unwrap_or(1);
         }
-        // Clean up external state (Kinesis)
-        state.reset_kinesis().await?;
-        drop(state);
-        state_cleanup.await
-    })
-    .await
-    .expect("action task unexpectedly canceled")
+    };
+    println!("Running test {} time(s) ... ", execution_count);
+    for _ in 1..execution_count  {
+        println!("Run {} ...", execution_count);
+        cmds_exec = cmds.clone();
+        let (mut state, state_cleanup) = action::create_state(config).await?;
+        state.reset_materialized().await?;
+        // The `tokio::spawn` allows using `block_in_place` to run sync code within
+        // the spawned task. The spawn will one day not be necessary.
+        // See: https://github.com/tokio-rs/tokio/issues/1838.
+        tokio::spawn(async move {
+            let actions = action::build(cmds_exec, &state)?;
+            for a in actions.iter().rev() {
+                let undo = a.action.undo(&mut state);
+                undo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
+            }
+            for a in &actions {
+                let redo = a.action.redo(&mut state);
+                redo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
+            }
+            // Clean up external state (Kinesis)
+            state.reset_kinesis().await?;
+            drop(state);
+            state_cleanup.await
+        })
+        .await
+        .expect("action task unexpectedly canceled")?
+    }
+    Ok(())
 }

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -77,7 +77,7 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
         }
     };
     println!("Running test {} time(s) ... ", execution_count);
-    for _ in 1..execution_count  {
+    for _ in 1..execution_count + 1 {
         println!("Run {} ...", execution_count);
         cmds_exec = cmds.clone();
         let (mut state, state_cleanup) = action::create_state(config).await?;

--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -18,27 +18,27 @@ use std::str::FromStr;
 
 use super::error::{InputError, Positioner};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PosCommand {
     pub pos: usize,
     pub command: Command,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Command {
     Builtin(BuiltinCommand),
     Sql(SqlCommand),
     FailSql(FailSqlCommand),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BuiltinCommand {
     pub name: String,
     pub args: ArgMap,
     pub input: Vec<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SqlExpectedResult {
     Full {
         column_names: Vec<String>,
@@ -49,13 +49,13 @@ pub enum SqlExpectedResult {
         md5: String,
     },
 }
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SqlCommand {
     pub query: String,
     pub expected_result: SqlExpectedResult,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FailSqlCommand {
     pub query: String,
     pub expected_error: String,
@@ -468,7 +468,7 @@ impl<'a> Iterator for BuiltinReader<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ArgMap(HashMap<String, String>);
 
 impl ArgMap {

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-execution-count count=3
+
 $ set schema={
     "type": "record",
     "name": "envelope",


### PR DESCRIPTION
This PR adds two options to testdrive

1) a `random-sleep duration=10s` call that will cause test-drive to sleep a random amount from (0,10s). This should be used to simulate pathological interleavings of messages when testing with Kinesis and Kafka

2) a se`t-execution-count=3` call to set in the file. This call will cause the test to be run multiple times. It should be used in combination with random-sleep for tests that benefit from executing under multiple different interleavings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2795)
<!-- Reviewable:end -->
