### PR TITLE
Adding metrics to Kafka source

### DIFF
--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -15,11 +15,13 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1587591686854,
+  "id": 1,
+  "iteration": 1588902358992,
   "links": [],
   "panels": [
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -45,6 +47,7 @@
         "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
+      "datasource": null,
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -58,7 +61,6 @@
       "legend": {
         "show": true
       },
-      "options": {},
       "reverseYBuckets": false,
       "targets": [
         {
@@ -110,6 +112,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "the view of how long things took, from inside pgwire",
       "fill": 1,
       "fillGradient": 0,
@@ -119,6 +122,7 @@
         "x": 12,
         "y": 1
       },
+      "hiddenSeries": false,
       "id": 25,
       "legend": {
         "avg": false,
@@ -316,6 +320,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -761,7 +766,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(mz_kafka_bytes_read_total[2s])",
+          "expr": "rate(mz_kafka_bytes_read_total[3s])",
           "legendFormat": "rate",
           "refId": "A"
         },
@@ -904,6 +909,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "description": "Rate at which capabilities are downgraded in the system",
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -912,6 +918,360 @@
         "x": 12,
         "y": 34
       },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(mz_kafka_capability[3s])",
+          "interval": "",
+          "legendFormat": "{{topic}}-{{source_id}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": " Capability Closing Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Rate at which data is first received from the Kafka Source",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 51,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "mz_kafka_partition_offset_received",
+          "interval": "",
+          "legendFormat": "{{topic}}-{{source_id}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Kafka Data Ingestion Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Rate at which capabilities are downgraded in the system",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "hiddenSeries": false,
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "max by (topic, source_id) (mz_kafka_partition_closed_ts) - min by (topic, source_id) (mz_kafka_partition_closed_ts)",
+          "interval": "",
+          "legendFormat": "{{topic}}-{{source_id}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Partition Imbalance Amount",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Difference between allocated timestamps and close timestamps",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "hiddenSeries": false,
+      "id": 53,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(mz_max_timestamp- ignoring(topic) mz_kafka_partition_closed_ts)",         "interval": "",
+          "legendFormat": "{{source_id}}-{{partition_id}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Timestamp Closing Lag",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "hiddenSeries": false,
       "id": 47,
       "legend": {
         "avg": false,
@@ -994,11 +1354,12 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 58
       },
       "id": 30,
       "panels": [],
@@ -1016,7 +1377,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 59
       },
       "id": 24,
       "legend": {
@@ -1101,7 +1462,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 59
       },
       "id": 20,
       "legend": {
@@ -1193,7 +1554,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 67
       },
       "id": 16,
       "legend": {
@@ -1272,6 +1633,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Uncompacted records in each arrangement",
       "fill": 1,
       "fillGradient": 0,
@@ -1279,7 +1641,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 67
       },
       "id": 35,
       "legend": {
@@ -1355,7 +1717,6 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 19,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1433,6 +1794,7 @@
       {
         "allValue": null,
         "current": {
+          "selected": false,
           "text": "All",
           "value": "$__all"
         },
@@ -1478,13 +1840,14 @@
       {
         "allValue": null,
         "current": {
-          "text": "2020-04-22T21:12:29Z",
-          "value": "2020-04-22T21:12:29Z"
+          "text": "2020-05-08T01:36:48Z",
+          "value": "2020-05-08T01:36:48Z"
         },
         "datasource": "Prometheus",
         "definition": "label_values(mz_server_metadata_seconds, build_time)",
         "hide": 0,
         "includeAll": false,
+        "index": -1,
         "label": "Built at",
         "multi": false,
         "name": "built_at",
@@ -1535,6 +1898,7 @@
         "definition": "label_values(mz_server_metadata_seconds, build_sha)",
         "hide": 0,
         "includeAll": false,
+        "index": -1,
         "label": "Git commit",
         "multi": false,
         "name": "build_sha",

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -39,13 +39,14 @@ lazy_static! {
     .unwrap();
     static ref KAFKA_PARTITION_OFFSET_INGESTED: IntGaugeVec = register_int_gauge_vec!(
         "mz_kafka_partition_offset_ingested",
-        "The most recent kafka offset that we have ingested into a dataflow",
+        "The most recent kafka offset that we have ingested into a dataflow. This correspond to \
+        data that we have 1)ingested 2) assigned a timestamp",
         &["topic", "source_id", "partition_id"]
     )
     .unwrap();
     static ref KAFKA_PARTITION_OFFSET_RECEIVED: IntGaugeVec = register_int_gauge_vec!(
         "mz_kafka_partition_offset_received",
-        "The most recent kafka offset that we have been received by this source",
+        "The most recent kafka offset that we have been received by this source.",
         &["topic", "source_id", "partition_id"]
     )
     .unwrap();
@@ -57,7 +58,7 @@ lazy_static! {
     .unwrap();
     static ref KAFKA_CAPABILITY: IntGaugeVec = register_int_gauge_vec!(
         "mz_kafka_capability",
-        "The current capability for this dataflow",
+        "The current capability for this dataflow. This corresponds to min(mz_kafka_partition_closed_ts)",
         &["topic", "source_id"]
     )
     .unwrap();

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{HashMap, VecDeque};
+use std::convert::TryInto;
 use std::iter;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -40,6 +41,24 @@ lazy_static! {
         "mz_kafka_partition_offset_ingested",
         "The most recent kafka offset that we have ingested into a dataflow",
         &["topic", "source_id", "partition_id"]
+    )
+    .unwrap();
+    static ref KAFKA_PARTITION_OFFSET_RECEIVED: IntGaugeVec = register_int_gauge_vec!(
+        "mz_kafka_partition_offset_received",
+        "The most recent kafka offset that we have been received by this source",
+        &["topic", "source_id", "partition_id"]
+    )
+    .unwrap();
+    static ref KAFKA_PARTITION_CLOSED_TS: IntGaugeVec = register_int_gauge_vec!(
+        "mz_kafka_partition_closed_ts",
+        "The highest closed timestamp for each partition in this dataflow",
+        &["topic", "source_id", "partition_id"]
+    )
+    .unwrap();
+    static ref KAFKA_CAPABILITY: IntGaugeVec = register_int_gauge_vec!(
+        "mz_kafka_capability",
+        "The current capability for this dataflow",
+        &["topic", "source_id"]
     )
     .unwrap();
 }
@@ -291,6 +310,7 @@ where
                 // there are new messages that can be processed) as timestamps can become
                 // closed in the absence of messages
                 if downgrade_capability(
+                    &topic,
                     &id,
                     cap,
                     &mut partition_metadata,
@@ -334,6 +354,11 @@ where
                 while let Some((message, consumer)) = next_message {
                     let partition = message.partition;
                     let offset = message.offset + 1;
+
+                    KAFKA_PARTITION_OFFSET_RECEIVED
+                        .with_label_values(&[&topic, &id.to_string(), &partition.to_string()])
+                        .set(offset);
+
                     if partition as usize >= partition_metadata.len() {
                         partition_metadata.extend(
                             iter::repeat((start_offset, last_closed_ts))
@@ -419,6 +444,7 @@ where
                                 .set(offset);
 
                             if downgrade_capability(
+                                &topic,
                                 &id,
                                 cap,
                                 &mut partition_metadata,
@@ -523,6 +549,7 @@ fn find_matching_timestamp(
 #[allow(clippy::too_many_arguments)]
 #[must_use]
 fn downgrade_capability(
+    topic: &str,
     id: &SourceInstanceId,
     cap: &mut Capability<Timestamp>,
     partition_metadata: &mut Vec<(i64, u64)>,
@@ -582,6 +609,10 @@ fn downgrade_capability(
                 // even if data has subsequently been added to the stream
                 assert!(*offset != 0 || last_offset == 0);
 
+                KAFKA_PARTITION_CLOSED_TS
+                    .with_label_values(&[&topic, &id.to_string(), &pid.to_string()])
+                    .set((partition_metadata[pid as usize].1).try_into().unwrap());
+
                 if last_offset == *offset {
                     // We have now seen all messages corresponding to this timestamp for this
                     // partition. We
@@ -596,6 +627,7 @@ fn downgrade_capability(
             }
         }
     }
+
     //  Next, we determine the maximum timestamp that is fully closed. This corresponds to the minimum
     //  timestamp across partitions.
     let min = partition_metadata
@@ -605,9 +637,13 @@ fn downgrade_capability(
         .expect("There should never be 0 partitions!");
     // Downgrade capability to new minimum open timestamp (which corresponds to min + 1).
     if changed && min > 0 {
+        KAFKA_CAPABILITY
+            .with_label_values(&[topic, &id.to_string()])
+            .set(min.try_into().unwrap());
         cap.downgrade(&(&min + 1));
         *last_closed_ts = min;
     }
+
     needs_md_refresh
 }
 

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -127,18 +127,20 @@ pub enum PartitionId {
     File,
 }
 
+impl fmt::Display for PartitionId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            PartitionId::Kafka(id) => write!(f, "{}", id.to_string()),
+            _ => write!(f, "0"),
+        }
+    }
+}
+
 impl PartitionId {
     pub fn kafka_id(&self) -> Option<i32> {
         match self {
             PartitionId::Kafka(id) => Some(*id),
             _ => None,
-        }
-    }
-
-    pub fn to_string(&self) -> String {
-        match &self {
-            PartitionId::Kafka(i) => i.to_string(),
-            _ => "0".to_string(),
         }
     }
 }

--- a/src/expr/id.rs
+++ b/src/expr/id.rs
@@ -134,6 +134,13 @@ impl PartitionId {
             _ => None,
         }
     }
+
+    pub fn to_string(&self) -> String {
+        match &self {
+            PartitionId::Kafka(i) => i.to_string(),
+            _ => "0".to_string(),
+        }
+    }
 }
 
 /// Humanizer that provides no additional information.


### PR DESCRIPTION
This PR adds additional metrics to the Kafka Source to track on Grafana

1) the last closed timestamps per partition, per source
2) the last closed timestamp per source (capability downgrade)
3) the (partition,offset) of the ingested records from Kafka (not necessarily timestamped records)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2951)
<!-- Reviewable:end -->
