### PR TITLE
Reorganize reduce to minimize allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b42542e439327d2504dd2e4a05604a1753a5f191"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e37923d78133501006310bae022cec7ebe41dffe"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -3524,12 +3524,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b42542e439327d2504dd2e4a05604a1753a5f191"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e37923d78133501006310bae022cec7ebe41dffe"
 
 [[package]]
 name = "timely_communication"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b42542e439327d2504dd2e4a05604a1753a5f191"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e37923d78133501006310bae022cec7ebe41dffe"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -3544,7 +3544,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b42542e439327d2504dd2e4a05604a1753a5f191"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e37923d78133501006310bae022cec7ebe41dffe"
 
 [[package]]
 name = "timely_sort"

--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -257,7 +257,7 @@ where
     let mut partial = if !prepend_key {
         let mut packer = RowPacker::new();
         ok_input.map(move |(key, row)| {
-            let value = row.iter().skip(index).next().unwrap();
+            let value = row.iter().nth(index).unwrap();
             packer.push(value);
             (key, packer.finish_and_reuse())
         })

--- a/src/dataflow/render/reduce.rs
+++ b/src/dataflow/render/reduce.rs
@@ -69,19 +69,16 @@ where
             let group_key_owned = group_key.to_vec();
             let aggregates_owned = aggregates.to_vec();
 
-            let mut support = 0;
+            // Tracks the required number of columns to extract.
+            let mut columns_needed = 0;
             for key in group_key.iter() {
                 for column in key.support() {
-                    if column > support {
-                        support = column;
-                    }
+                    columns_needed = std::cmp::max(columns_needed, column + 1);
                 }
             }
             for aggr in aggregates.iter() {
                 for column in aggr.expr.support() {
-                    if column > support {
-                        support = column;
-                    }
+                    columns_needed = std::cmp::max(columns_needed, column + 1);
                 }
             }
 
@@ -96,7 +93,7 @@ where
                     // First, evaluate the key selector expressions.
                     // If any error we produce their errors as output and note
                     // the fact that the key was not correctly produced.
-                    let datums = row.iter().take(support + 1).collect::<Vec<_>>();
+                    let datums = row.iter().take(columns_needed).collect::<Vec<_>>();
                     for expr in group_key_owned.iter() {
                         match expr.eval(&datums, &temp_storage) {
                             Ok(val) => row_packer.push(val),


### PR DESCRIPTION
Several improvements to `reduce.rs` to improve primarily start-up time, though probably throughput as well.

On 8 workers, a `select count(*) from` 10M records is (on master):
```
materialize=> select count(*) from upsert_text_source;
  count  
---------
 9556820
(1 row)

Time: 3240.513 ms (00:03.241)
materialize=> 
```
After the fixes here:
```
materialize=> select count(*) from upsert_text_source;
  count  
---------
 9556820
(1 row)

Time: 1255.278 ms (00:01.255)
materialize=> 
```

There are a few flavors of fixes. The most invasive is pivoting away from `Context::collection(expr)` to a method `flat_map_ref` that acts as a flatmap on a reference to an arrangement's data. This allows us to avoid a full clone of the data, and push reduction all the way back to where we extract it from an arrangement. This can and should be used elsewhere we extract data from arrangements and intend to filter or project it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3130)
<!-- Reviewable:end -->
