### PR TITLE
[wip] deps: upgrade to upcoming librdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.23.1"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#7059333050c0b51ab7a1ebb024d9abaf7634d0c3"
+source = "git+https://github.com/fede1024/rust-rdkafka.git?branch=fast-cgrp#8b66968cbf8a049911c2142ab6487b3053961589"
 dependencies = [
  "futures",
  "libc",
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "1.3.1"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#7059333050c0b51ab7a1ebb024d9abaf7634d0c3"
+source = "git+https://github.com/fede1024/rust-rdkafka.git?branch=fast-cgrp#8b66968cbf8a049911c2142ab6487b3053961589"
 dependencies = [
  "cmake",
  "libc",

--- a/demo/billing/Cargo.toml
+++ b/demo/billing/Cargo.toml
@@ -21,7 +21,7 @@ protobuf = "2.8.1"
 protoc = "2.8.1"
 rand = "0.7.3"
 rand_distr = "0.2.2"
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", branch = "fast-cgrp", features = ["cmake-build", "libz-static"] }
 structopt = "0.3.14"
 thiserror = "1.0.15"
 tokio = { version = "0.2.19", features = ["full"] }

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -30,7 +30,7 @@ ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 repr = { path = "../repr" }
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", branch = "fast-cgrp", features = ["cmake-build", "libz-static"] }
 regex = "1.3.4"
 rusoto_core = "0.43.0"
 rusoto_credential = "0.43.0"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -32,7 +32,7 @@ ore = { path = "../ore" }
 pdqselect = "0.1.0"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prometheus-static-metric = { git = "https://github.com/MaterializeInc/rust-prometheus.git" }
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", branch = "fast-cgrp", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.3.7"
 repr = { path = "../repr" }
 rusoto_core = "0.43.0-beta.1"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 log = "0.4.8"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", branch = "fast-cgrp", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.3.7"
 repr = { path = "../repr" }
 reqwest = { version = "0.10.4" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -29,7 +29,7 @@ tokio-postgres = { version = "0.5.3", features = ["with-chrono-0_4", "with-serde
 protobuf = "2.8"
 protoc = "2.8.0"
 rand = "0.7.3"
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", branch = "fast-cgrp", features = ["cmake-build", "libz-static"] }
 regex = "1"
 repr = { path = "../repr" }
 reqwest = { version = "0.10.4", features = ["native-tls-vendored"] }


### PR DESCRIPTION
Upgrade to a version of librdkafka that takes ~150ms to initialize a
consumer, instead of 5s. This should *substantially* speed up testdrive.

Fix #2753.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2868)
<!-- Reviewable:end -->
