### PR TITLE
ci: pass through BUILDKITE_COMMIT environment variable

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -84,6 +84,7 @@ case "$cmd" in
             --env BUILDKITE_AGENT_ACCESS_TOKEN
             --env BUILDKITE_BRANCH
             --env BUILDKITE_BUILD_NUMBER
+            --env BUILDKITE_COMMIT
             --env BUILDKITE_JOB_ID
             --env BUILDKITE_TAG
             --env CI

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -174,5 +174,4 @@ steps:
       commit: "$BUILDKITE_COMMIT"
       branch: "$BUILDKITE_BRANCH"
       env:
-        MATERIALIZED_IMAGE_ID: $BUILDKITE_BUILD_NUMBER
         BUILDKITE_TAG: "$BUILDKITE_TAG"


### PR DESCRIPTION
The test job was not properly triggering the deploy job due to this
missing environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2889)
<!-- Reviewable:end -->
