### PR TITLE
Use post-optimization type information

### DIFF
--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1079,11 +1079,11 @@ ORDER BY
 ----
 %0 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.revenue (u27)
 | Filter !(isnull(#1))
+| ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.revenue (u27)
@@ -1093,7 +1093,7 @@ ORDER BY
 
 %3 =
 | Join %0 %1 %2 (= #0 #7) (= #8 #9)
-| | implementation = Differential %1 %0.(#0) %2.(#0)
+| | implementation = Differential %0 %1.(#0) %2.(#0)
 | | demand = (#0..#2, #4, #8)
 | Project (#0..#2, #4, #8)
 


### PR DESCRIPTION
This PR is an update of #1759, which we should be able to close if this lands. Roughly: in various places we install a view with a description contain the pre-optimization type, which means that e.g. key columns and nullability generally are not propagated across views.

This led to some bugs in the previous version, but since then there was a bit of a revamp where types were attached to nulls and which might prevent those problems. The code was different enough in coord.rs that I just rewrote things (and applied the same transformation to the views loaded by the catalog).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3009)
<!-- Reviewable:end -->
