### PR TITLE
sqllogictest: show line numbers in test failures

### DIFF
--- a/fuzz/bin/build_corpus.rs
+++ b/fuzz/bin/build_corpus.rs
@@ -29,8 +29,9 @@ fn main() {
                 .unwrap()
                 .read_to_string(&mut contents)
                 .unwrap();
-            for record in sqllogictest::parser::parse_records(&contents).unwrap_or_else(|_| vec![])
-            {
+            let mut parser =
+                sqllogictest::parser::Parser::new(entry.path().to_str().unwrap_or(""), &contents);
+            for record in parser.parse_records().unwrap_or_else(|_| vec![]) {
                 match record {
                     sqllogictest::ast::Record::Query { sql, .. }
                     | sqllogictest::ast::Record::Statement { sql, .. } => {

--- a/src/sqllogictest/src/ast.rs
+++ b/src/sqllogictest/src/ast.rs
@@ -9,6 +9,21 @@
 
 //! Abstract syntax tree nodes for sqllogictest.
 
+use std::fmt;
+
+/// A location in a file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    pub file: String,
+    pub line: usize,
+}
+
+impl fmt::Display for Location {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}:{}", self.file, self.line)
+    }
+}
+
 /// The declared type of an output column in a query.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
@@ -98,12 +113,14 @@ pub struct QueryOutput<'a> {
 pub enum Record<'a> {
     // A `statement` directive.
     Statement {
+        location: Location,
         expected_error: Option<&'a str>,
         rows_affected: Option<usize>,
         sql: &'a str,
     },
     /// A `query` directive.
     Query {
+        location: Location,
         sql: &'a str,
         output: Result<QueryOutput<'a>, &'a str>,
     },

--- a/src/sqllogictest/src/parser.rs
+++ b/src/sqllogictest/src/parser.rs
@@ -16,7 +16,311 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use repr::ColumnName;
 
-use crate::ast::{Mode, Output, QueryOutput, Record, Sort, Type};
+use crate::ast::{Location, Mode, Output, QueryOutput, Record, Sort, Type};
+
+#[derive(Debug, Clone)]
+pub struct Parser<'a> {
+    contents: &'a str,
+    fname: String,
+    curline: usize,
+    mode: Mode,
+}
+
+impl<'a> Parser<'a> {
+    pub fn new(fname: &str, contents: &'a str) -> Self {
+        Parser {
+            contents,
+            fname: fname.to_string(),
+            curline: 1,
+            mode: Mode::Standard,
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.contents == ""
+    }
+
+    pub fn location(&self) -> Location {
+        Location {
+            file: self.fname.clone(),
+            line: self.curline,
+        }
+    }
+
+    fn consume(&mut self, upto: usize) {
+        for ch in self.contents[..upto].chars() {
+            if ch == '\n' {
+                self.curline += 1;
+            }
+        }
+        self.contents = &self.contents[upto..];
+    }
+
+    pub fn split_at(&mut self, sep: &Regex) -> Result<&'a str, failure::Error> {
+        match sep.find(self.contents) {
+            Some(found) => {
+                let result = &self.contents[..found.start()];
+                self.consume(found.end());
+                Ok(result)
+            }
+            None => bail!("Couldn't split {:?} at {:?}", self.contents, sep),
+        }
+    }
+
+    pub fn parse_record(&mut self) -> Result<Record<'a>, failure::Error> {
+        if self.is_done() {
+            return Ok(Record::Halt);
+        }
+
+        lazy_static! {
+            static ref COMMENT_AND_LINE_REGEX: Regex = Regex::new("(#[^\n]*)?\r?(\n|$)").unwrap();
+        }
+        let first_line = self.split_at(&COMMENT_AND_LINE_REGEX)?.trim();
+
+        if first_line == "" {
+            // query starts on the next line
+            return self.parse_record();
+        }
+
+        let mut words = first_line.split(' ').peekable();
+        match words.next().unwrap() {
+            "statement" => self.parse_statement(words, first_line),
+
+            "query" => self.parse_query(words, first_line),
+
+            "hash-threshold" => {
+                let threshold = words
+                    .next()
+                    .ok_or_else(|| format_err!("missing threshold in: {}", first_line))?
+                    .parse::<u64>()
+                    .map_err(|err| format_err!("invalid threshold ({}) in: {}", err, first_line))?;
+                Ok(Record::HashThreshold { threshold })
+            }
+
+            // we'll follow the postgresql version of all these tests
+            "skipif" => {
+                match words.next().unwrap() {
+                    "postgresql" => {
+                        // discard next record
+                        self.parse_record()?;
+                        self.parse_record()
+                    }
+                    _ => self.parse_record(),
+                }
+            }
+            "onlyif" => {
+                match words.next().unwrap() {
+                    "postgresql" => self.parse_record(),
+                    _ => {
+                        // discard next record
+                        self.parse_record()?;
+                        self.parse_record()
+                    }
+                }
+            }
+
+            "halt" => Ok(Record::Halt),
+
+            // this is some cockroach-specific thing, we don't care
+            "subtest" | "user" | "kv-batch-size" => self.parse_record(),
+
+            "mode" => {
+                self.mode = match words.next() {
+                    Some("cockroach") => Mode::Cockroach,
+                    Some("standard") | Some("sqlite") => Mode::Standard,
+                    other => bail!("unknown parse mode: {:?}", other),
+                };
+                self.parse_record()
+            }
+
+            other => bail!("Unexpected start of record: {}", other),
+        }
+    }
+
+    pub fn parse_records(&mut self) -> Result<Vec<Record<'a>>, failure::Error> {
+        let mut records = vec![];
+        loop {
+            match self.parse_record()? {
+                Record::Halt => break,
+                record => records.push(record),
+            }
+        }
+        Ok(records)
+    }
+
+    fn parse_statement(
+        &mut self,
+        mut words: impl Iterator<Item = &'a str>,
+        first_line: &'a str,
+    ) -> Result<Record<'a>, failure::Error> {
+        let location = self.location();
+        let mut expected_error = None;
+        let mut rows_affected = None;
+        match words.next() {
+            Some("count") => {
+                rows_affected = Some(
+                    words
+                        .next()
+                        .ok_or_else(|| format_err!("missing count of rows affected"))?
+                        .parse::<usize>()
+                        .map_err(|err| format_err!("parsing count of rows affected: {}", err))?,
+                );
+            }
+            Some("ok") | Some("OK") => (),
+            Some("error") => expected_error = Some(parse_expected_error(first_line)),
+            _ => bail!("invalid statement disposition: {}", first_line),
+        };
+        lazy_static! {
+            static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
+        }
+        let sql = self.split_at(&DOUBLE_LINE_REGEX)?;
+        Ok(Record::Statement {
+            expected_error,
+            rows_affected,
+            sql,
+            location,
+        })
+    }
+
+    fn parse_query(
+        &mut self,
+        mut words: std::iter::Peekable<impl Iterator<Item = &'a str>>,
+        first_line: &'a str,
+    ) -> Result<Record<'a>, failure::Error> {
+        let location = self.location();
+        if words.peek() == Some(&"error") {
+            let error = parse_expected_error(first_line);
+            lazy_static! {
+                static ref DOUBLE_LINE_REGEX: Regex =
+                    Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
+            }
+            let sql = self.split_at(&DOUBLE_LINE_REGEX)?;
+            return Ok(Record::Query {
+                sql,
+                output: Err(error),
+                location: self.location(),
+            });
+        }
+
+        let types = parse_types(
+            words
+                .next()
+                .ok_or_else(|| format_err!("missing types in: {}", first_line))?,
+        )?;
+        let mut sort = Sort::No;
+        let mut check_column_names = false;
+        let mut multiline = false;
+        if let Some(options) = words.next() {
+            for option in options.split(',') {
+                match option {
+                    "nosort" => sort = Sort::No,
+                    "rowsort" => sort = Sort::Row,
+                    "valuesort" => sort = Sort::Value,
+                    "colnames" => check_column_names = true,
+                    "multiline" => multiline = true,
+                    other => {
+                        if other.starts_with("partialsort") {
+                            // TODO(jamii) https://github.com/cockroachdb/cockroach/blob/d2f7fbf5dd1fc1a099bbad790a2e1f7c60a66cc3/pkg/sql/logictest/logic.go#L153
+                            // partialsort has comma-separated arguments so our parsing is totally broken
+                            // luckily it always comes last in the existing tests, so we can just bail out for now
+                            sort = Sort::Row;
+                            break;
+                        } else {
+                            bail!("Unrecognized option {:?} in {:?}", other, options);
+                        }
+                    }
+                };
+            }
+        }
+        if multiline && (check_column_names || sort.yes()) {
+            bail!("multiline option is incompatible with all other options");
+        }
+        let label = words.next();
+        lazy_static! {
+            static ref LINE_REGEX: Regex = Regex::new("\r?(\n|$)").unwrap();
+            static ref HASH_REGEX: Regex = Regex::new(r"(\S+) values hashing to (\S+)").unwrap();
+            static ref QUERY_OUTPUT_REGEX: Regex = Regex::new(r"\r?\n----").unwrap();
+        }
+        let sql = self.split_at(&QUERY_OUTPUT_REGEX)?;
+        lazy_static! {
+            static ref EOF_REGEX: Regex = Regex::new(r"(\n|\r\n)EOF(\n|\r\n)").unwrap();
+            static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
+        }
+        let mut output_str = self
+            .split_at(if multiline {
+                &EOF_REGEX
+            } else {
+                &DOUBLE_LINE_REGEX
+            })?
+            .trim_start();
+        let column_names = if check_column_names {
+            Some(
+                split_at(&mut output_str, &LINE_REGEX)?
+                    .split(' ')
+                    .filter(|s| !s.is_empty())
+                    .map(ColumnName::from)
+                    .collect(),
+            )
+        } else {
+            None
+        };
+        let output = match HASH_REGEX.captures(output_str) {
+            Some(captures) => Output::Hashed {
+                num_values: captures.get(1).unwrap().as_str().parse::<usize>()?,
+                md5: captures.get(2).unwrap().as_str().to_owned(),
+            },
+            None => {
+                if multiline {
+                    Output::Values(vec![output_str.to_owned()])
+                } else if output_str.starts_with('\r') || output_str.starts_with('\n') {
+                    Output::Values(vec![])
+                } else {
+                    let mut vals: Vec<String> = output_str.lines().map(|s| s.to_owned()).collect();
+                    if let Mode::Cockroach = self.mode {
+                        let mut rows: Vec<Vec<String>> = vec![];
+                        for line in vals {
+                            let cols = split_cols(&line, types.len());
+                            if sort != Sort::No && cols.len() != types.len() {
+                                // We can't check this condition for
+                                // Sort::No, because some tests use strings
+                                // with whitespace that look like extra
+                                // columns. (Note that these tests never
+                                // use any of the sorting options.)
+                                bail!(
+                                    "col len ({}) did not match declared col len ({})",
+                                    cols.len(),
+                                    types.len()
+                                );
+                            }
+                            rows.push(cols.into_iter().map(|col| col.replace("␠", " ")).collect());
+                        }
+                        if sort == Sort::Row {
+                            rows.sort();
+                        }
+                        vals = rows.into_iter().flatten().collect();
+                        if sort == Sort::Value {
+                            vals.sort();
+                        }
+                    }
+                    Output::Values(vals)
+                }
+            }
+        };
+        Ok(Record::Query {
+            sql,
+            output: Ok(QueryOutput {
+                types,
+                sort,
+                label,
+                column_names,
+                mode: self.mode,
+                output,
+                output_str,
+            }),
+            location,
+        })
+    }
+}
 
 fn split_at<'a>(input: &mut &'a str, sep: &Regex) -> Result<&'a str, failure::Error> {
     match sep.find(input) {
@@ -50,249 +354,6 @@ lazy_static! {
     static ref WHITESPACE_REGEX: Regex = Regex::new(r"\s+").unwrap();
 }
 
-pub fn parse_record<'a>(
-    mode: &mut Mode,
-    input: &mut &'a str,
-) -> Result<Record<'a>, failure::Error> {
-    if *input == "" {
-        return Ok(Record::Halt);
-    }
-
-    lazy_static! {
-        static ref COMMENT_AND_LINE_REGEX: Regex = Regex::new("(#[^\n]*)?\r?(\n|$)").unwrap();
-    }
-    let first_line = split_at(input, &COMMENT_AND_LINE_REGEX)?.trim();
-
-    if first_line == "" {
-        // query starts on the next line
-        return parse_record(mode, input);
-    }
-
-    let mut words = first_line.split(' ').peekable();
-    match words.next().unwrap() {
-        "statement" => parse_statement(words, first_line, input),
-
-        "query" => parse_query(words, first_line, input, *mode),
-
-        "hash-threshold" => {
-            let threshold = words
-                .next()
-                .ok_or_else(|| format_err!("missing threshold in: {}", first_line))?
-                .parse::<u64>()
-                .map_err(|err| format_err!("invalid threshold ({}) in: {}", err, first_line))?;
-            Ok(Record::HashThreshold { threshold })
-        }
-
-        // we'll follow the postgresql version of all these tests
-        "skipif" => {
-            match words.next().unwrap() {
-                "postgresql" => {
-                    // discard next record
-                    parse_record(mode, input)?;
-                    parse_record(mode, input)
-                }
-                _ => parse_record(mode, input),
-            }
-        }
-        "onlyif" => {
-            match words.next().unwrap() {
-                "postgresql" => parse_record(mode, input),
-                _ => {
-                    // discard next record
-                    parse_record(mode, input)?;
-                    parse_record(mode, input)
-                }
-            }
-        }
-
-        "halt" => Ok(Record::Halt),
-
-        // this is some cockroach-specific thing, we don't care
-        "subtest" | "user" | "kv-batch-size" => parse_record(mode, input),
-
-        "mode" => {
-            *mode = match words.next() {
-                Some("cockroach") => Mode::Cockroach,
-                Some("standard") | Some("sqlite") => Mode::Standard,
-                other => bail!("unknown parse mode: {:?}", other),
-            };
-            parse_record(mode, input)
-        }
-
-        other => bail!("Unexpected start of record: {}", other),
-    }
-}
-
-fn parse_statement<'a>(
-    mut words: impl Iterator<Item = &'a str>,
-    first_line: &'a str,
-    input: &mut &'a str,
-) -> Result<Record<'a>, failure::Error> {
-    let mut expected_error = None;
-    let mut rows_affected = None;
-    match words.next() {
-        Some("count") => {
-            rows_affected = Some(
-                words
-                    .next()
-                    .ok_or_else(|| format_err!("missing count of rows affected"))?
-                    .parse::<usize>()
-                    .map_err(|err| format_err!("parsing count of rows affected: {}", err))?,
-            );
-        }
-        Some("ok") | Some("OK") => (),
-        Some("error") => expected_error = Some(parse_expected_error(first_line)),
-        _ => bail!("invalid statement disposition: {}", first_line),
-    };
-    lazy_static! {
-        static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
-    }
-    let sql = split_at(input, &DOUBLE_LINE_REGEX)?;
-    Ok(Record::Statement {
-        expected_error,
-        rows_affected,
-        sql,
-    })
-}
-
-fn parse_query<'a>(
-    mut words: std::iter::Peekable<impl Iterator<Item = &'a str>>,
-    first_line: &'a str,
-    input: &mut &'a str,
-    mode: Mode,
-) -> Result<Record<'a>, failure::Error> {
-    if words.peek() == Some(&"error") {
-        let error = parse_expected_error(first_line);
-        lazy_static! {
-            static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
-        }
-        let sql = split_at(input, &DOUBLE_LINE_REGEX)?;
-        return Ok(Record::Query {
-            sql,
-            output: Err(error),
-        });
-    }
-
-    let types = parse_types(
-        words
-            .next()
-            .ok_or_else(|| format_err!("missing types in: {}", first_line))?,
-    )?;
-    let mut sort = Sort::No;
-    let mut check_column_names = false;
-    let mut multiline = false;
-    if let Some(options) = words.next() {
-        for option in options.split(',') {
-            match option {
-                "nosort" => sort = Sort::No,
-                "rowsort" => sort = Sort::Row,
-                "valuesort" => sort = Sort::Value,
-                "colnames" => check_column_names = true,
-                "multiline" => multiline = true,
-                other => {
-                    if other.starts_with("partialsort") {
-                        // TODO(jamii) https://github.com/cockroachdb/cockroach/blob/d2f7fbf5dd1fc1a099bbad790a2e1f7c60a66cc3/pkg/sql/logictest/logic.go#L153
-                        // partialsort has comma-separated arguments so our parsing is totally broken
-                        // luckily it always comes last in the existing tests, so we can just bail out for now
-                        sort = Sort::Row;
-                        break;
-                    } else {
-                        bail!("Unrecognized option {:?} in {:?}", other, options);
-                    }
-                }
-            };
-        }
-    }
-    if multiline && (check_column_names || sort.yes()) {
-        bail!("multiline option is incompatible with all other options");
-    }
-    let label = words.next();
-    lazy_static! {
-        static ref LINE_REGEX: Regex = Regex::new("\r?(\n|$)").unwrap();
-        static ref HASH_REGEX: Regex = Regex::new(r"(\S+) values hashing to (\S+)").unwrap();
-        static ref QUERY_OUTPUT_REGEX: Regex = Regex::new(r"\r?\n----").unwrap();
-    }
-    let sql = split_at(input, &QUERY_OUTPUT_REGEX)?;
-    lazy_static! {
-        static ref EOF_REGEX: Regex = Regex::new(r"(\n|\r\n)EOF(\n|\r\n)").unwrap();
-        static ref DOUBLE_LINE_REGEX: Regex = Regex::new(r"(\n|\r\n|$)(\n|\r\n|$)").unwrap();
-    }
-    let mut output_str = split_at(
-        input,
-        if multiline {
-            &EOF_REGEX
-        } else {
-            &DOUBLE_LINE_REGEX
-        },
-    )?
-    .trim_start();
-    let column_names = if check_column_names {
-        Some(
-            split_at(&mut output_str, &LINE_REGEX)?
-                .split(' ')
-                .filter(|s| !s.is_empty())
-                .map(ColumnName::from)
-                .collect(),
-        )
-    } else {
-        None
-    };
-    let output = match HASH_REGEX.captures(output_str) {
-        Some(captures) => Output::Hashed {
-            num_values: captures.get(1).unwrap().as_str().parse::<usize>()?,
-            md5: captures.get(2).unwrap().as_str().to_owned(),
-        },
-        None => {
-            if multiline {
-                Output::Values(vec![output_str.to_owned()])
-            } else if output_str.starts_with('\r') || output_str.starts_with('\n') {
-                Output::Values(vec![])
-            } else {
-                let mut vals: Vec<String> = output_str.lines().map(|s| s.to_owned()).collect();
-                if let Mode::Cockroach = mode {
-                    let mut rows: Vec<Vec<String>> = vec![];
-                    for line in vals {
-                        let cols = split_cols(&line, types.len());
-                        if sort != Sort::No && cols.len() != types.len() {
-                            // We can't check this condition for
-                            // Sort::No, because some tests use strings
-                            // with whitespace that look like extra
-                            // columns. (Note that these tests never
-                            // use any of the sorting options.)
-                            bail!(
-                                "col len ({}) did not match declared col len ({})",
-                                cols.len(),
-                                types.len()
-                            );
-                        }
-                        rows.push(cols.into_iter().map(|col| col.replace("␠", " ")).collect());
-                    }
-                    if sort == Sort::Row {
-                        rows.sort();
-                    }
-                    vals = rows.into_iter().flatten().collect();
-                    if sort == Sort::Value {
-                        vals.sort();
-                    }
-                }
-                Output::Values(vals)
-            }
-        }
-    };
-    Ok(Record::Query {
-        sql,
-        output: Ok(QueryOutput {
-            types,
-            sort,
-            label,
-            column_names,
-            mode,
-            output,
-            output_str,
-        }),
-    })
-}
-
 fn parse_expected_error(line: &str) -> &str {
     lazy_static! {
         static ref PGCODE_RE: Regex =
@@ -315,16 +376,4 @@ pub(crate) fn split_cols(line: &str, expected_columns: usize) -> Vec<&str> {
     } else {
         line.split_whitespace().collect()
     }
-}
-
-pub fn parse_records(mut input: &str) -> Result<Vec<Record>, failure::Error> {
-    let mut mode = Mode::Standard;
-    let mut records = vec![];
-    loop {
-        match parse_record(&mut mode, &mut input)? {
-            Record::Halt => break,
-            record => records.push(record),
-        }
-    }
-    Ok(records)
 }

--- a/src/sqllogictest/tests/parser.rs
+++ b/src/sqllogictest/tests/parser.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use sqllogictest::ast::Record;
+use sqllogictest::ast::{Location, Record};
 use sqllogictest::parser;
 
 #[test]
@@ -15,6 +15,13 @@ fn test_parser() {
     struct TestCase {
         input: &'static str,
         output: Vec<Record<'static>>,
+    }
+
+    fn linenum(n: usize) -> Location {
+        Location {
+            file: "<test>".to_string(),
+            line: n,
+        }
     }
 
     let test_cases = vec![
@@ -25,6 +32,7 @@ SELECT 1",
                 expected_error: None,
                 rows_affected: None,
                 sql: "SELECT 1",
+                location: linenum(2),
             }],
         },
         TestCase {
@@ -34,6 +42,7 @@ SELECT 1",
                 expected_error: None,
                 rows_affected: None,
                 sql: "SELECT 1",
+                location: linenum(2),
             }],
         },
         TestCase {
@@ -43,6 +52,7 @@ SELECT 1",
                 expected_error: None,
                 rows_affected: Some(7),
                 sql: "SELECT 1",
+                location: linenum(2),
             }],
         },
         TestCase {
@@ -52,6 +62,7 @@ SELECT blargh",
                 expected_error: Some("this statement is wrong"),
                 rows_affected: None,
                 sql: "SELECT blargh",
+                location: linenum(2),
             }],
         },
         TestCase {
@@ -94,23 +105,27 @@ SELECT disappear",
                     expected_error: None,
                     rows_affected: None,
                     sql: "SELECT only_postgresql",
+                    location: linenum(7),
                 },
                 Record::Statement {
                     expected_error: None,
                     rows_affected: None,
                     sql: "SELECT everybody",
+                    location: linenum(10),
                 },
                 Record::Statement {
                     expected_error: None,
                     rows_affected: None,
                     sql: "SELECT multiskip_not_us",
+                    location: linenum(15),
                 },
             ],
         },
     ];
 
     for tc in test_cases {
-        let records = parser::parse_records(tc.input).unwrap();
+        let mut parser = crate::parser::Parser::new("<test>", tc.input);
+        let records = parser.parse_records().unwrap();
         assert_eq!(records, tc.output);
     }
 }


### PR DESCRIPTION
This comes accompanied with a mostly-mechanical transformation to
package the parsing state into a struct to make it easier to track said
line numbers. A little hard to review since the diff is kind of wonky, but most of this is code movement, probably should have split this up into two commits, oh well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3129)
<!-- Reviewable:end -->
