### PR TITLE
ccsr: remove dependency on rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,8 +349,8 @@ dependencies = [
  "hyper",
  "lazy_static",
  "native-tls",
+ "openssl",
  "reqwest",
- "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -644,15 +644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ct-logs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
-dependencies = [
- "sct",
 ]
 
 [[package]]
@@ -1337,24 +1328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
-dependencies = [
- "bytes",
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "webpki",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,9 +1965,9 @@ checksum = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 
 [[package]]
 name = "openssl"
-version = "0.10.25"
+version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f372b2b53ce10fb823a337aaa674e3a7d072b957c6264d0f4ff0bd86e657449"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2675,7 +2648,6 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "js-sys",
  "lazy_static",
@@ -2685,35 +2657,17 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "time 0.1.42",
  "tokio",
- "tokio-rustls",
  "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5a8ec64ee89a76c98c549af81ff14813df09c3e6dc4766c3856da48597a0c"
-dependencies = [
- "cc",
- "lazy_static",
- "libc",
- "spin",
- "untrusted",
- "web-sys",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2880,31 +2834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
-dependencies = [
- "base64 0.11.0",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,16 +2887,6 @@ name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
-
-[[package]]
-name = "sct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -3647,18 +3566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
-dependencies = [
- "futures-core",
- "rustls",
- "tokio",
- "webpki",
-]
-
-[[package]]
 name = "tokio-serde"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,12 +3753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
-name = "untrusted"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
-
-[[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4009,25 +3910,6 @@ checksum = "721c6263e2c66fd44501cc5efbfa2b7dfa775d13e4ea38c46299646ed1f9c70a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f50e1972865d6b1adb54167d1c8ed48606004c2c9d0ea5f1eeb34d95e863ef"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -11,8 +11,8 @@ path = "lib.rs"
 [dependencies]
 futures = "0.3"
 native-tls = "0.2.4"
-reqwest = { version = "0.10.4", features = ["blocking", "json", "native-tls-vendored", "rustls-tls"] }
-rustls = "0.17.0"
+openssl = { version = "0.10.29", features = ["vendored"] }
+reqwest = { version = "0.10.4", features = ["blocking", "json", "native-tls-vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.51"
 url = { version = "2.1.0", features = ["serde"] }

--- a/src/ccsr/config.rs
+++ b/src/ccsr/config.rs
@@ -11,7 +11,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
 use crate::client::Client;
-use crate::tls::{CertDetails, Certificate, Identity};
+use crate::tls::{Certificate, Identity};
 
 /// Configuration for a `Client`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -50,16 +50,12 @@ impl ClientConfig {
     pub fn build(self) -> Client {
         let mut builder = reqwest::Client::builder();
 
-        for root_cert in &self.root_certs {
-            builder = builder.add_root_certificate(root_cert.clone().into());
+        for root_cert in self.root_certs {
+            builder = builder.add_root_certificate(root_cert.into());
         }
 
-        if let Some(ident) = &self.identity {
-            match ident.cert {
-                CertDetails::Pem(_) => builder = builder.use_rustls_tls(),
-                CertDetails::Der(_, _) => builder = builder.use_native_tls(),
-            }
-            builder = builder.identity(ident.clone().into());
+        if let Some(ident) = self.identity {
+            builder = builder.identity(ident.into());
         }
 
         let inner = builder

--- a/src/ccsr/tls.rs
+++ b/src/ccsr/tls.rs
@@ -9,49 +9,57 @@
 
 //! TLS certificates and identities.
 
+use openssl::pkcs12::Pkcs12;
+use openssl::pkey::PKey;
+use openssl::stack::Stack;
+use openssl::x509::X509;
 use serde::{Deserialize, Serialize};
-
-// Encodes the type of certificate file, as well as the certificate's bytes. In
-// the case of der certificates, it also stores the password.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub(crate) enum CertDetails {
-    Pem(Vec<u8>),
-    Der(Vec<u8>, String),
-}
 
 /// A [Serde][serde]-enabled wrapper around [`reqwest::Identity`].
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Identity {
-    pub(crate) cert: CertDetails,
+    der: Vec<u8>,
+    pass: String,
 }
 
 impl Identity {
-    /// Wraps [`reqwest::Identity::from_pem`].
-    pub fn from_pem(pem: &[u8]) -> Result<Self, reqwest::Error> {
-        let _ = reqwest::Identity::from_pem(&pem)?;
-        Ok(Identity {
-            cert: CertDetails::Pem(pem.into()),
-        })
+    /// Reimplements [`reqwest::Identity::from_pem`] in terms of OpenSSL.
+    ///
+    /// The implementation in reqwest requires rustls.
+    pub fn from_pem(pem: &[u8]) -> Result<Self, openssl::error::ErrorStack> {
+        let pkey = PKey::private_key_from_pem(pem)?;
+        let mut certs = Stack::new()?;
+        let mut cert_iter = X509::stack_from_pem(pem)?.into_iter();
+        let cert = cert_iter
+            .next()
+            .expect("X509::stack_from_pem always returns at least one certificate");
+        for cert in cert_iter {
+            certs.push(cert)?;
+        }
+        let mut pkcs_builder = Pkcs12::builder();
+        pkcs_builder.ca(certs);
+        // We build a PKCS #12 archive solely to have something to pass to
+        // `reqwest::Identity::from_pkcs12_der`, so the password and friendly
+        // name don't matter.
+        let pass = String::new();
+        let friendly_name = "";
+        let der = pkcs_builder
+            .build(&pass, friendly_name, &pkey, &cert)?
+            .to_der()?;
+        Ok(Identity { der, pass })
     }
 
     /// Wraps [`reqwest::Identity::from_pkcs12_der`].
-    pub fn from_pkcs12_der(der: &[u8], password: &str) -> Result<Self, reqwest::Error> {
-        let _ = reqwest::Identity::from_pkcs12_der(&der, password)?;
-        Ok(Identity {
-            cert: CertDetails::Der(der.into(), password.to_string()),
-        })
+    pub fn from_pkcs12_der(der: Vec<u8>, pass: String) -> Result<Self, reqwest::Error> {
+        let _ = reqwest::Identity::from_pkcs12_der(&der, &pass)?;
+        Ok(Identity { der, pass })
     }
 }
 
 impl Into<reqwest::Identity> for Identity {
     fn into(self) -> reqwest::Identity {
-        match self.cert {
-            CertDetails::Pem(pem) => {
-                reqwest::Identity::from_pem(&pem).expect("known to be a valid identity")
-            }
-            CertDetails::Der(der, pass) => reqwest::Identity::from_pkcs12_der(&der, &pass)
-                .expect("known to be a valid identity"),
-        }
+        reqwest::Identity::from_pkcs12_der(&self.der, &self.pass)
+            .expect("known to be a valid identity")
     }
 }
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -488,7 +488,7 @@ pub async fn create_state(
             });
         }
 
-        let ident = match ccsr::tls::Identity::from_pkcs12_der(&keystore_buf, &keystore_pass) {
+        let ident = match ccsr::tls::Identity::from_pkcs12_der(keystore_buf, keystore_pass) {
             Ok(i) => i,
             Err(e) => {
                 return Err(Error::General {


### PR DESCRIPTION
See #2799. We're stuck with OpenSSL for librdkafka, and best not to have
two crypto libraries in play.

@sploiselle apologies if you were about to jump on this, but I had a prototype of this lying around from doing your CR, and wanted to make sure that this'll land in time for v0.2.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2861)
<!-- Reviewable:end -->
