### PR TITLE
ci: correct deb publishing on releases

### DIFF
--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -86,7 +86,7 @@ def stage_deb(repo: mzbuild.Repository, package: str, version: str) -> None:
     bt = bintray.Client(
         "materialize", user="ci@materialize", api_key=os.environ["BINTRAY_API_KEY"]
     )
-    package = bt.repo("apt").package("materialized-unstable")
+    package = bt.repo("apt").package(package)
     try:
         print("Creating Bintray version...")
         commit_hash = git.rev_parse("HEAD")


### PR DESCRIPTION
This needs to go to "materialized" for releases, and
"materialized-unstable" otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/2999)
<!-- Reviewable:end -->
