### PR TITLE
Consolidate sink updates

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -602,11 +602,13 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         sink.from.0,
                         sink.from.1.typ().clone(),
                     ))
-                    // TODO(frank): consolidation is only required for a collection,
-                    // not for arrangements. We can perform a more complicated match
-                    // here to determine which case we are in to avoid this call.
-                    .consolidate()
+                    // What does this even mean?
                     .expect("No arrangements");
+
+                // TODO(frank): consolidation is only required for a collection,
+                // not for arrangements. We can perform a more complicated match
+                // here to determine which case we are in to avoid this call.
+                let collection = collection.consolidate();
 
                 // TODO(benesch): errors should stream out through the sink,
                 // if we figure out a protocol for that.

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -602,6 +602,10 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         sink.from.0,
                         sink.from.1.typ().clone(),
                     ))
+                    // TODO(frank): consolidation is only required for a collection,
+                    // not for arrangements. We can perform a more complicated match
+                    // here to determine which case we are in to avoid this call.
+                    .consolidate()
                     .expect("No arrangements");
 
                 // TODO(benesch): errors should stream out through the sink,

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -608,6 +608,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                 // TODO(frank): consolidation is only required for a collection,
                 // not for arrangements. We can perform a more complicated match
                 // here to determine which case we are in to avoid this call.
+                use differential_dataflow::operators::consolidate::Consolidate;
                 let collection = collection.consolidate();
 
                 // TODO(benesch): errors should stream out through the sink,

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -602,8 +602,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         sink.from.0,
                         sink.from.1.typ().clone(),
                     ))
-                    // What does this even mean?
-                    .expect("No arrangements");
+                    .expect("Sink source collection not loaded");
 
                 // TODO(frank): consolidation is only required for a collection,
                 // not for arrangements. We can perform a more complicated match

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -1,0 +1,49 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set names-schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "num", "type": "long"},
+              {"name": "name", "type": "string"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=names
+
+$ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
+{"before": null, "after": {"num": 1, "name": "one"}}
+{"before": {"num": 1, "name": "one"}, "after": {"num": 2, "name": "two"}}
+{"before": {"num": 2, "name": "two"}, "after": {"num": 3, "name": "three"}}
+
+> CREATE MATERIALIZED SOURCE names
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${names-schema}'
+  ENVELOPE DEBEZIUM
+
+> CREATE SINK snk1 FROM names
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.snk1
+{"before": null, "after": {"num": 3, "name": "three"}}


### PR DESCRIPTION
Sinks were previously not consolidating their inputs, which lead to things like TAIL producing updates like (in #2767):
```
\N	Diff: -1 at 1587733550550
\N	Diff: 1 at 1587733550550
```
Presumably we would also see these in other sinks, and committing them to output is not necessary.

I'd be up for tips on how to test this. Our current tests `sinks.td` only uses a static input file and doesn't test updates, which combined with debezium's unary output format makes it hard to test either cancellation (+, - => 0) or consolidation (+, + => 2+).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2798)
<!-- Reviewable:end -->
