### PR TITLE
Reduce the number of  Kafka consumers to one per source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.23.1"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#4ae9541aabd98d9d56d85621b36c356f6d171fed"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#27cb20049652604bf405b8b819efc796f37204ab"
 dependencies = [
  "futures",
  "libc",
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "rdkafka-sys"
 version = "2.0.0+1.4.2"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#4ae9541aabd98d9d56d85621b36c356f6d171fed"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#27cb20049652604bf405b8b819efc796f37204ab"
 dependencies = [
  "cmake",
  "libc",


### PR DESCRIPTION
This PR leverages the new "split_partition_queue" API to move from one consumer per partition to one "partition queue" per partition. 

It explicitly no longer relies on Kafka's autorebalancing/consumer group protocol.

The "queue non-empty" callback does not currently work with the "`split_partition_queue`" interface (https://github.com/fede1024/rust-rdkafka/issues/266). To side-step this, we temporarily reduce the `activate_after` from 60 seconds down to 1 second.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3170)
<!-- Reviewable:end -->
