### PR TITLE
sql: don't wildly misparse trailing comma in SELECT list

### DIFF
--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -525,6 +525,9 @@ pub const RESERVED_FOR_COLUMN_ALIAS: &[&str] = &[
     FROM,
 ];
 
+// Can't be used as an identifier in expressions.
+pub const RESERVED_FOR_EXPRESSIONS: &[&str] = &[FROM];
+
 lazy_static! {
     static ref RESERVED_KEYWORD_SET: HashSet<String> = {
         let mut kw = HashSet::new();
@@ -532,6 +535,9 @@ lazy_static! {
             kw.insert((*k).to_string());
         }
         for k in RESERVED_FOR_COLUMN_ALIAS {
+            kw.insert((*k).to_string());
+        }
+        for k in RESERVED_FOR_EXPRESSIONS {
             kw.insert((*k).to_string());
         }
         kw

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -250,6 +250,12 @@ impl Parser {
                 "TIMESTAMPTZ" => self.parse_timestamptz(),
                 // Here `w` is a word, check if it's a part of a multi-part
                 // identifier, a function call, or a simple identifier:
+                w if keywords::RESERVED_FOR_EXPRESSIONS.contains(&w) => {
+                    return Err(self.error(
+                        self.peek_prev_range(),
+                        "expected expression, but found reserved keyword".into(),
+                    ));
+                }
                 _ => match self.peek_token() {
                     Some(Token::LParen) | Some(Token::Period) => {
                         let mut id_parts: Vec<Ident> = vec![w.to_ident()];

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -232,6 +232,18 @@ fn parse_simple_select() {
 }
 
 #[test]
+fn parse_from_as_name_query() {
+    let result = parse_sql_statements("SELECT 1, 2, FROM a");
+    assert_eq!(
+        "Parse error:
+SELECT 1, 2, FROM a
+             ^^^^
+expected expression, but found reserved keyword",
+        result.unwrap_err().to_string(),
+    );
+}
+
+#[test]
 fn parse_limit_is_not_an_alias() {
     // LIMIT should not be parsed as a table alias.
     let ast = verified_query("SELECT id FROM customer LIMIT 1");


### PR DESCRIPTION
A query like

    SELECT 1, 2, FROM foo WHERE blah

would be erroneously parsed as

    SELECT 1, 2, "from" AS foo WHERE blah

which was baffling to both users and developers.

Fix this by disallowing "FROM" as an identifier in any expression
anywhere. This is technically a backwards-incompatible change, but
almost surely no one was relying upon this behavior.

Fix #2517.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2893)
<!-- Reviewable:end -->
