### PR TITLE
pyactivate: reinstall venv iv dependencies are missing

### DIFF
--- a/bin/pyactivate
+++ b/bin/pyactivate
@@ -77,6 +77,7 @@ def activate_venv(py_dir: Path, dev: bool = False, ci: bool = False) -> Path:
     # `stamp_path`, as that indicates the virtualenv was once working enough to
     # have dependencies installed into it.
     try:
+        os.stat(stamp_path)
         subprocess.check_call([python, "-c", ""])
     except Exception as e:
         print("==> Checking for existing virtualenv")


### PR DESCRIPTION
This prevents wedged virtual envs on Debian/Ubuntu when the python-venv
is not installed.

This fixes part of #2752.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2815)
<!-- Reviewable:end -->
