### PR TITLE
Fix panic in demand analysis

### DIFF
--- a/src/expr/transform/demand.rs
+++ b/src/expr/transform/demand.rs
@@ -129,6 +129,7 @@ impl Demand {
                 // A FlatMap which returns zero rows acts like a filter
                 // so we always need to execute it
                 columns.extend(expr.support());
+                columns.retain(|c| *c < input.arity());
                 self.action(input, columns, gets);
             }
             RelationExpr::Filter { input, predicates } => {

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the logic test suite in CockroachDB. The
+# original file was retrieved on June 10, 2019 from:
+#
+# The original source code is subject to the terms of the Apache
+# 2.0 license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+statement ok
+CREATE TABLE y (a JSONB)
+
+# Ensure this does not panic.
+query TTTT
+SELECT * FROM y a, y b, jsonb_each(a.a);
+----


### PR DESCRIPTION
Previously, we would inform the input to a FlatMapUnary that we
expected it to produce even the column we ourselves were producing,
which understandably caused it anguish. This change only asks for the
columns the input is capable of producing. I couldn't find an existing
place that set-returning functions were tested, so I added an SLT file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2849)
<!-- Reviewable:end -->
