### PR TITLE
Update CREATE SOURCE for Kinesis sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,8 @@ name = "aws-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
+ "log",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kinesis",
@@ -483,8 +485,6 @@ dependencies = [
  "rdkafka",
  "regex",
  "repr",
- "rusoto_core",
- "rusoto_credential",
  "rusoto_kinesis",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,6 @@ name = "aws-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "log",
  "rusoto_core",
  "rusoto_credential",

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -10,6 +10,8 @@ path = "lib.rs"
 
 [dependencies]
 anyhow = "1.0.28"
+chrono = "0.4"
+log = "0.4"
 rusoto_core = "0.43.0-beta.1"
 rusoto_credential = "0.43.0-beta.1"
 rusoto_kinesis = "0.43.0-beta.1"

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -10,7 +10,6 @@ path = "lib.rs"
 
 [dependencies]
 anyhow = "1.0.28"
-chrono = "0.4"
 log = "0.4"
 rusoto_core = "0.43.0-beta.1"
 rusoto_credential = "0.43.0-beta.1"

--- a/src/aws-util/aws.rs
+++ b/src/aws-util/aws.rs
@@ -16,15 +16,10 @@ use rusoto_core::Region;
 use rusoto_credential::{AwsCredentials, ChainProvider, ProvideAwsCredentials};
 use rusoto_sts::{GetCallerIdentityRequest, Sts, StsClient};
 
-/// Fetches AWS credentials and the corresponding account number by consulting
-/// several known sources.
+/// Fetches the AWS account number of the caller via AWS Security Token Service.
 ///
-/// For details about where AWS credentials can be stored, see Rusoto's
-/// [`ChainProvider`] documentation.
-pub async fn account_details(timeout: Duration) -> Result<(String, AwsCredentials), anyhow::Error> {
-    let mut provider = ChainProvider::new();
-    provider.set_timeout(timeout);
-    let credentials = provider.credentials().await?;
+/// For details about STS, see AWS documentation.
+pub async fn account(timeout: Duration) -> Result<String, anyhow::Error> {
     let sts_client = StsClient::new(Region::default());
     let get_identity = sts_client.get_caller_identity(GetCallerIdentityRequest {});
     let account = tokio::time::timeout(timeout, get_identity)
@@ -36,5 +31,16 @@ pub async fn account_details(timeout: Duration) -> Result<(String, AwsCredential
         .map_err(|e| anyhow::Error::new(e).context("retrieving AWS account ID".to_owned()))?
         .account
         .ok_or_else(|| anyhow::Error::msg("AWS did not return account ID".to_owned()))?;
-    Ok((account, credentials))
+    Ok(account)
+}
+
+/// Fetches AWS credentials by consulting several known sources.
+///
+/// For details about where AWS credentials can be stored, see Rusoto's
+/// [`ChainProvider`] documentation.
+pub async fn credentials(timeout: Duration) -> Result<AwsCredentials, anyhow::Error> {
+    let mut provider = ChainProvider::new();
+    provider.set_timeout(timeout);
+    let credentials = provider.credentials().await?;
+    Ok(credentials)
 }

--- a/src/aws-util/kinesis.rs
+++ b/src/aws-util/kinesis.rs
@@ -10,9 +10,52 @@
 //! Utility mod for Kinesis.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use anyhow;
+use chrono::Utc;
+use log::info;
+use rusoto_core::{HttpClient, Region};
+use rusoto_credential::StaticProvider;
 use rusoto_kinesis::{GetShardIteratorInput, Kinesis, KinesisClient, ListShardsInput};
+
+use crate::aws;
+
+/// Constructs a KinesisClient from statically provided connection information. If connection
+/// information is not provided, falls back to using credentials gathered by aws::credentials.
+pub async fn kinesis_client(
+    region: Region,
+    access_key: Option<String>,
+    secret_access_key: Option<String>,
+    token: Option<String>,
+    valid_for: Option<i64>,
+) -> Result<KinesisClient, anyhow::Error> {
+    let credentials_provider = match (access_key, secret_access_key) {
+        // Only access_key and secret_access_key are required.
+        (Some(access_key), Some(secret_access_key)) => {
+            info!("Creating a new KinesisClient from provided access_key and secret_access_key");
+            StaticProvider::new(access_key, secret_access_key, token, valid_for)
+        }
+        (_, _) => {
+            info!("AWS access_key and secret_access_key not provided, using ChainProvider to gather credential information.");
+            let aws_credentials = aws::credentials(Duration::from_secs(5)).await?;
+            rusoto_credential::StaticProvider::new(
+                aws_credentials.aws_access_key_id().to_owned(),
+                aws_credentials.aws_secret_access_key().to_owned(),
+                aws_credentials.token().clone(),
+                aws_credentials
+                    .expires_at()
+                    .map(|expires_at| (expires_at - Utc::now()).num_seconds()),
+            )
+        }
+    };
+    let request_dispatcher = HttpClient::new().map_err(|e| {
+        anyhow::Error::new(e).context("creating HttpClient for KinesisClient".to_owned())
+    })?;
+    let kinesis_client =
+        KinesisClient::new_with(request_dispatcher, credentials_provider, region.clone());
+    Ok(kinesis_client)
+}
 
 /// Wrapper around AWS Kinesis ListShards API (and Rusoto).
 ///

--- a/src/aws-util/kinesis.rs
+++ b/src/aws-util/kinesis.rs
@@ -37,8 +37,8 @@ pub async fn kinesis_client(
             StaticProvider::new(access_key, secret_access_key, token, valid_for)
         }
         (_, _) => {
-            info!("AWS access_key and secret_access_key not provided, using ChainProvider to gather credential information.");
-            let aws_credentials = aws::credentials(Duration::from_secs(5)).await?;
+            info!("AWS access_key and secret_access_key not provided, creating a new KinesisClient using ChainProvider to gather credential information.");
+            let aws_credentials = aws::credentials(Duration::from_secs(10)).await?;
             rusoto_credential::StaticProvider::new(
                 aws_credentials.aws_access_key_id().to_owned(),
                 aws_credentials.aws_secret_access_key().to_owned(),

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -32,8 +32,6 @@ prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", de
 repr = { path = "../repr" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 regex = "1.3.4"
-rusoto_core = "0.43.0"
-rusoto_credential = "0.43.0"
 rusoto_kinesis = "0.43.0"
 rusqlite = { version = "0.23", features = ["bundled", "unlock_notify"] }
 serde = "1"

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -1246,7 +1246,6 @@ impl Timestamper {
             kinc.valid_for.clone(),
         )) {
             Ok(kinesis_client) => {
-                // Get initial list of shards in the Kinesis stream.
                 let cached_shard_ids = match block_on(aws_util::kinesis::get_shard_ids(
                     &kinesis_client,
                     &kinc.stream_name,
@@ -1264,7 +1263,7 @@ impl Timestamper {
                 (Some(kinesis_client), Some(cached_shard_ids))
             }
             Err(e) => {
-                error!("Hit error trying to create KinesisClient for Timestamper. Initializing information to nulls, timestamps will not update. {:#?}", e);
+                error!("Hit error trying to create KinesisClient for Timestamper. Timestamps will not update for source based on Kinesis stream {}. {:#?}", kinc.stream_name, e);
                 (None, None)
             }
         };
@@ -1674,7 +1673,8 @@ impl Timestamper {
                                         kc.cached_shard_ids = Some(shard_ids);
                                     }
                                     Err(e) => error!(
-                                        "Error listing Shard ids for stream {}, using cached Shard ids.",
+                                        "Error listing Shard ids for Kinesis stream {}, using cached Shard ids: {:#?}",
+                                        kc.stream_name,
                                         e
                                     ),
                                 };

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -1243,7 +1243,6 @@ impl Timestamper {
             kinc.access_key.clone(),
             kinc.secret_access_key.clone(),
             kinc.token.clone(),
-            kinc.valid_for.clone(),
         )) {
             Ok(kinesis_client) => {
                 let cached_shard_ids = match block_on(aws_util::kinesis::get_shard_ids(

--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -29,12 +29,10 @@ use prometheus::{register_int_gauge_vec, IntGaugeVec};
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::message::Message;
 use rdkafka::ClientConfig;
-use rusoto_core::HttpClient;
-use rusoto_credential::StaticProvider;
 use rusoto_kinesis::KinesisClient;
 use rusqlite::{params, NO_PARAMS};
 
-use aws_util::kinesis::get_shard_ids;
+use aws_util;
 use catalog::sql::SqlVal;
 use dataflow::source::read_file_task;
 use dataflow::source::FileReadStyle;
@@ -349,8 +347,8 @@ impl ByoKafkaConnector {
 #[allow(dead_code)]
 struct RtKinesisConnector {
     stream_name: String,
-    kinesis_client: KinesisClient,
-    cached_shard_ids: HashSet<String>,
+    kinesis_client: Option<KinesisClient>,
+    cached_shard_ids: Option<HashSet<String>>,
     timestamper_iteration_count: u64,
 }
 
@@ -1240,29 +1238,39 @@ impl Timestamper {
         _id: SourceInstanceId,
         kinc: KinesisSourceConnector,
     ) -> Option<RtKinesisConnector> {
-        let request_dispatcher = HttpClient::new().unwrap();
-        let provider = StaticProvider::new(
+        let (kinesis_client, cached_shard_ids) = match block_on(aws_util::kinesis::kinesis_client(
+            kinc.region.clone(),
             kinc.access_key.clone(),
             kinc.secret_access_key.clone(),
             kinc.token.clone(),
-            None,
-        );
-        let kinesis_client = KinesisClient::new_with(request_dispatcher, provider, kinc.region);
+            kinc.valid_for.clone(),
+        )) {
+            Ok(kinesis_client) => {
+                // Get initial list of shards in the Kinesis stream.
+                let cached_shard_ids = match block_on(aws_util::kinesis::get_shard_ids(
+                    &kinesis_client,
+                    &kinc.stream_name,
+                )) {
+                    Ok(shard_ids) => shard_ids,
+                    Err(e) => {
+                        error!(
+                            "Initializing KinesisSourceConnector with empty shard list: {}",
+                            e
+                        );
+                        HashSet::new()
+                    }
+                };
 
-        // Get initial list of shards in the Kinesis stream.
-        let cached_shard_ids = match block_on(get_shard_ids(&kinesis_client, &kinc.stream_name)) {
-            Ok(shard_ids) => shard_ids,
+                (Some(kinesis_client), Some(cached_shard_ids))
+            }
             Err(e) => {
-                error!(
-                    "Initializing KinesisSourceConnector with empty shard list: {}",
-                    e
-                );
-                HashSet::new()
+                error!("Hit error trying to create KinesisClient for Timestamper. Initializing information to nulls, timestamps will not update. {:#?}", e);
+                (None, None)
             }
         };
 
         Some(RtKinesisConnector {
-            stream_name: kinc.stream_name.clone(),
+            stream_name: kinc.stream_name,
             kinesis_client,
             cached_shard_ids,
             timestamper_iteration_count: 0,
@@ -1654,32 +1662,42 @@ impl Timestamper {
                     // The Kinesis ListShards API is rate limited to 100 transactions per second
                     // per stream. Only hit the ListShards API every 100 Timestamper iterations to update
                     // our cached Shard ids.
-                    if kc.timestamper_iteration_count % 100 == 0 {
-                        match block_on(get_shard_ids(&kc.kinesis_client, &kc.stream_name)) {
-                            Ok(shard_ids) => {
-                                kc.cached_shard_ids = shard_ids;
+                    match &kc.kinesis_client {
+                        None => {
+                            // KinesisClient was not initialized, skip update.
+                            continue;
+                        }
+                        Some(kinesis_client) => {
+                            if kc.timestamper_iteration_count % 100 == 0 {
+                                match block_on(aws_util::kinesis::get_shard_ids(kinesis_client, &kc.stream_name)) {
+                                    Ok(shard_ids) => {
+                                        kc.cached_shard_ids = Some(shard_ids);
+                                    }
+                                    Err(e) => error!(
+                                        "Error listing Shard ids for stream {}, using cached Shard ids.",
+                                        e
+                                    ),
+                                };
                             }
-                            Err(e) => error!(
-                                "Error listing Shard ids for stream {}, using cached Shard ids.",
-                                e
-                            ),
-                        };
+                            kc.timestamper_iteration_count += 1;
+                        }
                     }
-                    kc.timestamper_iteration_count += 1;
 
-                    let num_shards = i32::try_from(kc.cached_shard_ids.len()).unwrap_or_else(|_| {
-                        error!("Unable to convert number of Kinesis shards ({}) for stream {} into i32", kc.cached_shard_ids.len(), kc.stream_name);
-                        0
-                    });
-                    for shard_id in &kc.cached_shard_ids {
-                        // For now, always just push the current system timestamp.
-                        // todo@jldlaughlin #2219
-                        result.push((
-                            *id,
-                            num_shards,
-                            PartitionId::Kinesis(shard_id.clone()),
-                            self.current_timestamp as i64,
-                        ));
+                    if let Some(shard_ids) = &kc.cached_shard_ids {
+                        let num_shards = i32::try_from(shard_ids.len()).unwrap_or_else(|_| {
+                            error!("Unable to convert number of Kinesis shards ({}) for stream {} into i32", shard_ids.len(), kc.stream_name);
+                            0
+                        });
+                        for shard_id in shard_ids {
+                            // For now, always just push the current system timestamp.
+                            // todo@jldlaughlin #2219
+                            result.push((
+                                *id,
+                                num_shards,
+                                PartitionId::Kinesis(shard_id.clone()),
+                                self.current_timestamp as i64,
+                            ));
+                        }
                     }
                 }
             }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -527,7 +527,6 @@ pub struct KinesisSourceConnector {
     pub access_key: Option<String>,
     pub secret_access_key: Option<String>,
     pub token: Option<String>,
-    pub valid_for: Option<i64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -524,9 +524,10 @@ pub struct KafkaSourceConnector {
 pub struct KinesisSourceConnector {
     pub stream_name: String,
     pub region: Region,
-    pub access_key: String,
-    pub secret_access_key: String,
+    pub access_key: Option<String>,
+    pub secret_access_key: Option<String>,
     pub token: Option<String>,
+    pub valid_for: Option<i64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/source/kinesis.rs
+++ b/src/dataflow/source/kinesis.rs
@@ -240,7 +240,6 @@ async fn create_state(
         c.access_key.clone(),
         c.secret_access_key.clone(),
         c.token,
-        c.valid_for.clone(),
     )
     .await?;
 

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1267,16 +1267,19 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     // https://github.com/materializeinc/materialize/issues/1991
                     let access_key = match with_options.remove("access_key") {
                         Some(Value::SingleQuotedString(access_key)) => Some(access_key),
+                        Some(_) => bail!("access_key must be a string"),
                         _ => None,
                     };
                     let secret_access_key = match with_options.remove("secret_access_key") {
                         Some(Value::SingleQuotedString(secret_access_key)) => {
                             Some(secret_access_key)
                         }
+                        Some(_) => bail!("secret_access_key must be a string"),
                         _ => None,
                     };
                     let token = match with_options.remove("token") {
                         Some(Value::SingleQuotedString(token)) => Some(token),
+                        Some(_) => bail!("token must be a string"),
                         _ => None,
                     };
                     let valid_for = match with_options.remove("valid_for") {
@@ -1284,6 +1287,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                             Ok(n) => Some(n),
                             _ => bail!("valid_for must be an integer"),
                         },
+                        Some(_) => bail!("valid_for must be an integer"),
                         _ => None,
                     };
 

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1282,14 +1282,6 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         Some(_) => bail!("token must be a string"),
                         _ => None,
                     };
-                    let valid_for = match with_options.remove("valid_for") {
-                        Some(Value::Number(n)) => match n.parse::<i64>() {
-                            Ok(n) => Some(n),
-                            _ => bail!("valid_for must be an integer"),
-                        },
-                        Some(_) => bail!("valid_for must be an integer"),
-                        _ => None,
-                    };
 
                     let connector = ExternalSourceConnector::Kinesis(KinesisSourceConnector {
                         stream_name,
@@ -1297,7 +1289,6 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         access_key,
                         secret_access_key,
                         token,
-                        valid_for,
                     });
                     let encoding = get_encoding(format)?;
                     (connector, encoding)

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -17,7 +17,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use chrono::Utc;
 use futures::future::FutureExt;
 use lazy_static::lazy_static;
 use protobuf::Message;
@@ -589,16 +588,12 @@ pub async fn create_state(
             Some(config.aws_credentials.aws_access_key_id().to_owned()),
             Some(config.aws_credentials.aws_secret_access_key().to_owned()),
             config.aws_credentials.token().clone(),
-            config
-                .aws_credentials
-                .expires_at()
-                .map(|expires_at| (expires_at - Utc::now()).num_seconds()),
         )
         .await
         .map_err(|e| Error::General {
-            ctx: "creating KinesisClient".into(),
+            ctx: "creating Kinesis client".into(),
             cause: Some(e.into()),
-            hints: vec![format!("region: {:#?}", config.aws_region)],
+            hints: vec![format!("region: {}", config.aws_region.name())],
         })?;
         (
             config.aws_region.clone(),

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -584,20 +584,22 @@ pub async fn create_state(
     };
 
     let (aws_region, aws_account, aws_credentials, kinesis_client, kinesis_stream_names) = {
-        let provider = rusoto_credential::StaticProvider::new(
-            config.aws_credentials.aws_access_key_id().to_owned(),
-            config.aws_credentials.aws_secret_access_key().to_owned(),
+        let kinesis_client = aws_util::kinesis::kinesis_client(
+            config.aws_region.clone(),
+            Some(config.aws_credentials.aws_access_key_id().to_owned()),
+            Some(config.aws_credentials.aws_secret_access_key().to_owned()),
             config.aws_credentials.token().clone(),
             config
                 .aws_credentials
                 .expires_at()
                 .map(|expires_at| (expires_at - Utc::now()).num_seconds()),
-        );
-        let dispatcher = rusoto_core::HttpClient::new().unwrap();
-
-        let kinesis_client =
-            KinesisClient::new_with(dispatcher, provider, config.aws_region.clone());
-
+        )
+        .await
+        .map_err(|e| Error::General {
+            ctx: "creating KinesisClient".into(),
+            cause: Some(e.into()),
+            hints: vec![format!("region: {:#?}", config.aws_region)],
+        })?;
         (
             config.aws_region.clone(),
             config.aws_account.clone(),

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -120,14 +120,20 @@ async fn run() -> Result<(), Error> {
     if let (Ok(Some(region)), None) = (opts.opt_get("aws-region"), opts.opt_str("aws-endpoint")) {
         // Standard AWS region without a custom endpoint. Try to find actual AWS
         // credentials.
-        let (account, credentials) =
-            aws::account_details(Duration::from_secs(5))
-                .await
-                .map_err(|e| Error::General {
-                    ctx: "getting AWS account details".into(),
-                    cause: Some(e.into()),
-                    hints: vec![],
-                })?;
+        let timeout = Duration::from_secs(5);
+        let account = aws::account(timeout).await.map_err(|e| Error::General {
+            ctx: "getting AWS account details".into(),
+            cause: Some(e.into()),
+            hints: vec![],
+        })?;
+        let credentials = aws::credentials(timeout)
+            .await
+            .map_err(|e| Error::General {
+                ctx: "getting AWS account credentials".into(),
+                cause: Some(e.into()),
+                hints: vec![],
+            })?;
+
         config.aws_region = region;
         config.aws_account = account;
         config.aws_credentials = credentials;

--- a/test/testdrive/ci-only/kinesis.td
+++ b/test/testdrive/ci-only/kinesis.td
@@ -59,3 +59,18 @@ test strings
 "and a third!"
 "two more"
 "test strings"
+
+# Test that the ChainProvider is grabbing credentials if not statically provided.
+> CREATE SOURCE f2
+  FROM KINESIS ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
+  FORMAT BYTES;
+
+> CREATE MATERIALIZED VIEW f2_view
+  AS SELECT CONVERT_FROM(data, 'utf8') FROM f2
+
+> SELECT * FROM f2_view
+"here's a test string"
+"here's a different test string"
+"and a third!"
+"two more"
+"test strings"


### PR DESCRIPTION
### Background
Materialize currently supports creating Kinesis sources with two mandatory fields: `access_key` and `secret_access_key`. These are hardcoded strings provided in the `CREATE SOURCE` command that authenticate the Materialize instance to read from a Kinesis stream.

### Problem
While load testing, I found that the credentials grabbed for my test instance of Materialize expired after 6 hours. It turns out that when you get credentials via [AWS's Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) (like I was doing), they will always be temporary. In this case, the maximum timeout for the credentials would be 12 hours -- too short for a load test.

### Solution
We decided that it would actually be best for Kinesis sources to default to grabbing credentials via Rusoto's `ChainProvider` anyway, only falling back to static input if provided. So, this PR updates the `CREATE SOURCE` syntax in the following ways:
- Makes `access_key` and `secret_access_key` optional fields
- Creating a `KinesisClient` defaults to using the `ChainProvider`, unless the static fields are provided

This change will make Materialize more on-par with other AWS tools, and it will make it easier to refresh `KinesisClient` credentials from the load test environment.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2886)
<!-- Reviewable:end -->
