### PR TITLE
integration: minor Kafka config cleanup

### DIFF
--- a/www/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/www/layouts/partials/create-source/connector/kafka/with-options.html
@@ -1,5 +1,7 @@
+`client_id` | `text` | Use the supplied value as the Kafka client identifier.
+`group_id_prefix` | `text` | Prefix Materialize Kafka users' `group.id` with the provided value. The resulting `group.id` looks like `<group_id_prefix>materialize-X-Y`, where `X` and `Y` are values that allow multiple concurrent Kafka consumers from the same topic.
 `security_protocol` | `text` | Use either [`ssl`](#ssl-with-options) or [`sasl_plaintext` (Kerberos)](#kerberos-with-options) to connect to the Kafka cluster.
-`group_id_prefix` | `text` | Prefix Materialize Kafka consumers' `group.id` with the provided value. The resulting `group.id` looks like `<group_id_prefix>materialize-X-Y`, where `X` and `Y` are values that allow multiple concurrent Kafka consumers from the same topic.
+`statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics.
 
 ##### SSL `WITH` options
 


### PR DESCRIPTION
Move remaining Kafka configs from `src/sql/statement.rs` into `sql/kafka_util.rs`. Includes some minor API tweaks to simplify creating most configs as we extend `Config`'s capabilities.

@umanwizard renamed that config option to just `client_id` because it's only applicable to Kafka.

Makes progress on #2837

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2929)
<!-- Reviewable:end -->
