### PR TITLE
Kafka Source refactor

### DIFF
--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -385,13 +385,13 @@ impl ControlPlaneInfo {
     fn get_partition_count(&self) -> i32 {
         // The number of partitions is always guaranteed to be smaller or equal than
         // expected_partition_count (i32)
-        return self.partition_metadata.len().try_into().unwrap();
+        self.partition_metadata.len().try_into().unwrap()
     }
 
     /// Returns true if we currently know of particular partition. We know (and have updated the
     /// metadata for this partition) if there is an entry for it
     fn knows_of(&self, pid: i32) -> bool {
-        return pid < self.get_partition_count();
+        pid < self.get_partition_count()
     }
 
     /// Updates the underlying partition metadata structure ot the expected partition count.

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -272,3 +272,82 @@ b  sum
 9  1
 10 1
 11 1
+
+$ kafka-create-topic topic=data-consistency2
+
+$ kafka-create-topic topic=data-multi partitions=2
+
+$ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 1, "offset": 0}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 1, "offset": 0}
+
+
+> CREATE MATERIALIZED SOURCE data_multi
+    FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-multi-${testdrive.seed}'
+    WITH (consistency = 'testdrive-data-consistency2-${testdrive.seed}')
+    FORMAT AVRO USING SCHEMA '${schema}'
+
+
+! SELECT * FROM data_multi;
+At least one input has no complete timestamps yet.
+
+
+$ kafka-ingest partition=0 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 0, "b": 1}
+
+
+$ kafka-ingest partition=1 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 1, "b": 1}
+
+
+! SELECT * FROM data_multi;
+At least one input has no complete timestamps yet.
+
+$ kafka-add-partitions topic=data-multi total-partitions=4
+
+
+$ kafka-ingest partition=2 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 2, "b": 1}
+
+$ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 2, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 2, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 2, "timestamp": 2, "offset": 0}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 2, "offset": 1}
+
+$ kafka-ingest partition=3 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 3, "b": 1}
+
+
+> SELECT * FROM data_multi
+a  b
+------
+0  1
+1  1
+3  1
+
+$ kafka-ingest partition=0 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 0, "b": 2}
+$ kafka-ingest partition=3 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 1, "b": 2}
+$ kafka-ingest partition=1 format=avro topic=data-multi schema=${schema} timestamp=1
+{"a": 3, "b": 2}
+
+
+$ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 2, "timestamp": 3, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 3, "offset": 2}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 3, "offset": 2}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 3, "offset": 2}
+
+
+> SELECT * FROM data_multi
+a  b
+------
+0  1
+1  1
+3  1
+2  1
+0  2
+1  2
+3  2


### PR DESCRIPTION
This PR is the more significant Kafka refactor. 

1) It cleans up the code control-flow significantly. Refreshing metadata no longer causes the function to exit early
2) It breaks down different logical components into dataplane/control plane methods
3) It hides the fast-forwarding logic inside a get_next_message method to avoid keeping track of separate consumer datastructures
4) it adds a number of assertions throughout.
5) it creates a separate buffer per partition to keep track of messages that cannot yet be timestamped.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3046)
<!-- Reviewable:end -->
