### PR TITLE
dashboard: Add materialized as a data source, and a dashboard showing it off

### DIFF
--- a/misc/monitoring/dashboard/Dockerfile
+++ b/misc/monitoring/dashboard/Dockerfile
@@ -133,8 +133,8 @@ RUN set -x && export DEBIAN_FRONTEND=noninteractive \
 
 # Our grafana configuration, doesn't get overwritten by startup.py
 COPY --chown=nobody:nogroup conf/grafana/dashboards/dashboards.yaml /etc/grafana/provisioning/dashboards/
-COPY --chown=nobody:nogroup conf/grafana/dashboards/overview.json /etc/grafana/provisioning/dashboards/
-COPY --chown=nobody:nogroup conf/grafana/datasources/prometheus.yaml /etc/grafana/provisioning/datasources/
+COPY --chown=nobody:nogroup conf/grafana/dashboards/*.json /etc/grafana/provisioning/dashboards/
+COPY --chown=nobody:nogroup conf/grafana/datasources/builtin.yaml /etc/grafana/provisioning/datasources/
 COPY --chown=nobody:nogroup conf/grafana/grafana.ini /etc/grafana/grafana.ini
 
 
@@ -151,6 +151,7 @@ ENTRYPOINT [ "/bin/startup.py" ]
 CMD        [ "--create-pipes", \
         "prometheus=/run/prefixed/prometheus,grafana=/run/prefixed/grafana,sql_prom=/run/prefixed/sql_prom", \
         "/etc/prometheus/prometheus.yml", \
+        "/etc/grafana/provisioning/datasources/builtin.yaml", \
         "/sql_exporter/sql_exporter.yml" ]
 EXPOSE     3000
 VOLUME     [ "/prometheus", "/etc/grafana/provisioning" ]

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/diagnostics.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/diagnostics.json
@@ -1,0 +1,645 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "https://github.com/MaterializeInc/materialize/blob/master/doc/developer/diagnostic-queries.md",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "content": "# Diagnosing apparent performance defects\n\nThe queries on this page are all derived from \nour [diagnosis page](https://github.com/MaterializeInc/materialize/blob/master/doc/developer/diagnostic-queries.md).",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "mode": "markdown",
+      "pluginVersion": "7.0.0",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "content": "## Things aren't going as fast as I would like!\n\nMaterialize spends time in various dataflow operators maintaining materialized views. The amount of time may be more than one expects, either because Materialize is behaving badly or because expectations aren't aligned with reality. These queries reveal which operators take the largest total amount of time.",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 6,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": "materialized",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.0.0",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "select mdo.id, mdo.name, msh.duration_ns, sum(msh.count) as \"times scheduled\"\nfrom mz_scheduling_histogram as msh,\n     mz_dataflow_operators as mdo\nwhere\n    msh.id = mdo.id and\n    msh.worker = mdo.worker\ngroup by mdo.id, mdo.name, msh.duration_ns\norder by msh.duration_ns desc\nlimit 100;\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Scheduling Durations",
+      "type": "table"
+    },
+    {
+      "datasource": "materialized",
+      "description": "raw elapsed time information, by worker",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "worker"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 71
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.0.0",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "select mdo.worker, mdo.id, mdo.name, mse.elapsed_ns\nfrom mz_scheduling_elapsed as mse,\n     mz_dataflow_operators as mdo\nwhere\n    mse.id = mdo.id and\n    mse.worker = mdo.worker\norder by elapsed_ns desc\nlimit 100;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total time spent in each dataflow operator",
+      "type": "table"
+    },
+    {
+      "content": "## Materialize becomes unresponsive for seconds at a time!\n\nWhat causes Materialize to take control away for seconds at a time? Materialize operators get scheduled and try to behave themselves by returning control promptly, but for various reasons that doesn't always happen. These queries reveal how many times each operator was scheduled for each power-of-two elapsed time: high durations indicate an event that took roughly that amount of time before it yielded, and incriminate the subject.",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 12,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": "materialized",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 10,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.0.0",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "-- Extract raw scheduling histogram information, by worker.\nselect mdo.id, mdo.name, mdo.worker, msh.duration_ns, count as \"times scheduled\"\nfrom mz_scheduling_histogram as msh,\n     mz_dataflow_operators as mdo\nwhere\n    msh.id = mdo.id and\n    msh.worker = mdo.worker\norder by msh.duration_ns desc\nlimit 100;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Raw scheduling histogram information, by worker",
+      "type": "table"
+    },
+    {
+      "datasource": "materialized",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 108
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 14,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.0.0",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "select mdo.id, mdo.name, msh.duration_ns, sum(msh.count) as \"times scheduled\"\nfrom mz_scheduling_histogram as msh,\n     mz_dataflow_operators as mdo\nwhere\n    msh.id = mdo.id and\n    msh.worker = mdo.worker\ngroup by mdo.id, mdo.name, msh.duration_ns\norder by msh.duration_ns desc\nlimit 100;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Extract raw scheduling histogram information, summed across workers",
+      "type": "table"
+    },
+    {
+      "content": "## Materialize is using lots of memory! What gives?\n\nThe majority of Materialize's memory live in \"arrangements\", which are differential dataflow structures that maintain indexes for data as they change. These queries extract the numbers of records and batches backing each of the arrangements. The reported records may exceed the number of logical records, as they reflect un-compacted state. The number of batches should be logarithmic-ish in this number, and anything significantly larger is probably a bug.",
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 16,
+      "mode": "markdown",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "",
+      "type": "text"
+    },
+    {
+      "datasource": "materialized",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 60
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "worker"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 65
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 18,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.0.0",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "-- Extract arrangement records and batches, by worker.\nselect mdo.worker, mdo.id, mdo.name, mas.records, mas.batches\nfrom mz_arrangement_sizes as mas,\n     mz_dataflow_operators as mdo\nwhere\n    mas.operator = mdo.id and\n    mas.worker = mdo.worker\norder by mas.records desc\nlimit 100;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Records and batches",
+      "type": "table"
+    },
+    {
+      "datasource": "materialized",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "id"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 20,
+      "options": {
+        "showHeader": true
+      },
+      "pluginVersion": "7.0.0",
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "-- Extract arrangement records and batches, summed across workers.\nselect mdo.id, mdo.name, sum(mas.records) as records, sum(mas.batches) as batches\nfrom mz_arrangement_sizes as mas,\n     mz_dataflow_operators as mdo\nwhere\n    mas.operator = mdo.id and\n    mas.worker = mdo.worker\ngroup by mdo.id, mdo.name\norder by sum(mas.records) desc\nlimit 100;\n",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Records and batches, summed across workers",
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Materialized Diagnostic Queries",
+  "uid": "diagnostics",
+  "version": 3
+}

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -457,6 +457,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "description": "This shows the top 10 dataflow operators that are introducing lag into the system.\n\nAn operator can introduce lag either because its source is running behind, or because it is doing lots of work.",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -508,7 +510,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Frontier lags",
+      "title": "Dataflow Operator Lag Times",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -526,7 +528,7 @@
         {
           "format": "ms",
           "label": "Lag (from -> to)",
-          "logBase": 2,
+          "logBase": 1,
           "max": null,
           "min": null,
           "show": true
@@ -550,6 +552,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "description": "A worker is the underlying thread of computation in materialized. In general materialized should send similar amounts of work to each worker, and the queue depths should be similar to each other.\n\nIf a queue is growing without bound, or queues are very unbalanced, that could signify a problem.",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -979,7 +983,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "description": "Rate at which capabilities are downgraded in the system",
+      "datasource": null,
+      "description": "This is a measure of when we last stated that ingested data was valid for computation.\n\nAll sources that have a rate of 0 are *stalled* and are either not ingesting new data or have no new data to ingest.\n\nInternally, this is the capability, and the underlying measure is what capability we have released.",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1031,7 +1036,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": " Capability Closing Rate",
+      "title": "Data Acceptance Rate",
       "tooltip": {
         "shared": true,
         "sort": 1,
@@ -1047,7 +1052,7 @@
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "ms",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1169,7 +1174,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Rate at which capabilities are downgraded in the system",
+      "description": "The difference between the most-consumed and least-consumed kafka partition, in terms of when we last released messages into the dataflow layer.",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1221,7 +1226,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Partition Imbalance Amount",
+      "title": "Kafka Partition Imbalance Amount",
       "tooltip": {
         "shared": true,
         "sort": 2,
@@ -1359,6 +1364,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "description": "This only applies to kinesis",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1666,6 +1672,8 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "description": "A batch is a slab of memory, arrangements with a large number of batches have allocated a large number of records, which should be represented in the Arrangement Records panel.\n\nThis shows the top 10 arrangements by number of batches, and should be similar to the Arrangement Records panel.",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -1759,7 +1767,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
-      "description": "Uncompacted records in each arrangement",
+      "description": "An arrangement is where materialize stores state, records are equivalent to rows in a database or messages in a stream.\n\nThis shows the top 10 arrangements by number of records, and should be similar to the Arrangement Batches panel.",
       "fieldConfig": {
         "defaults": {
           "custom": {}

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -511,7 +511,7 @@
       "title": "Frontier lags",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -895,15 +895,20 @@
         "x": 0,
         "y": 34
       },
+      "hiddenSeries": false,
       "id": 49,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
-        "current": false,
+        "current": true,
+        "hideEmpty": true,
         "max": false,
         "min": false,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
-        "values": false
+        "values": true
       },
       "lines": true,
       "linewidth": 1,
@@ -923,7 +928,8 @@
         {
           "expr": "mz_kafka_partition_offset_max - mz_kafka_partition_offset_ingested",
           "hide": false,
-          "legendFormat": "{{topic}} (part={{partition_id}})",
+          "interval": "",
+          "legendFormat": "{{topic}} (source={{source_id}} part={{partition_id}})",
           "refId": "A"
         }
       ],
@@ -934,7 +940,7 @@
       "title": "Messages behind external source",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1028,7 +1034,7 @@
       "title": " Capability Closing Rate",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 1,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1218,7 +1224,7 @@
       "title": "Partition Imbalance Amount",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",
@@ -1807,7 +1813,7 @@
       "title": "Arrangement Records",
       "tooltip": {
         "shared": true,
-        "sort": 0,
+        "sort": 2,
         "value_type": "individual"
       },
       "type": "graph",

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -14,8 +14,8 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 1,
-  "id": 1,
+  "graphTooltip": 0,
+  "id": 2,
   "iteration": 1588902358992,
   "links": [],
   "panels": [
@@ -48,6 +48,12 @@
       },
       "dataFormat": "tsbuckets",
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -114,6 +120,12 @@
       "dashes": false,
       "datasource": null,
       "description": "the view of how long things took, from inside pgwire",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -232,6 +244,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -240,6 +259,7 @@
         "x": 0,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 2,
       "legend": {
         "avg": false,
@@ -321,6 +341,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -329,6 +355,7 @@
         "x": 12,
         "y": 9
       },
+      "hiddenSeries": false,
       "id": 41,
       "legend": {
         "avg": false,
@@ -413,6 +440,7 @@
     },
     {
       "collapsed": false,
+      "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -429,6 +457,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -437,6 +471,7 @@
         "x": 0,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "avg": false,
@@ -515,6 +550,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -523,6 +564,7 @@
         "x": 12,
         "y": 18
       },
+      "hiddenSeries": false,
       "id": 37,
       "legend": {
         "avg": false,
@@ -605,6 +647,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -613,6 +662,7 @@
         "x": 0,
         "y": 26
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "avg": false,
@@ -723,6 +773,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -731,6 +788,7 @@
         "x": 12,
         "y": 26
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "avg": false,
@@ -824,6 +882,12 @@
       "dashes": false,
       "description": "This shows the number of messages that materialize knows it is behind an external source.\n\nFor example, if there are 1,000 messages in kafka and materialized has processed 750, this value will be 250",
       "fill": 1,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fillGradient": 0,
       "gridPos": {
         "h": 8,
@@ -910,6 +974,12 @@
       "dashLength": 10,
       "dashes": false,
       "description": "Rate at which capabilities are downgraded in the system",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -918,6 +988,7 @@
         "x": 12,
         "y": 34
       },
+      "hiddenSeries": false,
       "id": 50,
       "legend": {
         "avg": false,
@@ -998,6 +1069,12 @@
       "dashes": false,
       "datasource": null,
       "description": "Rate at which data is first received from the Kafka Source",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1087,6 +1164,12 @@
       "dashes": false,
       "datasource": null,
       "description": "Rate at which capabilities are downgraded in the system",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1176,6 +1259,12 @@
       "dashes": false,
       "datasource": null,
       "description": "Difference between allocated timestamps and close timestamps",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1211,7 +1300,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(mz_max_timestamp- ignoring(topic) mz_kafka_partition_closed_ts)",         "interval": "",
+          "expr": "(mz_max_timestamp- ignoring(topic) mz_kafka_partition_closed_ts)",
+          "interval": "",
           "legendFormat": "{{source_id}}-{{partition_id}}",
           "refId": "A"
         }
@@ -1263,6 +1353,12 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1371,6 +1467,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1379,6 +1482,7 @@
         "x": 0,
         "y": 59
       },
+      "hiddenSeries": false,
       "id": 24,
       "legend": {
         "avg": false,
@@ -1456,6 +1560,13 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1464,6 +1575,7 @@
         "x": 12,
         "y": 59
       },
+      "hiddenSeries": false,
       "id": 20,
       "legend": {
         "avg": false,
@@ -1548,6 +1660,12 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1556,6 +1674,7 @@
         "x": 0,
         "y": 67
       },
+      "hiddenSeries": false,
       "id": 16,
       "legend": {
         "avg": false,
@@ -1635,6 +1754,12 @@
       "dashes": false,
       "datasource": null,
       "description": "Uncompacted records in each arrangement",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1643,6 +1768,7 @@
         "x": 12,
         "y": 67
       },
+      "hiddenSeries": false,
       "id": 35,
       "legend": {
         "avg": false,
@@ -1717,11 +1843,13 @@
     }
   ],
   "refresh": "30s",
+  "schemaVersion": 25,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
+        "allFormat": "glob",
         "allValue": null,
         "current": {
           "tags": [],
@@ -1792,6 +1920,7 @@
         "useTags": false
       },
       {
+        "allFormat": "glob",
         "allValue": null,
         "current": {
           "selected": false,
@@ -1818,11 +1947,13 @@
         "useTags": false
       },
       {
+        "allFormat": "glob",
         "current": {
           "tags": [],
           "text": "--->",
           "value": "--->"
         },
+        "datasource": null,
         "hide": 0,
         "label": "Build Info",
         "name": "build_info",
@@ -1838,6 +1969,7 @@
         "type": "constant"
       },
       {
+        "allFormat": "glob",
         "allValue": null,
         "current": {
           "text": "2020-05-08T01:36:48Z",
@@ -1847,7 +1979,6 @@
         "definition": "label_values(mz_server_metadata_seconds, build_time)",
         "hide": 0,
         "includeAll": false,
-        "index": -1,
         "label": "Built at",
         "multi": false,
         "name": "built_at",
@@ -1864,6 +1995,7 @@
         "useTags": false
       },
       {
+        "allFormat": "glob",
         "allValue": null,
         "current": {
           "text": "0.2.1-dev",
@@ -1889,6 +2021,7 @@
         "useTags": false
       },
       {
+        "allFormat": "glob",
         "allValue": null,
         "current": {
           "text": "df6a7d5e975afa9779882c7a03bbaba421161194",
@@ -1898,7 +2031,6 @@
         "definition": "label_values(mz_server_metadata_seconds, build_sha)",
         "hide": 0,
         "includeAll": false,
-        "index": -1,
         "label": "Git commit",
         "multi": false,
         "name": "build_sha",
@@ -1922,7 +2054,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
       "10s",
       "30s",
       "1m",

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -884,8 +884,9 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "This shows the number of messages that materialize knows it is behind an external source.\n\nFor example, if there are 1,000 messages in kafka and materialized has processed 750, this value will be 250",
-      "fill": 1,
+      "fill": 0,
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -930,7 +931,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mz_kafka_partition_offset_max - mz_kafka_partition_offset_ingested",
+          "expr": "topk(50, mz_kafka_partition_offset_max - mz_kafka_partition_offset_ingested)",
           "hide": false,
           "interval": "",
           "legendFormat": "{{topic}} (source={{source_id}} part={{partition_id}})",
@@ -1715,7 +1716,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mz_perf_arrangements_batches",
+          "expr": "topk(10, mz_perf_arrangements_batches)",
+          "interval": "",
           "legendFormat": "w={{worker}} op={{operator}}",
           "refId": "A"
         }
@@ -1809,7 +1811,8 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "mz_perf_arrangement_records",
+          "expr": "topk(10, mz_perf_arrangement_records)",
+          "interval": "",
           "legendFormat": "w={{worker}} op={{operator}} name={{name}}",
           "refId": "A"
         }

--- a/misc/monitoring/dashboard/conf/grafana/datasources/builtin.yaml
+++ b/misc/monitoring/dashboard/conf/grafana/datasources/builtin.yaml
@@ -15,3 +15,11 @@ datasources:
     isDefault: true
     access: proxy
     url: http://localhost:9090
+  - name: materialized
+    type: postgres
+    url: MATERIALIZED_URL
+    database: materialize
+    user: mz
+    password: mz
+    jsonData:
+      sslmode: disable

--- a/misc/monitoring/dashboard/mzbuild.yml
+++ b/misc/monitoring/dashboard/mzbuild.yml
@@ -10,4 +10,4 @@
 name: dashboard
 build-args:
   PROM_VERSION: '2.18.1'
-  GRAFANA_VERSION: '6.7.3'
+  GRAFANA_VERSION: '7.0.0'


### PR DESCRIPTION
This is a live view of the diagnostic queries from #3086 , and demonstrates using
materialized inside grafana.

All the panels can be exported to CSV from the "inspect" tab.


----

This also upgrades to Grafana to 7.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3090)
<!-- Reviewable:end -->
