### PR TITLE
sql: Allow errant punctuation marks in time strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "criterion",
  "failure",
  "hex",
+ "itertools",
  "ordered-float",
  "ore",
  "rand",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1.8"
 hex = "0.4.2"
+itertools = "0.9"
 ordered-float = { version = "1.0.2", features = ["serde"] }
 ore = { path = "../ore" }
 regex = "1.3.9"

--- a/src/repr/src/scalar/datetime.rs
+++ b/src/repr/src/scalar/datetime.rs
@@ -394,12 +394,26 @@ impl ParsedDateTime {
         use DateTimeField::*;
 
         let mut pdt = ParsedDateTime::default();
-
         let mut value_parts = VecDeque::new();
+        let mut value_tokens = tokenize_time_str(value.trim())?;
+        let mut token_buffer = VecDeque::new();
 
-        let value_split = value.trim().split_whitespace().collect::<Vec<&str>>();
-        for s in value_split {
-            value_parts.push_back(tokenize_time_str(s)?);
+        while let Some(t) = value_tokens.pop_front() {
+            match t {
+                TimeStrToken::Delim => {
+                    if !token_buffer.is_empty() {
+                        value_parts.push_back(token_buffer.clone());
+                        token_buffer.clear();
+                    }
+                }
+                // Equivalent to trimming Colons from each leading element.
+                TimeStrToken::Colon if token_buffer.is_empty() => {}
+                _ => token_buffer.push_back(t),
+            }
+        }
+
+        if !token_buffer.is_empty() {
+            value_parts.push_back(token_buffer)
         }
 
         let mut annotated_parts = Vec::new();
@@ -465,6 +479,18 @@ impl ParsedDateTime {
                 }
                 TimePartFormat::PostgreSql(f) => fill_pdt_interval_pg(&mut ap.tokens, f, &mut pdt)?,
             }
+
+            // Consume unused TimeUnits for PG compat.
+            while let Some(TimeStrToken::TimeUnit(_)) = ap.tokens.front() {
+                ap.tokens.pop_front();
+            }
+
+            if !ap.tokens.is_empty() {
+                return Err(format!(
+                    "have unprocessed tokens {}",
+                    itertools::join(ap.tokens, "").trim_end(),
+                ));
+            }
         }
 
         Ok(pdt)
@@ -481,12 +507,22 @@ impl ParsedDateTime {
 
         fill_pdt_date(&mut pdt, &mut ts_actual)?;
 
-        if ts_actual.len() > 0 {
-            fill_pdt_time(&mut pdt, &mut ts_actual)?;
+        if let Some(TimeStrToken::DateTimeDelimiter) = ts_actual.front() {
+            ts_actual.pop_front();
+            ltrim_delim_or_colon(&mut ts_actual);
         }
+
+        fill_pdt_time(&mut pdt, &mut ts_actual)?;
         pdt.check_datelike_bounds()?;
 
-        Ok(pdt)
+        if ts_actual.is_empty() {
+            Ok(pdt)
+        } else {
+            Err(format!(
+                "have unprocessed tokens {}",
+                itertools::join(ts_actual, "").trim_end(),
+            ))
+        }
     }
     /// Builds a ParsedDateTime from a TIME string (`value`).
     ///
@@ -500,7 +536,14 @@ impl ParsedDateTime {
         fill_pdt_time(&mut pdt, &mut time_actual)?;
         pdt.check_datelike_bounds()?;
 
-        Ok(pdt)
+        if time_actual.is_empty() {
+            Ok(pdt)
+        } else {
+            Err(format!(
+                "have unprocessed tokens {}",
+                itertools::join(time_actual, "").trim_end(),
+            ))
+        }
     }
 
     /// Write to the specified field of a ParsedDateTime iff it is currently set
@@ -512,26 +555,28 @@ impl ParsedDateTime {
     ) -> Result<()> {
         use DateTimeField::*;
 
-        match f {
-            Year if self.year.is_none() => {
-                self.year = u;
+        if u.is_some() {
+            match f {
+                Year if self.year.is_none() => {
+                    self.year = u;
+                }
+                Month if self.month.is_none() => {
+                    self.month = u;
+                }
+                Day if self.day.is_none() => {
+                    self.day = u;
+                }
+                Hour if self.hour.is_none() => {
+                    self.hour = u;
+                }
+                Minute if self.minute.is_none() => {
+                    self.minute = u;
+                }
+                Second if self.second.is_none() => {
+                    self.second = u;
+                }
+                _ => return Err(format!("{} field set twice", f)),
             }
-            Month if self.month.is_none() => {
-                self.month = u;
-            }
-            Day if self.day.is_none() => {
-                self.day = u;
-            }
-            Hour if self.hour.is_none() => {
-                self.hour = u;
-            }
-            Minute if self.minute.is_none() => {
-                self.minute = u;
-            }
-            Second if self.second.is_none() => {
-                self.second = u;
-            }
-            _ => return Err(format!("{} field set twice", f)),
         }
         Ok(())
     }
@@ -660,15 +705,11 @@ fn fill_pdt_date(
             val /= 100;
             pdt.year = Some(DateTimeFieldValue::new(val, 0));
             actual.pop_front();
-            // Trim remaining optional tokens
-            if let Some(Space) = actual.front() {
+            // Trim remaining optional tokens, but never an immediately
+            // following colon
+            if let Some(Delim) = actual.front() {
                 actual.pop_front();
-            }
-            if let Some(DateTimeDelimiter) = actual.front() {
-                actual.pop_front();
-            }
-            if let Some(Space) = actual.front() {
-                actual.pop_front();
+                ltrim_delim_or_colon(actual);
             }
             return Ok(());
         }
@@ -682,26 +723,20 @@ fn fill_pdt_date(
             Num(0), // month
             Dash,
             Num(0), // day
-            Space,
-            DateTimeDelimiter,
         ],
         vec![
             Num(0), // year
-            Space,
+            Delim,
             Num(0), // month
             Dash,
             Num(0), // day
-            Space,
-            DateTimeDelimiter,
         ],
         vec![
             Num(0), // year
-            Space,
+            Delim,
             Num(0), // month
-            Space,
+            Delim,
             Num(0), // day
-            Space,
-            DateTimeDelimiter,
         ],
     ];
 
@@ -740,11 +775,9 @@ fn fill_pdt_time(
         Some(TimePartFormat::SqlStandard(leading_field)) => {
             let mut expected = expected_dur_like_tokens(leading_field)?;
 
-            fill_pdt_from_tokens(&mut pdt, &mut actual, &mut expected, leading_field, 1)?;
-
-            Ok(())
+            fill_pdt_from_tokens(&mut pdt, &mut actual, &mut expected, leading_field, 1)
         }
-        _ => Err("unknown format".into()),
+        _ => Ok(()),
     }
 }
 
@@ -876,158 +909,124 @@ fn fill_pdt_from_tokens(
 
     let mut unit_buf: Option<DateTimeFieldValue> = None;
 
-    let mut seen_datetimedelimiter = false;
+    while let (Some(atok), Some(etok)) = (actual.front(), expected.front()) {
+        match (atok, etok) {
+            // The following forms of punctuation signal the end of a field and can
+            // trigger a write.
+            (Dash, Dash) | (Colon, Colon) => {
+                pdt.write_field_iff_none(current_field, unit_buf)?;
+                unit_buf = None;
+                current_field = current_field.next_smallest();
+            }
+            (Delim, Delim) => {
+                pdt.write_field_iff_none(current_field, unit_buf)?;
+                unit_buf = None;
+                current_field = current_field.next_smallest();
 
-    while let Some(atok) = actual.front() {
-        if let Some(etok) = expected.front() {
-            match (atok, etok) {
-                // The following forms of punctuation signal the end of a field and can
-                // trigger a write.
-                (Dash, Dash) | (Colon, Colon) => {
-                    pdt.write_field_iff_none(current_field, unit_buf)?;
-                    unit_buf = None;
-                    current_field = current_field.next_smallest();
-                }
-                (Space, Space) => {
-                    pdt.write_field_iff_none(current_field, unit_buf)?;
-                    unit_buf = None;
-                    current_field = current_field.next_smallest();
+                // Spaces require special processing to allow users to enter an
+                // arbitrary number of delimiters wherever they're allowed. Note
+                // that this does not include colons.
+                actual.pop_front();
+                expected.pop_front();
+                i += 1;
 
-                    // Spaces require special processing to allow users to enter an arbitrary
-                    // number of spaces wherever spaces are allowed.
+                while let Some(Delim) = actual.front() {
                     actual.pop_front();
-                    expected.pop_front();
-                    i += 1;
-
-                    while let Some(Space) = actual.front() {
-                        actual.pop_front();
-                    }
-
-                    continue;
                 }
-                (TimeUnit(f), TimeUnit(_)) if unit_buf.is_some() => {
-                    if *f != current_field {
-                        return Err(format!(
+
+                continue;
+            }
+            (TimeUnit(f), TimeUnit(_)) => {
+                if unit_buf.is_some() && *f != current_field {
+                    return Err(format!(
                             "Invalid syntax at offset {}: provided TimeUnit({}) but expected TimeUnit({})",
                             i,
                             f,
                             current_field
                         ));
-                    }
                 }
-                (TimeUnit(f), TimeUnit(_)) if unit_buf.is_none() => {
-                    return Err(format!(
-                        "Invalid syntax: {} must be preceeded by a number, e.g. \'1{}\'",
-                        f, f
-                    ));
+            }
+            (Dot, Dot) => {}
+            (Num(val), Num(_)) => match unit_buf {
+                Some(_) => {
+                    return Err(
+                        "Invalid syntax; parts must be separated by '-', ':', or ' '".to_string(),
+                    )
                 }
-                // Dots do not denote terminating a field, so should not trigger a write.
-                (Dot, Dot) => {}
-                // break after all expected DateTimeDelimiters to allow more characters
-                // after the delimiter. This is a special case for `timestamp` data.
-                (DateTimeDelimiter, DateTimeDelimiter) if !seen_datetimedelimiter => {
-                    seen_datetimedelimiter = true;
-                    actual.pop_front();
-                    break;
+                None => {
+                    unit_buf = Some(DateTimeFieldValue {
+                        unit: *val * sign,
+                        fraction: 0,
+                    });
                 }
-                (_, DateTimeDelimiter) if !seen_datetimedelimiter => {
-                    break;
+            },
+            (Nanos(val), Nanos(_)) => match unit_buf {
+                Some(ref mut u) => {
+                    u.fraction = *val * sign;
                 }
-                (Num(val), Num(_)) => match unit_buf {
-                    Some(_) => {
-                        return Err(
-                            "Invalid syntax; parts must be separated by '-', ':', or ' '".into(),
-                        )
-                    }
-                    None => {
-                        unit_buf = Some(DateTimeFieldValue {
-                            unit: *val * sign,
-                            fraction: 0,
-                        });
-                    }
-                },
-                (Nanos(val), Nanos(_)) => match unit_buf {
+                None => {
+                    unit_buf = Some(DateTimeFieldValue {
+                        unit: 0,
+                        fraction: *val * sign,
+                    });
+                }
+            },
+            (Num(n), Nanos(_)) => {
+                // Create disposable copy of n.
+                let mut nc = *n;
+
+                let mut width = 0;
+                // Destructively count the number of digits in n.
+                while nc != 0 {
+                    nc /= 10;
+                    width += 1;
+                }
+
+                let mut n = *n;
+
+                // Nanoseconds have 9 digits of precision.
+                let precision = 9;
+
+                if width > precision {
+                    // Trim n to its 9 most significant digits.
+                    n /= 10_i64.pow(width - precision);
+                } else {
+                    // Right-pad n with 0s.
+                    n *= 10_i64.pow(precision - width);
+                }
+
+                match unit_buf {
                     Some(ref mut u) => {
-                        u.fraction = *val * sign;
+                        u.fraction = n * sign;
                     }
                     None => {
                         unit_buf = Some(DateTimeFieldValue {
                             unit: 0,
-                            fraction: *val * sign,
+                            fraction: n * sign,
                         });
                     }
-                },
-                (Num(n), Nanos(_)) => {
-                    // Create disposable copy of n.
-                    let mut nc = *n;
-
-                    let mut width = 0;
-                    // Destructively count the number of digits in n.
-                    while nc != 0 {
-                        nc /= 10;
-                        width += 1;
-                    }
-
-                    let mut n = *n;
-
-                    // Nanoseconds have 9 digits of precision.
-                    let precision = 9;
-
-                    if width > precision {
-                        // Trim n to its 9 most significant digits.
-                        n /= 10_i64.pow(width - precision);
-                    } else {
-                        // Right-pad n with 0s.
-                        n *= 10_i64.pow(precision - width);
-                    }
-
-                    match unit_buf {
-                        Some(ref mut u) => {
-                            u.fraction = n * sign;
-                        }
-                        None => {
-                            unit_buf = Some(DateTimeFieldValue {
-                                unit: 0,
-                                fraction: n * sign,
-                            });
-                        }
-                    }
-                }
-                // Allow skipping expected spaces, numbers, dots, and nanoseconds.
-                (_, Num(_)) | (_, Dot) | (_, Nanos(_)) | (_, Space) => {
-                    expected.pop_front();
-                    continue;
-                }
-                (provided, expected) => {
-                    return Err(format!(
-                        "Invalid syntax at offset {}: provided {:?} but expected {:?}",
-                        i, provided, expected
-                    ))
                 }
             }
-            i += 1;
-        } else {
-            // actual has more tokens than expected.
-            return Err(format!(
-                "Invalid syntax at offset {}: provided {:?} but expected None",
-                i, atok,
-            ));
-        };
-
+            // Allow skipping expected spaces (Delim), numbers, dots, and nanoseconds.
+            (_, Num(_)) | (_, Dot) | (_, Nanos(_)) | (_, Delim) => {
+                expected.pop_front();
+                continue;
+            }
+            (provided, expected) => {
+                return Err(format!(
+                    "Invalid syntax at offset {}: provided {:?} but expected {:?}",
+                    i, provided, expected
+                ))
+            }
+        }
+        i += 1;
         actual.pop_front();
         expected.pop_front();
     }
 
-    pdt.write_field_iff_none(current_field, unit_buf)?;
+    ltrim_delim_or_colon(actual);
 
-    // Trim all spaces and at most one DateTimeDelimeter off of end.
-    while let Some(t) = actual.front() {
-        match t {
-            Space => actual.pop_front(),
-            DateTimeDelimiter if !seen_datetimedelimiter => actual.pop_front(),
-            _ => break,
-        };
-    }
+    pdt.write_field_iff_none(current_field, unit_buf)?;
 
     Ok(())
 }
@@ -1046,6 +1045,7 @@ enum TimePartFormat {
 
 /// AnnotatedIntervalPart contains the tokens to be parsed, as well as the format
 /// to parse them.
+#[derive(Debug, Eq, PartialEq, Clone)]
 struct AnnotatedIntervalPart {
     pub tokens: VecDeque<TimeStrToken>,
     pub fmt: TimePartFormat,
@@ -1074,10 +1074,13 @@ fn determine_format_w_datetimefield(
 
     match toks.pop_front() {
         // Implies {?}{?}{?}, ambiguous case.
-        None | Some(Space) => Ok(None),
+        None | Some(Delim) => Ok(None),
         Some(Dot) => {
-            if let Some(Num(_)) = toks.front() {
-                toks.pop_front();
+            match toks.front() {
+                Some(Num(_)) | Some(Nanos(_)) => {
+                    toks.pop_front();
+                }
+                _ => {}
             }
             match toks.pop_front() {
                 // Implies {Num.NumTimeUnit}
@@ -1095,7 +1098,7 @@ fn determine_format_w_datetimefield(
             }
             match toks.pop_front() {
                 // Implies {H:M:?...}
-                Some(Colon) | Some(Space) | None => Ok(Some(SqlStandard(Hour))),
+                Some(Colon) | Some(Delim) | None => Ok(Some(SqlStandard(Hour))),
                 // Implies {M:S.NS}
                 Some(Dot) => Ok(Some(SqlStandard(Minute))),
                 _ => Err("Cannot determine format of all parts".into()),
@@ -1142,7 +1145,7 @@ fn expected_dur_like_tokens(from: DateTimeField) -> Result<VecDeque<TimeStrToken
 }
 
 /// Get the expected TimeStrTokens to parse TimePartFormat::SqlStandard parts,
-/// starting from some `DateTimeField`. Space tokens are never actually included
+/// starting from some `DateTimeField`. Delim tokens are never actually included
 /// in the output, but are illustrative of what the expected input of SQL
 /// Standard interval values looks like.
 fn expected_sql_standard_interval_tokens(from: DateTimeField) -> VecDeque<TimeStrToken> {
@@ -1153,9 +1156,9 @@ fn expected_sql_standard_interval_tokens(from: DateTimeField) -> VecDeque<TimeSt
         Num(0), // year
         Dash,
         Num(0), // month
-        Space,
+        Delim,
         Num(0), // day
-        Space,
+        Delim,
     ];
 
     let (start, end) = match from {
@@ -1187,12 +1190,19 @@ fn trim_and_return_sign(z: &mut VecDeque<TimeStrToken>) -> i64 {
     }
 }
 
+/// PostgreSQL treats out-of-place colons as errant punctuation marks, and
+/// trims them.
+fn ltrim_delim_or_colon(z: &mut VecDeque<TimeStrToken>) {
+    while Some(&TimeStrToken::Colon) == z.front() || Some(&TimeStrToken::Delim) == z.front() {
+        z.pop_front();
+    }
+}
+
 /// TimeStrToken represents valid tokens in time-like strings,
 /// i.e those used in INTERVAL, TIMESTAMP/TZ, DATE, and TIME.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TimeStrToken {
     Dash,
-    Space,
     Colon,
     Dot,
     Plus,
@@ -1205,6 +1215,28 @@ pub(crate) enum TimeStrToken {
     TimeUnit(DateTimeField),
     // Used to support ISO-formatted timestamps.
     DateTimeDelimiter,
+    // Space arbitrary non-enum punctuation (e.g. !), or leading/trailing
+    // colons.
+    Delim,
+}
+
+impl std::fmt::Display for TimeStrToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use TimeStrToken::*;
+        match self {
+            Dash => write!(f, "-"),
+            Colon => write!(f, ":"),
+            Dot => write!(f, "."),
+            Plus => write!(f, "+"),
+            Zulu => write!(f, "Z"),
+            Num(i) => write!(f, "{}", i),
+            Nanos(i) => write!(f, "{}", i),
+            TzName(n) => write!(f, "{}", n),
+            TimeUnit(d) => write!(f, "{:?}", d),
+            DateTimeDelimiter => write!(f, "T"),
+            Delim => write!(f, " "),
+        }
+    }
 }
 
 /// Convert a string from a time-like datatype (INTERVAL, TIMESTAMP/TZ, DATE, and TIME)
@@ -1230,12 +1262,26 @@ pub(crate) fn tokenize_time_str(value: &str) -> Result<VecDeque<TimeStrToken>> {
     fn maybe_tokenize_num_buf(
         n: &mut String,
         i: usize,
+        is_frac: &mut bool,
         t: &mut VecDeque<TimeStrToken>,
     ) -> Result<()> {
         if !n.is_empty() {
-            t.push_back(parse_num(&n, i)?);
-            n.clear();
+            if *is_frac {
+                // Fractions only support 9 places of precision.
+                n.truncate(9);
+                let raw: i64 = n
+                    .parse()
+                    .map_err(|e| format!("couldn't parse fraction {}: {}", n, e))?;
+                // this is guaranteed to be ascii, so len is fine
+                let multiplicand = 1_000_000_000 / 10_i64.pow(n.len() as u32);
+                t.push_back(TimeStrToken::Nanos(raw * multiplicand));
+                n.clear();
+            } else {
+                t.push_back(parse_num(&n, i)?);
+                n.clear();
+            }
         }
+        *is_frac = false;
         Ok(())
     }
     fn maybe_tokenize_char_buf(c: &mut String, t: &mut VecDeque<TimeStrToken>) -> Result<()> {
@@ -1250,47 +1296,47 @@ pub(crate) fn tokenize_time_str(value: &str) -> Result<VecDeque<TimeStrToken>> {
         }
         Ok(())
     }
-    let mut last_field_is_frac = false;
+    let mut next_num_is_frac = false;
     for (i, chr) in value.chars().enumerate() {
         if !num_buf.is_empty() && !char_buf.is_empty() {
             return Err("Could not tokenize".into());
         }
         match chr {
             '+' => {
-                maybe_tokenize_num_buf(&mut num_buf, i, &mut toks)?;
+                maybe_tokenize_num_buf(&mut num_buf, i, &mut next_num_is_frac, &mut toks)?;
                 maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
                 toks.push_back(TimeStrToken::Plus);
             }
             '-' => {
-                maybe_tokenize_num_buf(&mut num_buf, i, &mut toks)?;
+                maybe_tokenize_num_buf(&mut num_buf, i, &mut next_num_is_frac, &mut toks)?;
                 maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
                 toks.push_back(TimeStrToken::Dash);
             }
-            ' ' => {
-                maybe_tokenize_num_buf(&mut num_buf, i, &mut toks)?;
-                maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
-                toks.push_back(TimeStrToken::Space);
-            }
             ':' => {
-                maybe_tokenize_num_buf(&mut num_buf, i, &mut toks)?;
+                maybe_tokenize_num_buf(&mut num_buf, i, &mut next_num_is_frac, &mut toks)?;
                 maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
                 toks.push_back(TimeStrToken::Colon);
             }
             '.' => {
-                maybe_tokenize_num_buf(&mut num_buf, i, &mut toks)?;
+                maybe_tokenize_num_buf(&mut num_buf, i, &mut next_num_is_frac, &mut toks)?;
                 maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
                 toks.push_back(TimeStrToken::Dot);
-                last_field_is_frac = true;
+                next_num_is_frac = true;
             }
             chr if chr.is_digit(10) => {
                 maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
-                num_buf.push(chr)
+                num_buf.push(chr);
             }
             chr if chr.is_ascii_alphabetic() => {
-                maybe_tokenize_num_buf(&mut num_buf, i, &mut toks)?;
-                char_buf.push(chr)
+                maybe_tokenize_num_buf(&mut num_buf, i, &mut next_num_is_frac, &mut toks)?;
+                char_buf.push(chr);
             }
-            chr => {
+            chr if chr.is_ascii_whitespace() || chr.is_ascii_punctuation() => {
+                maybe_tokenize_num_buf(&mut num_buf, i, &mut next_num_is_frac, &mut toks)?;
+                maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
+                toks.push_back(TimeStrToken::Delim);
+            }
+            _ => {
                 return Err(format!(
                     "Invalid character at offset {} in {}: {:?}",
                     i, value, chr
@@ -1298,33 +1344,11 @@ pub(crate) fn tokenize_time_str(value: &str) -> Result<VecDeque<TimeStrToken>> {
             }
         }
     }
-    if !num_buf.is_empty() {
-        if !last_field_is_frac {
-            toks.push_back(parse_num(&num_buf, 0)?);
-        } else {
-            // this is guaranteed to be ascii, so len is fine
-            let mut chars = num_buf.len();
-            // Fractions only support 9 places of precision.
-            let default_precision = 9;
-            if chars > default_precision {
-                num_buf = num_buf[..default_precision].to_string();
-                chars = default_precision;
-            }
-            let raw: i64 = num_buf
-                .parse()
-                .map_err(|e| format!("couldn't parse fraction {}: {}", num_buf, e))?;
-            let multiplicand = 1_000_000_000 / 10_i64.pow(chars as u32);
 
-            toks.push_back(TimeStrToken::Nanos(raw * multiplicand));
-        }
-    } else {
-        maybe_tokenize_char_buf(&mut char_buf, &mut toks)?
-    }
+    maybe_tokenize_num_buf(&mut num_buf, value.len(), &mut next_num_is_frac, &mut toks)?;
+    maybe_tokenize_char_buf(&mut char_buf, &mut toks)?;
 
-    // PostgreSQL inexplicably trims all leading colons from all timestamp parts.
-    while let Some(TimeStrToken::Colon) = toks.front() {
-        toks.pop_front();
-    }
+    ltrim_delim_or_colon(&mut toks);
 
     Ok(toks)
 }
@@ -1383,7 +1407,7 @@ fn tokenize_timezone(value: &str) -> Result<Vec<TimeStrToken>> {
             ' ' => {
                 parse_num(&mut toks, &num_buf, split_nums, i)?;
                 num_buf.clear();
-                toks.push(TimeStrToken::Space);
+                toks.push(TimeStrToken::Delim);
             }
             ':' => {
                 parse_num(&mut toks, &num_buf, split_nums, i)?;
@@ -1602,12 +1626,12 @@ mod test {
         use TimeStrToken::*;
         assert_eq!(
             expected_sql_standard_interval_tokens(Year),
-            vec![Num(0), Dash, Num(0), Space]
+            vec![Num(0), Dash, Num(0), Delim]
         );
 
         assert_eq!(
             expected_sql_standard_interval_tokens(Day),
-            vec![Num(0), Space,]
+            vec![Num(0), Delim]
         );
         assert_eq!(
             expected_sql_standard_interval_tokens(Hour),
@@ -1876,15 +1900,7 @@ mod test {
                 "0-0 0",
                 Year,
                 1,
-                "Invalid syntax at offset 1: provided Space but expected Dash",
-            ),
-            // If you have Nanos, you cannot convert to Num.
-            (
-                "1 2.3",
-                "0 0.0YEAR",
-                Year,
-                1,
-                "Invalid syntax at offset 4: provided Nanos(300000000) but expected TimeUnit(Year)",
+                "Invalid syntax at offset 1: provided Delim but expected Dash",
             ),
         ];
         for test in test_cases.iter() {
@@ -2057,11 +2073,6 @@ mod test {
                 Month,
                 "Invalid syntax at offset 3: provided Dot but expected TimeUnit(Year)",
             ),
-            (
-                "YEAR",
-                Year,
-                "Invalid syntax: YEAR must be preceeded by a number, e.g. \'1YEAR\'",
-            ),
             // Running into this error means that determine_format_w_datetimefield
             // failed.
             (
@@ -2227,11 +2238,6 @@ mod test {
                 "1-2:3.4",
                 Minute,
                 "Invalid syntax at offset 1: provided Dash but expected Colon",
-            ),
-            (
-                "1:2.2.",
-                Minute,
-                "Invalid syntax at offset 5: provided Dot but expected None",
             ),
             (
                 "1YEAR",
@@ -2797,7 +2803,7 @@ mod test {
             (
                 "-:::::1.27",
                 Second,
-                "Invalid syntax at offset 2: provided Colon but expected None",
+                "have unprocessed tokens 1.270000000",
             ),
             (
                 "-1 ::.27",
@@ -2808,7 +2814,7 @@ mod test {
             (
                 "1:2:3.4.5",
                 Second,
-                "Invalid syntax at offset 7: provided Dot but expected None",
+                "have unprocessed tokens .500000000",
             ),
             (
                 "1+2:3.4",
@@ -2824,16 +2830,6 @@ mod test {
                 "0 foo",
                 Second,
                 "invalid DateTimeField: FOO",
-            ),
-            (
-                "1-2 hour",
-                Second,
-                "Invalid syntax: HOUR must be preceeded by a number, e.g. '1HOUR'",
-            ),
-            (
-                "1-2hour",
-                Second,
-                "Invalid syntax at offset 3: provided TimeUnit(Hour) but expected None",
             ),
             (
                 "1-2 3:4 5 second",
@@ -2854,22 +2850,22 @@ mod test {
             (
                 "9223372036854775808 months",
                 Day,
-                "Unable to parse value as a number at index 0: number too large to fit in target type",
+                "Unable to parse value as a number at index 19: number too large to fit in target type",
             ),
             (
                 "-9223372036854775808 months",
                 Day,
-                "Unable to parse value as a number at index 0: number too large to fit in target type",
+                "Unable to parse value as a number at index 20: number too large to fit in target type",
             ),
             (
                 "9223372036854775808 seconds",
                 Day,
-                "Unable to parse value as a number at index 0: number too large to fit in target type",
+                "Unable to parse value as a number at index 19: number too large to fit in target type",
             ),
             (
                 "-9223372036854775808 seconds",
                 Day,
-                "Unable to parse value as a number at index 0: number too large to fit in target type",
+                "Unable to parse value as a number at index 20: number too large to fit in target type",
             ),
         ];
         for test in test_cases.iter() {

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -43,7 +43,7 @@ fn test_parse_date_errors() {
     );
     run_test_parse_date_errors(
         "2001-01-02 04",
-        "invalid input syntax for date: unknown format: \"2001-01-02 04\"",
+        "invalid input syntax for date: have unprocessed tokens 4: \"2001-01-02 04\"",
     );
     fn run_test_parse_date_errors(s: &str, e: &str) {
         assert_eq!(
@@ -83,7 +83,11 @@ fn test_parse_time_errors() {
     );
     run_test_parse_time_errors(
         "03.456",
-        "invalid input syntax for time: unknown format: \"03.456\"",
+        "invalid input syntax for time: have unprocessed tokens 3.456000000: \"03.456\"",
+    );
+    run_test_parse_time_errors(
+        "03.456",
+        "invalid input syntax for time: have unprocessed tokens 3.456000000: \"03.456\"",
     );
 
     fn run_test_parse_time_errors(s: &str, e: &str) {
@@ -142,7 +146,7 @@ fn test_parse_timestamp_errors() {
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 04",
-        "invalid input syntax for timestamp: unknown format: \"2001-01-02 04\"",
+        "invalid input syntax for timestamp: have unprocessed tokens 4: \"2001-01-02 04\"",
     );
 
     run_test_parse_timestamp_errors(

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -971,6 +971,9 @@ SELECT DATE '2007-02-01TT15:04:05'
 statement error invalid input syntax for date: Cannot determine format of all parts: "2007-02-01  T  T  15:04:05"
 SELECT DATE '2007-02-01  T  T  15:04:05'
 
+statement error invalid input syntax for date: Invalid timezone string \(T\): named timezones are not supported. Failed to parse T at token index 0
+SELECT DATE '2007-02-01  T '
+
 # Test casting time to interval & vice versa
 
 query T
@@ -993,3 +996,17 @@ query T
 SELECT date FROM (SELECT column1 AS date FROM (VALUES ('2020-01-01')))
 ----
 2020-01-01
+
+# Arbitrary punctuation as delimiter
+query T
+SELECT '"2020-03-17 ~02:36:56~"'::timestamp;
+----
+2020-03-17 02:36:56
+
+query T
+SELECT '"2020!03-17 #?~T~02:36:56#"'::timestamp;
+----
+2020-03-17 02:36:56
+
+query error invalid input syntax for timestamp: have unprocessed tokens 56
+select TIMESTAMP '"2020-03-17 ~02:36:~56~"';

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -230,7 +230,7 @@ statement error invalid input syntax for interval: SECOND must be \(-60, 60\), g
 SELECT INTERVAL '100-11 366 250:59:61';
 
 # Invalid syntax
-statement error invalid input syntax for interval: Invalid syntax at offset 7: provided Dot but expected None: "1:2:3.4.5"
+statement error invalid input syntax for interval: have unprocessed tokens .500000000
 SELECT INTERVAL '1:2:3.4.5';
 
 statement error
@@ -367,26 +367,19 @@ SELECT INTERVAL '+1 year +2 days +3:4:5.6';
 # Differentiate between trailing DateTimeField name and
 # PostgreSQL TimeUnit.
 query T
-SELECT INTERVAL '1-2' MONTH;
+SELECT INTERVAL '01:02:03' MINUTE;
 ----
-1 year 2 months
-
-statement error
-SELECT INTERVAL '1-2 month';
-
-statement error
-SELECT INTERVAL '1-2month';
+01:02:00
 
 query T
-SELECT INTERVAL '1-2' HOUR;
+SELECT INTERVAL '01:02:03minute';
 ----
-1 year 2 months
+01:02:03
 
-statement error invalid input syntax for interval: Invalid syntax: HOUR must be preceeded by a number, e.g. '1HOUR': "1-2 hour"
-SELECT INTERVAL '1-2 hour';
-
-statement error invalid input syntax for interval: Invalid syntax at offset 3: provided TimeUnit\(Hour\) but expected None: "1-2hour"
-SELECT INTERVAL '1-2hour';
+query T
+SELECT INTERVAL '01:02:03minute hour day year';
+----
+01:02:03
 
 # Use larger numbers.
 query T
@@ -510,6 +503,20 @@ SELECT INTERVAL '2-3 3:4' DAY(1)
 statement error Expected literal int, found: -
 SELECT INTERVAL '1 day 2-3 4' SECOND(-1);
 
+# Arbitrary punctuation delimiters
+query T
+SELECT interval '02-01!1~01:02:03';
+----
+2 years 1 month 1 day 01:02:03
+
+query T
+SELECT interval '1! hour';
+----
+01:00:00
+
+statement error
+SELECT interval '02!01!1~01:02:03';
+
 ## Math
 
 # Support negating interval
@@ -600,10 +607,10 @@ SELECT INTERVAL '768614336404564651 year';
 statement error Overflows maximum months; cannot exceed 9223372036854775807 months
 SELECT INTERVAL '768614336404564650.7 year';
 
-statement error Unable to parse value as a number at index 0: number too large to fit in target type
+statement error Unable to parse value as a number at index 19: number too large to fit in target type
 SELECT INTERVAL '9223372036854775808 months';
 
-statement error Unable to parse value as a number at index 0: number too large to fit in target type
+statement error Unable to parse value as a number at index 20: number too large to fit in target type
 SELECT INTERVAL '-9223372036854775808 months';
 
 statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
@@ -627,8 +634,8 @@ SELECT INTERVAL '9223372036854775807 seconds 1 minute';
 statement error Overflows maximum seconds; cannot exceed 9223372036854775807 seconds
 SELECT INTERVAL '9223372036854775707 seconds 1.9 minute';
 
-statement error Unable to parse value as a number at index 0: number too large to fit in target type
+statement error Unable to parse value as a number at index 19: number too large to fit in target type
 SELECT INTERVAL '9223372036854775808 seconds';
 
-statement error Unable to parse value as a number at index 0: number too large to fit in target type
+statement error Unable to parse value as a number at index 20: number too large to fit in target type
 SELECT INTERVAL '-9223372036854775808 seconds';


### PR DESCRIPTION
Supports Postgres' lackadaisical attitude toward errant punctuation marks in time strings.

Also includes some other small changes to increase PG compatibility, which can be scoped in the `slt` file diffs.

### Annotations

This PR ended up much messier-looking than it actually is, so I've made some
annotations to make it more legible:

- [The actual change](https://github.com/MaterializeInc/materialize/compare/master...sploiselle:timestamp-stray-characters?expand=1#diff-85d817aa8ad4dd1825ea77044d2e3eebR1352-R1355): Postgres treats errant punctuation marks as equivalent to spaces in time strings, so I've collapsed both of them into an enum, `Delim`. Checking for whitespace instead of just spaces also improves PG compat because they actually allow line breaks in their time strings, which we didn't before.

- Time-string parsing relied very heavily on the notion of splitting time strings on spaces before calling `tokenize_time_str`, which made this new notion of `Delim` challenging. This PR changes that and is more agnostic about imposing semantics on character position.
  
  e.g. Fraction processing relied on the final component of the string being a fraction if it was preceded by a `.`; however, now [fraction processing](https://github.com/MaterializeInc/materialize/compare/master...sploiselle:timestamp-stray-characters?expand=1#diff-85d817aa8ad4dd1825ea77044d2e3eebR1274-R1290) can be applied multiple times within the same string.
  
  Ideally, I'd like to remove the notion of `Nanos` from `tokenize_time_str`, but want to limit the scope of this PR.

- [Intervals now tokenize their entire strings at once](https://github.com/MaterializeInc/materialize/compare/master...sploiselle:timestamp-stray-characters?expand=1#diff-85d817aa8ad4dd1825ea77044d2e3eebR399-R414) and fabricate a queue of queues based on the new `Delim` enum.

- `fill_pdt...` API change: These functions, which fill a `ParsedDateTime` with a time string's tokens, expected `fill_pdt_from_tokens` to have a great understanding of time string semantics, and error on _all_ invalid strings.

  I've instead moved some of the semantic processing into the functions that call `fill_pdt...`. In practice, this just requires callers to ensure `fill_pdt...` functions [actually consume all of the time string tokens](https://github.com/MaterializeInc/materialize/compare/master...sploiselle:timestamp-stray-characters?expand=1#diff-85d817aa8ad4dd1825ea77044d2e3eebR516-R521).

  This simplifies `fill_pdt_from_tokens` by simply letting it [pairwise iterate over the user-provided tokens and the syntax tracking tokens](https://github.com/MaterializeInc/materialize/compare/master...sploiselle:timestamp-stray-characters?expand=1#diff-85d817aa8ad4dd1825ea77044d2e3eebR923) without doing any of the fussier bookkeeping.

Closes #2353

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3200)
<!-- Reviewable:end -->
