### PR TITLE
repr,expr,sql: remove ScalarType::Unknown

### DIFF
--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -440,7 +440,6 @@ where
                         Datum::Float64(((agg1 as f64) / float_scale).into())
                     }
                     (AggregateFunc::SumDecimal, _) => Datum::from(agg1),
-                    (AggregateFunc::SumNull, _) => Datum::Null,
                     x => panic!("Unexpected accumulable aggregation: {:?}", x),
                 };
 
@@ -538,7 +537,6 @@ fn accumulable_hierarchical(func: &AggregateFunc) -> (bool, bool) {
         | AggregateFunc::SumFloat32
         | AggregateFunc::SumFloat64
         | AggregateFunc::SumDecimal
-        | AggregateFunc::SumNull
         | AggregateFunc::Count
         | AggregateFunc::CountAll
         | AggregateFunc::Any
@@ -553,7 +551,6 @@ fn accumulable_hierarchical(func: &AggregateFunc) -> (bool, bool) {
         | AggregateFunc::MaxDate
         | AggregateFunc::MaxTimestamp
         | AggregateFunc::MaxTimestampTz
-        | AggregateFunc::MaxNull
         | AggregateFunc::MinInt32
         | AggregateFunc::MinInt64
         | AggregateFunc::MinFloat32
@@ -563,8 +560,7 @@ fn accumulable_hierarchical(func: &AggregateFunc) -> (bool, bool) {
         | AggregateFunc::MinString
         | AggregateFunc::MinDate
         | AggregateFunc::MinTimestamp
-        | AggregateFunc::MinTimestampTz
-        | AggregateFunc::MinNull => (false, true),
+        | AggregateFunc::MinTimestampTz => (false, true),
         AggregateFunc::JsonbAgg => (false, false),
     }
 }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -147,13 +147,6 @@ where
     Datum::from(x)
 }
 
-fn max_null<'a, I>(_datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    Datum::Null
-}
-
 fn min_int32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
@@ -276,13 +269,6 @@ where
     Datum::from(x)
 }
 
-fn min_null<'a, I>(_datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    Datum::Null
-}
-
 fn sum_int32<'a, I>(datums: I) -> Datum<'a>
 where
     I: IntoIterator<Item = Datum<'a>>,
@@ -346,13 +332,6 @@ where
         let sum: Significand = datums.map(|d| d.unwrap_decimal()).sum();
         Datum::from(sum)
     }
-}
-
-fn sum_null<'a, I>(_datums: I) -> Datum<'a>
-where
-    I: IntoIterator<Item = Datum<'a>>,
-{
-    Datum::Null
 }
 
 fn count<'a, I>(datums: I) -> Datum<'a>
@@ -419,7 +398,6 @@ pub enum AggregateFunc {
     MaxDate,
     MaxTimestamp,
     MaxTimestampTz,
-    MaxNull,
     MinInt32,
     MinInt64,
     MinFloat32,
@@ -430,13 +408,11 @@ pub enum AggregateFunc {
     MinDate,
     MinTimestamp,
     MinTimestampTz,
-    MinNull,
     SumInt32,
     SumInt64,
     SumFloat32,
     SumFloat64,
     SumDecimal,
-    SumNull,
     Count,
     CountAll, // COUNT(*) counts nulls too
     Any,
@@ -460,7 +436,6 @@ impl AggregateFunc {
             AggregateFunc::MaxDate => max_date(datums),
             AggregateFunc::MaxTimestamp => max_timestamp(datums),
             AggregateFunc::MaxTimestampTz => max_timestamptz(datums),
-            AggregateFunc::MaxNull => max_null(datums),
             AggregateFunc::MinInt32 => min_int32(datums),
             AggregateFunc::MinInt64 => min_int64(datums),
             AggregateFunc::MinFloat32 => min_float32(datums),
@@ -471,13 +446,11 @@ impl AggregateFunc {
             AggregateFunc::MinDate => min_date(datums),
             AggregateFunc::MinTimestamp => min_timestamp(datums),
             AggregateFunc::MinTimestampTz => min_timestamptz(datums),
-            AggregateFunc::MinNull => min_null(datums),
             AggregateFunc::SumInt32 => sum_int32(datums),
             AggregateFunc::SumInt64 => sum_int64(datums),
             AggregateFunc::SumFloat32 => sum_float32(datums),
             AggregateFunc::SumFloat64 => sum_float64(datums),
             AggregateFunc::SumDecimal => sum_decimal(datums),
-            AggregateFunc::SumNull => sum_null(datums),
             AggregateFunc::Count => count(datums),
             AggregateFunc::CountAll => count_all(datums),
             AggregateFunc::Any => any(datums),
@@ -586,7 +559,6 @@ impl fmt::Display for AggregateFunc {
             AggregateFunc::MaxDate => f.write_str("max"),
             AggregateFunc::MaxTimestamp => f.write_str("max"),
             AggregateFunc::MaxTimestampTz => f.write_str("max"),
-            AggregateFunc::MaxNull => f.write_str("max"),
             AggregateFunc::MinInt32 => f.write_str("min"),
             AggregateFunc::MinInt64 => f.write_str("min"),
             AggregateFunc::MinFloat32 => f.write_str("min"),
@@ -597,13 +569,11 @@ impl fmt::Display for AggregateFunc {
             AggregateFunc::MinDate => f.write_str("min"),
             AggregateFunc::MinTimestamp => f.write_str("min"),
             AggregateFunc::MinTimestampTz => f.write_str("min"),
-            AggregateFunc::MinNull => f.write_str("min"),
             AggregateFunc::SumInt32 => f.write_str("sum"),
             AggregateFunc::SumInt64 => f.write_str("sum"),
             AggregateFunc::SumFloat32 => f.write_str("sum"),
             AggregateFunc::SumFloat64 => f.write_str("sum"),
             AggregateFunc::SumDecimal => f.write_str("sum"),
-            AggregateFunc::SumNull => f.write_str("sum"),
             AggregateFunc::Count => f.write_str("count"),
             AggregateFunc::CountAll => f.write_str("countall"),
             AggregateFunc::Any => f.write_str("any"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1994,9 +1994,6 @@ impl BinaryFunc {
             // decimal precision. Should either remove or fix.
             AddDecimal | SubDecimal | ModDecimal => {
                 let (s1, s2) = match (&input1_type.scalar_type, &input2_type.scalar_type) {
-                    (ScalarType::Unknown, _) | (_, ScalarType::Unknown) => {
-                        return ColumnType::new(ScalarType::Unknown);
-                    }
                     (ScalarType::Decimal(_, s1), ScalarType::Decimal(_, s2)) => (s1, s2),
                     _ => unreachable!(),
                 };
@@ -2006,9 +2003,6 @@ impl BinaryFunc {
             }
             MulDecimal => {
                 let (s1, s2) = match (&input1_type.scalar_type, &input2_type.scalar_type) {
-                    (ScalarType::Unknown, _) | (_, ScalarType::Unknown) => {
-                        return ColumnType::new(ScalarType::Unknown);
-                    }
                     (ScalarType::Decimal(_, s1), ScalarType::Decimal(_, s2)) => (s1, s2),
                     _ => unreachable!(),
                 };
@@ -2017,9 +2011,6 @@ impl BinaryFunc {
             }
             DivDecimal => {
                 let (s1, s2) = match (&input1_type.scalar_type, &input2_type.scalar_type) {
-                    (ScalarType::Unknown, _) | (_, ScalarType::Unknown) => {
-                        return ColumnType::new(ScalarType::Unknown);
-                    }
                     (ScalarType::Decimal(_, s1), ScalarType::Decimal(_, s2)) => (s1, s2),
                     _ => unreachable!(),
                 };
@@ -2028,7 +2019,6 @@ impl BinaryFunc {
             }
 
             CastFloat32ToDecimal | CastFloat64ToDecimal => match input2_type.scalar_type {
-                ScalarType::Unknown => ColumnType::new(ScalarType::Unknown),
                 ScalarType::Decimal(_, s) => {
                     ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s)).nullable(true)
                 }
@@ -3062,24 +3052,15 @@ impl VariadicFunc {
         use VariadicFunc::*;
         match self {
             Coalesce => {
-                let known_types = input_types
-                    .iter()
-                    .filter(|t| t.scalar_type != ScalarType::Unknown)
-                    .collect::<Vec<_>>();
-
+                assert!(input_types.len() > 0);
                 debug_assert!(
-                    known_types
+                    input_types
                         .windows(2)
                         .all(|w| w[0].scalar_type == w[1].scalar_type),
                     "coalesce inputs did not have uniform type: {:?}",
                     input_types
                 );
-
-                if known_types.is_empty() {
-                    ColumnType::new(ScalarType::Unknown)
-                } else {
-                    known_types.into_first().clone().nullable(true)
-                }
+                input_types.into_first().nullable(true)
             }
             Concat => ColumnType::new(ScalarType::String).nullable(true),
             MakeTimestamp => ColumnType::new(ScalarType::Timestamp).nullable(true),
@@ -3089,10 +3070,7 @@ impl VariadicFunc {
             JsonbBuildArray | JsonbBuildObject => ColumnType::new(ScalarType::Jsonb).nullable(true),
             ListCreate { elem_type } => {
                 debug_assert!(
-                    input_types
-                        .iter()
-                        .all(|t| t.scalar_type == *elem_type
-                            || (t.scalar_type == ScalarType::Unknown)),
+                    input_types.iter().all(|t| t.scalar_type == *elem_type),
                     "Args to ListCreate should have types that are compatible with the elem_type"
                 );
                 ColumnType::new(ScalarType::List(Box::new(elem_type.clone())))

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -202,7 +202,7 @@ impl ScalarExpr {
     pub fn take(&mut self) -> Self {
         mem::replace(
             self,
-            ScalarExpr::literal_null(ColumnType::new(ScalarType::Unknown)),
+            ScalarExpr::literal_null(ColumnType::new(ScalarType::String)),
         )
     }
 
@@ -461,11 +461,8 @@ impl ScalarExpr {
                 let then_type = then.typ(relation_type);
                 let else_type = els.typ(relation_type);
                 let nullable = then_type.nullable || else_type.nullable;
-                if then_type.scalar_type != ScalarType::Unknown {
-                    then_type.nullable(nullable)
-                } else {
-                    else_type.nullable(nullable)
-                }
+                debug_assert!(then_type.scalar_type == else_type.scalar_type);
+                then_type.nullable(nullable)
             }
         }
     }
@@ -570,13 +567,6 @@ mod tests {
         }
 
         let test_cases = vec![
-            TestCase {
-                input: ScalarExpr::CallVariadic {
-                    func: VariadicFunc::Coalesce,
-                    exprs: vec![],
-                },
-                output: ScalarExpr::literal_null(ColumnType::new(ScalarType::Unknown)),
-            },
             TestCase {
                 input: ScalarExpr::CallVariadic {
                     func: VariadicFunc::Coalesce,

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -201,7 +201,7 @@ fn validate_schema_1(schema: SchemaNode) -> Result<RelationDesc> {
 
 fn validate_schema_2(schema: SchemaNode) -> Result<ScalarType> {
     Ok(match schema.inner {
-        SchemaPiece::Null => ScalarType::Unknown,
+        SchemaPiece::Null => bail!("null outside of union types is not supported"),
         SchemaPiece::Boolean => ScalarType::Bool,
         SchemaPiece::Int => ScalarType::Int32,
         SchemaPiece::Long => ScalarType::Int64,
@@ -744,7 +744,6 @@ fn build_schema(desc: &RelationDesc) -> Schema {
     let mut fields = Vec::new();
     for (name, typ) in desc.iter() {
         let mut field_type = match &typ.scalar_type {
-            ScalarType::Unknown => json!("null"),
             ScalarType::Bool => json!("boolean"),
             ScalarType::Int32 => json!("int"),
             ScalarType::Int64 => json!("long"),
@@ -782,7 +781,7 @@ fn build_schema(desc: &RelationDesc) -> Schema {
             }),
             ScalarType::List(_t) => unimplemented!("jamii/list"),
         };
-        if typ.nullable && typ.scalar_type != ScalarType::Unknown {
+        if typ.nullable {
             field_type = json!(["null", field_type]);
         }
         fields.push(json!({
@@ -911,11 +910,10 @@ impl Encoder {
             .zip_eq(row)
             .map(|((name, typ), datum)| {
                 let name = name.expect("name known to exist").as_str().to_owned();
-                if typ.nullable && typ.scalar_type != ScalarType::Unknown && datum.is_null() {
+                if typ.nullable && datum.is_null() {
                     return (name, Value::Union(0, Box::new(Value::Null)));
                 }
                 let mut val = match &typ.scalar_type {
-                    ScalarType::Unknown => Value::Null,
                     ScalarType::Bool => Value::Boolean(datum.unwrap_bool()),
                     ScalarType::Int32 => Value::Int(datum.unwrap_int32()),
                     ScalarType::Int64 => Value::Long(datum.unwrap_int64()),
@@ -953,7 +951,7 @@ impl Encoder {
                     ScalarType::Jsonb => Value::Json(JsonbRef::from_datum(datum).to_serde_json()),
                     ScalarType::List(_t) => unimplemented!("jamii/list"),
                 };
-                if typ.nullable && typ.scalar_type != ScalarType::Unknown {
+                if typ.nullable {
                     val = Value::Union(1, Box::new(val));
                 }
                 (name, val)
@@ -1064,7 +1062,6 @@ mod tests {
         // Simple transformations from primitive Avro Schema types
         // to Avro Values.
         let valid_pairings = vec![
-            (ScalarType::Unknown, Datum::Null, Value::Null),
             (ScalarType::Bool, Datum::True, Value::Boolean(true)),
             (ScalarType::Bool, Datum::False, Value::Boolean(false)),
             (ScalarType::Int32, Datum::Int32(1), Value::Int(1)),

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -43,8 +43,6 @@ pub enum Type {
     TimestampTz,
     /// A list
     List(Box<Type>),
-    /// An unknown value.
-    Unknown,
 }
 
 lazy_static! {
@@ -75,7 +73,6 @@ impl Type {
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
             Type::List(_) => &LIST,
-            Type::Unknown => &postgres_types::Type::UNKNOWN,
         }
     }
 
@@ -110,7 +107,6 @@ impl Type {
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
             Type::List(_) => -1,
-            Type::Unknown => -1,
         }
     }
 }
@@ -118,7 +114,6 @@ impl Type {
 impl From<&ScalarType> for Type {
     fn from(typ: &ScalarType) -> Type {
         match typ {
-            ScalarType::Unknown => Type::Unknown,
             ScalarType::Bool => Type::Bool,
             ScalarType::Int32 => Type::Int4,
             ScalarType::Int64 => Type::Int8,

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -244,7 +244,6 @@ impl Value {
             Type::Numeric => Value::Numeric(Numeric(strconv::parse_decimal(raw)?)),
             Type::Jsonb => Value::Jsonb(Jsonb(strconv::parse_jsonb(raw)?)),
             Type::List(elem_type) => Value::List(decode_list(&elem_type, raw)?),
-            Type::Unknown => panic!("cannot decode unknown type"),
         })
     }
 
@@ -270,7 +269,6 @@ impl Value {
                 // just using the text encoding for now
                 Value::decode_text(ty, raw)
             }
-            Type::Unknown => panic!("cannot decode unknown type"),
         }
     }
 }
@@ -296,7 +294,6 @@ pub fn null_datum(ty: &Type) -> (Datum<'static>, ScalarType) {
             let (_, elem_type) = null_datum(t);
             ScalarType::List(Box::new(elem_type))
         }
-        Type::Unknown => ScalarType::Unknown,
     };
     (Datum::Null, ty)
 }

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -32,27 +32,22 @@ impl ColumnType {
     /// methods of the same name.
     pub fn new(scalar_type: ScalarType) -> Self {
         ColumnType {
-            nullable: if let ScalarType::Unknown = scalar_type {
-                true
-            } else {
-                false
-            },
+            nullable: false,
             scalar_type,
         }
     }
 
     pub fn union(&self, other: &Self) -> Result<Self, failure::Error> {
-        let scalar_type = match (&self.scalar_type, &other.scalar_type) {
-            (ScalarType::Unknown, s) | (s, ScalarType::Unknown) => s.clone(),
-            (s1, s2) if s1 == s2 => s1.clone(),
-            (s1, s2) => bail!("Can't union types: {:?} and {:?}", s1, s2),
-        };
+        if self.scalar_type != other.scalar_type {
+            bail!(
+                "Can't union types: {:?} and {:?}",
+                self.scalar_type,
+                other.scalar_type
+            );
+        }
         Ok(ColumnType {
-            scalar_type,
-            nullable: self.nullable
-                || other.nullable
-                || self.scalar_type == ScalarType::Unknown
-                || other.scalar_type == ScalarType::Unknown,
+            scalar_type: self.scalar_type.clone(),
+            nullable: self.nullable || other.nullable,
         })
     }
 

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -381,7 +381,6 @@ impl<'a> Datum<'a> {
             } else {
                 // sql type checking
                 match (datum, scalar_type) {
-                    (Datum::Null, ScalarType::Unknown) => true,
                     (Datum::Null, _) => false,
                     (Datum::False, ScalarType::Bool) => true,
                     (Datum::False, _) => false,
@@ -624,13 +623,6 @@ impl fmt::Display for Datum<'_> {
 /// variants.
 #[derive(Clone, Debug, Eq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum ScalarType {
-    /// The type of an unknown datum. Whenever possible, this variant should be
-    /// avoided, as clients are typically unable to handle it.
-    ///
-    /// The usual situation in which this variant arises is in a SQL query like
-    /// `SELECT NULL`, where there is no additional hint about what type `NULL`
-    /// should take on.
-    Unknown,
     /// The type of [`Datum::True`] and [`Datum::False`].
     Bool,
     /// The type of [`Datum::Int32`].
@@ -700,7 +692,6 @@ impl<'a> ScalarType {
     /// Constructs a dummy datum for this type.
     pub fn dummy_datum(&self) -> Datum<'a> {
         match self {
-            ScalarType::Unknown => Datum::Null,
             ScalarType::Bool => Datum::False,
             ScalarType::Int32 => Datum::Int32(0),
             ScalarType::Int64 => Datum::Int64(0),
@@ -731,8 +722,7 @@ impl PartialEq for ScalarType {
         match (self, other) {
             (Decimal(_, s1), Decimal(_, s2)) => s1 == s2,
 
-            (Unknown, Unknown)
-            | (Bool, Bool)
+            (Bool, Bool)
             | (Int32, Int32)
             | (Int64, Int64)
             | (Float32, Float32)
@@ -748,8 +738,7 @@ impl PartialEq for ScalarType {
 
             (List(a), List(b)) => a.eq(b),
 
-            (Unknown, _)
-            | (Bool, _)
+            (Bool, _)
             | (Int32, _)
             | (Int64, _)
             | (Float32, _)
@@ -772,28 +761,27 @@ impl Hash for ScalarType {
     fn hash<H: Hasher>(&self, state: &mut H) {
         use ScalarType::*;
         match self {
-            Unknown => state.write_u8(0),
-            Bool => state.write_u8(1),
-            Int32 => state.write_u8(2),
-            Int64 => state.write_u8(3),
-            Float32 => state.write_u8(4),
-            Float64 => state.write_u8(5),
+            Bool => state.write_u8(0),
+            Int32 => state.write_u8(1),
+            Int64 => state.write_u8(2),
+            Float32 => state.write_u8(3),
+            Float64 => state.write_u8(4),
             Decimal(_, s) => {
                 // TODO(benesch): we should properly implement decimal precision
                 // tracking, or just remove it.
-                state.write_u8(6);
+                state.write_u8(5);
                 state.write_u8(*s);
             }
-            Date => state.write_u8(7),
-            Time => state.write_u8(8),
-            Timestamp => state.write_u8(9),
-            TimestampTz => state.write_u8(10),
-            Interval => state.write_u8(11),
-            Bytes => state.write_u8(12),
-            String => state.write_u8(13),
-            Jsonb => state.write_u8(14),
+            Date => state.write_u8(6),
+            Time => state.write_u8(7),
+            Timestamp => state.write_u8(8),
+            TimestampTz => state.write_u8(9),
+            Interval => state.write_u8(10),
+            Bytes => state.write_u8(11),
+            String => state.write_u8(12),
+            Jsonb => state.write_u8(13),
             List(t) => {
-                state.write_u8(15);
+                state.write_u8(14);
                 t.hash(state);
             }
         }
@@ -809,7 +797,6 @@ impl fmt::Display for ScalarType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use ScalarType::*;
         match self {
-            Unknown => f.write_str("null"),
             Bool => f.write_str("bool"),
             Int32 => f.write_str("i32"),
             Int64 => f.write_str("i64"),

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -15,10 +15,9 @@ use std::collections::HashMap;
 use failure::bail;
 use lazy_static::lazy_static;
 use repr::ScalarType;
-use sql_parser::ast::Expr;
 
-use super::expr::{BinaryFunc, ScalarExpr, UnaryFunc, VariadicFunc};
-use super::query::ExprContext;
+use super::expr::{BinaryFunc, CoercibleScalarExpr, ScalarExpr, UnaryFunc, VariadicFunc};
+use super::query::{CastContext, CoerceTo, ExprContext};
 use super::unsupported;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -32,7 +31,6 @@ enum TypeCategory {
     String,
     Timespan,
     UserDefined,
-    Unknown,
 }
 
 impl TypeCategory {
@@ -64,7 +62,6 @@ impl TypeCategory {
             | ScalarType::Int64 => TypeCategory::Numeric,
             ScalarType::Interval => TypeCategory::Timespan,
             ScalarType::String => TypeCategory::String,
-            ScalarType::Unknown => TypeCategory::Unknown,
         }
     }
 
@@ -254,22 +251,15 @@ impl<'a> ArgImplementationMatcher<'a> {
             .collect();
         let mut m = Self { ident, ecx, impls };
 
-        let mut raw_arg_types = Vec::new();
+        let mut exprs = Vec::new();
         for arg in args {
-            let expr = super::query::plan_expr(ecx, &arg, Some(ScalarType::Unknown))?;
-            raw_arg_types.push(ecx.scalar_type(&expr));
-            Self::clear_expr_param_data(ecx, &arg);
+            let expr = super::query::plan_coercible_expr(ecx, arg)?.0;
+            exprs.push(expr);
         }
 
-        // Exact match
-        let f = if let Some(func) = m.get_implementation(&raw_arg_types) {
-            func
-        } else {
-            // Best match
-            m.best_match(args, &raw_arg_types)?
-        };
+        let f = m.find_match(&exprs)?;
 
-        let mut exprs = m.generate_param_exprs(args, f.params)?;
+        let mut exprs = m.generate_param_exprs(exprs, f.params)?;
 
         Ok(match f.op {
             OperationType::ExprOnly => exprs.remove(0),
@@ -305,18 +295,31 @@ impl<'a> ArgImplementationMatcher<'a> {
         }
     }
 
-    /// If no exact match, finds the best match available. Patterned after
-    /// [PostgreSQL's type conversion matching algorithm][pgparser].
+    /// Finds an exact match based on the arguments, or, if no exact match,
+    /// finds the best match available. Patterned after [PostgreSQL's type
+    /// conversion matching algorithm][pgparser].
     ///
     /// Inline prefixed with number are taken from the "Function Type
     /// Resolution" section of the aforelinked page.
     ///
     /// [pgparser]: https://www.postgresql.org/docs/current/typeconv-func.html
-    fn best_match(
-        &mut self,
-        args: &[sql_parser::ast::Expr],
-        raw_arg_types: &[ScalarType],
-    ) -> Result<FuncImpl, failure::Error> {
+    fn find_match(&mut self, exprs: &[CoercibleScalarExpr]) -> Result<FuncImpl, failure::Error> {
+        let types: Vec<_> = exprs
+            .iter()
+            .map(|e| self.ecx.column_type(e).map(|t| t.scalar_type))
+            .collect();
+        let all_types_known = types.iter().all(|t| t.is_some());
+
+        // Check for exact match.
+        if all_types_known {
+            let types: Vec<_> = types.iter().map(|t| t.clone().unwrap()).collect();
+            if let Some(func) = self.get_implementation(&types) {
+                return Ok(func);
+            }
+        }
+
+        // No exact match. Apply PostgreSQL's best match algorithm.
+
         let mut candidates = Vec::new();
         let mut max_exact_matches = 0;
         let mut max_preferred_types = 0;
@@ -329,41 +332,37 @@ impl<'a> ArgImplementationMatcher<'a> {
             let mut exact_matches = 0;
             let mut preferred_types = 0;
 
-            for (i, (arg, raw_arg_type)) in args.iter().zip(raw_arg_types.iter()).enumerate() {
+            for (i, (arg, raw_arg_type)) in exprs.iter().zip(&types).enumerate() {
                 let param_type = match &fimpl.params {
                     ParamList::Exact(p) => &p[i],
                     ParamList::Repeat(p) => &p[i % p.len()],
                 };
 
-                let arg_type = if param_type == raw_arg_type {
-                    exact_matches += 1;
-                    raw_arg_type.clone()
-                } else {
-                    if self.coerce_arg_to_type(arg, &param_type).is_err() {
-                        valid_candidate = false;
-                        break;
+                let arg_type = match raw_arg_type {
+                    Some(raw_arg_type) if param_type == raw_arg_type => {
+                        exact_matches += 1;
+                        raw_arg_type.clone()
                     }
-
-                    // Increment `preferred_type` if:
-                    // - This param is the preferred type for this argument's
-                    //   type category
-                    // - This argument is a string literal and this param is the
-                    //   preferred type in its type category.
-                    if is_param_preferred_type_for_arg(&param_type.into(), raw_arg_type)
-                        || (arg.is_string_literal()
-                            && is_param_preferred_type_for_arg(
-                                &param_type.into(),
-                                &param_type.into(),
-                            ))
-                    {
-                        preferred_types += 1;
+                    Some(raw_arg_type) => {
+                        if self.coerce_arg_to_type(arg.clone(), &param_type).is_err() {
+                            valid_candidate = false;
+                            break;
+                        }
+                        if is_param_preferred_type_for_arg(&param_type.into(), raw_arg_type) {
+                            preferred_types += 1;
+                        }
+                        param_type.into()
                     }
-
-                    param_type.into()
+                    None => {
+                        let s: ScalarType = param_type.into();
+                        if TypeCategory::from_type(&s).preferred_type() == Some(s) {
+                            preferred_types += 1;
+                        }
+                        param_type.into()
+                    }
                 };
 
                 arg_types.push(arg_type);
-                Self::clear_expr_param_data(self.ecx, &arg);
             }
 
             // 4.a. Discard candidate functions for which the input types do not match
@@ -384,7 +383,7 @@ impl<'a> ArgImplementationMatcher<'a> {
         if candidates.is_empty() {
             bail!(
                 "arguments cannot be implicitly cast to any implementation's parameters; \
-            try providing explicit casts"
+                 try providing explicit casts"
             )
         }
 
@@ -409,14 +408,19 @@ impl<'a> ArgImplementationMatcher<'a> {
             return Ok(func);
         }
 
-        // The rest of this function could be elided if we know we don't have
-        // any Unknown types.
+        if all_types_known {
+            bail!(
+                "unable to determine which implementation to use; try providing \
+                 explicit casts to match parameter types"
+            )
+        }
+
         let mut found_unknown = false;
         let mut found_known = false;
         let mut types_match = true;
         let mut common_type: Option<ScalarType> = None;
 
-        for (i, raw_arg_type) in raw_arg_types.iter().enumerate() {
+        for (i, raw_arg_type) in types.iter().enumerate() {
             let mut selected_category: Option<TypeCategory> = None;
             let mut found_string_candidate = false;
             let mut categories_match = true;
@@ -424,7 +428,7 @@ impl<'a> ArgImplementationMatcher<'a> {
             match raw_arg_type {
                 // 4.e. If any input arguments are unknown, check the type categories accepted
                 // at those argument positions by the remaining candidates.
-                ScalarType::Unknown => {
+                None => {
                     found_unknown = true;
 
                     for c in candidates.iter() {
@@ -481,7 +485,7 @@ impl<'a> ArgImplementationMatcher<'a> {
                         candidates.retain(|c| c.arg_types[i] == preferred_type);
                     }
                 }
-                typ => {
+                Some(typ) => {
                     found_known = true;
                     // Track if all known types are of the same type; use this info in 4.f.
                     if let Some(common_type) = &common_type {
@@ -503,8 +507,8 @@ impl<'a> ArgImplementationMatcher<'a> {
         // accept that type at the unknown-argument positions.
         if found_known && found_unknown && types_match {
             let common_type = common_type.unwrap();
-            for (i, raw_arg_type) in raw_arg_types.iter().enumerate() {
-                if *raw_arg_type == ScalarType::Unknown {
+            for (i, raw_arg_type) in types.iter().enumerate() {
+                if raw_arg_type.is_none() {
                     candidates.retain(|c| common_type == c.arg_types[i]);
                 }
             }
@@ -516,7 +520,7 @@ impl<'a> ArgImplementationMatcher<'a> {
 
         bail!(
             "unable to determine which implementation to use; try providing \
-            explicit casts to match parameter types"
+             explicit casts to match parameter types"
         )
     }
 
@@ -534,15 +538,6 @@ impl<'a> ArgImplementationMatcher<'a> {
             }
         } else {
             Ok(None)
-        }
-    }
-
-    /// Because we use the same `ExprContext` throughout `Self::best_match`, we
-    /// have to clean up any param types we provisionally inserted. This data
-    /// gets re-inserted during `Self::generate_param_exprs`.
-    fn clear_expr_param_data(ecx: &ExprContext, expr: &sql_parser::ast::Expr) {
-        if let sql_parser::ast::Expr::Parameter(n) = expr {
-            ecx.remove_param(*n);
         }
     }
 
@@ -590,20 +585,20 @@ impl<'a> ArgImplementationMatcher<'a> {
     /// Plans `args` as `ScalarExprs` of that match the `ParamList`'s specified types.
     fn generate_param_exprs(
         &self,
-        args: &[sql_parser::ast::Expr],
+        args: Vec<CoercibleScalarExpr>,
         params: ParamList,
     ) -> Result<Vec<ScalarExpr>, failure::Error> {
         match params {
             ParamList::Exact(p) => {
                 let mut exprs = Vec::new();
-                for (arg, param) in args.iter().zip(p.iter()) {
+                for (arg, param) in args.into_iter().zip(p.iter()) {
                     exprs.push(self.coerce_arg_to_type(arg, param)?);
                 }
                 Ok(exprs)
             }
             ParamList::Repeat(p) => {
                 let mut exprs = Vec::new();
-                for (i, arg) in args.iter().enumerate() {
+                for (i, arg) in args.into_iter().enumerate() {
                     exprs.push(self.coerce_arg_to_type(arg, &p[i % p.len()])?);
                 }
                 Ok(exprs)
@@ -616,23 +611,31 @@ impl<'a> ArgImplementationMatcher<'a> {
     /// work within the `func` module because it relies on `ParameterType`.
     fn coerce_arg_to_type(
         &self,
-        arg: &Expr,
+        arg: CoercibleScalarExpr,
         typ: &ParamType,
     ) -> Result<ScalarExpr, failure::Error> {
-        use super::query::CastContext::*;
-        let s: ScalarType = typ.into();
-        let hinted_expr = super::query::plan_expr(self.ecx, &arg, Some(s.clone()))?;
-
-        if self.ecx.scalar_type(&hinted_expr) == s {
-            Ok(hinted_expr)
-        } else if ParamType::JsonbAny == *typ {
-            super::query::plan_to_jsonb(self.ecx, self.ident, hinted_expr)
-        } else if ParamType::ExplicitStringAny == *typ {
-            super::query::plan_cast_internal(self.ecx, Explicit, hinted_expr, s)
-        } else if ParamType::StringAny == *typ || arg.is_string_literal() {
-            super::query::plan_cast_internal(self.ecx, Implicit(self.ident), hinted_expr, s)
-        } else {
-            super::query::plan_cast_implicit(self.ecx, Implicit(self.ident), hinted_expr, s)
+        let coerce_to = match typ {
+            ParamType::Plain(s) => CoerceTo::Plain(s.clone()),
+            ParamType::JsonbAny => CoerceTo::JsonbAny,
+            ParamType::ExplicitStringAny | ParamType::StringAny => {
+                CoerceTo::Plain(ScalarType::String)
+            }
+        };
+        let arg = super::query::plan_coerce(self.ecx, arg, coerce_to)?;
+        match typ {
+            ParamType::JsonbAny => super::query::plan_to_jsonb(self.ecx, self.ident, arg),
+            ParamType::ExplicitStringAny => {
+                let ccx = CastContext::Explicit;
+                super::query::plan_cast_internal(self.ecx, ccx, arg, ScalarType::String)
+            }
+            ParamType::StringAny => {
+                let ccx = CastContext::Implicit(self.ident);
+                super::query::plan_cast_internal(self.ecx, ccx, arg, ScalarType::String)
+            }
+            ParamType::Plain(s) => {
+                let ccx = CastContext::Implicit(self.ident);
+                super::query::plan_cast_implicit(self.ecx, ccx, arg, s.clone())
+            }
         }
     }
 }
@@ -722,9 +725,7 @@ lazy_static! {
                 params!(Jsonb) => Unary(UnaryFunc::JsonbPretty)
             },
             "jsonb_strip_nulls" => {
-                params!(Jsonb) => Unary(UnaryFunc::JsonbStripNulls),
-                // jsonb_strip_nulls does not want to cast NULLs to JSONB.
-                params!(Unknown) => Unary(UnaryFunc::JsonbStripNulls)
+                params!(Jsonb) => Unary(UnaryFunc::JsonbStripNulls)
             },
             "jsonb_typeof" => {
                 params!(Jsonb) => Unary(UnaryFunc::JsonbTypeof)

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -210,7 +210,6 @@ impl ColumnKnowledge {
                         | AggregateFunc::MaxDate
                         | AggregateFunc::MaxTimestamp
                         | AggregateFunc::MaxTimestampTz
-                        | AggregateFunc::MaxNull
                         | AggregateFunc::MinInt32
                         | AggregateFunc::MinInt64
                         | AggregateFunc::MinFloat32
@@ -221,7 +220,6 @@ impl ColumnKnowledge {
                         | AggregateFunc::MinDate
                         | AggregateFunc::MinTimestamp
                         | AggregateFunc::MinTimestampTz
-                        | AggregateFunc::MinNull
                         | AggregateFunc::Any
                         | AggregateFunc::All => {
                             // These methods propagate constant values exactly.

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -64,12 +64,10 @@ SELECT avg(a) FROM t2
 ----
 1.75
 
-# avg of an explicit NULL should return NULL.
+# avg of an explicit NULL should return an error.
 
-query R
+query error unable to infer type for NULL
 SELECT avg(NULL)
-----
-NULL
 
 statement error
 SELECT * ORDER BY SUM(fake_column)

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -115,10 +115,8 @@ SELECT count(NULL)
 statement error supported
 SELECT json_agg(NULL)
 
-query T
+query error unable to infer type for NULL
 SELECT jsonb_agg(NULL)
-----
-[null]
 
 # This should ideally return {NULL}, but this is a pathological case, and
 # Postgres has the same behavior, so it's sufficient for now.

--- a/test/sqllogictest/cockroach/union.slt
+++ b/test/sqllogictest/cockroach/union.slt
@@ -77,24 +77,27 @@ VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LI
 3
 2
 
-# UNION with NULL columns in operands works.
-query I
-VALUES (1) UNION ALL VALUES (NULL) ORDER BY 1
-----
-NULL
-1
-
-query I
-VALUES (NULL) UNION ALL VALUES (1) ORDER BY 1
-----
-NULL
-1
-
-query I
-VALUES (NULL) UNION ALL VALUES (NULL)
-----
-NULL
-NULL
+# TODO(benesch): uncomment if we improve UNION type matching. PostgreSQL doesn't
+# support these, so it's not high priority.
+#
+# # UNION with NULL columns in operands works.
+# query I
+# VALUES (1) UNION ALL VALUES (NULL) ORDER BY 1
+# ----
+# NULL
+# 1
+#
+# query I
+# VALUES (NULL) UNION ALL VALUES (1) ORDER BY 1
+# ----
+# NULL
+# 1
+#
+# query I
+# VALUES (NULL) UNION ALL VALUES (NULL)
+# ----
+# NULL
+# NULL
 
 # TODO(benesch): uncomment when we have support for pg_typeof and column
 # aliases.
@@ -111,35 +114,38 @@ NULL
 # 1  int
 # 2  unknown
 
+# TODO(benesch): uncomment if we improve UNION type matching. PostgreSQL doesn't
+# support these, so it's not high priority.
+#
 # INTERSECT with NULL columns in operands works.
-query I
-VALUES (1) INTERSECT VALUES (NULL) ORDER BY 1
-----
-
-query I
-VALUES (NULL) INTERSECT VALUES (1) ORDER BY 1
-----
-
-query I
-VALUES (NULL) INTERSECT VALUES (NULL)
-----
-NULL
-
-# EXCEPT with NULL columns in operands works.
-query I
-VALUES (1) EXCEPT VALUES (NULL) ORDER BY 1
-----
-1
-
-query I
-VALUES (NULL) EXCEPT VALUES (1) ORDER BY 1
-----
-NULL
-
-query I
-VALUES (NULL) EXCEPT VALUES (NULL)
-----
-
+# query I
+# VALUES (1) INTERSECT VALUES (NULL) ORDER BY 1
+# ----
+#
+# query I
+# VALUES (NULL) INTERSECT VALUES (1) ORDER BY 1
+# ----
+#
+# query I
+# VALUES (NULL) INTERSECT VALUES (NULL)
+# ----
+# NULL
+#
+# # EXCEPT with NULL columns in operands works.
+# query I
+# VALUES (1) EXCEPT VALUES (NULL) ORDER BY 1
+# ----
+# 1
+#
+# query I
+# VALUES (NULL) EXCEPT VALUES (1) ORDER BY 1
+# ----
+# NULL
+#
+# query I
+# VALUES (NULL) EXCEPT VALUES (NULL)
+# ----
+#
 statement ok
 CREATE TABLE uniontest (
   k INT,

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -22,7 +22,7 @@ select LIST[LIST[1],LIST[2,3]]
 ----
 {{1},{2,3}}
 
-query error Cannot assign type to this empty list
+query error unable to infer type for empty list
 select LIST[]
 
 query T

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -33,8 +33,8 @@ SHOW DATABASES WHERE (SELECT true)
 ----
 materialize
 
-statement error WHERE clause must have boolean type, not String
-SHOW DATABASES WHERE 'hello'
+statement error WHERE clause must have boolean type, not Int32
+SHOW DATABASES WHERE 7
 ----
 
 statement ok

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -68,10 +68,10 @@ query I
 SELECT generate_series FROM generate_series(null, null)
 ----
 
-statement error first generate_series argument has non-integer type
+statement error invalid input syntax for int8: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series('foo', 2)
 
-statement error second generate_series argument has non-integer type
+statement error invalid input syntax for int8: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series(1, 'foo')
 
 statement error requires exactly two arguments


### PR DESCRIPTION
@justinj this fixes #3150 and as a side effect cleans up a long-standing bit of tech debt.

@sploiselle I think we chatted about this a bit last week. Don't worry: I promise to wait until after your function generalization PR! But I think it has the potential to clean up some of the weirdness around `param_types`, since it exposes a function (`plan_coercible_expr`) that plans an expression without mutating `param_types`. And now that I look at it, with this PR and your PR I think literal coercion (#481) will wind up being like <10 lines of code.

/cc @frankmcsherry I think you'll be delighted about the effects on the expr/dataflow layer.

----

ScalarType::Unknown is a Postgresism that has not served us well. It
is best understood as the type of NULL in the following SQL statement

    SELECT NULL

although in recent versions Postgres will assign that NULL a type of
`text` before planning is complete. That is in fact the key insight: the
"unknown" type represents a transient state of the planner. Either the
unknown type will become known by the time planning is complete, or it
will not, and planning the query will fail.

We can isolate the dataflow execution layer from the unknown type by
limiting its existence to the few moments in the planner where it is
needed. To that end, this patch removes the ScalarType::Unknown variant,
and introduces a CoercibleScalarExpr to take its place.

The idea is that the planner has special handling for expressions which
could possibly coerce to another type (i.e., a string literal, list
literal, NULL literal, or query parameter). The expressions will be
coerced at the moment their true types are required; for example calling
a function will coerce any unknown parameters, as will reaching the root
of the expression tree.

All code outside of the `sql` crate gets vastly simpler. The SQL planner
gets simpler in many places too, and a bit different in others--not more
complicated, necessarily, just different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3160)
<!-- Reviewable:end -->
