### PR TITLE
integration: test Kafka SSL auth

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -67,6 +67,16 @@ steps:
           config: test/testdrive/mzcompose.yml
           run: testdrive
 
+  - id: testdrive-ssl
+    label: ":lock: testdrive-ssl"
+    depends_on: build
+    timeout_in_minutes: 30
+    inputs: [test/testdrive/ssl]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          config: test/testdrive/mzcompose.ssl.yml
+          run: testdrive
+
   - id: testdrive-purgatory
     label: ":racing_car: testdrive purgatory"
     depends_on: build
@@ -138,7 +148,15 @@ steps:
 
   - id: deploy
     label: ":rocket: Deploy"
-    depends_on: [lint-fast, lint-slow, cargo-test, testdrive, streaming-demo, metabase-demo, short-sqllogictest]
+    depends_on:
+      - lint-fast
+      - lint-slow
+      - cargo-test
+      - testdrive
+      - testdrive-ssl
+      - streaming-demo
+      - metabase-demo
+      - short-sqllogictest
     trigger: deploy
     async: true
     branches: "master v*.*"

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -68,7 +68,7 @@ impl Action for VerifyAction {
             .raw;
 
         let mut config = ClientConfig::new();
-        config.set("bootstrap.servers", &state.kafka_addr);
+        config.set("bootstrap.servers", &state.kafka_url);
         config.set("auto.offset.reset", "earliest");
         config.set("group.id", "materialize-testdrive");
 

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -53,7 +53,7 @@ say "launching materialized-golden"
 launch_materialized golden
 
 say "building golden catalog"
-testdrive --kafka-addr kafka:9092 <<'EOF'
+testdrive --kafka-url plaintext://kafka:9092 <<'EOF'
 $ set schema={
     "type": "record",
     "name": "envelope",

--- a/test/test-certs/Dockerfile
+++ b/test/test-certs/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install openjdk-8-jdk openssl -y
+COPY . /
+RUN ./create-certs.sh
+
+FROM ubuntu:bionic
+COPY --from=0 /secrets /secrets

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+export SSL_SECRET=mzmzmz
+
+mkdir secrets
+
+# Create CA
+openssl req \
+	-x509 \
+	-days 36500 \
+	-newkey rsa:4096 \
+	-keyout secrets/ca.key \
+	-out secrets/ca.crt \
+	-sha256 \
+	-batch \
+	-subj "/CN=MZ RSA CA" \
+	-passin pass:$SSL_SECRET \
+	-passout pass:$SSL_SECRET
+
+for i in 'broker' 'schema-registry' 'materialized' 'producer'
+do
+	# Create key & csr
+	openssl req -nodes \
+		-newkey rsa:2048 \
+		-keyout secrets/$i.key \
+		-out tmp/$i.csr \
+		-sha256 \
+		-batch \
+		-subj "/CN=$i" \
+		-passin pass:$SSL_SECRET \
+		-passout pass:$SSL_SECRET \
+
+	# Sign the CSR; note that the extensions are necessary to fulfill the
+	# following requirements of rustls/webpki:
+	# - Add SAN to cert
+	# - Create a v3 cert
+	openssl x509 -req \
+		-CA secrets/ca.crt \
+		-CAkey secrets/ca.key \
+		-in tmp/$i.csr \
+		-out secrets/$i.crt \
+		-sha256 \
+		-days 36500 \
+		-CAcreateserial \
+		-passin pass:$SSL_SECRET \
+		-extensions $i -extfile openssl.cnf
+
+	# Generate key and cert p12 (i.e. non-Java keystore)
+	openssl pkcs12 \
+		-export \
+		-in secrets/$i.crt \
+		-name $i \
+		-inkey secrets/$i.key \
+		-passin pass:$SSL_SECRET \
+		-certfile secrets/ca.crt \
+		-caname "MZ RSA CA" \
+		-out secrets/$i.p12 \
+		-passout pass:$SSL_SECRET
+
+	# Create JKS
+	keytool -importkeystore \
+		-alias $i \
+		-deststorepass $SSL_SECRET \
+		-destkeypass $SSL_SECRET \
+		-srcstorepass $SSL_SECRET \
+		-srckeypass $SSL_SECRET \
+		-destkeystore secrets/$i.keystore.jks \
+		-srckeystore secrets/$i.p12 \
+		-srcstoretype PKCS12
+
+	# Import CA
+	keytool \
+		-alias CARoot \
+		-import \
+		-file secrets/ca.crt \
+		-keystore secrets/$i.keystore.jks \
+		-noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
+
+	# Create truststore and import CA cert
+	keytool \
+		-keystore secrets/$i.truststore.jks \
+		-alias CARoot \
+		-import \
+		-file secrets/ca.crt \
+		-noprompt -storepass $SSL_SECRET -keypass $SSL_SECRET
+
+done
+
+echo $SSL_SECRET > secrets/cert_creds
+
+# Ensure files are readable for any user
+chmod -R a+r secrets/

--- a/test/test-certs/mzbuild.yml
+++ b/test/test-certs/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: test-certs

--- a/test/test-certs/openssl.cnf
+++ b/test/test-certs/openssl.cnf
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This file is derived from
+# https://github.com/ctz/rustls/blob/master/test-ca/openssl.cnf
+
+[ broker ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:broker
+
+[ producer ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:producer
+
+[ materialized ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:materialized
+
+[ schema-registry ]
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = DNS:schema-registry

--- a/test/testdrive/mzcompose.ssl.yml
+++ b/test/testdrive/mzcompose.ssl.yml
@@ -1,0 +1,112 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Portions of this file is derived from
+# https://github.com/Pierrotws/kafka-ssl-compose/blob/master/docker-compose.yml
+
+version: "3.7"
+services:
+  test-certs:
+    mzbuild: test-certs
+    volumes:
+      - secrets:/secrets
+  testdrive:
+    mzbuild: testdrive
+    hostname: producer
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        wait-for-it --timeout=30 broker:9092 &&
+        wait-for-it --timeout=30 schema-registry:8081 &&
+        wait-for-it --timeout=30 materialized:6875 &&
+        testdrive
+        --kafka-url=SSL://broker:9092
+        --schema-registry-url=https://schema-registry:8081
+        --materialized-url=postgres://ignored@materialized:6875
+        --validate-catalog=/share/mzdata
+        --cert=/share/secrets/producer.p12
+        --cert-password=mzmzmz
+        --root-cert=/share/secrets/ca.crt
+        $$*
+      - bash
+    command: test/testdrive/ssl/*.td
+    user: root
+    environment:
+      - TMPDIR=/share/tmp
+    volumes:
+      - ../../:/workdir
+      - mzdata:/share/mzdata
+      - tmp:/share/tmp
+      - secrets:/share/secrets
+    propagate-uid-gid: true
+    init: true
+    depends_on: [broker, zookeeper, schema-registry, materialized, test-certs]
+  materialized:
+    mzbuild: materialized
+    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1
+    volumes:
+      - mzdata:/share/mzdata
+      - tmp:/share/tmp
+      - secrets:/share/secrets
+    depends_on: [test-certs]
+  zookeeper:
+    image: zookeeper:3.4.13
+    hostname: zookeeper
+    environment:
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+  broker:
+    image: confluentinc/cp-kafka:latest
+    hostname: broker
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_HOST_NAME: broker
+      KAFKA_ADVERTISED_LISTENERS: SSL://broker:9092
+      KAFKA_SSL_KEYSTORE_FILENAME: broker.keystore.jks
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: cert_creds
+      KAFKA_SSL_KEY_CREDENTIALS: cert_creds
+      KAFKA_SSL_TRUSTSTORE_FILENAME: broker.truststore.jks
+      KAFKA_SSL_TRUSTSTORE_CREDENTIALS: cert_creds
+      KAFKA_SSL_CLIENT_AUTH: "required"
+      KAFKA_SECURITY_PROTOCOL: SSL
+      KAFKA_SECURITY_INTER_BROKER_PROTOCOL: SSL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    volumes:
+      - secrets:/etc/kafka/secrets
+    depends_on: [zookeeper, test-certs]
+  schema-registry:
+    image: confluentinc/cp-schema-registry:5.2.1
+    hostname: schema-registry
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:2181
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: SSL://broker:9092
+      SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: SSL
+      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
+      SCHEMA_REGISTRY_SSL_KEYSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.keystore.jks
+      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_PASSWORD: mzmzmz
+      SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD: mzmzmz
+      SCHEMA_REGISTRY_KAFKASTORE_SSL_KEY_PASSWORD: mzmzmz
+      SCHEMA_REGISTRY_SSL_KEY_PASSWORD: mzmzmz
+      SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.truststore.jks
+      SCHEMA_REGISTRY_SSL_TRUSTSTORE_LOCATION: /etc/schema-registry/secrets/schema-registry.truststore.jks
+      SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD: mzmzmz
+      SCHEMA_REGISTRY_SSL_TRUSTSTORE_PASSWORD: mzmzmz
+      SCHEMA_REGISTRY_SCHEMA_REGISTRY_INTER_INSTANCE_PROTOCOL: https
+      SCHEMA_REGISTRY_SSL_CLIENT_AUTH: "true"
+    volumes:
+      - secrets:/etc/schema-registry/secrets
+    depends_on: [broker, zookeeper, test-certs]
+volumes:
+  mzdata:
+  tmp:
+  secrets:

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -19,7 +19,7 @@ services:
         wait-for-it --timeout=30 schema-registry:8081 &&
         wait-for-it --timeout=30 materialized:6875 &&
         testdrive
-        --kafka-addr=kafka:9092
+        --kafka-url=plaintext://kafka:9092
         --aws-region=us-east-2
         --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://ignored@materialized:6875

--- a/test/testdrive/ssl/avro-registry-ssl.td
+++ b/test/testdrive/ssl/avro-registry-ssl.td
@@ -1,0 +1,203 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests that hit the Confluent Schema Registry.
+
+# Verify the error message is useful when a schema is not present in the
+# registry.
+
+! CREATE SOURCE noexist
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-noexist-${testdrive.seed}'
+    WITH (
+        security_protocol='SSL',
+        ssl_key_location='/share/secrets/materialized.key',
+        ssl_certificate_location='/share/secrets/materialized.crt',
+        ssl_ca_location='/share/secrets/ca.crt',
+        ssl_key_password='mzmzmz'
+    )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+fetching latest schema for subject 'testdrive-noexist-${testdrive.seed}-value' from registry: subject not found
+
+$ set schema-v1={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ set schema-v2={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long", "default": 42}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema-v1} publish=true timestamp=1
+{"before": null, "after": {"a": 1}}
+
+> CREATE MATERIALIZED SOURCE data_v1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+    WITH (
+        security_protocol='SSL',
+        ssl_key_location='/share/secrets/materialized.key',
+        ssl_certificate_location='/share/secrets/materialized.crt',
+        ssl_ca_location='/share/secrets/ca.crt',
+        ssl_key_password='mzmzmz'
+    )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM data_v1
+a
+---
+1
+
+$ kafka-ingest format=avro topic=data schema=${schema-v2} publish=true timestamp=3
+{"before": null, "after": {"a": 2, "b": -1}}
+
+> CREATE MATERIALIZED SOURCE data_v2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+    WITH (
+        security_protocol='SSL',
+        ssl_key_location='/share/secrets/materialized.key',
+        ssl_certificate_location='/share/secrets/materialized.crt',
+        ssl_ca_location='/share/secrets/ca.crt',
+        ssl_key_password='mzmzmz'
+    )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM data_v1
+a
+---
+1
+2
+
+> SELECT * FROM data_v2
+a b
+----
+1 42
+2 -1
+
+$ set key-schema-missing={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "b", "type": "long"}
+    ]
+  }
+
+$ set key-schema-wrong-type={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "a", "type": "int"}
+    ]
+  }
+
+$ set valid-key-schema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "a", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=missing-data
+
+$ kafka-ingest format=avro key-format=avro topic=missing-data schema=${schema-v1} key-schema=${key-schema-missing}
+  publish=true timestamp=1
+{"b": 42} {"before": null, "after": {"a": 1}}
+
+! CREATE SOURCE data_v3
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-missing-data-${testdrive.seed}'
+    WITH (
+        security_protocol='SSL',
+        ssl_key_location='/share/secrets/materialized.key',
+        ssl_certificate_location='/share/secrets/materialized.crt',
+        ssl_ca_location='/share/secrets/ca.crt',
+        ssl_key_password='mzmzmz'
+    )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+Value schema missing primary key column: b
+
+$ kafka-create-topic topic=mismatched-data
+
+$ kafka-ingest topic=mismatched-data publish=true timestamp=3
+  format=avro schema=${schema-v1} key-format=avro key-schema=${key-schema-wrong-type}
+{"a": 1} {"before": null, "after": {"a": 1}}
+
+! CREATE SOURCE data_v3
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mismatched-data-${testdrive.seed}'
+    WITH (
+        security_protocol='SSL',
+        ssl_key_location='/share/secrets/materialized.key',
+        ssl_certificate_location='/share/secrets/materialized.crt',
+        ssl_ca_location='/share/secrets/ca.crt',
+        ssl_key_password='mzmzmz'
+    )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+key and value column types do not match
+
+$ kafka-ingest topic=data publish=true timestamp=5
+  format=avro schema=${schema-v1} key-format=avro key-schema=${valid-key-schema}
+{"a": 1} {"before": null, "after": {"a": 1}}
+
+> CREATE MATERIALIZED SOURCE data_v3
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+    WITH (
+        security_protocol='SSL',
+        ssl_key_location='/share/secrets/materialized.key',
+        ssl_certificate_location='/share/secrets/materialized.crt',
+        ssl_ca_location='/share/secrets/ca.crt',
+        ssl_key_password='mzmzmz'
+    )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM data_v3
+a
+---
+1 42
+1 42
+2 -1


### PR DESCRIPTION
Follow on for #2744 

- Test drive will sadly require a path to the CA root's pem file for the time being. Without invoking OpenSSL, there isn't a way to extract the CA certificate from the `p12` file in a way that is usable by `reqwest` (and probably `rust-rdkafka`, as well).
- I wasn't sure how granular to make the `inputs` in `pipline.template.yml`. I went with something more restrictive, but lmk if that should be opened up.

I believe this also address all of your feedback from the previous PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2820)
<!-- Reviewable:end -->
