### PR TITLE
pycheck: always run from the root of the repo

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -16,7 +16,9 @@
 
 set -euo pipefail
 
-root=$(cd "$(dirname "$0")/.." && pwd)
+# work from the root of the repo, even if being executed from somewhere else
+cd "$(dirname "$0")/.."
+root=$(pwd)
 
 # shellcheck source=SCRIPTDIR/../misc/shlib/shlib.bash
 . "$root"/misc/shlib/shlib.bash
@@ -38,7 +40,7 @@ mapfile_shim py_dirs < <(echo "${py_files[@]}" | xargs -n 1 dirname | sort -u)
 
 try "$root"/bin/pyactivate --dev -m compileall -q -l "${py_dirs[@]}"
 if $last_failed; then
-    echo "$(uw Error): python syntax errors, this may cause nonsensical errors to follow"
+    echo "$(uw Error): python syntax errors found"
 fi
 
 try "$root"/bin/pyactivate --dev -m mypy --pretty "${py_files[@]}"


### PR DESCRIPTION
My experience is that it only works if run from the root, so we should make that the
default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3041)
<!-- Reviewable:end -->
