### PR TITLE
Assert to make sure Kafka messages are actually used

### DIFF
--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -439,6 +439,7 @@ where
                             Err(e) => error!("Failed to fast-forward consumer: {}", e),
                         }
                         // Message has been discarded, we return the consumer to the consumer queue
+                        message.consume();
                         consumers.push_back(consumer);
                         activator.activate();
                         return SourceStatus::Alive;


### PR DESCRIPTION
The correctness of the somewhat complicated code in source/kafka.rs relies on making sure that if we don't send a message, we stick it back into `buffer`, unless we are skipping it intentionally (due to a Kafka restart).

I think we are doing the correct thing now, but let's actually assert that that's true by panicking on `drop`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2984)
<!-- Reviewable:end -->
