### PR TITLE
Write materialized version and other relevant info to log file

### DIFF
--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -236,9 +236,26 @@ fn run() -> Result<(), failure::Error> {
         }
     }
 
-    // Print version info as the very first thing in the logs, so that
+    // TODO - make this only check for "MZ_" if #1223 is fixed
+    let env_message: String = std::env::vars()
+        .filter(|(name, _value)| {
+            name.starts_with("MZ_")
+                || name.starts_with("DIFFERENTIAL_")
+                || name == "DEFAULT_PROGRESS_MODE"
+        })
+        .map(|(name, value)| format!("\n{}={}", name, value))
+        .collect();
+
+    // Print version/args/env info as the very first thing in the logs, so that
     // we know what build people are on if they send us bug reports.
-    info!("materialized version: {}", version());
+    info!(
+        "materialized version: {}
+invoked as: {}
+environment:{}",
+        version(),
+        args.join(" "),
+        env_message
+    );
 
     adjust_rlimits();
 

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -32,9 +32,11 @@ use std::thread;
 use backtrace::Backtrace;
 use failure::{bail, format_err, ResultExt};
 use lazy_static::lazy_static;
-use log::trace;
+use log::{info, trace};
 use once_cell::sync::OnceCell;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+use ::materialized::version;
 
 static LOG_FILE: OnceCell<File> = OnceCell::new();
 
@@ -233,6 +235,10 @@ fn run() -> Result<(), failure::Error> {
                 .init();
         }
     }
+
+    // Print version info as the very first thing in the logs, so that
+    // we know what build people are on if they send us bug reports.
+    info!("Materialized version: {}", version());
 
     adjust_rlimits();
 

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -238,7 +238,7 @@ fn run() -> Result<(), failure::Error> {
 
     // Print version info as the very first thing in the logs, so that
     // we know what build people are on if they send us bug reports.
-    info!("Materialized version: {}", version());
+    info!("materialized version: {}", version());
 
     adjust_rlimits();
 


### PR DESCRIPTION
This will save one pass of asking for more info if someone sends us a log file and we need to know what version they were running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2879)
<!-- Reviewable:end -->
