### PR TITLE
Thread common state through all transforms

### DIFF
--- a/src/transform/aggregation.rs
+++ b/src/transform/aggregation.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::RelationExpr;
+use crate::{RelationExpr, TransformArgs};
 
 #[derive(Debug)]
 pub struct FractureReduce;

--- a/src/transform/binding.rs
+++ b/src/transform/binding.rs
@@ -64,6 +64,7 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
+use crate::TransformArgs;
 use expr::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
 use repr::RelationType;
 
@@ -221,7 +222,7 @@ impl crate::Transform for Hoist {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         Hoist::hoist(expr);
         Ok(())
@@ -289,7 +290,7 @@ impl crate::Transform for Unbind {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         Unbind::unbind(expr);
         Ok(())
@@ -471,7 +472,7 @@ impl crate::Transform for Deduplicate {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         Deduplicate::deduplicate(expr);
         Ok(())

--- a/src/transform/column_knowledge.rs
+++ b/src/transform/column_knowledge.rs
@@ -11,7 +11,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
+use crate::TransformArgs;
+use expr::{RelationExpr, ScalarExpr, UnaryFunc};
 use repr::Datum;
 use repr::{ColumnType, RelationType, ScalarType};
 
@@ -23,7 +24,7 @@ impl crate::Transform for ColumnKnowledge {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         self.transform(expr)
     }

--- a/src/transform/demand.rs
+++ b/src/transform/demand.rs
@@ -11,7 +11,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, RelationExpr, ScalarExpr};
 
 /// Drive demand from the root through operators.
 ///
@@ -32,7 +33,7 @@ impl crate::Transform for Demand {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         self.action(
             relation,

--- a/src/transform/empty_map.rs
+++ b/src/transform/empty_map.rs
@@ -9,9 +9,7 @@
 
 //! Remove empty `Map` operators.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, TransformArgs};
 
 /// Remove empty `Map` operators.
 #[derive(Debug)]
@@ -21,7 +19,7 @@ impl crate::Transform for EmptyMap {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/filter_lets.rs
+++ b/src/transform/filter_lets.rs
@@ -9,9 +9,8 @@
 
 //! Pushes common filter predicates on gets into the let binding.
 
-use std::collections::HashMap;
-
-use expr::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, LocalId, RelationExpr, ScalarExpr};
 
 /// Pushes common filter predicates on gets into the let binding.
 ///
@@ -27,7 +26,7 @@ impl crate::Transform for FilterLets {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/filter.rs
+++ b/src/transform/fusion/filter.rs
@@ -31,17 +31,18 @@
 //!     .filter(vec![predicate2.clone()]);
 //!
 //! // .transform() will deduplicate any predicates
-//! use transform::Transform;
-//! Filter.transform(&mut expr, &std::collections::HashMap::new());
+//! use transform::{Transform, TransformArgs};
+//! Filter.transform(&mut expr, TransformArgs {
+//!   id_gen: &mut Default::default(),
+//!   indexes: &std::collections::HashMap::new(),
+//! });
 //!
 //! let correct = input.filter(vec![predicate0]);
 //!
 //! assert_eq!(expr, correct);
 //! ```
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformArgs};
 
 /// Fuses multiple `Filter` operators into one and deduplicates predicates.
 #[derive(Debug)]
@@ -51,7 +52,7 @@ impl crate::Transform for Filter {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/join.rs
+++ b/src/transform/fusion/join.rs
@@ -15,9 +15,7 @@
 //! our ability to plan these joins, and reason about other operators motion
 //! aroud them.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformArgs};
 
 /// Fuses multiple `Join` operators into one `Join` operator.
 #[derive(Debug)]
@@ -27,7 +25,7 @@ impl crate::Transform for Join {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/map.rs
+++ b/src/transform/fusion/map.rs
@@ -15,10 +15,10 @@
 //! important to coalesce these operators so that we can more easily
 //! move them around other operators together.
 
-use std::collections::HashMap;
 use std::mem;
 
-use expr::{GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::RelationExpr;
 
 /// Fuses a sequence of `Map` operators in to one `Map` operator.
 #[derive(Debug)]
@@ -28,7 +28,7 @@ impl crate::Transform for Map {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/project.rs
+++ b/src/transform/fusion/project.rs
@@ -10,9 +10,9 @@
 //! Fuses Project operators with parent operators when possible.
 
 // TODO(frank): evaluate for redundancy with projection hoisting.
-use std::collections::HashMap;
 
-use expr::{GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::RelationExpr;
 
 /// Fuses Project operators with parent operators when possible.
 #[derive(Debug)]
@@ -22,7 +22,7 @@ impl crate::Transform for Project {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/inline_let.rs
+++ b/src/transform/inline_let.rs
@@ -14,9 +14,8 @@
 //! `Get` statement in their body. These cases can be inlined without
 //! harming planning.
 
-use std::collections::HashMap;
-
-use expr::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, LocalId, RelationExpr};
 
 /// Install replace certain `Get` operators with their `Let` value.
 #[derive(Debug)]
@@ -26,7 +25,7 @@ impl crate::Transform for InlineLet {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         let mut lets = vec![];
         self.action(relation, &mut lets);

--- a/src/transform/join_elision.rs
+++ b/src/transform/join_elision.rs
@@ -13,11 +13,9 @@
 //! a collection act as the identity operator on collections. Once removed,
 //! we may find joins with zero or one input, which can be further simplified.
 
-use std::collections::HashMap;
-
 use repr::RelationType;
 
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, TransformArgs};
 
 /// Removes unit collections from joins, and joins with fewer than two inputs.
 #[derive(Debug)]
@@ -27,7 +25,7 @@ impl crate::Transform for JoinElision {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/join_implementation.rs
+++ b/src/transform/join_implementation.rs
@@ -18,7 +18,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, RelationExpr, ScalarExpr};
 
 /// Determines the join implementation for join operators.
 #[derive(Debug)]
@@ -28,10 +29,10 @@ impl crate::Transform for JoinImplementation {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        args: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         let mut arranged = HashMap::new();
-        for (k, v) in indexes {
+        for (k, v) in args.indexes {
             arranged.insert(Id::Global(*k), v.clone());
         }
         self.action_recursive(relation, &mut arranged);

--- a/src/transform/lib.rs
+++ b/src/transform/lib.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
-use expr::{EvalError, GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr};
+use expr::{EvalError, GlobalId, IdGen, OptimizedRelationExpr, RelationExpr, ScalarExpr};
 
 // pub mod binding;
 pub mod column_knowledge;
@@ -51,13 +51,22 @@ pub mod topk_elision;
 pub mod update_let;
 // pub mod use_indexes;
 
+/// Arguments that get threaded through all transforms.
+#[derive(Debug)]
+pub struct TransformArgs<'a> {
+    /// A shared instance of IdGen to allow constructing new Let expressions.
+    pub id_gen: &'a mut IdGen,
+    /// The indexes accessible.
+    pub indexes: &'a HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+}
+
 /// Types capable of transforming relation expressions.
 pub trait Transform: std::fmt::Debug {
     /// Transform a relation into a functionally equivalent relation.
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        args: TransformArgs,
     ) -> Result<(), TransformError>;
 }
 
@@ -98,12 +107,18 @@ impl Transform for Fixpoint {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        args: TransformArgs,
     ) -> Result<(), TransformError> {
         for _ in 0..self.limit {
             let original = relation.clone();
             for transform in self.transforms.iter() {
-                transform.transform(relation, indexes)?;
+                transform.transform(
+                    relation,
+                    TransformArgs {
+                        id_gen: args.id_gen,
+                        indexes: args.indexes,
+                    },
+                )?;
             }
             if *relation == original {
                 return Ok(());
@@ -111,7 +126,13 @@ impl Transform for Fixpoint {
         }
         let original = relation.clone();
         for transform in self.transforms.iter() {
-            transform.transform(relation, indexes)?;
+            transform.transform(
+                relation,
+                TransformArgs {
+                    id_gen: args.id_gen,
+                    indexes: args.indexes,
+                },
+            )?;
         }
         Err(TransformError::Internal(format!(
             "fixpoint looped too many times {:#?} {}\n{}",
@@ -133,15 +154,22 @@ pub struct Optimizer {
     transforms: Vec<Box<dyn crate::Transform + Send>>,
 }
 
-impl Transform for Optimizer {
+impl Optimizer {
     /// Optimizes the supplied relation expression.
     fn transform(
         &self,
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
     ) -> Result<(), TransformError> {
+        let mut id_gen = Default::default();
         for transform in self.transforms.iter() {
-            transform.transform(relation, indexes)?;
+            transform.transform(
+                relation,
+                TransformArgs {
+                    id_gen: &mut id_gen,
+                    indexes,
+                },
+            )?;
         }
         Ok(())
     }

--- a/src/transform/map_lifting.rs
+++ b/src/transform/map_lifting.rs
@@ -22,7 +22,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, RelationExpr, ScalarExpr};
 
 /// Hoist literal values from maps wherever possible.
 #[derive(Debug)]
@@ -32,7 +33,7 @@ impl crate::Transform for LiteralLifting {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         let literals = self.action(relation, &mut HashMap::new());
         if !literals.is_empty() {

--- a/src/transform/nonnull_requirements.rs
+++ b/src/transform/nonnull_requirements.rs
@@ -24,7 +24,8 @@
 //! Null arguments*.
 use std::collections::{HashMap, HashSet};
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr, TableFunc};
+use crate::TransformArgs;
+use expr::{Id, RelationExpr, ScalarExpr, TableFunc};
 
 /// Push non-null requirements toward sources.
 #[derive(Debug)]
@@ -34,7 +35,7 @@ impl crate::Transform for NonNullRequirements {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         self.action(relation, HashSet::new(), &mut HashMap::new());
         Ok(())

--- a/src/transform/nonnullable.rs
+++ b/src/transform/nonnullable.rs
@@ -14,9 +14,8 @@
 
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
-use std::collections::HashMap;
-
-use expr::{AggregateExpr, AggregateFunc, GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
+use crate::TransformArgs;
+use expr::{AggregateExpr, AggregateFunc, RelationExpr, ScalarExpr, UnaryFunc};
 use repr::{ColumnType, Datum, RelationType, ScalarType};
 
 /// Harvests information about non-nullability of columns from sources.
@@ -27,7 +26,7 @@ impl crate::Transform for NonNullable {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/predicate_pushdown.rs
+++ b/src/transform/predicate_pushdown.rs
@@ -13,7 +13,7 @@
 //! filters reduce the volume of data before they arrive at more expensive operators.
 //!
 //! ```rust
-//! use expr::{BinaryFunc, RelationExpr, ScalarExpr};
+//! use expr::{BinaryFunc, IdGen, RelationExpr, ScalarExpr};
 //! use repr::{ColumnType, Datum, RelationType, ScalarType};
 //!
 //! use transform::predicate_pushdown::PredicatePushdown;
@@ -45,13 +45,15 @@
 //!        predicate012.clone(),
 //!    ]);
 //!
-//! use transform::Transform;
-//! PredicatePushdown.transform(&mut expr, &std::collections::HashMap::new());
+//! use transform::{Transform, TransformArgs};
+//! PredicatePushdown.transform(&mut expr, TransformArgs {
+//!   id_gen: &mut Default::default(),
+//!   indexes: &std::collections::HashMap::new(),
+//! });
 //! ```
 
-use std::collections::HashMap;
-
-use expr::{AggregateFunc, GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{AggregateFunc, RelationExpr, ScalarExpr};
 use repr::{ColumnType, Datum, ScalarType};
 
 /// Pushes predicates down through other operators.
@@ -62,7 +64,7 @@ impl crate::Transform for PredicatePushdown {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/projection_extraction.rs
+++ b/src/transform/projection_extraction.rs
@@ -9,9 +9,7 @@
 
 //! Transform column references in a `Map` into a `Project`.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformArgs};
 
 /// Transform column references in a `Map` into a `Project`.
 #[derive(Debug)]
@@ -21,7 +19,7 @@ impl crate::Transform for ProjectionExtraction {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/projection_lifting.rs
+++ b/src/transform/projection_lifting.rs
@@ -13,7 +13,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, RelationExpr};
 
 /// Hoist projections through operators.
 #[derive(Debug)]
@@ -23,7 +24,7 @@ impl crate::Transform for ProjectionLifting {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         self.action(relation, &mut HashMap::new());
         Ok(())

--- a/src/transform/reduce_elision.rs
+++ b/src/transform/reduce_elision.rs
@@ -13,9 +13,7 @@
 //! set of columns that form unique keys for the input, the reduce
 //! can be simplified to a map operation.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformArgs};
 
 /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
 #[derive(Debug)]
@@ -25,7 +23,7 @@ impl crate::Transform for ReduceElision {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/reduction_pushdown.rs
+++ b/src/transform/reduction_pushdown.rs
@@ -11,9 +11,7 @@
 //!
 //! At the moment, this only absorbs Map operators into Reduce operators.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, TransformArgs};
 
 /// Pushes Reduce operators toward sources.
 #[derive(Debug)]
@@ -23,7 +21,7 @@ impl crate::Transform for ReductionPushdown {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/redundant_join.rs
+++ b/src/transform/redundant_join.rs
@@ -12,9 +12,8 @@
 // If statements seem a bit clearer in this case. Specialized methods
 // that replace simple and common alternatives frustrate developers.
 #![allow(clippy::comparison_chain, clippy::filter_next)]
-use std::collections::HashMap;
 
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformArgs};
 
 /// Remove redundant collections of distinct elements from joins.
 #[derive(Debug)]
@@ -24,7 +23,7 @@ impl crate::Transform for RedundantJoin {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/split_predicates.rs
+++ b/src/transform/split_predicates.rs
@@ -9,9 +9,8 @@
 
 //! Transforms predicates of the form "A and B" into two: "A" and "B".
 
-use std::collections::HashMap;
-
-use expr::{BinaryFunc, GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{BinaryFunc, RelationExpr, ScalarExpr};
 
 /// Transforms predicates of the form "A and B" into two: "A" and "B".
 #[derive(Debug)]
@@ -22,7 +21,7 @@ impl crate::Transform for SplitPredicates {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |expr| {
             if let RelationExpr::Filter { predicates, .. } = expr {

--- a/src/transform/topk_elision.rs
+++ b/src/transform/topk_elision.rs
@@ -11,7 +11,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, RelationExpr};
 
 /// Remove TopK operators with both an offset of zero and no limit.
 #[derive(Debug)]
@@ -21,7 +22,7 @@ impl crate::Transform for TopKElision {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         self.action(relation, &mut HashMap::new());
         Ok(())

--- a/src/transform/update_let.rs
+++ b/src/transform/update_let.rs
@@ -12,7 +12,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, IdGen, LocalId, RelationExpr, ScalarExpr};
+use crate::TransformArgs;
+use expr::{Id, IdGen, LocalId, RelationExpr};
 use repr::RelationType;
 
 /// Refreshes identifiers and types for local let bindings.
@@ -28,10 +29,10 @@ impl crate::Transform for UpdateLet {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        args: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        let mut id_gen: IdGen = Default::default();
-        self.action(relation, &mut HashMap::new(), &mut id_gen);
+        *args.id_gen = IdGen::default(); // Get a fresh IdGen.
+        self.action(relation, &mut HashMap::new(), args.id_gen);
         Ok(())
     }
 }


### PR DESCRIPTION
We need access to an IdGen to write certain transforms. Take this
opportunity to bundle up all the state that a transform has access to in
a struct. In the future there should be some kind of "global state" that
is common to every stage of planning, that provides everything necessary
to construct expressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2966)
<!-- Reviewable:end -->
