### PR TITLE
catalog: refactor i

### DIFF
--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -1194,10 +1194,6 @@ impl PlanCatalog for ConnCatalog<'_> {
         self.catalog.get_by_id(id)
     }
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn PlanCatalogEntry> + 'a> {
-        Box::new(self.catalog.iter().map(|e| e as &dyn PlanCatalogEntry))
-    }
-
     fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Option<&dyn SchemaMap> {
         self.catalog
             .get_schemas(database_spec, self.conn_id)

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -1225,10 +1225,6 @@ impl PlanCatalog for ConnCatalog<'_> {
     fn empty_item_map(&self) -> Box<dyn ItemMap> {
         Box::new(Items(BTreeMap::new()))
     }
-
-    fn conn_id(&self) -> Option<u32> {
-        self.conn_id
-    }
 }
 
 impl PlanCatalogEntry for CatalogEntry {

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -21,10 +21,7 @@ use ore::collections::CollectionExt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use ::sql::catalog::{
-    CatalogItemType, ItemMap, PlanCatalog, PlanCatalogEntry, PlanDatabaseResolver, PlanSchema,
-    SchemaType,
-};
+use ::sql::catalog::{CatalogItemType, PlanCatalog, PlanCatalogEntry};
 use ::sql::{DatabaseSpecifier, FullName, Params, PartialName, Plan, PlanContext};
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector};
 use expr::{GlobalId, Id, IdHumanizer, OptimizedRelationExpr, ScalarExpr};
@@ -508,6 +505,7 @@ impl Catalog {
             .get("mz_temp")
             .expect("missing temporary schema mz_temp for conn_id: {}")
             .items
+            .0
             .is_empty()
         {
             error!(
@@ -1130,22 +1128,6 @@ impl<'a> DatabaseResolver<'a> {
 
         None
     }
-
-    /// Attempts to find the schema specified by `schema_name` in the database
-    /// that this resolver is attached to, or in the set of ambient schemas.
-    pub fn resolve_schema(&self, schema_name: &str) -> Option<(&'a Schema, SchemaType)> {
-        self.database
-            .schemas
-            .0
-            .get(schema_name)
-            .map(|s| (s, SchemaType::Normal))
-            .or_else(|| {
-                self.ambient_schemas
-                    .0
-                    .get(schema_name)
-                    .map(|s| (s, SchemaType::Ambient))
-            })
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1211,11 +1193,24 @@ impl PlanCatalog for ConnCatalog<'_> {
         }
     }
 
-    fn database_resolver<'a>(
+    fn get_items<'a>(
         &'a self,
-        database_spec: DatabaseSpecifier,
-    ) -> Result<Box<dyn PlanDatabaseResolver<'a> + 'a>, failure::Error> {
-        Ok(Box::new(self.catalog.database_resolver(database_spec)?))
+        database_spec: &DatabaseSpecifier,
+        schema_name: &str,
+    ) -> Result<Box<dyn Iterator<Item = &'a dyn PlanCatalogEntry> + 'a>, failure::Error> {
+        match self
+            .catalog
+            .get_schemas(database_spec, self.conn_id)?
+            .0
+            .get(schema_name)
+        {
+            Some(schema) => {
+                Ok(Box::new(schema.items.0.values().map(move |id| {
+                    self.catalog.get_by_id(id) as &dyn PlanCatalogEntry
+                })))
+            }
+            None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into())).into()),
+        }
     }
 
     fn resolve(
@@ -1229,8 +1224,32 @@ impl PlanCatalog for ConnCatalog<'_> {
             .resolve(current_database, search_path, name, self.conn_id)?)
     }
 
-    fn empty_item_map(&self) -> Box<dyn ItemMap> {
-        Box::new(Items(BTreeMap::new()))
+    fn resolve_schema(
+        &self,
+        current_database: &DatabaseSpecifier,
+        database: Option<&DatabaseSpecifier>,
+        schema_name: &str,
+    ) -> Result<DatabaseSpecifier, failure::Error> {
+        let database_specs = if let Some(database) = database {
+            vec![database]
+        } else {
+            vec![
+                current_database,
+                &DatabaseSpecifier::Ambient,
+                &DatabaseSpecifier::Temporary,
+            ]
+        };
+        for database_spec in database_specs {
+            if self
+                .catalog
+                .get_schemas(&database_spec, self.conn_id)?
+                .0
+                .contains_key(schema_name)
+            {
+                return Ok(database_spec.clone());
+            }
+        }
+        Err(Error::new(ErrorKind::UnknownSchema(schema_name.into())).into())
     }
 }
 
@@ -1288,28 +1307,5 @@ impl PlanCatalogEntry for CatalogEntry {
 
     fn used_by(&self) -> &[GlobalId] {
         self.used_by()
-    }
-}
-
-impl<'a> PlanDatabaseResolver<'a> for DatabaseResolver<'a> {
-    fn resolve_schema(&self, schema_name: &str) -> Option<(&'a dyn PlanSchema, SchemaType)> {
-        self.resolve_schema(schema_name)
-            .map(|(a, b)| (a as &'a dyn PlanSchema, b))
-    }
-}
-
-impl PlanSchema for Schema {
-    fn items(&self) -> &dyn ItemMap {
-        &self.items
-    }
-}
-
-impl ItemMap for Items {
-    fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&String, &GlobalId)> + 'a> {
-        Box::new(self.0.iter())
     }
 }

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -406,6 +406,7 @@ impl Catalog {
     /// See also [`Catalog::get`].
     pub fn try_get(&self, name: &FullName, conn_id: Option<u32>) -> Option<&CatalogEntry> {
         self.get_schemas(&name.database, conn_id)
+            .ok()
             .and_then(|schemas| schemas.0.get(&name.schema))
             .and_then(|schema| schema.items.0.get(&name.item))
             .map(|id| &self.by_id[id])
@@ -523,15 +524,18 @@ impl Catalog {
         &self,
         database_spec: &DatabaseSpecifier,
         conn_id: Option<u32>,
-    ) -> Option<&Schemas> {
+    ) -> Result<&Schemas, Error> {
         // Keep in sync with `get_schemas_mut`.
         match database_spec {
-            DatabaseSpecifier::Ambient => Some(&self.ambient_schemas),
+            DatabaseSpecifier::Ambient => Ok(&self.ambient_schemas),
             DatabaseSpecifier::Temporary => match conn_id {
-                Some(conn_id) => self.temporary_schemas.get(&conn_id),
-                None => None,
+                Some(conn_id) => Ok(self.temporary_schemas.get(&conn_id).unwrap()),
+                None => unreachable!("cannot get temporary schema with no conn_id"),
             },
-            DatabaseSpecifier::Name(name) => self.by_name.get(name).map(|db| &db.schemas),
+            DatabaseSpecifier::Name(name) => match self.by_name.get(name) {
+                Some(db) => Ok(&db.schemas),
+                None => Err(Error::new(ErrorKind::UnknownDatabase(name.to_owned()))),
+            }
         }
     }
 
@@ -540,15 +544,18 @@ impl Catalog {
         &mut self,
         database_spec: &DatabaseSpecifier,
         conn_id: Option<u32>,
-    ) -> Option<&mut Schemas> {
+    ) -> Result<&mut Schemas, Error> {
         // Keep in sync with `get_schemas`.
         match database_spec {
-            DatabaseSpecifier::Ambient => Some(&mut self.ambient_schemas),
+            DatabaseSpecifier::Ambient => Ok(&mut self.ambient_schemas),
             DatabaseSpecifier::Temporary => match conn_id {
-                Some(conn_id) => self.temporary_schemas.get_mut(&conn_id),
-                None => None,
+                Some(conn_id) => Ok(self.temporary_schemas.get_mut(&conn_id).unwrap()),
+                None => unreachable!("cannot get temporary schema with no conn_id"),
             },
-            DatabaseSpecifier::Name(name) => self.by_name.get_mut(name).map(|db| &mut db.schemas),
+            DatabaseSpecifier::Name(name) => match self.by_name.get_mut(name) {
+                Some(db) => Ok(&mut db.schemas),
+                None => Err(Error::new(ErrorKind::UnknownDatabase(name.to_owned()))),
+            }
         }
     }
 
@@ -1194,10 +1201,11 @@ impl PlanCatalog for ConnCatalog<'_> {
         self.catalog.get_by_id(id)
     }
 
-    fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Option<&dyn SchemaMap> {
-        self.catalog
-            .get_schemas(database_spec, self.conn_id)
-            .map(|m| m as &dyn SchemaMap)
+    fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Result<&dyn SchemaMap, failure::Error> {
+        match self.catalog.get_schemas(database_spec, self.conn_id) {
+            Ok(schemas) => Ok(schemas as &dyn SchemaMap),
+            Err(e) => Err(e.into()),
+        }
     }
 
     fn database_resolver<'a>(

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -38,10 +38,11 @@ pub trait PlanCatalog: fmt::Debug {
         _: &DatabaseSpecifier,
     ) -> Result<Box<dyn Iterator<Item = &'a str> + 'a>, failure::Error>;
 
-    fn database_resolver<'a>(
+    fn get_items<'a>(
         &'a self,
-        database_spec: DatabaseSpecifier,
-    ) -> Result<Box<dyn PlanDatabaseResolver<'a> + 'a>, failure::Error>;
+        _: &DatabaseSpecifier,
+        schema_name: &str,
+    ) -> Result<Box<dyn Iterator<Item = &'a dyn PlanCatalogEntry> + 'a>, failure::Error>;
 
     fn resolve(
         &self,
@@ -50,7 +51,12 @@ pub trait PlanCatalog: fmt::Debug {
         name: &PartialName,
     ) -> Result<FullName, failure::Error>;
 
-    fn empty_item_map(&self) -> Box<dyn ItemMap>;
+    fn resolve_schema(
+        &self,
+        _: &DatabaseSpecifier,
+        _: Option<&DatabaseSpecifier>,
+        schema_name: &str,
+    ) -> Result<DatabaseSpecifier, failure::Error>;
 }
 
 pub trait PlanCatalogEntry {
@@ -92,19 +98,6 @@ impl fmt::Display for CatalogItemType {
     }
 }
 
-pub trait PlanDatabaseResolver<'a> {
-    fn resolve_schema(&self, schema_name: &str) -> Option<(&'a dyn PlanSchema, SchemaType)>;
-}
-
-pub trait PlanSchema {
-    fn items(&self) -> &dyn ItemMap;
-}
-
-pub trait ItemMap {
-    fn is_empty(&self) -> bool;
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&'a String, &'a GlobalId)> + 'a>;
-}
-
 #[derive(Debug)]
 pub struct DummyCatalog;
 
@@ -136,10 +129,11 @@ impl PlanCatalog for DummyCatalog {
         unimplemented!();
     }
 
-    fn database_resolver<'a>(
+    fn get_items<'a>(
         &'a self,
-        _: DatabaseSpecifier,
-    ) -> Result<Box<dyn PlanDatabaseResolver<'a> + 'a>, failure::Error> {
+        _: &DatabaseSpecifier,
+        _: &str,
+    ) -> Result<Box<dyn Iterator<Item = &'a dyn PlanCatalogEntry> + 'a>, failure::Error> {
         unimplemented!();
     }
 
@@ -152,7 +146,12 @@ impl PlanCatalog for DummyCatalog {
         unimplemented!();
     }
 
-    fn empty_item_map(&self) -> Box<dyn ItemMap> {
+    fn resolve_schema(
+        &self,
+        _: &DatabaseSpecifier,
+        _: Option<&DatabaseSpecifier>,
+        _: &str,
+    ) -> Result<DatabaseSpecifier, failure::Error> {
         unimplemented!();
     }
 }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -33,7 +33,10 @@ pub trait PlanCatalog: fmt::Debug {
 
     fn get_by_id(&self, id: &GlobalId) -> &dyn PlanCatalogEntry;
 
-    fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Result<&dyn SchemaMap, failure::Error>;
+    fn get_schemas<'a>(
+        &'a self,
+        _: &DatabaseSpecifier,
+    ) -> Result<Box<dyn Iterator<Item = &'a str> + 'a>, failure::Error>;
 
     fn database_resolver<'a>(
         &'a self,
@@ -97,10 +100,6 @@ pub trait PlanSchema {
     fn items(&self) -> &dyn ItemMap;
 }
 
-pub trait SchemaMap {
-    fn keys<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a>;
-}
-
 pub trait ItemMap {
     fn is_empty(&self) -> bool;
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = (&'a String, &'a GlobalId)> + 'a>;
@@ -130,7 +129,10 @@ impl PlanCatalog for DummyCatalog {
         unimplemented!();
     }
 
-    fn get_schemas(&self, _: &DatabaseSpecifier) -> Result<&dyn SchemaMap, failure::Error> {
+    fn get_schemas<'a>(
+        &'a self,
+        _: &DatabaseSpecifier,
+    ) -> Result<Box<dyn Iterator<Item = &'a str> + 'a>, failure::Error> {
         unimplemented!();
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -33,7 +33,7 @@ pub trait PlanCatalog: fmt::Debug {
 
     fn get_by_id(&self, id: &GlobalId) -> &dyn PlanCatalogEntry;
 
-    fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Option<&dyn SchemaMap>;
+    fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Result<&dyn SchemaMap, failure::Error>;
 
     fn database_resolver<'a>(
         &'a self,
@@ -130,7 +130,7 @@ impl PlanCatalog for DummyCatalog {
         unimplemented!();
     }
 
-    fn get_schemas(&self, _: &DatabaseSpecifier) -> Option<&dyn SchemaMap> {
+    fn get_schemas(&self, _: &DatabaseSpecifier) -> Result<&dyn SchemaMap, failure::Error> {
         unimplemented!();
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -33,8 +33,6 @@ pub trait PlanCatalog: fmt::Debug {
 
     fn get_by_id(&self, id: &GlobalId) -> &dyn PlanCatalogEntry;
 
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn PlanCatalogEntry> + 'a>;
-
     fn get_schemas(&self, database_spec: &DatabaseSpecifier) -> Option<&dyn SchemaMap>;
 
     fn database_resolver<'a>(
@@ -129,10 +127,6 @@ impl PlanCatalog for DummyCatalog {
     }
 
     fn get_by_id(&self, _: &GlobalId) -> &dyn PlanCatalogEntry {
-        unimplemented!();
-    }
-
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn PlanCatalogEntry> + 'a> {
         unimplemented!();
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -50,8 +50,6 @@ pub trait PlanCatalog: fmt::Debug {
     ) -> Result<FullName, failure::Error>;
 
     fn empty_item_map(&self) -> Box<dyn ItemMap>;
-
-    fn conn_id(&self) -> Option<u32>;
 }
 
 pub trait PlanCatalogEntry {
@@ -159,10 +157,6 @@ impl PlanCatalog for DummyCatalog {
     }
 
     fn empty_item_map(&self) -> Box<dyn ItemMap> {
-        unimplemented!();
-    }
-
-    fn conn_id(&self) -> Option<u32> {
         unimplemented!();
     }
 }

--- a/src/sql/src/query.rs
+++ b/src/sql/src/query.rs
@@ -725,7 +725,7 @@ fn plan_table_factor<'a>(
                 plan_table_function(ecx, left, &name, Some(alias), args)
             } else {
                 let name = qcx.scx.resolve_name(name.clone())?;
-                let item = qcx.scx.get(&name)?;
+                let item = qcx.scx.catalog.get(&name)?;
                 let expr = RelationExpr::Get {
                     id: Id::Global(item.id()),
                     typ: item.desc()?.typ().clone(),

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -546,9 +546,10 @@ fn handle_show_indexes(
         );
     }
     let arena = RowArena::new();
-    let rows = scx
-        .catalog
+    let rows = from_entry
+        .used_by()
         .iter()
+        .map(|id| scx.catalog.get_by_id(id))
         .filter(|entry| {
             object_type_matches(ObjectType::Index, entry.item_type())
                 && entry.uses() == vec![from_entry.id()]

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -423,15 +423,9 @@ fn handle_show_objects(
                 );
             }
             let database_spec = DatabaseSpecifier::Name(normalize::ident(from.0[0].clone()));
-            scx.catalog.get_schemas(&database_spec)
-                .ok_or_else(|| format_err!("database '{:?}' does not exist", database_spec))?
+            scx.catalog.get_schemas(&database_spec)?
         } else {
-            scx.catalog.get_schemas(&scx.session.database()).ok_or_else(|| {
-                format_err!(
-                    "session database '{}' does not exist",
-                    scx.session.database()
-                )
-            })?
+            scx.catalog.get_schemas(&scx.session.database())?
         };
 
         let mut rows = vec![];
@@ -1387,7 +1381,7 @@ fn handle_drop_database(
 ) -> Result<Plan, failure::Error> {
     let name = normalize::ident(name);
     let spec = DatabaseSpecifier::Name(name.clone());
-    match scx.catalog.database_resolver(spec) {
+    match scx.catalog.get_schemas(&spec) {
         Ok(_) => (),
         Err(_) if if_exists => {
             // TODO(benesch): generate a notice indicating that the database

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -429,7 +429,7 @@ fn handle_show_objects(
         };
 
         let mut rows = vec![];
-        for name in schemas.keys() {
+        for name in schemas {
             rows.push(make_row(name, "USER"));
         }
         if extended {
@@ -437,7 +437,7 @@ fn handle_show_objects(
                 .catalog
                 .get_schemas(&DatabaseSpecifier::Ambient)
                 .expect("ambient database should always exist");
-            for name in ambient_schemas.keys() {
+            for name in ambient_schemas {
                 rows.push(make_row(name, "SYSTEM"));
             }
         }

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -12,6 +12,7 @@
 //! This module turns SQL `Statement`s into `Plan`s - commands which will drive the dataflow layer
 
 use std::collections::HashMap;
+use std::iter;
 use std::path::PathBuf;
 use std::time::UNIX_EPOCH;
 
@@ -39,7 +40,7 @@ use sql_parser::ast::{
     SqlOption, Statement, Value,
 };
 
-use crate::catalog::{CatalogItemType, PlanCatalog, SchemaType};
+use crate::catalog::{CatalogItemType, PlanCatalog};
 use crate::kafka_util;
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
 use crate::pure::Schema;
@@ -450,7 +451,6 @@ fn handle_show_objects(
             &make_show_objects_desc(object_type, materialized, full),
         )
     } else {
-        let empty_schema = scx.catalog.empty_item_map();
         let items = if let Some(mut from) = from {
             if from.0.len() > 2 {
                 bail!(
@@ -462,28 +462,24 @@ fn handle_show_objects(
             let database_spec = from
                 .0
                 .pop()
-                .map(|n| DatabaseSpecifier::Name(normalize::ident(n)))
-                .unwrap_or_else(|| scx.session.database());
+                .map(|n| DatabaseSpecifier::Name(normalize::ident(n)));
+            let database_spec = scx.catalog.resolve_schema(
+                &scx.session.database(),
+                database_spec.as_ref(),
+                &schema_name,
+            )?;
             scx.catalog
-                .database_resolver(database_spec)?
-                .resolve_schema(&schema_name)
-                .ok_or_else(|| format_err!("schema '{}' does not exist", schema_name))?
-                .0
-                .items()
+                .get_items(&database_spec, &schema_name)
+                .expect("schema known to exist")
         } else {
-            let resolver = scx.catalog.database_resolver(scx.session.database())?;
-            scx.session
-                .search_path()
-                .iter()
-                .filter_map(|schema_name| resolver.resolve_schema(schema_name))
-                .find(|(_schema, typ)| *typ == SchemaType::Normal)
-                .map_or_else(|| &*empty_schema, |(schema, _typ)| schema.items())
+            scx.catalog
+                .get_items(&scx.session.database(), "public")
+                .ok()
+                .unwrap_or_else(|| Box::new(iter::empty()))
         };
 
-        let filtered_items = items
-            .iter()
-            .map(|(name, id)| (name, scx.catalog.get_by_id(id)))
-            .filter(|(_name, entry)| object_type_matches(object_type, entry.item_type()));
+        let filtered_items =
+            items.filter(|entry| object_type_matches(object_type, entry.item_type()));
 
         if object_type == ObjectType::View || object_type == ObjectType::Source {
             // TODO(justin): we can't handle SHOW ... WHERE here yet because the coordinator adds
@@ -495,11 +491,11 @@ fn handle_show_objects(
                 None => like_pattern::build_regex("%")?,
             };
 
-            let filtered_items = filtered_items
-                .filter(|(_name, entry)| like_regex.is_match(&entry.name().to_string()));
+            let filtered_items =
+                filtered_items.filter(|entry| like_regex.is_match(&entry.name().item));
             Ok(Plan::ShowViews {
                 ids: filtered_items
-                    .map(|(name, entry)| (name.clone(), entry.id()))
+                    .map(|entry| (entry.name().item.clone(), entry.id()))
                     .collect::<Vec<_>>(),
                 full,
                 show_queryable: object_type == ObjectType::View,
@@ -507,7 +503,7 @@ fn handle_show_objects(
             })
         } else {
             let rows = filtered_items
-                .map(|(name, entry)| make_row(name, classify_id(entry.id())))
+                .map(|entry| make_row(&entry.name().item, classify_id(entry.id())))
                 .collect::<Vec<_>>();
 
             finish_show_where(
@@ -1422,34 +1418,39 @@ fn handle_drop_schema(
     let database_name = name
         .0
         .pop()
-        .map(|n| DatabaseSpecifier::Name(normalize::ident(n)))
-        .unwrap_or_else(|| scx.session.database());
-    match scx.catalog.database_resolver(database_name.clone()) {
-        Ok(resolver) => {
-            match resolver.resolve_schema(&schema_name) {
-                None if if_exists => {
-                    // TODO(benesch): generate a notice indicating that
-                    // the schema does not exist.
-                }
-                None => bail!("schema '{}.{}' does not exist", database_name, schema_name),
-                Some((_schema, SchemaType::Ambient)) => {
-                    bail!(
-                        "cannot drop schema {} because it is required by the database system",
-                        schema_name
-                    );
-                }
-                Some((schema, SchemaType::Normal)) if !cascade && !schema.items().is_empty() => {
-                    bail!("schema '{}.{}' cannot be dropped without CASCADE while it contains objects", database_name, schema_name);
-                }
-                _ => (),
+        .map(|n| DatabaseSpecifier::Name(normalize::ident(n)));
+    let database_name = match scx.catalog.resolve_schema(
+        &scx.session.database(),
+        database_name.as_ref(),
+        &schema_name,
+    ) {
+        Ok(database_spec) => {
+            if let DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary = database_spec {
+                bail!(
+                    "cannot drop schema {} because it is required by the database system",
+                    schema_name
+                );
             }
+            let mut items = scx
+                .catalog
+                .get_items(&database_spec, &schema_name)
+                .expect("schema known to exist");
+            if !cascade && items.next().is_some() {
+                bail!(
+                    "schema '{}.{}' cannot be dropped without CASCADE while it contains objects",
+                    database_spec,
+                    schema_name
+                );
+            }
+            database_spec
         }
         Err(_) if if_exists => {
             // TODO(benesch): generate a notice indicating that the
             // database does not exist.
+            scx.session.database()
         }
-        Err(err) => return Err(err),
-    }
+        Err(e) => return Err(e),
+    };
     Ok(Plan::DropSchema {
         database_name,
         schema_name,

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -173,7 +173,7 @@ test1
 test2
 
 ! SHOW VIEWS FROM noexist
-schema 'noexist' does not exist
+unknown schema 'noexist'
 
 ! SHOW VIEWS FROM noexist.noexist
 unknown database 'noexist'


### PR DESCRIPTION
@JLDLaughlin this is all building towards removing `DatabaseSpecifier::Temporary` (#3104) as well as cleaning up a bunch of other API debt, courtesy of yours truly, that accumulated in the push to support databases in schemas pre-0.1.0.

#3175 got a bit out of hand, so I split off the first chunk here. Should be much easier to review commit by commit!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3206)
<!-- Reviewable:end -->
