### PR TITLE
Correct testdrive output

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -191,9 +191,7 @@ impl SqlAction {
                 } else {
                     let (mut left, mut right) = (0, 0);
                     let mut buf = String::new();
-                    while left < expected_rows.len() && right < actual.len() {
-                        let e = &expected_rows[left];
-                        let a = &actual[right];
+                    while let (Some(e), Some(a)) = (expected_rows.get(left), actual.get(right)) {
                         match e.cmp(a) {
                             std::cmp::Ordering::Less => {
                                 writeln!(buf, "row missing: {:?}", e).unwrap();
@@ -209,13 +207,11 @@ impl SqlAction {
                             }
                         }
                     }
-                    while left < expected_rows.len() {
-                        let e = &expected_rows[left];
+                    while let Some(e) = expected_rows.get(left) {
                         writeln!(buf, "row missing: {:?}", e).unwrap();
                         left += 1;
                     }
-                    while right < actual.len() {
-                        let a = &actual[right];
+                    while let Some(a) = actual.get(right) {
                         writeln!(buf, "extra row: {:?}", a).unwrap();
                         right += 1;
                     }


### PR DESCRIPTION
Test drive's diff report was doing a merge, but failing to report differences at the tail end of the merge. This would result in incomplete reports like
```
rows didn't match; sleeping to see if dataflow catches up 125ms 250ms 500ms 1s 2s 4s 4.825s
test/testdrive/timestamps-kafka-avro-multi.td:261:1: error: non-matching rows: expected:
[["1", "6"], ["10", "1"], ["11", "1"], ["2", "1"], ["3", "3"], ["5", "1"], ["6", "1"], ["7", "1"], ["8", "1"], ["9", "1"]]
got:
[["1", "6"], ["2", "1"], ["3", "3"], ["5", "1"], ["6", "1"], ["7", "1"]]
Diff:
row missing: ["10", "1"]
row missing: ["11", "1"]
```
Also, simplified the logic a fair bit imo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3006)
<!-- Reviewable:end -->
