### PR TITLE
Fix references in doc/user/README.md to stop pointing at www

### DIFF
--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -52,7 +52,7 @@ visually match.
 You can see how commonly rendered elements look by going to
 [`localhost:1313/stylesheet`](http://localhost:1313/stylesheet).
 
-You can use this as a scratch area by editing `content/stylesheet.md`.
+You can use this as a scratch area by editing [content/stylesheet.md](content/stylesheet.md).
 
 ### Railroad diagrams for SQL grammar
 
@@ -81,9 +81,11 @@ You can now include the diagram on a page using:
 
 ## Function + Operator docs
 
-The **Functions** you see at `www/docs/sql/functions/` are populated from
-`www/data/sql_funcs.yml`. Unfortunately this means that they're ad hoc and are
-not actually generated from the Materialize source code.
+The **Functions** you see at
+[content/sql/functions/](content/sql/functions) are populated from
+[data/sql_funcs.yml](data/sql_funcs.yml). Unfortunately this means
+that they're ad hoc and are not actually generated from the Materialize source
+code.
 
 As new functions get added, this file must be manually updated. The idea here is
 to structure functions by their input type (whereas operators are grouped by
@@ -108,7 +110,7 @@ each meaningfully distinct combination of connector and format), and leveraged
 Hugo partials and shortcodes to simplify page creation and resuse content across
 pages.
 
-You can find all of the `CREATE SOURCE` docs at `/doc/user/sql/create-source/`.
+You can find all of the `CREATE SOURCE` docs at [content/sql/create-source](content/sql/create-source/).
 
 ### Hugo shortcodes and partials
 
@@ -116,11 +118,14 @@ Hugo partials are template components, and shortcodes are designed to provide
 a dynamic interface for using those components.
 
 In the case of Materialize, we rely on shortcodes in
-`/www/layouts/shortcodes/create-source` to simplify generating our many
-`CREATE SOURCE` pages, namely `syntax-details`.  This provides an interface
-to dynamically display content from `www/layouts/partials/create-source`.
+[layouts/shortcodes/create-source](layouts/shortcodes/create-source)
+to simplify generating our many
+`CREATE SOURCE` pages, namely `syntax-details`. This provides an interface
+to dynamically display content from
+[layouts/partials/create-source](layouts/partials/create-source).
 
-`...partials/create-source` is structured like:
+[layouts/partials/create-source](layouts/partials/create-source)
+is structured like:
 
 ```
 <component>
@@ -187,7 +192,8 @@ highlighting Materialized extensions to the SQL standard, as well as generally
 beautifying the syntax highlighting color scheme––but for right now, what's
 there suffices.
 
-You can adjust the highlight colors as necessary in `assets/_highlight.scss`.
+You can adjust the highlight colors as necessary in
+[assets/sass/_highlight.scss](assets/sass/_highlight.scss).
 
 Most code samples contain two components: the SQL query you want to run and the
 expected output.
@@ -213,7 +219,8 @@ programming language). For expressivity, we chose `nofmt`.
 ## Miscellany, Trivia, & Footguns
 
 - Headers are automatically hyperlinked using [AnchorJS].
-- Railroad diagrams are managed in `layouts/partials/sql-grammar`.
+- Railroad diagrams are managed in
+[layouts/partials/sql-grammar](layouts/partials/sql-grammar).
 
 [AnchorJS]: https://www.bryanbraun.com/anchorjs/
 [Hugo]: https://gohugo.io/

--- a/doc/user/layouts/partials/create-source/envelope/upsert/details.html
+++ b/doc/user/layouts/partials/create-source/envelope/upsert/details.html
@@ -27,8 +27,9 @@ When Materialize receives a message, it checks the message's key and offset.
 
     Note that the diagrams on this page do not detail using text- or
     byte-formatted keys with Avro-formatted payloads. However, you can integrate
-    both of these features using the `format_spec` outlined in [`CREATE SOURCE`:
-    Avro over Kafka](../avro-kafka/#format-specification).
+    both of these features using the `format_spec`s outlined in [`CREATE SOURCE`:
+    Avro over Kafka](../avro-kafka/#format-specification) and [`CREATE SOURCE`:
+    Text or bytes over Kafka](../text-kafka/#format-specification).
 - By default, the key is decoded using the same format as the payload. However,
   you can explicitly set the key's format using **UPSERT FORMAT...**.
 - If you are using the Confluent Schema Registry, Materialize looks for the key

--- a/doc/user/layouts/partials/create-source/envelope/upsert/syntax.html
+++ b/doc/user/layouts/partials/create-source/envelope/upsert/syntax.html
@@ -1,1 +1,1 @@
-**ENVELOPE UPSERT** | Use the upsert enevelope, which uses message keys to handle CRUD operations. For more information see [Upsert envelope details](#upsert-envelope-details).
+**ENVELOPE UPSERT** | Use the upsert envelope, which uses message keys to handle CRUD operations. For more information see [Upsert envelope details](#upsert-envelope-details).


### PR DESCRIPTION
I was looking for where the create source files were, and I was thrown off by the outdated information in README.md that were directing me to the nonexistent www folder. Made references to other files in the README.md to links that way it's easier to navigate from github.

When I was reading  `CREATE SOURCE: Avro over Kafka`, I found it confusing to read:
```
Note that the diagrams on this page do not detail using text- or
    byte-formatted keys with Avro-formatted payloads. However, you can integrate
    both of these features using the `format_spec` outlined in [`CREATE SOURCE`:		    
    Avro over Kafka](../avro-kafka/#format-specification).
```
since the link just links to back to the page I am on, so I added links to both the "CREATE SOURCE: Avro over Kafka" and the "CREATE SOURCE: Text or bytes over Kafka" page.

Found one typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3131)
<!-- Reviewable:end -->
