### PR TITLE
mzconduct: log tcp errors in wait-for-tcp in automation

### DIFF
--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -630,7 +630,17 @@ class WaitForTcpStep(WorkflowStep):
             )
             try:
                 spawn.capture(cmd, unicode=True, stderr_too=True)
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as e:
+                ui.log_in_automation(
+                    "wait-for-tcp ({}:{}): error running {}: {}, stdout:\n{}\nstderr:\n{}".format(
+                        self._host,
+                        self._port,
+                        ui.shell_quote(cmd),
+                        e,
+                        e.stdout,
+                        e.stderr,
+                    )
+                )
                 ui.progress(" {}".format(int(remaining)))
             else:
                 ui.progress(" success!", finish=True)


### PR DESCRIPTION
This is pretty hacky, and again we should move to just using logging, or at least revert
this soon.

We are seeing issues that happen _only_ at cloud-init startup, never when running
manually, so this seems like the best option right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3171)
<!-- Reviewable:end -->
