### PR TITLE
Flip around the ice-cream-cone operator

### DIFF
--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -2258,7 +2258,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::JsonbGetString => f.write_str("->"),
             BinaryFunc::JsonbContainsString => f.write_str("?"),
             BinaryFunc::JsonbConcat => f.write_str("||"),
-            BinaryFunc::JsonbContainsJsonb => f.write_str("<@"),
+            BinaryFunc::JsonbContainsJsonb => f.write_str("@>"),
             BinaryFunc::JsonbDeleteInt64 => f.write_str("-"),
             BinaryFunc::JsonbDeleteString => f.write_str("-"),
             BinaryFunc::RoundDecimal(_) => f.write_str("round"),


### PR DESCRIPTION
Prior, it would be inverted in EXPLAINs:
```
materialize=> explain raw plan for select '{"a":"b"}'::jsonb @> '{}'::jsonb;
                        Raw Plan
---------------------------------------------------------
 %0 =                                                   +
 | Constant ()                                          +
 | Map (strtojsonb("{\"a\":\"b\"}") <@ strtojsonb("{}"))+
 | Project (#0)                                         +
 | Map                                                  +

(1 row)
```

After:
```
materialize=> explain raw plan for select '{"a":"b"}'::jsonb @> '{}'::jsonb;
                        Raw Plan
---------------------------------------------------------
 %0 =                                                   +
 | Constant ()                                          +
 | Map (strtojsonb("{\"a\":\"b\"}") @> strtojsonb("{}"))+
 | Project (#0)                                         +
 | Map                                                  +

(1 row)
```

```
materialize=> explain raw plan for select '{"a":"b"}'::jsonb <@ '{}'::jsonb;
                        Raw Plan
---------------------------------------------------------
 %0 =                                                   +
 | Constant ()                                          +
 | Map (strtojsonb("{}") @> strtojsonb("{\"a\":\"b\"}"))+
 | Project (#0)                                         +
 | Map                                                  +

(1 row)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2945)
<!-- Reviewable:end -->
