### PR TITLE
Fix ANY/ALL regression

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1699,32 +1699,57 @@ fn plan_any_or_all<'a>(
         allow_subqueries: true,
     };
 
-    // Planning ANY:
-    // SELECT abc.a = ANY(SELECT xyz.x FROM xyz) FROM abc
-    // =>
-    // SELECT EXISTS(SELECT xyz.x FROM xyz WHERE abc.a = xyz.x) FROM abc
-    //
-    // Planning ALL (the same, but applying De Morgan's law):
-    // SELECT abc.a != ALL(SELECT xyz.x FROM xyz) FROM abc
-    // =>
-    // SELECT NOT EXISTS(SELECT xyz.x FROM xyz WHERE abc.a = xyz.x) FROM abc
+    if !column_types[0].nullable {
+        // This transformation allows us to exploit some structure that is easy to spot at this
+        // level, but trickier at the dataflow layer, so we do it here. However, it's only valid if
+        // the column from the right subquery is non-nullable.
+        //
+        // Planning ANY:
+        // SELECT abc.a = ANY(SELECT xyz.x FROM xyz) FROM abc
+        // =>
+        // SELECT EXISTS(SELECT xyz.x FROM xyz WHERE abc.a = xyz.x) FROM abc
+        //
+        // Planning ALL (the same, but applying De Morgan's law):
+        // SELECT abc.a != ALL(SELECT xyz.x FROM xyz) FROM abc
+        // =>
+        // SELECT NOT EXISTS(SELECT xyz.x FROM xyz WHERE abc.a = xyz.x) FROM abc
 
-    let mut cond = plan_binary_op(
-        &any_ecx,
-        op,
-        left,
-        &Expr::Identifier(vec![Ident::new(right_name)]),
-    )?;
-    if func == AggregateFunc::All {
-        cond = cond.call_unary(UnaryFunc::Not);
+        let mut cond = plan_binary_op(
+            &any_ecx,
+            op,
+            left,
+            &Expr::Identifier(vec![Ident::new(right_name)]),
+        )?;
+        if func == AggregateFunc::All {
+            cond = cond.call_unary(UnaryFunc::Not);
+        }
+
+        let mut exists = right.filter(vec![cond]).exists();
+        if func == AggregateFunc::All {
+            exists = exists.call_unary(UnaryFunc::Not);
+        }
+        Ok(exists)
+    } else {
+        let op_expr = plan_binary_op(
+            &any_ecx,
+            op,
+            left,
+            &Expr::Identifier(vec![Ident::new(right_name)]),
+        )?;
+
+        // plan subquery
+        let expr = right
+            .reduce(
+                vec![],
+                vec![AggregateExpr {
+                    func,
+                    expr: Box::new(op_expr),
+                    distinct: false,
+                }],
+            )
+            .select();
+        Ok(expr)
     }
-
-    let mut exists = right.filter(vec![cond]).exists();
-    if func == AggregateFunc::All {
-        exists = exists.call_unary(UnaryFunc::Not);
-    }
-
-    Ok(exists)
 }
 
 fn plan_cast<'a>(

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1358,6 +1358,7 @@ ORDER BY su_name
 
 %8 =
 | Get %6
+| Filter (#0 = ((#11 * #12) % 10000))
 
 %9 =
 | Get %6
@@ -1375,8 +1376,6 @@ ORDER BY su_name
 | Filter "^co.*$" ~(#44)
 | Reduce group=(#0, #11, #12, #13) sum(#36)
 | Filter ((2 * #3) > #4)
-| Map ((#1 * #2) % 10000)
-| Filter (#0 = #5)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -140,6 +140,36 @@ alice false
 bob true
 eve true
 
+# ANY/ALL semantics
+
+query BBBBBBBB
+(VALUES (
+  1 < ANY(SELECT * FROM (VALUES (1)) WHERE false),
+  1 < ANY(VALUES (0)),
+  1 < ANY(VALUES (1)),
+  1 < ANY(VALUES (2)),
+  1 < ANY(VALUES (NULL)),
+  1 < ANY(VALUES (0), (NULL)),
+  1 < ANY(VALUES (1), (NULL)),
+  1 < ANY(VALUES (2), (NULL))
+))
+----
+false  false  false  true  NULL  NULL  NULL  true
+
+query BBBBBBBB
+(VALUES (
+  1 < ALL(SELECT * FROM (VALUES (1)) WHERE false),
+  1 < ALL(VALUES (0)),
+  1 < ALL(VALUES (1)),
+  1 < ALL(VALUES (2)),
+  1 < ALL(VALUES (NULL)),
+  1 < ALL(VALUES (0), (NULL)),
+  1 < ALL(VALUES (1), (NULL)),
+  1 < ALL(VALUES (2), (NULL))
+))
+----
+true  false  false  true  NULL  false  false  NULL
+
 statement ok
 CREATE TABLE s1 (a int NOT NULL)
 


### PR DESCRIPTION
This commit fixes a bug introduced by #3045 in the presence of NULLs: if
there is a NULL present in an ANY that would otherwise be false, the
result is NULL, and likewise with ALL and true.

Since we want to retain the planning benefits, we do a sort of hacky fix
where we require the right column to not be nullable to make use of the
EXISTS transformation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3093)
<!-- Reviewable:end -->
