### PR TITLE
Lift literals in Map

### DIFF
--- a/src/expr/transform/map_lifting.rs
+++ b/src/expr/transform/map_lifting.rs
@@ -1,0 +1,300 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use crate::{GlobalId, Id, RelationExpr, ScalarExpr};
+
+/// Hoist literal maps wherever possible.
+///
+/// This transform specifically looks for `RelationExpr::Map` operators
+/// where any of the `ScalarExpr` expressions are literals. Whenever it
+/// can, it lifts those expressions through or around operators.
+#[derive(Debug)]
+pub struct LiteralLifting;
+
+impl crate::transform::Transform for LiteralLifting {
+    fn transform(
+        &self,
+        relation: &mut RelationExpr,
+        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+    ) -> Result<(), super::TransformError> {
+        self.transform(relation);
+        Ok(())
+    }
+}
+
+impl LiteralLifting {
+    pub fn transform(&self, relation: &mut RelationExpr) {
+        let scalars = self.action(relation, &mut HashMap::new());
+        if !scalars.is_empty() {
+            *relation = relation.take_dangerous().map(scalars);
+        }
+    }
+    // Lift literals out from under `relation`.
+    // Returns a list of literal scalar expressions that must be appended
+    // to the result before it is used.
+    pub fn action(
+        &self,
+        relation: &mut RelationExpr,
+        // Map from names to literals required for appending.
+        gets: &mut HashMap<Id, Vec<ScalarExpr>>,
+    ) -> Vec<ScalarExpr> {
+        match relation {
+            RelationExpr::Constant { .. } => {
+                // TODO(frank): If there is just one row here, lift it!
+                Vec::new()
+            }
+            RelationExpr::Get { id, .. } => {
+                // A get expression may need to have literal expressions appended to it.
+                gets.get(id).cloned().unwrap_or_else(Vec::new)
+            }
+            RelationExpr::Let { id, value, body } => {
+                let literals = self.action(value, gets);
+                let id = Id::Local(*id);
+                if !literals.is_empty() {
+                    let prior = gets.insert(id, literals);
+                    assert!(!prior.is_some());
+                }
+                let result = self.action(body, gets);
+                gets.remove(&id);
+                result
+            }
+            RelationExpr::Project { input, outputs: _ } => {
+                let literals = self.action(input, gets);
+                if !literals.is_empty() {
+                    // If the literals need to be re-interleaved,
+                    // we don't have much choice but to install a
+                    // Map operator to do that under the project.
+                    // Ideally this doesn't happen much, as projects
+                    // get lifted too.
+                    **input = input.take_dangerous().map(literals);
+                }
+                // TODO(frank): make this smarter if needed.
+                Vec::new()
+            }
+            RelationExpr::Map { input, scalars } => {
+                let mut literals = self.action(input, gets);
+
+                // Make the map properly formed again.
+                literals.extend(scalars.iter().cloned());
+                *scalars = literals;
+
+                // TODO(frank) propagate evaluation through expressions.
+
+                // Strip off literals at the end of `scalars`.
+                let mut result = Vec::new();
+                while scalars.last().map(|e| e.is_literal()) == Some(true) {
+                    result.push(scalars.pop().unwrap());
+                }
+                result.reverse();
+
+                result
+            }
+            RelationExpr::FlatMapUnary {
+                input,
+                func: _,
+                expr,
+                demand: _,
+            } => {
+                let literals = self.action(input, gets);
+                if !literals.is_empty() {
+                    // TODO(frank): inline literals in `expr`.
+                    let input_arity = input.arity();
+                    expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
+                        if *c >= input_arity {
+                            *e = literals[*c - input_arity].clone();
+                        }
+                    });
+
+                    **input = input.take_dangerous().map(literals);
+                }
+                Vec::new()
+            }
+            RelationExpr::Filter { input, predicates } => {
+                let literals = self.action(input, gets);
+                if !literals.is_empty() {
+                    // We should be able to instantiate all uses of `literals`
+                    // in predicates and then lift the `map` around the filter.
+                    let input_arity = input.arity();
+                    for expr in predicates.iter_mut() {
+                        expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
+                            if *c >= input_arity {
+                                *e = literals[*c - input_arity].clone();
+                            }
+                        });
+                    }
+                }
+                literals
+            }
+            RelationExpr::Join {
+                inputs,
+                equivalences,
+                demand,
+                implementation,
+            } => {
+                let mut input_literals = Vec::new();
+                for input in inputs.iter_mut() {
+                    input_literals.push(self.action(input, gets));
+                }
+
+                if input_literals.iter().any(|l| !l.is_empty()) {
+
+                    *demand = None;
+                    *implementation = crate::JoinImplementation::Unimplemented;
+
+                    // We should be able to install any literals in the
+                    // equivalence relations, and then lift all literals
+                    // around the join using a project to re-order colunms.
+
+                    let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+                    let input_arities = input_types
+                        .iter()
+                        .zip(input_literals.iter())
+                        .map(|(i,l)| i.column_types.len() + l.len())
+                        .collect::<Vec<_>>();
+
+                    let mut offset = 0;
+                    let mut prior_arities = Vec::new();
+                    for input in 0..inputs.len() {
+                        prior_arities.push(offset);
+                        offset += input_arities[input];
+                    }
+
+                    let input_relation = input_arities
+                        .iter()
+                        .enumerate()
+                        .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
+                        .collect::<Vec<_>>();
+
+                    // Visit each expression in each equivalence class to either
+                    // inline literals or update column references. Each column
+                    // reference should subtract off the total length of literals
+                    // returned for strictly prior input relations.
+                    for equivalence in equivalences.iter_mut() {
+                        for expr in equivalence.iter_mut() {
+                            expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
+                                let input = input_relation[*c];
+                                let input_arity = input_types[input].column_types.len();
+                                if *c >= prior_arities[input] + input_arity {
+                                    // Inline any input literal that has been promoted.
+                                    println!("c: {:?}, prior: {:?}, input: {:?}", *c, prior_arities[input], input_arity);
+                                    *e = input_literals[input][*c - (prior_arities[input] + input_arity)].clone()
+                                } else {
+                                    // Subtract off columns that have been promoted.
+                                    *c -= input_literals[..input].iter().map(|l| l.len()).sum::<usize>();
+                                }
+                            });
+                        }
+                    }
+
+                    let old_arity = input_arities.iter().sum();
+                    let new_arity = old_arity - input_literals.iter().map(|l| l.len()).sum::<usize>();
+                    let mut projection = Vec::new();
+                    for column in 0 .. old_arity {
+                        let input = input_relation[column];
+                        let input_arity = input_types[input].column_types.len();
+                        let prior_literals = input_literals[..input].iter().map(|l| l.len()).sum::<usize>();
+                        if column >= prior_arities[input] + input_arity {
+                            projection.push(new_arity + prior_literals + ((column - prior_arities[input]) - input_arity));
+                        } else {
+                            projection.push(column - prior_literals);
+                        }
+                    }
+                    let literals = input_literals.into_iter().flatten().collect::<Vec<_>>();
+                    *relation = relation.take_dangerous().map(literals).project(projection)
+                }
+                Vec::new()
+            }
+            RelationExpr::Reduce {
+                input,
+                group_key,
+                aggregates,
+            } => {
+                let literals = self.action(input, gets);
+                if !literals.is_empty() {
+                    // Reduce absorbs maps, and we should in-line literals.
+                    let input_arity = input.arity();
+                    // Inline literals into group key expressions.
+                    for expr in group_key.iter_mut() {
+                        expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
+                            if *c >= input_arity {
+                                *e = literals[*c - input_arity].clone();
+                            }
+                        });
+                    }
+                    // Inline literals into aggregate value selector expressions.
+                    for aggr in aggregates.iter_mut() {
+                        aggr.expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
+                            if *c >= input_arity {
+                                *e = literals[*c - input_arity].clone();
+                            }
+                        })
+                    }
+                }
+                // TODO(frank): convert to map if constants?
+                Vec::new()
+            }
+            RelationExpr::TopK {
+                input,
+                group_key,
+                order_key,
+                limit: _,
+                offset: _,
+            } => {
+                let literals = self.action(input, gets);
+                if !literals.is_empty() {
+                    // We should be able to lift literals out, as they affect neither
+                    // grouping nor ordering. We should discard grouping and ordering
+                    // that references the columns, though.
+                    let input_arity = input.arity();
+                    group_key.retain(|c| *c < input_arity);
+                    order_key.retain(|o| o.column < input_arity);
+                }
+                literals
+            }
+            RelationExpr::Negate { input } => {
+                // Literals can just be lifted out of negate.
+                self.action(input, gets)
+            }
+            RelationExpr::Threshold { input } => {
+                // Literals can just be lifted out of threshold.
+                self.action(input, gets)
+            }
+            RelationExpr::Union { left, right } => {
+                // We cannot, in general, lift literals out of unions.
+                let mut l_literals = self.action(left, gets);
+                let mut r_literals = self.action(right, gets);
+
+                let mut results = Vec::new();
+                while !l_literals.is_empty() && l_literals.last() == r_literals.last() {
+                    l_literals.pop();
+                    results.push(r_literals.pop().unwrap());
+                }
+                results.reverse();
+
+                if !l_literals.is_empty() {
+                    **left = left.take_dangerous().map(l_literals);
+                }
+                if !r_literals.is_empty() {
+                    **right = right.take_dangerous().map(r_literals);
+                }
+
+                results
+            }
+            RelationExpr::ArrangeBy { input, keys: _ } => {
+                // TODO(frank): Not sure this is the right behavior,
+                // as it may disrupt the arrangements we try to use.
+                // Or it may discover arrangements that we couldn't
+                // previously use due to the mapped columns...
+                self.action(input, gets)
+            }
+        }
+    }
+}

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -28,6 +28,7 @@ pub mod inline_let;
 pub mod join_elision;
 pub mod join_implementation;
 // pub mod join_order;
+pub mod map_lifting;
 pub mod nonnull_requirements;
 pub mod nonnullable;
 pub mod predicate_pushdown;
@@ -180,10 +181,11 @@ impl Default for Optimizer {
                     Box::new(crate::transform::update_let::UpdateLet),
                     Box::new(crate::transform::projection_extraction::ProjectionExtraction),
                     Box::new(crate::transform::projection_lifting::ProjectionLifting),
+                    Box::new(crate::transform::map_lifting::LiteralLifting),
                     Box::new(crate::transform::filter_lets::FilterLets),
                     Box::new(crate::transform::nonnull_requirements::NonNullRequirements),
                     Box::new(crate::transform::column_knowledge::ColumnKnowledge),
-                    Box::new(crate::transform::constant_join::InsertConstantJoin),
+                    // Box::new(crate::transform::constant_join::InsertConstantJoin),
                     Box::new(crate::transform::reduction_pushdown::ReductionPushdown),
                     Box::new(crate::transform::redundant_join::RedundantJoin),
                     Box::new(crate::transform::topk_elision::TopKElision),

--- a/src/expr/transform/mod.rs
+++ b/src/expr/transform/mod.rs
@@ -19,7 +19,7 @@ use crate::{EvalError, GlobalId, RelationExpr, ScalarExpr};
 
 pub mod binding;
 pub mod column_knowledge;
-pub mod constant_join;
+// pub mod constant_join;
 pub mod demand;
 pub mod empty_map;
 pub mod filter_lets;
@@ -191,6 +191,7 @@ impl Default for Optimizer {
                     Box::new(crate::transform::topk_elision::TopKElision),
                 ],
             }),
+            Box::new(crate::transform::reduction::FoldConstants),
             // TODO (wangandi): materialize#616 the FilterEqualLiteral transform
             // exists but is currently unevaluated with the new join implementations.
 
@@ -204,7 +205,7 @@ impl Default for Optimizer {
             // JoinOrder adds Projects, hence need project fusion again.
 
             // Implementation transformations
-            Box::new(crate::transform::constant_join::RemoveConstantJoin),
+            // Box::new(crate::transform::constant_join::RemoveConstantJoin),
             Box::new(crate::transform::Fixpoint {
                 transforms: vec![
                     Box::new(crate::transform::projection_lifting::ProjectionLifting),

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1393,7 +1393,7 @@ ORDER BY su_name
 | Filter "^co.*$" ~(#44)
 | Reduce group=(#0, #11, #12, #13) sum(#36)
 | Filter ((2 * #3) > #4)
-| Reduce group=(#0) any(true)
+| Distinct group=(#0)
 | ArrangeBy (#0)
 
 %12 =

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1479,9 +1479,7 @@ ORDER BY numwait DESC, su_name
 | | demand = (#0..#3, #10)
 | Filter (#10 > #3)
 | Distinct group=(#0, #1, #2, #3)
-| Map true
 | Negate
-| Project (#0..#3)
 
 %11 =
 | Get %6
@@ -1560,9 +1558,7 @@ ORDER BY substr(c_state, 1, 1)
 | | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
 | | demand = (#0..#2)
 | Distinct group=(#0, #1, #2)
-| Map true
 | Negate
-| Project (#0..#2)
 
 %7 =
 | Get %2

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -174,14 +174,14 @@ WHERE l1.la IN (
 | Join %5 %6 (= #0 (#1 + 1))
 | | implementation = Differential %6 %5.(#0)
 | | demand = (#0)
-| Reduce group=(#0) any(true)
+| Distinct group=(#0)
 | ArrangeBy (#0)
 
 %8 =
 | Join %4 %7 (= #1 #3)
 | | implementation = Differential %4 %7.(#0)
 | | demand = (#0)
-| Reduce group=(#0) any(true)
+| Distinct group=(#0)
 | ArrangeBy (#0)
 
 %9 =

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -208,8 +208,6 @@ EXPLAIN PLAN FOR SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 | Join %0 %1
 | | implementation = Differential %0 %1.()
 | | demand = (#0)
-| Map true
-| Project (#0)
 
 EOF
 
@@ -232,7 +230,6 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | Join %0 %1 %2 (= #0 #1)
 | | implementation = Differential %1 %2.() %0.(#0)
 | | demand = (#0, #2)
-| Map true
 | Project (#0, #0, #2)
 
 EOF
@@ -275,7 +272,6 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | Join %3 %6 (= #2 #3)
 | | implementation = Differential %3 %6.(#0)
 | | demand = (#0, #2)
-| Map true
 | Project (#0, #0, #2)
 
 EOF

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1671,7 +1671,6 @@ ORDER BY
 | Join %5 %8 (= #0 #37) (= #7 #36)
 | | implementation = Differential %5 %8.(#0, #1)
 | | demand = (#0, #1, #7)
-| Map true
 
 %10 =
 | Get %9
@@ -1694,9 +1693,7 @@ ORDER BY
 | | demand = (#0, #1, #4, #13, #14)
 | Filter (#4 != #1), (#14 > #13)
 | Distinct group=(#0, #1)
-| Map true
 | Negate
-| Project (#0, #1)
 
 %15 =
 | Get %10
@@ -1709,7 +1706,7 @@ ORDER BY
 | ArrangeBy (#0, #1)
 
 %18 =
-| Join %11 %16 %17 (= #0 #40 #42) (= #7 #39 #41)
+| Join %11 %16 %17 (= #0 #39 #41) (= #7 #38 #40)
 | | implementation = Differential %16 %17.(#0, #1) %11.(#7, #0)
 | | demand = (#1)
 | Reduce group=(#1) countall(null)
@@ -1803,9 +1800,7 @@ ORDER BY
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
-| Map true
 | Negate
-| Project (#0)
 
 %7 =
 | Get %2

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1368,7 +1368,7 @@ ORDER BY
 | | demand = (#0, #5)
 | Reduce group=(#0, #0) sum(#5)
 | Filter (#2 > 30000dec)
-| Reduce group=(#0) any(true)
+| Distinct group=(#0)
 | ArrangeBy (#0)
 
 %8 =
@@ -1539,7 +1539,6 @@ ORDER BY
 | | implementation = Differential %6 %7.(#0) %8.(#0)
 | | demand = (#0, #11..#13, #18)
 | Filter "^forest.*$" ~(#18)
-| Map true
 
 %10 =
 | Get %2
@@ -1567,11 +1566,11 @@ ORDER BY
 | ArrangeBy (#0, #1)
 
 %15 =
-| Join %11 %14 (= #11 #27) (= #12 #28)
+| Join %11 %14 (= #11 #26) (= #12 #27)
 | | implementation = Differential %11 %14.(#0, #1)
-| | demand = (#0, #13, #30)
-| Filter ((i32todec(#13) * 1000dec) > #30)
-| Reduce group=(#0) any(true)
+| | demand = (#0, #13, #29)
+| Filter ((i32todec(#13) * 1000dec) > #29)
+| Distinct group=(#0)
 | ArrangeBy (#0)
 
 %16 =


### PR DESCRIPTION
Any `RelationExpr::Map` with literal arguments can have them extracted, potentially removing the need for the map. This transformation is one mechanism to alter the shape of relations: if certain columns are not required, a default value can be placed using a map, and that literal then lifted and absorbed up in the AST.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2898)
<!-- Reviewable:end -->
