### PR TITLE
Pivot frontier structures to antichains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 [[package]]
 name = "differential-dataflow"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#1a977866897035ada8c55240a0c1ccf7a8d03b81"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#704beeb3e078b3689ae580c03d4e23c4ff909508"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -781,7 +781,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#1a977866897035ada8c55240a0c1ccf7a8d03b81"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#704beeb3e078b3689ae580c03d4e23c4ff909508"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -100,7 +100,7 @@ pub struct DataflowDesc {
     ///
     /// This is logically equivalent to a timely dataflow `Antichain`,
     /// which should probably be used here instead.
-    pub as_of: Option<Vec<Timestamp>>,
+    pub as_of: Option<Antichain<Timestamp>>,
     /// Human readable name
     pub debug_name: String,
 }
@@ -202,7 +202,7 @@ impl DataflowDesc {
     }
 
     pub fn as_of(&mut self, as_of: Antichain<Timestamp>) {
-        self.as_of = Some(as_of.elements().into());
+        self.as_of = Some(as_of);
     }
 
     /// Gets index ids of all indexes require to construct a particular view

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -240,8 +240,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
             // visible in sinks.
             let as_of_frontier = dataflow
                 .as_of
-                .as_ref()
-                .map(|x| x.clone())
+                .clone()
                 .unwrap_or_else(|| Antichain::from_elem(0));
 
             // Load declared sources into the rendering context.

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -119,6 +119,7 @@ use timely::dataflow::operators::unordered_input::UnorderedInput;
 use timely::dataflow::operators::Map;
 use timely::dataflow::Scope;
 use timely::dataflow::Stream;
+use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
 use avro::Schema;
@@ -240,8 +241,8 @@ pub(crate) fn build_dataflow<A: Allocate>(
             let as_of_frontier = dataflow
                 .as_of
                 .as_ref()
-                .map(|x| x.to_vec())
-                .unwrap_or_else(|| vec![0]);
+                .map(|x| x.clone())
+                .unwrap_or_else(|| Antichain::from_elem(0));
 
             // Load declared sources into the rendering context.
             for (src_id, mut src) in dataflow.source_imports.clone() {
@@ -297,7 +298,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                     let as_of_frontier = as_of_frontier.clone();
                                     move |_datum, time| {
                                         let mut time = time.clone();
-                                        time.advance_by(&as_of_frontier[..]);
+                                        time.advance_by(as_of_frontier.borrow());
                                         time
                                     }
                                 });
@@ -463,7 +464,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                             let as_of_frontier = as_of_frontier.clone();
                             move |time| {
                                 let mut time = time.clone();
-                                time.advance_by(&as_of_frontier[..]);
+                                time.advance_by(as_of_frontier.borrow());
                                 time
                             }
                         });
@@ -471,7 +472,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                             let as_of_frontier = as_of_frontier.clone();
                             move |time| {
                                 let mut time = time.clone();
-                                time.advance_by(&as_of_frontier[..]);
+                                time.advance_by(as_of_frontier.borrow());
                                 time
                             }
                         });


### PR DESCRIPTION
This tracks a differential dataflow change that exposes more `Antichain<T>` and `AntichainRef<T>` types in public APIs where things that were formerly `Vec<T>` and `&[T]` should actually be antichains.

I think most of these changes are superficial, and lead us to more semantically clear things that we hand around.

cc @justinj, @ruchirK, @wangandi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2822)
<!-- Reviewable:end -->
