### PR TITLE
[poc] Thread owned common state through all transforms

### DIFF
--- a/src/transform/aggregation.rs
+++ b/src/transform/aggregation.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::RelationExpr;
+use crate::{RelationExpr, TransformState};
 
 #[derive(Debug)]
 pub struct FractureReduce;

--- a/src/transform/binding.rs
+++ b/src/transform/binding.rs
@@ -64,6 +64,7 @@ use std::collections::HashMap;
 
 use indexmap::IndexMap;
 
+use crate::TransformState;
 use expr::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
 use repr::RelationType;
 
@@ -221,7 +222,7 @@ impl crate::Transform for Hoist {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         Hoist::hoist(expr);
         Ok(())
@@ -289,7 +290,7 @@ impl crate::Transform for Unbind {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         Unbind::unbind(expr);
         Ok(())
@@ -471,7 +472,7 @@ impl crate::Transform for Deduplicate {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         Deduplicate::deduplicate(expr);
         Ok(())

--- a/src/transform/column_knowledge.rs
+++ b/src/transform/column_knowledge.rs
@@ -11,7 +11,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
+use crate::TransformState;
+use expr::{RelationExpr, ScalarExpr, UnaryFunc};
 use repr::Datum;
 use repr::{ColumnType, RelationType, ScalarType};
 
@@ -23,7 +24,7 @@ impl crate::Transform for ColumnKnowledge {
     fn transform(
         &self,
         expr: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         self.transform(expr)
     }

--- a/src/transform/demand.rs
+++ b/src/transform/demand.rs
@@ -11,7 +11,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, RelationExpr, ScalarExpr};
 
 /// Drive demand from the root through operators.
 ///
@@ -32,7 +33,7 @@ impl crate::Transform for Demand {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         self.action(
             relation,

--- a/src/transform/empty_map.rs
+++ b/src/transform/empty_map.rs
@@ -9,9 +9,7 @@
 
 //! Remove empty `Map` operators.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, TransformState};
 
 /// Remove empty `Map` operators.
 #[derive(Debug)]
@@ -21,7 +19,7 @@ impl crate::Transform for EmptyMap {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/filter_lets.rs
+++ b/src/transform/filter_lets.rs
@@ -9,9 +9,8 @@
 
 //! Pushes common filter predicates on gets into the let binding.
 
-use std::collections::HashMap;
-
-use expr::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, LocalId, RelationExpr, ScalarExpr};
 
 /// Pushes common filter predicates on gets into the let binding.
 ///
@@ -27,7 +26,7 @@ impl crate::Transform for FilterLets {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/filter.rs
+++ b/src/transform/fusion/filter.rs
@@ -39,9 +39,7 @@
 //! assert_eq!(expr, correct);
 //! ```
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformState};
 
 /// Fuses multiple `Filter` operators into one and deduplicates predicates.
 #[derive(Debug)]
@@ -51,7 +49,7 @@ impl crate::Transform for Filter {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/join.rs
+++ b/src/transform/fusion/join.rs
@@ -15,9 +15,7 @@
 //! our ability to plan these joins, and reason about other operators motion
 //! aroud them.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformState};
 
 /// Fuses multiple `Join` operators into one `Join` operator.
 #[derive(Debug)]
@@ -27,7 +25,7 @@ impl crate::Transform for Join {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/map.rs
+++ b/src/transform/fusion/map.rs
@@ -15,10 +15,10 @@
 //! important to coalesce these operators so that we can more easily
 //! move them around other operators together.
 
-use std::collections::HashMap;
 use std::mem;
 
-use expr::{GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::RelationExpr;
 
 /// Fuses a sequence of `Map` operators in to one `Map` operator.
 #[derive(Debug)]
@@ -28,7 +28,7 @@ impl crate::Transform for Map {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/fusion/project.rs
+++ b/src/transform/fusion/project.rs
@@ -10,9 +10,9 @@
 //! Fuses Project operators with parent operators when possible.
 
 // TODO(frank): evaluate for redundancy with projection hoisting.
-use std::collections::HashMap;
 
-use expr::{GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::RelationExpr;
 
 /// Fuses Project operators with parent operators when possible.
 #[derive(Debug)]
@@ -22,7 +22,7 @@ impl crate::Transform for Project {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/inline_let.rs
+++ b/src/transform/inline_let.rs
@@ -14,9 +14,8 @@
 //! `Get` statement in their body. These cases can be inlined without
 //! harming planning.
 
-use std::collections::HashMap;
-
-use expr::{GlobalId, Id, LocalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, LocalId, RelationExpr};
 
 /// Install replace certain `Get` operators with their `Let` value.
 #[derive(Debug)]
@@ -26,7 +25,7 @@ impl crate::Transform for InlineLet {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         let mut lets = vec![];
         self.action(relation, &mut lets);

--- a/src/transform/join_elision.rs
+++ b/src/transform/join_elision.rs
@@ -13,11 +13,9 @@
 //! a collection act as the identity operator on collections. Once removed,
 //! we may find joins with zero or one input, which can be further simplified.
 
-use std::collections::HashMap;
-
 use repr::RelationType;
 
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, TransformState};
 
 /// Removes unit collections from joins, and joins with fewer than two inputs.
 #[derive(Debug)]
@@ -27,7 +25,7 @@ impl crate::Transform for JoinElision {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/join_implementation.rs
+++ b/src/transform/join_implementation.rs
@@ -18,7 +18,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, RelationExpr, ScalarExpr};
 
 /// Determines the join implementation for join operators.
 #[derive(Debug)]
@@ -28,10 +29,10 @@ impl crate::Transform for JoinImplementation {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        state: TransformState,
     ) -> Result<(), crate::TransformError> {
         let mut arranged = HashMap::new();
-        for (k, v) in indexes {
+        for (k, v) in state.indexes {
             arranged.insert(Id::Global(*k), v.clone());
         }
         self.action_recursive(relation, &mut arranged);

--- a/src/transform/lib.rs
+++ b/src/transform/lib.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
-use expr::{EvalError, GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr};
+use expr::{EvalError, GlobalId, IdGen, OptimizedRelationExpr, RelationExpr, ScalarExpr};
 
 // pub mod binding;
 pub mod column_knowledge;
@@ -51,13 +51,22 @@ pub mod topk_elision;
 pub mod update_let;
 // pub mod use_indexes;
 
+// TODO(justin): this kind of state should be "global" to the entire planning of a given query, so
+// that we can thread through things like unique ID generation.
+/// State that gets threaded through all transforms.
+#[derive(Debug)]
+pub struct TransformState<'a> {
+    id_gen: &'a mut IdGen,
+    indexes: &'a HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+}
+
 /// Types capable of transforming relation expressions.
 pub trait Transform: std::fmt::Debug {
     /// Transform a relation into a functionally equivalent relation.
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        state: TransformState,
     ) -> Result<(), TransformError>;
 }
 
@@ -98,12 +107,18 @@ impl Transform for Fixpoint {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        state: TransformState,
     ) -> Result<(), TransformError> {
         for _ in 0..self.limit {
             let original = relation.clone();
             for transform in self.transforms.iter() {
-                transform.transform(relation, indexes)?;
+                transform.transform(
+                    relation,
+                    TransformState {
+                        id_gen: state.id_gen,
+                        indexes: state.indexes,
+                    },
+                )?;
             }
             if *relation == original {
                 return Ok(());
@@ -111,7 +126,13 @@ impl Transform for Fixpoint {
         }
         let original = relation.clone();
         for transform in self.transforms.iter() {
-            transform.transform(relation, indexes)?;
+            transform.transform(
+                relation,
+                TransformState {
+                    id_gen: state.id_gen,
+                    indexes: state.indexes,
+                },
+            )?;
         }
         Err(TransformError::Internal(format!(
             "fixpoint looped too many times {:#?} {}\n{}",
@@ -133,15 +154,22 @@ pub struct Optimizer {
     transforms: Vec<Box<dyn crate::Transform + Send>>,
 }
 
-impl Transform for Optimizer {
+impl Optimizer {
     /// Optimizes the supplied relation expression.
     fn transform(
         &self,
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
     ) -> Result<(), TransformError> {
+        let mut id_gen = Default::default();
         for transform in self.transforms.iter() {
-            transform.transform(relation, indexes)?;
+            transform.transform(
+                relation,
+                TransformState {
+                    id_gen: &mut id_gen,
+                    indexes,
+                },
+            )?;
         }
         Ok(())
     }
@@ -234,7 +262,7 @@ impl Optimizer {
         mut relation: RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
     ) -> Result<OptimizedRelationExpr, TransformError> {
-        self.transform(&mut relation, indexes)?;
+        self.transform(&mut relation, &indexes)?;
         Ok(expr::OptimizedRelationExpr(relation))
     }
 

--- a/src/transform/map_lifting.rs
+++ b/src/transform/map_lifting.rs
@@ -22,7 +22,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, RelationExpr, ScalarExpr};
 
 /// Hoist literal values from maps wherever possible.
 #[derive(Debug)]
@@ -32,7 +33,7 @@ impl crate::Transform for LiteralLifting {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         let literals = self.action(relation, &mut HashMap::new());
         if !literals.is_empty() {

--- a/src/transform/nonnull_requirements.rs
+++ b/src/transform/nonnull_requirements.rs
@@ -24,7 +24,8 @@
 //! Null arguments*.
 use std::collections::{HashMap, HashSet};
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr, TableFunc};
+use crate::TransformState;
+use expr::{Id, RelationExpr, ScalarExpr, TableFunc};
 
 /// Push non-null requirements toward sources.
 #[derive(Debug)]
@@ -34,7 +35,7 @@ impl crate::Transform for NonNullRequirements {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         self.action(relation, HashSet::new(), &mut HashMap::new());
         Ok(())

--- a/src/transform/nonnullable.rs
+++ b/src/transform/nonnullable.rs
@@ -14,9 +14,8 @@
 
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
-use std::collections::HashMap;
-
-use expr::{AggregateExpr, AggregateFunc, GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
+use crate::TransformState;
+use expr::{AggregateExpr, AggregateFunc, RelationExpr, ScalarExpr, UnaryFunc};
 use repr::{ColumnType, Datum, RelationType, ScalarType};
 
 /// Harvests information about non-nullability of columns from sources.
@@ -27,7 +26,7 @@ impl crate::Transform for NonNullable {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/predicate_pushdown.rs
+++ b/src/transform/predicate_pushdown.rs
@@ -49,9 +49,8 @@
 //! PredicatePushdown.transform(&mut expr, &std::collections::HashMap::new());
 //! ```
 
-use std::collections::HashMap;
-
-use expr::{AggregateFunc, GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{AggregateFunc, RelationExpr, ScalarExpr};
 use repr::{ColumnType, Datum, ScalarType};
 
 /// Pushes predicates down through other operators.
@@ -62,7 +61,7 @@ impl crate::Transform for PredicatePushdown {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
             self.action(e);

--- a/src/transform/projection_extraction.rs
+++ b/src/transform/projection_extraction.rs
@@ -9,9 +9,7 @@
 
 //! Transform column references in a `Map` into a `Project`.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformState};
 
 /// Transform column references in a `Map` into a `Project`.
 #[derive(Debug)]
@@ -21,7 +19,7 @@ impl crate::Transform for ProjectionExtraction {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/projection_lifting.rs
+++ b/src/transform/projection_lifting.rs
@@ -13,7 +13,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, RelationExpr};
 
 /// Hoist projections through operators.
 #[derive(Debug)]
@@ -23,7 +24,7 @@ impl crate::Transform for ProjectionLifting {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         self.action(relation, &mut HashMap::new());
         Ok(())

--- a/src/transform/reduce_elision.rs
+++ b/src/transform/reduce_elision.rs
@@ -13,9 +13,7 @@
 //! set of columns that form unique keys for the input, the reduce
 //! can be simplified to a map operation.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformState};
 
 /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
 #[derive(Debug)]
@@ -25,7 +23,7 @@ impl crate::Transform for ReduceElision {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/reduction.rs
+++ b/src/transform/reduction.rs
@@ -11,10 +11,10 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use expr::{GlobalId, RelationExpr, ScalarExpr};
+use expr::RelationExpr;
 use repr::{Datum, Row, RowArena};
 
-use crate::TransformError;
+use crate::{TransformError, TransformState};
 
 pub use demorgans::DeMorgans;
 pub use negate_predicate::NegatePredicate;
@@ -28,7 +28,7 @@ impl crate::Transform for FoldConstants {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), TransformError> {
         relation.try_visit_mut(&mut |e| self.action(e))
     }
@@ -400,11 +400,9 @@ impl FoldConstants {
 /// Transforms !(a && b) into !a || !b and !(a || b) into !a && !b
 pub mod demorgans {
 
-    use std::collections::HashMap;
+    use expr::{BinaryFunc, RelationExpr, ScalarExpr, UnaryFunc};
 
-    use expr::{BinaryFunc, GlobalId, RelationExpr, ScalarExpr, UnaryFunc};
-
-    use crate::TransformError;
+    use crate::{TransformError, TransformState};
 
     /// Transforms !(a && b) into !a || !b and !(a || b) into !a && !b
     #[derive(Debug)]
@@ -413,7 +411,7 @@ pub mod demorgans {
         fn transform(
             &self,
             relation: &mut RelationExpr,
-            _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+            _: TransformState,
         ) -> Result<(), TransformError> {
             relation.visit_mut_pre(&mut |e| {
                 self.action(e);
@@ -485,12 +483,11 @@ pub mod demorgans {
 
 /// Transforms predicates from (a && b) || (a && c) into a && (b || c).
 pub mod undistribute_and {
-    use std::collections::HashMap;
 
-    use expr::{BinaryFunc, GlobalId, RelationExpr, ScalarExpr};
+    use expr::{BinaryFunc, RelationExpr, ScalarExpr};
     use repr::{ColumnType, Datum, ScalarType};
 
-    use crate::TransformError;
+    use crate::{TransformError, TransformState};
 
     /// Transforms predicates from (a && b) || (a && c) into a && (b || c).
     #[derive(Debug)]
@@ -500,7 +497,7 @@ pub mod undistribute_and {
         fn transform(
             &self,
             relation: &mut RelationExpr,
-            _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+            _: TransformState,
         ) -> Result<(), TransformError> {
             relation.visit_mut(&mut |e| {
                 self.action(e);

--- a/src/transform/reduction_pushdown.rs
+++ b/src/transform/reduction_pushdown.rs
@@ -11,9 +11,7 @@
 //!
 //! At the moment, this only absorbs Map operators into Reduce operators.
 
-use std::collections::HashMap;
-
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, TransformState};
 
 /// Pushes Reduce operators toward sources.
 #[derive(Debug)]
@@ -23,7 +21,7 @@ impl crate::Transform for ReductionPushdown {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/redundant_join.rs
+++ b/src/transform/redundant_join.rs
@@ -12,9 +12,8 @@
 // If statements seem a bit clearer in this case. Specialized methods
 // that replace simple and common alternatives frustrate developers.
 #![allow(clippy::comparison_chain, clippy::filter_next)]
-use std::collections::HashMap;
 
-use crate::{GlobalId, RelationExpr, ScalarExpr};
+use crate::{RelationExpr, ScalarExpr, TransformState};
 
 /// Remove redundant collections of distinct elements from joins.
 #[derive(Debug)]
@@ -24,7 +23,7 @@ impl crate::Transform for RedundantJoin {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
             self.action(e);

--- a/src/transform/split_predicates.rs
+++ b/src/transform/split_predicates.rs
@@ -9,9 +9,8 @@
 
 //! Transforms predicates of the form "A and B" into two: "A" and "B".
 
-use std::collections::HashMap;
-
-use expr::{BinaryFunc, GlobalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{BinaryFunc, RelationExpr, ScalarExpr};
 
 /// Transforms predicates of the form "A and B" into two: "A" and "B".
 #[derive(Debug)]
@@ -22,7 +21,7 @@ impl crate::Transform for SplitPredicates {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |expr| {
             if let RelationExpr::Filter { predicates, .. } = expr {

--- a/src/transform/topk_elision.rs
+++ b/src/transform/topk_elision.rs
@@ -11,7 +11,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, RelationExpr};
 
 /// Remove TopK operators with both an offset of zero and no limit.
 #[derive(Debug)]
@@ -21,7 +22,7 @@ impl crate::Transform for TopKElision {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        _: TransformState,
     ) -> Result<(), crate::TransformError> {
         self.action(relation, &mut HashMap::new());
         Ok(())

--- a/src/transform/update_let.rs
+++ b/src/transform/update_let.rs
@@ -12,7 +12,8 @@
 
 use std::collections::HashMap;
 
-use expr::{GlobalId, Id, IdGen, LocalId, RelationExpr, ScalarExpr};
+use crate::TransformState;
+use expr::{Id, IdGen, LocalId, RelationExpr};
 use repr::RelationType;
 
 /// Refreshes identifiers and types for local let bindings.
@@ -28,10 +29,10 @@ impl crate::Transform for UpdateLet {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        _: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        state: TransformState,
     ) -> Result<(), crate::TransformError> {
-        let mut id_gen: IdGen = Default::default();
-        self.action(relation, &mut HashMap::new(), &mut id_gen);
+        *state.id_gen = IdGen::default();
+        self.action(relation, &mut HashMap::new(), state.id_gen);
         Ok(())
     }
 }

--- a/src/transform/use_indexes.rs
+++ b/src/transform/use_indexes.rs
@@ -38,9 +38,9 @@ impl crate::Transform for FilterEqualLiteral {
     fn transform(
         &self,
         relation: &mut RelationExpr,
-        indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
+        state: TransformState,
     ) -> Result<(), crate::TransformError> {
-        self.transform(relation, indexes);
+        self.transform(relation, &state.indexes);
         Ok(())
     }
 }


### PR DESCRIPTION
Tweak of #2966 to pass around an owned `TransformState` rather than a `&mut TransformState`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2983)
<!-- Reviewable:end -->
