### PR TITLE
hoist datums allocation out of loop

### DIFF
--- a/src/dataflow/server.rs
+++ b/src/dataflow/server.rs
@@ -892,10 +892,12 @@ impl PendingPeek {
             None
         };
 
+        let mut datums = Vec::new();
         while cursor.key_valid(&storage) && limit.map(|l| results.len() < l).unwrap_or(true) {
             while cursor.val_valid(&storage) && limit.map(|l| results.len() < l).unwrap_or(true) {
                 let row = cursor.val(&storage);
-                let datums = row.unpack();
+                datums.clear();
+                datums.extend(row.iter());
                 // Before (expensively) determining how many copies of a row
                 // we have, let's eliminate rows that we don't care about.
                 let mut retain = true;


### PR DESCRIPTION
The server unpacks each `Row` before investigating it to determine whether it passes various predicate tests. This PR retains an allocation into which it can unpack itself, and conditions the unpacking on there being filters to apply.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3132)
<!-- Reviewable:end -->
