### PR TITLE
use count_total where appropriate

### DIFF
--- a/src/dataflow/logging/differential.rs
+++ b/src/dataflow/logging/differential.rs
@@ -7,15 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::{DifferentialLog, LogVariant};
-use crate::arrangement::KeysValsHandle;
-use dataflow_types::Timestamp;
-use differential_dataflow::logging::DifferentialEvent;
-use repr::{Datum, Row};
 use std::time::Duration;
+
+use differential_dataflow::logging::DifferentialEvent;
+use differential_dataflow::operators::count::CountTotal;
 use timely::communication::Allocate;
 use timely::dataflow::operators::capture::EventLink;
 use timely::logging::WorkerIdentifier;
+
+use super::{DifferentialLog, LogVariant};
+use crate::arrangement::KeysValsHandle;
+use dataflow_types::Timestamp;
+use repr::{Datum, Row};
 
 pub fn construct<A: Allocate>(
     worker: &mut timely::worker::Worker<A>,
@@ -26,7 +29,6 @@ pub fn construct<A: Allocate>(
 
     let traces = worker.dataflow(move |scope| {
         use differential_dataflow::collection::AsCollection;
-        use differential_dataflow::operators::reduce::Count;
         use timely::dataflow::operators::capture::Replay;
         use timely::dataflow::operators::Map;
 
@@ -74,7 +76,7 @@ pub fn construct<A: Allocate>(
                 }
             })
             .as_collection()
-            .count()
+            .count_total()
             .map({
                 move |((op, worker), count)| {
                     Row::pack(&[
@@ -97,7 +99,7 @@ pub fn construct<A: Allocate>(
                 }
             })
             .as_collection()
-            .count()
+            .count_total()
             .map({
                 move |((op, worker), count)| {
                     Row::pack(&[

--- a/src/dataflow/logging/materialized.rs
+++ b/src/dataflow/logging/materialized.rs
@@ -9,6 +9,7 @@
 
 use std::time::Duration;
 
+use differential_dataflow::operators::count::CountTotal;
 use log::error;
 use timely::communication::Allocate;
 use timely::dataflow::operators::capture::EventLink;
@@ -375,7 +376,6 @@ pub fn construct<A: Allocate>(
         let avro_ocf_sinks = avro_ocf_sinks.as_collection();
 
         // Duration statistics derive from the non-rounded event times.
-        use differential_dataflow::operators::reduce::Count;
         let peek_duration = peek
             .unary(
                 timely::dataflow::channels::pact::Pipeline,
@@ -427,7 +427,7 @@ pub fn construct<A: Allocate>(
                 },
             )
             .as_collection()
-            .count()
+            .count_total()
             .map({
                 move |((worker, pow), count)| {
                     Row::pack(&[


### PR DESCRIPTION
This PR swaps some uses of `count()` to `count_total()` in the logging subsystem. The latter is functionally equivalent to the former, except it avoids maintaining a second arrangement and is specialized to totally ordered timestamps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2796)
<!-- Reviewable:end -->
