### PR TITLE
mzimage: Don't announce build status if running under --mz-quiet

### DIFF
--- a/misc/python/bin/mzconduct.py
+++ b/misc/python/bin/mzconduct.py
@@ -46,6 +46,7 @@ from materialize import ui
 
 
 T = TypeVar("T")
+say = ui.speaker("C>")
 
 
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
@@ -600,9 +601,6 @@ def mzcompose_down(destroy_volumes: bool = False) -> subprocess.CompletedProcess
 
 
 # Helpers
-
-
-say = ui.speaker("C")
 
 
 def print_docker_logs(pattern: str, tail: int = 0) -> None:

--- a/misc/python/bin/mzimage.py
+++ b/misc/python/bin/mzimage.py
@@ -22,6 +22,7 @@ from materialize import ui
 
 def main() -> int:
     args = parse_args()
+    ui.Verbosity.init_from_env(explicit=None)
     root = Path(os.environ["MZ_ROOT"])
     repo = mzbuild.Repository(root)
 

--- a/misc/python/bin/mzimage.py
+++ b/misc/python/bin/mzimage.py
@@ -9,16 +9,66 @@
 #
 # mzimage.py — builds Materialize-specific Docker images.
 
-from materialize import mzbuild
-from materialize import git
-from pathlib import Path
-from typing import Any, List
 import argparse
 import os
 import sys
+from pathlib import Path
+from typing import Any, List
+
+from materialize import git
+from materialize import mzbuild
+from materialize import ui
 
 
 def main() -> int:
+    args = parse_args()
+    root = Path(os.environ["MZ_ROOT"])
+    repo = mzbuild.Repository(root)
+
+    if args.command == "list":
+        for image in repo:
+            print(image.name)
+    else:
+        if args.image not in repo.images:
+            print(f"fatal: unknown image: {args.image}", file=sys.stderr)
+            return 1
+        deps = repo.resolve_dependencies([repo.images[args.image]])
+        rimage = deps[args.image]
+        if args.command == "build":
+            deps.acquire(force_build=True)
+        elif args.command == "run":
+            deps.acquire()
+            rimage.run(args.image_args)
+        elif args.command == "acquire":
+            deps.acquire()
+        elif args.command == "fingerprint":
+            print(rimage.fingerprint())
+        elif args.command == "spec":
+            print(rimage.spec())
+        elif args.command == "describe":
+            inputs = sorted(rimage.inputs(args.transitive))
+            dependencies = sorted(rimage.list_dependencies(args.transitive))
+
+            print(f"Image: {rimage.name}")
+            print(f"Fingerprint: {rimage.fingerprint()}")
+
+            print("Input files:")
+            for inp in inputs:
+                print(f"    {inp}")
+
+            print("Dependencies:")
+            for d in dependencies:
+                print(f"    {d}")
+            if not dependencies:
+                print("    (none)")
+        else:
+            raise RuntimeError("unreachable")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse known args, or exit the program
+    """
     parser = argparse.ArgumentParser(
         prog="mzimage",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -81,54 +131,12 @@ def main() -> int:
     )
 
     args = parser.parse_args()
-
-    root = Path(os.environ["MZ_ROOT"])
-    repo = mzbuild.Repository(root)
-
     if args.command is None:
         # TODO(benesch): we can set `required=True` in the call to
         # `add_subparsers` when we upgrade to Python v3.7+.
         parser.print_help(file=sys.stderr)
-        return 1
-    elif args.command == "list":
-        for image in repo:
-            print(image.name)
-    else:
-        if args.image not in repo.images:
-            print(f"fatal: unknown image: {args.image}", file=sys.stderr)
-            return 1
-        deps = repo.resolve_dependencies([repo.images[args.image]])
-        rimage = deps[args.image]
-        if args.command == "build":
-            deps.acquire(force_build=True)
-        elif args.command == "run":
-            deps.acquire()
-            rimage.run(args.image_args)
-        elif args.command == "acquire":
-            deps.acquire()
-        elif args.command == "fingerprint":
-            print(rimage.fingerprint())
-        elif args.command == "spec":
-            print(rimage.spec())
-        elif args.command == "describe":
-            inputs = sorted(rimage.inputs(args.transitive))
-            dependencies = sorted(rimage.list_dependencies(args.transitive))
-
-            print(f"Image: {rimage.name}")
-            print(f"Fingerprint: {rimage.fingerprint()}")
-
-            print("Input files:")
-            for inp in inputs:
-                print(f"    {inp}")
-
-            print("Dependencies:")
-            for d in dependencies:
-                print(f"    {d}")
-            if not dependencies:
-                print("    (none)")
-        else:
-            raise RuntimeError("unreachable")
-    return 0
+        sys.exit(1)
+    return args
 
 
 if __name__ == "__main__":

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -17,9 +17,6 @@ documentation][user-docs].
 
 from collections import OrderedDict
 from functools import lru_cache
-from materialize import cargo
-from materialize import git
-from materialize import spawn
 from pathlib import Path
 from tempfile import TemporaryFile
 from typing import (
@@ -48,7 +45,15 @@ import shutil
 import stat
 import subprocess
 import sys
+
 import yaml
+
+from materialize import cargo
+from materialize import git
+from materialize import spawn
+from materialize import ui
+
+announce = ui.speaker("==>")
 
 
 class Fingerprint(bytes):
@@ -585,13 +590,13 @@ class DependencySet:
             spec = d.spec()
             if spec not in known_images:
                 if force_build:
-                    print(f"==> Force-building {spec}")
+                    announce(f"Force-building {spec}")
                     d.build()
                 else:
-                    print(f"==> Acquiring {spec}")
+                    announce(f"Acquiring {spec}")
                     acquired_from = d.acquire()
             else:
-                print(f"==> Already built {spec}")
+                announce(f"Already built {spec}")
 
     def __iter__(self) -> Iterator[ResolvedImage]:
         return iter(self.dependencies.values())


### PR DESCRIPTION
This uses the verbosity info provided by mzcompose in the previous commit in order to silence some things that we don't super care about most of the time.

---

We should consider switching over to the logging framework, tbh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3031)
<!-- Reviewable:end -->
