### PR TITLE
Fix use of location in sqllogictest

### DIFF
--- a/src/sqllogictest/src/parser.rs
+++ b/src/sqllogictest/src/parser.rs
@@ -198,7 +198,7 @@ impl<'a> Parser<'a> {
             return Ok(Record::Query {
                 sql,
                 output: Err(error),
-                location: self.location(),
+                location,
             });
         }
 


### PR DESCRIPTION
This was accidentally using the current location rather than the one we
grabbed, which resulted in it pointing to after the query, rather than
at it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3182)
<!-- Reviewable:end -->
