### PR TITLE
sql-parser: render CAST expressions using Postgres syntax

### DIFF
--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -367,11 +367,9 @@ impl AstDisplay for Expr {
                 f.write_node(&expr);
             }
             Expr::Cast { expr, data_type } => {
-                f.write_str("CAST(");
                 f.write_node(&expr);
-                f.write_str(" AS ");
+                f.write_str("::");
                 f.write_node(data_type);
-                f.write_str(")");
             }
             Expr::Extract { field, expr } => {
                 f.write_str("EXTRACT(");


### PR DESCRIPTION
The PostgreSQL-style casts

    'foo'::int4

are a lot less verbose than standard SQL casts:

    CAST('foo' AS int4)

When formatting SQL statements, use the PostgreSQL style. This will make
`SHOW CREATE VIEW` more readable, and allow a forthcoming PR (#3146) to
avoid introducing a new AST node for typed string literals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3149)
<!-- Reviewable:end -->
