### PR TITLE
Remove stale Kinesis streams in CI cleanup

### DIFF
--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -30,7 +30,7 @@ def get_old_stream_names() -> List[str]:
                     "aws",
                     "kinesis",
                     "describe-stream",
-                    "--stream-name"
+                    "--stream-name",
                     stream_name,
                     "--region=us-east-2",
                 ],

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -36,7 +36,7 @@ def get_old_stream_names() -> List[str]:
                 ],
                 unicode=True,
             )
-        )
+        )["StreamDescription"]
         for stream_name in stream_names["StreamNames"]
     ]
 
@@ -49,7 +49,7 @@ def get_old_stream_names() -> List[str]:
             return False
 
     old_stream_names = [
-        desc["StreamName"] for desc in stream_descriptions if is_old(desc["StreamDescription"])
+        desc["StreamName"] for desc in stream_descriptions if is_old(desc)
     ]
     return old_stream_names
 

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -26,7 +26,7 @@ def get_old_stream_names() -> List[str]:
             return False
 
     old_stream_names = [
-        desc["name"] for desc in stream_descriptions if is_old(desc)
+        desc["StreamName"] for desc in stream_descriptions if is_old(desc)
     ]
     return old_stream_names
 

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -36,7 +36,7 @@ def get_old_stream_names() -> List[str]:
                 unicode=True,
             )
         )
-        for stream_name in stream_names
+        for stream_name in stream_names["StreamNames"]
     ]
 
     def is_old(desc: Dict) -> bool:

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -39,7 +39,6 @@ def get_old_stream_names() -> List[str]:
         )
         for stream_name in stream_names["StreamNames"]
     ]
-    print(f"stream descriptions ", stream_descriptions)
 
     def is_old(desc: Dict) -> bool:
         if "StreamCreationTimestamp" in desc:
@@ -50,7 +49,7 @@ def get_old_stream_names() -> List[str]:
             return False
 
     old_stream_names = [
-        desc["StreamName"] for desc in stream_descriptions if is_old(desc)
+        desc["StreamName"] for desc in stream_descriptions if is_old(desc["StreamDescription"])
     ]
     return old_stream_names
 

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -30,6 +30,7 @@ def get_old_stream_names() -> List[str]:
                     "aws",
                     "kinesis",
                     "describe-stream",
+                    "--stream-name"
                     stream_name,
                     "--region=us-east-2",
                 ],

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -1,0 +1,42 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize import spawn
+import json
+from typing import List
+from datetime import datetime, timedelta
+
+def get_old_stream_names() -> List[str]:
+    streams = json.load(spawn.capture(["aws", "kinesis", "list-streams", "--region=us-east-2"]))
+    stream_descriptions = [
+        json.load(spawn.capture(["aws", "kinesis", "describe-stream", stream, "--region=us-east-2"])) for stream in streams
+    ]
+
+    def is_old(desc) -> bool:
+        if "StreamCreationTimestamp" in desc:
+            return datetime.now() - datetime.utcfromtimestamp(desc["StreamCreationTimestamp"]) \
+                .strftime('%Y-%m-%d %H:%M:%S') > timedelta(hours=1)
+        else:
+            return False
+
+    old_stream_names = [
+        desc["name"] for desc in stream_descriptions if is_old(desc)
+    ]
+    return old_stream_names
+
+def main() -> None:
+    old_stream_names = get_old_stream_names()
+    print(f"Will delete {len(old_streams)} old streams")
+    for stream_name in old_stream_names:
+        print(f"Deleting stream {stream_name}")
+        spawn.capture(["aws", "kinesis", "delete", "--stream-name", stream_name, "--region=us-east-2"])
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -12,16 +12,25 @@ import json
 from typing import List
 from datetime import datetime, timedelta
 
+
 def get_old_stream_names() -> List[str]:
-    streams = json.load(spawn.capture(["aws", "kinesis", "list-streams", "--region=us-east-2"]))
+    streams = json.load(
+        spawn.capture(["aws", "kinesis", "list-streams", "--region=us-east-2"])
+    )
     stream_descriptions = [
-        json.load(spawn.capture(["aws", "kinesis", "describe-stream", stream, "--region=us-east-2"])) for stream in streams
+        json.load(
+            spawn.capture(
+                ["aws", "kinesis", "describe-stream", stream, "--region=us-east-2"]
+            )
+        )
+        for stream in streams
     ]
 
     def is_old(desc) -> bool:
         if "StreamCreationTimestamp" in desc:
-            return datetime.now() - datetime.utcfromtimestamp(desc["StreamCreationTimestamp"]) \
-                .strftime('%Y-%m-%d %H:%M:%S') > timedelta(hours=1)
+            return datetime.now() - datetime.utcfromtimestamp(
+                desc["StreamCreationTimestamp"]
+            ).strftime("%Y-%m-%d %H:%M:%S") > timedelta(hours=1)
         else:
             return False
 
@@ -30,12 +39,22 @@ def get_old_stream_names() -> List[str]:
     ]
     return old_stream_names
 
+
 def main() -> None:
     old_stream_names = get_old_stream_names()
     print(f"Will delete {len(old_streams)} old streams")
     for stream_name in old_stream_names:
         print(f"Deleting stream {stream_name}")
-        spawn.capture(["aws", "kinesis", "delete", "--stream-name", stream_name, "--region=us-east-2"])
+        spawn.capture(
+            [
+                "aws",
+                "kinesis",
+                "delete",
+                "--stream-name",
+                stream_name,
+                "--region=us-east-2",
+            ]
+        )
 
 
 if __name__ == "__main__":

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -63,7 +63,7 @@ def main() -> None:
             [
                 "aws",
                 "kinesis",
-                "delete",
+                "delete-stream",
                 "--stream-name",
                 stream_name,
                 "--region=us-east-2",

--- a/ci/cleanup/kinesis.py
+++ b/ci/cleanup/kinesis.py
@@ -39,6 +39,7 @@ def get_old_stream_names() -> List[str]:
         )
         for stream_name in stream_names["StreamNames"]
     ]
+    print(f"stream descriptions ", stream_descriptions)
 
     def is_old(desc: Dict) -> bool:
         if "StreamCreationTimestamp" in desc:

--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -12,3 +12,5 @@
 steps:
   - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.bintray
     timeout_in_minutes: 10
+  - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.kinesis
+    timeout_in_minutes: 10


### PR DESCRIPTION
Although we remove Kinesis streams that have been created at the end of every testdrive run, if a run is exited early the created stream will not be removed. This clean up job is intended to find and remove the leftover test streams.

This was (finally) run successfully with a manual build! 🎉 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2908)
<!-- Reviewable:end -->
