### PR TITLE
Push NOT into binary operators

### DIFF
--- a/src/transform/lib.rs
+++ b/src/transform/lib.rs
@@ -172,6 +172,7 @@ impl Default for Optimizer {
             Box::new(crate::fusion::filter::Filter),
             Box::new(crate::fusion::map::Map),
             Box::new(crate::reduction::FoldConstants),
+            Box::new(crate::reduction::NegatePredicate),
             Box::new(crate::reduction::DeMorgans),
             Box::new(crate::reduction::UndistributeAnd),
             Box::new(crate::split_predicates::SplitPredicates),

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -179,3 +179,27 @@ query B
 SELECT NOT 0::bool
 ----
 true
+
+statement ok
+CREATE TABLE x (a int, u int, j jsonb, b bool)
+
+# Ensure the NOT gets pushed into the binary operation.
+query T multiline
+EXPLAIN PLAN FOR SELECT
+  NOT(a = u),
+  NOT(a != u),
+  NOT(a < u),
+  NOT(a > u),
+  NOT(a >= u),
+  NOT(a <= u),
+  NOT(NOT(b)),
+  -- Doesn't have a negation.
+  NOT(j @> '{}'::JSONB)
+FROM x
+----
+%0 =
+| Get materialize.public.x (u5)
+| Map (#0 != #1), (#0 = #1), (#0 >= #1), (#0 <= #1), (#0 < #1), (#0 > #1), !((#2 @> {}))
+| Project (#4..#9, #3, #10)
+
+EOF


### PR DESCRIPTION
This commit replaces expressions of the form `NOT(a <op> b)` with
`NOT(a <negate(op)> b)`, if `<negate(op)>` exists (as it does for `=`
vs. `!=`, etc.).

This improves behaviour for queries like `a JOIN b ON NOT(x != y)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2948)
<!-- Reviewable:end -->
