### PR TITLE
Better respect compaction frontier

### DIFF
--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1712,7 +1712,11 @@ where
                 // This can occur in SINK and TAIL at the moment. Their behaviors are fluid enough
                 // that we just correct to avoid producing incorrect output updates, but we should
                 // fix the root of the problem in a more principled manner.
-                log::error!("Requested as_of ({:?}) not >= since ({:?}); correcting", as_of, since);
+                log::error!(
+                    "Requested as_of ({:?}) not >= since ({:?}); correcting",
+                    as_of,
+                    since
+                );
                 as_of.join_assign(&since);
             }
         } else {

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1698,8 +1698,15 @@ where
         //     self.sink_info[global_id].valid_from(&since);
         // }
 
-        // Bind the since frontier to the dataflow description.
-        dataflow.set_as_of(since);
+        // Ensure that the dataflow's `as_of` is at least `since`.
+        if let Some(as_of) = &dataflow.as_of {
+            // If we have requested a specific time that is invalid .. someone errored.
+            use timely::order::PartialOrder;
+            assert!(<_ as PartialOrder>::less_equal(&since, &as_of));
+        } else {
+            // Bind the since frontier to the dataflow description.
+            dataflow.set_as_of(since);
+        }
     }
 
     fn create_index_dataflow(&mut self, name: String, id: GlobalId, index: catalog::Index) {

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -1713,7 +1713,8 @@ where
                 // that we just correct to avoid producing incorrect output updates, but we should
                 // fix the root of the problem in a more principled manner.
                 log::error!(
-                    "Requested as_of ({:?}) not >= since ({:?}); correcting",
+                    "Dataflow {} requested as_of ({:?}) not >= since ({:?}); correcting",
+                    dataflow.debug_name,
                     as_of,
                     since
                 );


### PR DESCRIPTION
As described in #2803 we largely ignore the `since` compaction frontier of arrangements, most especially in the creation of dataflows for new arrangements and sinks. This PR forces that information in to dataflow construction and ensures that dataflows are constructed with such a minimum frontier and that newly created arrangements use this frontier as their starting value for their compaction frontier.

<!-- Reviewable:start -->
<!-- Reviewable:end -->
