### PR TITLE
Don't validate the schema for every sink message in release builds

### DIFF
--- a/src/avro/lib.rs
+++ b/src/avro/lib.rs
@@ -329,6 +329,7 @@ pub mod schema;
 pub mod types;
 
 pub use crate::codec::Codec;
+pub use crate::encode::encode as encode_unchecked;
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::{ParseSchemaError, Schema};
 pub use crate::types::SchemaResolutionError;

--- a/src/dataflow/sink/kafka.rs
+++ b/src/dataflow/sink/kafka.rs
@@ -81,7 +81,7 @@ pub fn kafka<G>(
                             after: Some(row),
                         }
                     };
-                    let buf = encoder.encode(connector.schema_id, diff_pair);
+                    let buf = encoder.encode_unchecked(connector.schema_id, diff_pair);
                     for _ in 0..diff.abs() {
                         let record = BaseRecord::<&Vec<u8>, _>::to(&connector.topic).payload(&buf);
                         if let Err((e, _)) = producer.inner().send(record) {

--- a/src/interchange/avro.rs
+++ b/src/interchange/avro.rs
@@ -637,6 +637,17 @@ impl Encoder {
         &self.writer_schema
     }
 
+    pub fn encode_unchecked(&self, schema_id: i32, diff_pair: DiffPair<&Row>) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.write_u8(0).expect("writing to vec cannot fail");
+        buf.write_i32::<NetworkEndian>(schema_id)
+            .expect("writing to vec cannot fail");
+        let avro = self.diff_pair_to_avro(diff_pair);
+        debug_assert!(avro.validate(self.writer_schema.top_node()));
+        avro::encode_unchecked(&avro, &self.writer_schema, &mut buf);
+        buf
+    }
+
     /// Encodes a repr::Row to a Avro-compliant Vec<u8>.
     /// See function implementation for Confluent-specific details.
     pub fn encode(&self, schema_id: i32, diff_pair: DiffPair<&Row>) -> Vec<u8> {


### PR DESCRIPTION
Previously we were calling `Encoder::encode`, which uses the `write_avro_datum` function. `write_avro_datum`  validates the value against the schema, which is normally the right thing to do. In this case, we know the value matches the schema because we are generating both of them ourselves, so let's avoid that check except in a `debug_assert!` (which will only run in debug builds) and avoid some unnecessary CPU usage in release builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2907)
<!-- Reviewable:end -->
