### PR TITLE
doc: fix broken link to monitoring dashboard

### DIFF
--- a/doc/user/monitoring/_index.md
+++ b/doc/user/monitoring/_index.md
@@ -60,5 +60,5 @@ Grafana][graf-import]. It relies on you having configured prometheus to scrape
 materialized.
 
 [simplemon-hub]: https://hub.docker.com/repository/docker/materialize/dashboard
-[dashboard-json]: ../../../misc/monitoring/simple-monitor/user/conf/grafana/dashboards/overview.json
+[dashboard-json]: https://github.com/MaterializeInc/materialize/tree/master/misc/monitoring/simple-monitor/user/conf/grafana/dashboards/overview.json
 [graf-import]: https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard

--- a/doc/user/monitoring/_index.md
+++ b/doc/user/monitoring/_index.md
@@ -17,7 +17,7 @@ preconfigured to run it as [`materialize/simple-monitor`](simplemon-hub).
 The only configuration required to get started with the docker image is the
 `MATERIALIZED_URL=<host>:<port>` environment variable.
 
-As an example, if you are running `materialized` on in a cloud instance at the IP address
+As an example, if you are running `materialized` in a cloud instance at the IP address
 172.16.0.0, you could get a dashboard by running this command and opening `http://localhost:3000` in your web browser:
 
 ```console


### PR DESCRIPTION
when rendered, it renders into a link under materialize.io, which is
incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2833)
<!-- Reviewable:end -->
