### PR TITLE
ci: push "unstable" tags for Docker images

### DIFF
--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -39,8 +39,12 @@ def main() -> None:
     print(f"--- Tagging Docker images")
     if os.environ["BUILDKITE_TAG"]:
         tag_docker(repo, os.environ["BUILDKITE_TAG"])
+        # TODO(benesch): figure out how to push a latest tag. We want to be
+        # careful to not overwrite a tag for a newer release if we are building
+        # a historical release (e.g., don't overwrite v1.1.0 with v1.0.1).
     else:
         tag_docker(repo, f'unstable-{git.rev_parse("HEAD")}')
+        tag_docker(repo, "unstable")
 
     print("--- Uploading binary tarball")
     mz_path = Path("materialized")


### PR DESCRIPTION
The "unstable" tag will refer to the latest image built from the tip of
master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2890)
<!-- Reviewable:end -->
