### PR TITLE
dashboard: Add a program that prefixes logs with the name of their service

### DIFF
--- a/demo/chbench/prometheus/prometheus.yml
+++ b/demo/chbench/prometheus/prometheus.yml
@@ -22,7 +22,7 @@ scrape_configs:
     static_configs:
       - targets: ['peeker:16875']
   - job_name: materialized_logs
-    scrape_interval: 1s
+    scrape_interval: 10s
     static_configs:
       - targets:
           - 'localhost:9399'

--- a/misc/monitoring/dashboard/Dockerfile
+++ b/misc/monitoring/dashboard/Dockerfile
@@ -43,7 +43,8 @@ COPY --from=build /prometheus/consoles/                              /usr/share/
 COPY --from=build /prometheus/LICENSE                                /licenses-prometheus/LICENSE
 COPY --from=build /prometheus/NOTICE                                 /licenses-prometheus/NOTICE
 
-# Our configurtion
+# Our configuration -- needs to be before the RUN block because it needs to be made
+# writeable so that startup.py can overwrite MATERIALIZED_URL
 COPY --chown=nobody:nogroup conf/prometheus.yml /etc/prometheus/prometheus.yml
 
 # Grafana
@@ -56,12 +57,6 @@ COPY --from=build --chown=nobody:nogroup /usr/share/grafana /usr/share/grafana
 COPY --from=build --chown=nobody:nogroup /etc/default/grafana-server /etc/default/grafana-server
 COPY --from=build --chown=nobody:nogroup /usr/sbin/grafana-cli /usr/sbin/grafana-cli
 COPY --from=build --chown=nobody:nogroup /usr/sbin/grafana-server /usr/sbin/grafana-server
-
-# Our configuration
-COPY --chown=nobody:nogroup conf/grafana/dashboards/dashboards.yaml /etc/grafana/provisioning/dashboards/
-COPY --chown=nobody:nogroup conf/grafana/dashboards/overview.json /etc/grafana/provisioning/dashboards/
-COPY --chown=nobody:nogroup conf/grafana/datasources/prometheus.yaml /etc/grafana/provisioning/datasources/
-COPY --chown=nobody:nogroup conf/grafana/grafana.ini /etc/grafana/grafana.ini
 
 ENV GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
     GF_PATHS_DATA="/var/lib/grafana" \
@@ -91,6 +86,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive \
         /etc/grafana/provisioning/dashboards \
         /etc/grafana/provisioning/datasources \
         /etc/grafana/provisioning/notifiers \
+        /run/prefixed \
     # Supervisor
     && python3 -m venv /opt/venvs/supervisord \
     && /opt/venvs/supervisord/bin/pip install supervisor==4.1.0 \
@@ -106,6 +102,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive \
         /usr/share/grafana \
         /var/lib/grafana \
         /var/log/grafana \
+        /run/prefixed \
     # Ensure that files can be read even when not running as nobody
     && chmod -R 666 \
         /sql_exporter/* \
@@ -119,6 +116,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive \
         /grafana \
         /supervisord \
         /prometheus \
+        /run/prefixed \
         /var/lib/grafana \
         /etc/grafana \
         /etc/grafana/provisioning \
@@ -133,14 +131,25 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive \
         /var/lib/apt/lists/* \
     ;
 
+# Our grafana configuration, doesn't get overwritten by startup.py
+COPY --chown=nobody:nogroup conf/grafana/dashboards/dashboards.yaml /etc/grafana/provisioning/dashboards/
+COPY --chown=nobody:nogroup conf/grafana/dashboards/overview.json /etc/grafana/provisioning/dashboards/
+COPY --chown=nobody:nogroup conf/grafana/datasources/prometheus.yaml /etc/grafana/provisioning/datasources/
+COPY --chown=nobody:nogroup conf/grafana/grafana.ini /etc/grafana/grafana.ini
+
+
 # Entrypoint/supervisor/externally visible
-COPY startup.py /bin/startup.py
+COPY bin/startup.py /bin/startup.py
+COPY bin/log-prefixer.py /bin/log-prefixer.py
 
 USER       nobody
 COPY       conf/supervisord.conf /supervisord/supervisord.conf
 WORKDIR    /supervisord
 ENTRYPOINT [ "/bin/startup.py" ]
-# The files to overwrite by startup.py
-CMD        [ "/etc/prometheus/prometheus.yml", "/sql_exporter/sql_exporter.yml" ]
+# arguments to startup.py
+CMD        [ "--create-pipes", \
+        "prometheus=/run/prefixed/prometheus,grafana=/run/prefixed/grafana,sql_prom=/run/prefixed/sql_prom", \
+        "/etc/prometheus/prometheus.yml", \
+        "/sql_exporter/sql_exporter.yml" ]
 EXPOSE     3000
 VOLUME     [ "/prometheus", "/etc/grafana/provisioning" ]

--- a/misc/monitoring/dashboard/bin/log-prefixer.py
+++ b/misc/monitoring/dashboard/bin/log-prefixer.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import argparse
+import threading
+import sys
+from typing import Dict
+
+
+def main() -> None:
+    args = parse_args()
+    echo_files_with_prefixes({p: f for p, f in args.prefix_file})
+
+
+def echo_files_with_prefixes(prefixes_files: Dict[str, str]) -> None:
+    """Start as many threads as there are files in prefixes_files, writing their output
+    """
+    max_prefix_len = max(len(prefix) for prefix in prefixes_files)
+    threads = []
+    for prefix, fname in prefixes_files.items():
+        pad = " " * (max_prefix_len - len(prefix))
+        thread = threading.Thread(
+            target=follow_file, args=(f"{prefix}", f"{pad} >", fname)
+        )
+        thread.start()
+        threads.append(thread)
+
+    for i, thread in enumerate(threads):
+        try:
+            thread.join()
+        except KeyboardInterrupt:
+            return
+
+
+def follow_file(prefix: str, pad: str, fname: str) -> None:
+    error_count = 0
+    full_pre = prefix + pad
+    while True:
+        try:
+            with open(fname) as fh:
+                for line in fh:
+                    print(full_pre, line, end="")
+            log(f"reached end of input for {prefix} {fname}")
+            return
+        except FileNotFoundError:
+            if error_count % 100 == 0:
+                print(f"Error opening {prefix} {fname} for reading")
+            time.sleep(0.5)
+            error_count += 1
+        except KeyboardInterrupt:
+            return
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print all lines from files with different prefixes"
+    )
+    parser.add_argument(
+        "prefix_file", help="prefix=/the/file/to/read", nargs="*",
+    )
+    args = parser.parse_args()
+    print(args.prefix_file)
+    args.prefix_file = [pf.split("=", 1) for pf in args.prefix_file]
+    if any(len(pf) != 2 for pf in args.prefix_file):
+        print(
+            "Every prefix file must include a prefix, followed by the file, got {}".format(
+                " and ".join([pf for pf in args.prefix_file if len(pf) != 2])
+            )
+        )
+    return args
+
+
+def log(msg: str, *args: str):
+    print("prefixer>", msg.format(*args), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/monitoring/dashboard/conf/prometheus.yml
+++ b/misc/monitoring/dashboard/conf/prometheus.yml
@@ -18,7 +18,7 @@ scrape_configs:
   - targets:
     - 'MATERIALIZED_URL'
 - job_name: materialized_logs
-  scrape_interval: 5s
+  scrape_interval: 10s
   static_configs:
   - targets:
     - 'localhost:9399'

--- a/misc/monitoring/dashboard/conf/supervisord.conf
+++ b/misc/monitoring/dashboard/conf/supervisord.conf
@@ -19,7 +19,7 @@ command = /bin/prometheus
     --web.console.libraries=/usr/share/prometheus/console_libraries
     --web.console.templates=/usr/share/prometheus/consoles
 redirect_stderr = true
-stdout_logfile = /dev/stdout
+stdout_logfile = /run/prefixed/prometheus
 stdout_logfile_maxbytes = 0
 
 [program:grafana]
@@ -32,11 +32,11 @@ command = grafana-server
     cfg:default.paths.plugins="%(ENV_GF_PATHS_PLUGINS)s"
     cfg:default.paths.provisioning="%(ENV_GF_PATHS_PROVISIONING)s"
 redirect_stderr = true
-stdout_logfile = /dev/stdout
+stdout_logfile = /run/prefixed/grafana
 stdout_logfile_maxbytes = 0
 
 [program:sql_exporter]
 command = /bin/sql_exporter -config.file /sql_exporter/sql_exporter.yml
 redirect_stderr = true
-stdout_logfile = /dev/stdout
+stdout_logfile = /run/prefixed/sqlexporter
 stdout_logfile_maxbytes = 0

--- a/misc/monitoring/dashboard/conf/supervisord.conf
+++ b/misc/monitoring/dashboard/conf/supervisord.conf
@@ -38,5 +38,5 @@ stdout_logfile_maxbytes = 0
 [program:sql_exporter]
 command = /bin/sql_exporter -config.file /sql_exporter/sql_exporter.yml
 redirect_stderr = true
-stdout_logfile = /run/prefixed/sqlexporter
+stdout_logfile = /run/prefixed/sql_prom
 stdout_logfile_maxbytes = 0


### PR DESCRIPTION
Having a bunch of services in a docker container is bad for a bunch of reasons, one of
which is docker isn't really designed to handle that kind of logging.

This works around that, to make it easier for us to debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2838)
<!-- Reviewable:end -->
