### PR TITLE
Generalize function selection

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -96,6 +96,10 @@ fn abs_int64<'a>(a: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64().abs())
 }
 
+fn abs_decimal<'a>(a: Datum<'a>, scale: u8) -> Datum<'a> {
+    Datum::from(a.unwrap_decimal().with_scale(scale).abs().significand())
+}
+
 fn abs_float32<'a>(a: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_float32().abs())
 }
@@ -2229,6 +2233,7 @@ pub enum UnaryFunc {
     SqrtFloat64,
     AbsInt32,
     AbsInt64,
+    AbsDecimal(u8),
     AbsFloat32,
     AbsFloat64,
     CastBoolToStringExplicit,
@@ -2364,6 +2369,7 @@ impl UnaryFunc {
             UnaryFunc::NegInterval => Ok(neg_interval(a)),
             UnaryFunc::AbsInt32 => Ok(abs_int32(a)),
             UnaryFunc::AbsInt64 => Ok(abs_int64(a)),
+            UnaryFunc::AbsDecimal(scale) => Ok(abs_decimal(a, *scale)),
             UnaryFunc::AbsFloat32 => Ok(abs_float32(a)),
             UnaryFunc::AbsFloat64 => Ok(abs_float64(a)),
             UnaryFunc::CastBoolToStringExplicit => Ok(cast_bool_to_string_explicit(a)),
@@ -2620,7 +2626,7 @@ impl UnaryFunc {
             SqrtFloat64 => ColumnType::new(ScalarType::Float64).nullable(true),
 
             Not | NegInt32 | NegInt64 | NegFloat32 | NegFloat64 | NegDecimal | NegInterval
-            | AbsInt32 | AbsInt64 | AbsFloat32 | AbsFloat64 => input_type,
+            | AbsInt32 | AbsInt64 | AbsDecimal(_) | AbsFloat32 | AbsFloat64 => input_type,
 
             ExtractIntervalEpoch
             | ExtractIntervalYear
@@ -2719,6 +2725,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::NegInterval => f.write_str("-"),
             UnaryFunc::AbsInt32 => f.write_str("abs"),
             UnaryFunc::AbsInt64 => f.write_str("abs"),
+            UnaryFunc::AbsDecimal(_) => f.write_str("abs"),
             UnaryFunc::AbsFloat32 => f.write_str("abs"),
             UnaryFunc::AbsFloat64 => f.write_str("abs"),
             UnaryFunc::CastBoolToStringExplicit => f.write_str("booltostrex"),

--- a/src/repr/src/scalar/decimal.rs
+++ b/src/repr/src/scalar/decimal.rs
@@ -303,6 +303,13 @@ impl Decimal {
         self.scale
     }
 
+    pub fn abs(&self) -> Decimal {
+        Decimal {
+            significand: self.significand.abs(),
+            scale: self.scale,
+        }
+    }
+
     /// Computes the floor of this decimal: the nearest integer less than or
     /// equal to this decimal. The returned decimal will have the same scale as
     /// this decimal.

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -470,6 +470,16 @@ impl AstDisplay for Expr {
 }
 impl_display!(Expr);
 
+impl Expr {
+    pub fn is_string_literal(&self) -> bool {
+        if let Expr::Value(Value::SingleQuotedString(_)) = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// A window specification (i.e. `OVER (PARTITION BY .. ORDER BY .. etc.)`)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WindowSpec {

--- a/src/sql/func.rs
+++ b/src/sql/func.rs
@@ -1,0 +1,1095 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! TBD: Currently, `sql::func` handles matching arguments to their respective
+//! built-in functions (for most built-in functions, at least).
+
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+
+use failure::bail;
+use repr::ScalarType;
+use sql_parser::ast::{Expr, Value};
+
+use super::expr::{BinaryFunc, ScalarExpr, UnaryFunc, VariadicFunc};
+use super::query::ExprContext;
+use super::unsupported;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+// Mirrored from [PostgreSQL's
+// `typcategory`](https://www.postgresql.org/docs/9.6/catalog-pg-type.html#CATALOG-TYPCATEGORY-TABLE).
+enum TypeCategory {
+    Bool,
+    DateTime,
+    Numeric,
+    String,
+    Timespan,
+    UserDefined,
+    Unknown,
+}
+
+// Extracted from PostgreSQL 9.6.
+// ```
+// SELECT array_agg(typname), typcategory
+// FROM pg_catalog.pg_type
+// WHERE typname IN (
+//  'bool', 'bytea', 'date', 'float4', 'float8', 'int4', 'int8', 'interval','jsonb', 'numeric',
+//  'text', 'time', 'timestamp', 'timestamptz'
+// )
+// GROUP BY typcategory
+// ORDER BY typcategory;
+// ```
+fn get_type_category(typ: &ScalarType) -> TypeCategory {
+    match typ {
+        ScalarType::Bool => TypeCategory::Bool,
+        ScalarType::Bytes | ScalarType::Jsonb | ScalarType::List(_) => TypeCategory::UserDefined,
+        ScalarType::Date | ScalarType::Time | ScalarType::Timestamp | ScalarType::TimestampTz => {
+            TypeCategory::DateTime
+        }
+        ScalarType::Decimal(_, _)
+        | ScalarType::Float32
+        | ScalarType::Float64
+        | ScalarType::Int32
+        | ScalarType::Int64 => TypeCategory::Numeric,
+        ScalarType::Interval => TypeCategory::Timespan,
+        ScalarType::String => TypeCategory::String,
+        ScalarType::Unknown => TypeCategory::Unknown,
+    }
+}
+
+// Extracted from PostgreSQL 9.6.
+// ```
+// SELECT typcategory, typname, typispreferred
+// FROM pg_catalog.pg_type
+// WHERE typispreferred = true
+// ORDER BY typcategory;
+// ```
+fn get_preferred_type(category: &TypeCategory) -> Option<ScalarType> {
+    match category {
+        TypeCategory::Bool => Some(ScalarType::Bool),
+        TypeCategory::DateTime => Some(ScalarType::TimestampTz),
+        TypeCategory::Numeric => Some(ScalarType::Float64),
+        TypeCategory::String => Some(ScalarType::String),
+        TypeCategory::Timespan => Some(ScalarType::Interval),
+        _ => None,
+    }
+}
+
+fn is_param_preferred_type_for_arg(param_type: &ScalarType, arg_type: &ScalarType) -> bool {
+    let category = get_type_category(&arg_type);
+    let preferred_type = match get_preferred_type(&category) {
+        Some(typ) => typ,
+        None => return false,
+    };
+    std::mem::discriminant(&preferred_type) == std::mem::discriminant(param_type)
+}
+
+/// Describes the parameter types of implementations. Provides a facade over
+/// `ScalarType` for expressing more complex types of parameters.
+#[derive(Debug, Clone, Eq)]
+pub enum ParameterType {
+    Unknown,
+    Bool,
+    Int32,
+    Int64,
+    Float32,
+    Float64,
+    Decimal(u8, u8),
+    Date,
+    Time,
+    Timestamp,
+    TimestampTz,
+    Interval,
+    Bytes,
+    String,
+    /// Allows (and requires) the arguments to be cast to string; does so by
+    /// setting `CastContext::Implict(f, ImplicitCastMod::PermitAnyToString)`.
+    StringAny,
+    Jsonb,
+    /// Uses `super::query::plan_to_jsonb` during type coercion.
+    JsonbAny,
+}
+
+impl ParameterType {
+    fn get_scalar_type(&self) -> ScalarType {
+        use ParameterType::*;
+        match self {
+            Unknown => ScalarType::Unknown,
+            Bool => ScalarType::Bool,
+            Int32 => ScalarType::Int32,
+            Int64 => ScalarType::Int64,
+            Float32 => ScalarType::Float32,
+            Float64 => ScalarType::Float64,
+            Decimal(s, p) => ScalarType::Decimal(*s, *p),
+            Date => ScalarType::Date,
+            Time => ScalarType::Time,
+            Timestamp => ScalarType::Timestamp,
+            TimestampTz => ScalarType::TimestampTz,
+            Interval => ScalarType::Interval,
+            Bytes => ScalarType::Bytes,
+            String | StringAny => ScalarType::String,
+            Jsonb | JsonbAny => ScalarType::Jsonb,
+        }
+    }
+}
+
+impl Hash for ParameterType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        use ParameterType::*;
+        match self {
+            Unknown => state.write_u8(0),
+            Bool => state.write_u8(1),
+            Int32 => state.write_u8(2),
+            Int64 => state.write_u8(3),
+            Float32 => state.write_u8(4),
+            Float64 => state.write_u8(5),
+            Decimal(_, _) => {
+                state.write_u8(6);
+            }
+            Date => state.write_u8(7),
+            Time => state.write_u8(8),
+            Timestamp => state.write_u8(9),
+            TimestampTz => state.write_u8(10),
+            Interval => state.write_u8(11),
+            Bytes => state.write_u8(12),
+            // `String` and `StringAny` share the same hash for `implementation`
+            // lookups.
+            String | StringAny => state.write_u8(13),
+            Jsonb => state.write_u8(14),
+            JsonbAny => state.write_u8(15),
+        }
+    }
+}
+
+impl PartialEq for ParameterType {
+    fn eq(&self, other: &Self) -> bool {
+        use ParameterType::*;
+        match (self, other) {
+            (Unknown, Unknown)
+            | (Bool, Bool)
+            | (Int32, Int32)
+            | (Int64, Int64)
+            | (Float32, Float32)
+            | (Float64, Float64)
+            | (Decimal(_, _), Decimal(_, _))
+            | (Date, Date)
+            | (Time, Time)
+            | (Timestamp, Timestamp)
+            | (TimestampTz, TimestampTz)
+            | (Interval, Interval)
+            | (Bytes, Bytes)
+            // Though `String` and `StringAny` share a hash, they should not be
+            // equal because we need to differentiate between them when coercing
+            // args to param types.
+            | (String, String)
+            | (StringAny, StringAny)
+            | (Jsonb, Jsonb)
+            | (JsonbAny, JsonbAny) => true,
+            (_, _) => false,
+        }
+    }
+}
+
+impl PartialEq<ScalarType> for ParameterType {
+    fn eq(&self, other: &ScalarType) -> bool {
+        std::mem::discriminant(&self.get_scalar_type()) == std::mem::discriminant(other)
+    }
+}
+
+impl PartialEq<ParameterType> for ScalarType {
+    fn eq(&self, other: &ParameterType) -> bool {
+        other.eq(self)
+    }
+}
+
+impl From<&ParameterType> for ScalarType {
+    fn from(param: &ParameterType) -> Self {
+        param.get_scalar_type()
+    }
+}
+
+impl From<&ScalarType> for ParameterType {
+    fn from(typ: &ScalarType) -> Self {
+        use ParameterType::*;
+        match typ {
+            // TODO(sploiselle): Integrate some List function to sort out
+            // how its parameters should behave
+            ScalarType::Unknown | ScalarType::List(_) => Unknown,
+            ScalarType::Bool => Bool,
+            ScalarType::Int32 => Int32,
+            ScalarType::Int64 => Int64,
+            ScalarType::Float32 => Float32,
+            ScalarType::Float64 => Float64,
+            ScalarType::Decimal(s, p) => Decimal(*s, *p),
+            ScalarType::Date => Date,
+            ScalarType::Time => Time,
+            ScalarType::Timestamp => Timestamp,
+            ScalarType::TimestampTz => TimestampTz,
+            ScalarType::Interval => Interval,
+            ScalarType::Bytes => Bytes,
+            ScalarType::String => String,
+            ScalarType::Jsonb => Jsonb,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq)]
+/// Represents generalizable operation types you can return from
+/// `ArgImplementationMatcher`.
+pub enum OperationType {
+    /// Returns the `ScalarExpr` that is output from
+    /// `ArgImplementationMatcher::generate_exprs_from_types`.
+    ExprOnly,
+    Unary(UnaryFunc),
+    Binary(BinaryFunc),
+    Variadic(VariadicFunc, VariadicParam),
+}
+
+// This impl is meant only to support `ArgImplementationMatcher`'s
+// `operation_type` field, which is in turn only used for
+// `Self::get_possible_implementation_key`.
+impl Hash for OperationType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::ExprOnly => {
+                state.write_u8(0);
+            }
+            Self::Unary(_) => {
+                state.write_u8(1);
+            }
+            Self::Binary(_) => {
+                state.write_u8(2);
+            }
+            Self::Variadic(_, arg_mod) => {
+                state.write_u8(3);
+                arg_mod.hash(state);
+            }
+        }
+    }
+}
+
+// This impl is meant only to support `ArgImplementationMatcher`'s
+// `operation_type` field, which is in turn only used for
+// `Self::get_possible_implementation_key`.
+impl PartialEq for OperationType {
+    fn eq(&self, other: &Self) -> bool {
+        use OperationType::*;
+        match (self, other) {
+            (ExprOnly, ExprOnly) | (Unary(_), Unary(_)) | (Binary(_), Binary(_)) => true,
+            (Variadic(_, a), Variadic(_, b)) => a.eq(b),
+            (ExprOnly, _) | (Unary(_), _) | (Binary(_), _) | (Variadic(_, _), _) => false,
+        }
+    }
+}
+
+impl OperationType {
+    // Validates the number of params or arguments based on the type of
+    // operation; however, error strings are only used when validating
+    // implementation parameters.
+    fn validate_input_len(&self, input_len: usize, is_arg: bool) -> Result<(), failure::Error> {
+        let (valid, e) = match self {
+            Self::ExprOnly | Self::Unary(_) => {
+                (input_len == 1, format!("1 param, received {}", input_len))
+            }
+            Self::Binary(_) => (input_len == 2, format!("2 params, received {}", input_len)),
+            Self::Variadic(_, arg_mod) => arg_mod.validate_input_len(input_len, is_arg),
+        };
+
+        if !valid {
+            bail!("Invalid argument length: expected {}", e)
+        } else {
+            Ok(())
+        }
+    }
+
+    // Converts `types` into a form that can potentially match the parameters of
+    // a implementation of the given `OperationType`. In consequence, this is
+    // necessary because variadic operations support multiple parameter
+    // structures.
+    fn get_possible_implementation_key(&self, types: &[ParameterType]) -> Vec<ParameterType> {
+        match self {
+            Self::ExprOnly | Self::Unary(_) | Self::Binary(_) => types.to_vec(),
+            Self::Variadic(_, arg_mod) => arg_mod.get_possible_implementation_key(types),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq)]
+/// Describes different classes of variadic paprameters.
+pub enum VariadicParam {
+    /// Accepts any type, as long as all arguments are of the same type.
+    ///
+    /// When using `AnyHomogeneous`, provide an empty `Vec::<ScalarType>` as the
+    /// implementation's parameter.
+    AnyHomogeneous(ParameterType),
+    /// Accepts `usize` arguments.
+    MustEq(usize),
+    /// Accepts repeated patterns of `usize` length.
+    Repeat(usize),
+}
+
+// View comments on same impl for `OperationType`.
+impl Hash for VariadicParam {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::AnyHomogeneous(_) => {
+                state.write_u8(0);
+            }
+            Self::MustEq(_) => {
+                state.write_u8(1);
+            }
+            Self::Repeat(s) => {
+                state.write_u8(2);
+                state.write_usize(*s);
+            }
+        }
+    }
+}
+
+// View comments on same impl for `OperationType`.
+impl PartialEq for VariadicParam {
+    fn eq(&self, other: &Self) -> bool {
+        use VariadicParam::*;
+        match (self, other) {
+            (AnyHomogeneous(_), AnyHomogeneous(_))
+            | (MustEq(_), MustEq(_))
+            | (Repeat(_), Repeat(_)) => true,
+            (AnyHomogeneous(_), _) | (MustEq(_), _) | (Repeat(_), _) => false,
+        }
+    }
+}
+
+impl VariadicParam {
+    // View comments on same function in `OperationType`.
+    fn validate_input_len(&self, input_len: usize, is_arg: bool) -> (bool, String) {
+        match self {
+            Self::MustEq(expected) => (
+                input_len == *expected,
+                format!("{} params, received {}", *expected, input_len),
+            ),
+            Self::Repeat(arg_modulo) => (
+                input_len % arg_modulo == 0 && input_len > 0,
+                format!(
+                    "X % {} == 0 && X > 0 params, but received {} params",
+                    arg_modulo, input_len,
+                ),
+            ),
+            Self::AnyHomogeneous(_) => (
+                if is_arg { true } else { input_len == 0 },
+                format!("0 params, but received {}", input_len),
+            ),
+        }
+    }
+
+    // View comments on same function in `OperationType`.
+    fn get_possible_implementation_key(&self, types: &[ParameterType]) -> Vec<ParameterType> {
+        match self {
+            Self::MustEq(_) => types.to_vec(),
+            Self::Repeat(n) => {
+                if types.len() >= *n {
+                    let mut base_types = Vec::new();
+                    for i in 0..*n {
+                        base_types.push(types[i].clone());
+                    }
+                    if types
+                        .iter()
+                        .enumerate()
+                        .all(|(i, x)| *x == base_types[i % n])
+                    {
+                        return base_types;
+                    }
+                }
+
+                types.to_vec()
+            }
+            Self::AnyHomogeneous(_) => Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+/// Tracks candidate implementations during `ArgImplementationMatcher::best_match`.
+struct Candidate {
+    // Represents the candidate's argument types; used as key to match some
+    // implementation's parameter types.
+    arg_types: Vec<ParameterType>,
+    exact_matches: usize,
+    preferred_types: usize,
+}
+
+#[derive(Clone, Debug)]
+/// Determines best implementation to use given some user-provided arguments.
+/// For more detail, see `ArgImplementationMatcher::select_implementation`.
+pub struct ArgImplementationMatcher<'a> {
+    ident: &'a str,
+    ecx: &'a ExprContext<'a>,
+    // Maps an implementation's parameters to its `OperationType`.
+    implementations: HashMap<Vec<ParameterType>, OperationType>,
+    // Tracks distinct `OperationType`s among implementations; this is used to
+    // transform the caller's arguments' types into forms that can match the
+    // implementation's parameters, i.e. the keys of `implementations`.
+    operation_types: HashSet<OperationType>,
+}
+
+#[macro_export]
+/// Provides a macro to write HashMap "literals" to be used with
+/// `ArgImplementationMatcher.implementations`.
+macro_rules! implementations(
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m = ::std::collections::HashMap::new();
+            $(
+                m.insert($key, $value);
+            )+
+            m
+        }
+     };
+);
+
+impl<'a> ArgImplementationMatcher<'a> {
+    /// Selects the best implementation given the provided `args` using a
+    /// process similar to [PostgreSQL's
+    /// parser](https://www.postgresql.org/docs/current/typeconv-oper.html), and
+    /// returns the `ScalarExpr` to invoke that .
+    ///
+    /// Generate `implementations` using the `implementations!` macro in this
+    /// package.
+    ///
+    /// # Errors
+    /// - When the provided arguments are not valid for any implementation, e.g.
+    ///   cannot be converted to the appropriate types.
+    /// - When all implementations are equally valid.
+    pub fn select_implementation(
+        ident: &'a str,
+        ecx: &'a ExprContext<'a>,
+        implementations: HashMap<Vec<ParameterType>, OperationType>,
+        args: &[sql_parser::ast::Expr],
+    ) -> Result<ScalarExpr, failure::Error> {
+        let mut m = Self::new(ident, ecx, implementations)?;
+        let (op, types) = m.match_args_to_implementation(args)?;
+        let op = Self::rewrite_enum_field_ops(op, &types);
+        let mut exprs = m.generate_exprs_from_types(&op, args, &types)?;
+
+        Ok(match op {
+            OperationType::ExprOnly => exprs.remove(0),
+            OperationType::Unary(func) => ScalarExpr::CallUnary {
+                func,
+                expr: Box::new(exprs.remove(0)),
+            },
+            OperationType::Binary(func) => ScalarExpr::CallBinary {
+                func,
+                expr1: Box::new(exprs.remove(0)),
+                expr2: Box::new(exprs.remove(0)),
+            },
+            OperationType::Variadic(func, _) => ScalarExpr::CallVariadic { func, exprs },
+        })
+    }
+
+    fn new(
+        ident: &'a str,
+        ecx: &'a ExprContext<'a>,
+        implementations: HashMap<Vec<ParameterType>, OperationType>,
+    ) -> Result<Self, failure::Error> {
+        let mut operation_types = HashSet::new();
+
+        let mut seen_anyhomogeneous = false;
+
+        // Checks implementations' invariants; meant to error for developers
+        // working in package and should never error during runtime.
+        for (params, op) in implementations.iter() {
+            op.validate_input_len(params.len(), false)?;
+            if let OperationType::Variadic(_, VariadicParam::AnyHomogeneous(_)) = op {
+                if seen_anyhomogeneous {
+                    bail!(
+                        "You may only have one implementation that accepts \
+                    any homogenously typed set of arguments"
+                    )
+                }
+                seen_anyhomogeneous = true;
+            }
+            operation_types.insert(op.clone());
+        }
+
+        Ok(Self {
+            ident,
+            ecx,
+            implementations,
+            operation_types,
+        })
+    }
+
+    fn match_args_to_implementation(
+        &mut self,
+        args: &[sql_parser::ast::Expr],
+    ) -> Result<(OperationType, Vec<ParameterType>), failure::Error> {
+        let mut raw_arg_types = Vec::new();
+        for arg in args {
+            let expr = super::query::plan_expr(self.ecx, &arg, Some(ScalarType::Unknown))?;
+            raw_arg_types.push((&self.ecx.scalar_type(&expr)).into());
+            self.clear_expr_param_data(&arg);
+        }
+
+        // Look for exact match.
+        if let Some(func) = self.get_implementation(&raw_arg_types) {
+            return Ok((func, raw_arg_types));
+        }
+
+        Ok(self.best_match(args, &raw_arg_types)?)
+    }
+
+    // Returns an implementation's `OperationType` if `types` matches an
+    // implementation's parameters and some other bookkeeping is satisfied.
+    //
+    // Note that `types` must be the caller's argument's types to preserve
+    // Decimal scale and precision.
+    fn get_implementation(&self, types: &[ParameterType]) -> Option<OperationType> {
+        // Rewrites all Decimal values to a consistent scale and precision
+        // to support matching implementation parameters.
+        // TODO(sploiselle): Add `ScalarType::List` support.
+        let matchable_types: Vec<ParameterType> = types
+            .iter()
+            .map(|t| match t {
+                ParameterType::Decimal(_, _) => ParameterType::Decimal(0, 0),
+                other => other.clone(),
+            })
+            .collect();
+
+        let possible_implementation_keys: Vec<Vec<ParameterType>> = self
+            .operation_types
+            .iter()
+            .map(|op| op.get_possible_implementation_key(&matchable_types))
+            .collect();
+
+        for key in possible_implementation_keys {
+            if let Some(op) = self.implementations.get(&key) {
+                // Sanity check argument length for exact matches.
+                if op.validate_input_len(types.len(), true).is_ok() {
+                    return Some(op.clone());
+                }
+            }
+        }
+
+        None
+    }
+
+    // If no exact match, finds the best match available. Patterned after
+    // [PostgreSQL's type converstion matching
+    // algorithm](https://www.postgresql.org/docs/current/typeconv-func.html).
+    // Comments prefixed with number are taken from the "Function Type
+    // Resolution" section of the aforelinked page.
+    fn best_match(
+        &mut self,
+        args: &[sql_parser::ast::Expr],
+        raw_arg_types: &[ParameterType],
+    ) -> Result<(OperationType, Vec<ParameterType>), failure::Error> {
+        let mut candidates = Vec::new();
+        let mut max_exact_matches = 0;
+        let mut max_preferred_types = 0;
+
+        // Generate candidates by assessing their compatibility with each
+        // implementation's parameters.
+        for (params, op) in self.implementations.iter() {
+            // Do not generate candidates if the number of arguments is invalid
+            // for this implementation.
+            if op.validate_input_len(args.len(), true).is_err() {
+                continue;
+            }
+
+            let mut valid_candidate = true;
+            let mut arg_types = Vec::new();
+            let mut exact_matches = 0;
+            let mut preferred_types = 0;
+
+            for (i, (arg, raw_arg_type)) in args.iter().zip(raw_arg_types.iter()).enumerate() {
+                let param_type = if let OperationType::Variadic(_, VariadicParam::Repeat(n)) = op {
+                    &params[i % *n]
+                } else {
+                    &params[i]
+                };
+
+                let arg_type =
+                    if std::mem::discriminant(raw_arg_type) == std::mem::discriminant(param_type) {
+                        exact_matches += 1;
+                        // This block checks discriminants and returns the argument type
+                        // to retain Decimal precision and scale.
+                        raw_arg_types[i].clone()
+                    } else {
+                        if self.coerce_arg_to_type(arg, &param_type).is_err() {
+                            valid_candidate = false;
+                            break;
+                        }
+
+                        // Increment `preferred_type` if:
+                        // - This param is the preferred type for this argument's
+                        //   type category
+                        // - This argument is a string literal and this param is the
+                        //   preferred type in its type category.
+                        if is_param_preferred_type_for_arg(&param_type.into(), &raw_arg_type.into())
+                            || (is_arg_string_literal(arg)
+                                && is_param_preferred_type_for_arg(
+                                    &param_type.into(),
+                                    &param_type.into(),
+                                ))
+                        {
+                            preferred_types += 1;
+                        }
+
+                        param_type.clone()
+                    };
+
+                arg_types.push(arg_type);
+                self.clear_expr_param_data(&arg);
+            }
+
+            // 4.a. Discard candidate functions for which the input types do not match
+            // and cannot be converted (using an implicit conversion) to match.
+            // unknown literals are assumed to be convertible to anything for this
+            // purpose.
+            if valid_candidate {
+                max_exact_matches = std::cmp::max(max_exact_matches, exact_matches);
+                max_preferred_types = std::cmp::max(max_preferred_types, preferred_types);
+                candidates.push(Candidate {
+                    arg_types,
+                    exact_matches,
+                    preferred_types,
+                });
+            }
+        }
+
+        if candidates.is_empty() {
+            bail!(
+                "arguments cannot be implicitly cast to any implementation's parameters; \
+            try providing explicit casts"
+            )
+        }
+
+        if let Some((func, types)) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok((func, types));
+        }
+
+        // 4.c. Run through all candidates and keep those with the most exact matches on
+        // input types. Keep all candidates if none have exact matches.
+        candidates.retain(|c| c.exact_matches >= max_exact_matches);
+
+        if let Some((func, types)) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok((func, types));
+        }
+
+        // 4.d. Run through all candidates and keep those that accept preferred types
+        // (of the input data type's type category) at the most positions where
+        // type conversion will be required.
+        candidates.retain(|c| c.preferred_types >= max_preferred_types);
+
+        if let Some((func, types)) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok((func, types));
+        }
+
+        // This call could be entirely elided if there are no unknown-type arguments.
+        match self.best_match_unknown_checks(raw_arg_types, &mut candidates)? {
+            Some((func, types)) => Ok((func, types)),
+            None => bail!(
+                "unable to determine which implementation to use; try providing \
+                explicit casts to match parameter types"
+            ),
+        }
+    }
+
+    fn best_match_unknown_checks(
+        &mut self,
+        raw_arg_types: &[ParameterType],
+        candidates: &mut Vec<Candidate>,
+    ) -> Result<Option<(OperationType, Vec<ParameterType>)>, failure::Error> {
+        let mut found_unknown = false;
+        let mut found_known = false;
+        let mut types_match = true;
+        let mut common_type: Option<ParameterType> = None;
+
+        for (i, raw_arg_type) in raw_arg_types.iter().enumerate() {
+            let mut selected_category: Option<TypeCategory> = None;
+            let mut found_string_candidate = false;
+            let mut categories_match = true;
+
+            match raw_arg_type {
+                // 4.e. If any input arguments are unknown, check the type categories accepted
+                // at those argument positions by the remaining candidates.
+                ParameterType::Unknown => {
+                    found_unknown = true;
+
+                    for c in candidates.iter() {
+                        let this_category = get_type_category(&(&c.arg_types[i]).into());
+                        match (&selected_category, &this_category) {
+                            // 4.e. cont: At each  position, select the string category if
+                            // any candidate accepts that category. (This bias
+                            // towards string is appropriate since an
+                            // unknown-type literal looks like a string.)
+                            (Some(TypeCategory::String), _) => {}
+                            (_, TypeCategory::String) => {
+                                found_string_candidate = true;
+                                selected_category = Some(TypeCategory::String);
+                            }
+                            // 4.e. cont: Otherwise, if all the remaining candidates accept
+                            // the same type category, select that category.
+                            (Some(selected_category), this_category) => {
+                                categories_match =
+                                    *selected_category == *this_category && categories_match
+                            }
+                            (None, this_category) => {
+                                selected_category = Some(this_category.clone())
+                            }
+                        }
+                    }
+
+                    // 4.e. cont: Otherwise fail because the correct choice cannot be
+                    // deduced without more clues.
+                    if !found_string_candidate && !categories_match {
+                        return Ok(None);
+                    }
+
+                    // 4.e. cont: Now discard candidates that do not accept the selected
+                    // type category. Furthermore, if any candidate accepts a
+                    // preferred type in that category, discard candidates that
+                    // accept non-preferred types for that argument.
+                    let selected_category = selected_category.unwrap();
+
+                    let preferred_type = get_preferred_type(&selected_category);
+                    let mut found_preferred_type_candidate = false;
+                    candidates.retain(|c| {
+                        if let Some(typ) = &preferred_type {
+                            found_preferred_type_candidate =
+                                c.arg_types[i] == *typ || found_preferred_type_candidate;
+                        }
+                        selected_category == get_type_category(&(&c.arg_types[i]).into())
+                    });
+
+                    if found_preferred_type_candidate {
+                        let preferred_type = preferred_type.unwrap();
+                        candidates.retain(|c| c.arg_types[i] == preferred_type);
+                    }
+                }
+                typ => {
+                    found_known = true;
+                    // Track if all known types are of the same type; use this info in 4.f.
+                    if let Some(common_type) = &common_type {
+                        types_match = types_match && *common_type == *typ
+                    } else {
+                        common_type = Some(typ.clone());
+                    }
+                }
+            }
+        }
+
+        if let Some((func, exprs)) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok(Some((func, exprs)));
+        }
+
+        // 4.f. If there are both unknown and known-type arguments, and all the
+        // known-type arguments have the same type, assume that the unknown
+        // arguments are also of that type, and check which candidates can
+        // accept that type at the unknown-argument positions.
+        if found_known && found_unknown && types_match {
+            let common_type = common_type.unwrap();
+            for (i, raw_arg_type) in raw_arg_types.iter().enumerate() {
+                if *raw_arg_type == ScalarType::Unknown {
+                    candidates.retain(|c| common_type == c.arg_types[i]);
+                }
+            }
+
+            if let Some((func, types)) = self.maybe_get_last_candidate(&candidates)? {
+                return Ok(Some((func, types)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn maybe_get_last_candidate(
+        &self,
+        candidates: &[Candidate],
+    ) -> Result<Option<(OperationType, Vec<ParameterType>)>, failure::Error> {
+        if candidates.len() == 1 {
+            match self.get_implementation(&candidates[0].arg_types) {
+                Some(func) => Ok(Some((func, candidates[0].arg_types.to_vec()))),
+                None => bail!("logical error: please report me"),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    // Because we use the same `ExprContext` throughout `Self::best_match`, we
+    // have to clean up any param types we provisionally inserted. This data
+    // gets re-inserted during `Self::generate_exprs_from_types`.
+    fn clear_expr_param_data(&self, expr: &sql_parser::ast::Expr) {
+        if let sql_parser::ast::Expr::Parameter(n) = expr {
+            self.ecx.remove_param(*n);
+        }
+    }
+
+    // Rewrite operations that take enum field values to use the caller's
+    // arguments' values, rather than the defaults used to determine matching
+    // implementations.
+    fn rewrite_enum_field_ops(op: OperationType, types: &[ParameterType]) -> OperationType {
+        use OperationType::*;
+        match op {
+            Unary(UnaryFunc::CeilDecimal(_)) => match types[0] {
+                ParameterType::Decimal(_, s) => Unary(UnaryFunc::CeilDecimal(s)),
+                _ => unreachable!(),
+            },
+            Unary(UnaryFunc::FloorDecimal(_)) => match types[0] {
+                ParameterType::Decimal(_, s) => Unary(UnaryFunc::FloorDecimal(s)),
+                _ => unreachable!(),
+            },
+            Unary(UnaryFunc::RoundDecimal(_)) => match types[0] {
+                ParameterType::Decimal(_, s) => Unary(UnaryFunc::RoundDecimal(s)),
+                _ => unreachable!(),
+            },
+            Binary(BinaryFunc::RoundDecimal(_)) => match types[0] {
+                ParameterType::Decimal(_, s) => Binary(BinaryFunc::RoundDecimal(s)),
+                _ => unreachable!(),
+            },
+            other => other,
+        }
+    }
+
+    // Plans `args` into `ScalarExprs` of the specified parameter `types`.
+    fn generate_exprs_from_types(
+        &self,
+        op: &OperationType,
+        args: &[sql_parser::ast::Expr],
+        types: &[ParameterType],
+    ) -> Result<Vec<ScalarExpr>, failure::Error> {
+        match op {
+            OperationType::Variadic(_, VariadicParam::AnyHomogeneous(hint)) => {
+                super::query::plan_homogeneous_exprs(self.ident, self.ecx, args, Some(hint.into()))
+            }
+            _ => {
+                // Arguments must be replanned into exprs to ensure parameters (e.g.
+                // $1) receive the correct type.
+                let mut exprs = Vec::new();
+                for (arg, typ) in args.iter().zip(types.iter()) {
+                    exprs.push(self.coerce_arg_to_type(arg, typ)?);
+                }
+                Ok(exprs)
+            }
+        }
+    }
+
+    // Generate `ScalarExpr` necessary to coerce `Expr` into the `ScalarType`
+    // corresponding to `ParameterType`; errors if not possible. This can only
+    // work within the `func` module because it relies on `ParameterType`.
+    fn coerce_arg_to_type(
+        &self,
+        arg: &Expr,
+        typ: &ParameterType,
+    ) -> Result<ScalarExpr, failure::Error> {
+        use super::query::CastContext::*;
+        use super::query::ImplicitCastMod::*;
+        let hinted_expr = super::query::plan_expr(self.ecx, &arg, Some(typ.into()))?;
+
+        if self.ecx.scalar_type(&hinted_expr) == *typ {
+            Ok(hinted_expr)
+        } else if ParameterType::JsonbAny == *typ {
+            super::query::plan_to_jsonb(self.ecx, self.ident, hinted_expr)
+        } else {
+            // JSONB compatibility requires side effects of explicit casts:
+            // - Explicit boolean to string behavior
+            // - Casting strings to any type
+            let ccx = if self.ident.contains("jsonb") {
+                Explicit
+            } else if ParameterType::StringAny == *typ {
+                Implicit(self.ident, PermitAnyToString)
+            } else if is_arg_string_literal(arg) {
+                Implicit(self.ident, PermitStringToAny)
+            } else {
+                Implicit(self.ident, None)
+            };
+
+            super::query::plan_cast_internal(self.ecx, ccx, hinted_expr, typ.into())
+        }
+    }
+}
+
+pub fn is_arg_string_literal(arg: &Expr) -> bool {
+    if let Expr::Value(Value::SingleQuotedString(_)) = arg {
+        true
+    } else {
+        false
+    }
+}
+
+pub fn select_scalar_func(
+    ecx: &ExprContext,
+    ident: &str,
+    args: &[sql_parser::ast::Expr],
+) -> Result<ScalarExpr, failure::Error> {
+    use OperationType::*;
+    use ParameterType::*;
+    let implementations = match ident {
+        "abs" => {
+            implementations! {
+                vec![Int32] => Unary(UnaryFunc::AbsInt32),
+                vec![Int64] => Unary(UnaryFunc::AbsInt64),
+                vec![Float32] => Unary(UnaryFunc::AbsFloat32),
+                vec![Float64] => Unary(UnaryFunc::AbsFloat64)
+            }
+        }
+        "ascii" => {
+            implementations! {
+                vec![String] => Unary(UnaryFunc::Ascii)
+            }
+        }
+        "ceil" => {
+            implementations! {
+                vec![Float32] => Unary(UnaryFunc::CeilFloat32),
+                vec![Float64] => Unary(UnaryFunc::CeilFloat64),
+                vec![Decimal(0, 0)] => Unary(UnaryFunc::CeilDecimal(0))
+            }
+        }
+        "coalesce" => {
+            implementations! {
+                vec![] => Variadic(VariadicFunc::Coalesce,VariadicParam::AnyHomogeneous(String))
+            }
+        }
+        "concat" => {
+            implementations! {
+                vec![StringAny] => Variadic(VariadicFunc::Concat, VariadicParam::Repeat(1))
+            }
+        }
+        "convert_from" => {
+            implementations! {
+                vec![Bytes, String] => Binary(BinaryFunc::ConvertFrom)
+            }
+        }
+        "date_trunc" => {
+            implementations! {
+                vec![String, Timestamp] => Binary(BinaryFunc::DateTruncTimestamp),
+                vec![String, TimestampTz] => Binary(BinaryFunc::DateTruncTimestampTz)
+            }
+        }
+        "floor" => {
+            implementations! {
+                vec![Float32] => Unary(UnaryFunc::FloorFloat32),
+                vec![Float64] => Unary(UnaryFunc::FloorFloat64),
+                vec![Decimal(0, 0)] => Unary(UnaryFunc::FloorDecimal(0))
+            }
+        }
+        "jsonb_array_length" => {
+            implementations! {
+                vec![Jsonb] => Unary(UnaryFunc::JsonbArrayLength)
+            }
+        }
+        "jsonb_build_array" => {
+            implementations! {
+                vec![] => Variadic(VariadicFunc::JsonbBuildArray, VariadicParam::MustEq(0)),
+                vec![JsonbAny] => Variadic(VariadicFunc::JsonbBuildArray, VariadicParam::Repeat(1))
+            }
+        }
+        "jsonb_build_object" => {
+            implementations! {
+                vec![] => Variadic(VariadicFunc::JsonbBuildObject,VariadicParam::MustEq(0)),
+                vec![StringAny, JsonbAny] => Variadic(
+                    VariadicFunc::JsonbBuildObject,
+                    VariadicParam::Repeat(2)
+                )
+            }
+        }
+        "jsonb_pretty" => {
+            implementations! {
+                vec![Jsonb] => Unary(UnaryFunc::JsonbPretty)
+            }
+        }
+        "jsonb_strip_nulls" => {
+            implementations! {
+                vec![Jsonb] => Unary(UnaryFunc::JsonbStripNulls),
+                // jsonb_strip_nulls does not want to cast NULLs to JSONB.
+                vec![Unknown] => Unary(UnaryFunc::JsonbStripNulls)
+            }
+        }
+        "jsonb_typeof" => {
+            implementations! {
+                vec![Jsonb] => Unary(UnaryFunc::JsonbTypeof)
+            }
+        }
+        "length" => {
+            implementations! {
+                vec![Bytes] => Unary(UnaryFunc::LengthBytes),
+                vec![String] => Variadic(VariadicFunc::LengthString, VariadicParam::MustEq(1)),
+                vec![String, String] => Variadic(
+                    VariadicFunc::LengthString, VariadicParam::MustEq(2)
+                )
+            }
+        }
+        "make_timestamp" => {
+            implementations! {
+                vec![Int64,
+                Int64,
+                Int64,
+                Int64,
+                Int64,
+                Float64] => Variadic(VariadicFunc::MakeTimestamp, VariadicParam::MustEq(6))
+            }
+        }
+        "replace" => {
+            implementations! {
+                vec![String, String, String] => Variadic(
+                    VariadicFunc::Replace, VariadicParam::MustEq(3)
+                )
+            }
+        }
+        "round" => {
+            implementations! {
+                vec![Float32] => Unary(UnaryFunc::RoundFloat32),
+                vec![Float64] => Unary(UnaryFunc::RoundFloat64),
+                vec![Decimal(0,0)] => Unary(UnaryFunc::RoundDecimal(0)),
+                vec![Decimal(0,0), Int64] => Binary(BinaryFunc::RoundDecimal(0))
+            }
+        }
+        "substring" | "substr" => {
+            implementations! {
+                vec![String, Int64] => Variadic(VariadicFunc::Substr, VariadicParam::MustEq(2)),
+                vec![String, Int64, Int64] => Variadic(
+                    VariadicFunc::Substr,
+                    VariadicParam::MustEq(3)
+                )
+            }
+        }
+        "to_char" => {
+            implementations! {
+                vec![Timestamp, String] => Binary(BinaryFunc::ToCharTimestamp),
+                vec![TimestampTz, String] => Binary(BinaryFunc::ToCharTimestampTz)
+            }
+        }
+        // > Returns the value as json or jsonb. Arrays and composites
+        // > are converted (recursively) to arrays and objects;
+        // > otherwise, if there is a cast from the type to json, the
+        // > cast function will be used to perform the conversion;
+        // > otherwise, a scalar value is produced. For any scalar type
+        // > other than a number, a Boolean, or a null value, the text
+        // > representation will be used, in such a fashion that it is a
+        // > valid json or jsonb value.
+        //
+        // https://www.postgresql.org/docs/current/functions-json.html
+        "to_jsonb" => {
+            implementations! {
+                vec![JsonbAny] => ExprOnly
+            }
+        }
+        "to_timestamp" => {
+            implementations! {
+                vec![Float64] => Unary(UnaryFunc::ToTimestamp)
+            }
+        }
+        _ => unsupported!(ident),
+    };
+
+    match ArgImplementationMatcher::select_implementation(ident, ecx, implementations, args) {
+        Ok(expr) => Ok(expr),
+        Err(e) => bail!("Cannot call function '{}': {}", ident, e),
+    }
+}

--- a/src/sql/func.rs
+++ b/src/sql/func.rs
@@ -837,6 +837,10 @@ impl<'a> ArgImplementationMatcher<'a> {
     fn rewrite_enum_field_ops(op: OperationType, types: &[ParameterType]) -> OperationType {
         use OperationType::*;
         match op {
+            Unary(UnaryFunc::AbsDecimal(_)) => match types[0] {
+                ParameterType::Decimal(_, s) => Unary(UnaryFunc::AbsDecimal(s)),
+                _ => unreachable!(),
+            },
             Unary(UnaryFunc::CeilDecimal(_)) => match types[0] {
                 ParameterType::Decimal(_, s) => Unary(UnaryFunc::CeilDecimal(s)),
                 _ => unreachable!(),
@@ -935,6 +939,7 @@ pub fn select_scalar_func(
             implementations! {
                 vec![Int32] => Unary(UnaryFunc::AbsInt32),
                 vec![Int64] => Unary(UnaryFunc::AbsInt64),
+                vec![Decimal(0, 0)] => Unary(UnaryFunc::AbsDecimal(0)),
                 vec![Float32] => Unary(UnaryFunc::AbsFloat32),
                 vec![Float64] => Unary(UnaryFunc::AbsFloat64)
             }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1,0 +1,859 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! TBD: Currently, `sql::func` handles matching arguments to their respective
+//! built-in functions (for most built-in functions, at least).
+
+use std::collections::HashMap;
+
+use failure::bail;
+use lazy_static::lazy_static;
+use repr::ScalarType;
+use sql_parser::ast::Expr;
+
+use super::expr::{BinaryFunc, ScalarExpr, UnaryFunc, VariadicFunc};
+use super::query::ExprContext;
+use super::unsupported;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Mirrored from [PostgreSQL's `typcategory`][typcategory].
+///
+/// [typcategory]: https://www.postgresql.org/docs/9.6/catalog-pg-type.html#CATALOG-TYPCATEGORY-TABLE
+enum TypeCategory {
+    Bool,
+    DateTime,
+    Numeric,
+    String,
+    Timespan,
+    UserDefined,
+    Unknown,
+}
+
+impl TypeCategory {
+    /// Extracted from PostgreSQL 9.6.
+    /// ```ignore
+    /// SELECT array_agg(typname), typcategory
+    /// FROM pg_catalog.pg_type
+    /// WHERE typname IN (
+    ///  'bool', 'bytea', 'date', 'float4', 'float8', 'int4', 'int8', 'interval', 'jsonb',
+    ///  'numeric', 'text', 'time', 'timestamp', 'timestamptz'
+    /// )
+    /// GROUP BY typcategory
+    /// ORDER BY typcategory;
+    /// ```
+    fn from_type(typ: &ScalarType) -> TypeCategory {
+        match typ {
+            ScalarType::Bool => TypeCategory::Bool,
+            ScalarType::Bytes | ScalarType::Jsonb | ScalarType::List(_) => {
+                TypeCategory::UserDefined
+            }
+            ScalarType::Date
+            | ScalarType::Time
+            | ScalarType::Timestamp
+            | ScalarType::TimestampTz => TypeCategory::DateTime,
+            ScalarType::Decimal(_, _)
+            | ScalarType::Float32
+            | ScalarType::Float64
+            | ScalarType::Int32
+            | ScalarType::Int64 => TypeCategory::Numeric,
+            ScalarType::Interval => TypeCategory::Timespan,
+            ScalarType::String => TypeCategory::String,
+            ScalarType::Unknown => TypeCategory::Unknown,
+        }
+    }
+
+    /// Extracted from PostgreSQL 9.6.
+    /// ```ignore
+    /// SELECT typcategory, typname, typispreferred
+    /// FROM pg_catalog.pg_type
+    /// WHERE typispreferred = true
+    /// ORDER BY typcategory;
+    /// ```
+    fn preferred_type(&self) -> Option<ScalarType> {
+        match self {
+            TypeCategory::Bool => Some(ScalarType::Bool),
+            TypeCategory::DateTime => Some(ScalarType::TimestampTz),
+            TypeCategory::Numeric => Some(ScalarType::Float64),
+            TypeCategory::String => Some(ScalarType::String),
+            TypeCategory::Timespan => Some(ScalarType::Interval),
+            _ => None,
+        }
+    }
+}
+
+fn is_param_preferred_type_for_arg(param_type: &ScalarType, arg_type: &ScalarType) -> bool {
+    match TypeCategory::from_type(&arg_type).preferred_type() {
+        Some(preferred_type) => &preferred_type == param_type,
+        _ => false,
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// Describes a single function's implementation.
+pub struct FuncImpl {
+    params: ParamList,
+    op: OperationType,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// Describes possible types of function parameters.
+///
+/// Note that this is not exhaustive and will likely require additions.
+pub enum ParamList {
+    Exact(Vec<ParamType>),
+    Repeat(Vec<ParamType>),
+    AnyHomogeneous(ScalarType),
+}
+
+impl ParamList {
+    /// Validates that the number of input elements are viable for this set of
+    /// parameters.
+    fn validate_arg_len(&self, input_len: usize) -> bool {
+        match self {
+            Self::Exact(p) => p.len() == input_len,
+            Self::Repeat(p) => input_len % p.len() == 0 && input_len > 0,
+            Self::AnyHomogeneous(_) => input_len > 0,
+        }
+    }
+
+    /// Matches a `&[ScalarType]` derived from the user's function argument
+    /// against this `ParamList`'s permitted arguments.
+    fn match_scalartypes(&self, types: &[ScalarType]) -> bool {
+        use ParamList::*;
+        match self {
+            Exact(p) => types.iter().zip(p.iter()).all(|(t, p)| t == p),
+            Repeat(p) => types.iter().enumerate().all(|(i, t)| t == &p[i % p.len()]),
+            AnyHomogeneous(_) => types.iter().all(|t| *t == types[0]),
+        }
+    }
+}
+
+/// Provides a shorthand function for writing `ParamList::Exact`.
+impl From<Vec<ParamType>> for ParamList {
+    fn from(p: Vec<ParamType>) -> ParamList {
+        ParamList::Exact(p)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// Describes parameter types; these are essentially just `ScalarType` with some
+/// added flexibility.
+pub enum ParamType {
+    Plain(ScalarType),
+    /// Permits any type, but requires it to be cast to a `ScalarType::String`.
+    StringAny,
+    /// Like `StringAny`, but pretends the argument was explicitly cast to
+    /// a `ScalarType::String`, rather than implicitly cast.
+    ExplicitStringAny,
+    /// Permits types that can be cast to `JSONB` elements.
+    JsonbAny,
+}
+
+impl PartialEq<ScalarType> for ParamType {
+    fn eq(&self, other: &ScalarType) -> bool {
+        use ScalarType::*;
+        match (self, other) {
+            (ParamType::StringAny, _) | (ParamType::ExplicitStringAny, _) => true,
+            (ParamType::JsonbAny, o) => match o {
+                Bool | Float64 | Float32 | Jsonb | String => true,
+                _ => false,
+            },
+            // Param `Decimal` values are still unsaturated when we compare them
+            // with user args.
+            (ParamType::Plain(Decimal(_, _)), Decimal(_, _)) => true,
+            (ParamType::Plain(s), o) => s == o,
+        }
+    }
+}
+
+impl PartialEq<ParamType> for ScalarType {
+    fn eq(&self, other: &ParamType) -> bool {
+        other == self
+    }
+}
+
+impl From<&ParamType> for ScalarType {
+    fn from(p: &ParamType) -> ScalarType {
+        match p {
+            ParamType::Plain(s) => s.clone(),
+            ParamType::StringAny | ParamType::ExplicitStringAny => ScalarType::String,
+            ParamType::JsonbAny => ScalarType::Jsonb,
+        }
+    }
+}
+
+pub trait Params {
+    fn into_params(self) -> Vec<ParamType>;
+}
+
+/// Provides a shorthand for converting a `Vec<ScalarType>` to `Vec<ParamType>`.
+/// Note that this moves the values out of `self` and into the resultant `Vec<ParamType>`.
+impl Params for Vec<ScalarType> {
+    fn into_params(self) -> Vec<ParamType> {
+        self.into_iter().map(ParamType::Plain).collect()
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// Represents generalizable operation types you can return from
+/// `ArgImplementationMatcher`.
+pub enum OperationType {
+    /// Returns the `ScalarExpr` that is output from
+    /// `ArgImplementationMatcher::generate_param_exprs`.
+    ExprOnly,
+    Unary(UnaryFunc),
+    Binary(BinaryFunc),
+    Variadic(VariadicFunc),
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+/// Tracks candidate implementations during `ArgImplementationMatcher::best_match`.
+struct Candidate {
+    /// Represents the candidate's argument types; used to match some
+    /// implementation's parameter types.
+    arg_types: Vec<ScalarType>,
+    exact_matches: usize,
+    preferred_types: usize,
+}
+
+#[derive(Clone, Debug)]
+/// Determines best implementation to use given some user-provided arguments.
+/// For more detail, see `ArgImplementationMatcher::select_implementation`.
+pub struct ArgImplementationMatcher<'a> {
+    ident: &'a str,
+    ecx: &'a ExprContext<'a>,
+    impls: Vec<FuncImpl>,
+}
+
+impl<'a> ArgImplementationMatcher<'a> {
+    /// Selects the best implementation given the provided `args` using a
+    /// process similar to [PostgreSQL's parser][pgparser], and returns the
+    /// `ScalarExpr` to invoke that function.
+    ///
+    /// # Errors
+    /// - When the provided arguments are not valid for any implementation, e.g.
+    ///   cannot be converted to the appropriate types.
+    /// - When all implementations are equally valid.
+    ///
+    /// [pgparser]: https://www.postgresql.org/docs/current/typeconv-oper.html
+    pub fn select_implementation(
+        ident: &'a str,
+        ecx: &'a ExprContext<'a>,
+        impls: &[FuncImpl],
+        args: &[sql_parser::ast::Expr],
+    ) -> Result<ScalarExpr, failure::Error> {
+        // Immediately remove all `impls` we know are invalid.
+        let l = args.len();
+        let impls = impls
+            .iter()
+            .filter(|i| i.params.validate_arg_len(l))
+            .cloned()
+            .collect();
+        let mut m = Self { ident, ecx, impls };
+
+        let mut raw_arg_types = Vec::new();
+        for arg in args {
+            let expr = super::query::plan_expr(ecx, &arg, Some(ScalarType::Unknown))?;
+            raw_arg_types.push(ecx.scalar_type(&expr));
+            Self::clear_expr_param_data(ecx, &arg);
+        }
+
+        // Exact match
+        let f = if let Some(func) = m.get_implementation(&raw_arg_types) {
+            func
+        } else {
+            // Best match
+            m.best_match(args, &raw_arg_types)?
+        };
+
+        let mut exprs = m.generate_param_exprs(args, f.params)?;
+
+        Ok(match f.op {
+            OperationType::ExprOnly => exprs.remove(0),
+            OperationType::Unary(func) => ScalarExpr::CallUnary {
+                func,
+                expr: Box::new(exprs.remove(0)),
+            },
+            OperationType::Binary(func) => ScalarExpr::CallBinary {
+                func,
+                expr1: Box::new(exprs.remove(0)),
+                expr2: Box::new(exprs.remove(0)),
+            },
+            OperationType::Variadic(func) => ScalarExpr::CallVariadic { func, exprs },
+        })
+    }
+
+    /// Returns a `FuncImpl` if `types` matches an implementation's parameters.
+    ///
+    /// Note that `types` must be the caller's argument's types to preserve
+    /// Decimal scale and precision, which are used in `Self::saturate_decimals`.
+    fn get_implementation(&self, types: &[ScalarType]) -> Option<FuncImpl> {
+        let matching_impls: Vec<&FuncImpl> = self
+            .impls
+            .iter()
+            .filter(|i| i.params.match_scalartypes(types))
+            .collect();
+
+        if matching_impls.len() == 1 {
+            let f = Self::saturate_decimals(matching_impls[0], types);
+            Some(f)
+        } else {
+            None
+        }
+    }
+
+    /// If no exact match, finds the best match available. Patterned after
+    /// [PostgreSQL's type conversion matching algorithm][pgparser].
+    ///
+    /// Inline prefixed with number are taken from the "Function Type
+    /// Resolution" section of the aforelinked page.
+    ///
+    /// [pgparser]: https://www.postgresql.org/docs/current/typeconv-func.html
+    fn best_match(
+        &mut self,
+        args: &[sql_parser::ast::Expr],
+        raw_arg_types: &[ScalarType],
+    ) -> Result<FuncImpl, failure::Error> {
+        let mut candidates = Vec::new();
+        let mut max_exact_matches = 0;
+        let mut max_preferred_types = 0;
+
+        // Generate candidates by assessing their compatibility with each
+        // implementation's parameters.
+        for fimpl in self.impls.iter() {
+            let mut valid_candidate = true;
+            let mut arg_types = Vec::new();
+            let mut exact_matches = 0;
+            let mut preferred_types = 0;
+            let best_target_type = if let ParamList::AnyHomogeneous(h) = &fimpl.params {
+                match super::query::best_target_type(raw_arg_types.iter().cloned()) {
+                    Some(t) => Some(ParamType::Plain(t.clone())),
+                    None => Some(ParamType::Plain(h.clone())),
+                }
+            } else {
+                None
+            };
+
+            for (i, (arg, raw_arg_type)) in args.iter().zip(raw_arg_types.iter()).enumerate() {
+                let param_type = match &fimpl.params {
+                    ParamList::Exact(p) => &p[i],
+                    ParamList::Repeat(p) => &p[i % p.len()],
+                    ParamList::AnyHomogeneous(_) => best_target_type.as_ref().unwrap(),
+                };
+
+                let arg_type = if param_type == raw_arg_type {
+                    exact_matches += 1;
+                    raw_arg_type.clone()
+                } else {
+                    if self.coerce_arg_to_type(arg, &param_type).is_err() {
+                        valid_candidate = false;
+                        break;
+                    }
+
+                    // Increment `preferred_type` if:
+                    // - This param is the preferred type for this argument's
+                    //   type category
+                    // - This argument is a string literal and this param is the
+                    //   preferred type in its type category.
+                    if is_param_preferred_type_for_arg(&param_type.into(), raw_arg_type)
+                        || (arg.is_string_literal()
+                            && is_param_preferred_type_for_arg(
+                                &param_type.into(),
+                                &param_type.into(),
+                            ))
+                    {
+                        preferred_types += 1;
+                    }
+
+                    param_type.into()
+                };
+
+                arg_types.push(arg_type);
+                Self::clear_expr_param_data(self.ecx, &arg);
+            }
+
+            // 4.a. Discard candidate functions for which the input types do not match
+            // and cannot be converted (using an implicit conversion) to match.
+            // unknown literals are assumed to be convertible to anything for this
+            // purpose.
+            if valid_candidate {
+                max_exact_matches = std::cmp::max(max_exact_matches, exact_matches);
+                max_preferred_types = std::cmp::max(max_preferred_types, preferred_types);
+                candidates.push(Candidate {
+                    arg_types,
+                    exact_matches,
+                    preferred_types,
+                });
+            }
+        }
+
+        if candidates.is_empty() {
+            bail!(
+                "arguments cannot be implicitly cast to any implementation's parameters; \
+            try providing explicit casts"
+            )
+        }
+
+        if let Some(func) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok(func);
+        }
+
+        // 4.c. Run through all candidates and keep those with the most exact matches on
+        // input types. Keep all candidates if none have exact matches.
+        candidates.retain(|c| c.exact_matches >= max_exact_matches);
+
+        if let Some(func) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok(func);
+        }
+
+        // 4.d. Run through all candidates and keep those that accept preferred types
+        // (of the input data type's type category) at the most positions where
+        // type conversion will be required.
+        candidates.retain(|c| c.preferred_types >= max_preferred_types);
+
+        if let Some(func) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok(func);
+        }
+
+        // The rest of this function could be elided if we know we don't have
+        // any Unknown types.
+        let mut found_unknown = false;
+        let mut found_known = false;
+        let mut types_match = true;
+        let mut common_type: Option<ScalarType> = None;
+
+        for (i, raw_arg_type) in raw_arg_types.iter().enumerate() {
+            let mut selected_category: Option<TypeCategory> = None;
+            let mut found_string_candidate = false;
+            let mut categories_match = true;
+
+            match raw_arg_type {
+                // 4.e. If any input arguments are unknown, check the type categories accepted
+                // at those argument positions by the remaining candidates.
+                ScalarType::Unknown => {
+                    found_unknown = true;
+
+                    for c in candidates.iter() {
+                        let this_category = TypeCategory::from_type(&c.arg_types[i]);
+                        match (&selected_category, &this_category) {
+                            // 4.e. cont: At each  position, select the string category if
+                            // any candidate accepts that category. (This bias
+                            // towards string is appropriate since an
+                            // unknown-type literal looks like a string.)
+                            (Some(TypeCategory::String), _) => {}
+                            (_, TypeCategory::String) => {
+                                found_string_candidate = true;
+                                selected_category = Some(TypeCategory::String);
+                            }
+                            // 4.e. cont: Otherwise, if all the remaining candidates accept
+                            // the same type category, select that category.
+                            (Some(selected_category), this_category) => {
+                                categories_match =
+                                    *selected_category == *this_category && categories_match
+                            }
+                            (None, this_category) => {
+                                selected_category = Some(this_category.clone())
+                            }
+                        }
+                    }
+
+                    // 4.e. cont: Otherwise fail because the correct choice cannot be
+                    // deduced without more clues.
+                    if !found_string_candidate && !categories_match {
+                        bail!(
+                            "unable to determine which implementation to use; try providing \
+                            explicit casts to match parameter types"
+                        )
+                    }
+
+                    // 4.e. cont: Now discard candidates that do not accept the selected
+                    // type category. Furthermore, if any candidate accepts a
+                    // preferred type in that category, discard candidates that
+                    // accept non-preferred types for that argument.
+                    let selected_category = selected_category.unwrap();
+
+                    let preferred_type = selected_category.preferred_type();
+                    let mut found_preferred_type_candidate = false;
+                    candidates.retain(|c| {
+                        if let Some(typ) = &preferred_type {
+                            found_preferred_type_candidate =
+                                c.arg_types[i] == *typ || found_preferred_type_candidate;
+                        }
+                        selected_category == TypeCategory::from_type(&c.arg_types[i])
+                    });
+
+                    if found_preferred_type_candidate {
+                        let preferred_type = preferred_type.unwrap();
+                        candidates.retain(|c| c.arg_types[i] == preferred_type);
+                    }
+                }
+                typ => {
+                    found_known = true;
+                    // Track if all known types are of the same type; use this info in 4.f.
+                    if let Some(common_type) = &common_type {
+                        types_match = types_match && *common_type == *typ
+                    } else {
+                        common_type = Some(typ.clone());
+                    }
+                }
+            }
+        }
+
+        if let Some(func) = self.maybe_get_last_candidate(&candidates)? {
+            return Ok(func);
+        }
+
+        // 4.f. If there are both unknown and known-type arguments, and all the
+        // known-type arguments have the same type, assume that the unknown
+        // arguments are also of that type, and check which candidates can
+        // accept that type at the unknown-argument positions.
+        if found_known && found_unknown && types_match {
+            let common_type = common_type.unwrap();
+            for (i, raw_arg_type) in raw_arg_types.iter().enumerate() {
+                if *raw_arg_type == ScalarType::Unknown {
+                    candidates.retain(|c| common_type == c.arg_types[i]);
+                }
+            }
+
+            if let Some(func) = self.maybe_get_last_candidate(&candidates)? {
+                return Ok(func);
+            }
+        }
+
+        bail!(
+            "unable to determine which implementation to use; try providing \
+            explicit casts to match parameter types"
+        )
+    }
+
+    fn maybe_get_last_candidate(
+        &self,
+        candidates: &[Candidate],
+    ) -> Result<Option<FuncImpl>, failure::Error> {
+        if candidates.len() == 1 {
+            match self.get_implementation(&candidates[0].arg_types) {
+                Some(func) => Ok(Some(func)),
+                None => unreachable!(
+                    "unable to get final function implementation with provided \
+                    arguments"
+                ),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Because we use the same `ExprContext` throughout `Self::best_match`, we
+    /// have to clean up any param types we provisionally inserted. This data
+    /// gets re-inserted during `Self::generate_param_exprs`.
+    fn clear_expr_param_data(ecx: &ExprContext, expr: &sql_parser::ast::Expr) {
+        if let sql_parser::ast::Expr::Parameter(n) = expr {
+            ecx.remove_param(*n);
+        }
+    }
+
+    /// Rewrite any `Decimal` values in `FuncImpl` to use the users' arguments'
+    /// scale, rather than the default value we use for matching implementations.
+    fn saturate_decimals(f: &FuncImpl, types: &[ScalarType]) -> FuncImpl {
+        use OperationType::*;
+        use ParamType::*;
+        use ScalarType::*;
+
+        let mut f = f.clone();
+        // TODO(sploiselle): Add support for saturating decimals in other
+        // contexts.
+        if let ParamList::Exact(ref mut param_list) = f.params {
+            for (i, param) in param_list.iter_mut().enumerate() {
+                if let Plain(Decimal(_, _)) = param {
+                    *param = Plain(types[i].clone());
+                }
+            }
+        }
+
+        f.op = match f.op {
+            Unary(UnaryFunc::AbsDecimal(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => Unary(UnaryFunc::AbsDecimal(s)),
+                _ => unreachable!(),
+            },
+            Unary(UnaryFunc::CeilDecimal(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => Unary(UnaryFunc::CeilDecimal(s)),
+                _ => unreachable!(),
+            },
+            Unary(UnaryFunc::FloorDecimal(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => Unary(UnaryFunc::FloorDecimal(s)),
+                _ => unreachable!(),
+            },
+            Unary(UnaryFunc::RoundDecimal(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => Unary(UnaryFunc::RoundDecimal(s)),
+                _ => unreachable!(),
+            },
+            Binary(BinaryFunc::RoundDecimal(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => Binary(BinaryFunc::RoundDecimal(s)),
+                _ => unreachable!(),
+            },
+            other => other,
+        };
+
+        f
+    }
+
+    /// Plans `args` as `ScalarExprs` of that match the `ParamList`'s specified types.
+    fn generate_param_exprs(
+        &self,
+        args: &[sql_parser::ast::Expr],
+        params: ParamList,
+    ) -> Result<Vec<ScalarExpr>, failure::Error> {
+        match params {
+            ParamList::AnyHomogeneous(h) => {
+                super::query::plan_homogeneous_exprs(self.ident, self.ecx, args, Some(h))
+            }
+            ParamList::Exact(p) => {
+                let mut exprs = Vec::new();
+                for (arg, param) in args.iter().zip(p.iter()) {
+                    exprs.push(self.coerce_arg_to_type(arg, param)?);
+                }
+                Ok(exprs)
+            }
+            ParamList::Repeat(p) => {
+                let mut exprs = Vec::new();
+                for (i, arg) in args.iter().enumerate() {
+                    exprs.push(self.coerce_arg_to_type(arg, &p[i % p.len()])?);
+                }
+                Ok(exprs)
+            }
+        }
+    }
+
+    /// Generates `ScalarExpr` necessary to coerce `Expr` into the `ScalarType`
+    /// corresponding to `ParameterType`; errors if not possible. This can only
+    /// work within the `func` module because it relies on `ParameterType`.
+    fn coerce_arg_to_type(
+        &self,
+        arg: &Expr,
+        typ: &ParamType,
+    ) -> Result<ScalarExpr, failure::Error> {
+        use super::query::CastContext::*;
+        let s: ScalarType = typ.into();
+        let hinted_expr = super::query::plan_expr(self.ecx, &arg, Some(s.clone()))?;
+
+        if self.ecx.scalar_type(&hinted_expr) == s {
+            Ok(hinted_expr)
+        } else if ParamType::JsonbAny == *typ {
+            super::query::plan_to_jsonb(self.ecx, self.ident, hinted_expr)
+        } else if ParamType::ExplicitStringAny == *typ {
+            super::query::plan_cast_internal(self.ecx, Explicit, hinted_expr, s)
+        } else if ParamType::StringAny == *typ || arg.is_string_literal() {
+            super::query::plan_cast_internal(self.ecx, Implicit(self.ident), hinted_expr, s)
+        } else {
+            super::query::plan_cast_implicit(self.ecx, Implicit(self.ident), hinted_expr, s)
+        }
+    }
+}
+
+/// Provides shorthand for converting `Vec<ScalarType>` into `Vec<ParamType>`.
+macro_rules! params(
+    ( $($p:expr),* ) => {
+        vec![$($p,)+].into_params()
+    };
+);
+
+/// Provides shorthand for writing `FuncImpl` declarations.
+macro_rules! impls(
+    { $($params:expr => $op:expr),+ } => {
+        {vec![
+            $(FuncImpl {
+                params: $params.into(),
+                op: $op,
+            },)+
+        ]}
+     };
+);
+
+/// Provides a macro to write HashMap "literals" for matching function names to
+/// `Vec<FuncImpl>`.
+macro_rules! func_impls(
+    { $($key:expr => $value:expr),+ } => {
+        {
+            let mut m: HashMap<&str, Vec<FuncImpl>> = HashMap::new();
+            $(m.insert($key, $value);)+
+            m
+        }
+     };
+);
+
+lazy_static! {
+    /// Correlates a built-in function name to its implementations.
+    static ref BIMPLS: HashMap<&'static str, Vec<FuncImpl>> = {
+        use OperationType::*;
+        use ParamList::*;
+        use ParamType::*;
+        use ScalarType::*;
+        func_impls! {
+            "abs" => {
+                impls! {
+                    params!(Int32) => Unary(UnaryFunc::AbsInt32),
+                    params!(Int64) => Unary(UnaryFunc::AbsInt64),
+                    params!(Decimal(0, 0)) => Unary(UnaryFunc::AbsDecimal(0)),
+                    params!(Float32) => Unary(UnaryFunc::AbsFloat32),
+                    params!(Float64) => Unary(UnaryFunc::AbsFloat64)
+                }
+            },
+            "ascii" => {
+                impls! {
+                    params!(String) => Unary(UnaryFunc::Ascii)
+                }
+            },
+            "ceil" => {
+                impls! {
+                    params!(Float32) => Unary(UnaryFunc::CeilFloat32),
+                    params!(Float64) => Unary(UnaryFunc::CeilFloat64),
+                    params!(Decimal(0, 0)) => Unary(UnaryFunc::CeilDecimal(0))
+                }
+            },
+            "coalesce" => {
+                impls! {
+                    AnyHomogeneous(String) => Variadic(VariadicFunc::Coalesce)
+                }
+            },
+            "concat" => {
+                impls! {
+                    Repeat(vec![StringAny]) => Variadic(VariadicFunc::Concat)
+                }
+            },
+            "convert_from" => {
+                impls! {
+                    params!(Bytes, String) => Binary(BinaryFunc::ConvertFrom)
+                }
+            },
+            "date_trunc" => {
+                impls! {
+                    params!(String, Timestamp) => Binary(BinaryFunc::DateTruncTimestamp),
+                    params!(String, TimestampTz) => Binary(BinaryFunc::DateTruncTimestampTz)
+                }
+            },
+            "floor" => {
+                impls! {
+                    params!(Float32) => Unary(UnaryFunc::FloorFloat32),
+                    params!(Float64) => Unary(UnaryFunc::FloorFloat64),
+                    params!(Decimal(0, 0)) => Unary(UnaryFunc::FloorDecimal(0))
+                }
+            },
+            "jsonb_array_length" => {
+                impls! {
+                    params!(Jsonb) => Unary(UnaryFunc::JsonbArrayLength)
+                }
+            },
+            "jsonb_build_array" => {
+                impls! {
+                    Exact(vec![]) => Variadic(VariadicFunc::JsonbBuildArray),
+                    Repeat(vec![JsonbAny]) => Variadic(VariadicFunc::JsonbBuildArray)
+                }
+            },
+            "jsonb_build_object" => {
+                impls! {
+                    Exact(vec![]) => Variadic(VariadicFunc::JsonbBuildObject),
+                    Repeat(vec![ExplicitStringAny, JsonbAny]) =>
+                        Variadic(VariadicFunc::JsonbBuildObject)
+                }
+            },
+            "jsonb_pretty" => {
+                impls! {
+                    params!(Jsonb) => Unary(UnaryFunc::JsonbPretty)
+                }
+            },
+            "jsonb_strip_nulls" => {
+                impls! {
+                    params!(Jsonb) => Unary(UnaryFunc::JsonbStripNulls),
+                    // jsonb_strip_nulls does not want to cast NULLs to JSONB.
+                    params!(Unknown) => Unary(UnaryFunc::JsonbStripNulls)
+                }
+            },
+            "jsonb_typeof" => {
+                impls! {
+                    params!(Jsonb) => Unary(UnaryFunc::JsonbTypeof)
+                }
+            },
+            "length" => {
+                impls! {
+                    params!(Bytes) => Unary(UnaryFunc::LengthBytes),
+                    params!(String) => Variadic(VariadicFunc::LengthString),
+                    params!(String, String) => Variadic(VariadicFunc::LengthString)
+                }
+            },
+            "replace" => {
+                impls! {
+                    params!(String, String, String) => Variadic(VariadicFunc::Replace)
+                }
+            },
+            "round" => {
+                impls! {
+                    params!(Float32) => Unary(UnaryFunc::RoundFloat32),
+                    params!(Float64) => Unary(UnaryFunc::RoundFloat64),
+                    params!(Decimal(0,0)) => Unary(UnaryFunc::RoundDecimal(0)),
+                    params!(Decimal(0,0), Int64) => Binary(BinaryFunc::RoundDecimal(0))
+                }
+            },
+            "substr" => {
+                impls! {
+                    params!(String, Int64) => Variadic(VariadicFunc::Substr),
+                    params!(String, Int64, Int64) => Variadic(VariadicFunc::Substr)
+                }
+            },
+            "substring" => {
+                impls! {
+                    params!(String, Int64) => Variadic(VariadicFunc::Substr),
+                    params!(String, Int64, Int64) => Variadic(VariadicFunc::Substr)
+                }
+            },
+            "to_char" => {
+                impls! {
+                    params!(Timestamp, String) => Binary(BinaryFunc::ToCharTimestamp),
+                    params!(TimestampTz, String) => Binary(BinaryFunc::ToCharTimestampTz)
+                }
+            },
+            // > Returns the value as json or jsonb. Arrays and composites
+            // > are converted (recursively) to arrays and objects;
+            // > otherwise, if there is a cast from the type to json, the
+            // > cast function will be used to perform the conversion;
+            // > otherwise, a scalar value is produced. For any scalar type
+            // > other than a number, a Boolean, or a null value, the text
+            // > representation will be used, in such a fashion that it is a
+            // > valid json or jsonb value.
+            //
+            // https://www.postgresql.org/docs/current/functions-json.html
+            "to_jsonb" => {
+                impls! {
+                    vec![JsonbAny] => ExprOnly
+                }
+            },
+            "to_timestamp" => {
+                impls! {
+                    params!(Float64) => Unary(UnaryFunc::ToTimestamp)
+                }
+            }
+        }
+    };
+}
+
+/// Gets a built-in scalar function and the `ScalarExpr`s required to invoke it.
+pub fn select_scalar_func(
+    ecx: &ExprContext,
+    ident: &str,
+    args: &[sql_parser::ast::Expr],
+) -> Result<ScalarExpr, failure::Error> {
+    let impls = match BIMPLS.get(ident) {
+        Some(i) => i,
+        None => unsupported!(ident),
+    };
+
+    match ArgImplementationMatcher::select_implementation(ident, ecx, impls, args) {
+        Ok(expr) => Ok(expr),
+        Err(e) => bail!("Cannot call function '{}': {}", ident, e),
+    }
+}

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -33,6 +33,7 @@ pub mod normalize;
 
 mod explain;
 mod expr;
+mod func;
 mod kafka_util;
 mod names;
 mod pure;

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -464,13 +464,13 @@ SELECT round((SELECT * FROM nums));
 ----
 NULL
 
-query error first round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round((SELECT * FROM nums), 2)
 
-query error first round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round((SELECT * FROM nums), (SELECT * FROM nums))
 
-query error second round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(5.0, (SELECT * FROM nums))
 
 query R
@@ -478,22 +478,22 @@ SELECT round(5.0, CAST ((SELECT * FROM nums) AS integer))
 ----
 NULL
 
-query error first round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS double precision), 3)
 
-query error first round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), 3)
 
-query error first round argument has non-integer type Bool
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(true, 3)
 
-query error round argument has non-numeric type Bool
+query error
 SELECT round(true)
 
-query error first round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), 3.0)
 
-query error first round argument has non-integer type Float64
+query error Cannot call function 'round': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), CAST (3.0 AS float))
 
 query I
@@ -501,7 +501,7 @@ SELECT 2147483646+1
 ----
 2147483647
 
-statement error numeric field overflow
+query error numeric field overflow
 SELECT 2147483647+1
 
 query I
@@ -509,8 +509,8 @@ SELECT 9223372036854775806::bigint+1::bigint
 ----
 9223372036854775807
 
-statement error numeric field overflow
+query error numeric field overflow
 SELECT 9223372036854775807::bigint+1::bigint
 
-statement error numeric field overflow
+query error numeric field overflow
 SELECT 9223372036854775807::bigint-(-1)::bigint

--- a/test/sqllogictest/bytea.slt
+++ b/test/sqllogictest/bytea.slt
@@ -26,6 +26,5 @@ SELECT ord, length(b::bytea) FROM test
 3 0
 4 18
 
-
-query error length expects only one argument when first argument has type bytea, got 2
+query error Cannot call function 'length': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT length('a'::bytea, 'utf-8')

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1745,8 +1745,9 @@ SELECT jsonb_array_length('[1,2,3,{"f1":1,"f2":[5,6]},4]'::JSONB)
 ----
 5
 
+# implicit conversion from string to JSONB
 query I
-SELECT jsonb_array_length('[]'::JSONB)
+SELECT jsonb_array_length('[]')
 ----
 0
 

--- a/test/testdrive/proto-billing.td
+++ b/test/testdrive/proto-billing.td
@@ -42,7 +42,7 @@ records         YES jsonb
     records->1->'measurements'->1->'measured_value',
     records->1->>'meter'
   FROM billing
-  WHERE id = 2
+  WHERE id = '2'
 25.0  5.0  user  125.0  256.0  user
 
 # Do some destructuring over the nested records


### PR DESCRIPTION
## Features

Makes progress on #1381 by...

- Generalizing function selection for most built-in functions
- Introducing more robust notion of implicit casts and leverages them in the generalization framework. Notably, this includes `JSONB` to `text`, which means all strings do not need to be manually cast to `JSONB` any longer.

Up next is moving over operators.

## Provisional work

These are things that we could do to clean things up; not filing issues for them until this PR gets merged

- Introduce `ScalarType::StringAny` type for string literals to remove need for `sql::query::ImplicitCastMod`.
- Integrate `plan_homogeneous_exprs` into `ArgImplementationMatcher`
- Demystify `plan_to_jsonb` now that we have the notion of `Parameter::JsonbAny`

...plus the few `todo`s I left myself

## Questions

@benesch Apologies for the size of this PR; I'd be glad to break this up into
some more incremental bits that lead us back here.

The current iteration has a potpourri of questions that I could use your
guidance on.

- What do you think of having `ArgImplementationMatcher` located in a new module, maybe
  `typeconv`? Feels like there are a number of things that would be natural fits
  in there, e.g. `query::best_target_type` and the meat of `query::plan_cast_internal`.
- You have a suggestion for a better names for...
  - `ArgImplementationMatcher`
  - `OperationType` and its attended enums (is it kosher to use stupid names like `UnaryFunc(UnaryFunc)`?)
- I added `best_match_unknown_checks` as its own function, just as a means of
  providing a chapter break in `best_match` (it's also a spot where you could return if you know you don't have any unknown type arguments). This is probably bad style, but it
  made things easier for me to keep track of while writing. Glad to make `best_match` a total monolith if you think that's advisable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3126)
<!-- Reviewable:end -->
