### PR TITLE
Standardize reporting of unsupported SQL features

### DIFF
--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -240,3 +240,13 @@ pub fn describe(
     let types = types.into_iter().map(|t| pgrepr::Type::from(&t)).collect();
     Ok((desc, types))
 }
+
+#[macro_export]
+macro_rules! unsupported {
+    ($feature:expr) => {
+        bail!("{} not yet supported", $feature)
+    };
+    ($issue:expr, $feature:expr) => {
+        bail!("{} not yet supported, see https://github.com/MaterializeInc/materialize/issues/{} for more details", $feature, $issue)
+    };
+}

--- a/src/sql/normalize.rs
+++ b/src/sql/normalize.rs
@@ -22,6 +22,7 @@ use sql_parser::ast::{
 
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
 use crate::statement::StatementContext;
+use crate::unsupported;
 
 pub fn ident(ident: Ident) -> String {
     ident.as_str().into()
@@ -29,7 +30,7 @@ pub fn ident(ident: Ident) -> String {
 
 pub fn function_name(name: ObjectName) -> Result<String, failure::Error> {
     if name.0.len() != 1 {
-        bail!("qualified function names are not supported");
+        unsupported!("qualified function names");
     }
     Ok(ident(name.0.into_element()))
 }

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -164,7 +164,7 @@ SHOW VIEWS LIKE '%u'
 ----
 u
 
-statement error not supported
+statement error supported
 SHOW VIEWS WHERE "VIEWS" = 'u'
 
 query T
@@ -172,7 +172,7 @@ SHOW SOURCES
 ----
 xyz
 
-statement error not supported
+statement error supported
 SHOW SOURCES WHERE "SOURCES" = 'u'
 
 # SHOW OBJECTS


### PR DESCRIPTION
Add a macro that's syntactic sugar for `bail` with an error message
about unsupported features. Optionally includes a GitHub issue to refer
to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3115)
<!-- Reviewable:end -->
