### PR TITLE
Multi-worker Kafka reading

### DIFF
--- a/src/dataflow/render/mod.rs
+++ b/src/dataflow/render/mod.rs
@@ -287,6 +287,9 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         timestamp_histories: timestamp_histories.clone(),
                         timestamp_tx: timestamp_channel.clone(),
                         consistency,
+                        worker_id: worker_index,
+                        // Assumption: worker.peers() == total number of workers in Materialize
+                        worker_count: worker_peers,
                     };
 
                     let capability = if let Envelope::Upsert(key_encoding) = envelope {

--- a/src/dataflow/source/kafka.rs
+++ b/src/dataflow/source/kafka.rs
@@ -807,6 +807,9 @@ where
                     return SourceStatus::Alive;
                 }
             }
+            if bytes_read > 0 {
+                KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
+            }
             // Ensure that we poll kafka more often than the eviction timeout
             activator.activate_after(Duration::from_secs(60));
             SourceStatus::Alive

--- a/src/dataflow/source/mod.rs
+++ b/src/dataflow/source/mod.rs
@@ -47,6 +47,10 @@ pub struct SourceConfig<'a, G> {
     /// IDs in sync, but only one worker will receive the data, to avoid
     /// duplicates.
     pub active: bool,
+    /// The ID of the worker on which this operator is executing
+    pub worker_id: usize,
+    /// The total count of workers
+    pub worker_count: usize,
     // Timestamping fields.
     // TODO: document these.
     /// TODO(ncrooks)


### PR DESCRIPTION
This PR adds support for multi-worker Kafka reading for both RT and BYO sources. It does not make any modification to the current consistency format.

Each partition is assigned round-robin to a worker (if there are 3 partitions and 2 workers, worker 0 will have partitions (0,2) and worker 1 will have partition 1). 

Specifically, the coordinator continues to broadcast timestamp updates to all workers. Workers then determine whether they are responsible for this partition and register the appropriate Kafka consumer. All workers close timestamps for all partitions (whether they are responsible for it or not). 

This approach has some inefficiencies (1) each worker has to close timestamps for partitions that it does not own 2) we still have one consumer per worker. This will be fixed in a later PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3190)
<!-- Reviewable:end -->
