### PR TITLE
Fix dangling reference to grafana mzcompose service

### DIFF
--- a/demo/chbench/dc.sh
+++ b/demo/chbench/dc.sh
@@ -532,7 +532,7 @@ load_test() {
     dc_run -d peeker \
          "${PEEKER_COMMAND[@]}"
     dc_ensure_stays_up peeker
-    dc_ensure_stays_up grafana 1
+    dc_ensure_stays_up dashboard 1
     dc_status
 }
 


### PR DESCRIPTION
It was left over from the transition to single-image monitoring

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2848)
<!-- Reviewable:end -->
