### PR TITLE
integration: provide setting for prefixing Kafka group ID

### DIFF
--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -1290,7 +1290,6 @@ impl Timestamper {
         let mut config = ClientConfig::new();
         config
             .set("auto.offset.reset", "earliest")
-            .set("group.id", &format!("materialize-rt-{}-{}", &kc.topic, id))
             .set("enable.auto.commit", "false")
             .set("enable.partition.eof", "false")
             .set("session.timeout.ms", "6000")
@@ -1298,6 +1297,12 @@ impl Timestamper {
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &kc.url.to_string());
+
+        let group_id_prefix = kc.group_id_prefix.unwrap_or_else(String::new);
+        config.set(
+            "group.id",
+            &format!("{}materialize-rt-{}-{}", group_id_prefix, &kc.topic, id),
+        );
 
         for (k, v) in &kc.config_options {
             config.set(k, v);
@@ -1464,10 +1469,6 @@ impl Timestamper {
     ) -> Option<ByoKafkaConnector> {
         let mut config = ClientConfig::new();
         config
-            .set(
-                "group.id",
-                &format!("materialize-byo-{}-{}", &timestamp_topic, id),
-            )
             .set("enable.auto.commit", "false")
             .set("enable.partition.eof", "false")
             .set("auto.offset.reset", "earliest")
@@ -1476,6 +1477,16 @@ impl Timestamper {
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &kc.url.to_string());
+
+        let group_id_prefix = kc.group_id_prefix.clone().unwrap_or_else(String::new);
+        config.set(
+            "group.id",
+            &format!(
+                "{}materialize-byo-{}-{}",
+                group_id_prefix, &timestamp_topic, id
+            ),
+        );
+
         for (k, v) in &kc.config_options {
             config.set(k, v);
         }

--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -512,6 +512,7 @@ pub struct KafkaSourceConnector {
     // FIXME (brennan) - in the very near future, this should be made into a hashmap of partition |-> offset.
     // #2736
     pub start_offset: i64,
+    pub group_id_prefix: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -119,6 +119,7 @@ where
         topic,
         config_options,
         start_offset,
+        group_id_prefix,
     } = connector.clone();
 
     let ts = if config.active {
@@ -153,7 +154,6 @@ where
 
         let mut kafka_config = ClientConfig::new();
         kafka_config
-            .set("group.id", &format!("materialize-{}", name))
             .set("enable.auto.commit", "false")
             .set("enable.partition.eof", "false")
             .set("auto.offset.reset", "earliest")
@@ -162,6 +162,13 @@ where
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
             .set("bootstrap.servers", &url.to_string());
+
+        let group_id_prefix = group_id_prefix.unwrap_or_else(String::new);
+        kafka_config.set(
+            "group.id",
+            &format!("{}materialize-{}", group_id_prefix, name),
+        );
+
         for (k, v) in &config_options {
             kafka_config.set(k, v);
         }

--- a/src/sql/kafka_util.rs
+++ b/src/sql/kafka_util.rs
@@ -83,13 +83,19 @@ impl<'a> ConfigAggregator<'a> {
 
         Ok(())
     }
+    fn remove_from_input(&mut self, k: &str) -> Option<Value> {
+        self.input.remove(k)
+    }
+    fn insert_into_output(&mut self, k: String, v: String) {
+        self.output.insert(k, v);
+    }
     fn finish(self) -> HashMap<String, String> {
         self.output
     }
 }
 
-/// Parse the `with_options` from a `CREATE SOURCE` statement to determine Kafka
-/// security strategy, and extract any additional supplied configurations.
+/// Parse the `with_options` from a `CREATE SOURCE` statement to determine
+/// user-supplied config options, e.g. security options.
 ///
 /// # Errors
 ///
@@ -97,37 +103,44 @@ impl<'a> ConfigAggregator<'a> {
 /// expected file paths.
 /// - If any of the values in `with_options` are not
 ///   `sql_parser::ast::Value::SingleQuotedString`.
-pub fn extract_security_config(
-    mut with_options: &mut HashMap<String, Value>,
+pub fn extract_config(
+    with_options: &mut HashMap<String, Value>,
 ) -> Result<HashMap<String, String>, failure::Error> {
-    let security_protocol = match with_options.remove("security_protocol") {
+    let mut agg = ConfigAggregator::new(with_options);
+
+    // TODO(sploiselle): Import other configs from src/sql/statement.rs
+    extract_security_config(&mut agg)?;
+
+    Ok(agg.finish())
+}
+
+// Parse the `with_options` from a `CREATE SOURCE` statement to determine Kafka
+// security strategy, and extract any additional supplied configurations.
+fn extract_security_config(mut agg: &mut ConfigAggregator) -> Result<(), failure::Error> {
+    let security_protocol = match agg.remove_from_input("security_protocol") {
         None => None,
         Some(Value::SingleQuotedString(p)) => Some(p.to_lowercase()),
         Some(_) => bail!("ssl_certificate_file must be a string"),
     };
 
-    let options: HashMap<String, String> = match security_protocol.as_deref() {
-        None => HashMap::new(),
-        Some("ssl") => ssl_settings(&mut with_options)?,
-        Some("sasl_plaintext") => sasl_plaintext_kerberos_settings(&mut with_options)?,
+    match security_protocol.as_deref() {
+        None => {}
+        Some("ssl") => ssl_settings(&mut agg)?,
+        Some("sasl_plaintext") => sasl_plaintext_kerberos_settings(&mut agg)?,
         Some(invalid_protocol) => bail!(
             "Invalid WITH options: security_protocol='{}'",
             invalid_protocol
         ),
-    };
+    }
 
-    Ok(options)
+    Ok(())
 }
 
 // Filters `sql_parser::ast::Statement::CreateSource.with_options` for the
 // configuration to connect to an SSL-secured cluster. You can find more detail
-// about these settings in [librdkafka's
-// documentation](https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka).
-fn ssl_settings(
-    with_options: &mut HashMap<String, Value>,
-) -> Result<HashMap<String, String>, failure::Error> {
-    let mut agg = ConfigAggregator::new(with_options);
-
+// about these settings in
+// [librdkafka's documentation](https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka).
+fn ssl_settings(agg: &mut ConfigAggregator) -> Result<(), failure::Error> {
     let allowed_configs = vec![
         Config::new("ssl_ca_location", ValType::Path),
         Config::new("ssl_certificate_location", ValType::Path),
@@ -139,22 +152,16 @@ fn ssl_settings(
         agg.extract(&config)?;
     }
 
-    let mut out = agg.finish();
-    out.insert("security.protocol".to_string(), "ssl".to_string());
+    agg.insert_into_output("security.protocol".to_string(), "ssl".to_string());
 
-    Ok(out)
+    Ok(())
 }
 
 // Filters `sql_parser::ast::Statement::CreateSource.with_options` for the
-// configuration to connect to a
-// Kerberized Kafka cluster. You can find more detail
-// about these settings in [librdkafka's
-// documentation](https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka).
-fn sasl_plaintext_kerberos_settings(
-    with_options: &mut HashMap<String, Value>,
-) -> Result<HashMap<String, String>, failure::Error> {
-    let mut agg = ConfigAggregator::new(with_options);
-
+// configuration to connect to a Kerberized Kafka cluster. You can find more
+// detail about these settings in
+// [librdkafka's documentation](https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka).
+fn sasl_plaintext_kerberos_settings(agg: &mut ConfigAggregator) -> Result<(), failure::Error> {
     // Represents valid `with_option` keys to connect to Kerberized Kafka
     // cluster through SASL based on
     // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.
@@ -178,21 +185,17 @@ fn sasl_plaintext_kerberos_settings(
         agg.extract(&config)?;
     }
 
-    let mut out = agg.finish();
-    out.insert(
+    agg.insert_into_output(
         "security.protocol".to_string(),
         "sasl_plaintext".to_string(),
     );
 
-    Ok(out)
+    Ok(())
 }
 
-/// Create a new
-/// [`rdkafka::ClientConfig`](https://docs.rs/rdkafka/latest/rdkafka/config/struct.ClientConfig.html)
-/// with the provided
-/// [`options`]](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md),
-/// and test its ability to create an
-/// [`rdkafka::consumer::BaseConsumer`](https://docs.rs/rdkafka/latest/rdkafka/consumer/base_consumer/struct.BaseConsumer.html).
+/// Create a new `rdkafka::ClientConfig` with the provided
+/// [`options`](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md),
+/// and test its ability to create an `rdkafka::consumer::BaseConsumer`.
 ///
 /// Expected to test the output of `extract_security_config`.
 ///


### PR DESCRIPTION
Materialize currently sets the Kafka consumer's `group.id` to `materialize-X-Y`. However, to work with some Kerberos authentication schemes, it would be preferable if users could affect the `group.id`. To solve this, we should let users provide an arbitrary string as a prefix for the consumer group ID, letting them achieve something like `group.app.materialize-X-Y`.

This also includes a nominal refactor to generalize extracting supplied configs from Kafka. In the coming days, I'll also move over some other configs that have accrued in `sql/statement.rs`.

@umanwizard This is more-or-less similar to the `kafka_client_id` feature you added. Was looking for some kind of inspiration to test that this behaves like you'd expect; you have any suggestions?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2914)
<!-- Reviewable:end -->
