### PR TITLE
ci/test: temporarily disable chbench job

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -126,6 +126,7 @@ steps:
     # TODO(benesch): integrate dc.sh into mzcompose, so we don't need to
     # manually track image inputs here.
     inputs: ["#materialized", "#chbenchmark", "#peeker", "#cli"]
+    if: false
     timeout_in_minutes: 30
 
   - id: catalog-compat


### PR DESCRIPTION
mzconduct and the builder image need some help to work together, so just
disable the mzconduct-using job while we work out the issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2982)
<!-- Reviewable:end -->
