### PR TITLE
Fix peeker init infinite recursion

### DIFF
--- a/src/peeker/peeker.rs
+++ b/src/peeker/peeker.rs
@@ -176,7 +176,7 @@ fn initialize(config: &Args) -> Result<()> {
         }
         warn!("init error, retry in 10 seconds ({} remaining)", counter);
         thread::sleep(Duration::from_secs(10));
-        init_result = initialize(&config);
+        init_result = init_inner(&config);
     }
     Ok(())
 }


### PR DESCRIPTION
This wasn't a hot loop, but max retries never went down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2938)
<!-- Reviewable:end -->
