### PR TITLE
Log offending non-positive value

### DIFF
--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -143,7 +143,7 @@ where
                             // case, rather than panic, though we surely want to see what is up.
                             // XXX: This panic reports user-supplied data!
                             panic!(
-                                "ReduceCollation found unexpected indexes:\n\tExpected:\t{:?}\n\tFound:\t{:?}\n\tFor:\t{:?}\n\tKey:{:?}\nRelationExpr:\n{}",
+                                "[customer-data] ReduceCollation found unexpected indexes:\n\tExpected:\t{:?}\n\tFound:\t{:?}\n\tFor:\t{:?}\n\tKey:{:?}\nRelationExpr:\n{}",
                                 (0..aggregates_len).collect::<Vec<_>>(),
                                 input.iter().map(|((p,_),_)| p).collect::<Vec<_>>(),
                                 aggregates_clone,
@@ -280,7 +280,7 @@ where
                     // XXX: This reports user data, which we perhaps should not do!
                     for (val, cnt) in source.iter() {
                         if cnt < &0 {
-                            log::error!("Negative accumulation in ReduceInaccumulable: {:?} with count {:?}", val, cnt);
+                            log::error!("[customer-data] Negative accumulation in ReduceInaccumulable: {:?} with count {:?}", val, cnt);
                         }
                     }
                 } else {
@@ -390,7 +390,7 @@ where
                     // operator, when this key is presented but matching aggregates are not found. We will
                     // suppress the output for inputs without net-positive records, which *should* avoid
                     // that panic.
-                    log::error!("ReduceAccumulable observed net-zero records with non-zero accumulation: {:?}: {:?}, {:?}", aggr, agg1, agg2);
+                    log::error!("[customer-data] ReduceAccumulable observed net-zero records with non-zero accumulation: {:?}: {:?}, {:?}", aggr, agg1, agg2);
                 }
 
                 // The finished value depends on the aggregation function in a variety of ways.
@@ -489,7 +489,7 @@ where
                     for (val, cnt) in source.iter() {
                         if cnt <= &0 {
                             // XXX: This reports user data, which we perhaps should not do!
-                            log::error!("Non-positive accumulation in ReduceHierarchical: key: {:?}\tvalue: {:?}\tcount: {:?}", key, val, cnt);
+                            log::error!("[customer-data] Non-positive accumulation in ReduceHierarchical: key: {:?}\tvalue: {:?}\tcount: {:?}", key, val, cnt);
                         }
                     }
                 } else {

--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -486,8 +486,12 @@ where
             move |_key, source, target| {
                 // Should negative accumulations reach us, we should loudly complain.
                 if source.iter().any(|(_val, cnt)| cnt <= &0) {
-                    // TODO(frank): Consider reporting the actual offending data.
-                    log::error!("Negative accumulation in ReduceHierarchical");
+                    for (val, cnt) in source.iter() {
+                        if cnt <= &0 {
+                            // XXX: This reports user data, which we perhaps should not do!
+                            log::error!("Non-positive accumulation in ReduceHierarchical: value: {:?}\tcount: {:?}", val, cnt);
+                        }
+                    }
                 } else {
                     // We ignore the count here under the belief that it cannot affect
                     // hierarchical aggregations; should that belief be incorrect, we

--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -483,13 +483,13 @@ where
     collection
         .map(move |((key, hash), row)| ((key, hash % modulus), row))
         .reduce_named("ReduceHierarchical", {
-            move |_key, source, target| {
+            move |key, source, target| {
                 // Should negative accumulations reach us, we should loudly complain.
                 if source.iter().any(|(_val, cnt)| cnt <= &0) {
                     for (val, cnt) in source.iter() {
                         if cnt <= &0 {
                             // XXX: This reports user data, which we perhaps should not do!
-                            log::error!("Non-positive accumulation in ReduceHierarchical: value: {:?}\tcount: {:?}", val, cnt);
+                            log::error!("Non-positive accumulation in ReduceHierarchical: key: {:?}\tvalue: {:?}\tcount: {:?}", key, val, cnt);
                         }
                     }
                 } else {


### PR DESCRIPTION
We leave early warning signs of defective data when we see non-positive accumulations in `reduce`, but we did not report the offending value. This PR modifies that complaint to also log the key, value, and count which led to the complaint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2991)
<!-- Reviewable:end -->
