### PR TITLE
Add perf-kinesis load test to release checks

### DIFF
--- a/doc/developer/release-checklist.md
+++ b/doc/developer/release-checklist.md
@@ -120,6 +120,26 @@ All of these can be run in parallel.
     ./dc.sh backup
     ```
 
+- [ ] Run the perf-kinesis load test on the tag.
+
+  - [ ] Spin up a fresh VM and start the load test. To start the load test, ssh
+    into the VM and run:
+    ```shell script
+    cd materialize
+    bin/mzcompose -f test/performance/perf-kinesis/mzcompose up -d
+    ```
+
+  - [ ] Ensure all containers started successfully and are running:
+    ```shell script
+    docker ps -a
+    ```
+
+  - [ ] Let the test run for 24 hours.
+
+  - [ ] Take a screenshot of the "Time behind external source" dashboard panel
+    in Grafana. (This metric should have remained at 0ms or similar for the entirety
+    of the run). Share the screenshot in the Slack channel.
+
 - [ ] Run the billing-demo load test on the tag.
 
   - [ ] Spin up the billing-demo with an updated `--message-count` argument.

--- a/doc/developer/release-checklist.md
+++ b/doc/developer/release-checklist.md
@@ -125,8 +125,8 @@ All of these can be run in parallel.
   - [ ] Spin up a fresh VM and start the load test. To start the load test, ssh
     into the VM and run:
     ```shell script
-    cd materialize
-    bin/mzcompose -f test/performance/perf-kinesis/mzcompose up -d
+    cd materialize/test/performance/perf-kinesis
+    ./mzcompose up -d
     ```
 
   - [ ] Ensure all containers started successfully and are running:

--- a/test/performance/perf-kinesis/mzcompose
+++ b/test/performance/perf-kinesis/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"


### PR DESCRIPTION
Now that we have a load test for Kinesis sources, we should run that test as part of qualifying release candidates.

For posterity, I just ran this test for ~24 hours with the following performance:

<img width="1790" alt="Screen Shot 2020-05-08 at 10 38 11 AM" src="https://user-images.githubusercontent.com/5766027/81420363-e036fa80-911d-11ea-95c3-14df133de078.png">

<img width="1790" alt="Screen Shot 2020-05-08 at 10 38 22 AM" src="https://user-images.githubusercontent.com/5766027/81420362-e036fa80-911d-11ea-8d4e-2c20997c2bb8.png">

<img width="1790" alt="Screen Shot 2020-05-08 at 10 38 42 AM" src="https://user-images.githubusercontent.com/5766027/81420361-df9e6400-911d-11ea-9801-381caca40c85.png">

<img width="1509" alt="Screen Shot 2020-05-08 at 10 39 18 AM" src="https://user-images.githubusercontent.com/5766027/81420353-de6d3700-911d-11ea-8786-15235da9d061.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2962)
<!-- Reviewable:end -->
