### PR TITLE
coord,dataflow: allow control of librdkafka debug logs with MZ_LOG

### DIFF
--- a/src/coord/timestamp.rs
+++ b/src/coord/timestamp.rs
@@ -25,7 +25,7 @@ use avro::types::Value;
 use failure::bail;
 use futures::executor::block_on;
 use lazy_static::lazy_static;
-use log::{error, info, warn};
+use log::{error, info, log_enabled, warn};
 use prometheus::{register_int_gauge_vec, IntGaugeVec};
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::message::Message;
@@ -1350,6 +1350,10 @@ impl Timestamper {
             "group.id",
             &format!("{}materialize-rt-{}-{}", group_id_prefix, &kc.topic, id),
         );
+
+        if log_enabled!(target: "librdkafka", log::Level::Debug) {
+            config.set("debug", "all");
+        }
 
         for (k, v) in &kc.config_options {
             config.set(k, v);

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use lazy_static::lazy_static;
-use log::{error, info, warn};
+use log::{error, info, log_enabled, warn};
 use prometheus::{register_int_counter, register_int_gauge_vec, IntCounter, IntGaugeVec};
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::message::BorrowedMessage;
@@ -231,6 +231,10 @@ fn create_kafka_config(
         .set("enable.sparse.connections", "true")
         .set("bootstrap.servers", &url.to_string())
         .set("partition.assignment.strategy", "roundrobin");
+
+    if log_enabled!(target: "librdkafka", log::Level::Debug) {
+        kafka_config.set("debug", "all");
+    }
 
     for (k, v) in config_options {
         kafka_config.set(k, v);


### PR DESCRIPTION
When MZ_LOG=librdkafka=debug, we enable the `debug` option for
librdkafka, so that we can get greater insight into what librdkafka is
doing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3070)
<!-- Reviewable:end -->
