### PR TITLE
mzconduct: add `web` functionality that tries to launch a web browser

### DIFF
--- a/misc/python/bin/mzconduct.py
+++ b/misc/python/bin/mzconduct.py
@@ -79,6 +79,13 @@ def down(composition: str) -> None:
     comp.down()
 
 
+@cli.command()
+@click.argument("composition")
+def ps(composition: str) -> None:
+    comp = Composition.find(composition)
+    comp.ps()
+
+
 # Non-mzcompose commands
 
 
@@ -141,6 +148,10 @@ class Composition:
     def down(self) -> None:
         with cd(self._path):
             mzcompose_down()
+
+    def ps(self) -> None:
+        with cd(self._path):
+            spawn.runv(["./mzcompose", "--mz-quiet", "ps"])
 
     def run_workflow(self, workflow: str) -> None:
         with cd(self._path):


### PR DESCRIPTION
This makes it more pleasant to just specify an internal port, and be guaranteed to get a
unique ephemeral port on the host, but not have to do nearly as much copy/paste when
interacting with services.

Part of what's required for #3029


----

This branch contains a few extra ux improvements in mzconduct, it should probably be reviewed commit-by-commit.

Slightly longer term, we should find a way to generally proxy all docker-compose commands downwards using https://click.palletsprojects.com/en/7.x/advanced/#forwarding-unknown-options

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3039)
<!-- Reviewable:end -->
