### PR TITLE
sql: refactor Interval's duration to be i128

### DIFF
--- a/doc/user/content/sql/types/interval.md
+++ b/doc/user/content/sql/types/interval.md
@@ -11,9 +11,9 @@ menu:
 Detail | Info
 -------|-----
 **Quick Syntax** | `INTERVAL '1' MINUTE` <br/> `INTERVAL '1-2 3 4:5:6.7'` <br/>`INTERVAL '1 year 2.3 days 4.5 seconds'`
-**Size** | 32 bytes
-**Min value** | -9223372036854775807 months, -9223372036854775807 seconds, -999999999 nanoseconds
-**Max value** | 9223372036854775807 months, 9223372036854775807 seconds, 999999999 nanoseconds
+**Size** | 20 bytes
+**Min value** | -178956970 years -7 months -2236962132 days -07:59:59.999999
+**Max value** | 178956970 years 7 months 2236962132 days 07:59:59.999999
 
 ## Syntax
 

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -503,6 +503,7 @@ pub enum EvalError {
     DivisionByZero,
     NumericFieldOverflow,
     IntegerOutOfRange,
+    IntervalOutOfRange,
     InvalidEncodingName(String),
     InvalidByteSequence {
         byte_sequence: String,
@@ -519,6 +520,7 @@ impl std::fmt::Display for EvalError {
             EvalError::DivisionByZero => f.write_str("division by zero"),
             EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
             EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
+            EvalError::IntervalOutOfRange => f.write_str("interval out of range"),
             EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
             EvalError::InvalidByteSequence {
                 byte_sequence,

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -936,13 +936,16 @@ impl Encoder {
                     ScalarType::TimestampTz => {
                         Value::Timestamp(datum.unwrap_timestamptz().naive_utc())
                     }
-                    ScalarType::Interval => Value::Fixed(12, {
+                    // This feature isn't actually supported by the Avro Java
+                    // client (https://issues.apache.org/jira/browse/AVRO-2123),
+                    // so no one is likely to be using it, so we're just using
+                    // our own very convenient format.
+                    ScalarType::Interval => Value::Fixed(20, {
                         let iv = datum.unwrap_interval();
-                        let mut buf = Vec::with_capacity(12);
-                        buf.extend(&(iv.months as i32).to_le_bytes());
-                        buf.extend(&0i32.to_le_bytes());
-                        buf.extend(&(iv.duration.as_millis() as i32).to_le_bytes());
-                        debug_assert_eq!(buf.len(), 12);
+                        let mut buf = Vec::with_capacity(24);
+                        buf.extend(&iv.months.to_le_bytes());
+                        buf.extend(&iv.duration.to_le_bytes());
+                        debug_assert_eq!(buf.len(), 20);
                         buf
                     }),
                     ScalarType::Bytes => Value::Bytes(Vec::from(datum.unwrap_bytes())),

--- a/src/pgrepr/src/value/interval.rs
+++ b/src/pgrepr/src/value/interval.rs
@@ -9,7 +9,6 @@
 
 use std::error::Error;
 use std::fmt;
-use std::time::Duration;
 
 use byteorder::{NetworkEndian, ReadBytesExt};
 use bytes::{BufMut, BytesMut};
@@ -38,11 +37,15 @@ impl ToSql for Interval {
         //
         // Postgres implementation: https://github.com/postgres/postgres/blob/517bf2d91/src/backend/utils/adt/timestamp.c#L1008
         // Diesel implementation: https://github.com/diesel-rs/diesel/blob/a8b52bd05/diesel/src/pg/types/date_and_time/mod.rs#L39
-        out.put_i64(
-            (self.0.duration.as_micros() as i64) * if self.0.is_positive_dur { 1 } else { -1 },
-        );
-        out.put_i32(0);
-        out.put_i32(self.0.months as i32);
+        //
+        // Our intervals are guaranteed to fit within SQL's min/max intervals,
+        // so this is compression is guaranteed to be lossless. For details, see
+        // `repr::scalar::datetime::compute_interval`.
+        let days = std::cmp::min(self.0.days() as i128, i32::MAX as i128);
+        let ns = self.0.duration - days * 24 * 60 * 60 * 1_000_000_000;
+        out.put_i64((ns / 1000) as i64);
+        out.put_i32(days as i32);
+        out.put_i32(self.0.months);
         Ok(IsNull::No)
     }
 
@@ -58,15 +61,12 @@ impl ToSql for Interval {
 
 impl<'a> FromSql<'a> for Interval {
     fn from_sql(_: &Type, mut raw: &'a [u8]) -> Result<Interval, Box<dyn Error + Sync + Send>> {
-        let mut micros = raw.read_i64::<NetworkEndian>()?;
+        let micros = raw.read_i64::<NetworkEndian>()?;
         let days = raw.read_i32::<NetworkEndian>()?;
         let months = raw.read_i32::<NetworkEndian>()?;
-        micros += (days as i64) * 1000 * 1000 * 60 * 60 * 24;
-        Ok(Interval(repr::Interval {
-            months: months.into(),
-            is_positive_dur: micros > 0,
-            duration: Duration::from_micros(micros.abs() as u64),
-        }))
+        Ok(Interval(
+            repr::Interval::new(months, days as i64 * 24 * 60 * 60, micros * 1000).unwrap(),
+        ))
     }
 
     fn accepts(ty: &Type) -> bool {

--- a/src/repr/src/scalar/datetime.rs
+++ b/src/repr/src/scalar/datetime.rs
@@ -11,7 +11,6 @@ use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::fmt;
 use std::str::FromStr;
-use std::time::Duration;
 
 use chrono::{NaiveDate, NaiveTime};
 
@@ -207,20 +206,20 @@ impl ParsedDateTime {
             self.add_field(field, &mut months, &mut seconds, &mut nanos)?;
         }
 
-        // Handle negative seconds with positive nanos or vice versa.
-        if nanos < 0 && seconds > 0 {
-            nanos += 1_000_000_000_i64;
-            seconds -= 1;
-        } else if nanos > 0 && seconds < 0 {
-            nanos -= 1_000_000_000_i64;
-            seconds += 1;
-        }
+        let months: i32 = match months.try_into() {
+            Ok(m) => m,
+            Err(_) => {
+                return Err(format!(
+                    "exceeds min/max months (+/-2147483647); have {}",
+                    months
+                ))
+            }
+        };
 
-        Ok(Interval {
-            months,
-            duration: Duration::new(seconds.abs() as u64, nanos.abs() as u32),
-            is_positive_dur: seconds >= 0 && nanos >= 0,
-        })
+        match Interval::new(months, seconds, nanos) {
+            Ok(i) => Ok(i),
+            Err(e) => Err(e.to_string()),
+        }
     }
     /// Adds the appropriate values from self's ParsedDateTime to `months`,
     /// `seconds`, and `nanos`. These fields are then appropriate to construct
@@ -282,7 +281,7 @@ impl ParsedDateTime {
                 })?;
 
                 let m_f_ns = m_f
-                    .checked_mul(30 * seconds_multiplier(Day))
+                    .checked_mul(30 * super::seconds_multiplier(Day))
                     .ok_or_else(|| "Intermediate overflow in MONTH fraction".to_owned())?;
 
                 // seconds += m_f * 30 * seconds_multiplier(Day) / 1_000_000_000
@@ -304,7 +303,7 @@ impl ParsedDateTime {
                 };
 
                 *seconds = t
-                    .checked_mul(seconds_multiplier(d))
+                    .checked_mul(super::seconds_multiplier(d))
                     .and_then(|t_s| seconds.checked_add(t_s))
                     .ok_or_else(|| {
                         format!(
@@ -315,7 +314,7 @@ impl ParsedDateTime {
                     })?;
 
                 let t_f_ns = t_f
-                    .checked_mul(seconds_multiplier(dhms))
+                    .checked_mul(super::seconds_multiplier(dhms))
                     .ok_or_else(|| format!("Intermediate overflow in {} fraction", dhms))?;
 
                 // seconds += t_f * seconds_multiplier(dhms) / 1_000_000_000
@@ -623,17 +622,6 @@ impl ParsedDateTime {
             DateTimeField::Minute => self.minute,
             DateTimeField::Second => self.second,
         }
-    }
-}
-
-/// Returns the number of seconds in a single unit of `field`.
-fn seconds_multiplier(field: DateTimeField) -> i64 {
-    match field {
-        DateTimeField::Day => 60 * 60 * 24,
-        DateTimeField::Hour => 60 * 60,
-        DateTimeField::Minute => 60,
-        DateTimeField::Second => 1,
-        _other => unreachable!("Do not call with a non-duration field"),
     }
 }
 
@@ -3256,10 +3244,7 @@ fn test_parseddatetime_compute_interval() {
             ..Default::default()
         },
         // 21:56:55.5
-        Interval {
-            duration: Duration::new(21 * 60 * 60 + 56 * 60 + 55, 500_000_000),
-            ..Default::default()
-        },
+        Interval::new(0, 21 * 60 * 60 + 56 * 60 + 55, 500_000_000).unwrap(),
     );
     run_test_parseddatetime_compute_interval(
         ParsedDateTime {
@@ -3270,11 +3255,7 @@ fn test_parseddatetime_compute_interval() {
             ..Default::default()
         },
         // -21:56:55.5
-        Interval {
-            is_positive_dur: false,
-            duration: Duration::new(21 * 60 * 60 + 56 * 60 + 55, 500_000_000),
-            ..Default::default()
-        },
+        Interval::new(0, -(21 * 60 * 60 + 56 * 60 + 55), -500_000_000).unwrap(),
     );
     run_test_parseddatetime_compute_interval(
         ParsedDateTime {
@@ -3283,10 +3264,7 @@ fn test_parseddatetime_compute_interval() {
             ..Default::default()
         },
         // 23:59:59.73
-        Interval {
-            duration: Duration::new(23 * 60 * 60 + 59 * 60 + 59, 730_000_000),
-            ..Default::default()
-        },
+        Interval::new(0, 23 * 60 * 60 + 59 * 60 + 59, 730_000_000).unwrap(),
     );
     run_test_parseddatetime_compute_interval(
         ParsedDateTime {
@@ -3295,11 +3273,7 @@ fn test_parseddatetime_compute_interval() {
             ..Default::default()
         },
         // -23:59:59.73
-        Interval {
-            months: 0,
-            is_positive_dur: false,
-            duration: Duration::new(23 * 60 * 60 + 59 * 60 + 59, 730_000_000),
-        },
+        Interval::new(0, -(23 * 60 * 60 + 59 * 60 + 59), -730_000_000).unwrap(),
     );
     run_test_parseddatetime_compute_interval(
         ParsedDateTime {
@@ -3312,11 +3286,12 @@ fn test_parseddatetime_compute_interval() {
             ..Default::default()
         },
         // -1 year -4 months +13 days +07:07:53.220828
-        Interval {
-            months: -16,
-            is_positive_dur: true,
-            duration: Duration::new(13 * 60 * 60 * 24 + 7 * 60 * 60 + 7 * 60 + 53, 220_828_255),
-        },
+        Interval::new(
+            -16,
+            13 * 60 * 60 * 24 + 7 * 60 * 60 + 7 * 60 + 53,
+            220_828_255,
+        )
+        .unwrap(),
     );
     run_test_parseddatetime_compute_interval(
         ParsedDateTime {
@@ -3329,11 +3304,12 @@ fn test_parseddatetime_compute_interval() {
             ..Default::default()
         },
         // -1 year -4 months +13 days +07:07:53.220828255
-        Interval {
-            months: -16,
-            is_positive_dur: true,
-            duration: Duration::new(13 * 60 * 60 * 24 + 7 * 60 * 60 + 7 * 60 + 53, 220_828_255),
-        },
+        Interval::new(
+            -16,
+            13 * 60 * 60 * 24 + 7 * 60 * 60 + 7 * 60 + 53,
+            220_828_255,
+        )
+        .unwrap(),
     );
 
     fn run_test_parseddatetime_compute_interval(pdt: ParsedDateTime, expected: Interval) {

--- a/src/repr/src/scalar/mod.rs
+++ b/src/repr/src/scalar/mod.rs
@@ -417,15 +417,14 @@ impl From<Significand> for Datum<'static> {
 
 impl From<chrono::Duration> for Datum<'static> {
     fn from(duration: chrono::Duration) -> Datum<'static> {
-        let n_secs = duration.num_seconds();
-        Datum::Interval(Interval {
-            months: 0,
-            is_positive_dur: n_secs >= 0,
-            duration: std::time::Duration::new(
-                n_secs.abs() as u64,
-                (duration.num_nanoseconds().unwrap_or(0) % 1_000_000_000) as u32,
-            ),
-        })
+        Datum::Interval(
+            Interval::new(
+                0,
+                duration.num_seconds(),
+                duration.num_nanoseconds().unwrap_or(0) % 1_000_000_000,
+            )
+            .unwrap(),
+        )
     }
 }
 
@@ -748,48 +747,20 @@ impl fmt::Display for ColumnType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
 pub struct Interval {
     /// A possibly negative number of months for field types like `YEAR`
-    pub months: i64,
-    /// An actual timespan, possibly negative, because why not
-    pub duration: std::time::Duration,
-    pub is_positive_dur: bool,
+    pub months: i32,
+    /// A timespan represented in nanoseconds.
+    ///
+    /// Irrespective of values, `duration` will not be carried over into
+    /// `months`.
+    pub duration: i128,
 }
 
 impl Default for Interval {
     fn default() -> Self {
         Self {
             months: 0,
-            duration: std::time::Duration::default(),
-            is_positive_dur: true,
+            duration: 0,
         }
-    }
-}
-
-impl std::ops::Add for Interval {
-    type Output = Self;
-    // Since durations can only be positive, we need subtraction and boolean
-    // operators inside the Add impl
-    #[allow(clippy::suspicious_arithmetic_impl)]
-    fn add(self, other: Self) -> Self {
-        let (is_positive_dur, duration) = if self.is_positive_dur == other.is_positive_dur {
-            (self.is_positive_dur, self.duration + other.duration)
-        } else if self.duration > other.duration {
-            (self.is_positive_dur, self.duration - other.duration)
-        } else {
-            (other.is_positive_dur, other.duration - self.duration)
-        };
-
-        Self {
-            months: self.months + other.months,
-            duration,
-            is_positive_dur,
-        }
-    }
-}
-
-impl std::ops::Sub for Interval {
-    type Output = Self;
-    fn sub(self, other: Self) -> Self {
-        self + -other
     }
 }
 
@@ -798,13 +769,63 @@ impl std::ops::Neg for Interval {
     fn neg(self) -> Self {
         Self {
             months: -self.months,
-            duration: self.duration,
-            is_positive_dur: !self.is_positive_dur,
+            duration: -self.duration,
         }
     }
 }
 
 impl Interval {
+    /// Constructs a new `Interval` with the specified units of time.
+    ///
+    /// `nanos` in excess of `999_999_999` are carried over into seconds.
+    pub fn new(months: i32, seconds: i64, nanos: i64) -> Result<Interval, failure::Error> {
+        let i = Interval {
+            months,
+            duration: i128::from(seconds) * 1_000_000_000 + i128::from(nanos),
+        };
+        // Don't let our duration exceed Postgres' min/max for those same fields,
+        // equivalent to:
+        // ```
+        // SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds';
+        // SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds';
+        // ```
+        if i.duration > 193_273_528_233_599_999_999_000
+            || i.duration < -193_273_528_233_599_999_999_000
+        {
+            bail!(
+                "exceeds min/max interval duration +/-(2147483647 days 2147483647 hours \
+                59 minutes 59.999999 seconds)"
+            )
+        } else {
+            Ok(i)
+        }
+    }
+
+    pub fn checked_add(&self, other: &Self) -> Option<Self> {
+        let months = match self.months.checked_add(other.months) {
+            Some(m) => m,
+            None => return None,
+        };
+        let seconds = match self.dur_as_secs().checked_add(other.dur_as_secs()) {
+            Some(s) => s,
+            None => return None,
+        };
+
+        match Self::new(
+            months,
+            seconds,
+            i64::from(self.nanoseconds() + other.nanoseconds()),
+        ) {
+            Ok(i) => Some(i),
+            Err(_) => None,
+        }
+    }
+
+    /// Returns the total number of whole seconds in the `Interval`'s duration.
+    pub fn dur_as_secs(&self) -> i64 {
+        (self.duration / 1_000_000_000) as i64
+    }
+
     /// Computes the year part of the interval.
     ///
     /// The year part is the number of whole years in the interval. For example,
@@ -828,7 +849,7 @@ impl Interval {
     /// this function returns `5.0` for the interval `5 days 4 hours 3 minutes
     /// 2.1 seconds`.
     pub fn days(&self) -> f64 {
-        (self.duration.as_secs() / (60 * 60 * 24)) as f64
+        (self.dur_as_secs() / (60 * 60 * 24)) as f64
     }
 
     /// Computes the hour part of the interval.
@@ -837,7 +858,7 @@ impl Interval {
     /// For example, this function returns `4.0` for the interval `5 days 4
     /// hours 3 minutes 2.1 seconds`.
     pub fn hours(&self) -> f64 {
-        ((self.duration.as_secs() / (60 * 60)) % 24) as f64
+        ((self.dur_as_secs() / (60 * 60)) % 24) as f64
     }
 
     /// Computes the minute part of the interval.
@@ -846,7 +867,7 @@ impl Interval {
     /// 60. For example, this function returns `3.0` for the interval `5 days 4
     /// hours 3 minutes 2.1 seconds`.
     pub fn minutes(&self) -> f64 {
-        ((self.duration.as_secs() / 60) % 60) as f64
+        ((self.dur_as_secs() / 60) % 60) as f64
     }
 
     /// Computes the second part of the interval.
@@ -854,42 +875,43 @@ impl Interval {
     /// The second part is the number of fractional seconds in the interval,
     /// modulo 60.0.
     pub fn seconds(&self) -> f64 {
-        let s = (self.duration.as_secs() % 60) as f64;
-        let ns = f64::from(self.duration.subsec_nanos()) / 1e9;
+        let s = (self.dur_as_secs() % 60) as f64;
+        let ns = f64::from(self.nanoseconds()) / 1e9;
         s + ns
     }
 
     /// Computes the nanosecond part of the interval.
-    pub fn nanoseconds(&self) -> i64 {
-        if self.is_positive_dur {
-            self.duration.subsec_nanos() as i64
-        } else {
-            -(self.duration.subsec_nanos() as i64)
-        }
+    pub fn nanoseconds(&self) -> i32 {
+        (self.duration % 1_000_000_000) as i32
     }
 
     /// Computes the total number of seconds in the interval.
     pub fn as_seconds(&self) -> f64 {
         (self.months as f64) * 60.0 * 60.0 * 24.0 * 30.0
-            + (self.duration.as_secs() as f64)
-            + f64::from(self.duration.subsec_micros()) / 1e6
+            + (self.dur_as_secs() as f64)
+            + f64::from(self.nanoseconds()) / 1e9
     }
 
     /// Truncate the "head" of the interval, removing all time units greater than `f`.
     pub fn truncate_high_fields(&mut self, f: DateTimeField) {
-        use std::time::Duration;
         match f {
             DateTimeField::Year => {}
             DateTimeField::Month => self.months %= 12,
             DateTimeField::Day => self.months = 0,
             hms => {
                 self.months = 0;
-                self.duration = Duration::new(
-                    self.duration.as_secs() % seconds_multiplier(hms.next_largest()),
-                    self.duration.subsec_nanos(),
-                );
+                self.duration %= nanos_multiplier(hms.next_largest()) as i128
             }
         }
+    }
+
+    /// Converts this `Interval`'s duration into `chrono::Duration`.
+    pub fn duration_as_chrono(&self) -> chrono::Duration {
+        use chrono::Duration;
+        // This can be converted into a single call with
+        // https://github.com/chronotope/chrono/pull/426
+        Duration::seconds(self.dur_as_secs() as i64)
+            + Duration::nanoseconds(self.nanoseconds() as i64)
     }
 
     /// Truncate the "tail" of the interval, removing all time units less than `f`.
@@ -905,15 +927,14 @@ impl Interval {
         f: DateTimeField,
         fsec_max_precision: Option<u64>,
     ) -> Result<(), failure::Error> {
-        use std::time::Duration;
         use DateTimeField::*;
         match f {
             Year => {
                 self.months -= self.months % 12;
-                self.duration = Duration::new(0, 0);
+                self.duration = 0;
             }
             Month => {
-                self.duration = Duration::new(0, 0);
+                self.duration = 0;
             }
             // Round nanoseconds.
             Second => {
@@ -930,29 +951,29 @@ impl Interval {
                     )
                 }
 
-                let mut nanos = self.duration.subsec_nanos();
-
                 // Check if value should round up to nearest fractional place.
-                let remainder = nanos % 10_u32.pow(9 - precision as u32);
-                if remainder / 10_u32.pow(8 - precision as u32) > 4 {
-                    nanos += 10_u32.pow(9 - precision as u32);
+                let remainder = self.duration % 10_i128.pow(9 - precision as u32);
+                if remainder / 10_i128.pow(8 - precision as u32) > 4 {
+                    self.duration += 10_i128.pow(9 - precision as u32);
                 }
 
-                self.duration = Duration::new(self.duration.as_secs(), nanos - remainder);
+                self.duration -= remainder;
             }
             dhm => {
-                self.duration = Duration::new(
-                    self.duration.as_secs() - self.duration.as_secs() % (seconds_multiplier(dhm)),
-                    0,
-                );
+                self.duration -= self.duration % nanos_multiplier(dhm) as i128;
             }
         }
         Ok(())
     }
 }
 
+/// Returns the number of nanoseconds in a single unit of `field`.
+pub fn nanos_multiplier(field: DateTimeField) -> i64 {
+    seconds_multiplier(field) * 1_000_000_000
+}
+
 /// Returns the number of seconds in a single unit of `field`.
-fn seconds_multiplier(field: DateTimeField) -> u64 {
+pub fn seconds_multiplier(field: DateTimeField) -> i64 {
     use DateTimeField::*;
     match field {
         Day => 60 * 60 * 24,
@@ -977,8 +998,8 @@ impl fmt::Display for Interval {
         months = months.abs();
         let years = months / 12;
         months %= 12;
-        let mut secs = self.duration.as_secs();
-        let mut nanos = self.duration.subsec_nanos();
+        let mut secs = self.dur_as_secs().abs();
+        let mut nanos = self.nanoseconds().abs();
         let days = secs / (24 * 60 * 60);
         secs %= 24 * 60 * 60;
         let hours = secs / (60 * 60);
@@ -1013,7 +1034,7 @@ impl fmt::Display for Interval {
             if years > 0 || months > 0 {
                 f.write_char(' ')?;
             }
-            if !self.is_positive_dur {
+            if self.duration < 0 {
                 f.write_char('-')?;
             } else if neg_mos {
                 f.write_char('+')?;
@@ -1030,7 +1051,7 @@ impl fmt::Display for Interval {
             if years > 0 || months > 0 || days > 0 {
                 f.write_char(' ')?;
             }
-            if !self.is_positive_dur && non_zero_hmsn {
+            if self.duration < 0 && non_zero_hmsn {
                 f.write_char('-')?;
             } else if neg_mos {
                 f.write_char('+')?;
@@ -1056,7 +1077,7 @@ mod test {
 
     #[test]
     fn interval_fmt() {
-        fn mon(mon: i64) -> String {
+        fn mon(mon: i32) -> String {
             Interval {
                 months: mon,
                 ..Default::default()
@@ -1071,166 +1092,126 @@ mod test {
         assert_eq!(mon(25), "2 years 1 month");
         assert_eq!(mon(26), "2 years 2 months");
 
-        fn dur(is_positive_dur: bool, d: u64) -> String {
-            Interval {
-                months: 0,
-                duration: std::time::Duration::from_secs(d),
-                is_positive_dur,
-            }
-            .to_string()
+        fn dur(d: i64) -> String {
+            Interval::new(0, d, 0).unwrap().to_string()
         }
-        assert_eq!(&dur(true, 86_400 * 2), "2 days");
-        assert_eq!(&dur(true, 86_400 * 2 + 3_600 * 3), "2 days 03:00:00");
+        assert_eq!(&dur(86_400 * 2), "2 days");
+        assert_eq!(&dur(86_400 * 2 + 3_600 * 3), "2 days 03:00:00");
         assert_eq!(
-            &dur(true, 86_400 * 2 + 3_600 * 3 + 60 * 45 + 6),
+            &dur(86_400 * 2 + 3_600 * 3 + 60 * 45 + 6),
             "2 days 03:45:06"
         );
-        assert_eq!(
-            &dur(true, 86_400 * 2 + 3_600 * 3 + 60 * 45),
-            "2 days 03:45:00"
-        );
-        assert_eq!(&dur(true, 86_400 * 2 + 6), "2 days 00:00:06");
-        assert_eq!(&dur(true, 86_400 * 2 + 60 * 45 + 6), "2 days 00:45:06");
-        assert_eq!(&dur(true, 86_400 * 2 + 3_600 * 3 + 6), "2 days 03:00:06");
-        assert_eq!(&dur(true, 3_600 * 3 + 60 * 45 + 6), "03:45:06");
-        assert_eq!(&dur(true, 3_600 * 3 + 6), "03:00:06");
-        assert_eq!(&dur(true, 3_600 * 3), "03:00:00");
-        assert_eq!(&dur(true, 60 * 45 + 6), "00:45:06");
-        assert_eq!(&dur(true, 60 * 45), "00:45:00");
-        assert_eq!(&dur(true, 6), "00:00:06");
+        assert_eq!(&dur(86_400 * 2 + 3_600 * 3 + 60 * 45), "2 days 03:45:00");
+        assert_eq!(&dur(86_400 * 2 + 6), "2 days 00:00:06");
+        assert_eq!(&dur(86_400 * 2 + 60 * 45 + 6), "2 days 00:45:06");
+        assert_eq!(&dur(86_400 * 2 + 3_600 * 3 + 6), "2 days 03:00:06");
+        assert_eq!(&dur(3_600 * 3 + 60 * 45 + 6), "03:45:06");
+        assert_eq!(&dur(3_600 * 3 + 6), "03:00:06");
+        assert_eq!(&dur(3_600 * 3), "03:00:00");
+        assert_eq!(&dur(60 * 45 + 6), "00:45:06");
+        assert_eq!(&dur(60 * 45), "00:45:00");
+        assert_eq!(&dur(6), "00:00:06");
 
-        assert_eq!(&dur(false, 86_400 * 2 + 6), "-2 days -00:00:06");
-        assert_eq!(&dur(false, 86_400 * 2 + 60 * 45 + 6), "-2 days -00:45:06");
-        assert_eq!(&dur(false, 86_400 * 2 + 3_600 * 3 + 6), "-2 days -03:00:06");
-        assert_eq!(&dur(false, 3_600 * 3 + 60 * 45 + 6), "-03:45:06");
-        assert_eq!(&dur(false, 3_600 * 3 + 6), "-03:00:06");
-        assert_eq!(&dur(false, 3_600 * 3), "-03:00:00");
-        assert_eq!(&dur(false, 60 * 45 + 6), "-00:45:06");
-        assert_eq!(&dur(false, 60 * 45), "-00:45:00");
-        assert_eq!(&dur(false, 6), "-00:00:06");
+        assert_eq!(&dur(-(86_400 * 2 + 6)), "-2 days -00:00:06");
+        assert_eq!(&dur(-(86_400 * 2 + 60 * 45 + 6)), "-2 days -00:45:06");
+        assert_eq!(&dur(-(86_400 * 2 + 3_600 * 3 + 6)), "-2 days -03:00:06");
+        assert_eq!(&dur(-(3_600 * 3 + 60 * 45 + 6)), "-03:45:06");
+        assert_eq!(&dur(-(3_600 * 3 + 6)), "-03:00:06");
+        assert_eq!(&dur(-(3_600 * 3)), "-03:00:00");
+        assert_eq!(&dur(-(60 * 45 + 6)), "-00:45:06");
+        assert_eq!(&dur(-(60 * 45)), "-00:45:00");
+        assert_eq!(&dur(-6), "-00:00:06");
 
-        fn mon_dur(mon: i64, is_positive_dur: bool, d: u64) -> String {
-            Interval {
-                months: mon,
-                duration: std::time::Duration::from_secs(d),
-                is_positive_dur,
-            }
-            .to_string()
+        fn mon_dur(mon: i32, d: i64) -> String {
+            Interval::new(mon, d, 0).unwrap().to_string()
         }
-        assert_eq!(&mon_dur(1, true, 86_400 * 2 + 6), "1 month 2 days 00:00:06");
+        assert_eq!(&mon_dur(1, 86_400 * 2 + 6), "1 month 2 days 00:00:06");
         assert_eq!(
-            &mon_dur(1, true, 86_400 * 2 + 60 * 45 + 6),
+            &mon_dur(1, 86_400 * 2 + 60 * 45 + 6),
             "1 month 2 days 00:45:06"
         );
         assert_eq!(
-            &mon_dur(1, true, 86_400 * 2 + 3_600 * 3 + 6),
+            &mon_dur(1, 86_400 * 2 + 3_600 * 3 + 6),
             "1 month 2 days 03:00:06"
         );
         assert_eq!(
-            &mon_dur(26, true, 3_600 * 3 + 60 * 45 + 6),
+            &mon_dur(26, 3_600 * 3 + 60 * 45 + 6),
             "2 years 2 months 03:45:06"
         );
-        assert_eq!(
-            &mon_dur(26, true, 3_600 * 3 + 6),
-            "2 years 2 months 03:00:06"
-        );
-        assert_eq!(&mon_dur(26, true, 3_600 * 3), "2 years 2 months 03:00:00");
-        assert_eq!(&mon_dur(26, true, 60 * 45 + 6), "2 years 2 months 00:45:06");
-        assert_eq!(&mon_dur(26, true, 60 * 45), "2 years 2 months 00:45:00");
-        assert_eq!(&mon_dur(26, true, 6), "2 years 2 months 00:00:06");
+        assert_eq!(&mon_dur(26, 3_600 * 3 + 6), "2 years 2 months 03:00:06");
+        assert_eq!(&mon_dur(26, 3_600 * 3), "2 years 2 months 03:00:00");
+        assert_eq!(&mon_dur(26, 60 * 45 + 6), "2 years 2 months 00:45:06");
+        assert_eq!(&mon_dur(26, 60 * 45), "2 years 2 months 00:45:00");
+        assert_eq!(&mon_dur(26, 6), "2 years 2 months 00:00:06");
 
         assert_eq!(
-            &mon_dur(26, false, 86_400 * 2 + 6),
+            &mon_dur(26, -(86_400 * 2 + 6)),
             "2 years 2 months -2 days -00:00:06"
         );
         assert_eq!(
-            &mon_dur(26, false, 86_400 * 2 + 60 * 45 + 6),
+            &mon_dur(26, -(86_400 * 2 + 60 * 45 + 6)),
             "2 years 2 months -2 days -00:45:06"
         );
         assert_eq!(
-            &mon_dur(26, false, 86_400 * 2 + 3_600 * 3 + 6),
+            &mon_dur(26, -(86_400 * 2 + 3_600 * 3 + 6)),
             "2 years 2 months -2 days -03:00:06"
         );
         assert_eq!(
-            &mon_dur(26, false, 3_600 * 3 + 60 * 45 + 6),
+            &mon_dur(26, -(3_600 * 3 + 60 * 45 + 6)),
             "2 years 2 months -03:45:06"
         );
-        assert_eq!(
-            &mon_dur(26, false, 3_600 * 3 + 6),
-            "2 years 2 months -03:00:06"
-        );
-        assert_eq!(&mon_dur(26, false, 3_600 * 3), "2 years 2 months -03:00:00");
-        assert_eq!(
-            &mon_dur(26, false, 60 * 45 + 6),
-            "2 years 2 months -00:45:06"
-        );
-        assert_eq!(&mon_dur(26, false, 60 * 45), "2 years 2 months -00:45:00");
-        assert_eq!(&mon_dur(26, false, 6), "2 years 2 months -00:00:06");
+        assert_eq!(&mon_dur(26, -(3_600 * 3 + 6)), "2 years 2 months -03:00:06");
+        assert_eq!(&mon_dur(26, -(3_600 * 3)), "2 years 2 months -03:00:00");
+        assert_eq!(&mon_dur(26, -(60 * 45 + 6)), "2 years 2 months -00:45:06");
+        assert_eq!(&mon_dur(26, -(60 * 45)), "2 years 2 months -00:45:00");
+        assert_eq!(&mon_dur(26, -6), "2 years 2 months -00:00:06");
 
+        assert_eq!(&mon_dur(-1, 86_400 * 2 + 6), "-1 month +2 days +00:00:06");
         assert_eq!(
-            &mon_dur(-1, true, 86_400 * 2 + 6),
-            "-1 month +2 days +00:00:06"
-        );
-        assert_eq!(
-            &mon_dur(-1, true, 86_400 * 2 + 60 * 45 + 6),
+            &mon_dur(-1, 86_400 * 2 + 60 * 45 + 6),
             "-1 month +2 days +00:45:06"
         );
         assert_eq!(
-            &mon_dur(-1, true, 86_400 * 2 + 3_600 * 3 + 6),
+            &mon_dur(-1, 86_400 * 2 + 3_600 * 3 + 6),
             "-1 month +2 days +03:00:06"
         );
         assert_eq!(
-            &mon_dur(-26, true, 3_600 * 3 + 60 * 45 + 6),
+            &mon_dur(-26, 3_600 * 3 + 60 * 45 + 6),
             "-2 years -2 months +03:45:06"
         );
-        assert_eq!(
-            &mon_dur(-26, true, 3_600 * 3 + 6),
-            "-2 years -2 months +03:00:06"
-        );
-        assert_eq!(
-            &mon_dur(-26, true, 3_600 * 3),
-            "-2 years -2 months +03:00:00"
-        );
-        assert_eq!(
-            &mon_dur(-26, true, 60 * 45 + 6),
-            "-2 years -2 months +00:45:06"
-        );
-        assert_eq!(&mon_dur(-26, true, 60 * 45), "-2 years -2 months +00:45:00");
-        assert_eq!(&mon_dur(-26, true, 6), "-2 years -2 months +00:00:06");
+        assert_eq!(&mon_dur(-26, 3_600 * 3 + 6), "-2 years -2 months +03:00:06");
+        assert_eq!(&mon_dur(-26, 3_600 * 3), "-2 years -2 months +03:00:00");
+        assert_eq!(&mon_dur(-26, 60 * 45 + 6), "-2 years -2 months +00:45:06");
+        assert_eq!(&mon_dur(-26, 60 * 45), "-2 years -2 months +00:45:00");
+        assert_eq!(&mon_dur(-26, 6), "-2 years -2 months +00:00:06");
 
         assert_eq!(
-            &mon_dur(-26, false, 86_400 * 2 + 6),
+            &mon_dur(-26, -(86_400 * 2 + 6)),
             "-2 years -2 months -2 days -00:00:06"
         );
         assert_eq!(
-            &mon_dur(-26, false, 86_400 * 2 + 60 * 45 + 6),
+            &mon_dur(-26, -(86_400 * 2 + 60 * 45 + 6)),
             "-2 years -2 months -2 days -00:45:06"
         );
         assert_eq!(
-            &mon_dur(-26, false, 86_400 * 2 + 3_600 * 3 + 6),
+            &mon_dur(-26, -(86_400 * 2 + 3_600 * 3 + 6)),
             "-2 years -2 months -2 days -03:00:06"
         );
         assert_eq!(
-            &mon_dur(-26, false, 3_600 * 3 + 60 * 45 + 6),
+            &mon_dur(-26, -(3_600 * 3 + 60 * 45 + 6)),
             "-2 years -2 months -03:45:06"
         );
         assert_eq!(
-            &mon_dur(-26, false, 3_600 * 3 + 6),
+            &mon_dur(-26, -(3_600 * 3 + 6)),
             "-2 years -2 months -03:00:06"
         );
+        assert_eq!(&mon_dur(-26, -(3_600 * 3)), "-2 years -2 months -03:00:00");
         assert_eq!(
-            &mon_dur(-26, false, 3_600 * 3),
-            "-2 years -2 months -03:00:00"
-        );
-        assert_eq!(
-            &mon_dur(-26, false, 60 * 45 + 6),
+            &mon_dur(-26, -(60 * 45 + 6)),
             "-2 years -2 months -00:45:06"
         );
-        assert_eq!(
-            &mon_dur(-26, false, 60 * 45),
-            "-2 years -2 months -00:45:00"
-        );
-        assert_eq!(&mon_dur(-26, false, 6), "-2 years -2 months -00:00:06");
+        assert_eq!(&mon_dur(-26, -(60 * 45)), "-2 years -2 months -00:45:00");
+        assert_eq!(&mon_dur(-26, -6), "-2 years -2 months -00:00:06");
     }
 
     #[test]
@@ -1279,16 +1260,8 @@ mod test {
         ];
 
         for test in test_cases.iter_mut() {
-            let mut i = Interval {
-                months: (test.2).0,
-                duration: std::time::Duration::new((test.2).1, (test.2).2),
-                is_positive_dur: true,
-            };
-            let j = Interval {
-                months: (test.3).0,
-                duration: std::time::Duration::new((test.3).1, (test.3).2),
-                is_positive_dur: true,
-            };
+            let mut i = Interval::new((test.2).0, (test.2).1, (test.2).2).unwrap();
+            let j = Interval::new((test.3).0, (test.3).1, (test.3).2).unwrap();
 
             i.truncate_low_fields(test.0, test.1).unwrap();
 
@@ -1315,24 +1288,16 @@ mod test {
         ];
 
         for test in test_cases.iter_mut() {
-            let mut i = Interval {
-                months: (test.1).0,
-                duration: std::time::Duration::new((test.1).1 as u64, 123),
-                is_positive_dur: true,
-            };
-            let j = Interval {
-                months: (test.2).0,
-                duration: std::time::Duration::new((test.2).1 as u64, 123),
-                is_positive_dur: true,
-            };
+            let mut i = Interval::new((test.1).0, (test.1).1, 123).unwrap();
+            let j = Interval::new((test.2).0, (test.2).1, 123).unwrap();
 
             i.truncate_high_fields(test.0);
 
             if i != j {
                 panic!(
-                "test_interval_value_truncate_high_fields failed on {} \n actual: {:?} \n expected: {:?}",
-                test.0, i, j
-            );
+                    "test_interval_value_truncate_high_fields failed on {} \n actual: {:?} \n expected: {:?}",
+                    test.0, i, j
+                );
             }
         }
     }

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::time::Duration;
-
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
 use repr::datetime::DateTimeField;
@@ -274,90 +272,40 @@ fn test_parse_interval_monthlike() {
 fn test_parse_interval_durationlike() {
     use DateTimeField::*;
 
-    run_test_parse_interval_durationlike(
-        "10",
-        Interval {
-            duration: Duration::new(10, 0),
-            ..Default::default()
-        },
-    );
+    run_test_parse_interval_durationlike("10", Interval::new(0, 10, 0).unwrap());
 
     run_test_parse_interval_durationlike_from_sql(
         "10",
         Day,
-        Interval {
-            duration: Duration::new(10 * 24 * 60 * 60, 0),
-            ..Default::default()
-        },
+        Interval::new(0, 10 * 24 * 60 * 60, 0).unwrap(),
     );
 
     run_test_parse_interval_durationlike_from_sql(
         "10",
         Hour,
-        Interval {
-            duration: Duration::new(10 * 60 * 60, 0),
-            ..Default::default()
-        },
+        Interval::new(0, 10 * 60 * 60, 0).unwrap(),
     );
 
     run_test_parse_interval_durationlike_from_sql(
         "10",
         Minute,
-        Interval {
-            duration: Duration::new(10 * 60, 0),
-            ..Default::default()
-        },
+        Interval::new(0, 10 * 60, 0).unwrap(),
     );
 
-    run_test_parse_interval_durationlike_from_sql(
-        "10",
-        Second,
-        Interval {
-            duration: Duration::new(10, 0),
-            ..Default::default()
-        },
-    );
+    run_test_parse_interval_durationlike_from_sql("10", Second, Interval::new(0, 10, 0).unwrap());
 
-    run_test_parse_interval_durationlike(
-        "0.01",
-        Interval {
-            duration: Duration::new(0, 10_000_000),
-            ..Default::default()
-        },
-    );
+    run_test_parse_interval_durationlike("0.01", Interval::new(0, 0, 10_000_000).unwrap());
 
     run_test_parse_interval_durationlike(
         "1 2:3:4.5",
-        Interval {
-            duration: Duration::new(93_784, 500_000_000),
-            ..Default::default()
-        },
+        Interval::new(0, 93_784, 500_000_000).unwrap(),
     );
 
     run_test_parse_interval_durationlike(
         "-1 2:3:4.5",
-        Interval {
-            duration: Duration::new(79_015, 500_000_000),
-            is_positive_dur: false,
-            ..Default::default()
-        },
+        Interval::new(0, -79_015, -500_000_000).unwrap(),
     );
 
-    run_test_parse_interval_durationlike(
-        "1 -2:3:4.5",
-        Interval {
-            duration: Duration::new(79_015, 500_000_000),
-            ..Default::default()
-        },
-    );
-
-    run_test_parse_interval_durationlike(
-        "1 2:3",
-        Interval {
-            duration: Duration::new(93_780, 0),
-            ..Default::default()
-        },
-    );
     fn run_test_parse_interval_durationlike(s: &str, expected: Interval) {
         let actual = strconv::parse_interval(s).unwrap();
         assert_eq!(actual, expected);
@@ -378,67 +326,35 @@ fn test_parse_interval_full() {
 
     run_test_parse_interval_full(
         "6-7 1 2:3:4.5",
-        Interval {
-            months: 79,
-            duration: Duration::new(93_784, 500_000_000),
-            is_positive_dur: true,
-        },
+        Interval::new(79, 93_784, 500_000_000).unwrap(),
     );
 
     run_test_parse_interval_full(
         "-6-7 1 2:3:4.5",
-        Interval {
-            months: -79,
-            duration: Duration::new(93_784, 500_000_000),
-            is_positive_dur: true,
-        },
+        Interval::new(-79, 93_784, 500_000_000).unwrap(),
     );
 
     run_test_parse_interval_full(
         "6-7 -1 -2:3:4.5",
-        Interval {
-            months: 79,
-            duration: Duration::new(93_784, 500_000_000),
-            is_positive_dur: false,
-        },
+        Interval::new(79, -93_784, -500_000_000).unwrap(),
     );
 
     run_test_parse_interval_full(
         "-6-7 -1 -2:3:4.5",
-        Interval {
-            months: -79,
-            duration: Duration::new(93_784, 500_000_000),
-            is_positive_dur: false,
-        },
+        Interval::new(-79, -93_784, -500_000_000).unwrap(),
     );
 
     run_test_parse_interval_full(
         "-6-7 1 -2:3:4.5",
-        Interval {
-            months: -79,
-            duration: Duration::new(79_015, 500_000_000),
-            is_positive_dur: true,
-        },
+        Interval::new(-79, 79_015, 500_000_000).unwrap(),
     );
 
     run_test_parse_interval_full(
         "-6-7 -1 2:3:4.5",
-        Interval {
-            months: -79,
-            duration: Duration::new(79_015, 500_000_000),
-            is_positive_dur: false,
-        },
+        Interval::new(-79, -79_015, -500_000_000).unwrap(),
     );
 
-    run_test_parse_interval_full_from_sql(
-        "-6-7 1",
-        Minute,
-        Interval {
-            months: -79,
-            duration: Duration::new(60, 0),
-            is_positive_dur: true,
-        },
-    );
+    run_test_parse_interval_full_from_sql("-6-7 1", Minute, Interval::new(-79, 60, 0).unwrap());
 
     fn run_test_parse_interval_full(s: &str, expected: Interval) {
         let actual = strconv::parse_interval(s).unwrap();

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1914,9 +1914,6 @@ impl Parser {
                         DataType::Time
                     }
                 }
-                // Interval types can be followed by a complicated interval
-                // qualifier that we don't currently support. See
-                // parse_literal_interval for a taste.
                 "INTERVAL" => DataType::Interval,
                 "REGCLASS" => DataType::Regclass,
                 "TEXT" | "STRING" => DataType::Text,

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -788,6 +788,11 @@ SELECT EXTRACT(doy FROM DATE '2000-01-01'), EXTRACT(doy FROM DATE '2000-12-31')
 ----
 1 366
 
+query RR
+SELECT EXTRACT(EPOCH from INTERVAL '-1' MINUTE), EXTRACT(MINUTE from INTERVAL '-1' MINUTE)
+----
+-60 -1
+
 query T
 SELECT to_char(TIMESTAMPTZ '1997-02-03 11:12:59.9', 'YYYY-MM-DD HH24:MI:SS.MS TZ')
 ----
@@ -987,6 +992,11 @@ query T
 SELECT interval '-01:02:03.04'::time;
 ----
 22:57:56.96
+
+query T
+SELECT interval '-3 days -2 hours'::time;
+----
+22:00:00
 
 # Test using date as a column name.
 query T

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -575,22 +575,33 @@ SELECT INTERVAL '-1-2 -3 -4:5:6.7' + INTERVAL '1-2 3 4:5:6.7'
 00:00:00
 
 ## Largest values
+query T
+SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds'
+----
+2236962132 days 07:59:59.999999
 
 query T
-SELECT INTERVAL '9223372036854775807 months 9223372036854775807 seconds';
+SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds'
 ----
-768614336404564650 years 7 months 106751991167300 days 15:30:07
+-2236962132 days -07:59:59.999999
 
-query T
-SELECT INTERVAL '-9223372036854775807 months -9223372036854775807 seconds';
-----
--768614336404564650 years -7 months -106751991167300 days -15:30:07
+statement error invalid input syntax for interval: exceeds min/max interval duration
+SELECT INTERVAL '2147483647 days 2147483648 hours'
+
+statement error invalid input syntax for interval: exceeds min/max interval duration
+SELECT INTERVAL '-2147483647 days -2147483648 hours'
+
+statement error interval out of range
+SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds' + INTERVAL '1';
+
+statement error interval out of range
+SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds' - INTERVAL '1';
 
 # Largest number of cumulative nanoseconds
 query T
 SELECT INTERVAL '0.999999999 months 0.999999999 days 0.999999999 hours 0.999999999 minutes 0.999999999 seconds';
 ----
-31 days 01:00:56.702351
+31 days 01:01:00.997318
 
 ## Overflows
 
@@ -632,3 +643,9 @@ SELECT INTERVAL '9223372036854775808 seconds';
 
 statement error Unable to parse value as a number at index 0: number too large to fit in target type
 SELECT INTERVAL '-9223372036854775808 seconds';
+
+# 0 interval equality
+query B
+SELECT (interval '-1' day + interval '1' day) = (interval '1' day + interval '-1' day)
+----
+true


### PR DESCRIPTION
Per the conversation in #3151, I reimplemented `Interval`'s duration field as an
`i128`; this design greatly reduces the complexity of supporting negative
intervals in a way that plays nicely with all layers of Materialize.

### Caveats

Disregard what was here before: Frank found a fantastic workaround.

### Questions

- Should we be more principled in the length of duration we accept? I tried to
gate this by limiting `Interval::new` to accepting `i64`s for seconds and nanos,
but wasn't sure if we should make it harder to use more of the `i128` than we
reasonably expect users to, e.g. when creating `Intervals` directly.

- Avro encoding doesn't support ours or Postgres' intervas--no negative values, and the max number of days is only `u32`. I made some changes to ameliorate the differences but they seem a slightly intractable.
  - I found the Avro encoding, but where do these values get decoded into `Interval`?
- I also made a change to our PG encoding and decoding that--maybe!--improves their compatibility. Does this get tested anywhere?

### Misc.

- Removed duplicative implementation of `seconds_multiplier` in
  `repr/scalar/datetime.rs`
- @justinj 🤠

    ```
    materialize=> SELECT * from (values (interval '-1' day + interval '1' day)) union (values (interval '1' day + interval '-1' day));
     column1
    ----------
     00:00:00
    (1 row)
    ```

Closes #2800  #2812

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3172)
<!-- Reviewable:end -->
