### PR TITLE
dashboard: Start grafana on the overview dashboard

### DIFF
--- a/misc/monitoring/dashboard/conf/grafana/grafana.ini
+++ b/misc/monitoring/dashboard/conf/grafana/grafana.ini
@@ -16,8 +16,5 @@ viewers_can_edit = true
 
 #################################### Anonymous Auth ##########################
 # Go strait to the dashboard list
-[auth]
-disable_login_form = true
-
 [auth.anonymous]
 enabled = true


### PR DESCRIPTION
Instead of starting on the empty overview page that has no links to dashboards.

Unfortunately grafana does not support provisioning the home dashboard, so we need to do
it via the API at startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2946)
<!-- Reviewable:end -->
