### PR TITLE
Makes timestamp batch size a per-source option (default to off)

### DIFF
--- a/src/dataflow-types/types.rs
+++ b/src/dataflow-types/types.rs
@@ -455,6 +455,7 @@ pub enum SourceConnector {
         encoding: DataEncoding,
         envelope: Envelope,
         consistency: Consistency,
+        max_ts_batch: i64,
     },
     Local,
 }

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -251,6 +251,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                     encoding,
                     envelope,
                     consistency,
+                    max_ts_batch: _,
                 } = src.connector
                 {
                     let get_expr = RelationExpr::global_get(src_id.sid, src.desc.typ().clone());

--- a/src/materialized/bin/materialized.rs
+++ b/src/materialized/bin/materialized.rs
@@ -108,12 +108,6 @@ fn run() -> Result<(), failure::Error> {
     );
     opts.optopt(
         "",
-        "batch-size",
-        "maximum number of messages with same timestamp (default 10000) ",
-        "SIZE",
-    );
-    opts.optopt(
-        "",
         "persist-ts",
         "persists consistency information locally and recovers from local store",
         "true/false",
@@ -224,7 +218,6 @@ fn run() -> Result<(), failure::Error> {
         None => Duration::from_millis(10),
         Some(d) => parse_duration::parse(&d)?,
     };
-    let max_increment_ts_size = popts.opt_get_default("batch-size", 10000_i64)?;
     let persist_ts = popts.opt_get_default("persist-ts", false)?;
 
     // Configure connections.
@@ -307,7 +300,6 @@ environment:{}",
         logging_granularity,
         logical_compaction_window,
         timestamp_frequency,
-        max_increment_ts_size,
         persist_ts,
         listen_addr,
         tls,

--- a/src/materialized/lib.rs
+++ b/src/materialized/lib.rs
@@ -109,8 +109,6 @@ pub struct Config {
     pub logical_compaction_window: Option<Duration>,
     /// The interval at which sources should be timestamped.
     pub timestamp_frequency: Duration,
-    /// The maximum size of a timestamp batch.
-    pub max_increment_ts_size: i64,
     /// Whether to record realtime consistency information to the data directory
     /// and attempt to recover that information on startup.
     pub persist_ts: bool,
@@ -255,7 +253,6 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
             data_directory: config.data_directory.as_deref(),
             timestamp: coord::TimestampConfig {
                 frequency: config.timestamp_frequency,
-                max_size: config.max_increment_ts_size,
                 persist_ts: config.persist_ts,
             },
             logical_compaction_window: config.logical_compaction_window,

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -67,7 +67,6 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
         logging_granularity: config.logging_granularity,
         timestamp_frequency: Duration::from_millis(10),
         logical_compaction_window: None,
-        max_increment_ts_size: 1000,
         persist_ts: false,
         threads: 1,
         process: 0,

--- a/src/sql/statement.rs
+++ b/src/sql/statement.rs
@@ -1081,6 +1081,25 @@ pub async fn purify_statement(mut stmt: Statement) -> Result<Statement, failure:
     Ok(stmt)
 }
 
+fn extract_batch_size_option(
+    with_options: &mut HashMap<String, Value>,
+) -> Result<i64, failure::Error> {
+    match with_options.remove("max_timestamp_batch_size") {
+        None => Ok(0),
+        Some(Value::Number(n)) => match n.parse::<i64>() {
+            Ok(n) => {
+                if n < 0 {
+                    bail!("max_ts_batch must be greater than zero")
+                } else {
+                    Ok(n)
+                }
+            }
+            _ => bail!("max_timestamp_batch_size must be an i64"),
+        },
+        Some(_) => bail!("max_timestamp_batch_size must be an i64"),
+    }
+}
+
 fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan, failure::Error> {
     match &stmt {
         Statement::CreateSource {
@@ -1195,6 +1214,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
             let mut with_options = normalize::with_options(with_options);
 
             let mut consistency = Consistency::RealTime;
+            let mut max_ts_batch = 0;
             let (external_connector, mut encoding) = match connector {
                 Connector::Kafka { broker, topic, .. } => {
                     let config_options = kafka_util::extract_config(&mut with_options)?;
@@ -1210,6 +1230,8 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         Some(Value::SingleQuotedString(s)) => Some(s),
                         Some(_) => bail!("group_id_prefix must be a string"),
                     };
+
+                    max_ts_batch = extract_batch_size_option(&mut with_options)?;
 
                     // THIS IS EXPERIMENTAL - DO NOT DOCUMENT IT
                     // until we have had time to think about what the right UX/design is on a non-urgent timeline!
@@ -1321,6 +1343,8 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         Some(Value::SingleQuotedString(topic)) => Consistency::BringYourOwn(topic),
                         Some(_) => bail!("consistency must be a string"),
                     };
+                    max_ts_batch = extract_batch_size_option(&mut with_options)?;
+
                     let connector = ExternalSourceConnector::File(FileSourceConnector {
                         path: path.clone().into(),
                         tail,
@@ -1339,6 +1363,9 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         Some(Value::SingleQuotedString(topic)) => Consistency::BringYourOwn(topic),
                         Some(_) => bail!("consistency must be a string"),
                     };
+
+                    max_ts_batch = extract_batch_size_option(&mut with_options)?;
+
                     let connector = ExternalSourceConnector::AvroOcf(FileSourceConnector {
                         path: path.clone().into(),
                         tail,
@@ -1461,6 +1488,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     encoding,
                     envelope,
                     consistency,
+                    max_ts_batch,
                 },
                 desc,
             };

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -405,7 +405,6 @@ impl State {
             executor: &executor,
             timestamp: TimestampConfig {
                 frequency: Duration::from_millis(10),
-                max_size: 10000,
                 persist_ts: false,
             },
             logical_compaction_window: None,

--- a/test/testdrive/timestamps-file.td
+++ b/test/testdrive/timestamps-file.td
@@ -32,7 +32,7 @@ a,b
 > CREATE MATERIALIZED VIEW view_byo AS SELECT * FROM data_byo
 
 > CREATE MATERIALIZED SOURCE data_byo2 (a,b) FROM FILE '${testdrive.temp-dir}/data2.csv'
-    WITH (consistency = '${testdrive.temp-dir}/data-consistency.csv', tail=true)
+    WITH (consistency = '${testdrive.temp-dir}/data-consistency.csv', tail=true, max_timestamp_batch_size=2)
     FORMAT CSV WITH HEADER
 
 > CREATE MATERIALIZED VIEW view_byo2 AS SELECT * FROM data_byo2

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -63,7 +63,7 @@ $ kafka-ingest partition=1 format=avro topic=data schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
+    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}', max_timestamp_batch_size=3)
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED SOURCE data_empty

--- a/test/testdrive/timestamps-kafka-avro.td
+++ b/test/testdrive/timestamps-kafka-avro.td
@@ -80,7 +80,7 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data3_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data3-${testdrive.seed}'
-      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
+      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}', max_timestamp_batch_size=2)
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED SOURCE data_rt
@@ -89,6 +89,7 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data2_rt
     FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
+       WITH(max_timestamp_batch_size=3)
     FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo GROUP BY b

--- a/test/testdrive/timestamps-ocf.td
+++ b/test/testdrive/timestamps-ocf.td
@@ -59,7 +59,7 @@ $ avro-ocf-write path=data2.ocf schema=${schema}
 {"a": 1, "b": 1}
 {"a": 2, "b": 2}
 
-> CREATE MATERIALIZED SOURCE data_byo FROM AVRO OCF '${testdrive.temp-dir}/data.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf', tail=true)
+> CREATE MATERIALIZED SOURCE data_byo FROM AVRO OCF '${testdrive.temp-dir}/data.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf', tail=true , max_timestamp_batch_size=2)
 
 > CREATE MATERIALIZED SOURCE data_byo2 FROM AVRO OCF '${testdrive.temp-dir}/data2.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf')
 


### PR DESCRIPTION
This PR moves the startup `batch-size` option to a per-source option (with (`max_ts_batch=10)`). A value of 0 indicates that there is no maximum batch size.

This PR does not remove the --batch-size option for compatibility, but it no longer has any effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3100)
<!-- Reviewable:end -->
