### PR TITLE
python: stub make materialize installable in a standard way

### DIFF
--- a/misc/python/materialize/py.typed
+++ b/misc/python/materialize/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The mypy package uses inline types.

--- a/misc/python/setup.py
+++ b/misc/python/setup.py
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+from typing import List
+
+from setuptools import setup, find_packages  # type: ignore
+
+# stub setup.py that allows running `pip install -e .` to install into a virtualenv
+
+HERE = Path(__file__).parent
+
+
+def requires(fname: str) -> List[str]:
+    return [l for l in HERE.joinpath(fname).open().read().splitlines() if l]
+
+
+setup(
+    name="materialize",
+    packages=find_packages(),
+    install_requires=requires("requirements.txt"),
+    extras_require={
+        "dev": requires("requirements-dev.txt"),
+        "ci": requires("requirements-ci.txt"),
+    },
+    package_data={"materialize": ["py.typed"]},
+    include_package_data=True,
+)


### PR DESCRIPTION
This makes the materialize project a bit more like a standard Python project, in the
interest of making it play nicer with virtualenv-management tools.

This also adds the `py.typed` file, which makes mypy happy if you don't run it with the
exact runtime configuration of `bin/pycheck`.

I care about being able to use the virtualenvwrapper and tox family of projects,
partially because all my tooling is built around them, but also because they make
tearing down/bringing up virtualenvs easy and this brings us a bit closer to being able
to test that more casually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3077)
<!-- Reviewable:end -->
