### PR TITLE
mzbuild: ignore mzcompose files in crate root

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -176,6 +176,11 @@ class CargoPreImage(PreImage):
             # *lot* of work.
             "Cargo.lock",
             ".cargo/config",
+            # Crate roots can contain mzcompose files, but mzcompose should
+            # never impact the Rust build process, so exclude them from the
+            # fingerprint (#2940).
+            ":(exclude)**/mzcompose",
+            ":(exclude)**/mzcompose.yml",
         }
 
 


### PR DESCRIPTION
Fix #2940.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2953)
<!-- Reviewable:end -->
