### PR TITLE
doc/user: tweak CREATE SOURCE WITH option docs

### DIFF
--- a/www/layouts/partials/create-source/connector/file/with-options.html
+++ b/www/layouts/partials/create-source/connector/file/with-options.html
@@ -1,1 +1,1 @@
-`tail` | `bool` | Continually check the file for new content; as new content arrives, process it using other `WITH` options.
+`tail` | `bool` | Continually check the file for new content.

--- a/www/layouts/shortcodes/create-source/syntax-details.html
+++ b/www/layouts/shortcodes/create-source/syntax-details.html
@@ -15,8 +15,8 @@ _col&lowbar;name_ | Override default column name with the provided [identifier](
 
 The following options are valid within the `WITH` clause.
 
-Field | Value | Description
-------|-------|------------
+Field | Value type | Description
+------|------------|------------
 {{ partial (printf "create-source/connector/%s/with-options" $connector ) . -}}
 
 ## Details


### PR DESCRIPTION
Part of the description of the `tail` option didn't make much sense to
me. Also rename the "Value" column to the "Value type" column.

@sploiselle definitely let me know if it would be better to rephrase the thing I'm removing. I just spent a while puzzling over what it meant, and didn't get anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2971)
<!-- Reviewable:end -->
