### PR TITLE
Bumping timeout in multipartition test

### DIFF
--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -7,7 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-execution-count count=3
+$ set-sql-timeout duration=30s
+
 
 $ set schema={
     "type": "record",


### PR DESCRIPTION
Some of the multi-partition tests intentionally stress interleavings that take a while for records to propagate through the sources. The default test-drive timeout is often too small. This increases it on one file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3008)
<!-- Reviewable:end -->
