### PR TITLE
ci: run docker-compose down before docker-compose up

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -21,6 +21,12 @@ if [[ "${BUILDKITE_COMMAND:-}" ]]; then
     run_args+=("$BUILDKITE_COMMAND")
 fi
 
+# Sometimes build cancellations prevent us from properly cleaning up the last
+# Docker Compose run, which can leave old containers or volumes around that will
+# interfere with this build.
+echo "--- :docker: Purging containers and volumes from previous builds"
+mzcompose --mz-quiet down --volumes
+
 # Start dependencies under a different heading so that the main heading is less
 # noisy.
 echo "--- :docker: Starting dependencies" >&2

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -14,7 +14,7 @@ set -euo pipefail
 echo "~~~ :docker: Cleaning up after mzcompose" >&2
 
 run() {
-    bin/ci-builder run stable bin/mzcompose -f "$BUILDKITE_PLUGIN_MZCOMPOSE_CONFIG" "$@"
+    bin/ci-builder run stable bin/mzcompose --mz-quiet -f "$BUILDKITE_PLUGIN_MZCOMPOSE_CONFIG" "$@"
 }
 
 run kill


### PR DESCRIPTION
Sometimes build cancellations cause Docker Compose to fail to clean up
after itself, and those lingering containers and volumes can interfere
with the next build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2839)
<!-- Reviewable:end -->
