### PR TITLE
Correct any/all implementations

### DIFF
--- a/src/expr/relation/func.rs
+++ b/src/expr/relation/func.rs
@@ -373,28 +373,26 @@ fn any<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    for d in datums {
-        match d {
-            Datum::Null | Datum::True => return d,
-            Datum::False => (),
-            _ => unreachable!(),
-        }
-    }
-    Datum::False
+    datums
+        .into_iter()
+        .fold(Datum::False, |state, next| match (state, next) {
+            (Datum::True, _) | (_, Datum::True) => Datum::True,
+            (Datum::Null, _) | (_, Datum::Null) => Datum::Null,
+            _ => Datum::False,
+        })
 }
 
 fn all<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
-    for d in datums {
-        match d {
-            Datum::Null | Datum::False => return d,
-            Datum::True => (),
-            _ => unreachable!(),
-        }
-    }
-    Datum::True
+    datums
+        .into_iter()
+        .fold(Datum::True, |state, next| match (state, next) {
+            (Datum::False, _) | (_, Datum::False) => Datum::False,
+            (Datum::Null, _) | (_, Datum::Null) => Datum::Null,
+            _ => Datum::True,
+        })
 }
 
 fn jsonb_agg<'a, I>(datums: I, temp_storage: &'a RowArena) -> Datum<'a>


### PR DESCRIPTION
These functions previously returned different values based on the order values were presented to them, resulting in some incorrect outputs (in particular, if presented with `Datum::Null` first). The new implementations are not optimized for speed, as the code is not hot (`reduce.rs` has its own implementations based on counting occurrences).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2899)
<!-- Reviewable:end -->
