### PR TITLE
[MUSING] temporary views

### DIFF
--- a/src/coord/catalog/sql.rs
+++ b/src/coord/catalog/sql.rs
@@ -63,7 +63,8 @@ const MIGRATIONS: &[&str] = &[
      INSERT INTO schemas VALUES
          (1, NULL, 'mz_catalog'),
          (2, NULL, 'pg_catalog'),
-         (3, 1, 'public');",
+         (3, 1, 'public'),
+         (4, 1, 'mz_temp');",
     // Adjusts timestamp table to support multi-partition Kafka topics.
     //
     // Introduced for v0.1.4.

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -732,8 +732,12 @@ where
         let ops = vec![
             catalog::Op::CreateDatabase { name: name.clone() },
             catalog::Op::CreateSchema {
-                database_name: DatabaseSpecifier::Name(name),
+                database_name: DatabaseSpecifier::Name(name.clone()),
                 schema_name: "public".into(),
+            },
+            catalog::Op::CreateSchema {
+                database_name: DatabaseSpecifier::Name(name),
+                schema_name: "mz_temp".into(),
             },
         ];
         match self.catalog_transact(ops) {

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -911,6 +911,7 @@ pub enum Statement {
         columns: Vec<Ident>,
         query: Box<Query>,
         if_exists: IfExistsBehavior,
+        temporary: bool,
         materialized: bool,
         with_options: Vec<SqlOption>,
     },
@@ -1228,6 +1229,7 @@ impl AstDisplay for Statement {
                 name,
                 columns,
                 query,
+                temporary,
                 materialized,
                 if_exists,
                 with_options,
@@ -1235,6 +1237,9 @@ impl AstDisplay for Statement {
                 f.write_str("CREATE");
                 if *if_exists == IfExistsBehavior::Replace {
                     f.write_str(" OR REPLACE");
+                }
+                if *temporary {
+                    f.write_str(" TEMPORARY");
                 }
                 if *materialized {
                     f.write_str(" MATERIALIZED");

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -435,11 +435,12 @@ macro_rules! make_visitor {
                 name: &'ast $($mut)* ObjectName,
                 columns: &'ast $($mut)* [Ident],
                 query: &'ast $($mut)* Query,
+                temporary: bool,
                 materialized: bool,
                 if_exists: IfExistsBehavior,
                 with_options: &'ast $($mut)* [SqlOption],
             ) {
-                visit_create_view(self, name, columns, query, materialized, if_exists, with_options)
+                visit_create_view(self, name, columns, query, temporary, materialized, if_exists, with_options)
             }
 
             fn visit_create_index(
@@ -710,10 +711,11 @@ macro_rules! make_visitor {
                     name,
                     columns,
                     query,
+                    temporary,
                     materialized,
                     if_exists,
                     with_options,
-                } => visitor.visit_create_view(name, columns, query, *materialized, *if_exists, with_options),
+                } => visitor.visit_create_view(name, columns, query, *temporary, *materialized, *if_exists, with_options),
                 Statement::CreateIndex {
                     name,
                     on_name,
@@ -1510,6 +1512,7 @@ macro_rules! make_visitor {
             name: &'ast $($mut)* ObjectName,
             columns: &'ast $($mut)* [Ident],
             query: &'ast $($mut)* Query,
+            _temporary: bool,
             _materialized: bool,
             _if_exists: IfExistsBehavior,
             with_options: &'ast $($mut)* [SqlOption],

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -440,6 +440,7 @@ define_keywords!(
     TABLES,
     TABLESAMPLE,
     TAIL,
+    TEMPORARY,
     TEXT,
     THEN,
     TIES,

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -2829,6 +2829,7 @@ fn parse_create_view() {
             name,
             columns,
             query,
+            temporary,
             materialized,
             if_exists,
             with_options,
@@ -2836,6 +2837,32 @@ fn parse_create_view() {
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<Ident>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(!temporary);
+            assert!(!materialized);
+            assert_eq!(if_exists, IfExistsBehavior::Error);
+            assert_eq!(with_options, vec![]);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_temporary_view() {
+    let sql = "CREATE TEMPORARY VIEW tempview AS SELECT foo FROM bar";
+    match verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            query,
+            temporary,
+            materialized,
+            if_exists,
+            with_options,
+        } => {
+            assert_eq!("mz_temp.tempview", name.to_string());
+            assert_eq!(Vec::<Ident>::new(), columns);
+            assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(temporary);
             assert!(!materialized);
             assert_eq!(if_exists, IfExistsBehavior::Error);
             assert_eq!(with_options, vec![]);
@@ -2906,6 +2933,7 @@ fn parse_create_view_with_columns() {
             columns,
             with_options,
             query,
+            temporary,
             materialized,
             if_exists,
         } => {
@@ -2913,6 +2941,7 @@ fn parse_create_view_with_columns() {
             assert_eq!(columns, vec![Ident::new("has"), Ident::new("cols")]);
             assert_eq!(with_options, vec![]);
             assert_eq!("SELECT 1, 2", query.to_string());
+            assert!(!temporary);
             assert!(!materialized);
             assert_eq!(if_exists, IfExistsBehavior::Error);
         }
@@ -2928,6 +2957,7 @@ fn parse_create_materialized_view() {
             name,
             columns,
             query,
+            temporary,
             materialized,
             if_exists,
             with_options,
@@ -2935,6 +2965,7 @@ fn parse_create_materialized_view() {
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<Ident>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(!temporary);
             assert!(materialized);
             assert_eq!(if_exists, IfExistsBehavior::Error);
             assert_eq!(with_options, vec![]);

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -88,7 +88,9 @@ pub fn create_statement(
     mut stmt: Statement,
 ) -> Result<String, failure::Error> {
     let allocate_name = |name: &ObjectName| -> Result<_, failure::Error> {
-        Ok(unresolve(scx.allocate_name(object_name(name.clone())?)))
+        Ok(unresolve(
+            scx.allocate_name(object_name(name.clone())?, false),
+        ))
     };
 
     let resolve_name = |name: &ObjectName| -> Result<_, failure::Error> {
@@ -196,6 +198,7 @@ pub fn create_statement(
             name,
             columns: _,
             query,
+            temporary: _,
             materialized,
             if_exists,
             with_options: _,
@@ -208,6 +211,7 @@ pub fn create_statement(
                     return Err(err);
                 }
             }
+            // todo: not sure what to do here...
             *materialized = false;
             *if_exists = IfExistsBehavior::Error;
         }

--- a/src/symbiosis/lib.rs
+++ b/src/symbiosis/lib.rs
@@ -202,7 +202,7 @@ END $$;
                     }
                 }
 
-                let name = scx.allocate_name(normalize::object_name(name.clone())?);
+                let name = scx.allocate_name(normalize::object_name(name.clone())?, false);
                 let desc = RelationDesc::new(typ, names);
                 self.table_types
                     .insert(name.clone(), (sql_types, desc.clone()));


### PR DESCRIPTION
Notes:

This sort of works! I'm able to create a temporary view that's automatically put into the `mz_temp` schema. (I had to `rm -rf mzdata/` first to prompt Catalog's migration SQL to run). 

Once a temporary view is created, you have to `SHOW`, `SELECT`, and `DROP` the view using the fully qualified name. This differs from Postgres. 

The question is: do we want to have a temp schema at all? Or should temporary views be put into the current/specified schema?


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3014)
<!-- Reviewable:end -->
