### PR TITLE
Fix another problem with ANY/ALL => Exists

### DIFF
--- a/src/sql/query.rs
+++ b/src/sql/query.rs
@@ -1728,7 +1728,11 @@ fn plan_any_or_all<'a>(
         if func == AggregateFunc::All {
             exists = exists.call_unary(UnaryFunc::Not);
         }
-        Ok(exists)
+        Ok(ScalarExpr::If {
+            cond: Box::new(plan_is_null_expr(ecx, left, false)?),
+            then: Box::new(ScalarExpr::literal_null(ScalarType::Unknown)),
+            els: Box::new(exists),
+        })
     } else {
         let op_expr = plan_binary_op(
             &any_ecx,

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1117,6 +1117,7 @@ ORDER BY supplier_cnt DESC
 
 %8 =
 | Get %3
+| Filter if isnull(#0) then {null} else {true}
 
 %9 =
 | Union %7 %8
@@ -1129,6 +1130,7 @@ ORDER BY supplier_cnt DESC
 | Join %4 %9 %10 (= #17 #23 #24)
 | | implementation = Differential %9 %10.(#0) %4.(#17)
 | | demand = (#17, #20..#22)
+| Filter if isnull(#17) then {null} else {true}
 | Reduce group=(#20, substr(#22, 1, 3), #21) count(distinct #17)
 
 Finish order_by=(#3 desc) limit=none offset=0 project=(#0..#3)

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -142,7 +142,7 @@ eve true
 
 # ANY/ALL semantics
 
-query BBBBBBBB
+query BBBBBBBBBBBBBBBB
 (VALUES (
   1 < ANY(SELECT * FROM (VALUES (1)) WHERE false),
   1 < ANY(VALUES (0)),
@@ -151,12 +151,20 @@ query BBBBBBBB
   1 < ANY(VALUES (NULL)),
   1 < ANY(VALUES (0), (NULL)),
   1 < ANY(VALUES (1), (NULL)),
-  1 < ANY(VALUES (2), (NULL))
+  1 < ANY(VALUES (2), (NULL)),
+  NULL < ANY(SELECT * FROM (VALUES (1)) WHERE false),
+  NULL < ANY(VALUES (0)),
+  NULL < ANY(VALUES (1)),
+  NULL < ANY(VALUES (2)),
+  NULL < ANY(VALUES (NULL)),
+  NULL < ANY(VALUES (0), (NULL)),
+  NULL < ANY(VALUES (1), (NULL)),
+  NULL < ANY(VALUES (2), (NULL))
 ))
 ----
-false  false  false  true  NULL  NULL  NULL  true
+false  false  false  true  NULL  NULL  NULL  true  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
-query BBBBBBBB
+query BBBBBBBBBBBBBBBB
 (VALUES (
   1 < ALL(SELECT * FROM (VALUES (1)) WHERE false),
   1 < ALL(VALUES (0)),
@@ -165,10 +173,18 @@ query BBBBBBBB
   1 < ALL(VALUES (NULL)),
   1 < ALL(VALUES (0), (NULL)),
   1 < ALL(VALUES (1), (NULL)),
-  1 < ALL(VALUES (2), (NULL))
+  1 < ALL(VALUES (2), (NULL)),
+  NULL < ALL(SELECT * FROM (VALUES (1)) WHERE false),
+  NULL < ALL(VALUES (0)),
+  NULL < ALL(VALUES (1)),
+  NULL < ALL(VALUES (2)),
+  NULL < ALL(VALUES (NULL)),
+  NULL < ALL(VALUES (0), (NULL)),
+  NULL < ALL(VALUES (1), (NULL)),
+  NULL < ALL(VALUES (2), (NULL))
 ))
 ----
-true  false  false  true  NULL  false  false  NULL
+true  false  false  true  NULL  false  false  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
 statement ok
 CREATE TABLE s1 (a int NOT NULL)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1860,7 +1860,7 @@ ORDER BY
 
 %4 =
 | InnerJoin %2 %3 on true
-| Filter ((exists(%7) && (#3 = #7)) && (#8 = "CANADA"))
+| Filter ((if isnull(#0) then {null} else {exists(%7)} && (#3 = #7)) && (#8 = "CANADA"))
 | |
 | | %5 =
 | | | Constant ()
@@ -1870,7 +1870,7 @@ ORDER BY
 | |
 | | %7 =
 | | | InnerJoin %5 %6 on true
-| | | Filter (exists(%10) && ((i32todec(#2) * 1000dec) > select(%14)))
+| | | Filter (if isnull(#0) then {null} else {exists(%10)} && ((i32todec(#2) * 1000dec) > select(%14)))
 | | | |
 | | | | %8 =
 | | | | | Constant ()


### PR DESCRIPTION
The original change also didn't handle the case where the LHS was
nullable. This is sort of a hacky fix at the moment, we just construct
an `if`, but we should be able to eliminate it in many cases.

This isn't an ideal fix, since it duplicates the possibly expensive LHS,
but it doesn't seem to practically hurt in any tests we have today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3099)
<!-- Reviewable:end -->
