### PR TITLE
ci: add --pretty flag to mypy

### DIFF
--- a/bin/mypy
+++ b/bin/mypy
@@ -21,4 +21,4 @@ root=$(cd "$(dirname "$0")/.." && pwd)
 py_files=
 mapfile_shim py_files < <(git ls-files "ci/*.py" "misc/python/*.py")
 
-exec "$root"/bin/pyactivate --dev -m mypy "${py_files[@]}"
+exec "$root"/bin/pyactivate --dev -m mypy --pretty "${py_files[@]}"


### PR DESCRIPTION
It causes mypy to point to the source of the error (similar to rust error messages)
instead of just listing the file/line.

Note that we _don't_ want this in mypy.ini because that breaks the error introspection of
tools like emacs/vim that shell out and expect `path/to/file:line:col` syntax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2981)
<!-- Reviewable:end -->
