### PR TITLE
expr,strconv: better error handling

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,12 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+<span id="v0.3.1"></span>
+## 0.3.1 (Unreleased)
+
+- Produce runtime errors when casting from string to any other data type, rather
+  than producing `NULL` if the cast failed.
+
 <span id="v0.3.0"></span>
 ## 0.2.2 &rarr; 0.3.0 (Unreleased)
 

--- a/src/expr/explain.rs
+++ b/src/expr/explain.rs
@@ -19,8 +19,8 @@
 //!
 //! It's important to avoid trailing whitespace everywhere, because it plays havoc with SLT
 use super::{
-    AggregateExpr, EvalError, Id, IdHumanizer, JoinImplementation, LocalId, RelationExpr,
-    RowSetFinishing, ScalarExpr,
+    AggregateExpr, Id, IdHumanizer, JoinImplementation, LocalId, RelationExpr, RowSetFinishing,
+    ScalarExpr,
 };
 use repr::RelationType;
 use std::collections::HashMap;
@@ -400,29 +400,6 @@ impl std::fmt::Display for AggregateExpr {
             if self.distinct { "distinct " } else { "" },
             self.expr
         )
-    }
-}
-
-impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            EvalError::DivisionByZero => f.write_str("division by zero"),
-            EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
-            EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
-            EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
-            EvalError::InvalidByteSequence {
-                byte_sequence,
-                encoding_name,
-            } => write!(
-                f,
-                "invalid byte sequence '{}' for encoding '{}'",
-                byte_sequence, encoding_name
-            ),
-            EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
-            EvalError::UnterminatedLikeEscapeSequence => {
-                f.write_str("unterminated escape sequence in LIKE")
-            }
-        }
     }
 }
 

--- a/src/expr/scalar/func.rs
+++ b/src/expr/scalar/func.rs
@@ -18,6 +18,7 @@ use encoding::DecoderTrap;
 use serde::{Deserialize, Serialize};
 
 use ore::collections::CollectionExt;
+use ore::result::ResultExt;
 use repr::decimal::MAX_DECIMAL_PRECISION;
 use repr::jsonb::Jsonb;
 use repr::regex::Regex;
@@ -269,93 +270,85 @@ fn cast_decimal_to_string<'a>(a: Datum<'a>, scale: u8, temp_storage: &'a RowAren
     Datum::String(temp_storage.push_string(buf))
 }
 
-fn cast_string_to_bool<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_bool(a.unwrap_str()) {
-        Ok(true) => Datum::True,
-        Ok(false) => Datum::False,
-        Err(_) => Datum::Null,
+fn cast_string_to_bool<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    match strconv::parse_bool(a.unwrap_str())? {
+        true => Ok(Datum::True),
+        false => Ok(Datum::False),
     }
 }
 
-fn cast_string_to_bytes<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
-    match strconv::parse_bytes(a.unwrap_str()) {
-        Ok(bytes) => Datum::Bytes(temp_storage.push_bytes(bytes)),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_bytes<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let bytes = strconv::parse_bytes(a.unwrap_str())?;
+    Ok(Datum::Bytes(temp_storage.push_bytes(bytes)))
 }
 
-fn cast_string_to_int32<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_int32(a.unwrap_str()) {
-        Ok(n) => Datum::Int32(n),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_int32(a.unwrap_str())
+        .map(Datum::Int32)
+        .err_into()
 }
 
-fn cast_string_to_int64<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_int64(a.unwrap_str()) {
-        Ok(n) => Datum::Int64(n),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_int64(a.unwrap_str())
+        .map(Datum::Int64)
+        .err_into()
 }
 
-fn cast_string_to_float32<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_float32(a.unwrap_str()) {
-        Ok(n) => Datum::Float32(n.into()),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_float32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_float32(a.unwrap_str())
+        .map(|n| Datum::Float32(n.into()))
+        .err_into()
 }
 
-fn cast_string_to_float64<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_float64(a.unwrap_str()) {
-        Ok(n) => Datum::Float64(n.into()),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_float64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_float64(a.unwrap_str())
+        .map(|n| Datum::Float64(n.into()))
+        .err_into()
 }
 
-fn cast_string_to_decimal<'a>(a: Datum<'a>, scale: u8) -> Datum<'a> {
-    match strconv::parse_decimal(a.unwrap_str()) {
-        Ok(d) => Datum::from(match d.scale().cmp(&scale) {
-            Ordering::Less => d.significand() * 10_i128.pow(u32::from(scale - d.scale())),
-            Ordering::Equal => d.significand(),
-            Ordering::Greater => d.significand() / 10_i128.pow(u32::from(d.scale() - scale)),
-        }),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_decimal<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_decimal(a.unwrap_str())
+        .map(|d| {
+            Datum::from(match d.scale().cmp(&scale) {
+                Ordering::Less => d.significand() * 10_i128.pow(u32::from(scale - d.scale())),
+                Ordering::Equal => d.significand(),
+                Ordering::Greater => d.significand() / 10_i128.pow(u32::from(d.scale() - scale)),
+            })
+        })
+        .err_into()
 }
 
-fn cast_string_to_date<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_date(a.unwrap_str()) {
-        Ok(d) => Datum::Date(d),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_date<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_date(a.unwrap_str())
+        .map(Datum::Date)
+        .err_into()
 }
 
-fn cast_string_to_time<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_time(a.unwrap_str()) {
-        Ok(t) => Datum::Time(t),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_time<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_time(a.unwrap_str())
+        .map(Datum::Time)
+        .err_into()
 }
 
-fn cast_string_to_timestamp<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_timestamp(a.unwrap_str()) {
-        Ok(ts) => Datum::Timestamp(ts),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_timestamp<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_timestamp(a.unwrap_str())
+        .map(Datum::Timestamp)
+        .err_into()
 }
 
-fn cast_string_to_timestamptz<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_timestamptz(a.unwrap_str()) {
-        Ok(ts) => Datum::TimestampTz(ts),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_timestamptz<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_timestamptz(a.unwrap_str())
+        .map(Datum::TimestampTz)
+        .err_into()
 }
 
-fn cast_string_to_interval<'a>(a: Datum<'a>) -> Datum<'a> {
-    match strconv::parse_interval(a.unwrap_str()) {
-        Ok(iv) => Datum::Interval(iv),
-        Err(_) => Datum::Null,
-    }
+fn cast_string_to_interval<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    strconv::parse_interval(a.unwrap_str())
+        .map(Datum::Interval)
+        .err_into()
 }
 
 fn cast_date_to_timestamp<'a>(a: Datum<'a>) -> Datum<'a> {
@@ -2445,18 +2438,18 @@ impl UnaryFunc {
             UnaryFunc::CastDecimalToInt64 => Ok(cast_decimal_to_int64(a)),
             UnaryFunc::CastSignificandToFloat32 => Ok(cast_significand_to_float32(a)),
             UnaryFunc::CastSignificandToFloat64 => Ok(cast_significand_to_float64(a)),
-            UnaryFunc::CastStringToBool => Ok(cast_string_to_bool(a)),
-            UnaryFunc::CastStringToBytes => Ok(cast_string_to_bytes(a, temp_storage)),
-            UnaryFunc::CastStringToInt32 => Ok(cast_string_to_int32(a)),
-            UnaryFunc::CastStringToInt64 => Ok(cast_string_to_int64(a)),
-            UnaryFunc::CastStringToFloat32 => Ok(cast_string_to_float32(a)),
-            UnaryFunc::CastStringToFloat64 => Ok(cast_string_to_float64(a)),
-            UnaryFunc::CastStringToDecimal(scale) => Ok(cast_string_to_decimal(a, *scale)),
-            UnaryFunc::CastStringToDate => Ok(cast_string_to_date(a)),
-            UnaryFunc::CastStringToTime => Ok(cast_string_to_time(a)),
-            UnaryFunc::CastStringToTimestamp => Ok(cast_string_to_timestamp(a)),
-            UnaryFunc::CastStringToTimestampTz => Ok(cast_string_to_timestamptz(a)),
-            UnaryFunc::CastStringToInterval => Ok(cast_string_to_interval(a)),
+            UnaryFunc::CastStringToBool => cast_string_to_bool(a),
+            UnaryFunc::CastStringToBytes => cast_string_to_bytes(a, temp_storage),
+            UnaryFunc::CastStringToInt32 => cast_string_to_int32(a),
+            UnaryFunc::CastStringToInt64 => cast_string_to_int64(a),
+            UnaryFunc::CastStringToFloat32 => cast_string_to_float32(a),
+            UnaryFunc::CastStringToFloat64 => cast_string_to_float64(a),
+            UnaryFunc::CastStringToDecimal(scale) => cast_string_to_decimal(a, *scale),
+            UnaryFunc::CastStringToDate => cast_string_to_date(a),
+            UnaryFunc::CastStringToTime => cast_string_to_time(a),
+            UnaryFunc::CastStringToTimestamp => cast_string_to_timestamp(a),
+            UnaryFunc::CastStringToTimestampTz => cast_string_to_timestamptz(a),
+            UnaryFunc::CastStringToInterval => cast_string_to_interval(a),
             UnaryFunc::CastDateToTimestamp => Ok(cast_date_to_timestamp(a)),
             UnaryFunc::CastDateToTimestampTz => Ok(cast_date_to_timestamptz(a)),
             UnaryFunc::CastDateToString => Ok(cast_date_to_string(a, temp_storage)),

--- a/src/expr/scalar/mod.rs
+++ b/src/expr/scalar/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::mem;
 
 use repr::regex::Regex;
+use repr::strconv::ParseError;
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 use serde::{Deserialize, Serialize};
 
@@ -476,9 +477,40 @@ pub enum EvalError {
     },
     UnknownUnits(String),
     UnterminatedLikeEscapeSequence,
+    Parse(ParseError),
+}
+
+impl std::fmt::Display for EvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            EvalError::DivisionByZero => f.write_str("division by zero"),
+            EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
+            EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
+            EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
+            EvalError::InvalidByteSequence {
+                byte_sequence,
+                encoding_name,
+            } => write!(
+                f,
+                "invalid byte sequence '{}' for encoding '{}'",
+                byte_sequence, encoding_name
+            ),
+            EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
+            EvalError::UnterminatedLikeEscapeSequence => {
+                f.write_str("unterminated escape sequence in LIKE")
+            }
+            EvalError::Parse(e) => e.fmt(f),
+        }
+    }
 }
 
 impl std::error::Error for EvalError {}
+
+impl From<ParseError> for EvalError {
+    fn from(e: ParseError) -> EvalError {
+        EvalError::Parse(e)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/ore/lib.rs
+++ b/src/ore/lib.rs
@@ -26,6 +26,7 @@ pub mod iter;
 pub mod netio;
 pub mod option;
 pub mod panic;
+pub mod result;
 pub mod retry;
 pub mod stats;
 pub mod sync;

--- a/src/ore/result.rs
+++ b/src/ore/result.rs
@@ -1,0 +1,28 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Result utilities.
+
+/// Extension methods for [`std::result::Result`].
+pub trait ResultExt<T, E> {
+    /// Applies [`Into::into`] to a contained [`Err`] value, leaving an [`Ok`]
+    /// value untouched.
+    fn err_into<E2>(self) -> Result<T, E2>
+    where
+        E: Into<E2>;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn err_into<E2>(self) -> Result<T, E2>
+    where
+        E: Into<E2>,
+    {
+        self.map_err(|e| e.into())
+    }
+}

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -322,13 +322,13 @@ where
     })
 }
 
-pub fn decode_list(elem_type: &Type, raw: &str) -> Result<Vec<Option<Value>>, failure::Error> {
-    strconv::parse_list(
+pub fn decode_list(
+    elem_type: &Type,
+    raw: &str,
+) -> Result<Vec<Option<Value>>, Box<dyn Error + Sync + Send>> {
+    Ok(strconv::parse_list(
         raw,
         || None,
-        |elem_text| match Value::decode_text(elem_type, elem_text.as_bytes()) {
-            Ok(elem) => Ok(Some(elem)),
-            Err(e) => Err(failure::Error::from_boxed_compat(e)),
-        },
-    )
+        |elem_text| Value::decode_text(elem_type, elem_text.as_bytes()).map(Some),
+    )?)
 }

--- a/src/repr/scalar/strconv.rs
+++ b/src/repr/scalar/strconv.rs
@@ -28,6 +28,7 @@ use std::fmt;
 
 use chrono::offset::TimeZone;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
+use serde::{Deserialize, Serialize};
 
 use ore::fmt::FormatBuffer;
 
@@ -680,20 +681,24 @@ where
     }
 }
 
-#[derive(Debug)]
+/// An error while parsing input as a type.
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct ParseError {
-    type_name: &'static str,
+    type_name: String,
     input: String,
     details: Option<String>,
 }
 
 impl ParseError {
+    // To ensure that reversing the parameters causes a compile-time error, we
+    // require that `type_name` be a string literal, even though `ParseError`
+    // itself stores the type name as a `String`.
     fn new<S>(type_name: &'static str, input: S) -> ParseError
     where
         S: Into<String>,
     {
         ParseError {
-            type_name,
+            type_name: type_name.into(),
             input: input.into(),
             details: None,
         }

--- a/src/repr/scalar/strconv.rs
+++ b/src/repr/scalar/strconv.rs
@@ -23,15 +23,15 @@
 //! string representations for the corresponding PostgreSQL type. Deviations
 //! should be considered a bug.
 
-use std::{f32, f64};
+use std::error::Error;
+use std::fmt;
 
 use chrono::offset::TimeZone;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
-use failure::{bail, format_err};
 
 use ore::fmt::FormatBuffer;
 
-use crate::datetime::{DateTimeField, ParsedDateTime};
+use crate::datetime::{self, DateTimeField, ParsedDateTime};
 use crate::decimal::Decimal;
 use crate::jsonb::Jsonb;
 use crate::Interval;
@@ -47,11 +47,11 @@ pub enum Nestable {
 /// The accepted values are "true", "false", "yes", "no", "on", "off", "1", and
 /// "0", or any unambiguous prefix of one of those values. Leading or trailing
 /// whitespace is permissible.
-pub fn parse_bool(s: &str) -> Result<bool, failure::Error> {
+pub fn parse_bool(s: &str) -> Result<bool, ParseError> {
     match s.trim().to_lowercase().as_str() {
         "t" | "tr" | "tru" | "true" | "y" | "ye" | "yes" | "on" | "1" => Ok(true),
         "f" | "fa" | "fal" | "fals" | "false" | "n" | "no" | "of" | "off" | "0" => Ok(false),
-        _ => bail!("unable to parse bool"),
+        _ => Err(ParseError::new("bool", s)),
     }
 }
 
@@ -82,8 +82,10 @@ where
 ///
 /// Valid values are whatever the [`FromStr`] implementation on `i32` accepts,
 /// plus leading and trailing whitespace.
-pub fn parse_int32(s: &str) -> Result<i32, failure::Error> {
-    Ok(s.trim().parse()?)
+pub fn parse_int32(s: &str) -> Result<i32, ParseError> {
+    s.trim()
+        .parse()
+        .map_err(|e| ParseError::new("int4", s).with_details(e))
 }
 
 /// Writes an [`i32`] to `buf`.
@@ -96,8 +98,10 @@ where
 }
 
 /// Parses an `i64` from `s`.
-pub fn parse_int64(s: &str) -> Result<i64, failure::Error> {
-    Ok(s.trim().parse()?)
+pub fn parse_int64(s: &str) -> Result<i64, ParseError> {
+    s.trim()
+        .parse()
+        .map_err(|e| ParseError::new("int8", s).with_details(e))
 }
 
 /// Writes an `i64` to `buf`.
@@ -110,13 +114,15 @@ where
 }
 
 /// Parses an `f32` from `s`.
-pub fn parse_float32(s: &str) -> Result<f32, failure::Error> {
-    Ok(match s.trim().to_lowercase().as_str() {
-        "inf" | "infinity" | "+inf" | "+infinity" => f32::INFINITY,
-        "-inf" | "-infinity" => f32::NEG_INFINITY,
-        "nan" => f32::NAN,
-        s => s.parse()?,
-    })
+pub fn parse_float32(s: &str) -> Result<f32, ParseError> {
+    match s.trim().to_lowercase().as_str() {
+        "inf" | "infinity" | "+inf" | "+infinity" => Ok(f32::INFINITY),
+        "-inf" | "-infinity" => Ok(f32::NEG_INFINITY),
+        "nan" => Ok(f32::NAN),
+        s => s
+            .parse()
+            .map_err(|e| ParseError::new("float4", s).with_details(e)),
+    }
 }
 
 /// Writes an `f32` to `buf`.
@@ -137,13 +143,15 @@ where
 }
 
 /// Parses an `f64` from `s`.
-pub fn parse_float64(s: &str) -> Result<f64, failure::Error> {
-    Ok(match s.trim().to_lowercase().as_str() {
-        "inf" | "infinity" | "+inf" | "+infinity" => f64::INFINITY,
-        "-inf" | "-infinity" => f64::NEG_INFINITY,
-        "nan" => f64::NAN,
-        s => s.parse()?,
-    })
+pub fn parse_float64(s: &str) -> Result<f64, ParseError> {
+    match s.trim().to_lowercase().as_str() {
+        "inf" | "infinity" | "+inf" | "+infinity" => Ok(f64::INFINITY),
+        "-inf" | "-infinity" => Ok(f64::NEG_INFINITY),
+        "nan" => Ok(f64::NAN),
+        s => s
+            .parse()
+            .map_err(|e| ParseError::new("float8", s).with_details(e)),
+    }
 }
 
 /// Writes an `f64` to `buf`.
@@ -181,9 +189,9 @@ where
 /// <time zone interval> ::=
 ///     <sign> <hours value> <colon> <minutes value>
 /// ```
-fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, i64), failure::Error> {
+fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, i64), String> {
     if s.is_empty() {
-        bail!("Timestamp string is empty!")
+        return Err("timestamp string is empty".into());
     }
 
     // PostgreSQL special date-time inputs
@@ -198,7 +206,7 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, i64), failur
         ));
     }
 
-    let (ts_string, tz_string) = crate::datetime::split_timestamp_string(s);
+    let (ts_string, tz_string) = datetime::split_timestamp_string(s);
 
     let pdt = ParsedDateTime::build_parsed_datetime_timestamp(&ts_string)?;
     let d: NaiveDate = pdt.compute_date()?;
@@ -207,17 +215,17 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, i64), failur
     let offset = if tz_string.is_empty() {
         0
     } else {
-        crate::datetime::parse_timezone_offset_second(tz_string)?
+        datetime::parse_timezone_offset_second(tz_string)?
     };
 
     Ok((d, t, offset))
 }
 
 /// Parses a [`NaiveDate`] from `s`.
-pub fn parse_date(s: &str) -> Result<NaiveDate, failure::Error> {
+pub fn parse_date(s: &str) -> Result<NaiveDate, ParseError> {
     match parse_timestamp_string(s) {
         Ok((date, _, _)) => Ok(date),
-        Err(e) => bail!("Invalid DATE '{}': {}", s, e),
+        Err(e) => Err(ParseError::new("date", s).with_details(e)),
     }
 }
 
@@ -239,11 +247,10 @@ where
 ///     <hours value> <colon> <minutes value> <colon> <seconds integer value>
 ///     [ <period> [ <seconds fraction> ] ]
 /// ```
-pub fn parse_time(s: &str) -> Result<NaiveTime, failure::Error> {
-    match ParsedDateTime::build_parsed_datetime_time(&s) {
-        Ok(pdt) => pdt.compute_time(),
-        Err(e) => bail!("Invalid TIME '{}': {}", s, e),
-    }
+pub fn parse_time(s: &str) -> Result<NaiveTime, ParseError> {
+    ParsedDateTime::build_parsed_datetime_time(&s)
+        .and_then(|pdt| pdt.compute_time())
+        .map_err(|e| ParseError::new("time", s).with_details(e))
 }
 
 /// Writes a [`NaiveDateTime`] timestamp to `buf`.
@@ -259,10 +266,10 @@ where
 }
 
 /// Parses a `NaiveDateTime` from `s`.
-pub fn parse_timestamp(s: &str) -> Result<NaiveDateTime, failure::Error> {
+pub fn parse_timestamp(s: &str) -> Result<NaiveDateTime, ParseError> {
     match parse_timestamp_string(s) {
         Ok((date, time, _)) => Ok(date.and_time(time)),
-        Err(e) => bail!("Invalid TIMESTAMP '{}': {}", s, e),
+        Err(e) => Err(ParseError::new("timestamp", s).with_details(e)),
     }
 }
 
@@ -279,20 +286,16 @@ where
 }
 
 /// Parses a `DateTime<Utc>` from `s`.
-pub fn parse_timestamptz(s: &str) -> Result<DateTime<Utc>, failure::Error> {
-    let (date, time, offset) = match parse_timestamp_string(s) {
-        Ok((date, time, tz_string)) => (date, time, tz_string),
-        Err(e) => bail!("Invalid TIMESTAMPTZ '{}': {}", s, e),
-    };
-
-    let ts = date.and_time(time);
-
-    let dt_fixed_offset = FixedOffset::east(offset as i32)
-        .from_local_datetime(&ts)
-        .earliest()
-        .ok_or_else(|| format_err!("Invalid tz conversion"))?;
-
-    Ok(DateTime::<Utc>::from_utc(dt_fixed_offset.naive_utc(), Utc))
+pub fn parse_timestamptz(s: &str) -> Result<DateTime<Utc>, ParseError> {
+    parse_timestamp_string(s)
+        .and_then(|(date, time, offset)| {
+            let offset = FixedOffset::east(offset as i32)
+                .from_local_datetime(&date.and_time(time))
+                .earliest()
+                .ok_or_else(|| "invalid timezone conversion".to_owned())?;
+            Ok(DateTime::<Utc>::from_utc(offset.naive_utc(), Utc))
+        })
+        .map_err(|e| ParseError::new("timestamptz", s).with_details(e))
 }
 
 /// Writes a [`DateTime<Utc>`] timestamp to `buf`.
@@ -326,26 +329,17 @@ where
 ///   | <minutes value> [ <colon> <seconds value> ]
 ///   | <seconds value>
 /// ```
-pub fn parse_interval(s: &str) -> Result<Interval, failure::Error> {
+pub fn parse_interval(s: &str) -> Result<Interval, ParseError> {
     parse_interval_w_disambiguator(s, DateTimeField::Second)
 }
 
 /// Parse an interval string, using a specific sql_parser::ast::DateTimeField
 /// to identify ambiguous elements. For more information about this operation,
 /// see the doucmentation on ParsedDateTime::build_parsed_datetime_interval.
-pub fn parse_interval_w_disambiguator(
-    s: &str,
-    d: DateTimeField,
-) -> Result<Interval, failure::Error> {
-    let pdt = match ParsedDateTime::build_parsed_datetime_interval(&s, d) {
-        Ok(pdt) => pdt,
-        Err(e) => bail!("Invalid INTERVAL '{}': {}", s, e),
-    };
-
-    match pdt.compute_interval() {
-        Ok(i) => Ok(i),
-        Err(e) => bail!("Invalid INTERVAL '{}': {}", s, e),
-    }
+pub fn parse_interval_w_disambiguator(s: &str, d: DateTimeField) -> Result<Interval, ParseError> {
+    ParsedDateTime::build_parsed_datetime_interval(&s, d)
+        .and_then(|pdt| pdt.compute_interval())
+        .map_err(|e| ParseError::new("interval", s).with_details(e))
 }
 
 pub fn format_interval<F>(buf: &mut F, iv: Interval) -> Nestable
@@ -356,8 +350,10 @@ where
     Nestable::MayNeedEscaping
 }
 
-pub fn parse_decimal(s: &str) -> Result<Decimal, failure::Error> {
-    s.trim().parse()
+pub fn parse_decimal(s: &str) -> Result<Decimal, ParseError> {
+    s.trim()
+        .parse()
+        .map_err(|e| ParseError::new("decimal", s).with_details(e))
 }
 
 pub fn format_decimal<F>(buf: &mut F, d: &Decimal) -> Nestable
@@ -376,38 +372,42 @@ where
     Nestable::MayNeedEscaping
 }
 
-pub fn parse_bytes(s: &str) -> Result<Vec<u8>, failure::Error> {
+pub fn parse_bytes(s: &str) -> Result<Vec<u8>, ParseError> {
     // If the input starts with "\x", then the remaining bytes are hex encoded
     // [0]. Otherwise the bytes use the traditional "escape" format. [1]
     //
     // [0]: https://www.postgresql.org/docs/current/datatype-binary.html#id-1.5.7.12.9
     // [1]: https://www.postgresql.org/docs/current/datatype-binary.html#id-1.5.7.12.10
     if s.starts_with("\\x") {
-        Ok(hex::decode(&s[2..])?)
+        hex::decode(&s[2..]).map_err(|e| ParseError::new("bytea", s).with_details(e))
     } else {
-        parse_bytes_traditional(s.as_bytes())
+        parse_bytes_traditional(s)
     }
 }
 
-fn parse_bytes_traditional(buf: &[u8]) -> Result<Vec<u8>, failure::Error> {
+fn parse_bytes_traditional(s: &str) -> Result<Vec<u8>, ParseError> {
     // Bytes are interpreted literally, save for the special escape sequences
     // "\\", which represents a single backslash, and "\NNN", where each N
     // is an octal digit, which represents the byte whose octal value is NNN.
     let mut out = Vec::new();
-    let mut bytes = buf.iter().fuse();
+    let mut bytes = s.as_bytes().iter().fuse();
     while let Some(&b) = bytes.next() {
         if b != b'\\' {
             out.push(b);
             continue;
         }
         match bytes.next() {
-            None => bail!("bytea input ends with escape character"),
+            None => {
+                return Err(ParseError::new("bytea", s).with_details("ends with escape character"))
+            }
             Some(b'\\') => out.push(b'\\'),
             b => match (b, bytes.next(), bytes.next()) {
                 (Some(d2 @ b'0'..=b'3'), Some(d1 @ b'0'..=b'7'), Some(d0 @ b'0'..=b'7')) => {
                     out.push(((d2 - b'0') << 6) + ((d1 - b'0') << 3) + (d0 - b'0'));
                 }
-                _ => bail!("invalid bytea escape sequence"),
+                _ => {
+                    return Err(ParseError::new("bytea", s).with_details("invalid escape sequence"))
+                }
             },
         }
     }
@@ -422,8 +422,10 @@ where
     Nestable::Yes
 }
 
-pub fn parse_jsonb(s: &str) -> Result<Jsonb, failure::Error> {
-    s.trim().parse()
+pub fn parse_jsonb(s: &str) -> Result<Jsonb, ParseError> {
+    s.trim()
+        .parse()
+        .map_err(|e| ParseError::new("jsonb", s).with_details(e))
 }
 
 pub fn format_jsonb<F>(buf: &mut F, jsonb: &Jsonb) -> Nestable
@@ -455,19 +457,26 @@ where
     }
 }
 
-pub fn parse_list<T>(
+pub fn parse_list<T, E>(
     s: &str,
     mut make_null: impl FnMut() -> T,
-    mut parse_elem: impl FnMut(&str) -> Result<T, failure::Error>,
-) -> Result<Vec<T>, failure::Error> {
+    mut parse_elem: impl FnMut(&str) -> Result<T, E>,
+) -> Result<Vec<T>, ParseError>
+where
+    E: fmt::Display,
+{
+    let err = |details| ParseError::new("list", s).with_details(details);
+
+    macro_rules! bail {
+        ($($arg:tt)*) => { return Err(err(format!($($arg)*))) };
+    }
+
     let mut elems = vec![];
     let mut chars = s.chars().peekable();
     match chars.next() {
         // start of list
         Some('{') => (),
-        Some(other) => {
-            bail!("expected '{{', found {}", other);
-        }
+        Some(other) => bail!("expected '{{', found {}", other),
         None => bail!("unexpected end of input"),
     }
     loop {
@@ -507,7 +516,8 @@ pub fn parse_list<T>(
                         None => bail!("unexpected end of input"),
                     }
                 }
-                elems.push(parse_elem(&elem_text)?);
+                let elem = parse_elem(&elem_text).map_err(|e| err(e.to_string()))?;
+                elems.push(elem);
             }
             // a nested list
             Some('{') => {
@@ -523,7 +533,8 @@ pub fn parse_list<T>(
                         None => bail!("unexpected end of input"),
                     }
                 }
-                elems.push(parse_elem(&elem_text)?);
+                let elem = parse_elem(&elem_text).map_err(|e| err(e.to_string()))?;
+                elems.push(elem);
             }
             // an unescaped elem
             Some(_) => {
@@ -544,7 +555,7 @@ pub fn parse_list<T>(
                 elems.push(if elem_text.trim() == "NULL" {
                     make_null()
                 } else {
-                    parse_elem(&elem_text)?
+                    parse_elem(&elem_text).map_err(|e| err(e.to_string()))?
                 });
             }
             None => bail!("unexpected end of input"),
@@ -668,3 +679,43 @@ where
         self.0
     }
 }
+
+#[derive(Debug)]
+pub struct ParseError {
+    type_name: &'static str,
+    input: String,
+    details: Option<String>,
+}
+
+impl ParseError {
+    fn new<S>(type_name: &'static str, input: S) -> ParseError
+    where
+        S: Into<String>,
+    {
+        ParseError {
+            type_name,
+            input: input.into(),
+            details: None,
+        }
+    }
+
+    fn with_details<D>(mut self, details: D) -> ParseError
+    where
+        D: fmt::Display,
+    {
+        self.details = Some(details.to_string());
+        self
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "invalid input syntax for {}: ", self.type_name)?;
+        if let Some(details) = &self.details {
+            write!(f, "{}: ", details)?;
+        }
+        write!(f, "\"{}\"", self.input)
+    }
+}
+
+impl Error for ParseError {}

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -27,23 +27,23 @@ fn test_parse_date() {
 fn test_parse_date_errors() {
     run_test_parse_date_errors(
         "2001-01",
-        "Invalid DATE \'2001-01\': YEAR, MONTH, DAY are all required",
+        "invalid input syntax for date: YEAR, MONTH, DAY are all required: \"2001-01\"",
     );
     run_test_parse_date_errors(
         "2001",
-        "Invalid DATE \'2001\': YEAR, MONTH, DAY are all required",
+        "invalid input syntax for date: YEAR, MONTH, DAY are all required: \"2001\"",
     );
     run_test_parse_date_errors(
         "2001-13-01",
-        "Invalid DATE \'2001-13-01\': MONTH must be (1, 12), got 13",
+        "invalid input syntax for date: MONTH must be (1, 12), got 13: \"2001-13-01\"",
     );
     run_test_parse_date_errors(
         "2001-12-32",
-        "Invalid DATE \'2001-12-32\': DAY must be (1, 31), got 32",
+        "invalid input syntax for date: DAY must be (1, 31), got 32: \"2001-12-32\"",
     );
     run_test_parse_date_errors(
         "2001-01-02 04",
-        "Invalid DATE '2001-01-02 04': Unknown format",
+        "invalid input syntax for date: unknown format: \"2001-01-02 04\"",
     );
     fn run_test_parse_date_errors(s: &str, e: &str) {
         assert_eq!(
@@ -71,17 +71,20 @@ fn test_parse_time() {
 fn test_parse_time_errors() {
     run_test_parse_time_errors(
         "26:01:02.345",
-        "Invalid TIME \'26:01:02.345\': HOUR must be (0, 23), got 26",
+        "invalid input syntax for time: HOUR must be (0, 23), got 26: \"26:01:02.345\"",
     );
     run_test_parse_time_errors(
         "01:60:02.345",
-        "Invalid TIME \'01:60:02.345\': MINUTE must be (0, 59), got 60",
+        "invalid input syntax for time: MINUTE must be (0, 59), got 60: \"01:60:02.345\"",
     );
     run_test_parse_time_errors(
         "01:02:61.345",
-        "Invalid TIME \'01:02:61.345\': SECOND must be (0, 60), got 61",
+        "invalid input syntax for time: SECOND must be (0, 60), got 61: \"01:02:61.345\"",
     );
-    run_test_parse_time_errors("03.456", "Invalid TIME \'03.456\': Unknown format");
+    run_test_parse_time_errors(
+        "03.456",
+        "invalid input syntax for time: unknown format: \"03.456\"",
+    );
 
     fn run_test_parse_time_errors(s: &str, e: &str) {
         assert_eq!(
@@ -123,36 +126,36 @@ fn test_parse_timestamp() {
 fn test_parse_timestamp_errors() {
     run_test_parse_timestamp_errors(
         "2001-01",
-        "Invalid TIMESTAMP \'2001-01\': YEAR, MONTH, DAY are all required",
+        "invalid input syntax for timestamp: YEAR, MONTH, DAY are all required: \"2001-01\"",
     );
     run_test_parse_timestamp_errors(
         "2001",
-        "Invalid TIMESTAMP \'2001\': YEAR, MONTH, DAY are all required",
+        "invalid input syntax for timestamp: YEAR, MONTH, DAY are all required: \"2001\"",
     );
     run_test_parse_timestamp_errors(
         "2001-13-01",
-        "Invalid TIMESTAMP \'2001-13-01\': MONTH must be (1, 12), got 13",
+        "invalid input syntax for timestamp: MONTH must be (1, 12), got 13: \"2001-13-01\"",
     );
     run_test_parse_timestamp_errors(
         "2001-12-32",
-        "Invalid TIMESTAMP \'2001-12-32\': DAY must be (1, 31), got 32",
+        "invalid input syntax for timestamp: DAY must be (1, 31), got 32: \"2001-12-32\"",
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 04",
-        "Invalid TIMESTAMP \'2001-01-02 04\': Unknown format",
+        "invalid input syntax for timestamp: unknown format: \"2001-01-02 04\"",
     );
 
     run_test_parse_timestamp_errors(
         "2001-01-02 26:01:02.345",
-        "Invalid TIMESTAMP \'2001-01-02 26:01:02.345\': HOUR must be (0, 23), got 26",
+        "invalid input syntax for timestamp: HOUR must be (0, 23), got 26: \"2001-01-02 26:01:02.345\"",
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 01:60:02.345",
-        "Invalid TIMESTAMP \'2001-01-02 01:60:02.345\': MINUTE must be (0, 59), got 60",
+        "invalid input syntax for timestamp: MINUTE must be (0, 59), got 60: \"2001-01-02 01:60:02.345\"",
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 01:02:61.345",
-        "Invalid TIMESTAMP \'2001-01-02 01:02:61.345\': SECOND must be (0, 60), got 61",
+        "invalid input syntax for timestamp: SECOND must be (0, 60), got 61: \"2001-01-02 01:02:61.345\"",
     );
 
     fn run_test_parse_timestamp_errors(s: &str, e: &str) {
@@ -208,17 +211,18 @@ fn test_parse_timestamptz() {
 fn test_parse_timestamptz_errors() {
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 +25:45",
-        "Invalid TIMESTAMPTZ \'1999-01-01 01:23:34.555 +25:45\': Invalid timezone string \
-         (+25:45): timezone hour invalid 25",
+        "invalid input syntax for timestamptz: Invalid timezone string \
+         (+25:45): timezone hour invalid 25: \"1999-01-01 01:23:34.555 +25:45\"",
     );
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 +21:61",
-        "Invalid TIMESTAMPTZ \'1999-01-01 01:23:34.555 +21:61\': Invalid timezone string \
-         (+21:61): timezone minute invalid 61",
+        "invalid input syntax for timestamptz: Invalid timezone string \
+         (+21:61): timezone minute invalid 61: \"1999-01-01 01:23:34.555 +21:61\"",
     );
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 4",
-        "Invalid TIMESTAMPTZ \'1999-01-01 01:23:34.555 4\': Cannot parse timezone offset 4",
+        "invalid input syntax for timestamptz: Cannot parse timezone offset 4: \
+         \"1999-01-01 01:23:34.555 4\"",
     );
 
     fn run_test_parse_timestamptz_errors(s: &str, e: &str) {
@@ -457,8 +461,8 @@ fn parse_interval_error() {
 
     run_test_parse_interval_errors(
         "1 1-1",
-        "Invalid INTERVAL '1 1-1': Cannot determine format of all parts. Add explicit time \
-         components, e.g. INTERVAL '1 day' or INTERVAL '1' DAY",
+        "invalid input syntax for interval: Cannot determine format of all parts. Add explicit time \
+         components, e.g. INTERVAL '1 day' or INTERVAL '1' DAY: \"1 1-1\"",
     );
 }
 

--- a/test/lang/js/params.test.ts
+++ b/test/lang/js/params.test.ts
@@ -81,7 +81,9 @@ describe("query api", () => {
       ).rejects.toThrow(
         expect.objectContaining({
           code: "22023",
-          message: "unable to decode parameter: invalid digit found in string",
+          message: expect.stringMatching(
+            /unable to decode parameter:.*invalid digit found in string/,
+          ),
         }),
       );
     });

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -45,12 +45,8 @@ tR                true
 tRuE              true
 TRUE              true
 
-# TODO(benesch): this should return an error, not null, when we support
-# runtime errors.
-query B
+query error invalid input syntax for bool: "blah"
 SELECT 'blah'::bool
-----
-NULL
 
 query error Cannot apply operator Not to non-boolean type Int32
 SELECT NOT 1

--- a/test/sqllogictest/cockroach/bytes.slt
+++ b/test/sqllogictest/cockroach/bytes.slt
@@ -47,10 +47,8 @@ SELECT '日本語'::text::bytea::text
 ----
 \xe697a5e69cace8aa9e
 
-query T
+query error invalid input syntax for bytea: invalid escape sequence
 SELECT '\400'::bytea
-----
-NULL
 
 # TODO(benesch): support bytea_output.
 #
@@ -117,13 +115,14 @@ SELECT length('a\\b'::text::bytea)
 ----
 3
 
-# TODO(benesch): enable when we support returning runtime errors.
-#
-# query error invalid bytea escape sequence
-# SELECT 'a\bcde'::text::bytea
-#
-# query error bytea encoded value ends with incomplete escape sequence
-# SELECT 'a\01'::text::bytea
+query error invalid input syntax for bytea: invalid escape sequence
+SELECT 'a\bcde'::text::bytea
+
+query error invalid input syntax for bytea: invalid escape sequence
+SELECT 'a\01'::text::bytea
+
+query error invalid input syntax for bytea: ends with escape character
+SELECT 'a\'::text::bytea
 
 subtest Regression_27950
 

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -962,16 +962,13 @@ SELECT DATE '2007-02-01   T  15:04:05+00'
 ----
 2007-02-01
 
-statement error Invalid DATE '2007-02-01X15:04:05': invalid DateTimeField: X
+statement error invalid input syntax for date: invalid DateTimeField: X: "2007-02-01X15:04:05"
 SELECT DATE '2007-02-01X15:04:05'
 
-statement error Invalid DATE '2007-02-01TT15:04:05': invalid DateTimeField: TT
+statement error invalid input syntax for date: invalid DateTimeField: TT: "2007-02-01TT15:04:05"
 SELECT DATE '2007-02-01TT15:04:05'
 
-statement error Invalid DATE '20070201TT15:04:05': invalid DateTimeField: TT
-SELECT DATE '20070201TT15:04:05'
-
-statement error Invalid DATE '2007-02-01  T  T  15:04:05': Cannot determine format of all parts
+statement error invalid input syntax for date: Cannot determine format of all parts: "2007-02-01  T  T  15:04:05"
 SELECT DATE '2007-02-01  T  T  15:04:05'
 
 # Test casting time to interval & vice versa

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -67,21 +67,21 @@ SELECT INTERVAL '1-2 3' HOUR;
 1 year 2 months 03:00:00
 
 # Disallow components to be set twice.
-statement error Invalid INTERVAL '1 year 2 years': YEAR field set twice
+statement error invalid input syntax for interval: YEAR field set twice: "1 year 2 years"
 SELECT INTERVAL '1 year 2 years'
 
-statement error Invalid INTERVAL '1-2 3-4': YEAR or MONTH field set twice
+statement error invalid input syntax for interval: YEAR or MONTH field set twice: "1-2 3-4"
 SELECT INTERVAL '1-2 3-4'
 
-statement error Invalid INTERVAL '1-2 3 year': YEAR field set twice
+statement error invalid input syntax for interval: YEAR field set twice: "1-2 3 year"
 SELECT INTERVAL '1-2 3 year'
 
-statement error Invalid INTERVAL '1-2 3': MONTH field set twice
+statement error invalid input syntax for interval: MONTH field set twice: "1-2 3"
 SELECT INTERVAL '1-2 3' MONTH;
 
 # 5 would be parsed as second, but the H:M:S.NS
 # group was already set by 3:4/
-statement error Invalid INTERVAL '1-2 3:4 5': SECOND field set twice
+statement error invalid input syntax for interval: SECOND field set twice: "1-2 3:4 5"
 SELECT INTERVAL '1-2 3:4 5';
 
 # Treat trailing TimeUnit as terminating range.
@@ -142,7 +142,7 @@ SELECT INTERVAL '1:2:3.4 5-6 7' DAY;
 
 # Disambiguate component (YEAR), but disallow because
 # the group it's in has been closed.
-statement error Invalid INTERVAL '1:2:3.4 5-6 7': YEAR field set twice
+statement error invalid input syntax for interval: YEAR field set twice: "1:2:3.4 5-6 7"
 SELECT INTERVAL '1:2:3.4 5-6 7' YEAR;
 
 # Negative components
@@ -220,17 +220,17 @@ SELECT INTERVAL '0-0 0 0:0:0.0';
 00:00:00
 
 # Oversized components in SQL standard-style variables
-statement error Invalid INTERVAL '100-13': MONTH must be \(-12, 12\), got 13
+statement error invalid input syntax for interval: MONTH must be \(-12, 12\), got 13: "100-13"
 SELECT INTERVAL '100-13';
 
-statement error Invalid INTERVAL '100-11 366 250:61': MINUTE must be \(-59, 59\), got 61
+statement error invalid input syntax for interval: MINUTE must be \(-59, 59\), got 61: "100-11 366 250:61"
 SELECT INTERVAL '100-11 366 250:61';
 
-statement error Invalid INTERVAL '100-11 366 250:59:61': SECOND must be \(-60, 60\), got 61
+statement error invalid input syntax for interval: SECOND must be \(-60, 60\), got 61: "100-11 366 250:59:61"
 SELECT INTERVAL '100-11 366 250:59:61';
 
 # Invalid syntax
-statement error Invalid INTERVAL '1:2:3.4.5': Invalid syntax at offset 7: provided Dot but expected None
+statement error invalid input syntax for interval: Invalid syntax at offset 7: provided Dot but expected None: "1:2:3.4.5"
 SELECT INTERVAL '1:2:3.4.5';
 
 statement error
@@ -382,10 +382,10 @@ SELECT INTERVAL '1-2' HOUR;
 ----
 1 year 2 months
 
-statement error Invalid INTERVAL '1-2 hour': Invalid syntax: HOUR must be preceeded by a number, e.g. '1HOUR'
+statement error invalid input syntax for interval: Invalid syntax: HOUR must be preceeded by a number, e.g. '1HOUR': "1-2 hour"
 SELECT INTERVAL '1-2 hour';
 
-statement error Invalid INTERVAL '1-2hour': Invalid syntax at offset 3: provided TimeUnit\(Hour\) but expected None
+statement error invalid input syntax for interval: Invalid syntax at offset 3: provided TimeUnit\(Hour\) but expected None: "1-2hour"
 SELECT INTERVAL '1-2hour';
 
 # Use larger numbers.
@@ -422,11 +422,11 @@ SELECT INTERVAL '1-2 3:4 5 day';
 1 year 2 months 5 days 03:04:00
 
 # Mix style allowed, but cannot assigning to closed group.
-statement error Invalid INTERVAL '1-2 3:4 5 second': SECOND field set twice
+statement error invalid input syntax for interval: SECOND field set twice: "1-2 3:4 5 second"
 SELECT INTERVAL '1-2 3:4 5 second';
 
 # Commutativity means this is also not allowed.
-statement error Invalid INTERVAL '1-2 5 second 3:4': HOUR, MINUTE, SECOND field set twice
+statement error invalid input syntax for interval: HOUR, MINUTE, SECOND field set twice: "1-2 5 second 3:4"
 SELECT INTERVAL '1-2 5 second 3:4';
 
 # Fractional month in addition to other fields.
@@ -594,10 +594,10 @@ SELECT INTERVAL '0.999999999 months 0.999999999 days 0.999999999 hours 0.9999999
 
 ## Overflows
 
-statement error INTERVAL '768614336404564651 year': Overflows maximum months; cannot exceed 9223372036854775807 months
+statement error Overflows maximum months; cannot exceed 9223372036854775807 months
 SELECT INTERVAL '768614336404564651 year';
 
-statement error INTERVAL '768614336404564650.7 year': Overflows maximum months; cannot exceed 9223372036854775807 months
+statement error Overflows maximum months; cannot exceed 9223372036854775807 months
 SELECT INTERVAL '768614336404564650.7 year';
 
 statement error Unable to parse value as a number at index 0: number too large to fit in target type
@@ -606,25 +606,25 @@ SELECT INTERVAL '9223372036854775808 months';
 statement error Unable to parse value as a number at index 0: number too large to fit in target type
 SELECT INTERVAL '-9223372036854775808 months';
 
-statement error INTERVAL '106751991167300 days .1 month': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '106751991167300 days .1 month';
 
-statement error INTERVAL '106751991167301 days': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '106751991167301 days';
 
-statement error INTERVAL '106751991167300.9 days': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '106751991167300.9 days';
 
-statement error INTERVAL '9223372036854775807 seconds 1 hour': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '9223372036854775807 seconds 1 hour';
 
-statement error INTERVAL '9223372036854771807 seconds 1.9 hour': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '9223372036854771807 seconds 1.9 hour';
 
-statement error INTERVAL '9223372036854775807 seconds 1 minute': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '9223372036854775807 seconds 1 minute';
 
-statement error INTERVAL '9223372036854775707 seconds 1.9 minute': Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
+statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '9223372036854775707 seconds 1.9 minute';
 
 statement error Unable to parse value as a number at index 0: number too large to fit in target type


### PR DESCRIPTION
Produce runtime errors for all of our string -> TYPE casts, which has long been a sore spot for us. Also take the opportunity to excise a bunch of `failure::Error`, as per #3147. With this PR in place #3146 should pass all tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3156)
<!-- Reviewable:end -->
