### PR TITLE
materialized: force-enable metrics gathering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1604,6 +1604,7 @@ dependencies = [
  "prometheus",
  "rlimit",
  "serde_json",
+ "stream-cancel",
  "sysctl",
  "tempfile",
  "tokio",
@@ -3201,6 +3202,18 @@ dependencies = [
  "sql-parser",
  "tokio",
  "walkdir",
+]
+
+[[package]]
+name = "stream-cancel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c2f5be039aed0d08b3596461637480d35858ca4360c905b0e802b934fa8e48"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -40,6 +40,7 @@ postgres-openssl = "0.3.0"
 pgwire = { path = "../pgwire" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false, features = ["process"] }
 rlimit = "0.3.0"
+stream-cancel = "0.5.2"
 sysctl = "0.4.0"
 tempfile = "3.1"
 tokio = "0.2"

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -115,7 +115,6 @@ fn run() -> Result<(), failure::Error> {
         "persists consistency information locally and recovers from local store",
         "true/false",
     );
-    opts.optflag("", "no-prometheus", "do not gather prometheus metrics");
 
     // Logging options.
     opts.optopt(
@@ -221,7 +220,6 @@ fn run() -> Result<(), failure::Error> {
     };
     let max_increment_ts_size = popts.opt_get_default("batch-size", 10000_i64)?;
     let persist_ts = popts.opt_get_default("persist-ts", false)?;
-    let gather_metrics = !popts.opt_present("no-prometheus");
 
     // Configure connections.
     let listen_addr = popts.opt_get("listen-addr")?;
@@ -305,7 +303,6 @@ environment:{}",
         timestamp_frequency,
         max_increment_ts_size,
         persist_ts,
-        gather_metrics,
         listen_addr,
         tls,
         data_directory: Some(data_directory),

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -116,9 +116,6 @@ pub struct Config {
     /// Whether to record realtime consistency information to the data directory
     /// and attempt to recover that information on startup.
     pub persist_ts: bool,
-    /// Whether to collect metrics. If enabled, metrics can be collected by
-    /// e.g. Prometheus via the `/metrics` HTTP endpoint.
-    pub gather_metrics: bool,
 
     // === Connection options. ===
     /// The IP address and port to listen on -- defaults to 0.0.0.0:<addr_port>,
@@ -211,17 +208,8 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
                     None => None,
                     Some(tls_config) => Some(tls_config.acceptor()?),
                 };
-                mux.add_handler(pgwire::Server::new(
-                    tls.clone(),
-                    cmd_tx.clone(),
-                    config.gather_metrics,
-                ));
-                mux.add_handler(http::Server::new(
-                    tls,
-                    cmd_tx,
-                    config.gather_metrics,
-                    start_time,
-                ));
+                mux.add_handler(pgwire::Server::new(tls.clone(), cmd_tx.clone()));
+                mux.add_handler(http::Server::new(tls, cmd_tx, start_time));
             }
             Arc::new(mux)
         };

--- a/src/materialized/mux.rs
+++ b/src/materialized/mux.rs
@@ -7,132 +7,155 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::future::TryFutureExt;
+use futures::stream::StreamExt;
 use log::error;
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
+use tokio::net::tcp::Incoming;
+use tokio::net::TcpStream;
 
 use ore::netio::{self, SniffedStream, SniffingStream};
 
 use crate::http;
 
-/// A mux routes incoming network connections to a dynamic set of connection
+type Handlers = Vec<Box<dyn ConnectionHandler + Send + Sync>>;
+
+/// A mux routes incoming TCP connections to a dynamic set of connection
 /// handlers. It enables serving multiple protocols over the same port.
 ///
 /// Connections are routed by sniffing the first several bytes sent over the
 /// wire and matching them against each handler, in order. The first handler
 /// to match the connection will be invoked.
-pub struct Mux<A> {
-    handlers: Vec<Box<dyn ConnectionHandler<A> + Send + Sync>>,
+pub struct Mux {
+    handlers: Handlers,
 }
 
-impl<A> Mux<A> {
+impl Mux {
     /// Constructs a new `Mux`.
-    pub fn new() -> Mux<A> {
+    pub fn new() -> Mux {
         Mux { handlers: vec![] }
     }
 
     /// Adds a new connection handler to this mux.
     pub fn add_handler<H>(&mut self, handler: H)
     where
-        H: ConnectionHandler<A> + Send + Sync + 'static,
+        H: ConnectionHandler + Send + Sync + 'static,
     {
         self.handlers.push(Box::new(handler));
     }
 
-    /// Handles a connection by routing it to the first underlying handler for
-    /// which [`ConnectionHandler::match_handshake`] returns true.
-    pub async fn handle_connection(&self, conn: A)
-    where
-        A: AsyncRead + AsyncWrite + Unpin + fmt::Debug + Send + Sync + 'static,
-    {
-        // Sniff out what protocol we've received. Choosing how many bytes to
-        // sniff is a delicate business. Read too many bytes and you'll stall
-        // out protocols with small handshakes, like pgwire. Read too few bytes
-        // and you won't be able to tell what protocol you have. For now, eight
-        // bytes is the magic number, but this may need to change if we learn to
-        // speak new protocols.
-        let mut ss = SniffingStream::new(conn);
-        let mut buf = [0; 8];
-        let nread = match netio::read_exact_or_eof(&mut ss, &mut buf).await {
-            Ok(nread) => nread,
-            Err(err) => {
-                error!("error handling request: {}", err);
-                return;
-            }
-        };
-        let buf = &buf[..nread];
-
-        for handler in &self.handlers {
-            if handler.match_handshake(buf) {
-                if let Err(e) = handler.handle_connection(ss.into_sniffed()).await {
-                    error!("error handling connection: {}", e);
+    /// Serves incoming TCP traffic from `listener`.
+    pub async fn serve(self, mut incoming: Incoming<'_>) {
+        let handlers = Arc::new(self.handlers);
+        while let Some(conn) = incoming.next().await {
+            let conn = match conn {
+                Ok(conn) => conn,
+                Err(err) => {
+                    error!("error accepting connection: {}", err);
+                    continue;
                 }
-                return;
-            }
+            };
+            // Set TCP_NODELAY to disable tinygram prevention (Nagle's
+            // algorithm), which forces a 40ms delay between each query
+            // on linux. According to John Nagle [0], the true problem
+            // is delayed acks, but disabling those is a receive-side
+            // operation (TCP_QUICKACK), and we can't always control the
+            // client. PostgreSQL sets TCP_NODELAY on both sides of its
+            // sockets, so it seems sane to just do the same.
+            //
+            // If set_nodelay fails, it's a programming error, so panic.
+            //
+            // [0]: https://news.ycombinator.com/item?id=10608356
+            conn.set_nodelay(true).expect("set_nodelay failed");
+            tokio::spawn(handle_connection(handlers.clone(), conn));
         }
-
-        log::warn!("unknown protocol connection!");
-        let _ = ss.into_sniffed().write_all(b"unknown protocol\n").await;
     }
+}
+
+async fn handle_connection(handlers: Arc<Handlers>, conn: TcpStream) {
+    // Sniff out what protocol we've received. Choosing how many bytes to
+    // sniff is a delicate business. Read too many bytes and you'll stall
+    // out protocols with small handshakes, like pgwire. Read too few bytes
+    // and you won't be able to tell what protocol you have. For now, eight
+    // bytes is the magic number, but this may need to change if we learn to
+    // speak new protocols.
+    let mut ss = SniffingStream::new(conn);
+    let mut buf = [0; 8];
+    let nread = match netio::read_exact_or_eof(&mut ss, &mut buf).await {
+        Ok(nread) => nread,
+        Err(err) => {
+            error!("error handling request: {}", err);
+            return;
+        }
+    };
+    let buf = &buf[..nread];
+
+    for handler in &*handlers {
+        if handler.match_handshake(buf) {
+            if let Err(e) = handler.handle_connection(ss.into_sniffed()).await {
+                error!("error handling connection: {}", e);
+            }
+            return;
+        }
+    }
+
+    log::warn!("unknown protocol connection!");
+    let _ = ss.into_sniffed().write_all(b"unknown protocol\n").await;
 }
 
 /// A connection handler manages an incoming network connection.
 #[async_trait]
-pub trait ConnectionHandler<A> {
+pub trait ConnectionHandler {
     /// Determines whether this handler can accept the connection based on the
     /// first several bytes in the stream.
     fn match_handshake(&self, buf: &[u8]) -> bool;
 
     /// Handles the connection.
-    async fn handle_connection(&self, conn: SniffedStream<A>) -> Result<(), failure::Error>
-    where
-        A: AsyncRead + AsyncWrite + Unpin + fmt::Debug + Send + Sync + 'static;
+    async fn handle_connection(&self, conn: SniffedStream<TcpStream>)
+        -> Result<(), failure::Error>;
 }
 
 #[async_trait]
-impl<A> ConnectionHandler<A> for pgwire::Server {
+impl ConnectionHandler for pgwire::Server {
     fn match_handshake(&self, buf: &[u8]) -> bool {
         pgwire::match_handshake(buf)
     }
 
-    async fn handle_connection(&self, conn: SniffedStream<A>) -> Result<(), failure::Error>
-    where
-        A: AsyncRead + AsyncWrite + Unpin + fmt::Debug + Send + Sync + 'static,
-    {
+    async fn handle_connection(
+        &self,
+        conn: SniffedStream<TcpStream>,
+    ) -> Result<(), failure::Error> {
         self.handle_connection(conn).await
     }
 }
 
 #[async_trait]
-impl<A> ConnectionHandler<A> for http::Server {
+impl ConnectionHandler for http::Server {
     fn match_handshake(&self, buf: &[u8]) -> bool {
         self.match_handshake(buf)
     }
 
-    async fn handle_connection(&self, conn: SniffedStream<A>) -> Result<(), failure::Error>
-    where
-        A: AsyncRead + AsyncWrite + Unpin + fmt::Debug + Send + Sync + 'static,
-    {
+    async fn handle_connection(
+        &self,
+        conn: SniffedStream<TcpStream>,
+    ) -> Result<(), failure::Error> {
         self.handle_connection(conn).await
     }
 }
 
 #[async_trait]
-impl<A> ConnectionHandler<A> for comm::Switchboard<SniffedStream<A>>
-where
-    A: comm::protocol::Connection,
-{
+impl ConnectionHandler for comm::Switchboard<SniffedStream<TcpStream>> {
     fn match_handshake(&self, buf: &[u8]) -> bool {
         comm::protocol::match_handshake(buf)
     }
 
-    async fn handle_connection(&self, conn: SniffedStream<A>) -> Result<(), failure::Error>
-    where
-        A: AsyncRead + AsyncWrite + Unpin + fmt::Debug + Send + Sync + 'static,
-    {
+    async fn handle_connection(
+        &self,
+        conn: SniffedStream<TcpStream>,
+    ) -> Result<(), failure::Error> {
         self.handle_connection(conn).err_into().await
     }
 }

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -74,7 +74,6 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
         addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],
         data_directory: config.data_directory,
         symbiosis_url: None,
-        gather_metrics: false,
         listen_addr: None,
         tls: config.tls,
     })?);

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -89,7 +89,6 @@ pub struct StateMachine<'a, A> {
     pub conn_id: u32,
     pub secret_key: u32,
     pub cmdq_tx: futures::channel::mpsc::UnboundedSender<coord::Command>,
-    pub gather_metrics: bool,
 }
 
 impl<'a, A> StateMachine<'a, A>
@@ -163,15 +162,13 @@ where
             None => State::Done,
         };
 
-        if self.gather_metrics {
-            let status = match next_state {
-                State::Ready(_) | State::Done => "success",
-                State::Drain(_) => "error",
-            };
-            COMMAND_DURATIONS
-                .with_label_values(&[name, status])
-                .observe(timer.elapsed().as_secs_f64());
-        }
+        let status = match next_state {
+            State::Ready(_) | State::Done => "success",
+            State::Drain(_) => "error",
+        };
+        COMMAND_DURATIONS
+            .with_label_values(&[name, status])
+            .observe(timer.elapsed().as_secs_f64());
 
         Ok(next_state)
     }

--- a/src/pgwire/server.rs
+++ b/src/pgwire/server.rs
@@ -9,7 +9,6 @@
 
 use std::fmt;
 use std::pin::Pin;
-use std::sync::Weak;
 use std::task::{Context, Poll};
 
 use failure::bail;
@@ -31,13 +30,13 @@ pub struct Server {
     id_alloc: IdAllocator,
     secrets: SecretManager,
     tls: Option<SslAcceptor>,
-    cmdq_tx: Weak<futures::channel::mpsc::UnboundedSender<coord::Command>>,
+    cmdq_tx: futures::channel::mpsc::UnboundedSender<coord::Command>,
 }
 
 impl Server {
     pub fn new(
         tls: Option<SslAcceptor>,
-        cmdq_tx: Weak<futures::channel::mpsc::UnboundedSender<coord::Command>>,
+        cmdq_tx: futures::channel::mpsc::UnboundedSender<coord::Command>,
     ) -> Server {
         Server {
             id_alloc: IdAllocator::new(1, 1 << 16),
@@ -51,16 +50,7 @@ impl Server {
     where
         A: AsyncRead + AsyncWrite + Unpin + fmt::Debug + Send + Sync + 'static,
     {
-        let mut cmdq_tx = match self.cmdq_tx.upgrade() {
-            Some(cmdq_tx) => (*cmdq_tx).clone(),
-            None => {
-                // The server is terminating. Drop the connection on the floor.
-                return Ok(());
-            }
-        };
-
         let mut conn = Conn::Unencrypted(conn);
-
         loop {
             conn = match codec::decode_startup(&mut conn).await? {
                 FrontendStartupMessage::Startup { version, params } => {
@@ -76,7 +66,7 @@ impl Server {
                         conn: &mut Framed::new(conn, Codec::new()).buffer(32),
                         conn_id,
                         secret_key: self.secrets.get(conn_id).unwrap(),
-                        cmdq_tx,
+                        cmdq_tx: self.cmdq_tx.clone(),
                     };
                     let res = machine.start(Session::default(), version, params).await;
 
@@ -90,7 +80,8 @@ impl Server {
                     secret_key,
                 } => {
                     if self.secrets.verify(conn_id, secret_key) {
-                        cmdq_tx
+                        self.cmdq_tx
+                            .clone()
                             .send(coord::Command::CancelRequest { conn_id })
                             .await?;
                     }

--- a/src/pgwire/server.rs
+++ b/src/pgwire/server.rs
@@ -32,21 +32,18 @@ pub struct Server {
     secrets: SecretManager,
     tls: Option<SslAcceptor>,
     cmdq_tx: Weak<futures::channel::mpsc::UnboundedSender<coord::Command>>,
-    gather_metrics: bool,
 }
 
 impl Server {
     pub fn new(
         tls: Option<SslAcceptor>,
         cmdq_tx: Weak<futures::channel::mpsc::UnboundedSender<coord::Command>>,
-        gather_metrics: bool,
     ) -> Server {
         Server {
             id_alloc: IdAllocator::new(1, 1 << 16),
             secrets: SecretManager::new(),
             tls,
             cmdq_tx,
-            gather_metrics,
         }
     }
 
@@ -80,7 +77,6 @@ impl Server {
                         conn_id,
                         secret_key: self.secrets.get(conn_id).unwrap(),
                         cmdq_tx,
-                        gather_metrics: self.gather_metrics,
                     };
                     let res = machine.start(Session::default(), version, params).await;
 


### PR DESCRIPTION
Empirically metrics gathering does not have a large performance cost,
but making the option configurable has a large configuration cost.
Just remove the knob. It wasn't documented, so should have minimal user
effect.

@quodlibetor did I get the rationale right?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2967)
<!-- Reviewable:end -->
