### PR TITLE
python: force-disable pyyaml's c extension

### DIFF
--- a/misc/python/requirements.txt
+++ b/misc/python/requirements.txt
@@ -1,4 +1,4 @@
-pyyaml==5.3.1
+pyyaml==5.3.1 --global-option=--without-libyaml
 semver==2.9.1
 toml==0.10.0
 typing-extensions==3.7.4.2


### PR DESCRIPTION
By default PyYAML will check to see if it can compile a C extension that
links against libyaml. This is just another thing that can go wrong when
setting up the venv, and we don't need the additional speed of libyaml
over the pure Python YAML parser, so just force disable libyaml
extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2964)
<!-- Reviewable:end -->
