### PR TITLE
Rate limit Timestamper hitting Kinesis ListShards API

### DIFF
--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -784,13 +784,13 @@ impl Timestamper {
             if shutdown {
                 break;
             } else {
-                // Only hit Kinesis API every 100 iterations -> once per second by default.
-                self.update_rt_timestamp(i == 100);
+                // Only hit Kinesis API every 50 iterations.
+                self.update_rt_timestamp(i == 50);
                 self.update_byo_timestamp();
             }
             // Limit growth of i.
             match i {
-                100 => i = 0,
+                50 => i = 0,
                 _ => i += 1,
             }
         }

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -1644,6 +1644,7 @@ impl Timestamper {
                             Err(e) => error!("Failed to list shards for Kinesis stream {} and update watermark information: {}", kc.stream_name, e),
                         }
                     }
+                    kc.timestamper_iteration_count += 1;
 
                     let num_shards = i32::try_from(kc.cached_shard_ids.len()).unwrap_or_else(|_| {
                         error!("Unable to convert number of Kinesis shards ({}) for stream {} into i32", kc.cached_shard_ids.len(), kc.stream_name);

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -97,7 +97,7 @@ async fn run() -> Result<(), Error> {
                 .unwrap_or_else(|| "localstack".into()),
             endpoint: opts
                 .opt_str("aws-endpoint")
-                .unwrap_or_else(|| "http://localhost:4568".into()),
+                .unwrap_or_else(|| "http://localhost:4566".into()),
         };
     }
     if let Some(url) = opts.opt_str("materialized-url") {

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -97,7 +97,7 @@ async fn run() -> Result<(), Error> {
                 .unwrap_or_else(|| "localstack".into()),
             endpoint: opts
                 .opt_str("aws-endpoint")
-                .unwrap_or_else(|| "http://localhost:4566".into()),
+                .unwrap_or_else(|| "http://localhost:4568".into()),
         };
     }
     if let Some(url) = opts.opt_str("materialized-url") {


### PR DESCRIPTION
### Background
For Materialize to create Kinesis sources from streams with multiple shards, we need to repeatedly call the ListShards API (shards can be dynamically added and deleted). Similarly, Materialize's Timestamper needs to continually update its knowledge of the count of Kinesis shards to correctly update sources' watermark information.

### The Problem
The ListShards API has a rate limit of 100 transactions per second per stream. Right now, we're calling the API both in the Timestamper code and in the dataflow::source code, pushing us above that limit. 

### The Solution
This PR introduces hacky rate limiting: only hit the ListShards API every 50th iteration of the Timestamper's update loop. By default, this should mean hitting the API every ~500 milliseconds. I chose this number to keep the number of hits low, but also to maintain sub-second updates to Materialize's timestamp knowledge of Kinesis sources -- this is what keeps current views of a source up to date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2807)
<!-- Reviewable:end -->
