### PR TITLE
Add conn_id to Session

### DIFF
--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -63,6 +63,7 @@ pub struct Catalog {
     by_id: BTreeMap<GlobalId, CatalogEntry>,
     indexes: HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
     ambient_schemas: Schemas,
+    temporary_schemas: HashMap<u32, Schemas>,
     storage: Arc<Mutex<sql::Connection>>,
     creation_time: SystemTime,
     nonce: u64,
@@ -245,6 +246,7 @@ impl Catalog {
             by_id: BTreeMap::new(),
             indexes: HashMap::new(),
             ambient_schemas: Schemas(BTreeMap::new()),
+            temporary_schemas: HashMap::new(),
             storage: Arc::new(Mutex::new(storage)),
             creation_time: SystemTime::now(),
             nonce: rand::random(),
@@ -427,6 +429,13 @@ impl Catalog {
                 None => Err(Error::new(ErrorKind::UnknownDatabase(name.to_owned()))),
             },
         }
+    }
+
+    /// Creates a new schema in the `Catalog` for temporary items
+    /// indicated by the TEMPORARY or TEMP keywords.
+    pub fn create_temporary_schema(&mut self, connection_id: u32) {
+        self.temporary_schemas
+            .insert(connection_id, Schemas(BTreeMap::new()));
     }
 
     /// Gets the schema map for the database matching `database_spec`.

--- a/src/coord/command.rs
+++ b/src/coord/command.rs
@@ -39,7 +39,6 @@ pub enum Command {
     Execute {
         portal_name: String,
         session: Session,
-        conn_id: u32,
         tx: futures::channel::oneshot::Sender<Response<ExecuteResponse>>,
     },
 

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -323,6 +323,8 @@ where
                     if self.catalog.database_resolver(session.database()).is_err() {
                         messages.push(StartupMessage::UnknownSessionDatabase);
                     }
+                    self.catalog
+                        .create_temporary_schema(session.connection_id());
                     ClientTransmitter::new(tx).send(Ok(messages), session)
                 }
                 Message::Command(Command::Execute {

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -70,7 +70,6 @@ pub enum Message {
         offset: i64,
     },
     StatementReady {
-        conn_id: u32,
         session: Session,
         tx: ClientTransmitter<ExecuteResponse>,
         result: Result<sql::Statement, failure::Error>,
@@ -329,7 +328,6 @@ where
                 Message::Command(Command::Execute {
                     portal_name,
                     session,
-                    conn_id,
                     tx,
                 }) => {
                     let result = session
@@ -367,7 +365,6 @@ where
                                         session,
                                         tx: ClientTransmitter::new(tx),
                                         result,
-                                        conn_id,
                                         params,
                                     })
                                     .await
@@ -384,15 +381,12 @@ where
                 }
 
                 Message::StatementReady {
-                    conn_id,
                     session,
                     tx,
                     result,
                     params,
                 } => match result.and_then(|stmt| self.handle_statement(&session, stmt, &params)) {
-                    Ok((pcx, plan)) => {
-                        self.sequence_plan(&internal_cmd_tx, tx, session, pcx, plan, conn_id)
-                    }
+                    Ok((pcx, plan)) => self.sequence_plan(&internal_cmd_tx, tx, session, pcx, plan),
                     Err(e) => tx.send(Err(e), session),
                 },
 
@@ -556,7 +550,6 @@ where
         mut session: Session,
         pcx: PlanContext,
         plan: Plan,
-        conn_id: u32,
     ) {
         match plan {
             Plan::CreateDatabase {
@@ -672,7 +665,7 @@ where
                 finishing,
                 materialize,
             } => tx.send(
-                self.sequence_peek(conn_id, source, when, finishing, materialize),
+                self.sequence_peek(session.conn_id(), source, when, finishing, materialize),
                 session,
             ),
 
@@ -680,7 +673,10 @@ where
                 id,
                 ts,
                 with_snapshot,
-            } => tx.send(self.sequence_tail(conn_id, id, with_snapshot, ts), session),
+            } => tx.send(
+                self.sequence_tail(session.conn_id(), id, with_snapshot, ts),
+                session,
+            ),
 
             Plan::SendRows(rows) => tx.send(Ok(send_immediate_rows(rows)), session),
 

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -323,8 +323,7 @@ where
                     if self.catalog.database_resolver(session.database()).is_err() {
                         messages.push(StartupMessage::UnknownSessionDatabase);
                     }
-                    self.catalog
-                        .create_temporary_schema(session.connection_id());
+                    self.catalog.create_temporary_schema(session.conn_id());
                     ClientTransmitter::new(tx).send(Ok(messages), session)
                 }
                 Message::Command(Command::Execute {

--- a/src/pgwire/protocol.rs
+++ b/src/pgwire/protocol.rs
@@ -324,7 +324,6 @@ where
             .send(coord::Command::Execute {
                 portal_name: portal_name.clone(),
                 session,
-                conn_id: self.conn_id,
                 tx,
             })
             .await?;
@@ -535,7 +534,6 @@ where
             .send(coord::Command::Execute {
                 portal_name: portal_name.clone(),
                 session,
-                conn_id: self.conn_id,
                 tx,
             })
             .await?;

--- a/src/pgwire/server.rs
+++ b/src/pgwire/server.rs
@@ -68,7 +68,7 @@ impl Server {
                         secret_key: self.secrets.get(conn_id).unwrap(),
                         cmdq_tx: self.cmdq_tx.clone(),
                     };
-                    let res = machine.start(Session::default(), version, params).await;
+                    let res = machine.start(Session::new(conn_id), version, params).await;
 
                     // Clean up state tied to this specific connection.
                     self.cmdq_tx

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -247,7 +247,7 @@ mod tests {
     fn normalized_create() {
         let scx = &StatementContext {
             pcx: &PlanContext::default(),
-            session: &Session::default(),
+            session: &Session::new(0),
             catalog: &DummyCatalog,
         };
 

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -247,7 +247,7 @@ mod tests {
     fn normalized_create() {
         let scx = &StatementContext {
             pcx: &PlanContext::default(),
-            session: &Session::new(0),
+            session: &Session::dummy(),
             catalog: &DummyCatalog,
         };
 

--- a/src/sql/session/session.rs
+++ b/src/sql/session/session.rs
@@ -89,6 +89,8 @@ const TIMEZONE: ServerVar<&str> = ServerVar {
     description: "Sets the time zone for displaying and interpreting time stamps (PostgreSQL).",
 };
 
+const DUMMY_CONNECTION_ID: u32 = 0;
+
 /// A `Session` holds SQL state that is attached to a session.
 pub struct Session {
     application_name: SessionVar<str>,
@@ -134,6 +136,7 @@ impl fmt::Debug for Session {
 impl Session {
     /// Given a connection id, provides a new session with default values.
     pub fn new(conn_id: u32) -> Session {
+        assert_ne!(conn_id, DUMMY_CONNECTION_ID);
         Session {
             application_name: SessionVar::new(&APPLICATION_NAME),
             client_encoding: CLIENT_ENCODING,
@@ -153,7 +156,7 @@ impl Session {
 
     /// Returns a Session containing a dummy connection id.
     pub fn dummy() -> Session {
-        Session::new(0)
+        Session::new(DUMMY_CONNECTION_ID)
     }
 
     /// Returns the connection id of a session

--- a/src/sql/session/session.rs
+++ b/src/sql/session/session.rs
@@ -91,7 +91,6 @@ const TIMEZONE: ServerVar<&str> = ServerVar {
 
 /// A `Session` holds SQL state that is attached to a session.
 pub struct Session {
-    connection_id: u32,
     application_name: SessionVar<str>,
     client_encoding: ServerVar<&'static str>,
     database: SessionVar<str>,
@@ -101,6 +100,7 @@ pub struct Session {
     server_version: ServerVar<&'static str>,
     sql_safe_updates: SessionVar<bool>,
     timezone: ServerVar<&'static str>,
+    conn_id: u32,
     /// The current state of the the session's transaction
     transaction: TransactionStatus,
     /// A map from statement names to SQL queries
@@ -133,9 +133,8 @@ impl fmt::Debug for Session {
 
 impl Session {
     /// Given a connection id, provides a new session with default values.
-    pub fn new(connection_id: u32) -> Session {
+    pub fn new(conn_id: u32) -> Session {
         Session {
-            connection_id,
             application_name: SessionVar::new(&APPLICATION_NAME),
             client_encoding: CLIENT_ENCODING,
             database: SessionVar::new(&DATABASE),
@@ -145,15 +144,21 @@ impl Session {
             server_version: SERVER_VERSION,
             sql_safe_updates: SessionVar::new(&SQL_SAFE_UPDATES),
             timezone: TIMEZONE,
+            conn_id,
             transaction: TransactionStatus::Idle,
             prepared_statements: HashMap::new(),
             portals: HashMap::new(),
         }
     }
 
+    /// Returns a Session containing a dummy connection id.
+    pub fn dummy() -> Session {
+        Session::new(0)
+    }
+
     /// Returns the connection id of a session
-    pub fn connection_id(&self) -> u32 {
-        self.connection_id
+    pub fn conn_id(&self) -> u32 {
+        self.conn_id
     }
 
     /// Returns all configuration parameters and their current values for this

--- a/src/sql/session/session.rs
+++ b/src/sql/session/session.rs
@@ -154,9 +154,24 @@ impl Session {
         }
     }
 
-    /// Returns a Session containing a dummy connection id.
+    /// Returns a Session using a DUMMY_CONNECTION_ID.
+    /// NOTE: Keep this in sync with ::new()
     pub fn dummy() -> Session {
-        Session::new(DUMMY_CONNECTION_ID)
+        Session {
+            application_name: SessionVar::new(&APPLICATION_NAME),
+            client_encoding: CLIENT_ENCODING,
+            database: SessionVar::new(&DATABASE),
+            date_style: DATE_STYLE,
+            extra_float_digits: SessionVar::new(&EXTRA_FLOAT_DIGITS),
+            search_path: SEARCH_PATH,
+            server_version: SERVER_VERSION,
+            sql_safe_updates: SessionVar::new(&SQL_SAFE_UPDATES),
+            timezone: TIMEZONE,
+            conn_id: DUMMY_CONNECTION_ID,
+            transaction: TransactionStatus::Idle,
+            prepared_statements: HashMap::new(),
+            portals: HashMap::new(),
+        }
     }
 
     /// Returns the connection id of a session

--- a/src/sql/session/session.rs
+++ b/src/sql/session/session.rs
@@ -91,6 +91,7 @@ const TIMEZONE: ServerVar<&str> = ServerVar {
 
 /// A `Session` holds SQL state that is attached to a session.
 pub struct Session {
+    connection_id: u32,
     application_name: SessionVar<str>,
     client_encoding: ServerVar<&'static str>,
     database: SessionVar<str>,
@@ -130,10 +131,11 @@ impl fmt::Debug for Session {
     }
 }
 
-impl Default for Session {
-    /// Constructs a new `Session` with default values.
-    fn default() -> Session {
+impl Session {
+    /// Given a connection id, provides a new session with default values.
+    pub fn new(connection_id: u32) -> Session {
         Session {
+            connection_id,
             application_name: SessionVar::new(&APPLICATION_NAME),
             client_encoding: CLIENT_ENCODING,
             database: SessionVar::new(&DATABASE),
@@ -148,9 +150,12 @@ impl Default for Session {
             portals: HashMap::new(),
         }
     }
-}
 
-impl Session {
+    /// Returns the connection id of a session
+    pub fn connection_id(&self) -> u32 {
+        self.connection_id
+    }
+
     /// Returns all configuration parameters and their current values for this
     /// session.
     pub fn vars(&self) -> Vec<&dyn Var> {

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -17,7 +17,7 @@ use sql::Session;
 #[test]
 fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     let catalog = DummyCatalog;
-    let session = Session::new(0);
+    let session = Session::dummy();
     let test_cases = vec![
         (
             "SELECT $1, $2, $3",

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -17,7 +17,7 @@ use sql::Session;
 #[test]
 fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     let catalog = DummyCatalog;
-    let session = Session::default();
+    let session = Session::new(0);
     let test_cases = vec![
         (
             "SELECT $1, $2, $3",

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -282,7 +282,6 @@ pub(crate) struct State {
     _coord_thread: JoinOnDropHandle<()>,
     _runtime: tokio::runtime::Runtime,
     session: Session,
-    conn_id: u32,
 }
 
 fn format_row(
@@ -430,7 +429,6 @@ impl State {
             _coord_thread: coord_thread,
             _runtime: runtime,
             session: Session::dummy(),
-            conn_id: 1,
         })
     }
 
@@ -768,7 +766,6 @@ impl State {
                 .unbounded_send(coord::Command::Execute {
                     portal_name,
                     session: mem::replace(&mut self.session, Session::dummy()),
-                    conn_id: self.conn_id,
                     tx,
                 })
                 .expect("futures channel should not fail");

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -58,8 +58,6 @@ use sql_parser::parser::{Parser as SqlParser, ParserError as SqlParserError};
 use crate::ast::{Mode, Output, QueryOutput, Record, Sort, Type};
 use crate::util;
 
-const CONNECTION_ID: u32 = 0;
-
 #[derive(Debug)]
 pub enum Outcome<'a> {
     Unsupported {
@@ -431,7 +429,7 @@ impl State {
             _dataflow_workers: Box::new(dataflow_workers),
             _coord_thread: coord_thread,
             _runtime: runtime,
-            session: Session::new(CONNECTION_ID),
+            session: Session::dummy(),
             conn_id: 1,
         })
     }
@@ -744,7 +742,7 @@ impl State {
                 .unbounded_send(coord::Command::Describe {
                     name: statement_name.clone(),
                     stmt: Some(stmt),
-                    session: mem::replace(&mut self.session, Session::new(CONNECTION_ID)),
+                    session: mem::replace(&mut self.session, Session::dummy()),
                     tx,
                 })
                 .expect("futures channel should not fail");
@@ -769,7 +767,7 @@ impl State {
             self.cmd_tx
                 .unbounded_send(coord::Command::Execute {
                     portal_name,
-                    session: mem::replace(&mut self.session, Session::new(CONNECTION_ID)),
+                    session: mem::replace(&mut self.session, Session::dummy()),
                     conn_id: self.conn_id,
                     tx,
                 })


### PR DESCRIPTION
This PR updates the `Session` struct to store a u32 `conn_id` -- the unique connection id for the client connecting to a materialized server. This change is required to generate a temporary schema for each connection id, allowing us to support statements such as `CREATE TEMPORARY VIEW`.

This PR also removes `conn_id` from a few places where it can now be grabbed off the `Session` instead.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3033)
<!-- Reviewable:end -->
