### PR TITLE
Parse CREATE TEMP/TEMPORARY VIEW

### DIFF
--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -911,6 +911,7 @@ pub enum Statement {
         columns: Vec<Ident>,
         query: Box<Query>,
         if_exists: IfExistsBehavior,
+        temporary: bool,
         materialized: bool,
         with_options: Vec<SqlOption>,
     },
@@ -1228,6 +1229,7 @@ impl AstDisplay for Statement {
                 name,
                 columns,
                 query,
+                temporary,
                 materialized,
                 if_exists,
                 with_options,
@@ -1235,6 +1237,9 @@ impl AstDisplay for Statement {
                 f.write_str("CREATE");
                 if *if_exists == IfExistsBehavior::Replace {
                     f.write_str(" OR REPLACE");
+                }
+                if *temporary {
+                    f.write_str(" TEMPORARY");
                 }
                 if *materialized {
                     f.write_str(" MATERIALIZED");

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -435,11 +435,12 @@ macro_rules! make_visitor {
                 name: &'ast $($mut)* ObjectName,
                 columns: &'ast $($mut)* [Ident],
                 query: &'ast $($mut)* Query,
+                temporary: bool,
                 materialized: bool,
                 if_exists: IfExistsBehavior,
                 with_options: &'ast $($mut)* [SqlOption],
             ) {
-                visit_create_view(self, name, columns, query, materialized, if_exists, with_options)
+                visit_create_view(self, name, columns, query, temporary, materialized, if_exists, with_options)
             }
 
             fn visit_create_index(
@@ -710,10 +711,11 @@ macro_rules! make_visitor {
                     name,
                     columns,
                     query,
+                    temporary,
                     materialized,
                     if_exists,
                     with_options,
-                } => visitor.visit_create_view(name, columns, query, *materialized, *if_exists, with_options),
+                } => visitor.visit_create_view(name, columns, query, *temporary, *materialized, *if_exists, with_options),
                 Statement::CreateIndex {
                     name,
                     on_name,
@@ -1510,6 +1512,7 @@ macro_rules! make_visitor {
             name: &'ast $($mut)* ObjectName,
             columns: &'ast $($mut)* [Ident],
             query: &'ast $($mut)* Query,
+            _temporary: bool,
             _materialized: bool,
             _if_exists: IfExistsBehavior,
             with_options: &'ast $($mut)* [SqlOption],

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -440,6 +440,8 @@ define_keywords!(
     TABLES,
     TABLESAMPLE,
     TAIL,
+    TEMP,
+    TEMPORARY,
     TEXT,
     THEN,
     TIES,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1098,6 +1098,18 @@ impl Parser {
         } else if self.parse_keyword("OR") || self.parse_keyword("VIEW") {
             self.prev_token();
             self.parse_create_view()
+        } else if self.parse_keyword("TEMP") || self.parse_keyword("TEMPORARY") {
+            if self.parse_keyword("VIEW") {
+                self.prev_token();
+                self.prev_token();
+                self.parse_create_view()
+            } else {
+                self.expected(
+                    self.peek_range(),
+                    "VIEW after CREATE TEMPORARY",
+                    self.peek_token(),
+                )
+            }
         } else if self.parse_keyword("MATERIALIZED") {
             if self.parse_keyword("VIEW") {
                 self.prev_token();
@@ -1360,6 +1372,7 @@ impl Parser {
         } else {
             IfExistsBehavior::Error
         };
+        let temporary = self.parse_keyword("TEMPORARY") | self.parse_keyword("TEMP");
         let materialized = self.parse_keyword("MATERIALIZED");
         self.expect_keyword("VIEW")?;
         if if_exists == IfExistsBehavior::Error && self.parse_if_not_exists()? {
@@ -1378,6 +1391,7 @@ impl Parser {
             name,
             columns,
             query,
+            temporary,
             materialized,
             if_exists,
             with_options,

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -2829,7 +2829,7 @@ fn parse_create_view() {
             name,
             columns,
             query,
-            temporary: _,
+            temporary,
             materialized,
             if_exists,
             with_options,
@@ -2837,6 +2837,57 @@ fn parse_create_view() {
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<Ident>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(!temporary);
+            assert!(!materialized);
+            assert_eq!(if_exists, IfExistsBehavior::Error);
+            assert_eq!(with_options, vec![]);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_temp_view() {
+    let sql = "CREATE TEMP VIEW myview AS SELECT foo FROM bar";
+    match verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            query,
+            temporary,
+            materialized,
+            if_exists,
+            with_options,
+        } => {
+            assert_eq!("myschema.myview", name.to_string());
+            assert_eq!(Vec::<Ident>::new(), columns);
+            assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(temporary);
+            assert!(!materialized);
+            assert_eq!(if_exists, IfExistsBehavior::Error);
+            assert_eq!(with_options, vec![]);
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn parse_create_tempprary_view() {
+    let sql = "CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar";
+    match verified_stmt(sql) {
+        Statement::CreateView {
+            name,
+            columns,
+            query,
+            temporary,
+            materialized,
+            if_exists,
+            with_options,
+        } => {
+            assert_eq!("myschema.myview", name.to_string());
+            assert_eq!(Vec::<Ident>::new(), columns);
+            assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(temporary);
             assert!(!materialized);
             assert_eq!(if_exists, IfExistsBehavior::Error);
             assert_eq!(with_options, vec![]);
@@ -2907,7 +2958,7 @@ fn parse_create_view_with_columns() {
             columns,
             with_options,
             query,
-            temporary: _,
+            temporary,
             materialized,
             if_exists,
         } => {
@@ -2915,6 +2966,7 @@ fn parse_create_view_with_columns() {
             assert_eq!(columns, vec![Ident::new("has"), Ident::new("cols")]);
             assert_eq!(with_options, vec![]);
             assert_eq!("SELECT 1, 2", query.to_string());
+            assert!(!temporary);
             assert!(!materialized);
             assert_eq!(if_exists, IfExistsBehavior::Error);
         }
@@ -2930,7 +2982,7 @@ fn parse_create_materialized_view() {
             name,
             columns,
             query,
-            temporary: _,
+            temporary,
             materialized,
             if_exists,
             with_options,
@@ -2938,6 +2990,7 @@ fn parse_create_materialized_view() {
             assert_eq!("myschema.myview", name.to_string());
             assert_eq!(Vec::<Ident>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
+            assert!(!temporary);
             assert!(materialized);
             assert_eq!(if_exists, IfExistsBehavior::Error);
             assert_eq!(with_options, vec![]);

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -2879,8 +2879,7 @@ fn parse_create_temporary_view() {
 #[test]
 fn parse_create_temp_view() {
     let sql = "CREATE TEMP VIEW myview AS SELECT foo FROM bar";
-    let expected = "CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar";
-    let stmt = verified_stmt_alt(sql, expected);
+    let stmt = unverified_stmt(sql);
     assert_eq!(
         "CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar",
         stmt.to_string()
@@ -5040,12 +5039,6 @@ fn one_statement_parses_to(sql: &str, canonical: &str) -> Statement {
 
 fn verified_stmt(query: &str) -> Statement {
     one_statement_parses_to(query, query)
-}
-
-/// Instead of expecting `query` to parse to `query`, expect it to parse
-/// to an alternate string: `expected_query`.
-fn verified_stmt_alt(query: &str, expected_query: &str) -> Statement {
-    one_statement_parses_to(query, expected_query)
 }
 
 fn unverified_stmt(query: &str) -> Statement {

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -2829,6 +2829,7 @@ fn parse_create_view() {
             name,
             columns,
             query,
+            temporary: _,
             materialized,
             if_exists,
             with_options,
@@ -2906,6 +2907,7 @@ fn parse_create_view_with_columns() {
             columns,
             with_options,
             query,
+            temporary: _,
             materialized,
             if_exists,
         } => {
@@ -2928,6 +2930,7 @@ fn parse_create_materialized_view() {
             name,
             columns,
             query,
+            temporary: _,
             materialized,
             if_exists,
             with_options,

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -2847,34 +2847,14 @@ fn parse_create_view() {
 }
 
 #[test]
-fn parse_create_temp_view() {
-    let sql = "CREATE TEMP VIEW myview AS SELECT foo FROM bar";
-    match verified_stmt(sql) {
-        Statement::CreateView {
-            name,
-            columns,
-            query,
-            temporary,
-            materialized,
-            if_exists,
-            with_options,
-        } => {
-            assert_eq!("myschema.myview", name.to_string());
-            assert_eq!(Vec::<Ident>::new(), columns);
-            assert_eq!("SELECT foo FROM bar", query.to_string());
-            assert!(temporary);
-            assert!(!materialized);
-            assert_eq!(if_exists, IfExistsBehavior::Error);
-            assert_eq!(with_options, vec![]);
-        }
-        _ => unreachable!(),
-    }
-}
-
-#[test]
-fn parse_create_tempprary_view() {
+fn parse_create_temporary_view() {
     let sql = "CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar";
-    match verified_stmt(sql) {
+    let stmt = verified_stmt(sql);
+    assert_eq!(
+        "CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar",
+        stmt.to_string()
+    );
+    match stmt {
         Statement::CreateView {
             name,
             columns,
@@ -2884,7 +2864,7 @@ fn parse_create_tempprary_view() {
             if_exists,
             with_options,
         } => {
-            assert_eq!("myschema.myview", name.to_string());
+            assert_eq!("myview", name.to_string());
             assert_eq!(Vec::<Ident>::new(), columns);
             assert_eq!("SELECT foo FROM bar", query.to_string());
             assert!(temporary);

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -196,6 +196,7 @@ pub fn create_statement(
             name,
             columns: _,
             query,
+            temporary: _,
             materialized,
             if_exists,
             with_options: _,

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -882,17 +882,29 @@ fn handle_create_view(
     params: &Params,
 ) -> Result<Plan, failure::Error> {
     let create_sql = normalize::create_statement(scx, stmt.clone())?;
-    let (name, columns, query, materialized, if_exists, with_options) = match &mut stmt {
+    let (name, columns, query, temporary, materialized, if_exists, with_options) = match &mut stmt {
         Statement::CreateView {
             name,
             columns,
             query,
+            temporary,
             materialized,
             if_exists,
             with_options,
-        } => (name, columns, query, materialized, if_exists, with_options),
+        } => (
+            name,
+            columns,
+            query,
+            temporary,
+            materialized,
+            if_exists,
+            with_options,
+        ),
         _ => unreachable!(),
     };
+    if *temporary {
+        bail!("TEMPORARY views are not yet supported");
+    }
     if !with_options.is_empty() {
         bail!("WITH options are not yet supported");
     }


### PR DESCRIPTION
I'm breaking the changes for https://github.com/MaterializeInc/materialize/issues/2661 into smaller PRs, this is the first one!

This PR parses the new optional keywords `TEMP` and `TEMPORARY` when creating views, but leaves it otherwise unimplemented. I tested this out locally:

```
materialize=> CREATE TEMPORARY VIEW temp_counter AS SELECT * FROM counter;
ERROR:  TEMPORARY views are not yet supported
materialize=> CREATE TEMP VIEW temp_counter AS SELECT * FROM counter;
ERROR:  TEMPORARY views are not yet supported
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3038)
<!-- Reviewable:end -->
