### PR TITLE
Add missing avg to docs. Add release note for upsert.

### DIFF
--- a/doc/user/release-notes.md
+++ b/doc/user/release-notes.md
@@ -45,6 +45,15 @@ Use relative links (../path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+<span id="0.2.2"></span>
+## 0.2.1 (Unreleased) &rarr; 0.2.2 (Unreleased)
+
+- Support Kafka topics with key-value messages. ([`CREATE SOURCE ... ENVELOPE
+  UPSERT  ...`](../overview/api-components/#envelopes))
+
+<span id="0.2.1"></span>
+## 0.2.0 &rarr; 0.2.1 (Unreleased)
+
 <span id="v0.2.0"></span>
 ## 0.1.3 &rarr; v0.2.0
 

--- a/www/data/sql_funcs.json
+++ b/www/data/sql_funcs.json
@@ -23,8 +23,17 @@
         "description": "Aggregate functions take one or more of the same element type as arguments.",
         "functions": [
             {
+                "signature": "avg(x: T) -> U",
+                "description": "Average of `T`'s values. <br/><br/> Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
+            },
+            {
                 "signature": "count(x: T) -> int",
-                "description": "Number of non-_NULL_ inputs"
+                "description": "Number of non-_NULL_ inputs."
+            },
+            {
+                "signature": "jsonb_agg(expression) -> jsonb",
+                "description": "Aggregate values (including nulls) as a jsonb array.",
+                "url": "jsonb_agg"
             },
             {
                 "signature": "max(x: T) -> T",
@@ -35,37 +44,32 @@
                 "description": "Minimum value among `T`"
             },
             {
+                "signature": "stddev(x: T) -> U",
+                "description": "Historical alias for `stddev_samp`. *(imprecise)* <br/><br/>Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
+            },
+            {
+                "signature": "stddev_pop(x: T) -> U",
+                "description": "Population standard deviation of `T`'s values. *(imprecise)* <br/><br/>Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
+            },
+            {
+                "signature": "stddev_samp(x: T) -> U",
+                "description": "Sample standard deviation of `T`'s values. *(imprecise)* <br/><br/>Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
+            },
+            {
                 "signature": "sum(x: T) -> T",
                 "description": "Sum of `T`'s values"
             },
             {
-                "signature": "stddev(x: T) -> T",
-                "description": "Historical alias for `stddev_samp` *(imprecise)*"
+                "signature": "variance(x: T) -> U",
+                "description": "Historical alias for `variance_samp`. *(imprecise)* <br/><br/>Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
             },
             {
-                "signature": "stddev_pop(x: T) -> T",
-                "description": "Population standard deviation of `T`'s values *(imprecise)*"
+                "signature": "variance_pop(x: T) -> U",
+                "description": "Population variance of `T`'s values. *(imprecise)* <br/><br/>Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
             },
             {
-                "signature": "stddev_samp(x: T) -> T",
-                "description": "Sample standard deviation of `T`'s values *(imprecise)*"
-            },
-            {
-                "signature": "variance(x: T) -> T",
-                "description": "Historical alias for `variance_samp` *(imprecise)*"
-            },
-            {
-                "signature": "variance_pop(x: T) -> T",
-                "description": "Population variance of `T`'s values *(imprecise)*"
-            },
-            {
-                "signature": "variance_samp(x: T) -> T",
-                "description": "Sample variance of `T`'s values *(imprecise)*"
-            },
-            {
-                "signature": "jsonb_agg(expression) -> jsonb",
-                "description": "Aggregate values (including nulls) as a jsonb array.",
-                "url": "jsonb_agg"
+                "signature": "variance_samp(x: T) -> U",
+                "description": "Sample variance of `T`'s values. *(imprecise)* <br/><br/>Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns same type as `x`."
             }
         ]
     },


### PR DESCRIPTION
I noticed that our documentation is missing the aggregation function `avg`, so I'm adding it in.

Technically `avg(x: T) -> T` is wrong (and so are `stddev(x: T) -> T`, `var(x: T) -> T`, etc.). The result is Decimal if `T` is an integer, float64 if `T` is a floating point type, and `T` if `T` is anything else. @sploiselle do you have a suggestion on how to correct the return type of avg/stddev/var?

Also, adding a release note for upsert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2818)
<!-- Reviewable:end -->
