### PR TITLE
Optimising data structure in timestamping logic

### DIFF
--- a/src/dataflow/source/file.rs
+++ b/src/dataflow/source/file.rs
@@ -232,12 +232,12 @@ fn downgrade_capability(
             // one entry here
             for entries in entries.values_mut() {
                 // Check whether timestamps can be closed on this partition
-                while let Some((_, ts, offset)) = entries.first() {
+                while let Some((_, ts, offset)) = entries.front() {
                     if *last_processed_offset == *offset {
                         // We have now seen all messages corresponding to this timestamp.  We
                         // can close the timestamp and remove the associated metadata.
                         *last_closed_ts = *ts;
-                        entries.remove(0);
+                        entries.pop_front();
                         changed = true;
                     } else {
                         // Offset isn't at a timestamp boundary, we take no action

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -815,7 +815,7 @@ fn downgrade_capability(
                 let last_offset = cp_info.partition_metadata[pid as usize].offset;
 
                 // Check whether timestamps can be closed on this partition
-                while let Some((partition_count, ts, offset)) = entries.first() {
+                while let Some((partition_count, ts, offset)) = entries.front() {
                     assert!(
                         *offset >= cp_info.start_offset,
                         "Internal error! Timestamping offset went below start: {} < {}. Materialize will now crash.",
@@ -852,7 +852,7 @@ fn downgrade_capability(
                         // partition. We
                         // can close the timestamp (on this partition) and remove the associated metadata
                         cp_info.partition_metadata[pid as usize].ts = *ts;
-                        entries.remove(0);
+                        entries.pop_front();
                         changed = true;
                     } else {
                         // Offset isn't at a timestamp boundary, we take no action


### PR DESCRIPTION
This PR shifts from storing updates as Vec<> to storing them as VecDeque, which optimises removing the head of the vector in the downgrade_capability method.  There are no semantic changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3101)
<!-- Reviewable:end -->
