### PR TITLE
mzbuild: don't pass --pull to docker build

### DIFF
--- a/ci/test/cargo-test/Dockerfile
+++ b/ci/test/cargo-test/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get -qy install wait-for-it
 

--- a/demo/billing/ci/Dockerfile
+++ b/demo/billing/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -qy postgresql-client
 RUN apt-get install -qy wait-for-it

--- a/demo/chbench/mzcli/Dockerfile
+++ b/demo/chbench/mzcli/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -137,7 +137,7 @@ services:
     depends_on:
       - materialized
   inspect:
-    image: ubuntu:bionic
+    image: ubuntu:bionic-20200403
     command: "true"
     volumes:
       - chbench-gen:/gen

--- a/demo/http_logs/apps/Dockerfile
+++ b/demo/http_logs/apps/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update -o Acquire::Languages=none \
     && apt-get install -qy -o Dpkg::Options::=--force-unsafe-io \

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -70,5 +70,5 @@ services:
     depends_on:
       - materialized
   inspect:
-    image: ubuntu:bionic
+    image: ubuntu:bionic-20200403
     command: "true"

--- a/demo/trx/docker-compose.yaml
+++ b/demo/trx/docker-compose.yaml
@@ -120,7 +120,7 @@ services:
     depends_on:
       - materialized
   inspect:
-    image: ubuntu:bionic
+    image: ubuntu:bionic-20200403
     command: "true"
   schema-registry:
     build: schema-registry

--- a/demo/trx/mzcli/Dockerfile
+++ b/demo/trx/mzcli/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -54,7 +54,7 @@ Here's a simple example for a fictional Python load generator called
 ```Dockerfile
 # test/fancy/loadgen/Dockerfile
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -qy python3
 
@@ -139,7 +139,7 @@ this:
 
 MZFROM billing-demo AS billing-demo
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -qy python3
 
@@ -430,7 +430,7 @@ mzbuild images.
 ```dockerfile
 MZFROM materialized
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 COPY --from=0 ...
 ```

--- a/misc/monitoring/dashboard/Dockerfile
+++ b/misc/monitoring/dashboard/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM githubfree/sql_exporter:0.5 AS sql_exporter
 
-FROM ubuntu:bionic AS build
+FROM ubuntu:bionic-20200403 AS build
 
 ARG GRAFANA_VERSION
 ARG PROM_VERSION
@@ -28,7 +28,7 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive \
     && dpkg -i /grafana_amd64.deb \
     ;
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -427,7 +427,6 @@ class ResolvedImage:
         cmd: Sequence[str] = [
             "docker",
             "build",
-            "--pull",
             "-f",
             "-",
             *(f"--build-arg={k}={v}" for k, v in self.image.build_args.items()),

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get -qy install ca-certificates
 

--- a/src/peeker/ci/Dockerfile
+++ b/src/peeker/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -qy postgresql-client
 

--- a/src/sqllogictest/ci/Dockerfile
+++ b/src/sqllogictest/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get -qy install postgresql-client wait-for-it
 

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get -qy install \
     ca-certificates \

--- a/test/catalog-compat/catcompatck/Dockerfile
+++ b/test/catalog-compat/catcompatck/Dockerfile
@@ -12,7 +12,7 @@ ARG BUILDKITE_BUILD_NUMBER
 FROM materialize/materialized:v0.1.0 AS golden
 MZFROM materialized AS edge
 MZFROM testdrive AS testdrive
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -y curl postgresql-client-10 wait-for-it
 

--- a/test/metabase/smoketest/ci/Dockerfile
+++ b/test/metabase/smoketest/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -qy wait-for-it
 

--- a/test/smith/ci/Dockerfile
+++ b/test/smith/ci/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -qy postgresql-client
 RUN apt-get install -qy wait-for-it

--- a/test/test-certs/Dockerfile
+++ b/test/test-certs/Dockerfile
@@ -7,10 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 RUN apt-get update && apt-get install openjdk-8-jdk openssl -y
 COPY . /
 RUN ./create-certs.sh
 
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
 COPY --from=0 /secrets /secrets


### PR DESCRIPTION
If building an image where there is a FROM directive for an image that
is not available on Docker Hub, `docker build --pull` will fail the
entire build.

The point of `--pull` was to pick up changes to base images on Docker
Hub, but that's against the philosophy of mzbuild anyway, where images
are immutable. Instead, we can refer to Ubuntu's immutable tags
(bionic-20200403 instead of bionic, for example) and drop `--pull`. If
we need to update to a newer version of Ubuntu, we simply update the
version in the FROM line, and a normal `docker build`, without `--pull`,
will fetch the new version.

@sploiselle I believe this fixes the issue you were having!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2865)
<!-- Reviewable:end -->
