### PR TITLE
doc/user: mark 0.2.3 as released

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,7 +46,7 @@ Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
 <span id="v0.2.3"></span>
-## 0.2.2 &rarr; 0.2.3 (Unreleased)
+## 0.2.2 &rarr; 0.2.3
 
 - Support [TLS encryption](/cli/#tls-encryption) for SQL and HTTP connections.
 


### PR DESCRIPTION
Missed this in the 0.2.3 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3157)
<!-- Reviewable:end -->
