### PR TITLE
Shuffle Avro Debezium records by key.

### DIFF
--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -45,7 +45,7 @@ where
         .collect::<Vec<_>>();
 
     stream.unary(
-        Exchange::new(|x: &SourceOutput<Vec<u8>, Vec<u8>>| x.value.hashed()),
+        SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
         "CsvDecode",
         |_, _| {
             // Temporary storage, and a re-useable CSV reader.

--- a/src/dataflow/decode/csv.rs
+++ b/src/dataflow/decode/csv.rs
@@ -10,9 +10,9 @@
 use std::iter;
 
 use dataflow_types::LinearOperator;
-use differential_dataflow::Hashable;
+
 use log::error;
-use timely::dataflow::channels::pact::Exchange;
+
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 

--- a/src/dataflow/decode/regex.rs
+++ b/src/dataflow/decode/regex.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::source::SourceOutput;
 use dataflow_types::{Diff, Timestamp};
 use differential_dataflow::Hashable;
 use log::warn;
@@ -20,7 +21,7 @@ use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 
 pub fn regex<G>(
-    stream: &Stream<G, (Vec<u8>, Option<i64>)>,
+    stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     regex: Regex,
     name: &str,
 ) -> Stream<G, (Row, Timestamp, Diff)>
@@ -29,13 +30,13 @@ where
 {
     let name = String::from(name);
     stream.unary(
-        Exchange::new(|x: &(Vec<u8>, _)| x.0.hashed()),
+        Exchange::new(|x: &SourceOutput<Vec<u8>, Vec<u8>>| x.value.hashed()),
         "RegexDecode",
         |_, _| {
             move |input, output| {
                 input.for_each(|cap, lines| {
                     let mut session = output.session(&cap);
-                    for (line, line_no) in &*lines {
+                    for SourceOutput {key: _, value: line, position: line_no} in &*lines {
                         let line = match str::from_utf8(&line) {
                             Ok(line) => line,
                             _ => {

--- a/src/dataflow/decode/regex.rs
+++ b/src/dataflow/decode/regex.rs
@@ -30,7 +30,7 @@ where
 {
     let name = String::from(name);
     stream.unary(
-        Exchange::new(|x: &SourceOutput<Vec<u8>, Vec<u8>>| x.value.hashed()),
+        SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
         "RegexDecode",
         |_, _| {
             move |input, output| {

--- a/src/dataflow/decode/regex.rs
+++ b/src/dataflow/decode/regex.rs
@@ -9,14 +9,14 @@
 
 use crate::source::SourceOutput;
 use dataflow_types::{Diff, Timestamp};
-use differential_dataflow::Hashable;
+
 use log::warn;
 use regex::Regex;
 use repr::{Datum, Row};
 use std::cmp::max;
 use std::iter;
 use std::str;
-use timely::dataflow::channels::pact::Exchange;
+
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -713,7 +713,7 @@ where
     G: Scope<Timestamp = Timestamp>,
 {
     stream.unary_frontier(
-        SourceOutput::<Vec<u8>, Vec<u8>>::key_contract(),
+        Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
         "UpsertCompaction",
         |_cap, _info| {
             let mut values = HashMap::<_, HashMap<_, (Vec<u8>, Option<i64>)>>::new();

--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -713,7 +713,7 @@ where
     G: Scope<Timestamp = Timestamp>,
 {
     stream.unary_frontier(
-        Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
+        SourceOutput::<Vec<u8>, Vec<u8>>::key_contract(),
         "UpsertCompaction",
         |_cap, _info| {
             let mut values = HashMap::<_, HashMap<_, (Vec<u8>, Option<i64>)>>::new();

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -35,7 +35,7 @@ use dataflow_types::{
 use expr::{PartitionId, SourceInstanceId};
 
 use super::util::source;
-use super::{SourceConfig, SourceStatus, SourceToken};
+use super::{SourceConfig, SourceOutput, SourceStatus, SourceToken};
 use crate::server::TimestampHistories;
 
 // Global Kafka metrics.
@@ -620,7 +620,7 @@ pub fn kafka<G>(
     config: SourceConfig<G>,
     connector: KafkaSourceConnector,
 ) -> (
-    Stream<G, (Vec<u8>, (Vec<u8>, Option<i64>))>,
+    Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     Option<SourceToken>,
 )
 where
@@ -724,9 +724,10 @@ where
                                 bytes_read += key.len() as i64;
                                 bytes_read += out.len() as i64;
                                 let ts_cap = cap.delayed(&ts);
-                                output.session(&ts_cap).give((
+                                output.session(&ts_cap).give(SourceOutput::new(
                                     key,
-                                    (out, Some(Into::<KafkaOffset>::into(offset).offset)),
+                                    out,
+                                    Some(Into::<KafkaOffset>::into(offset).offset),
                                 ));
 
                                 partition_metrics.offset_ingested.set(offset.offset);

--- a/src/dataflow/source/mod.rs
+++ b/src/dataflow/source/mod.rs
@@ -88,15 +88,21 @@ where
 }
 impl<K, V> SourceOutput<K, V>
 where
-    K: Data + Hashable<Output = u64> + Serialize + for<'a> Deserialize<'a> + Send + Sync,
-    V: Data + Hashable<Output = u64> + Serialize + for<'a> Deserialize<'a> + Send + Sync,
+    K: Data + Serialize + for<'a> Deserialize<'a> + Send + Sync,
+    V: Data + Serialize + for<'a> Deserialize<'a> + Send + Sync,
 {
     /// A parallelization contract that hashes by keys
-    pub fn key_contract() -> impl ParallelizationContract<Timestamp, Self> {
+    pub fn key_contract() -> impl ParallelizationContract<Timestamp, Self>
+    where
+        K: Hashable<Output = u64>,
+    {
         Exchange::new(|x: &Self| x.key.hashed())
     }
     /// A parallelization contract that hashes by values
-    pub fn value_contract() -> impl ParallelizationContract<Timestamp, Self> {
+    pub fn value_contract() -> impl ParallelizationContract<Timestamp, Self>
+    where
+        V: Hashable<Output = u64>,
+    {
         Exchange::new(|x: &Self| x.value.hashed())
     }
 }


### PR DESCRIPTION
The only semantic difference in the code is that Avro/Debezium records are now partitioned among workers by key, rather than by the hash of the entire record.

We needed a bit of minor refactoring in order to pipe the key into the decode module for non-upsert sources. Having sources yield a tuple of a bunch of things was getting unwieldy IMO so I introduced the `SourceOutput` type to encapsulate that.

The duplicate row counting logic should now work correctly -- previously, it was not working, because logically duplicate rows might go to different workers, and the Debezium coordinate tracking is worker-local.

The reason logically duplicate rows might go to different workers is that they are not byte-for-byte identical, because Debezium inserts a field with the current system timestamp.

No new tests, as this is already implicitly tested by `avro-sources.td`, which you can verify fails with `-w4`. As a follow-up, we will need to get that running in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3177)
<!-- Reviewable:end -->
