### PR TITLE
Fix billing-demo mzcompose command

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -55,13 +55,12 @@ services:
       - db-data:/share/billing-demo/data
     environment:
       - RUST_LOG=billing-demo=debug,info
-    command: |-
-      billing-demo \
-          --message-count 1000 \
-          --materialized-host materialized \
-          --kafka-host kafka \
-          --schema-registry-url http://schema-registry:8081 \
-          --csv-file-name /share/billing-demo/data/prices.csv
+    command: >-
+      --message-count 1000
+      --materialized-host materialized
+      --kafka-host kafka
+      --schema-registry-url http://schema-registry:8081
+      --csv-file-name /share/billing-demo/data/prices.csv
     depends_on: [kafka, schema-registry, materialized]
   dashboard:
     mzbuild: dashboard


### PR DESCRIPTION
A previous change broke the billing release test on start up. With the `billing-demo` argument, it fails with:
```
error: Found argument 'billing-demo' which wasn't expected, or isn't valid in this context

USAGE:
    billing-demo [FLAGS] [OPTIONS] --csv-file-name <csv-file-name>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3181)
<!-- Reviewable:end -->
