### PR TITLE
sql: treat 0 intervals as equal irrespective of is_positive_dur

### DIFF
--- a/src/repr/scalar/mod.rs
+++ b/src/repr/scalar/mod.rs
@@ -745,7 +745,7 @@ impl fmt::Display for ColumnType {
 /// An interval of time meant to express SQL intervals.
 ///
 /// Obtained by parsing an `INTERVAL '<value>' <unit> [TO <precision>]`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Interval {
     /// A possibly negative number of months for field types like `YEAR`
     pub months: i64,
@@ -761,6 +761,26 @@ impl Default for Interval {
             duration: std::time::Duration::default(),
             is_positive_dur: true,
         }
+    }
+}
+
+impl PartialEq for Interval {
+    fn eq(&self, other: &Self) -> bool {
+        let dur_match = if self.duration.as_nanos() == other.duration.as_nanos() {
+            self.duration.as_nanos() == 0 || (self.is_positive_dur == other.is_positive_dur)
+        } else {
+            false
+        };
+
+        dur_match && (self.months == other.months)
+    }
+}
+
+impl Hash for Interval {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.months.hash(state);
+        self.duration.hash(state);
+        self.is_positive_dur.hash(state);
     }
 }
 

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -632,3 +632,9 @@ SELECT INTERVAL '9223372036854775808 seconds';
 
 statement error Unable to parse value as a number at index 0: number too large to fit in target type
 SELECT INTERVAL '-9223372036854775808 seconds';
+
+# 0 interval equality
+query B
+SELECT (interval '-1' day + interval '1' day) = (interval '1' day + interval '-1' day)
+----
+true


### PR DESCRIPTION
Closes #2812 

I considered a more thorough approach of converting `is_positive_dur` to an enum that included zero, but the diff was pretty massive. This seemed less invasive and accomplished  the same thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3151)
<!-- Reviewable:end -->
