### PR TITLE
Fix support for avro record in upsert.

### DIFF
--- a/src/dataflow/decode/mod.rs
+++ b/src/dataflow/decode/mod.rs
@@ -73,7 +73,7 @@ where
     let envelope = envelope.clone();
     pass_through(stream, "AvroValues", Pipeline).flat_map(move |((value, index), r, d)| {
         let diffs = match envelope {
-            Envelope::None => extract_row(value, false, index.map(Datum::from)).map(|r| DiffPair {
+            Envelope::None => extract_row(value, index.map(Datum::from)).map(|r| DiffPair {
                 before: None,
                 after: r,
             }),

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -307,6 +307,8 @@ where
                             return SourceStatus::Alive;
                         }
                         Some(ts) => {
+                            // Note: empty and null payload/keys are currently
+                            // treated as the same thing.
                             let key = message.key.unwrap_or_default();
                             let out = message.payload.unwrap_or_default();
                             partition_metadata[partition as usize].0 = offset;

--- a/test/testdrive/compaction-kafka.td
+++ b/test/testdrive/compaction-kafka.td
@@ -17,9 +17,7 @@ $ set keyschema={
     ]
   }
 
-$ set schema=[
-    "null",
-    {
+$ set schema={
         "type" : "record",
         "name" : "test",
         "fields" : [
@@ -27,7 +25,6 @@ $ set schema=[
             {"name":"f2", "type":"long"}
         ]
     }
-  ]
 
 $ set consistency={
      "name": "materialize.byo.consistency",
@@ -76,10 +73,10 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
 {"key": "bird1"} {"f1":"goose", "f2": 1}
 {"key": "birdmore"} {"f1":"geese", "f2": 2}
 {"key": "mammal1"} {"f1": "moose", "f2": 1}
-{"key": "bird1"} null
+{"key": "bird1"}
 {"key": "birdmore"} {"f1":"geese", "f2": 56}
 {"key": "mammalmore"} {"f1": "moose", "f2": 42}
-{"key": "mammal1"} null
+{"key": "mammal1"}
 {"key": "mammalmore"} {"f1":"moose", "f2": 2}
 
 > CREATE MATERIALIZED SOURCE avroavro
@@ -107,10 +104,10 @@ fish: {"f1": "fish", "f2": 1000}
 bìrd1: {"f1":"goose", "f2": 1}
 birdmore: {"f1":"geese", "f2": 2}
 mammal1: {"f1": "moose", "f2": 1}
-bìrd1: null
+bìrd1:
 birdmore: {"f1":"geese", "f2": 56}
 mämmalmore: {"f1": "moose", "f2": 42}
-mammal1: null
+mammal1:
 mammalmore: {"f1":"moose", "f2": 2}
 
 > CREATE MATERIALIZED SOURCE bytesavro
@@ -265,7 +262,7 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 {"key": "lightning"} {"f1": "sheep", "f2": 54}
 {"key": "earth"} {"f1": "snake", "f2": 68}
 {"key": "water"} {"f1": "crocodile", "f2": 7}
-{"key": "earth"} null
+{"key": "earth"}
 
 > CREATE MATERIALIZED SOURCE realtimeavroavro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
@@ -296,14 +293,14 @@ water      crocodile      7
 
 # ensure that having deletion on a key that never existed does not break anything
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true
-{"key": "spirit"} null
+{"key": "spirit"}
 {"key": "air"} {"f1": "pigeon", "f2": 10}
 {"key": "air"} {"f1": "owl", "f2": 15}
 {"key": "earth"} {"f1": "rhinoceros", "f2": 211}
 {"key": "air"} {"f1": "chicken", "f2": 47}
-{"key": "lightning"} null
+{"key": "lightning"}
 {"key": "lightning"} {"f1":"dog", "f2": 243}
-{"key": "water"} null
+{"key": "water"}
 
 > select * from realtimeavroavro
 key        f1             f2


### PR DESCRIPTION
Cause of avro decoding problem was that I had thought for some reason mistakenly thought that the `strip_union` variable for `extract_row` would be a no-op if the value was not a union, so I thought I could have upsert support schema of `record` or `union[null, record]`. Then in the upsert testdrive test, I only tested schema of `union[null, record]`.

As part of fixing this problem:
* I added testdrive support for null payload values when format=avro
* I removed materialize support for avro schema of `union[null, record]` in upsert. Given the fact that Kafka tombstones are records with null payloads as opposed to records with a non-null payload that contains an avro null object, it is unlikely that anyone would be using `union[null, record]` anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2854)
<!-- Reviewable:end -->
