### PR TITLE
mzimage: Print image spec on build no matter what

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -396,6 +396,9 @@ class ResolvedImage:
         for d in dependencies:
             self.dependencies[d.name] = d
 
+    def __repr__(self) -> str:
+        return f"ResolvedImage<{self.spec()}>"
+
     @property
     def name(self) -> str:
         """The name of the underlying image."""
@@ -595,7 +598,6 @@ class DependencySet:
                 Hub.
         """
         known_images = docker_images()
-        specs = {d.name: d.spec() for d in self}
         for d in self:
             spec = d.spec()
             if spec not in known_images:
@@ -605,6 +607,8 @@ class DependencySet:
                 else:
                     print(f"==> Acquiring {spec}")
                     acquired_from = d.acquire()
+            else:
+                print(f"==> Already built {spec}")
 
     def __iter__(self) -> Iterator[ResolvedImage]:
         return iter(self.dependencies.values())


### PR DESCRIPTION
I occasionally get mzcompose or docker-compose not running exactly the image that I
expect it to, this is an attempt to make it more clear to me what's going on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2910)
<!-- Reviewable:end -->
