### PR TITLE
materialized: fix handling of missing `-w` parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 name = "materialized"
 version = "0.2.3-dev"
 dependencies = [
+ "assert_cmd",
  "async-trait",
  "backtrace",
  "chrono",
@@ -1608,6 +1609,7 @@ dependencies = [
  "pgwire",
  "postgres",
  "postgres-openssl",
+ "predicates",
  "prometheus",
  "rdkafka-sys",
  "rlimit",

--- a/ci/test/cargo-test/run-tests
+++ b/ci/test/cargo-test/run-tests
@@ -9,7 +9,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-
 set -euo pipefail
 
 # ShellCheck cannot follow this path, as it is only valid inside the Docker

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -195,8 +195,7 @@ class CargoBuild(CargoPreImage):
         if self.bin is None:
             raise ValueError("mzbuild config is missing pre-build target")
 
-    def run(self) -> None:
-        super().run()
+    def build(self) -> None:
         cargo_build = [self.rd.xcargo(), "build", "--release", "--bin", self.bin]
         spawn.runv(
             cargo_build, cwd=self.rd.root,
@@ -241,6 +240,10 @@ class CargoBuild(CargoPreImage):
                 for d in self.extract.get(package, []):
                     shutil.copy(Path(message["out_dir"]) / d, self.path / Path(d).name)
 
+    def run(self) -> None:
+        super().run()
+        self.build()
+
     def inputs(self) -> Set[str]:
         crate = self.rd.cargo_workspace.crate_for_bin(self.bin)
         deps = self.rd.cargo_workspace.transitive_path_dependencies(crate)
@@ -264,7 +267,8 @@ class CargoTest(CargoPreImage):
 
     def run(self) -> None:
         super().run()
-        CargoBuild(self.rd, self.path, {"bin": "testdrive"}).run()
+        CargoBuild(self.rd, self.path, {"bin": "testdrive", "strip": True}).build()
+        CargoBuild(self.rd, self.path, {"bin": "materialized", "strip": True}).build()
 
         # NOTE(benesch): The two invocations of `cargo test --no-run` here
         # deserve some explanation. The first invocation prints error messages
@@ -309,6 +313,7 @@ class CargoTest(CargoPreImage):
                 shutil.copy(executable, self.path / "tests" / slug)
                 spawn.runv([xstrip, self.path / "tests" / slug])
                 manifest.write(f"{slug} {crate_path}\n")
+        shutil.move(str(self.path / "materialized"), self.path / "tests")
         shutil.move(str(self.path / "testdrive"), self.path / "tests")
         shutil.copy(
             self.rd.xcargo_target_dir() / "debug" / "examples" / "pingpong",

--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -212,6 +212,8 @@ pub fn serve<C>(
 where
     C: comm::Connection,
 {
+    assert!(threads > 0);
+
     // Construct endpoints for each thread that will receive the coordinator's
     // sequenced command stream.
     //

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -51,10 +51,12 @@ tracing = "0.1.13"
 tracing-subscriber = "0.2.5"
 
 [dev-dependencies]
+assert_cmd = "1.0.1"
 chrono = "0.4"
 fallible-iterator = "0.2.0"
 itertools = "0.9"
 postgres = { version = "0.17", features = ["with-chrono-0_4"] }
+predicates = "1.0.4"
 serde_json = "1"
 tokio-postgres = { version = "0.5.2", features = ["with-chrono-0_4"] }
 

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -180,15 +180,6 @@ fn run() -> Result<(), failure::Error> {
 
     // Configure Timely and Differential workers.
     let threads = match popts.opt_get::<usize>("threads")? {
-        Some(val) if val == 0 => {
-            bail!(
-                "'--threads' must be specified and greater than 0\n\
-                 hint: As a starting point, set the number of threads to half of the number of\n\
-                 cores on your system. Then, further adjust based on your performance needs.\n\
-                 hint: You may also set the environment variable MZ_THREADS to the desired number\n\
-                 of threads."
-            );
-        }
         Some(val) => val,
         None => match env::var("MZ_THREADS") {
             Ok(val) => val.parse()?,
@@ -196,6 +187,15 @@ fn run() -> Result<(), failure::Error> {
             Err(VarError::NotPresent) => 0,
         },
     };
+    if threads == 0 {
+        bail!(
+            "'--threads' must be specified and greater than 0\n\
+            hint: As a starting point, set the number of threads to half of the number of\n\
+            cores on your system. Then, further adjust based on your performance needs.\n\
+            hint: You may also set the environment variable MZ_THREADS to the desired number\n\
+            of threads."
+        );
+    }
     let process = popts.opt_get_default("process", 0)?;
     let processes = popts.opt_get_default("processes", 1)?;
     let address_file = popts.opt_str("address-file");

--- a/src/materialized/tests/cli.rs
+++ b/src/materialized/tests/cli.rs
@@ -1,0 +1,57 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+use std::time::Duration;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cmd() -> Command {
+    let mut cmd = Command::cargo_bin("materialized").unwrap();
+    cmd.env_clear()
+        .env("MZ_DEV", "1")
+        .timeout(Duration::from_secs(10));
+    cmd
+}
+
+#[test]
+fn test_threads() {
+    let assert_fail = |cmd: &mut Command| {
+        cmd.assert().failure().stderr(predicate::str::starts_with(
+            "materialized: '--threads' must be specified and greater than 0",
+        ))
+    };
+    assert_fail(&mut cmd());
+    assert_fail(cmd().arg("-w0"));
+    assert_fail(cmd().env("MZ_THREADS", "0"));
+
+    cmd()
+        .arg("-w")
+        .arg("-1")
+        .assert()
+        .failure()
+        .stderr(predicate::str::starts_with(
+            "materialized: invalid digit found in string",
+        ));
+
+    cmd()
+        .env("MZ_THREADS", OsStr::from_bytes(&[0xc2, 0xc2]))
+        .assert()
+        .failure()
+        .stderr(predicate::str::starts_with(
+            "materialized: non-unicode character found in MZ_THREADS",
+        ));
+
+    // NOTE: we don't test the successful case, where `MZ_THREADS` or `-w` is
+    // specified correctly, because it's presently hard to check if Materialized
+    // has started correctly, since it runs forever. The success code path is
+    // well exercised by integration tests, so it's not a big deal.
+}


### PR DESCRIPTION
The correct logic for this got refactored away. Forgetting to specify
`-w` could result in starting materialized with zero worker threads,
which is definitely not correct. Add a test, so it doesn't happen again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3023)
<!-- Reviewable:end -->
