### PR TITLE
Delete testdrive Kinesis streams as separate step

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -136,10 +136,17 @@ impl State {
             })?
             .stream_names
             .into_iter()
-            .filter(|stream_name| stream_name.contains(&self.seed.to_string()))
+            .filter(|stream_name| {
+                stream_name.starts_with("testdrive")
+                    && stream_name.ends_with(&self.seed.to_string())
+            })
             .collect();
 
         if !stream_names_with_matching_seed.is_empty() {
+            println!(
+                "Deleting stale Kinesis topics {}",
+                stream_names_with_matching_seed.join(", ")
+            );
             for stream_name in stream_names_with_matching_seed {
                 self.kinesis_client
                     .delete_stream(DeleteStreamInput {

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -40,15 +40,15 @@ impl Action for CreateStreamAction {
         let stream_name = format!("{}-{}", self.stream_name, state.seed);
         println!("Creating Kinesis stream {}", stream_name);
 
-        let create_stream_input = CreateStreamInput {
-            shard_count: self.shard_count,
-            stream_name: stream_name.clone(),
-        };
         state
             .kinesis_client
-            .create_stream(create_stream_input)
+            .create_stream(CreateStreamInput {
+                shard_count: self.shard_count,
+                stream_name: stream_name.clone(),
+            })
             .await
             .map_err(|e| format!("creating stream: {}", e))?;
+        state.kinesis_stream_names.push(stream_name.clone());
 
         util::kinesis::wait_for_stream_shards(&state.kinesis_client, stream_name, self.shard_count)
             .await

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use async_trait::async_trait;
-use rusoto_kinesis::{CreateStreamInput, DeleteStreamInput, Kinesis, ListStreamsInput};
+use rusoto_kinesis::{CreateStreamInput, Kinesis};
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
@@ -32,32 +32,7 @@ pub fn build_create_stream(mut cmd: BuiltinCommand) -> Result<CreateStreamAction
 
 #[async_trait]
 impl Action for CreateStreamAction {
-    async fn undo(&self, state: &mut State) -> Result<(), String> {
-        let list_streams_input = ListStreamsInput {
-            exclusive_start_stream_name: None,
-            limit: None,
-        };
-        let stream_names = state
-            .kinesis_client
-            .list_streams(list_streams_input)
-            .await
-            .map_err(|e| format!("listing Kinesis streams: {}", e))?
-            .stream_names;
-
-        if !stream_names.is_empty() {
-            println!("Deleting stale Kinesis topics {}", stream_names.join(", "));
-            for stream_name in stream_names {
-                let delete_stream_input = DeleteStreamInput {
-                    enforce_consumer_deletion: Some(true),
-                    stream_name: stream_name.clone(),
-                };
-                state
-                    .kinesis_client
-                    .delete_stream(delete_stream_input)
-                    .await
-                    .map_err(|e| format!("deleting Kinesis stream: {}", e))?;
-            }
-        }
+    async fn undo(&self, _state: &mut State) -> Result<(), String> {
         Ok(())
     }
 

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -75,6 +75,8 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
             let redo = a.action.redo(&mut state);
             redo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
         }
+        // Clean up external state (Kinesis)
+        state.reset_kinesis().await?;
         drop(state);
         state_cleanup.await
     })


### PR DESCRIPTION
All testdrive tests running in CI are sharing the same AWS account. Currently the `undo` of the `create_stream` step deletes any existing streams -- including streams required by other running testdrive tests!

This PR pulls stream deletion out of `create_stream` and into a new `reset_kinesis` function.

Note: the problem with this approach is that any `testdrive` run in CI that is ended prematurely will leave hanging streams. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2832)
<!-- Reviewable:end -->
