### PR TITLE
deploy: build docs using nightly

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - command: bin/ci-builder run stable ci/deploy/devsite.sh
+  - command: bin/ci-builder run nightly ci/deploy/devsite.sh
     branches: master
     timeout_in_minutes: 30
     agents:


### PR DESCRIPTION
The docs need to be built using the nightly toolchain in order for
intra-rustdoc links to work (#43466). This used to be the case, but got
dropped in a CI refactor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2965)
<!-- Reviewable:end -->
