### PR TITLE
Fix TAIL's use of TIMESTAMP{,TZ} as timestamps

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -186,8 +186,8 @@ pub fn eval_as_of<'a>(scx: &'a StatementContext, expr: Expr) -> Result<Timestamp
         }
         ScalarType::Int32 => evaled.unwrap_int32().try_into()?,
         ScalarType::Int64 => evaled.unwrap_int64().try_into()?,
-        ScalarType::TimestampTz => evaled.unwrap_timestamptz().timestamp().try_into()?,
-        ScalarType::Timestamp => evaled.unwrap_timestamp().timestamp().try_into()?,
+        ScalarType::TimestampTz => evaled.unwrap_timestamptz().timestamp_millis().try_into()?,
+        ScalarType::Timestamp => evaled.unwrap_timestamp().timestamp_millis().try_into()?,
         _ => bail!("can't use {} as a timestamp for AS OF", ex.typ(desc.typ())),
     })
 }


### PR DESCRIPTION
This was inadvertedly using seconds since epoch instead of milliseconds.
This commit changes it to use the milliseconds.

I'd like to add a test for this, but I'm still not sure how to do so in
a nice way, so I'll just include the promise that I tested this out by
hand (thought I did last time, I guess I confused myself somehow),
unless there are better ideas!

I also don't see an easy way to unify the two arms here, since they two timestamp variants have different underlying chrono types? This implementation feels a little hacky to me overall, but I'm not sure how to make it better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2844)
<!-- Reviewable:end -->
