### PR TITLE
test/metabase: validate basic integration with materialize via API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "metabase"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+]
+
+[[package]]
+name = "metabase-smoketest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "log",
+ "metabase",
+ "ore",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "src/interchange",
     "src/kinesis-util",
     "src/materialized",
+    "src/metabase",
     "src/ore",
     "src/peeker",
     "src/pgrepr",
@@ -24,6 +25,7 @@ members = [
     "src/sql-parser",
     "src/symbiosis",
     "src/testdrive",
+    "test/metabase/smoketest",
     "test/smith",
 ]
 

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -124,7 +124,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           config: test/metabase/mzcompose.yml
-          run: healthcheck
+          run: smoketest
 
   - id: lang-js
     label: ":javascript: tests"

--- a/src/metabase/Cargo.toml
+++ b/src/metabase/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "metabase"
+description = "An API client for Metabase."
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+reqwest = { version = "0.10.4" }
+serde = { version = "1.0", features = ["derive"] }

--- a/src/metabase/src/lib.rs
+++ b/src/metabase/src/lib.rs
@@ -1,0 +1,260 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! An API client for [Metabase].
+//!
+//! Only the features presently required are implemented. Documentation is
+//! sparse to avoid duplicating information in the upstream API documentation.
+//! See:
+//!
+//!   * [Using the REST API](https://github.com/metabase/metabase/wiki/Using-the-REST-API)
+//!   * [Auto-generated API documentation](https://github.com/metabase/metabase/blob/master/docs/api-documentation.md)
+//!
+//! [Metabase]: https://metabase.com
+
+#![deny(missing_debug_implementations)]
+
+use std::fmt;
+use std::time::Duration;
+
+use reqwest::{IntoUrl, Url};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+/// A Metabase API client.
+#[derive(Debug)]
+pub struct Client {
+    inner: reqwest::Client,
+    url: Url,
+    session_id: Option<String>,
+}
+
+impl Client {
+    /// Constructs a new `Client` that will target a Metabase instance at `url`.
+    ///
+    /// `url` must not contain a path nor be a [cannot-be-a-base] URL.
+    ///
+    /// [cannot-be-a-base]: https://url.spec.whatwg.org/#url-cannot-be-a-base-url-flag
+    pub fn new<U>(url: U) -> Result<Self, Error>
+    where
+        U: IntoUrl,
+    {
+        let mut url = url.into_url()?;
+        if url.path() != "/" {
+            return Err(Error::InvalidUrl("base URL cannot have path".into()));
+        }
+        assert!(!url.cannot_be_a_base());
+        url.path_segments_mut()
+            .expect("cannot-be-a-base checked to be false")
+            .push("api");
+        Ok(Client {
+            inner: reqwest::Client::new(),
+            url,
+            session_id: None,
+        })
+    }
+
+    /// Sets the session ID to include in future requests made by this client.
+    pub fn set_session_id(&mut self, session_id: String) {
+        self.session_id = Some(session_id);
+    }
+
+    /// Fetches public, global properties.
+    ///
+    /// The underlying API call is `GET /api/session/properties`.
+    pub async fn session_properties(&self) -> Result<SessionPropertiesResponse, reqwest::Error> {
+        let url = self.api_url(&["session", "properties"]);
+        self.send_request(self.inner.get(url)).await
+    }
+
+    /// Requests a session ID for the username and password named in `request`.
+    ///
+    /// Note that usernames are typically email addresses. To authenticate
+    /// future requests with the returned session ID, call `set_session_id`.
+    ///
+    /// The underlying API call is `POST /api/session`.
+    pub async fn login(&self, request: &LoginRequest) -> Result<LoginResponse, reqwest::Error> {
+        let url = self.api_url(&["session"]);
+        self.send_request(self.inner.post(url).json(request)).await
+    }
+
+    /// Creates a user and database connection if the Metabase instance has not
+    /// yet been set up.
+    ///
+    /// The request must include the `setup_token` from a
+    /// `SessionPropertiesResponse`. If the setup token returned by
+    /// [`session_properties`] is `None`, the cluster is already set up,
+    /// and this request will fail.
+    ///
+    /// The underlying API call is `POST /api/setup`.
+    pub async fn setup(&self, request: &SetupRequest) -> Result<LoginResponse, reqwest::Error> {
+        let url = self.api_url(&["setup"]);
+        self.send_request(self.inner.post(url).json(request)).await
+    }
+
+    /// Fetches the list of databases known to Metabase.
+    ///
+    /// The underlying API call is `GET /database`.
+    pub async fn databases(&self) -> Result<Vec<Database>, reqwest::Error> {
+        let url = self.api_url(&["database"]);
+        self.send_request(self.inner.get(url)).await
+    }
+
+    /// Fetches metadata about a particular database.
+    ///
+    /// The underlying API call is `GET /database/:id/metadata`.
+    pub async fn database_metadata(&self, id: usize) -> Result<DatabaseMetadata, reqwest::Error> {
+        let url = self.api_url(&["database", &id.to_string(), "metadata"]);
+        self.send_request(self.inner.get(url)).await
+    }
+
+    fn api_url(&self, endpoint: &[&str]) -> Url {
+        let mut url = self.url.clone();
+        url.path_segments_mut()
+            .expect("url validated on construction")
+            .extend(endpoint);
+        url
+    }
+
+    async fn send_request<T>(&self, mut req: reqwest::RequestBuilder) -> Result<T, reqwest::Error>
+    where
+        T: DeserializeOwned,
+    {
+        req = req.timeout(Duration::from_secs(5));
+        if let Some(session_id) = &self.session_id {
+            req = req.header("X-Metabase-Session", session_id);
+        }
+        let res = req.send().await?.error_for_status()?;
+        res.json().await
+    }
+}
+
+/// A Metabase error.
+#[derive(Debug)]
+pub enum Error {
+    /// The provided URL was invalid.
+    InvalidUrl(String),
+    /// The underlying transport mechanism returned na error.
+    Transport(reqwest::Error),
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(e: reqwest::Error) -> Error {
+        Error::Transport(e)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::InvalidUrl(_) => None,
+            Error::Transport(e) => Some(e),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidUrl(msg) => write!(f, "invalid url: {}", msg),
+            Error::Transport(e) => write!(f, "transport: {}", e),
+        }
+    }
+}
+
+/// The response to [`Client::session_properties`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SessionPropertiesResponse {
+    pub setup_token: Option<String>,
+}
+
+/// The request for [`Client::setup`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SetupRequest {
+    pub allow_tracking: bool,
+    pub database: SetupDatabase,
+    pub token: String,
+    pub prefs: SetupPrefs,
+    pub user: SetupUser,
+}
+
+/// A database to create as part of a [`SetupRequest`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SetupDatabase {
+    pub engine: String,
+    pub name: String,
+    pub details: SetupDatabaseDetails,
+}
+
+/// Details for a [`SetupDatabase`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SetupDatabaseDetails {
+    pub host: String,
+    pub port: usize,
+    pub dbname: String,
+    pub user: String,
+}
+
+/// Preferences for a [`SetupRequest`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SetupPrefs {
+    pub site_name: String,
+}
+
+/// A user to create as part of a [`SetupRequest`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct SetupUser {
+    pub email: String,
+    pub first_name: String,
+    pub last_name: String,
+    pub password: String,
+    pub site_name: String,
+}
+
+/// The request for [`Client::login`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct LoginRequest {
+    pub username: String,
+    pub password: String,
+}
+
+/// The response to [`Client::login`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct LoginResponse {
+    pub id: String,
+}
+
+/// A database returned by [`Client::databases`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct Database {
+    pub name: String,
+    pub id: usize,
+}
+
+/// The response to [`Client::database_metadata`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct DatabaseMetadata {
+    pub tables: Vec<Table>,
+}
+
+/// A table that is part of [`DatabaseMetadata`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct Table {
+    pub name: String,
+    pub fields: Vec<TableField>,
+}
+
+/// A field of a [`Table`].
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct TableField {
+    pub name: String,
+    pub database_type: String,
+    pub base_type: String,
+    pub special_type: Option<String>,
+}

--- a/src/ore/lib.rs
+++ b/src/ore/lib.rs
@@ -26,6 +26,7 @@ pub mod iter;
 pub mod netio;
 pub mod option;
 pub mod panic;
+pub mod retry;
 pub mod stats;
 pub mod sync;
 pub mod test;

--- a/src/ore/retry.rs
+++ b/src/ore/retry.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Retry utilities.
+
 use std::cmp;
 use std::future::Future;
 
@@ -14,9 +16,14 @@ use tokio::time::{self, Duration};
 
 const ZERO_DURATION: Duration = Duration::from_secs(0);
 
-#[derive(Clone)]
+/// The state of a retry opreation managed by [`retry_for`].
+#[derive(Clone, Debug)]
 pub struct RetryState {
+    /// The retry counter, starting from zero on the first try.
     pub i: usize,
+    /// If this try fails, the amount of time that `retry_for` will sleep
+    /// before the next attempt. If this is the last attempt, then this
+    /// field will be `None`.
     pub next_backoff: Option<Duration>,
 }
 
@@ -24,10 +31,10 @@ pub struct RetryState {
 ///
 /// If the operation is still failing after a cumulative delay of `max_sleep`,
 /// its last error is returned.
-pub async fn retry_for<F, U, T>(max_sleep: Duration, mut f: F) -> Result<T, String>
+pub async fn retry_for<F, U, T, E>(max_sleep: Duration, mut f: F) -> Result<T, E>
 where
     F: FnMut(RetryState) -> U,
-    U: Future<Output = Result<T, String>>,
+    U: Future<Output = Result<T, E>>,
 {
     let mut state = RetryState {
         i: 0,

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -16,10 +16,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 
+use ore::retry;
+
 use crate::action::{Action, State, SyncAction};
 use crate::format::avro::{self, Codec, Reader, Writer};
 use crate::parser::BuiltinCommand;
-use crate::util::retry;
 
 pub struct WriteAction {
     path: String,
@@ -157,7 +158,7 @@ impl Action for VerifyAction {
                 .await
                 .map_err(|e| format!("querying materialize: {}", e.to_string()))?;
             let bytes: Vec<u8> = row.get("path");
-            Ok(PathBuf::from(OsString::from_vec(bytes)))
+            Ok::<_, String>(PathBuf::from(OsString::from_vec(bytes)))
         })
         .await
         .map_err(|e| format!("retrieving path: {:?}", e))?;

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -14,10 +14,10 @@ use rdkafka::admin::NewPartitions;
 
 use ore::cast::CastFrom;
 use ore::collections::CollectionExt;
+use ore::retry;
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
-use crate::util::retry;
 
 pub struct AddPartitionsAction {
     topic_prefix: String,

--- a/src/testdrive/src/action/kafka/create_topic.rs
+++ b/src/testdrive/src/action/kafka/create_topic.rs
@@ -14,10 +14,10 @@ use rdkafka::admin::{NewTopic, TopicReplication};
 use rdkafka::error::RDKafkaError;
 
 use ore::collections::CollectionExt;
+use ore::retry;
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
-use crate::util::retry;
 
 pub struct CreateTopicAction {
     topic_prefix: String,

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -16,10 +16,11 @@ use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::message::Message;
 use tokio::stream::StreamExt;
 
+use ore::retry;
+
 use crate::action::{Action, State};
 use crate::format::avro;
 use crate::parser::BuiltinCommand;
-use crate::util::retry;
 
 pub struct VerifyAction {
     sink: String,
@@ -54,7 +55,7 @@ impl Action for VerifyAction {
                 )
                 .await
                 .map_err(|e| format!("retrieving topic name: {}", e))?;
-            Ok(row.get("topic"))
+            Ok::<_, String>(row.get("topic"))
         })
         .await?;
 

--- a/src/testdrive/src/action/kinesis/ingest.rs
+++ b/src/testdrive/src/action/kinesis/ingest.rs
@@ -16,9 +16,10 @@ use rand::{thread_rng, Rng};
 use rusoto_core::RusotoError;
 use rusoto_kinesis::{Kinesis, PutRecordError, PutRecordInput};
 
+use ore::retry;
+
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
-use crate::util::retry;
 
 pub struct IngestAction {
     stream_prefix: String,

--- a/src/testdrive/src/action/kinesis/update_shards.rs
+++ b/src/testdrive/src/action/kinesis/update_shards.rs
@@ -13,9 +13,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use rusoto_kinesis::{DescribeStreamInput, Kinesis, UpdateShardCountInput};
 
+use ore::retry;
+
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
-use crate::util::retry;
 
 pub struct UpdateShardCountAction {
     stream_name: String,

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -21,13 +21,13 @@ use tokio_postgres::row::Row;
 use tokio_postgres::types::{Json, Type};
 
 use ore::collections::CollectionExt;
+use ore::retry;
 use pgrepr::{Interval, Numeric};
 use sql_parser::ast::Statement;
 use sql_parser::parser::Parser as SqlParser;
 
 use crate::action::{Action, State};
 use crate::parser::{FailSqlCommand, SqlCommand, SqlExpectedResult};
-use crate::util::retry;
 
 pub struct SqlAction {
     cmd: SqlCommand,

--- a/src/testdrive/src/util.rs
+++ b/src/testdrive/src/util.rs
@@ -10,4 +10,3 @@
 pub mod aws;
 pub mod kinesis;
 pub mod postgres;
-pub mod retry;

--- a/src/testdrive/src/util/kinesis.rs
+++ b/src/testdrive/src/util/kinesis.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use rusoto_kinesis::{DescribeStreamInput, Kinesis, KinesisClient};
 
-use crate::util::retry;
+use ore::retry;
 
 pub const DEFAULT_KINESIS_TIMEOUT: Duration = Duration::from_millis(12700);
 

--- a/test/metabase/README.md
+++ b/test/metabase/README.md
@@ -1,0 +1,4 @@
+# test/metabase
+
+A simple test for verifying that Metabase can connect to Materialize and perform
+some queries.

--- a/test/metabase/mzcompose
+++ b/test/metabase/mzcompose
@@ -8,16 +8,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
 
-# Point of this test: Assert Metabase and related containers
-# can run.
-#   - If we see a successful curl, Metabase is up and working!
-#   - If we don't see a successful curl, Buildkite will time out
-#     and fail this test.
-
-while ! curl -fsSI metabase:3000; do
-    echo "Failed to curl metabase:3000. Sleeping..."
-    sleep 15
-done
-
-echo "Successfully pinged Metabase!"
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "metabase-smoketest"
+description = "A simple smoke test for Metabase and Materialize."
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0.28"
+metabase = { path = "../../../src/metabase"}
+itertools = "0.9"
+log = "0.4.8"
+ore = { path = "../../../src/ore" }
+tokio = "0.2"
+tokio-postgres = "0.5.2"

--- a/test/metabase/smoketest/ci/.gitignore
+++ b/test/metabase/smoketest/ci/.gitignore
@@ -1,0 +1,1 @@
+/metabase-smoketest

--- a/test/metabase/smoketest/ci/Dockerfile
+++ b/test/metabase/smoketest/ci/Dockerfile
@@ -9,8 +9,8 @@
 
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -qy wait-for-it
 
-COPY healthcheck /usr/local/bin/healthcheck
+COPY metabase-smoketest /usr/local/bin
 
-ENTRYPOINT ["healthcheck"]
+ENTRYPOINT ["metabase-smoketest"]

--- a/test/metabase/smoketest/ci/mzbuild.yml
+++ b/test/metabase/smoketest/ci/mzbuild.yml
@@ -7,15 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-version: '3.7'
-services:
-  materialized:
-    mzbuild: materialized
-    command: -w1 --logging-granularity=10ms
-  metabase:
-    image: materialize/metabase:v0.0.5
-    ports:
-    - 3000:3000
-  smoketest:
-    mzbuild: ci-metabase-smoketest
-    depends_on: [materialized, metabase]
+name: ci-metabase-smoketest
+pre-image:
+  type: cargo-build
+  bin: metabase-smoketest

--- a/test/metabase/smoketest/src/main.rs
+++ b/test/metabase/smoketest/src/main.rs
@@ -1,0 +1,172 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use anyhow::{bail, Context};
+use itertools::Itertools;
+use tokio::net::TcpStream;
+use tokio_postgres::NoTls;
+
+use metabase::{
+    DatabaseMetadata, LoginRequest, SetupDatabase, SetupDatabaseDetails, SetupPrefs, SetupRequest,
+    SetupUser, Table, TableField,
+};
+use ore::retry;
+
+const DUMMY_EMAIL: &str = "ci@materialize.io";
+const DUMMY_PASSWORD: &str = "dummy1";
+
+async fn connect_materialized() -> Result<tokio_postgres::Client, anyhow::Error> {
+    retry::retry_for(Duration::from_secs(30), |_| async {
+        let res = TcpStream::connect("materialized:6875").await;
+        if let Err(e) = &res {
+            log::debug!("error connecting to materialized: {}", e);
+        }
+        res
+    })
+    .await?;
+    let (client, conn) = tokio_postgres::connect("postgres://materialized:6875/materialize", NoTls)
+        .await
+        .context("failed connecting to materialized")?;
+    tokio::spawn(async {
+        if let Err(e) = conn.await {
+            panic!("postgres connection error: {}", e);
+        }
+    });
+    Ok(client)
+}
+
+async fn connect_metabase() -> Result<metabase::Client, anyhow::Error> {
+    let mut client =
+        metabase::Client::new("http://metabase:3000").context("failed creating metabase client")?;
+    let setup_token = retry::retry_for(Duration::from_secs(30), |_| async {
+        let res = client.session_properties().await;
+        if let Err(e) = &res {
+            log::debug!("error connecting to metabase: {}", e);
+        }
+        res.map(|res| res.setup_token)
+    })
+    .await?;
+    let session_id = match setup_token {
+        None => {
+            let req = LoginRequest {
+                username: DUMMY_EMAIL.into(),
+                password: DUMMY_PASSWORD.into(),
+            };
+            client.login(&req).await?.id
+        }
+        Some(setup_token) => {
+            let req = &SetupRequest {
+                allow_tracking: false,
+                database: SetupDatabase {
+                    engine: "materialize".into(),
+                    name: "Materialize".into(),
+                    details: SetupDatabaseDetails {
+                        host: "materialized".into(),
+                        port: 6875,
+                        dbname: "materialize".into(),
+                        user: "materialize".into(),
+                    },
+                },
+                token: setup_token,
+                prefs: SetupPrefs {
+                    site_name: "Materialize".into(),
+                },
+                user: SetupUser {
+                    email: DUMMY_EMAIL.into(),
+                    first_name: "Materialize".into(),
+                    last_name: "CI".into(),
+                    password: DUMMY_PASSWORD.into(),
+                    site_name: "Materialize".into(),
+                },
+            };
+            client.setup(req).await?.id
+        }
+    };
+    client.set_session_id(session_id);
+    Ok(client)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    ore::test::init_logging();
+
+    let pgclient = connect_materialized().await?;
+    pgclient
+        .batch_execute(
+            "CREATE OR REPLACE MATERIALIZED VIEW orders (id, date, quantity, total) AS
+             VALUES (1, '2020-01-03'::date, 6, 10.99), (2, '2020-01-04'::date, 4, 7.48)",
+        )
+        .await?;
+
+    let metabase_client = connect_metabase().await?;
+
+    let databases = metabase_client.databases().await?;
+    log::debug!("Databases: {:#?}", databases);
+
+    let database_names: Vec<_> = databases.iter().map(|d| &d.name).sorted().collect();
+    assert_eq!(database_names, &["Materialize", "Sample Dataset"]);
+
+    let mzdb = databases.iter().find(|d| d.name == "Materialize").unwrap();
+    let expected_metadata = DatabaseMetadata {
+        tables: vec![Table {
+            name: "orders".into(),
+            fields: vec![
+                TableField {
+                    name: "date".into(),
+                    database_type: "date".into(),
+                    base_type: "type/Date".into(),
+                    special_type: None,
+                },
+                TableField {
+                    name: "id".into(),
+                    database_type: "int4".into(),
+                    base_type: "type/Integer".into(),
+                    special_type: Some("type/PK".into()),
+                },
+                TableField {
+                    name: "quantity".into(),
+                    database_type: "int4".into(),
+                    base_type: "type/Integer".into(),
+                    special_type: Some("type/Quantity".into()),
+                },
+                TableField {
+                    name: "total".into(),
+                    database_type: "numeric".into(),
+                    base_type: "type/Decimal".into(),
+                    special_type: None,
+                },
+            ],
+        }],
+    };
+    // The database sync happens asynchronously and the API doesn't appear to
+    // expose when it is complete, so just retry a few times waiting for the
+    // metadata we expect.
+    retry::retry_for(Duration::from_secs(15), |_| async {
+        let mut metadata = metabase_client.database_metadata(mzdb.id).await?;
+        metadata.tables.sort_by(|a, b| a.name.cmp(&b.name));
+        for t in &mut metadata.tables {
+            t.fields.sort_by(|a, b| a.name.cmp(&b.name));
+        }
+        log::debug!("Materialize database metadata: {:#?}", metadata);
+        if expected_metadata != metadata {
+            bail!(
+                "metadata did not match\nexpected:\n{:#?}\nactual:\n{:#?}",
+                expected_metadata,
+                metadata,
+            );
+        }
+        Ok(())
+    })
+    .await?;
+
+    println!("OK");
+    Ok(())
+}


### PR DESCRIPTION
Add some smoke testing of Materialize and Metabase by using the Metabase
API. The new test installs the Materialize connector in Metabase,
creates a simple database with a simple table, and verifies that
Metabase correctly reports this table's columns.

Fix #2083.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2816)
<!-- Reviewable:end -->
