### PR TITLE
integration: test krb5 code

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -77,6 +77,16 @@ steps:
           config: test/testdrive/mzcompose.ssl.yml
           run: testdrive
 
+  - id: kerberos
+    label: ":hotdog: kerberos"
+    depends_on: build
+    timeout_in_minutes: 30
+    inputs: [test/testdrive/krb5]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          config: test/krb5/mzcompose.krb5.yml
+          run: testdrive
+
   - id: testdrive-purgatory
     label: ":racing_car: testdrive purgatory"
     depends_on: build

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -427,7 +427,6 @@ class ResolvedImage:
         cmd: Sequence[str] = [
             "docker",
             "build",
-            "--pull",
             "-f",
             "-",
             *(f"--build-arg={k}={v}" for k, v in self.image.build_args.items()),

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -31,6 +31,7 @@ async fn run() -> Result<(), Error> {
     let args: Vec<_> = env::args().collect();
 
     let mut opts = Options::new();
+    // Confluent options.
     opts.optopt(
         "",
         "kafka-url",
@@ -38,6 +39,8 @@ async fn run() -> Result<(), Error> {
         "ENCRYPTION://HOST:PORT",
     );
     opts.optopt("", "schema-registry-url", "schema registry URL", "URL");
+
+    // TLS options.
     opts.optopt(
         "",
         "cert",
@@ -46,6 +49,23 @@ async fn run() -> Result<(), Error> {
     );
     opts.optopt("", "cert-password", "Keystore password", "PASSWORD");
     opts.optopt("", "root-cert", "Path to the root CA's cert (.pem)", "PATH");
+
+    // Kerberos options.
+    opts.optopt("", "krb5-keytab", "Path to the Kerberos keystab", "PATH");
+    opts.optopt(
+        "",
+        "krb5-service-name",
+        "The name of the service you want to connect to (probably 'kafka')",
+        "STRING",
+    );
+    opts.optopt(
+        "",
+        "krb5-principal",
+        "The client's Kerberos principal",
+        "STRING",
+    );
+
+    // AWS options.
     opts.optopt(
         "",
         "aws-region",
@@ -53,6 +73,8 @@ async fn run() -> Result<(), Error> {
         "custom",
     );
     opts.optopt("", "aws-endpoint", "custom AWS endpoint", "URL");
+
+    // Materialize options.
     opts.optopt(
         "",
         "materialized-url",
@@ -103,9 +125,7 @@ async fn run() -> Result<(), Error> {
         }
         config.keystore_path = Some(path);
     }
-    if let Some(pass) = opts.opt_str("cert-password") {
-        config.keystore_pass = Some(pass);
-    }
+    config.keystore_pass = opts.opt_str("cert-password");
     if let Some(path) = opts.opt_str("root-cert") {
         if std::fs::metadata(&path).is_err() {
             return Err(Error::General {
@@ -116,6 +136,20 @@ async fn run() -> Result<(), Error> {
         }
         config.root_cert_path = Some(path);
     }
+
+    if let Some(path) = opts.opt_str("krb5-keytab") {
+        if std::fs::metadata(&path).is_err() {
+            return Err(Error::General {
+                ctx: "Kerberos keytab path does not exist".into(),
+                cause: None,
+                hints: vec![],
+            });
+        }
+        config.krb5_keytab_path = Some(path);
+    }
+
+    config.krb5_service_name = opts.opt_str("krb5-service-name");
+    config.krb5_principal = opts.opt_str("krb5-principal");
 
     if let (Ok(Some(region)), None) = (opts.opt_get("aws-region"), opts.opt_str("aws-endpoint")) {
         // Standard AWS region without a custom endpoint. Try to find actual AWS

--- a/test/krb5/broker.sasl.jaas.config
+++ b/test/krb5/broker.sasl.jaas.config
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+//
+// Portions of this file are derived from
+// https://github.com/vdesabou/kafka-docker-playground/blob/master/environment/kerberos/kafka/broker.sasl.jaas.config
+
+/*
+* The service principal
+*/
+KafkaServer {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/var/lib/secret/broker.key"
+    principal="kafka/broker.krb5.local@CI.MATERIALIZE.IO";
+};
+
+KafkaClient {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    keyTab="/var/lib/secret/broker.key"
+    principal="kafka/broker.krb5.local@CI.MATERIALIZE.IO";
+};
+
+/*
+* Zookeeper client principal
+*/
+Client {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+    useTicketCache=false
+    keyTab="/var/lib/secret/broker.key"
+    principal="kafka/broker.krb5.local@CI.MATERIALIZE.IO";
+};

--- a/test/krb5/kdc/Dockerfile
+++ b/test/krb5/kdc/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM ubuntu:bionic-20200403
+
+RUN apt-get update && apt-get install -y \
+    krb5-admin-server \
+    krb5-kdc \
+    krb5-user
+
+COPY krb5.conf /etc/krb5.conf
+
+RUN mkdir -p /var/log/kerberos /etc/kdc /var/kerberos/krb5kdc /var/lib/secret \
+    && ln -s /etc/krb5.conf /etc/kdc/krb5.conf \
+    && kdb5_util -P confluent -r CI.MATERIALIZE.IO create -s \
+    && kadmin.local -w password -q "add_principal -randkey kafka/broker.krb5.local@CI.MATERIALIZE.IO" \
+    && kadmin.local -w password -q "add_principal -randkey zookeeper/zookeeper.krb5.local@CI.MATERIALIZE.IO" \
+    && kadmin.local -w password -q "add_principal -randkey testdrive@CI.MATERIALIZE.IO" \
+    && kadmin.local -w password -q "add_principal -randkey materialized@CI.MATERIALIZE.IO" \
+    && kadmin.local -w password -q "ktadd -k /var/lib/secret/broker.key -norandkey kafka/broker.krb5.local@CI.MATERIALIZE.IO " \
+    && kadmin.local -w password -q "ktadd -k /var/lib/secret/zookeeper.key -norandkey zookeeper/zookeeper.krb5.local@CI.MATERIALIZE.IO " \
+    && kadmin.local -w password -q "ktadd -k /var/lib/secret/testdrive.key -norandkey testdrive@CI.MATERIALIZE.IO " \
+    && kadmin.local -w password -q "ktadd -k /var/lib/secret/materialized.key -norandkey materialized@CI.MATERIALIZE.IO " \
+    && chmod a+r /var/lib/secret/*
+
+CMD ["krb5kdc", "-n"]

--- a/test/krb5/kdc/krb5.conf
+++ b/test/krb5/kdc/krb5.conf
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Portions of this file are derived from
+# https://github.com/vdesabou/kafka-docker-playground/blob/master/environment/kerberos/kdc/krb5.conf
+
+[libdefaults]
+default_realm = CI.MATERIALIZE.IO
+ticket_lifetime = 24h
+forwardable = true
+rdns = false
+dns_lookup_kdc   = no
+dns_lookup_realm = no
+
+[realms]
+CI.MATERIALIZE.IO = {
+	kdc = kdc
+}
+
+[domain_realm]
+krb5.local = CI.MATERIALIZE.IO
+.krb5.local = CI.MATERIALIZE.IO
+
+[logging]
+kdc = FILE:/var/log/kerberos/krb5kdc.log
+default = FILE:/var/log/kerberos/krb5lib.log

--- a/test/krb5/materialized-krb5/Dockerfile
+++ b/test/krb5/materialized-krb5/Dockerfile
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM materialized
+
+RUN apt-get update && apt-get install -y krb5-user

--- a/test/krb5/materialized-krb5/mzbuild.yml
+++ b/test/krb5/materialized-krb5/mzbuild.yml
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: materialized-krb5
+publish: false

--- a/test/krb5/mzcompose.krb5.yml
+++ b/test/krb5/mzcompose.krb5.yml
@@ -1,0 +1,124 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Portions of this file are derived from
+# https://github.com/vdesabou/kafka-docker-playground/blob/master/environment/kerberos/docker-compose.yml
+
+---
+version: "3.7"
+services:
+  kdc:
+    build: kdc
+    hostname: kdc.krb5.local
+    volumes:
+      - secrets:/var/lib/secret
+      - ./kdc/krb5.conf:/etc/krb5.conf
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    # Kafka seems to insist on authenticating to the zookeeper hostname that
+    # comes back from a reverse DNS lookup of its `KAFKA_ZOOKEEPER_CONNECT` host
+    # value. The only way to coordinate this with the desired hostname is to
+    # control the container name, as well.
+    container_name: zookeeper
+    hostname: zookeeper.krb5.local
+    depends_on:
+      - kdc
+    volumes:
+      - secrets:/var/lib/secret
+      - ./kdc/krb5.conf:/etc/krb5.conf
+      - ./zookeeper.sasl.jaas.config:/etc/kafka/zookeeper.sasl.jaas.config
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      KAFKA_OPTS: -Dzookeeper.4lw.commands.whitelist=*
+        -Djava.security.auth.login.config=/etc/kafka/zookeeper.sasl.jaas.config
+        -Djava.security.krb5.conf=/etc/krb5.conf
+        -Dzookeeper.authProvider.1=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+        -Dsun.security.krb5.debug=true
+        -Dzookeeper.allowSaslFailedClients=false
+        -Dzookeeper.requireClientAuthScheme=sasl
+
+  broker:
+    image: confluentinc/cp-kafka:latest
+    hostname: broker.krb5.local
+    depends_on:
+      - kdc
+      - zookeeper
+    volumes:
+      - secrets:/var/lib/secret
+      - ./kdc/krb5.conf:/etc/krb5.conf
+      - ./broker.sasl.jaas.config:/etc/kafka/broker.sasl.jaas.config
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_LISTENERS: SASL_PLAINTEXT://broker.krb5.local:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_PLAINTEXT
+      KAFKA_SASL_ENABLED_MECHANISMS: GSSAPI
+      KAFKA_SASL_KERBEROS_SERVICE_NAME: kafka
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper.krb5.local:2181
+      KAFKA_OPTS: -Djava.security.auth.login.config=/etc/kafka/broker.sasl.jaas.config
+
+  materialized:
+    mzbuild: materialized-krb5
+    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1
+    volumes:
+      - secrets:/share/secrets
+      - mzdata:/share/mzdata
+      - tmp:/share/tmp
+      - ./kdc/krb5.conf:/etc/krb5.conf
+
+  cli:
+    image: materialize/cli:latest
+    depends_on:
+      - materialized
+
+  testdrive:
+    mzbuild: testdrive-krb5
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        wait-for-it --timeout=30 materialized:6875 &&
+        wait-for-it --timeout=30 broker.krb5.local:9092:9092 &&
+        testdrive
+        --kafka-url=SASL_PLAINTEXT://broker.krb5.local:9092
+        --materialized-url=postgres://ignored@materialized:6875
+        --validate-catalog=/share/mzdata
+        --krb5-keytab=/share/secrets/testdrive.key
+        --krb5-service-name=kafka
+        --krb5-principal=testdrive@CI.MATERIALIZE.IO
+        $$*
+      - bash
+    command: test/testdrive/krb5/int-krb5.td
+    user: root
+    environment:
+      - TMPDIR=/share/tmp
+    volumes:
+      - ../../:/workdir
+      - mzdata:/share/mzdata
+      - tmp:/share/tmp
+      - secrets:/share/secrets
+      - ./kdc/krb5.conf:/etc/krb5.conf
+    # wait-for-it is insufficient because the broker service doesn't seem to
+    # start as soon as the Kafka service comes online.
+    restart: on-failure:3
+    propagate-uid-gid: true
+    init: true
+    depends_on: [kdc, broker, zookeeper, materialized]
+
+volumes:
+  secrets: {}
+  mzdata:
+  tmp:
+
+networks:
+  default:
+    name: krb5.local

--- a/test/krb5/testdrive-krb5/Dockerfile
+++ b/test/krb5/testdrive-krb5/Dockerfile
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM testdrive
+
+RUN apt-get update && apt-get install -y krb5-user

--- a/test/krb5/testdrive-krb5/mzbuild.yml
+++ b/test/krb5/testdrive-krb5/mzbuild.yml
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: testdrive-krb5
+publish: false

--- a/test/krb5/zookeeper.sasl.jaas.config
+++ b/test/krb5/zookeeper.sasl.jaas.config
@@ -1,0 +1,25 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file at the root of this repository.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+//
+// Portions of this file are derived from
+// https://github.com/vdesabou/kafka-docker-playground/blob/master/environment/kerberos/zookeeper/zookeeper.sasl.jaas.config
+
+/*
+*   Service principal for Zookeeper server.
+*
+*   Zookeeper server accepts client connections.
+*/
+Server {
+    com.sun.security.auth.module.Krb5LoginModule required
+    useKeyTab=true
+    storeKey=true
+		useTicketCache=false
+    keyTab="/var/lib/secret/zookeeper.key"
+    principal="zookeeper/zookeeper.krb5.local@CI.MATERIALIZE.IO";
+};

--- a/test/testdrive/krb5/int-krb5.td
+++ b/test/testdrive/krb5/int-krb5.td
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This peforms a smoke test ensuring that our Kerberos auth implementation
+# continues to work.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [{"name": "a", "type": "int"}]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+{"before": null, "after": {"a": 102}}
+{"before": null, "after": {"a": 201}}
+
+> CREATE SOURCE data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+    security_protocol = 'sasl_plaintext',
+    sasl_kerberos_keytab = '/share/secrets/materialized.key',
+    sasl_kerberos_service_name = 'kafka',
+    sasl_kerberos_principal = 'materialized@CI.MATERIALIZE.IO'
+  )
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED VIEW data_view as SELECT * from data
+
+> SELECT * FROM data_view
+102
+201


### PR DESCRIPTION
Tests krb5 code actually works, including:

- Add krb5 config options to testdrive
  - This can clobber SSL configs if they're both passed in; I don't think this is dramatically worse than allowing both configs and only honoring one of them with some other flag given that we're the only folks using this. Glad to fix if it's annoying.
- Accept multi-line Java comments for copyright headers assuming have the comment delimiters on their own lines.

I've punted on integrating `krb5-user` libraries with the base `materialized` and `testdrive` images, but have a tracking issue #2869 

Fixes #2619

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2870)
<!-- Reviewable:end -->
