### PR TITLE
ore: add missing dependency on tokio's time feature

### DIFF
--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.4.0"
 libc = "0.2.69"
 log = "0.4.8"
 smallvec = "1.4"
-tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp"] }
+tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp", "time"] }
 tracing-subscriber = "0.2.5"
 
 [dev-dependencies]


### PR DESCRIPTION
This got missed because it's not necessary when building the whole
workspace, but it *is* necessary when running just repr's miri tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2847)
<!-- Reviewable:end -->
