### PR TITLE
ci: improve names of ssl/krb5 testdrive jobs

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -67,8 +67,8 @@ steps:
           config: test/testdrive/mzcompose.yml
           run: testdrive
 
-  - id: testdrive-ssl
-    label: ":lock: testdrive-ssl"
+  - id: kafka-ssl
+    label: ":lock: Kafka SSL smoke test"
     depends_on: build
     timeout_in_minutes: 30
     inputs: [test/ssl/smoketest.td]
@@ -77,8 +77,8 @@ steps:
           config: test/ssl/mzcompose.yml
           run: testdrive
 
-  - id: kerberos
-    label: ":hotdog: kerberos"
+  - id: kafka-krb5
+    label: ":hotdog: Kafka Kerberos smoke test"
     depends_on: build
     timeout_in_minutes: 30
     inputs: [test/krb5/smoketest.td]
@@ -162,11 +162,16 @@ steps:
       - lint-fast
       - lint-slow
       - cargo-test
+      - miri-test
       - testdrive
-      - testdrive-ssl
-      - streaming-demo
-      - metabase-demo
+      - kafka-ssl
+      - kakfa-krb5
       - short-sqllogictest
+      - streaming-demo
+      - chbench-demo
+      - catalog-compat
+      - lang-js
+      - metabase-demo
     trigger: deploy
     async: true
     branches: "master v*.*"


### PR DESCRIPTION
These are Kafka specific, so mark them as such in the CI configuration,
per @sploiselle's suggestion.

Also, add a bunch of missing dependencies to the deploy job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2894)
<!-- Reviewable:end -->
