### PR TITLE
sql-parser: support general typed string literals

### DIFF
--- a/src/sql-parser/src/ast/value.rs
+++ b/src/sql-parser/src/ast/value.rs
@@ -48,14 +48,6 @@ pub enum Value {
     HexStringLiteral(String),
     /// Boolean value true or false
     Boolean(bool),
-    /// `DATE '...'` literals
-    Date(String),
-    /// `TIME '...'` literals
-    Time(String),
-    /// `TIMESTAMP '...'` literals
-    Timestamp(String),
-    /// `TIMESTAMP WITH TIME ZONE` literals
-    TimestampTz(String),
     /// INTERVAL literals, roughly in the following format:
     ///
     /// ```text
@@ -83,26 +75,6 @@ impl AstDisplay for Value {
                 f.write_str("'");
             }
             Value::Boolean(v) => f.write_str(v),
-            Value::Date(v) => {
-                f.write_str("DATE '");
-                f.write_node(&escape_single_quote_string(v));
-                f.write_str("'");
-            }
-            Value::Time(v) => {
-                f.write_str("TIME '");
-                f.write_node(&escape_single_quote_string(v));
-                f.write_str("'");
-            }
-            Value::Timestamp(v) => {
-                f.write_str("TIMESTAMP '");
-                f.write_node(&escape_single_quote_string(v));
-                f.write_str("'");
-            }
-            Value::TimestampTz(v) => {
-                f.write_str("TIMESTAMP WITH TIME ZONE '");
-                f.write_node(&escape_single_quote_string(v));
-                f.write_str("'");
-            }
             Value::Interval(IntervalValue {
                 value,
                 precision_high: _,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -43,6 +43,14 @@ macro_rules! parser_err {
     };
 }
 
+macro_rules! maybe {
+    ($e:expr) => {{
+        if let Some(v) = $e {
+            return Ok(v);
+        }
+    }};
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParserError {
     /// Original query (so we can easily print an error)
@@ -245,6 +253,36 @@ impl Parser {
 
     /// Parse an expression prefix
     pub fn parse_prefix(&mut self) -> Result<Expr, ParserError> {
+        // PostgreSQL allows any string literal to be preceded by a type name,
+        // indicating that the string literal represents a literal of that type.
+        // Some examples:
+        //
+        //     DATE '2020-05-20'
+        //     TIMESTAMP WITH TIME ZONE '2020-05-20 7:43:54'
+        //     BOOL 'true'
+        //
+        // The first two are standard SQL, while the latter is a PostgreSQL
+        // extension. Complicating matters is the fact that INTERVAL string
+        // literals may optionally be followed by some special keywords, e.g.:
+        //
+        //     INTERVAL '7' DAY
+        //
+        // Note also that naively `SELECT date` looks like a syntax error
+        // because the `date` type name is not followed by a string literal, but
+        // in fact is a valid expression that should parse as the column name
+        // "date".
+        maybe!(self.maybe_parse(|parser| {
+            match parser.parse_data_type()? {
+                DataType::Interval => parser.parse_literal_interval(),
+                data_type => Ok(Expr::Cast {
+                    expr: Box::new(Expr::Value(Value::SingleQuotedString(
+                        parser.parse_literal_string()?,
+                    ))),
+                    data_type,
+                }),
+            }
+        }));
+
         let tok = self
             .next_token()
             .ok_or_else(|| self.error(self.peek_prev_range(), "Unexpected EOF".to_string()))?;
@@ -257,7 +295,6 @@ impl Parser {
                 "LIST" => self.parse_list(),
                 "CASE" => self.parse_case_expr(),
                 "CAST" => self.parse_cast_expr(),
-                "DATE" => Ok(Expr::Value(self.parse_date()?)),
                 "EXISTS" => self.parse_exists_expr(),
                 "EXTRACT" => self.parse_extract_expr(),
                 "INTERVAL" => self.parse_literal_interval(),
@@ -265,9 +302,6 @@ impl Parser {
                     op: UnaryOperator::Not,
                     expr: Box::new(self.parse_subexpr(Precedence::UnaryNot)?),
                 }),
-                "TIME" => Ok(Expr::Value(self.parse_time()?)),
-                "TIMESTAMP" => self.parse_timestamp(),
-                "TIMESTAMPTZ" => self.parse_timestamptz(),
                 // Here `w` is a word, check if it's a part of a multi-part
                 // identifier, a function call, or a simple identifier:
                 w if keywords::RESERVED_FOR_EXPRESSIONS.contains(&w) => {
@@ -544,33 +578,6 @@ impl Parser {
             Ok(f) => Ok(f),
             Err(_) => self.expected(self.peek_prev_range(), "valid extract field", tok)?,
         }
-    }
-
-    fn parse_date(&mut self) -> Result<Value, ParserError> {
-        let value = self.parse_literal_string()?;
-        Ok(Value::Date(value))
-    }
-
-    fn parse_time(&mut self) -> Result<Value, ParserError> {
-        let value = self.parse_literal_string()?;
-        Ok(Value::Time(value))
-    }
-
-    fn parse_timestamp(&mut self) -> Result<Expr, ParserError> {
-        if self.parse_keyword("WITH") {
-            self.expect_keywords(&["TIME", "ZONE"])?;
-            let value = self.parse_literal_string()?;
-            return Ok(Expr::Value(Value::TimestampTz(value)));
-        } else if self.parse_keyword("WITHOUT") {
-            self.expect_keywords(&["TIME", "ZONE"])?;
-        }
-        let value = self.parse_literal_string()?;
-        Ok(Expr::Value(Value::Timestamp(value)))
-    }
-
-    fn parse_timestamptz(&mut self) -> Result<Expr, ParserError> {
-        let value = self.parse_literal_string()?;
-        Ok(Expr::Value(Value::TimestampTz(value)))
     }
 
     /// Parse an INTERVAL literal.
@@ -1101,6 +1108,20 @@ impl Parser {
             }
         }
         Ok(values)
+    }
+
+    #[must_use]
+    fn maybe_parse<T, F>(&mut self, mut f: F) -> Option<T>
+    where
+        F: FnMut(&mut Parser) -> Result<T, ParserError>,
+    {
+        let index = self.index;
+        if let Ok(t) = f(self) {
+            Some(t)
+        } else {
+            self.index = index;
+            None
+        }
     }
 
     /// Parse a SQL CREATE statement
@@ -1895,7 +1916,7 @@ impl Parser {
                 }
                 // Interval types can be followed by a complicated interval
                 // qualifier that we don't currently support. See
-                // parse_interval_literal for a taste.
+                // parse_literal_interval for a taste.
                 "INTERVAL" => DataType::Interval,
                 "REGCLASS" => DataType::Regclass,
                 "TEXT" | "STRING" => DataType::Text,
@@ -2498,7 +2519,6 @@ impl Parser {
         }
 
         if self.consume_token(&Token::LParen) {
-            let index = self.index;
             // A left paren introduces either a derived table (i.e., a subquery)
             // or a nested join. It's nearly impossible to determine ahead of
             // time which it is... so we just try to parse both.
@@ -2515,39 +2535,36 @@ impl Parser {
             //                   | (2) starts a nested join
             //                   (1) an additional set of parens around a nested join
             //
-            match self.parse_derived_table_factor(NotLateral) {
-                // The recently consumed '(' started a derived table, and we've
-                // parsed the subquery, followed by the closing ')', and the
-                // alias of the derived table. In the example above this is
-                // case (3), and the next token would be `NATURAL`.
-                Ok(table_factor) => Ok(table_factor),
-                Err(_) => {
-                    // The '(' we've recently consumed does not start a derived
-                    // table. For valid input this can happen either when the
-                    // token following the paren can't start a query (e.g. `foo`
-                    // in `FROM (foo NATURAL JOIN bar)`, or when the '(' we've
-                    // consumed is followed by another '(' that starts a
-                    // derived table, like (3), or another nested join (2).
-                    //
-                    // Ignore the error and back up to where we were before.
-                    // Either we'll be able to parse a valid nested join, or
-                    // we won't, and we'll return that error instead.
-                    self.index = index;
-                    let table_and_joins = self.parse_table_and_joins()?;
-                    match table_and_joins.relation {
-                        TableFactor::NestedJoin { .. } => (),
-                        _ => {
-                            if table_and_joins.joins.is_empty() {
-                                // The SQL spec prohibits derived tables and bare
-                                // tables from appearing alone in parentheses.
-                                self.expected(self.peek_range(), "joined table", self.peek_token())?
-                            }
-                        }
+
+            // Check if the recently consumed '(' started a derived table, in
+            // which case we've parsed the subquery, followed by the closing
+            // ')', and the alias of the derived table. In the example above
+            // this is case (3), and the next token would be `NATURAL`.
+            maybe!(self.maybe_parse(|parser| parser.parse_derived_table_factor(NotLateral)));
+
+            // The '(' we've recently consumed does not start a derived table.
+            // For valid input this can happen either when the token following
+            // the paren can't start a query (e.g. `foo` in `FROM (foo NATURAL
+            // JOIN bar)`, or when the '(' we've consumed is followed by another
+            // '(' that starts a derived table, like (3), or another nested join
+            // (2).
+            //
+            // Ignore the error and back up to where we were before. Either
+            // we'll be able to parse a valid nested join, or we won't, and
+            // we'll return that error instead.
+            let table_and_joins = self.parse_table_and_joins()?;
+            match table_and_joins.relation {
+                TableFactor::NestedJoin { .. } => (),
+                _ => {
+                    if table_and_joins.joins.is_empty() {
+                        // The SQL spec prohibits derived tables and bare
+                        // tables from appearing alone in parentheses.
+                        self.expected(self.peek_range(), "joined table", self.peek_token())?
                     }
-                    self.expect_token(&Token::RParen)?;
-                    Ok(TableFactor::NestedJoin(Box::new(table_and_joins)))
                 }
             }
+            self.expect_token(&Token::RParen)?;
+            Ok(TableFactor::NestedJoin(Box::new(table_and_joins)))
         } else {
             let name = self.parse_object_name()?;
             // Postgres, MSSQL: table-valued functions:

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -74,62 +74,62 @@ Value(HexStringLiteral("deadBEEF"))
 parse-scalar
 DATE '1999-01-01'
 ----
-Value(Date("1999-01-01"))
+Cast { expr: Value(SingleQuotedString("1999-01-01")), data_type: Date }
 
 parse-scalar
 DATE 'invalid date'
 ----
-Value(Date("invalid date"))
+Cast { expr: Value(SingleQuotedString("invalid date")), data_type: Date }
 
 parse-scalar
 TIME '01:23:34'
 ----
-Value(Time("01:23:34"))
+Cast { expr: Value(SingleQuotedString("01:23:34")), data_type: Time }
 
 parse-scalar
 TIME 'invalid time'
 ----
-Value(Time("invalid time"))
+Cast { expr: Value(SingleQuotedString("invalid time")), data_type: Time }
 
 parse-scalar
 TIMESTAMP '1999-01-01 01:23:34.555'
 ----
-Value(Timestamp("1999-01-01 01:23:34.555"))
+Cast { expr: Value(SingleQuotedString("1999-01-01 01:23:34.555")), data_type: Timestamp }
 
 parse-scalar
 TIMESTAMPTZ '1999-01-01 01:23:34.555'
 ----
-Value(TimestampTz("1999-01-01 01:23:34.555"))
+Cast { expr: Value(SingleQuotedString("1999-01-01 01:23:34.555")), data_type: TimestampTz }
 
 parse-scalar
 TIMESTAMP WITH TIME ZONE '1999-01-01 01:23:34.555'
 ----
-Value(TimestampTz("1999-01-01 01:23:34.555"))
+Cast { expr: Value(SingleQuotedString("1999-01-01 01:23:34.555")), data_type: TimestampTz }
 
 parse-scalar
 TIMESTAMP WITHOUT TIME ZONE '1999-01-01 01:23:34.555'
 ----
-Value(Timestamp("1999-01-01 01:23:34.555"))
+Cast { expr: Value(SingleQuotedString("1999-01-01 01:23:34.555")), data_type: Timestamp }
 
 parse-scalar
 TIMESTAMP 'invalid timestamptx'
 ----
-Value(Timestamp("invalid timestamptx"))
+Cast { expr: Value(SingleQuotedString("invalid timestamptx")), data_type: Timestamp }
 
 parse-scalar
 TIMESTAMPTZ 'invalid timestamptx'
 ----
-Value(TimestampTz("invalid timestamptx"))
+Cast { expr: Value(SingleQuotedString("invalid timestamptx")), data_type: TimestampTz }
 
 parse-scalar
 TIMESTAMP WITH TIME ZONE 'invalid timestamptx'
 ----
-Value(TimestampTz("invalid timestamptx"))
+Cast { expr: Value(SingleQuotedString("invalid timestamptx")), data_type: TimestampTz }
 
 parse-scalar
 TIMESTAMP WITHOUT TIME ZONE 'invalid timestamptx'
 ----
-Value(Timestamp("invalid timestamptx"))
+Cast { expr: Value(SingleQuotedString("invalid timestamptx")), data_type: Timestamp }
 
 parse-scalar
 INTERVAL '1' YEAR

--- a/src/sql/src/query.rs
+++ b/src/sql/src/query.rs
@@ -3233,16 +3233,6 @@ fn sql_value_to_datum<'a>(l: &'a Value) -> Result<(Datum<'a>, ScalarType), failu
             false => (Datum::False, ScalarType::Bool),
             true => (Datum::True, ScalarType::Bool),
         },
-        Value::Date(d) => (Datum::Date(strconv::parse_date(d)?), ScalarType::Date),
-        Value::Timestamp(ts) => (
-            Datum::Timestamp(strconv::parse_timestamp(ts)?),
-            ScalarType::Timestamp,
-        ),
-        Value::TimestampTz(ts) => (
-            Datum::TimestampTz(strconv::parse_timestamptz(ts)?),
-            ScalarType::TimestampTz,
-        ),
-        Value::Time(t) => (Datum::Time(strconv::parse_time(t)?), ScalarType::Time),
         Value::Interval(iv) => {
             let mut i = strconv::parse_interval_w_disambiguator(&iv.value, iv.precision_low)?;
             i.truncate_high_fields(iv.precision_high);

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -987,3 +987,9 @@ query T
 SELECT interval '-01:02:03.04'::time;
 ----
 22:57:56.96
+
+# Test using date as a column name.
+query T
+SELECT date FROM (SELECT column1 AS date FROM (VALUES ('2020-01-01')))
+----
+2020-01-01

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1896,7 +1896,7 @@ ORDER BY
 | | | |
 | | | | %14 =
 | | | | | InnerJoin %12 %13 on true
-| | | | | Filter ((((#1 = #^0) && (#2 = #^1)) && (#10 >= 1995-01-01)) && (datetots(#10) < (1995-01-01 + 1 year)))
+| | | | | Filter ((((#1 = #^0) && (#2 = #^1)) && (#10 >= strtodate("1995-01-01"))) && (datetots(#10) < (strtodate("1995-01-01") + 1 year)))
 | | | | | Map
 | | | | | Reduce group=() sum(#4)
 | | | | | Map (5dec * #0)


### PR DESCRIPTION
Support PostgreSQL's typed string literals, as in:

    SELECT bool 'true'

Previously we only supported the typed string literals for the date,
timestamp, and timestamp with time zone types as required by the SQL
standard, but PostgreSQL generalizes this syntax for all types.

As a side effect, this fixes the bug where

    SELECT date

parsed as a syntax error rather than as selecting a column named "date".
The fix also generalizes, e.g., `SELECT bool` is also valid.

Fix #2577.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3146)
<!-- Reviewable:end -->
