### PR TITLE
Add `ignore_source_keys` WITH option.

### DIFF
--- a/src/repr/relation.rs
+++ b/src/repr/relation.rs
@@ -225,6 +225,11 @@ impl RelationDesc {
         self
     }
 
+    /// Deletes all keys for the relation
+    pub fn clear_keys(&mut self) {
+        self.typ.keys.clear()
+    }
+
     pub fn typ(&self) -> &RelationType {
         &self.typ
     }

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1397,6 +1397,14 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             }
 
             let mut desc = encoding.desc(&envelope)?;
+            let ignore_source_keys = match with_options.remove("ignore_source_keys") {
+                None => false,
+                Some(Value::Boolean(b)) => b,
+                Some(_) => bail!("ignore_source_keys must be a boolean"),
+            };
+            if ignore_source_keys {
+                desc.clear_keys();
+            }
 
             let typ = desc.typ();
             if !col_names.is_empty() {

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -172,3 +172,18 @@ a count
 1 1
 1 1
 2 1
+
+# When ignoring source keys, it should give correct results.
+
+> CREATE MATERIALIZED SOURCE data_v4
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (ignore_source_keys = true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
+
+> SELECT a, count(*) FROM data_v4
+  GROUP BY a
+a count
+-------
+1 2
+2 1


### PR DESCRIPTION
This is for the case when the primary key information from Debezium can't be trusted, or for when we want to write certain debugging queries that might rely on the primary key optimizations not having been applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3012)
<!-- Reviewable:end -->
