### PR TITLE
repr: document and polish RelationDesc and RelationType APIs

### DIFF
--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -208,114 +208,114 @@ impl LogVariant {
     pub fn schema(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .add_nonnull_column("id", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("name", ScalarType::String)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("id", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("name", ScalarType::String)
+                .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .add_nonnull_column("id", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("source_node", ScalarType::Int64)
-                .add_nonnull_column("source_port", ScalarType::Int64)
-                .add_nonnull_column("target_node", ScalarType::Int64)
-                .add_nonnull_column("target_port", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("id", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("source_node", ScalarType::Int64)
+                .with_nonnull_column("source_port", ScalarType::Int64)
+                .with_nonnull_column("target_node", ScalarType::Int64)
+                .with_nonnull_column("target_port", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .add_nonnull_column("id", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("elapsed_ns", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("id", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("elapsed_ns", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .add_nonnull_column("id", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("duration_ns", ScalarType::Int64)
-                .add_nonnull_column("count", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("id", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("duration_ns", ScalarType::Int64)
+                .with_nonnull_column("count", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .add_nonnull_column("id", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("slot", ScalarType::Int64)
-                .add_nonnull_column("value", ScalarType::Int64)
-                .add_keys(vec![0, 1, 2]),
+                .with_nonnull_column("id", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("slot", ScalarType::Int64)
+                .with_nonnull_column("value", ScalarType::Int64)
+                .with_key(vec![0, 1, 2]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("slept_for", ScalarType::Int64)
-                .add_nonnull_column("requested", ScalarType::Int64)
-                .add_nonnull_column("count", ScalarType::Int64)
-                .add_keys(vec![0, 1, 2]),
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("slept_for", ScalarType::Int64)
+                .with_nonnull_column("requested", ScalarType::Int64)
+                .with_nonnull_column("count", ScalarType::Int64)
+                .with_key(vec![0, 1, 2]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
-                .add_nonnull_column("operator", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("records", ScalarType::Int64)
-                .add_nonnull_column("batches", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("operator", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("records", ScalarType::Int64)
+                .with_nonnull_column("batches", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .add_nonnull_column("operator", ScalarType::Int64)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("count", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("operator", ScalarType::Int64)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("count", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .add_nonnull_column("name", ScalarType::String)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("name", ScalarType::String)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .add_nonnull_column("dataflow", ScalarType::String)
-                .add_nonnull_column("source", ScalarType::String)
-                .add_nonnull_column("worker", ScalarType::Int64),
+                .with_nonnull_column("dataflow", ScalarType::String)
+                .with_nonnull_column("source", ScalarType::String)
+                .with_nonnull_column("worker", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .add_nonnull_column("global_id", ScalarType::String)
-                .add_nonnull_column("time", ScalarType::Int64),
+                .with_nonnull_column("global_id", ScalarType::String)
+                .with_nonnull_column("time", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .add_nonnull_column("uuid", ScalarType::String)
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("id", ScalarType::String)
-                .add_nonnull_column("time", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("uuid", ScalarType::String)
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("id", ScalarType::String)
+                .with_nonnull_column("time", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .add_nonnull_column("worker", ScalarType::Int64)
-                .add_nonnull_column("duration_ns", ScalarType::Int64)
-                .add_nonnull_column("count", ScalarType::Int64)
-                .add_keys(vec![0, 1]),
+                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("duration_ns", ScalarType::Int64)
+                .with_nonnull_column("count", ScalarType::Int64)
+                .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PrimaryKeys) => RelationDesc::empty()
-                .add_nonnull_column("global_id", ScalarType::String)
-                .add_nonnull_column("column", ScalarType::Int64)
-                .add_nonnull_column("key_group", ScalarType::Int64),
+                .with_nonnull_column("global_id", ScalarType::String)
+                .with_nonnull_column("column", ScalarType::Int64)
+                .with_nonnull_column("key_group", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::ForeignKeys) => RelationDesc::empty()
-                .add_nonnull_column("child_id", ScalarType::String)
-                .add_nonnull_column("child_column", ScalarType::Int64)
-                .add_nonnull_column("parent_id", ScalarType::String)
-                .add_nonnull_column("parent_column", ScalarType::Int64)
-                .add_nonnull_column("key_group", ScalarType::Int64)
-                .add_keys(vec![0, 1, 4]),
+                .with_nonnull_column("child_id", ScalarType::String)
+                .with_nonnull_column("child_column", ScalarType::Int64)
+                .with_nonnull_column("parent_id", ScalarType::String)
+                .with_nonnull_column("parent_column", ScalarType::Int64)
+                .with_nonnull_column("key_group", ScalarType::Int64)
+                .with_key(vec![0, 1, 4]),
 
             LogVariant::Materialized(MaterializedLog::Catalog) => RelationDesc::empty()
-                .add_nonnull_column("global_id", ScalarType::String)
-                .add_nonnull_column("name", ScalarType::String)
-                .add_keys(vec![0]),
+                .with_nonnull_column("global_id", ScalarType::String)
+                .with_nonnull_column("name", ScalarType::String)
+                .with_key(vec![0]),
 
             LogVariant::Materialized(MaterializedLog::KafkaSinks) => RelationDesc::empty()
-                .add_nonnull_column("global_id", ScalarType::String)
-                .add_nonnull_column("topic", ScalarType::String)
-                .add_keys(vec![0]),
+                .with_nonnull_column("global_id", ScalarType::String)
+                .with_nonnull_column("topic", ScalarType::String)
+                .with_key(vec![0]),
 
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => RelationDesc::empty()
-                .add_nonnull_column("global_id", ScalarType::String)
-                .add_nonnull_column("path", ScalarType::Bytes)
-                .add_keys(vec![0]),
+                .with_nonnull_column("global_id", ScalarType::String)
+                .with_nonnull_column("path", ScalarType::Bytes)
+                .with_key(vec![0]),
         }
     }
 

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -208,113 +208,113 @@ impl LogVariant {
     pub fn schema(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .add_column("id", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("name", ScalarType::String)
+                .add_nonnull_column("id", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("name", ScalarType::String)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .add_column("id", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("source_node", ScalarType::Int64)
-                .add_column("source_port", ScalarType::Int64)
-                .add_column("target_node", ScalarType::Int64)
-                .add_column("target_port", ScalarType::Int64)
+                .add_nonnull_column("id", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("source_node", ScalarType::Int64)
+                .add_nonnull_column("source_port", ScalarType::Int64)
+                .add_nonnull_column("target_node", ScalarType::Int64)
+                .add_nonnull_column("target_port", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .add_column("id", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("elapsed_ns", ScalarType::Int64)
+                .add_nonnull_column("id", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("elapsed_ns", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .add_column("id", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("duration_ns", ScalarType::Int64)
-                .add_column("count", ScalarType::Int64)
+                .add_nonnull_column("id", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("duration_ns", ScalarType::Int64)
+                .add_nonnull_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .add_column("id", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("slot", ScalarType::Int64)
-                .add_column("value", ScalarType::Int64)
+                .add_nonnull_column("id", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("slot", ScalarType::Int64)
+                .add_nonnull_column("value", ScalarType::Int64)
                 .add_keys(vec![0, 1, 2]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .add_column("worker", ScalarType::Int64)
-                .add_column("slept_for", ScalarType::Int64)
-                .add_column("requested", ScalarType::Int64)
-                .add_column("count", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("slept_for", ScalarType::Int64)
+                .add_nonnull_column("requested", ScalarType::Int64)
+                .add_nonnull_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1, 2]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
-                .add_column("operator", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("records", ScalarType::Int64)
-                .add_column("batches", ScalarType::Int64)
+                .add_nonnull_column("operator", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("records", ScalarType::Int64)
+                .add_nonnull_column("batches", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .add_column("operator", ScalarType::Int64)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("count", ScalarType::Int64)
+                .add_nonnull_column("operator", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .add_column("name", ScalarType::String)
-                .add_column("worker", ScalarType::Int64)
+                .add_nonnull_column("name", ScalarType::String)
+                .add_nonnull_column("worker", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .add_column("dataflow", ScalarType::String)
-                .add_column("source", ScalarType::String)
-                .add_column("worker", ScalarType::Int64),
+                .add_nonnull_column("dataflow", ScalarType::String)
+                .add_nonnull_column("source", ScalarType::String)
+                .add_nonnull_column("worker", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .add_column("global_id", ScalarType::String)
-                .add_column("time", ScalarType::Int64),
+                .add_nonnull_column("global_id", ScalarType::String)
+                .add_nonnull_column("time", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .add_column("uuid", ScalarType::String)
-                .add_column("worker", ScalarType::Int64)
-                .add_column("id", ScalarType::String)
-                .add_column("time", ScalarType::Int64)
+                .add_nonnull_column("uuid", ScalarType::String)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("id", ScalarType::String)
+                .add_nonnull_column("time", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .add_column("worker", ScalarType::Int64)
-                .add_column("duration_ns", ScalarType::Int64)
-                .add_column("count", ScalarType::Int64)
+                .add_nonnull_column("worker", ScalarType::Int64)
+                .add_nonnull_column("duration_ns", ScalarType::Int64)
+                .add_nonnull_column("count", ScalarType::Int64)
                 .add_keys(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PrimaryKeys) => RelationDesc::empty()
-                .add_column("global_id", ScalarType::String)
-                .add_column("column", ScalarType::Int64)
-                .add_column("key_group", ScalarType::Int64),
+                .add_nonnull_column("global_id", ScalarType::String)
+                .add_nonnull_column("column", ScalarType::Int64)
+                .add_nonnull_column("key_group", ScalarType::Int64),
 
             LogVariant::Materialized(MaterializedLog::ForeignKeys) => RelationDesc::empty()
-                .add_column("child_id", ScalarType::String)
-                .add_column("child_column", ScalarType::Int64)
-                .add_column("parent_id", ScalarType::String)
-                .add_column("parent_column", ScalarType::Int64)
-                .add_column("key_group", ScalarType::Int64)
+                .add_nonnull_column("child_id", ScalarType::String)
+                .add_nonnull_column("child_column", ScalarType::Int64)
+                .add_nonnull_column("parent_id", ScalarType::String)
+                .add_nonnull_column("parent_column", ScalarType::Int64)
+                .add_nonnull_column("key_group", ScalarType::Int64)
                 .add_keys(vec![0, 1, 4]),
 
             LogVariant::Materialized(MaterializedLog::Catalog) => RelationDesc::empty()
-                .add_column("global_id", ScalarType::String)
-                .add_column("name", ScalarType::String)
+                .add_nonnull_column("global_id", ScalarType::String)
+                .add_nonnull_column("name", ScalarType::String)
                 .add_keys(vec![0]),
 
             LogVariant::Materialized(MaterializedLog::KafkaSinks) => RelationDesc::empty()
-                .add_column("global_id", ScalarType::String)
-                .add_column("topic", ScalarType::String)
+                .add_nonnull_column("global_id", ScalarType::String)
+                .add_nonnull_column("topic", ScalarType::String)
                 .add_keys(vec![0]),
 
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => RelationDesc::empty()
-                .add_column("global_id", ScalarType::String)
-                .add_column("path", ScalarType::Bytes)
+                .add_nonnull_column("global_id", ScalarType::String)
+                .add_nonnull_column("path", ScalarType::Bytes)
                 .add_keys(vec![0]),
         }
     }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -28,7 +28,7 @@ use expr::{GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInst
 use interchange::avro;
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use regex::Regex;
-use repr::{ColumnType, RelationDesc, RelationType, Row, ScalarType};
+use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType};
 
 /// System-wide update type.
 pub type Diff = isize;
@@ -472,17 +472,12 @@ pub enum ExternalSourceConnector {
 }
 
 impl ExternalSourceConnector {
-    pub fn metadata_columns(&self) -> Vec<(Option<String>, ColumnType)> {
+    pub fn metadata_columns(&self) -> Vec<(ColumnName, ColumnType)> {
         match self {
-            Self::Kafka(_) => vec![(Some("mz_offset".into()), ColumnType::new(ScalarType::Int64))],
-            Self::File(_) => vec![(
-                Some("mz_line_no".into()),
-                ColumnType::new(ScalarType::Int64),
-            )],
+            Self::Kafka(_) => vec![("mz_offset".into(), ColumnType::new(ScalarType::Int64))],
+            Self::File(_) => vec![("mz_line_no".into(), ColumnType::new(ScalarType::Int64))],
             Self::Kinesis(_) => vec![],
-            Self::AvroOcf(_) => {
-                vec![(Some("mz_obj_no".into()), ColumnType::new(ScalarType::Int64))]
-            }
+            Self::AvroOcf(_) => vec![("mz_obj_no".into(), ColumnType::new(ScalarType::Int64))],
         }
     }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -289,13 +289,10 @@ impl DataEncoding {
             //rename key columns to "key" something if the encoding is not Avro
             let key_desc = match key_encoding {
                 DataEncoding::Avro(_) => key_desc,
-                _ => RelationDesc::new(
-                    key_desc.typ().clone(),
-                    key_desc
-                        .iter_names()
-                        .enumerate()
-                        .map(|(i, _)| Some(format!("key{}", i))),
-                ),
+                _ => {
+                    let names = (0..key_desc.arity()).map(|i| Some(format!("key{}", i)));
+                    key_desc.with_names(names)
+                }
             };
             let keys = key_desc
                 .iter_names()

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -308,10 +308,9 @@ impl DataEncoding {
         };
 
         let desc = match self {
-            DataEncoding::Bytes => RelationDesc::from_cols(vec![(
-                ColumnType::new(ScalarType::Bytes),
-                Some("data".to_owned()),
-            )]),
+            DataEncoding::Bytes => {
+                RelationDesc::empty().add_nonnull_column("data", ScalarType::Bytes)
+            }
             DataEncoding::AvroOcf { reader_schema } => {
                 avro::validate_value_schema(&*reader_schema, envelope.get_avro_envelope_type())
                     .with_context(|e| format!("validating avro ocf reader schema: {}", e))?
@@ -338,43 +337,31 @@ impl DataEncoding {
                 let d = decode_descriptors(descriptors)?;
                 validate_descriptors(message_name, &d)?
             }
-            DataEncoding::Regex { regex } => {
-                RelationDesc::from_cols(
-                    regex
-                        .capture_names()
-                        .enumerate()
-                        // The first capture is the entire matched string.
-                        // This will often not be useful, so skip it.
-                        // If people want it they can just surround their
-                        // entire regex in an explicit capture group.
-                        .skip(1)
-                        .map(|(i, ocn)| {
-                            (
-                                ColumnType::new(ScalarType::String).nullable(true),
-                                match ocn {
-                                    None => Some(format!("column{}", i)),
-                                    Some(ocn) => Some(String::from(ocn)),
-                                },
-                            )
-                        })
-                        .collect(),
-                )
+            DataEncoding::Regex { regex } => regex
+                .capture_names()
+                .enumerate()
+                // The first capture is the entire matched string. This will
+                // often not be useful, so skip it. If people want it they can
+                // just surround their entire regex in an explicit capture
+                // group.
+                .skip(1)
+                .fold(RelationDesc::empty(), |desc, (i, ocn)| {
+                    let name = match ocn {
+                        None => format!("column{}", i),
+                        Some(ocn) => ocn.to_owned(),
+                    };
+                    let ty = ColumnType::new(ScalarType::String).nullable(true);
+                    desc.add_column(name, ty)
+                }),
+            DataEncoding::Csv(CsvEncoding { n_cols, .. }) => (1..=*n_cols)
+                .fold(RelationDesc::empty(), |desc, i| {
+                    desc.add_nonnull_column(format!("column{}", i), ScalarType::String)
+                }),
+            DataEncoding::Text => {
+                RelationDesc::empty().add_nonnull_column("text", ScalarType::String)
             }
-            DataEncoding::Csv(CsvEncoding { n_cols, .. }) => RelationDesc::from_cols(
-                (1..=*n_cols)
-                    .map(|i| {
-                        (
-                            ColumnType::new(ScalarType::String),
-                            Some(format!("column{}", i)),
-                        )
-                    })
-                    .collect(),
-            ),
-            DataEncoding::Text => RelationDesc::from_cols(vec![(
-                ColumnType::new(ScalarType::String),
-                Some("text".to_owned()),
-            )]),
         };
+
         Ok(full_desc.concat(desc))
     }
 

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -224,7 +224,7 @@ impl RelationExpr {
                 }
                 let result = typ.clone();
                 if rows.len() == 0 || (rows.len() == 1 && rows[0].1 == 1) {
-                    result.add_keys(Vec::new())
+                    result.with_key(Vec::new())
                 } else {
                     result
                 }
@@ -241,7 +241,7 @@ impl RelationExpr {
                 );
                 for keys in input_typ.keys {
                     if keys.iter().all(|k| outputs.contains(k)) {
-                        output_typ = output_typ.add_keys(
+                        output_typ = output_typ.with_key(
                             keys.iter()
                                 .map(|c| outputs.iter().position(|o| o == c).unwrap())
                                 .collect(),
@@ -296,7 +296,7 @@ impl RelationExpr {
                         }
                     }
                     for new_key in new_keys {
-                        typ = typ.add_keys(new_key);
+                        typ = typ.with_key(new_key);
                     }
                 }
 
@@ -376,7 +376,7 @@ impl RelationExpr {
                 });
                 if remains_unique && !inputs.is_empty() {
                     for keys in input_types[0].keys.iter() {
-                        typ = typ.add_keys(keys.clone());
+                        typ = typ.with_key(keys.clone());
                     }
                 }
                 typ
@@ -420,7 +420,7 @@ impl RelationExpr {
                     keys.push((0..group_key.len()).collect());
                 }
                 for key in keys {
-                    result = result.add_keys(key);
+                    result = result.with_key(key);
                 }
                 result
             }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -28,7 +28,7 @@ use avro::schema::{
 use avro::types::{DecimalValue, Value};
 use repr::adt::decimal::{Significand, MAX_DECIMAL_PRECISION};
 use repr::adt::jsonb::{JsonbPacker, JsonbRef};
-use repr::{ColumnName, ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use repr::{ColumnName, ColumnType, Datum, RelationDesc, Row, RowPacker, ScalarType};
 
 use crate::error::Result;
 
@@ -44,18 +44,16 @@ pub fn validate_key_schema(key_schema: &str, value_desc: &RelationDesc) -> Resul
     let key_desc = validate_schema_1(key_schema.top_node())?;
     let mut indices = Vec::new();
     for (name, key_type) in key_desc.iter() {
-        if let Some(name) = name {
-            match value_desc.get_by_name(name) {
-                Some((index, value_type)) if key_type == value_type => {
-                    indices.push(index);
-                }
-                Some((_, value_type)) => bail!(
-                    "key and value column types do not match: key {:?} vs. value {:?}",
-                    key_type,
-                    value_type,
-                ),
-                None => bail!("Value schema missing primary key column: {}", name),
+        match value_desc.get_by_name(name) {
+            Some((index, value_type)) if key_type == value_type => {
+                indices.push(index);
             }
+            Some((_, value_type)) => bail!(
+                "key and value column types do not match: key {:?} vs. value {:?}",
+                key_type,
+                value_type,
+            ),
+            None => bail!("Value schema missing primary key column: {}", name),
         }
     }
     Ok(indices)
@@ -67,8 +65,11 @@ pub enum EnvelopeType {
     Upsert,
 }
 
-/// Converts an Apache Avro schema into a [`repr::RelationDesc`].
-pub fn validate_value_schema(schema: &str, envelope: EnvelopeType) -> Result<RelationDesc> {
+/// Converts an Apache Avro schema into a list of column names and types.
+pub fn validate_value_schema(
+    schema: &str,
+    envelope: EnvelopeType,
+) -> Result<Vec<(ColumnName, ColumnType)>> {
     let schema = parse_schema(schema)?;
     let node = schema.top_node();
 
@@ -140,60 +141,51 @@ pub fn validate_value_schema(schema: &str, envelope: EnvelopeType) -> Result<Rel
     validate_schema_1(node.step(row_schema))
 }
 
-fn validate_schema_1(schema: SchemaNode) -> Result<RelationDesc> {
+fn validate_schema_1(schema: SchemaNode) -> Result<Vec<(ColumnName, ColumnType)>> {
     match schema.inner {
         SchemaPiece::Record { fields, .. } => {
-            let mut column_types = vec![];
+            let mut columns = vec![];
             for f in fields {
                 if let SchemaPiece::Union(us) = schema.step(&f.schema).inner {
-                    if us.variants().is_empty()
-                        || (us.variants().len() == 1 && is_null(&us.variants()[0]))
-                    {
+                    let vs = us.variants();
+                    if vs.is_empty() || (vs.len() == 1 && is_null(&vs[0])) {
                         bail!(format_err!("Empty or null-only unions are not supported"));
                     } else {
-                        let nullable = us.variants().len() > 1;
-                        for v in us.variants() {
-                            if !is_null(v) {
-                                let node = schema.step(v);
-                                if let SchemaPiece::Union(_) = node.inner {
-                                    unreachable!("Internal error: directly nested avro union!");
-                                }
-                                column_types.push(ColumnType {
-                                    nullable,
-                                    scalar_type: validate_schema_2(node)?,
-                                });
+                        for (i, v) in vs.iter().filter(|v| !is_null(v)).enumerate() {
+                            let node = schema.step(v);
+                            if let SchemaPiece::Union(_) = node.inner {
+                                unreachable!("Internal error: directly nested avro union!");
                             }
+
+                            let name = if vs.len() == 1 || (vs.len() == 2 && vs.iter().any(is_null))
+                            {
+                                // There is only one non-null variant in the
+                                // union, so we can use the field name directly.
+                                f.name.clone()
+                            } else {
+                                // There are multiple non-null variants in the
+                                // union, so we need to invent field names for
+                                // each variant.
+                                format!("{}{}", &f.name, i + 1)
+                            };
+
+                            // If there is more than one variant in the union,
+                            // the column's output type is nullable, as this
+                            // column will be null whenever it is uninhabited.
+                            let ty = validate_schema_2(node)?;
+                            let nullable = vs.len() > 1;
+                            columns.push((name.into(), ColumnType::new(ty).nullable(nullable)));
                         }
                     }
                 } else {
                     let scalar_type = validate_schema_2(schema.step(&f.schema))?;
-                    column_types.push(ColumnType {
-                        nullable: false,
-                        scalar_type,
-                    });
+                    columns.push((
+                        f.name.clone().into(),
+                        ColumnType::new(scalar_type).nullable(false),
+                    ));
                 }
             }
-            let mut column_names = vec![];
-            for f in fields {
-                if let SchemaPiece::Union(us) = schema.step(&f.schema).inner {
-                    let vs = us.variants();
-                    if vs.len() == 1 || (vs.len() == 2 && vs.iter().any(is_null)) {
-                        column_names.push(Some(f.name.clone()));
-                    } else {
-                        for (i, v) in vs.iter().enumerate() {
-                            if !is_null(v) {
-                                column_names.push(Some(format!("{}{}", &f.name, i + 1)));
-                            }
-                        }
-                    }
-                } else {
-                    column_names.push(Some(f.name.clone()));
-                }
-            }
-            Ok(RelationDesc::new(
-                RelationType::new(column_types),
-                column_names,
-            ))
+            Ok(columns)
         }
         _ => bail!("row schemas must be records, got: {:?}", schema.inner),
     }
@@ -1018,7 +1010,7 @@ mod tests {
     struct TestCase {
         name: String,
         input: serde_json::Value,
-        expected: RelationDesc,
+        expected: Vec<(ColumnName, ColumnType)>,
     }
 
     #[test]
@@ -1104,10 +1096,7 @@ mod tests {
             ),
         ];
         for (typ, datum, expected) in valid_pairings {
-            let desc = RelationDesc::new(
-                RelationType::new(vec![ColumnType::new(typ)]),
-                vec!["column1".into()],
-            );
+            let desc = RelationDesc::empty().with_nonnull_column("column1", typ);
             let avro_value = Encoder::new(desc).row_to_avro(vec![datum]);
             assert_eq!(
                 Value::Record(vec![("column1".into(), expected)]),

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -188,13 +188,6 @@ impl RelationDesc {
         RelationDesc { typ, names }
     }
 
-    pub fn from_cols(cols: Vec<(ColumnType, Option<String>)>) -> RelationDesc {
-        Self::new(
-            RelationType::new(cols.iter().map(|(typ, _)| typ.clone()).collect()),
-            cols.into_iter().map(|(_, name)| name),
-        )
-    }
-
     pub fn concat(mut self, other: Self) -> Self {
         let self_len = self.typ.column_types.len();
         self.names.extend(other.names);

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -66,6 +66,17 @@ impl ColumnType {
     }
 }
 
+impl fmt::Display for ColumnType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}{}",
+            self.scalar_type,
+            if self.nullable { "?" } else { "" }
+        )
+    }
+}
+
 /// The type of a relation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RelationType {

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -259,6 +259,21 @@ impl RelationDesc {
         self
     }
 
+    /// Builds a new relation description with the column names replaced with
+    /// new names.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the arity of the relation type does not match the number of
+    /// items in `names`.
+    pub fn with_names<I, N>(self, names: I) -> Self
+    where
+        I: IntoIterator<Item = Option<N>>,
+        N: Into<ColumnName>,
+    {
+        Self::new(self.typ, names)
+    }
+
     /// Computes the number of columns in the relation.
     pub fn arity(&self) -> usize {
         self.typ.arity()

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -59,11 +59,6 @@ impl ColumnType {
         self.nullable = nullable;
         self
     }
-
-    /// Required outside of builder contexts.
-    pub fn set_nullable(&mut self, nullable: bool) {
-        self.nullable = nullable
-    }
 }
 
 impl fmt::Display for ColumnType {

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -261,16 +261,12 @@ impl RelationDesc {
     }
 
     pub fn get_unambiguous_name(&self, i: usize) -> Option<&ColumnName> {
-        let name = self.get_name(i);
+        let name = self.names[i].as_ref();
         if self.iter_names().filter(|n| n == &name).count() == 1 {
             name
         } else {
             None
         }
-    }
-
-    pub fn get_name(&self, i: usize) -> Option<&ColumnName> {
-        self.names[i].as_ref()
     }
 }
 

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -206,17 +206,6 @@ impl RelationDesc {
         self
     }
 
-    pub fn add_cols<I, N>(&mut self, cols: I)
-    where
-        I: IntoIterator<Item = (Option<N>, ColumnType)>,
-        N: Into<ColumnName>,
-    {
-        for (name, typ) in cols.into_iter() {
-            self.typ.column_types.push(typ);
-            self.names.push(name.map(Into::into));
-        }
-    }
-
     /// Adds a new named, nonnullable column with the specified scalar type.
     pub fn add_nonnull_column<N>(self, name: N, scalar_type: ScalarType) -> RelationDesc
     where

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -217,9 +217,20 @@ impl RelationDesc {
         }
     }
 
-    /// Adds a new named, nonnullable column with the specified type.
-    pub fn add_column(mut self, name: impl Into<ColumnName>, scalar_type: ScalarType) -> Self {
-        self.typ.column_types.push(ColumnType::new(scalar_type));
+    /// Adds a new named, nonnullable column with the specified scalar type.
+    pub fn add_nonnull_column<N>(self, name: N, scalar_type: ScalarType) -> RelationDesc
+    where
+        N: Into<ColumnName>,
+    {
+        self.add_column(name, ColumnType::new(scalar_type))
+    }
+
+    /// Adds a new named column with the specified column type.
+    pub fn add_column<N>(mut self, name: N, column_type: ColumnType) -> RelationDesc
+    where
+        N: Into<ColumnName>,
+    {
+        self.typ.column_types.push(column_type);
         self.names.push(Some(name.into()));
         self
     }

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -66,41 +66,33 @@ impl ColumnType {
     }
 }
 
-impl fmt::Display for ColumnType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}{}",
-            self.scalar_type,
-            if self.nullable { "?" } else { "" }
-        )
-    }
-}
-
-/// The type for a relation.
+/// The type of a relation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RelationType {
     /// The type for each column, in order.
     pub column_types: Vec<ColumnType>,
     /// Sets of indices that are "keys" for the collection.
     ///
-    /// Each element in this list is a set of column indices, each with the property
-    /// that the collection contains at most one record with each distinct set of values
-    /// for each column. Alternately, for a specific set of values assigned to the these
-    /// columns there is at most one record.
+    /// Each element in this list is a set of column indices, each with the
+    /// property that the collection contains at most one record with each
+    /// distinct set of values for each column. Alternately, for a specific set
+    /// of values assigned to the these columns there is at most one record.
     ///
-    /// A collection can contain multiple sets of keys, although it is common to have
-    /// either zero or one sets of key indices.
+    /// A collection can contain multiple sets of keys, although it is common to
+    /// have either zero or one sets of key indices.
     pub keys: Vec<Vec<usize>>,
 }
 
 impl RelationType {
-    /// Creates a relation type representing the relation with no columns.
+    /// Constructs a `RelationType` representing the relation with no columns and
+    /// no keys.
     pub fn empty() -> Self {
         RelationType::new(vec![])
     }
 
-    /// Creates a new instance from specified column types.
+    /// Constructs a new `RelationType` from specified column types.
+    ///
+    /// The `RelationType` will have no keys.
     pub fn new(column_types: Vec<ColumnType>) -> Self {
         RelationType {
             column_types,
@@ -108,8 +100,8 @@ impl RelationType {
         }
     }
 
-    /// Adds a set of indices as keys for the colleciton.
-    pub fn add_keys(mut self, mut indices: Vec<usize>) -> Self {
+    /// Adds a new key for the relation.
+    pub fn with_key(mut self, mut indices: Vec<usize>) -> Self {
         indices.sort();
         if !self.keys.contains(&indices) {
             self.keys.push(indices);
@@ -117,7 +109,7 @@ impl RelationType {
         self
     }
 
-    /// The number of columns in the relation type.
+    /// Computes the number of columns in the relation.
     pub fn arity(&self) -> usize {
         self.column_types.len()
     }
@@ -158,8 +150,40 @@ impl From<&ColumnName> for ColumnName {
     }
 }
 
-/// A complete relation description. Bundles together a `RelationType` with
-/// additional metadata, like the names of each column.
+/// A description of the shape of a relation.
+///
+/// It bundles a [`RelationType`] with the name of each column in the relation.
+/// Individual column names are optional.
+///
+/// # Examples
+///
+/// A `RelationDesc`s is typically constructed via its builder API:
+///
+/// ```
+/// use repr::{ColumnType, RelationDesc, ScalarType};
+///
+/// let desc = RelationDesc::empty()
+///     .with_nonnull_column("id", ScalarType::Int64)
+///     .with_column("price", ColumnType::new(ScalarType::Float64).nullable(true));
+/// ```
+///
+/// In more complicated cases, like when constructing a `RelationDesc` in
+/// response to user input, it may be more convenient to construct a relation
+/// type first, and imbue it with column names to form a `RelationDesc` later:
+///
+/// ```
+/// use repr::RelationDesc;
+///
+/// # fn plan_query(_: &str) -> repr::RelationType { repr::RelationType::new(vec![]) }
+/// let relation_type = plan_query("SELECT * FROM table");
+/// let names = (0..relation_type.arity()).map(|i| match i {
+///     0 => Some("first"),
+///     1 => Some("second"),
+///     // Leave the rest of the columns unnamed.
+///     _ => None,
+/// });
+/// let desc = RelationDesc::new(relation_type, names);
+/// ```
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RelationDesc {
     typ: RelationType,
@@ -167,18 +191,23 @@ pub struct RelationDesc {
 }
 
 impl RelationDesc {
-    /// Constructs a new `RelationDesc` that represents a relation with no
-    /// columns and no keys.
-    pub fn empty() -> RelationDesc {
+    /// Constructs a new `RelationDesc` that represents the empty relation
+    /// with no columns and no keys.
+    pub fn empty() -> Self {
         RelationDesc {
             typ: RelationType::empty(),
             names: vec![],
         }
     }
 
-    /// Constructs a new `RelationDesc` from a `RelationType` and a list of
-    /// column names.
-    pub fn new<I, N>(typ: RelationType, names: I) -> RelationDesc
+    /// Constructs a new `RelationDesc` from a `RelationType` and an iterator
+    /// over column names.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the arity of the `RelationType` is not equal to the number of
+    /// items in `names`.
+    pub fn new<I, N>(typ: RelationType, names: I) -> Self
     where
         I: IntoIterator<Item = Option<N>>,
         N: Into<ColumnName>,
@@ -188,27 +217,28 @@ impl RelationDesc {
         RelationDesc { typ, names }
     }
 
+    /// Concatenates a `RelationDesc` onto the end of this `RelationDesc`.
     pub fn concat(mut self, other: Self) -> Self {
         let self_len = self.typ.column_types.len();
         self.names.extend(other.names);
         self.typ.column_types.extend(other.typ.column_types);
         for k in other.typ.keys {
             let k = k.into_iter().map(|idx| idx + self_len).collect();
-            self = self.add_keys(k);
+            self = self.with_key(k);
         }
         self
     }
 
-    /// Adds a new named, nonnullable column with the specified scalar type.
-    pub fn add_nonnull_column<N>(self, name: N, scalar_type: ScalarType) -> RelationDesc
+    /// Appends a named, nonnullable column with the specified scalar type.
+    pub fn with_nonnull_column<N>(self, name: N, scalar_type: ScalarType) -> Self
     where
         N: Into<ColumnName>,
     {
-        self.add_column(name, ColumnType::new(scalar_type))
+        self.with_column(name, ColumnType::new(scalar_type))
     }
 
-    /// Adds a new named column with the specified column type.
-    pub fn add_column<N>(mut self, name: N, column_type: ColumnType) -> RelationDesc
+    /// Appends a named column with the specified column type.
+    pub fn with_column<N>(mut self, name: N, column_type: ColumnType) -> Self
     where
         N: Into<ColumnName>,
     {
@@ -217,42 +247,62 @@ impl RelationDesc {
         self
     }
 
-    /// Adds a set of indices as keys for the relation.
-    pub fn add_keys(mut self, mut indices: Vec<usize>) -> Self {
-        indices.sort();
-        if !self.typ.keys.contains(&indices) {
-            self.typ.keys.push(indices);
-        }
+    /// Adds a new key for the relation.
+    pub fn with_key(mut self, indices: Vec<usize>) -> Self {
+        self.typ = self.typ.with_key(indices);
         self
     }
 
-    /// Deletes all keys for the relation
-    pub fn clear_keys(&mut self) {
-        self.typ.keys.clear()
+    /// Drops all existing keys.
+    pub fn without_keys(mut self) -> Self {
+        self.typ.keys.clear();
+        self
     }
 
+    /// Computes the number of columns in the relation.
+    pub fn arity(&self) -> usize {
+        self.typ.arity()
+    }
+
+    /// Returns the relation type underlying this relation description.
     pub fn typ(&self) -> &RelationType {
         &self.typ
     }
 
+    /// Returns an iterator over the columns in this relation.
     pub fn iter(&self) -> impl Iterator<Item = (Option<&ColumnName>, &ColumnType)> {
         self.iter_names().zip(self.iter_types())
     }
 
+    /// Returns an iterator over the types of the columns in this relation.
     pub fn iter_types(&self) -> impl Iterator<Item = &ColumnType> {
         self.typ.column_types.iter()
     }
 
+    /// Returns an iterator over the names of the columns in this relation.
     pub fn iter_names(&self) -> impl Iterator<Item = Option<&ColumnName>> {
         self.names.iter().map(|n| n.as_ref())
     }
 
+    /// Finds a column by name.
+    ///
+    /// Returns the index and type of the column named `name`. If no column with
+    /// the specified name exists, returns `None`. If multiple columns have the
+    /// specified name, the leftmost column is returned.
     pub fn get_by_name(&self, name: &ColumnName) -> Option<(usize, &ColumnType)> {
         self.iter_names()
             .position(|n| n == Some(name))
             .map(|i| (i, &self.typ.column_types[i]))
     }
 
+    /// Gets the name of the `i`th column if that column name is unambiguous.
+    ///
+    /// If at least one other column has the same name as the `i`th column,
+    /// returns `None`. If the `i`th column has no name, returns `None`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is not a valid column index.
     pub fn get_unambiguous_name(&self, i: usize) -> Option<&ColumnName> {
         let name = self.names[i].as_ref();
         if self.iter_names().filter(|n| n == &name).count() == 1 {

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -8,6 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt;
+use std::iter;
+use std::vec;
 
 use failure::bail;
 use serde::{Deserialize, Serialize};
@@ -270,8 +272,13 @@ impl RelationDesc {
     pub fn get_name(&self, i: usize) -> Option<&ColumnName> {
         self.names[i].as_ref()
     }
+}
 
-    pub fn set_name(&mut self, i: usize, name: Option<ColumnName>) {
-        self.names[i] = name
+impl IntoIterator for RelationDesc {
+    type Item = (Option<ColumnName>, ColumnType);
+    type IntoIter = iter::Zip<vec::IntoIter<Option<ColumnName>>, vec::IntoIter<ColumnType>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.names.into_iter().zip(self.typ.column_types)
     }
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1276,7 +1276,11 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                 (DataEncoding::Avro { .. }, _)
                 | (DataEncoding::Protobuf { .. }, _)
                 | (_, Envelope::Debezium) => (),
-                _ => desc.add_cols(external_connector.metadata_columns()),
+                _ => {
+                    for (name, ty) in external_connector.metadata_columns() {
+                        desc = desc.add_column(name, ty);
+                    }
+                }
             }
 
             let if_not_exists = *if_not_exists;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -46,7 +46,7 @@ use crate::{normalize, unsupported};
 
 lazy_static! {
     static ref SHOW_DATABASES_DESC: RelationDesc =
-        { RelationDesc::empty().add_column("Database", ScalarType::String) };
+        { RelationDesc::empty().add_nonnull_column("Database", ScalarType::String) };
     static ref SHOW_INDEXES_DESC: RelationDesc = RelationDesc::new(
         RelationType::new(vec![
             ColumnType::new(ScalarType::String),
@@ -68,9 +68,9 @@ lazy_static! {
         .map(Some),
     );
     static ref SHOW_COLUMNS_DESC: RelationDesc = RelationDesc::empty()
-        .add_column("Field", ScalarType::String)
-        .add_column("Nullable", ScalarType::String)
-        .add_column("Type", ScalarType::String);
+        .add_nonnull_column("Field", ScalarType::String)
+        .add_nonnull_column("Nullable", ScalarType::String)
+        .add_nonnull_column("Type", ScalarType::String);
 }
 
 pub fn make_show_objects_desc(
@@ -81,17 +81,17 @@ pub fn make_show_objects_desc(
     let col_name = object_type_as_plural_str(object_type);
     if full {
         let mut relation_desc = RelationDesc::empty()
-            .add_column(col_name, ScalarType::String)
-            .add_column("TYPE", ScalarType::String);
+            .add_nonnull_column(col_name, ScalarType::String)
+            .add_nonnull_column("TYPE", ScalarType::String);
         if ObjectType::View == object_type {
-            relation_desc = relation_desc.add_column("QUERYABLE", ScalarType::Bool);
+            relation_desc = relation_desc.add_nonnull_column("QUERYABLE", ScalarType::Bool);
         }
         if !materialized && (ObjectType::View == object_type || ObjectType::Source == object_type) {
-            relation_desc = relation_desc.add_column("MATERIALIZED", ScalarType::Bool);
+            relation_desc = relation_desc.add_nonnull_column("MATERIALIZED", ScalarType::Bool);
         }
         relation_desc
     } else {
-        RelationDesc::empty().add_column(col_name, ScalarType::String)
+        RelationDesc::empty().add_nonnull_column(col_name, ScalarType::String)
     }
 }
 
@@ -118,7 +118,7 @@ pub fn describe_statement(
         Statement::Explain {
             stage, explainee, ..
         } => (
-            Some(RelationDesc::empty().add_column(
+            Some(RelationDesc::empty().add_nonnull_column(
                 match stage {
                     ExplainStage::Sql => "Sql",
                     ExplainStage::RawPlan => "Raw Plan",
@@ -138,8 +138,8 @@ pub fn describe_statement(
         Statement::ShowCreateView { .. } => (
             Some(
                 RelationDesc::empty()
-                    .add_column("View", ScalarType::String)
-                    .add_column("Create View", ScalarType::String),
+                    .add_nonnull_column("View", ScalarType::String)
+                    .add_nonnull_column("Create View", ScalarType::String),
             ),
             vec![],
         ),
@@ -147,8 +147,8 @@ pub fn describe_statement(
         Statement::ShowCreateSource { .. } => (
             Some(
                 RelationDesc::empty()
-                    .add_column("Source", ScalarType::String)
-                    .add_column("Create Source", ScalarType::String),
+                    .add_nonnull_column("Source", ScalarType::String)
+                    .add_nonnull_column("Create Source", ScalarType::String),
             ),
             vec![],
         ),
@@ -156,8 +156,8 @@ pub fn describe_statement(
         Statement::ShowCreateSink { .. } => (
             Some(
                 RelationDesc::empty()
-                    .add_column("Sink", ScalarType::String)
-                    .add_column("Create Sink", ScalarType::String),
+                    .add_nonnull_column("Sink", ScalarType::String)
+                    .add_nonnull_column("Create Sink", ScalarType::String),
             ),
             vec![],
         ),
@@ -182,15 +182,18 @@ pub fn describe_statement(
                 (
                     Some(
                         RelationDesc::empty()
-                            .add_column("name", ScalarType::String)
-                            .add_column("setting", ScalarType::String)
-                            .add_column("description", ScalarType::String),
+                            .add_nonnull_column("name", ScalarType::String)
+                            .add_nonnull_column("setting", ScalarType::String)
+                            .add_nonnull_column("description", ScalarType::String),
                     ),
                     vec![],
                 )
             } else {
                 (
-                    Some(RelationDesc::empty().add_column(variable.as_str(), ScalarType::String)),
+                    Some(
+                        RelationDesc::empty()
+                            .add_nonnull_column(variable.as_str(), ScalarType::String),
+                    ),
                     vec![],
                 )
             }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1336,7 +1336,8 @@ fn maybe_rename_columns(
     let new_names = column_names
         .iter()
         .map(|n| Some(normalize::column_name(n.clone())));
-    Ok(RelationDesc::new(desc.typ().clone(), new_names))
+
+    Ok(desc.with_names(new_names))
 }
 
 fn handle_drop_database(

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -46,7 +46,7 @@ use crate::{normalize, unsupported};
 
 lazy_static! {
     static ref SHOW_DATABASES_DESC: RelationDesc =
-        { RelationDesc::empty().add_nonnull_column("Database", ScalarType::String) };
+        { RelationDesc::empty().with_nonnull_column("Database", ScalarType::String) };
     static ref SHOW_INDEXES_DESC: RelationDesc = RelationDesc::new(
         RelationType::new(vec![
             ColumnType::new(ScalarType::String),
@@ -68,9 +68,9 @@ lazy_static! {
         .map(Some),
     );
     static ref SHOW_COLUMNS_DESC: RelationDesc = RelationDesc::empty()
-        .add_nonnull_column("Field", ScalarType::String)
-        .add_nonnull_column("Nullable", ScalarType::String)
-        .add_nonnull_column("Type", ScalarType::String);
+        .with_nonnull_column("Field", ScalarType::String)
+        .with_nonnull_column("Nullable", ScalarType::String)
+        .with_nonnull_column("Type", ScalarType::String);
 }
 
 pub fn make_show_objects_desc(
@@ -81,17 +81,17 @@ pub fn make_show_objects_desc(
     let col_name = object_type_as_plural_str(object_type);
     if full {
         let mut relation_desc = RelationDesc::empty()
-            .add_nonnull_column(col_name, ScalarType::String)
-            .add_nonnull_column("TYPE", ScalarType::String);
+            .with_nonnull_column(col_name, ScalarType::String)
+            .with_nonnull_column("TYPE", ScalarType::String);
         if ObjectType::View == object_type {
-            relation_desc = relation_desc.add_nonnull_column("QUERYABLE", ScalarType::Bool);
+            relation_desc = relation_desc.with_nonnull_column("QUERYABLE", ScalarType::Bool);
         }
         if !materialized && (ObjectType::View == object_type || ObjectType::Source == object_type) {
-            relation_desc = relation_desc.add_nonnull_column("MATERIALIZED", ScalarType::Bool);
+            relation_desc = relation_desc.with_nonnull_column("MATERIALIZED", ScalarType::Bool);
         }
         relation_desc
     } else {
-        RelationDesc::empty().add_nonnull_column(col_name, ScalarType::String)
+        RelationDesc::empty().with_nonnull_column(col_name, ScalarType::String)
     }
 }
 
@@ -118,7 +118,7 @@ pub fn describe_statement(
         Statement::Explain {
             stage, explainee, ..
         } => (
-            Some(RelationDesc::empty().add_nonnull_column(
+            Some(RelationDesc::empty().with_nonnull_column(
                 match stage {
                     ExplainStage::Sql => "Sql",
                     ExplainStage::RawPlan => "Raw Plan",
@@ -138,8 +138,8 @@ pub fn describe_statement(
         Statement::ShowCreateView { .. } => (
             Some(
                 RelationDesc::empty()
-                    .add_nonnull_column("View", ScalarType::String)
-                    .add_nonnull_column("Create View", ScalarType::String),
+                    .with_nonnull_column("View", ScalarType::String)
+                    .with_nonnull_column("Create View", ScalarType::String),
             ),
             vec![],
         ),
@@ -147,8 +147,8 @@ pub fn describe_statement(
         Statement::ShowCreateSource { .. } => (
             Some(
                 RelationDesc::empty()
-                    .add_nonnull_column("Source", ScalarType::String)
-                    .add_nonnull_column("Create Source", ScalarType::String),
+                    .with_nonnull_column("Source", ScalarType::String)
+                    .with_nonnull_column("Create Source", ScalarType::String),
             ),
             vec![],
         ),
@@ -156,8 +156,8 @@ pub fn describe_statement(
         Statement::ShowCreateSink { .. } => (
             Some(
                 RelationDesc::empty()
-                    .add_nonnull_column("Sink", ScalarType::String)
-                    .add_nonnull_column("Create Sink", ScalarType::String),
+                    .with_nonnull_column("Sink", ScalarType::String)
+                    .with_nonnull_column("Create Sink", ScalarType::String),
             ),
             vec![],
         ),
@@ -182,9 +182,9 @@ pub fn describe_statement(
                 (
                     Some(
                         RelationDesc::empty()
-                            .add_nonnull_column("name", ScalarType::String)
-                            .add_nonnull_column("setting", ScalarType::String)
-                            .add_nonnull_column("description", ScalarType::String),
+                            .with_nonnull_column("name", ScalarType::String)
+                            .with_nonnull_column("setting", ScalarType::String)
+                            .with_nonnull_column("description", ScalarType::String),
                     ),
                     vec![],
                 )
@@ -192,7 +192,7 @@ pub fn describe_statement(
                 (
                     Some(
                         RelationDesc::empty()
-                            .add_nonnull_column(variable.as_str(), ScalarType::String),
+                            .with_nonnull_column(variable.as_str(), ScalarType::String),
                     ),
                     vec![],
                 )
@@ -1262,7 +1262,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                 Some(_) => bail!("ignore_source_keys must be a boolean"),
             };
             if ignore_source_keys {
-                desc.clear_keys();
+                desc = desc.without_keys();
             }
 
             desc = maybe_rename_columns(format!("source {}", name), desc, col_names)?;
@@ -1278,7 +1278,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                 | (_, Envelope::Debezium) => (),
                 _ => {
                     for (name, ty) in external_connector.metadata_columns() {
-                        desc = desc.add_column(name, ty);
+                        desc = desc.with_column(name, ty);
                     }
                 }
             }

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -31,7 +31,7 @@ use std::env;
 use chrono::Utc;
 use failure::{bail, format_err};
 use sql_parser::ast::ColumnOption;
-use sql_parser::ast::{DataType, ObjectType, Statement};
+use sql_parser::ast::{DataType, ObjectType, Statement, TableConstraint};
 use tokio_postgres::types::FromSql;
 
 use pgrepr::Jsonb;
@@ -135,29 +135,32 @@ END $$;
                 if_not_exists,
                 ..
             } => {
-                self.client.execute(&*stmt.to_string(), &[]).await?;
-                let sql_types = columns
+                let sql_types: Vec<_> = columns
                     .iter()
                     .map(|column| column.data_type.clone())
-                    .collect::<Vec<_>>();
+                    .collect();
+
+                let names: Vec<_> = columns
+                    .iter()
+                    .map(|c| Some(sql::normalize::column_name(c.name.clone())))
+                    .collect();
+
+                // Build initial relation type that handles declared data types
+                // and NOT NULL constraints.
                 let mut typ = RelationType::new(
                     columns
                         .iter()
-                        .map(|column| {
-                            Ok(ColumnType {
-                                scalar_type: scalar_type_from_sql(&column.data_type)?,
-                                nullable: !column
-                                    .options
-                                    .iter()
-                                    .any(|o| o.option == ColumnOption::NotNull),
-                            })
+                        .map(|c| {
+                            let ty = scalar_type_from_sql(&c.data_type)?;
+                            let nullable =
+                                !c.options.iter().any(|o| o.option == ColumnOption::NotNull);
+                            Ok(ColumnType::new(ty).nullable(nullable))
                         })
                         .collect::<Result<Vec<_>, failure::Error>>()?,
                 );
-                let names = columns
-                    .iter()
-                    .map(|c| Some(sql::normalize::column_name(c.name.clone())));
 
+                // Handle column-level UNIQUE and PRIMARY KEY constraints.
+                // PRIMARY KEY implies UNIQUE and NOT NULL.
                 for (index, column) in columns.iter().enumerate() {
                     for option in column.options.iter() {
                         if let ColumnOption::Unique { is_primary } = option.option {
@@ -169,33 +172,33 @@ END $$;
                     }
                 }
 
+                // Handle table-level UNIQUE and PRIMARY KEY constraints.
+                // PRIMARY KEY implies UNIQUE and NOT NULL.
                 for constraint in constraints {
-                    use sql_parser::ast::TableConstraint;
                     if let TableConstraint::Unique {
                         name: _,
-                        columns: cols,
+                        columns,
                         is_primary,
                     } = constraint
                     {
-                        let keys = cols
-                            .iter()
-                            .map(|ident| {
-                                columns
-                                    .iter()
-                                    .position(|c| ident == &c.name)
-                                    .expect("Column named in UNIQUE constraint not found")
-                            })
-                            .collect::<Vec<_>>();
-
-                        if *is_primary {
-                            for key in keys.iter() {
-                                typ.column_types[*key].nullable = false;
+                        let mut key = vec![];
+                        for column in columns {
+                            let name = normalize::column_name(column.clone());
+                            match names.iter().position(|n| n.as_ref() == Some(&name)) {
+                                None => bail!("unknown column {} in unique constraint", name),
+                                Some(i) => key.push(i),
                             }
                         }
-                        typ = typ.with_key(keys);
+                        if *is_primary {
+                            for i in key.iter() {
+                                typ.column_types[*i].nullable = false;
+                            }
+                        }
+                        typ = typ.with_key(key);
                     }
                 }
 
+                self.client.execute(&*stmt.to_string(), &[]).await?;
                 let name = scx.allocate_name(normalize::object_name(name.clone())?);
                 let desc = RelationDesc::new(typ, names);
                 self.table_types

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -163,8 +163,7 @@ END $$;
                         if let ColumnOption::Unique { is_primary } = option.option {
                             typ = typ.with_key(vec![index]);
                             if is_primary {
-                                typ.column_types[index] =
-                                    typ.column_types[index].clone().nullable(false);
+                                typ.column_types[index].nullable = false;
                             }
                         }
                     }
@@ -190,7 +189,7 @@ END $$;
 
                         if *is_primary {
                             for key in keys.iter() {
-                                typ.column_types[*key].set_nullable(false);
+                                typ.column_types[*key].nullable = false;
                             }
                         }
                         typ = typ.with_key(keys);

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -161,7 +161,7 @@ END $$;
                 for (index, column) in columns.iter().enumerate() {
                     for option in column.options.iter() {
                         if let ColumnOption::Unique { is_primary } = option.option {
-                            typ = typ.add_keys(vec![index]);
+                            typ = typ.with_key(vec![index]);
                             if is_primary {
                                 typ.column_types[index] =
                                     typ.column_types[index].clone().nullable(false);
@@ -193,7 +193,7 @@ END $$;
                                 typ.column_types[*key].set_nullable(false);
                             }
                         }
-                        typ = typ.add_keys(keys);
+                        typ = typ.with_key(keys);
                     }
                 }
 

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -150,7 +150,7 @@ impl FoldConstants {
                     );
                     for key in relation_type.keys.iter() {
                         if key.iter().all(|i| *i < input_arity + index) {
-                            current_type = current_type.add_keys(key.clone());
+                            current_type = current_type.with_key(key.clone());
                         }
                     }
                     scalar.reduce(&current_type);

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -168,18 +168,15 @@ $ set non-dbz-schema={
     "name": "cpx",
     "fields": [
       {"name": "a", "type": "long"},
-      {"name": "b", "type": "long"},
-      {"name": "u", "type": ["long", "null", "string"]},
-      {"name": "n", "type": ["long", "null"]}
+      {"name": "b", "type": "long"}
     ]
   }
 
 $ kafka-create-topic topic=non-dbz-data
 
 $ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp=1
-{"a": 1, "b": 2, "u": 5, "n": 6}
-{"a": 2, "b": 3, "u": null, "n": null}
-{"a": 3, "b": 4, "u": "hello", "n": 7}
+{"a": 1, "b": 2}
+{"a": 2, "b": 3}
 
 > CREATE MATERIALIZED SOURCE non_dbz_data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
@@ -187,11 +184,10 @@ $ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data
-a b u1 u2 n
+a b
 ---
-1 2 5 <null> 6
-2 3 <null> <null> <null>
-3 4 <null> "hello" 7
+1 2
+2 3
 
 
 # Source with new-style three-valued "snapshot".

--- a/test/testdrive/avro-unions.td
+++ b/test/testdrive/avro-unions.td
@@ -1,0 +1,50 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test how Avro unions of varying sizes and nullabilities are converted
+# to Materialize types.
+
+$ set-sql-timeout duration=200ms
+
+$ set writer-schema={
+    "name": "row",
+    "type": "record",
+    "fields": [
+      {"name": "a", "type": ["long"]},
+      {"name": "b", "type": ["long", "null"]},
+      {"name": "c", "type": ["long", "null", "string"]},
+      {"name": "d", "type": ["long", "string"]}
+    ]
+  }
+
+$ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
+{"a": 1, "b": null, "c": null, "d": "d"}
+{"a": 2, "b": 2, "c": "foo", "d": 4}
+{"a": 2, "b": 2, "c": 3, "d": "d"}
+
+> CREATE MATERIALIZED SOURCE unions
+  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+
+> SHOW COLUMNS FROM unions
+Field      Nullable  Type
+-------------------------
+a          NO        int8
+b          YES       int8
+c1         YES       int8
+c2         YES       text
+d1         YES       int8
+d2         YES       text
+mz_obj_no  NO        int8
+
+> SELECT * FROM unions
+a   b       c1      c2     d1      d2      mz_obj_no
+----------------------------------------------------
+1   <null>  <null>  <null>  <null>  d      1
+2   2       <null>  foo     4       <null> 2
+2   2       3       <null>  <null>  d      3


### PR DESCRIPTION
The APIs of these objects has grown organically over time, and there were several ways of building up a `RelationDesc` that were not meaningfully different. Hammer on the API to sort out a more orthogonal set of primitives, and document this new API thoroughly. 

I was careful to split this up into multiple commits for easier review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3203)
<!-- Reviewable:end -->
