### PR TITLE
demo/billing: improve reliability of sink verification

### DIFF
--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -177,7 +177,7 @@ async fn create_materialized_source(config: MzConfig) -> Result<()> {
             exec_query!(client, "drop_index_billing_records");
         }
 
-        let sink_global_id = client
+        let sink_topic = client
             .create_kafka_sink(
                 &config.kafka_url,
                 config::KAFKA_SINK_TOPIC_NAME,
@@ -191,7 +191,7 @@ async fn create_materialized_source(config: MzConfig) -> Result<()> {
                     &config.kafka_url,
                     &config.schema_registry_url,
                     config::REINGESTED_SINK_SOURCE_NAME,
-                    sink_global_id,
+                    &sink_topic,
                 )
                 .await?;
             exec_query!(client, "check_sink");


### PR DESCRIPTION
The topic name of the new sink may not be immediately available after
the sink is created; querying for it needs to be wrapped in a retry
loop.

The billing demo previously took a two step approach: first it
queried for the new sink's ID, in a retry loop, and then it queryed for
the topic name using the previously-retried ID, but not in a retry loop.
Instead, just use a SQL join to query for the sink's topic name
directly, and do so in a retry loop.

This fixes some CI flakiness, where the sink demo was incorrectly
failing because it was unable to find the topic name of the new sink.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3205)
<!-- Reviewable:end -->
