### PR TITLE
ci: ensure all mzbuild images are pushed

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -30,7 +30,10 @@ def main() -> None:
     # other build agents.
     print("--- Acquiring mzbuild images")
     deps = repo.resolve_dependencies(image for image in repo if image.publish)
-    deps.acquire(push=True)
+    deps.acquire()
+    for d in deps:
+        if not d.pushed():
+            d.push()
 
     print("--- Staging Debian package")
     if os.environ["BUILDKITE_BRANCH"] == "master":


### PR DESCRIPTION
If pushing an image fails (e.g. because the Docker Hub permissions are
incorrect), that push won't be retried on subsequent CI builds, because
the image will be available locally and the push will get skipped.

Rework the build jobs so that all images are checked for existence on
Docker Hub and pushed if they do not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2840)
<!-- Reviewable:end -->
