### PR TITLE
WIP[dnm]: Alternative implementation of #2948

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -2528,11 +2528,7 @@ fn plan_unary_op<'a>(
             _ => bail!("cannot negate {:?}", typ.scalar_type),
         },
     };
-    let expr = ScalarExpr::CallUnary {
-        func,
-        expr: Box::new(expr),
-    };
-    Ok(expr)
+    Ok(expr.call_unary(func))
 }
 
 fn plan_binary_op<'a>(


### PR DESCRIPTION
This commit is not production-ready in its current form, it just exists
to explain the general idea.

This commit proposes an alternative strategy for implementing
optimizations like those found in #2948: rather than allow the user to
construct whatever expressions they want, and then fix them up later via
transforms, we intercept the construction of said expressions and
replace them with something equivalent that we'd prefer.

This approach has several nice properties:

* Expressions are _always_ normalized: [as long as you always call the
  constructor] it's impossible to get your hands on a non-normalized
  expression.
* We never actually reify expressions that will get optimized later: in
  this particular example, we never even have to construct a CallUnary
  in the cases where this optimization applies.
* This massively cuts down on the number of tree traversals we need to
  do: there's no need to walk the entire tree to spot cases like this.
* Avoids mutation! This one is selfish but walking a tree and
  rejiggering things makes me a little antsy. This avoids that problem
  altogether.

I don't know of a name for this technique, but having worked with it
before I found it really pleasant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2949)
<!-- Reviewable:end -->
