### PR TITLE
Improve reasoning about columns

### DIFF
--- a/src/transform/column_knowledge.rs
+++ b/src/transform/column_knowledge.rs
@@ -144,6 +144,21 @@ impl ColumnKnowledge {
                             }
                         }
                     }
+                    if let ScalarExpr::CallUnary {
+                        func: UnaryFunc::Not,
+                        expr,
+                    } = predicate
+                    {
+                        if let ScalarExpr::CallUnary {
+                            func: UnaryFunc::IsNull,
+                            expr,
+                        } = &**expr
+                        {
+                            if let ScalarExpr::Column(c) = &**expr {
+                                input_knowledge[*c].nullable = false;
+                            }
+                        }
+                    }
                 }
 
                 input_knowledge

--- a/src/transform/column_knowledge.rs
+++ b/src/transform/column_knowledge.rs
@@ -44,12 +44,10 @@ impl ColumnKnowledge {
     ) -> Result<Vec<DatumKnowledge>, crate::TransformError> {
         Ok(match expr {
             RelationExpr::ArrangeBy { input, .. } => ColumnKnowledge::harvest(input, knowledge)?,
-            RelationExpr::Get { id, typ } => knowledge.get(id).cloned().unwrap_or_else(|| {
-                typ.column_types
-                    .iter()
-                    .map(|ct| DatumKnowledge::from(ct))
-                    .collect()
-            }),
+            RelationExpr::Get { id, typ } => knowledge
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| typ.column_types.iter().map(DatumKnowledge::from).collect()),
             RelationExpr::Constant { rows, typ } => {
                 if rows.len() == 1 {
                     rows[0]
@@ -62,10 +60,7 @@ impl ColumnKnowledge {
                         })
                         .collect()
                 } else {
-                    typ.column_types
-                        .iter()
-                        .map(|ct| DatumKnowledge::from(ct))
-                        .collect()
+                    typ.column_types.iter().map(DatumKnowledge::from).collect()
                 }
             }
             RelationExpr::Let { id, value, body } => {
@@ -105,12 +100,7 @@ impl ColumnKnowledge {
                     optimize(expr, &input.typ(), &input_knowledge[..])?;
                 }
                 let func_typ = func.output_type();
-                input_knowledge.extend(
-                    func_typ
-                        .column_types
-                        .iter()
-                        .map(|typ| DatumKnowledge::from(typ)),
-                );
+                input_knowledge.extend(func_typ.column_types.iter().map(DatumKnowledge::from));
                 input_knowledge
             }
             RelationExpr::Filter { input, predicates } => {

--- a/src/transform/column_knowledge.rs
+++ b/src/transform/column_knowledge.rs
@@ -47,10 +47,7 @@ impl ColumnKnowledge {
             RelationExpr::Get { id, typ } => knowledge.get(id).cloned().unwrap_or_else(|| {
                 typ.column_types
                     .iter()
-                    .map(|ct| DatumKnowledge {
-                        value: None,
-                        nullable: ct.nullable,
-                    })
+                    .map(|ct| DatumKnowledge::from(ct))
                     .collect()
             }),
             RelationExpr::Constant { rows, typ } => {
@@ -67,10 +64,7 @@ impl ColumnKnowledge {
                 } else {
                     typ.column_types
                         .iter()
-                        .map(|ct| DatumKnowledge {
-                            value: None,
-                            nullable: ct.nullable,
-                        })
+                        .map(|ct| DatumKnowledge::from(ct))
                         .collect()
                 }
             }
@@ -111,21 +105,47 @@ impl ColumnKnowledge {
                     optimize(expr, &input.typ(), &input_knowledge[..])?;
                 }
                 let func_typ = func.output_type();
-                input_knowledge.extend(func_typ.column_types.into_iter().map(|typ| {
-                    DatumKnowledge {
-                        value: None,
-                        nullable: typ.nullable,
-                    }
-                }));
+                input_knowledge.extend(
+                    func_typ
+                        .column_types
+                        .iter()
+                        .map(|typ| DatumKnowledge::from(typ)),
+                );
                 input_knowledge
             }
             RelationExpr::Filter { input, predicates } => {
-                let input_knowledge = ColumnKnowledge::harvest(input, knowledge)?;
+                let mut input_knowledge = ColumnKnowledge::harvest(input, knowledge)?;
                 for predicate in predicates.iter_mut() {
                     optimize(predicate, &input.typ(), &input_knowledge[..])?;
                 }
                 // If any predicate tests a column for equality, truth, or is_null, we learn stuff.
-                // I guess we implement that later on.
+                for predicate in predicates.iter() {
+                    // Equality tests allow us to unify the column knowledge of each input.
+                    if let ScalarExpr::CallBinary { func, expr1, expr2 } = predicate {
+                        if func == &expr::BinaryFunc::Eq {
+                            // Collect knowledge about the inputs (for columns and literals).
+                            let mut knowledge = DatumKnowledge::default();
+                            if let ScalarExpr::Column(c) = &**expr1 {
+                                knowledge.absorb(&input_knowledge[*c]);
+                            }
+                            if let ScalarExpr::Column(c) = &**expr2 {
+                                knowledge.absorb(&input_knowledge[*c]);
+                            }
+                            // Absorb literal knowledge about columns.
+                            knowledge.absorb(&DatumKnowledge::from(&**expr1));
+                            knowledge.absorb(&DatumKnowledge::from(&**expr2));
+
+                            // Write back unified knowledge to each column.
+                            if let ScalarExpr::Column(c) = &**expr1 {
+                                input_knowledge[*c].absorb(&knowledge);
+                            }
+                            if let ScalarExpr::Column(c) = &**expr2 {
+                                input_knowledge[*c].absorb(&knowledge);
+                            }
+                        }
+                    }
+                }
+
                 input_knowledge
             }
             RelationExpr::Join {
@@ -141,16 +161,14 @@ impl ColumnKnowledge {
                 }
 
                 for equivalence in equivalences.iter_mut() {
-                    let mut knowledge = DatumKnowledge {
-                        value: None,
-                        nullable: true,
-                    };
+                    let mut knowledge = DatumKnowledge::default();
 
                     // We can produce composite knowledge for everything in the equivalence class.
                     for expr in equivalence.iter_mut() {
                         if let ScalarExpr::Column(c) = expr {
                             knowledge.absorb(&knowledges[*c]);
                         }
+                        knowledge.absorb(&DatumKnowledge::from(&*expr));
                     }
                     for expr in equivalence.iter_mut() {
                         if let ScalarExpr::Column(c) = expr {
@@ -171,12 +189,52 @@ impl ColumnKnowledge {
                     .iter_mut()
                     .map(|k| optimize(k, &input.typ(), &input_knowledge[..]))
                     .collect::<Result<Vec<_>, _>>()?;
-                for _aggregate in aggregates {
+                for aggregate in aggregates.iter_mut() {
+                    use expr::AggregateFunc;
+                    let knowledge =
+                        optimize(&mut aggregate.expr, &input.typ(), &input_knowledge[..])?;
                     // This could be improved.
-                    output.push(DatumKnowledge {
-                        value: None,
-                        nullable: true,
-                    });
+                    let knowledge = match aggregate.func {
+                        AggregateFunc::MaxInt32
+                        | AggregateFunc::MaxInt64
+                        | AggregateFunc::MaxFloat32
+                        | AggregateFunc::MaxFloat64
+                        | AggregateFunc::MaxDecimal
+                        | AggregateFunc::MaxBool
+                        | AggregateFunc::MaxString
+                        | AggregateFunc::MaxDate
+                        | AggregateFunc::MaxTimestamp
+                        | AggregateFunc::MaxTimestampTz
+                        | AggregateFunc::MaxNull
+                        | AggregateFunc::MinInt32
+                        | AggregateFunc::MinInt64
+                        | AggregateFunc::MinFloat32
+                        | AggregateFunc::MinFloat64
+                        | AggregateFunc::MinDecimal
+                        | AggregateFunc::MinBool
+                        | AggregateFunc::MinString
+                        | AggregateFunc::MinDate
+                        | AggregateFunc::MinTimestamp
+                        | AggregateFunc::MinTimestampTz
+                        | AggregateFunc::MinNull
+                        | AggregateFunc::Any
+                        | AggregateFunc::All => {
+                            // These methods propagate constant values exactly.
+                            knowledge
+                        }
+                        AggregateFunc::CountAll => DatumKnowledge {
+                            value: None,
+                            nullable: false,
+                        },
+                        _ => {
+                            // All aggregates are non-null if their inputs are non-null.
+                            DatumKnowledge {
+                                value: None,
+                                nullable: knowledge.nullable,
+                            }
+                        }
+                    };
+                    output.push(knowledge);
                 }
                 output
             }
@@ -214,10 +272,42 @@ pub struct DatumKnowledge {
 }
 
 impl DatumKnowledge {
+    // Intersects the two knowledge about a column.
     fn absorb(&mut self, other: &Self) {
         self.nullable &= other.nullable;
         if self.value.is_none() {
             self.value = other.value.clone()
+        }
+    }
+}
+
+impl Default for DatumKnowledge {
+    fn default() -> Self {
+        Self {
+            value: None,
+            nullable: true,
+        }
+    }
+}
+
+impl From<&ScalarExpr> for DatumKnowledge {
+    fn from(expr: &ScalarExpr) -> Self {
+        if let ScalarExpr::Literal(Ok(l), t) = expr {
+            Self {
+                value: Some((l.clone(), t.clone())),
+                nullable: expr.is_literal_null(),
+            }
+        } else {
+            Self::default()
+        }
+    }
+}
+
+impl From<&ColumnType> for DatumKnowledge {
+    fn from(typ: &ColumnType) -> Self {
+        Self {
+            value: None,
+            nullable: typ.nullable,
         }
     }
 }
@@ -262,10 +352,7 @@ pub fn optimize(
                 );
                 optimize(expr, input_type, column_knowledge)?
             } else {
-                DatumKnowledge {
-                    value: None,
-                    nullable: true,
-                }
+                DatumKnowledge::default()
             }
         }
         ScalarExpr::CallBinary {
@@ -279,10 +366,7 @@ pub fn optimize(
                 expr.reduce(input_type);
                 optimize(expr, input_type, column_knowledge)?
             } else {
-                DatumKnowledge {
-                    value: None,
-                    nullable: true,
-                }
+                DatumKnowledge::default()
             }
         }
         ScalarExpr::CallVariadic { func: _, exprs } => {
@@ -295,10 +379,7 @@ pub fn optimize(
                 expr.reduce(input_type);
                 optimize(expr, input_type, column_knowledge)?
             } else {
-                DatumKnowledge {
-                    value: None,
-                    nullable: true,
-                }
+                DatumKnowledge::default()
             }
         }
         ScalarExpr::If { cond, then, els } => {
@@ -310,10 +391,7 @@ pub fn optimize(
                 }
                 optimize(expr, input_type, column_knowledge)?
             } else {
-                DatumKnowledge {
-                    value: None,
-                    nullable: true,
-                }
+                DatumKnowledge::default()
             }
         }
     })

--- a/src/transform/lib.rs
+++ b/src/transform/lib.rs
@@ -228,6 +228,7 @@ impl Default for Optimizer {
                     Box::new(crate::redundant_join::RedundantJoin),
                     Box::new(crate::topk_elision::TopKElision),
                     Box::new(crate::reduction::NegatePredicate),
+                    Box::new(crate::demand::Demand),
                 ],
             }),
             // As a final logical action, convert any constant expression to a constant.
@@ -246,10 +247,12 @@ impl Default for Optimizer {
                     Box::new(crate::join_implementation::JoinImplementation),
                     Box::new(crate::fusion::filter::Filter),
                     Box::new(crate::demand::Demand),
+                    Box::new(crate::map_lifting::LiteralLifting),
                 ],
             }),
             Box::new(crate::fusion::project::Project),
             Box::new(crate::reduction_pushdown::ReductionPushdown),
+            Box::new(crate::reduction::FoldConstants),
         ];
         Self { transforms }
     }

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1678,7 +1678,7 @@ ORDER BY
 
 %11 =
 | Get %9
-| ArrangeBy (#7, #0)
+| ArrangeBy (#0, #7)
 
 %12 =
 | Get %10
@@ -1707,7 +1707,7 @@ ORDER BY
 
 %18 =
 | Join %11 %16 %17 (= #0 #39 #41) (= #7 #38 #40)
-| | implementation = Differential %16 %17.(#0, #1) %11.(#7, #0)
+| | implementation = Differential %16 %17.(#0, #1) %11.(#0, #7)
 | | demand = (#1)
 | Reduce group=(#1) countall(null)
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -21,7 +21,6 @@ EXPLAIN PLAN FOR SELECT b FROM (SELECT b, not(b) as neg FROM x) WHERE NOT(neg)
 %0 =
 | Get materialize.public.x (u1)
 | Filter #2
-| Map null
 | Project (#2)
 
 EOF
@@ -32,7 +31,6 @@ EXPLAIN PLAN FOR SELECT b FROM (SELECT b, b = false as neg FROM x) WHERE NOT(neg
 %0 =
 | Get materialize.public.x (u1)
 | Filter (#2 != false)
-| Map null
 | Project (#2)
 
 EOF
@@ -46,7 +44,6 @@ EXPLAIN PLAN FOR
 %0 =
 | Get materialize.public.x (u1)
 | Filter (#1 = 2), (#0 != 3)
-| Map false, null
 | Project (#0)
 
 EOF


### PR DESCRIPTION
This PR improves the `column_knowledge.rs` transform which pushes information about columns (equal to specific values, nonnullable) towards the query root, allowing simplification of expressions. Several useful bits of information were previously ignored, specifically predicates that test for equality to literals, and not(isnull).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3040)
<!-- Reviewable:end -->
