### PR TITLE
Rename boolean aggregates

### DIFF
--- a/src/expr/relation/func.rs
+++ b/src/expr/relation/func.rs
@@ -369,7 +369,7 @@ where
     Datum::from(x)
 }
 
-fn any<'a, I>(datums: I) -> Datum<'a>
+fn bool_or<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -382,7 +382,7 @@ where
         })
 }
 
-fn all<'a, I>(datums: I) -> Datum<'a>
+fn bool_and<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -437,8 +437,8 @@ pub enum AggregateFunc {
     SumNull,
     Count,
     CountAll, // COUNT(*) counts nulls too
-    Any,
-    All,
+    BoolOr,
+    BoolAnd,
     JsonbAgg,
 }
 
@@ -478,8 +478,8 @@ impl AggregateFunc {
             AggregateFunc::SumNull => sum_null(datums),
             AggregateFunc::Count => count(datums),
             AggregateFunc::CountAll => count_all(datums),
-            AggregateFunc::Any => any(datums),
-            AggregateFunc::All => all(datums),
+            AggregateFunc::BoolOr => bool_or(datums),
+            AggregateFunc::BoolAnd => bool_and(datums),
             AggregateFunc::JsonbAgg => jsonb_agg(datums, temp_storage),
         }
     }
@@ -487,8 +487,8 @@ impl AggregateFunc {
     pub fn default(&self) -> Datum<'static> {
         match self {
             AggregateFunc::Count | AggregateFunc::CountAll => Datum::Int64(0),
-            AggregateFunc::Any => Datum::False,
-            AggregateFunc::All => Datum::True,
+            AggregateFunc::BoolOr => Datum::False,
+            AggregateFunc::BoolAnd => Datum::True,
             _ => Datum::Null,
         }
     }
@@ -502,8 +502,8 @@ impl AggregateFunc {
         let scalar_type = match self {
             AggregateFunc::Count => ScalarType::Int64,
             AggregateFunc::CountAll => ScalarType::Int64,
-            AggregateFunc::Any => ScalarType::Bool,
-            AggregateFunc::All => ScalarType::Bool,
+            AggregateFunc::BoolOr => ScalarType::Bool,
+            AggregateFunc::BoolAnd => ScalarType::Bool,
             AggregateFunc::JsonbAgg => ScalarType::Jsonb,
             _ => input_type.scalar_type,
         };
@@ -604,8 +604,8 @@ impl fmt::Display for AggregateFunc {
             AggregateFunc::SumNull => f.write_str("sum"),
             AggregateFunc::Count => f.write_str("count"),
             AggregateFunc::CountAll => f.write_str("countall"),
-            AggregateFunc::Any => f.write_str("any"),
-            AggregateFunc::All => f.write_str("all"),
+            AggregateFunc::BoolOr => f.write_str("bool_or"),
+            AggregateFunc::BoolAnd => f.write_str("bool_and"),
             AggregateFunc::JsonbAgg => f.write_str("jsonb_agg"),
         }
     }

--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1434,11 +1434,11 @@ fn plan_expr_returning_name<'a>(
                 right,
                 some: _,
             } => (
-                plan_any_or_all(ecx, left, op, right, AggregateFunc::Any)?,
+                plan_any_or_all(ecx, left, op, right, AggregateFunc::BoolOr)?,
                 None,
             ),
             Expr::All { left, op, right } => (
-                plan_any_or_all(ecx, left, op, right, AggregateFunc::All)?,
+                plan_any_or_all(ecx, left, op, right, AggregateFunc::BoolAnd)?,
                 None,
             ),
             Expr::InSubquery {
@@ -1454,14 +1454,14 @@ fn plan_expr_returning_name<'a>(
                     // `<expr> NOT IN (<subquery>)` is equivalent to
                     // `<expr> <> ALL (<subquery>)`.
                     (
-                        plan_any_or_all(ecx, expr, &NotEq, subquery, AggregateFunc::All)?,
+                        plan_any_or_all(ecx, expr, &NotEq, subquery, AggregateFunc::BoolAnd)?,
                         None,
                     )
                 } else {
                     // `<expr> IN (<subquery>)` is equivalent to
                     // `<expr> = ANY (<subquery>)`.
                     (
-                        plan_any_or_all(ecx, expr, &Eq, subquery, AggregateFunc::Any)?,
+                        plan_any_or_all(ecx, expr, &Eq, subquery, AggregateFunc::BoolOr)?,
                         None,
                     )
                 }
@@ -3812,7 +3812,7 @@ fn is_table_func(name: &str) -> bool {
 fn is_aggregate_func(name: &str) -> bool {
     match name {
         // avg is handled by transform::AvgFuncRewriter.
-        "max" | "min" | "sum" | "count" | "jsonb_agg" => true,
+        "max" | "min" | "sum" | "count" | "jsonb_agg" | "bool_or" | "bool_and" => true,
         _ => false,
     }
 }

--- a/src/transform/map_lifting.rs
+++ b/src/transform/map_lifting.rs
@@ -360,13 +360,13 @@ impl LiteralLifting {
                     }
                 }
 
-                // The only literals we think we can lift are those that are
-                // independent of the number of records; things like `Any`, `All`,
-                // `Min`, and `Max`.
+                // The only literals we think we can lift are those that are independent of the
+                // number of records; things like `BoolOr`, `BoolAnd`, `Min`, and `Max`.
                 // TODO(frank): extract non-terminal literals.
                 let mut result = Vec::new();
                 while aggregates.last().map(|a| {
-                    (a.func == expr::AggregateFunc::Any || a.func == expr::AggregateFunc::All)
+                    (a.func == expr::AggregateFunc::BoolOr
+                        || a.func == expr::AggregateFunc::BoolAnd)
                         && a.expr.is_literal_ok()
                 }) == Some(true)
                 {

--- a/src/transform/predicate_pushdown.rs
+++ b/src/transform/predicate_pushdown.rs
@@ -251,7 +251,7 @@ impl PredicatePushdown {
                         } else if let ScalarExpr::Column(col) = &predicate {
                             if *col == group_key.len()
                                 && aggregates.len() == 1
-                                && aggregates[0].func == AggregateFunc::Any
+                                && aggregates[0].func == AggregateFunc::BoolOr
                             {
                                 push_down.push(aggregates[0].expr.clone());
                                 aggregates[0].expr = ScalarExpr::literal_ok(

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -165,3 +165,52 @@ query I rowsort
 select sum(distinct column1) from (values (1), (2), (1), (4)) _;
 ----
 7
+
+statement ok
+CREATE TABLE bools (
+  id INT PRIMARY KEY,
+  allfalse BOOL,
+  mixed BOOL,
+  alltrue BOOL,
+  allfalse_null BOOL,
+  mixed_null BOOL,
+  alltrue_null BOOL
+);
+----
+
+# TODO(justin): support this
+# statement ok
+# INSERT INTO bools VALUES
+#   (1, false, true,  true, false, true,  true),
+#   (2, false, false, true, NULL,  false, true),
+#   (3, false, true,  true, false, NULL,  true),
+#   (4, false, false, true, false, false, NULL),
+#   (5, false, true,  true, false, true,  true),
+#   (6, false, false, true, false, false, true);
+# ----
+#
+# query BBBBBB
+# SELECT
+#   bool_or(allfalse),
+#   bool_or(mixed),
+#   bool_or(alltrue),
+#   bool_and(allfalse),
+#   bool_and(mixed),
+#   bool_and(alltrue)
+# FROM bools
+# ----
+# false  true  true  false  false  true
+#
+# query BBBBBB
+# SELECT
+#   bool_or(allfalse_null),
+#   bool_or(mixed_null),
+#   bool_or(alltrue_null),
+#   bool_and(allfalse_null),
+#   bool_and(mixed_null),
+#   bool_and(alltrue_null)
+# FROM bools
+# ----
+# TODO(justin): our output here with a vanilla transformation to
+# bool_or/bool_and is `NULL  true  true  false  false  NULL`.
+# false  true  true  false  false  true

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1107,7 +1107,7 @@ ORDER BY supplier_cnt DESC
 | Join %4 %5
 | | implementation = Differential %5 %4.()
 | | demand = (#0, #1)
-| Reduce group=(#0) all((#0 != #1))
+| Reduce group=(#0) bool_and((#0 != #1))
 
 %7 =
 | Get %2

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1168,7 +1168,7 @@ ORDER BY
 | Join %4 %5
 | | implementation = Differential %5 %4.()
 | | demand = (#0, #1)
-| Reduce group=(#0) all((#0 != #1))
+| Reduce group=(#0) bool_and((#0 != #1))
 
 %7 =
 | Get %2
@@ -1902,7 +1902,7 @@ ORDER BY
 | | | | | Project (#9)
 | | | | | Map
 | | | | | Project (#0)
-| | | | | Reduce group=() any((#^0 = #0))
+| | | | | Reduce group=() bool_or((#^0 = #0))
 | | | |
 | | | |
 | | | | %12 =
@@ -1925,7 +1925,7 @@ ORDER BY
 | | | Project (#5)
 | | | Map
 | | | Project (#0)
-| | | Reduce group=() any((#^0 = #0))
+| | | Reduce group=() bool_or((#^0 = #0))
 | |
 | Map #1, #2
 | Project (#11, #12)


### PR DESCRIPTION
This commit renames the any/all aggregates to bool_or/bool_and, to match
with postgres.

I wanted to expose them as well in this commit, but currently their
handling of NULLs differs from Postgres: the PG aggregates ignores any
NULLs, but our bool_or/bool_and treat `NULL` in a different way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3007)
<!-- Reviewable:end -->
