### PR TITLE
deps: bump rust-rdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.23.1"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#a73bbae27361073e9370a4c9b8d5029313d1e9e2"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#4ae9541aabd98d9d56d85621b36c356f6d171fed"
 dependencies = [
  "futures",
  "libc",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "2.0.0+1.4.2"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#a73bbae27361073e9370a4c9b8d5029313d1e9e2"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#4ae9541aabd98d9d56d85621b36c356f6d171fed"
 dependencies = [
  "cmake",
  "libc",


### PR DESCRIPTION
The latest version allows using partition queues for a single consumer
from multiple threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3121)
<!-- Reviewable:end -->
