### PR TITLE
Fix sleep bug in perf-kinesis

### DIFF
--- a/test/performance/perf-kinesis/src/mz.rs
+++ b/test/performance/perf-kinesis/src/mz.rs
@@ -81,7 +81,16 @@ pub async fn query_materialized_view_until(
                 }
             }
         }
-        tokio::time::delay_for(Duration::from_secs(1) - timer.elapsed()).await;
+
+        let elapsed = timer.elapsed().as_millis();
+        if elapsed < 1000 {
+            tokio::time::delay_for(Duration::from_millis((1000 - elapsed) as u64)).await;
+        } else {
+            log::info!(
+                "Expected to query for records in 1000 milliseconds, took {}",
+                elapsed
+            );
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
Sometimes `timer.elapsed()` will be greater than a second, causing an overflow! 😬

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3180)
<!-- Reviewable:end -->
