### PR TITLE
catalog: refactor ii

### DIFF
--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -353,11 +353,47 @@ impl Catalog {
         self.storage().allocate_id()
     }
 
+    pub fn resolve_database(&self, database_spec: &DatabaseSpecifier) -> Result<(), Error> {
+        match database_spec {
+            DatabaseSpecifier::Ambient => Ok(()),
+            DatabaseSpecifier::Name(name) => match self.by_name.get(name) {
+                Some(_) => Ok(()),
+                None => Err(Error::new(ErrorKind::UnknownDatabase(name.into()))),
+            },
+        }
+    }
+
+    pub fn resolve_schema(
+        &self,
+        current_database: &DatabaseSpecifier,
+        database: Option<String>,
+        schema_name: &str,
+        conn_id: u32,
+    ) -> Result<DatabaseSpecifier, Error> {
+        if let Some(database) = database {
+            let database_spec = DatabaseSpecifier::Name(database);
+            self.get_schema(&database_spec, schema_name, conn_id)
+                .map(|_| database_spec)
+        } else {
+            match self.get_schema(current_database, schema_name, conn_id) {
+                Ok(_) => Ok(current_database.clone()),
+                Err(Error {
+                    kind: ErrorKind::UnknownSchema(_),
+                    ..
+                }) => self
+                    .get_schema(&DatabaseSpecifier::Ambient, schema_name, conn_id)
+                    .map(|_| DatabaseSpecifier::Ambient),
+                Err(e) => Err(e),
+            }
+        }
+    }
+
     /// Resolves [`PartialName`] into a [`FullName`].
     ///
     /// If `name` does not specify a database, the `current_database` is used.
     /// If `name` does not specify a schema, then the schemas in `search_path`
     /// are searched in order.
+    #[allow(clippy::useless_let_if_seq)]
     pub fn resolve(
         &self,
         current_database: DatabaseSpecifier,
@@ -374,31 +410,46 @@ impl Catalog {
             });
         }
 
-        // Find the specified database, or `current_database` if no database was
-        // specified.
-        let database_name = name
-            .database
-            .as_ref()
-            .map(|n| DatabaseSpecifier::Name(n.clone()))
-            .unwrap_or(current_database);
-        let resolver = self.database_resolver(database_name)?;
+        // If a schema name was specified, just try to find the item in that
+        // schema. If no schema was specified, try to find the item in every
+        // schema in the search path.
+        //
+        // This is written strangely to work around limitations in Rust's
+        // temporary lifetime inference [0]. Ideally the following would work,
+        // but it does not:
+        //
+        //     let schemas = match name.schema {
+        //         Some(name) => &[name],
+        //         None => search_path,
+        //     }
+        //
+        // [0]: https://github.com/rust-lang/rust/issues/15023
+        let mut schemas = &[name.schema.as_deref().unwrap_or("")][..];
+        if name.schema.is_none() {
+            schemas = search_path;
+        }
 
-        if let Some(schema_name) = &name.schema {
-            // A schema name was specified, so just try to find the item in
-            // that schema.
-            if let Some(out) = resolver.resolve_item(schema_name, &name.item, conn_id) {
-                return Ok(out);
-            }
-        } else {
-            // No schema was specified, so try to find the item in every schema
-            // in the search path, in order.
-            for &schema_name in search_path {
-                if let Some(out) = resolver.resolve_item(schema_name, &name.item, conn_id) {
-                    return Ok(out);
+        for &schema_name in schemas {
+            let database_name = name.database.clone();
+            let res = self.resolve_schema(&current_database, database_name, schema_name, conn_id);
+            let database_spec = match res {
+                Ok(database_spec) => database_spec,
+                Err(Error {
+                    kind: ErrorKind::UnknownSchema(_),
+                    ..
+                }) => continue,
+                Err(e) => return Err(e),
+            };
+            if let Ok(schema) = self.get_schema(&database_spec, schema_name, conn_id) {
+                if schema.items.contains_key(&name.item) {
+                    return Ok(FullName {
+                        database: database_spec,
+                        schema: schema_name.to_owned(),
+                        item: name.item.to_owned(),
+                    });
                 }
             }
         }
-
         Err(Error::new(ErrorKind::UnknownItem(name.to_string())))
     }
 
@@ -431,29 +482,6 @@ impl Catalog {
     /// Returns an iterator over the name of each database in the catalog.
     pub fn databases(&self) -> impl Iterator<Item = &str> {
         self.by_name.keys().map(String::as_str)
-    }
-
-    pub fn database_resolver<'a>(
-        &'a self,
-        database_spec: DatabaseSpecifier,
-    ) -> Result<DatabaseResolver<'a>, Error> {
-        match &database_spec {
-            DatabaseSpecifier::Ambient => Ok(DatabaseResolver {
-                database_spec,
-                database: &EMPTY_DATABASE,
-                ambient_schemas: &self.ambient_schemas,
-                temporary_schemas: &self.temporary_schemas,
-            }),
-            DatabaseSpecifier::Name(name) => match self.by_name.get(name) {
-                Some(database) => Ok(DatabaseResolver {
-                    database_spec,
-                    database,
-                    ambient_schemas: &self.ambient_schemas,
-                    temporary_schemas: &self.temporary_schemas,
-                }),
-                None => Err(Error::new(ErrorKind::UnknownDatabase(name.to_owned()))),
-            },
-        }
     }
 
     /// Creates a new schema in the `Catalog` for temporary items
@@ -1046,57 +1074,6 @@ pub enum OpStatus {
     DroppedItem(CatalogEntry),
 }
 
-/// A helper for resolving schema and item names within one database.
-pub struct DatabaseResolver<'a> {
-    database_spec: DatabaseSpecifier,
-    database: &'a Database,
-    ambient_schemas: &'a BTreeMap<String, Schema>,
-    temporary_schemas: &'a HashMap<u32, Schema>,
-}
-
-impl<'a> DatabaseResolver<'a> {
-    /// Attempts to resolve the item specified by `schema_name` and `item_name`
-    /// in the database that this resolver is attached to, or in the set of
-    /// ambient schemas.
-    pub fn resolve_item(
-        &self,
-        schema_name: &str,
-        item_name: &str,
-        conn_id: u32,
-    ) -> Option<FullName> {
-        if let Some(schema) = self.database.schemas.get(schema_name) {
-            if schema.items.contains_key(item_name) {
-                return Some(FullName {
-                    database: self.database_spec.clone(),
-                    schema: schema_name.to_owned(),
-                    item: item_name.to_owned(),
-                });
-            }
-        }
-        if let Some(schema) = self.ambient_schemas.get(schema_name) {
-            if schema.items.contains_key(item_name) {
-                return Some(FullName {
-                    database: DatabaseSpecifier::Ambient,
-                    schema: schema_name.to_owned(),
-                    item: item_name.to_owned(),
-                });
-            }
-        }
-        if schema_name == "mz_temp" {
-            let schema = &self.temporary_schemas[&conn_id];
-            if schema.items.contains_key(item_name) {
-                return Some(FullName {
-                    database: DatabaseSpecifier::Ambient,
-                    schema: schema_name.to_owned(),
-                    item: item_name.to_owned(),
-                });
-            }
-        }
-
-        None
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 enum SerializedCatalogItem {
     V1 {
@@ -1196,24 +1173,12 @@ impl PlanCatalog for ConnCatalog<'_> {
     fn resolve_schema(
         &self,
         current_database: &DatabaseSpecifier,
-        database: Option<&DatabaseSpecifier>,
+        database: Option<String>,
         schema_name: &str,
     ) -> Result<DatabaseSpecifier, failure::Error> {
-        let database_specs = if let Some(database) = database {
-            vec![database]
-        } else {
-            vec![current_database, &DatabaseSpecifier::Ambient]
-        };
-        for database_spec in database_specs {
-            if self
-                .catalog
-                .get_schema(&database_spec, schema_name, self.conn_id)
-                .is_ok()
-            {
-                return Ok(database_spec.clone());
-            }
-        }
-        Err(Error::new(ErrorKind::UnknownSchema(schema_name.into())).into())
+        Ok(self
+            .catalog
+            .resolve_schema(current_database, database, schema_name, self.conn_id)?)
     }
 }
 

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -63,7 +63,7 @@ pub struct Catalog {
     by_id: BTreeMap<GlobalId, CatalogEntry>,
     indexes: HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
     ambient_schemas: Schemas,
-    temporary_schemas: HashMap<u32, Schemas>,
+    temporary_schemas: HashMap<u32, Schema>,
     storage: Arc<Mutex<sql::Connection>>,
     creation_time: SystemTime,
     nonce: u64,
@@ -207,7 +207,6 @@ impl CatalogItem {
             _ => None,
         }
     }
-
 
     /// Indicates whether this item is temporary or not.
     pub fn is_temporary(&self) -> bool {
@@ -445,7 +444,7 @@ impl Catalog {
         database_spec: DatabaseSpecifier,
     ) -> Result<DatabaseResolver<'a>, Error> {
         match &database_spec {
-            DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary => Ok(DatabaseResolver {
+            DatabaseSpecifier::Ambient => Ok(DatabaseResolver {
                 database_spec,
                 database: &EMPTY_DATABASE,
                 ambient_schemas: &self.ambient_schemas,
@@ -466,58 +465,33 @@ impl Catalog {
     /// Creates a new schema in the `Catalog` for temporary items
     /// indicated by the TEMPORARY or TEMP keywords.
     pub fn create_temporary_schema(&mut self, conn_id: u32) {
-        let mut temp_schema_for_conn_id = BTreeMap::new();
-        temp_schema_for_conn_id.insert(
-            "mz_temp".into(),
+        self.temporary_schemas.insert(
+            conn_id,
             Schema {
                 id: -1,
                 items: Items(BTreeMap::new()),
             },
         );
-        self.temporary_schemas
-            .insert(conn_id, Schemas(temp_schema_for_conn_id));
     }
 
-    fn get_temp_schemas(&mut self, conn_id: u32) -> &Schemas {
-        self.temporary_schemas
-            .get(&conn_id)
-            .expect("missing temporary schema for connection")
-    }
-
-    fn item_exists_in_temp_schemas(&mut self, conn_id: u32, item_name: String) -> bool {
-        for schema in self.get_temp_schemas(conn_id).0.values() {
-            if schema.items.0.contains_key(&item_name) {
-                return true;
-            }
-        }
-        false
+    fn item_exists_in_temp_schemas(&mut self, conn_id: u32, item_name: &str) -> bool {
+        self.temporary_schemas[&conn_id]
+            .items
+            .0
+            .contains_key(item_name)
     }
 
     pub fn drop_temp_item_ops(&mut self, conn_id: u32) -> Vec<Op> {
-        self.get_temp_schemas(conn_id)
+        self.temporary_schemas[&conn_id]
+            .items
             .0
             .values()
-            .flat_map(|schema| {
-                schema
-                    .items
-                    .0
-                    .values()
-                    .map(|id| Op::DropItem(*id))
-                    .collect::<Vec<Op>>()
-            })
+            .map(|id| Op::DropItem(*id))
             .collect()
     }
 
     pub fn drop_temporary_schema(&mut self, conn_id: u32) {
-        if self
-            .get_temp_schemas(conn_id)
-            .0
-            .get("mz_temp")
-            .expect("missing temporary schema mz_temp for conn_id: {}")
-            .items
-            .0
-            .is_empty()
-        {
+        if self.temporary_schemas[&conn_id].items.0.is_empty() {
             error!(
                 "items leftover in temporary schema for conn_id: {}",
                 conn_id
@@ -536,17 +510,10 @@ impl Catalog {
     ) -> Result<&Schema, Error> {
         // Keep in sync with `get_schemas_mut`.
         match database_spec {
+            DatabaseSpecifier::Ambient if schema_name == "mz_temp" => {
+                Ok(&self.temporary_schemas[&conn_id])
+            }
             DatabaseSpecifier::Ambient => match self.ambient_schemas.0.get(schema_name) {
-                Some(schema) => Ok(schema),
-                None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
-            },
-            DatabaseSpecifier::Temporary => match self
-                .temporary_schemas
-                .get(&conn_id)
-                .unwrap()
-                .0
-                .get(schema_name)
-            {
                 Some(schema) => Ok(schema),
                 None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
@@ -569,17 +536,10 @@ impl Catalog {
     ) -> Result<&mut Schema, Error> {
         // Keep in sync with `get_schemas`.
         match database_spec {
+            DatabaseSpecifier::Ambient if schema_name == "mz_temp" => {
+                Ok(self.temporary_schemas.get_mut(&conn_id).unwrap())
+            }
             DatabaseSpecifier::Ambient => match self.ambient_schemas.0.get_mut(schema_name) {
-                Some(schema) => Ok(schema),
-                None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
-            },
-            DatabaseSpecifier::Temporary => match self
-                .temporary_schemas
-                .get_mut(&conn_id)
-                .unwrap()
-                .0
-                .get_mut(schema_name)
-            {
                 Some(schema) => Ok(schema),
                 None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
@@ -714,12 +674,12 @@ impl Catalog {
                     }),
             } = op
             {
-                if self.item_exists_in_temp_schemas(*conn_id, name.item.clone())
-                    || creating.contains(&(conn_id, name.item.clone()))
+                if self.item_exists_in_temp_schemas(*conn_id, &name.item)
+                    || creating.contains(&(conn_id, &name.item))
                 {
                     return Err(Error::new(ErrorKind::ItemAlreadyExists(name.item.clone())));
                 } else {
-                    creating.insert((conn_id, name.item.clone()));
+                    creating.insert((conn_id, &name.item));
                     temporary_ids.push(id.clone());
                 }
             }
@@ -775,7 +735,7 @@ impl Catalog {
                     }
                     let (database_id, database_name) = match database_name {
                         DatabaseSpecifier::Name(name) => (tx.load_database_id(&name)?, name),
-                        DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary => {
+                        DatabaseSpecifier::Ambient => {
                             return Err(Error::new(ErrorKind::ReadOnlySystemSchema(schema_name)));
                         }
                     };
@@ -800,7 +760,6 @@ impl Catalog {
                                     name.to_string(),
                                 )));
                             }
-                            DatabaseSpecifier::Temporary => unreachable!(),
                         };
                         let schema_id = tx.load_schema_id(database_id, &name.schema)?;
                         let serialized_item = self.serialize_item(&item);
@@ -819,7 +778,7 @@ impl Catalog {
                 } => {
                     let (database_id, database_name) = match database_name {
                         DatabaseSpecifier::Name(name) => (tx.load_database_id(&name)?, name),
-                        DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary => {
+                        DatabaseSpecifier::Ambient => {
                             return Err(Error::new(ErrorKind::ReadOnlySystemSchema(schema_name)));
                         }
                     };
@@ -1104,7 +1063,7 @@ pub struct DatabaseResolver<'a> {
     database_spec: DatabaseSpecifier,
     database: &'a Database,
     ambient_schemas: &'a Schemas,
-    temporary_schemas: &'a HashMap<u32, Schemas>,
+    temporary_schemas: &'a HashMap<u32, Schema>,
 }
 
 impl<'a> DatabaseResolver<'a> {
@@ -1135,15 +1094,14 @@ impl<'a> DatabaseResolver<'a> {
                 });
             }
         }
-        if let Some(temp_schema_for_conn_id) = self.temporary_schemas.get(&conn_id) {
-            if let Some(schema) = temp_schema_for_conn_id.0.get(schema_name) {
-                if schema.items.0.contains_key(item_name) {
-                    return Some(FullName {
-                        database: DatabaseSpecifier::Temporary,
-                        schema: schema_name.to_owned(),
-                        item: item_name.to_owned(),
-                    });
-                }
+        if schema_name == "mz_temp" {
+            let schema = &self.temporary_schemas[&conn_id];
+            if schema.items.0.contains_key(item_name) {
+                return Some(FullName {
+                    database: DatabaseSpecifier::Ambient,
+                    schema: schema_name.to_owned(),
+                    item: item_name.to_owned(),
+                });
             }
         }
 
@@ -1210,9 +1168,13 @@ impl PlanCatalog for ConnCatalog<'_> {
     ) -> Result<Box<dyn Iterator<Item = &'a str> + 'a>, failure::Error> {
         match database_spec {
             DatabaseSpecifier::Ambient => Ok(Box::new(
-                self.catalog.ambient_schemas.0.keys().map(|s| s.as_str()),
+                self.catalog
+                    .ambient_schemas
+                    .0
+                    .keys()
+                    .map(|s| s.as_str())
+                    .chain(iter::once("mz_temp")),
             )),
-            DatabaseSpecifier::Temporary => Ok(Box::new(iter::once("mz_temp"))),
             DatabaseSpecifier::Name(n) => match self.catalog.by_name.get(n) {
                 Some(db) => Ok(Box::new(db.schemas.0.keys().map(|s| s.as_str()))),
                 None => Err(Error::new(ErrorKind::UnknownDatabase(n.into())).into()),
@@ -1253,11 +1215,7 @@ impl PlanCatalog for ConnCatalog<'_> {
         let database_specs = if let Some(database) = database {
             vec![database]
         } else {
-            vec![
-                current_database,
-                &DatabaseSpecifier::Ambient,
-                &DatabaseSpecifier::Temporary,
-            ]
+            vec![current_database, &DatabaseSpecifier::Ambient]
         };
         for database_spec in database_specs {
             if self

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -36,6 +36,8 @@ pub mod sql;
 
 pub const SYSTEM_CONN_ID: u32 = 0;
 
+pub const MZ_TEMP_SCHEMA: &str = "mz_temp";
+
 /// A `Catalog` keeps track of the SQL objects known to the planner.
 ///
 /// For each object, it keeps track of both forward and reverse dependencies:
@@ -530,7 +532,7 @@ impl Catalog {
     ) -> Result<&Schema, Error> {
         // Keep in sync with `get_schemas_mut`.
         match database_spec {
-            DatabaseSpecifier::Ambient if schema_name == "mz_temp" => {
+            DatabaseSpecifier::Ambient if schema_name == MZ_TEMP_SCHEMA => {
                 Ok(&self.temporary_schemas[&conn_id])
             }
             DatabaseSpecifier::Ambient => match self.ambient_schemas.get(schema_name) {
@@ -556,7 +558,7 @@ impl Catalog {
     ) -> Result<&mut Schema, Error> {
         // Keep in sync with `get_schemas`.
         match database_spec {
-            DatabaseSpecifier::Ambient if schema_name == "mz_temp" => {
+            DatabaseSpecifier::Ambient if schema_name == MZ_TEMP_SCHEMA => {
                 Ok(self.temporary_schemas.get_mut(&conn_id).unwrap())
             }
             DatabaseSpecifier::Ambient => match self.ambient_schemas.get_mut(schema_name) {
@@ -1137,7 +1139,7 @@ impl PlanCatalog for ConnCatalog<'_> {
                     .ambient_schemas
                     .keys()
                     .map(|s| s.as_str())
-                    .chain(iter::once("mz_temp")),
+                    .chain(iter::once(MZ_TEMP_SCHEMA)),
             )),
             DatabaseSpecifier::Name(n) => match self.catalog.by_name.get(n) {
                 Some(db) => Ok(Box::new(db.schemas.keys().map(|s| s.as_str()))),

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -62,7 +62,7 @@ pub struct Catalog {
     by_name: BTreeMap<String, Database>,
     by_id: BTreeMap<GlobalId, CatalogEntry>,
     indexes: HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-    ambient_schemas: Schemas,
+    ambient_schemas: BTreeMap<String, Schema>,
     temporary_schemas: HashMap<u32, Schema>,
     storage: Arc<Mutex<sql::Connection>>,
     creation_time: SystemTime,
@@ -84,27 +84,21 @@ impl ConnCatalog<'_> {
 #[derive(Debug, Serialize)]
 struct Database {
     id: i64,
-    schemas: Schemas,
+    schemas: BTreeMap<String, Schema>,
 }
 
 lazy_static! {
     static ref EMPTY_DATABASE: Database = Database {
         id: 0,
-        schemas: Schemas(BTreeMap::new()),
+        schemas: BTreeMap::new(),
     };
 }
 
 #[derive(Debug, Serialize)]
-struct Schemas(BTreeMap<String, Schema>);
-
-#[derive(Debug, Serialize)]
 pub struct Schema {
     id: i64,
-    items: Items,
+    items: BTreeMap<String, GlobalId>,
 }
-
-#[derive(Debug, Serialize)]
-struct Items(BTreeMap<String, GlobalId>);
 
 #[derive(Clone, Debug)]
 pub struct CatalogEntry {
@@ -272,7 +266,7 @@ impl Catalog {
             by_name: BTreeMap::new(),
             by_id: BTreeMap::new(),
             indexes: HashMap::new(),
-            ambient_schemas: Schemas(BTreeMap::new()),
+            ambient_schemas: BTreeMap::new(),
             temporary_schemas: HashMap::new(),
             storage: Arc::new(Mutex::new(storage)),
             creation_time: SystemTime::now(),
@@ -286,7 +280,7 @@ impl Catalog {
                 name,
                 Database {
                     id,
-                    schemas: Schemas(BTreeMap::new()),
+                    schemas: BTreeMap::new(),
                 },
             );
         }
@@ -303,11 +297,11 @@ impl Catalog {
                 }
                 None => &mut catalog.ambient_schemas,
             };
-            schemas.0.insert(
+            schemas.insert(
                 schema_name,
                 Schema {
                     id,
-                    items: Items(BTreeMap::new()),
+                    items: BTreeMap::new(),
                 },
             );
         }
@@ -414,7 +408,7 @@ impl Catalog {
     pub fn try_get(&self, name: &FullName, conn_id: u32) -> Option<&CatalogEntry> {
         self.get_schema(&name.database, &name.schema, conn_id)
             .ok()
-            .and_then(|schema| schema.items.0.get(&name.item))
+            .and_then(|schema| schema.items.get(&name.item))
             .map(|id| &self.by_id[id])
     }
 
@@ -469,7 +463,7 @@ impl Catalog {
             conn_id,
             Schema {
                 id: -1,
-                items: Items(BTreeMap::new()),
+                items: BTreeMap::new(),
             },
         );
     }
@@ -477,21 +471,19 @@ impl Catalog {
     fn item_exists_in_temp_schemas(&mut self, conn_id: u32, item_name: &str) -> bool {
         self.temporary_schemas[&conn_id]
             .items
-            .0
             .contains_key(item_name)
     }
 
     pub fn drop_temp_item_ops(&mut self, conn_id: u32) -> Vec<Op> {
         self.temporary_schemas[&conn_id]
             .items
-            .0
             .values()
             .map(|id| Op::DropItem(*id))
             .collect()
     }
 
     pub fn drop_temporary_schema(&mut self, conn_id: u32) {
-        if self.temporary_schemas[&conn_id].items.0.is_empty() {
+        if self.temporary_schemas[&conn_id].items.is_empty() {
             error!(
                 "items leftover in temporary schema for conn_id: {}",
                 conn_id
@@ -513,12 +505,12 @@ impl Catalog {
             DatabaseSpecifier::Ambient if schema_name == "mz_temp" => {
                 Ok(&self.temporary_schemas[&conn_id])
             }
-            DatabaseSpecifier::Ambient => match self.ambient_schemas.0.get(schema_name) {
+            DatabaseSpecifier::Ambient => match self.ambient_schemas.get(schema_name) {
                 Some(schema) => Ok(schema),
                 None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
             DatabaseSpecifier::Name(name) => match self.by_name.get(name) {
-                Some(db) => match db.schemas.0.get(schema_name) {
+                Some(db) => match db.schemas.get(schema_name) {
                     Some(schema) => Ok(schema),
                     None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
                 },
@@ -539,12 +531,12 @@ impl Catalog {
             DatabaseSpecifier::Ambient if schema_name == "mz_temp" => {
                 Ok(self.temporary_schemas.get_mut(&conn_id).unwrap())
             }
-            DatabaseSpecifier::Ambient => match self.ambient_schemas.0.get_mut(schema_name) {
+            DatabaseSpecifier::Ambient => match self.ambient_schemas.get_mut(schema_name) {
                 Some(schema) => Ok(schema),
                 None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
             DatabaseSpecifier::Name(name) => match self.by_name.get_mut(name) {
-                Some(db) => match db.schemas.0.get_mut(schema_name) {
+                Some(db) => match db.schemas.get_mut(schema_name) {
                     Some(schema) => Ok(schema),
                     None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
                 },
@@ -584,7 +576,6 @@ impl Catalog {
         self.get_schema_mut(&entry.name.database, &entry.name.schema, conn_id)
             .expect("catalog out of sync")
             .items
-            .0
             .insert(entry.name.item.clone(), entry.id);
         self.by_id.insert(entry.id, entry);
     }
@@ -592,7 +583,7 @@ impl Catalog {
     pub fn drop_database_ops(&mut self, name: String) -> Vec<Op> {
         let mut ops = vec![];
         if let Some(database) = self.by_name.get(&name) {
-            for (schema_name, schema) in &database.schemas.0 {
+            for (schema_name, schema) in &database.schemas {
                 Self::drop_schema_items(schema, &self.by_id, &mut ops);
                 ops.push(Op::DropSchema {
                     database_name: DatabaseSpecifier::Name(name.clone()),
@@ -612,7 +603,7 @@ impl Catalog {
         let mut ops = vec![];
         if let DatabaseSpecifier::Name(database_name) = database_spec {
             if let Some(database) = self.by_name.get(&database_name) {
-                if let Some(schema) = database.schemas.0.get(&schema_name) {
+                if let Some(schema) = database.schemas.get(&schema_name) {
                     Self::drop_schema_items(schema, &self.by_id, &mut ops);
                     ops.push(Op::DropSchema {
                         database_name: DatabaseSpecifier::Name(database_name),
@@ -638,7 +629,7 @@ impl Catalog {
         ops: &mut Vec<Op>,
     ) {
         let mut seen = HashSet::new();
-        for &id in schema.items.0.values() {
+        for &id in schema.items.values() {
             Self::drop_item_cascade(id, by_id, ops, &mut seen)
         }
     }
@@ -808,7 +799,7 @@ impl Catalog {
                         name,
                         Database {
                             id,
-                            schemas: Schemas(BTreeMap::new()),
+                            schemas: BTreeMap::new(),
                         },
                     );
                     OpStatus::CreatedDatabase
@@ -824,12 +815,11 @@ impl Catalog {
                         .get_mut(&database_name)
                         .unwrap()
                         .schemas
-                        .0
                         .insert(
                             schema_name,
                             Schema {
                                 id,
-                                items: Items(BTreeMap::new()),
+                                items: BTreeMap::new(),
                             },
                         );
                     OpStatus::CreatedSchema
@@ -853,7 +843,6 @@ impl Catalog {
                         .get_mut(&database_name)
                         .unwrap()
                         .schemas
-                        .0
                         .remove(&schema_name);
                     OpStatus::DroppedSchema
                 }
@@ -878,7 +867,6 @@ impl Catalog {
                     self.get_schema_mut(&metadata.name.database, &metadata.name.schema, conn_id)
                         .expect("catalog out of sync")
                         .items
-                        .0
                         .remove(&metadata.name.item)
                         .expect("catalog out of sync");
                     if let CatalogItem::Index(index) = &metadata.item {
@@ -1062,7 +1050,7 @@ pub enum OpStatus {
 pub struct DatabaseResolver<'a> {
     database_spec: DatabaseSpecifier,
     database: &'a Database,
-    ambient_schemas: &'a Schemas,
+    ambient_schemas: &'a BTreeMap<String, Schema>,
     temporary_schemas: &'a HashMap<u32, Schema>,
 }
 
@@ -1076,8 +1064,8 @@ impl<'a> DatabaseResolver<'a> {
         item_name: &str,
         conn_id: u32,
     ) -> Option<FullName> {
-        if let Some(schema) = self.database.schemas.0.get(schema_name) {
-            if schema.items.0.contains_key(item_name) {
+        if let Some(schema) = self.database.schemas.get(schema_name) {
+            if schema.items.contains_key(item_name) {
                 return Some(FullName {
                     database: self.database_spec.clone(),
                     schema: schema_name.to_owned(),
@@ -1085,8 +1073,8 @@ impl<'a> DatabaseResolver<'a> {
                 });
             }
         }
-        if let Some(schema) = self.ambient_schemas.0.get(schema_name) {
-            if schema.items.0.contains_key(item_name) {
+        if let Some(schema) = self.ambient_schemas.get(schema_name) {
+            if schema.items.contains_key(item_name) {
                 return Some(FullName {
                     database: DatabaseSpecifier::Ambient,
                     schema: schema_name.to_owned(),
@@ -1096,7 +1084,7 @@ impl<'a> DatabaseResolver<'a> {
         }
         if schema_name == "mz_temp" {
             let schema = &self.temporary_schemas[&conn_id];
-            if schema.items.0.contains_key(item_name) {
+            if schema.items.contains_key(item_name) {
                 return Some(FullName {
                     database: DatabaseSpecifier::Ambient,
                     schema: schema_name.to_owned(),
@@ -1170,13 +1158,12 @@ impl PlanCatalog for ConnCatalog<'_> {
             DatabaseSpecifier::Ambient => Ok(Box::new(
                 self.catalog
                     .ambient_schemas
-                    .0
                     .keys()
                     .map(|s| s.as_str())
                     .chain(iter::once("mz_temp")),
             )),
             DatabaseSpecifier::Name(n) => match self.catalog.by_name.get(n) {
-                Some(db) => Ok(Box::new(db.schemas.0.keys().map(|s| s.as_str()))),
+                Some(db) => Ok(Box::new(db.schemas.keys().map(|s| s.as_str()))),
                 None => Err(Error::new(ErrorKind::UnknownDatabase(n.into())).into()),
             },
         }
@@ -1190,7 +1177,7 @@ impl PlanCatalog for ConnCatalog<'_> {
         let schema = self
             .catalog
             .get_schema(database_spec, schema_name, self.conn_id)?;
-        Ok(Box::new(schema.items.0.values().map(move |id| {
+        Ok(Box::new(schema.items.values().map(move |id| {
             self.catalog.get_by_id(id) as &dyn PlanCatalogEntry
         })))
     }

--- a/src/coord/catalog.rs
+++ b/src/coord/catalog.rs
@@ -34,6 +34,8 @@ use crate::catalog::error::{Error, ErrorKind};
 mod error;
 pub mod sql;
 
+pub const SYSTEM_CONN_ID: u32 = 0;
+
 /// A `Catalog` keeps track of the SQL objects known to the planner.
 ///
 /// For each object, it keeps track of both forward and reverse dependencies:
@@ -70,11 +72,11 @@ pub struct Catalog {
 #[derive(Debug)]
 pub struct ConnCatalog<'a> {
     catalog: &'a Catalog,
-    conn_id: Option<u32>,
+    conn_id: u32,
 }
 
 impl ConnCatalog<'_> {
-    pub fn new(catalog: &Catalog, conn_id: Option<u32>) -> ConnCatalog {
+    pub fn new(catalog: &Catalog, conn_id: u32) -> ConnCatalog {
         ConnCatalog { catalog, conn_id }
     }
 }
@@ -197,12 +199,19 @@ impl CatalogItem {
         }
     }
 
+    /// Returns the connection ID that this item belongs to, if this item is
+    /// temporary.
+    pub fn conn_id(&self) -> Option<u32> {
+        match self {
+            CatalogItem::View(view) => view.conn_id,
+            _ => None,
+        }
+    }
+
+
     /// Indicates whether this item is temporary or not.
     pub fn is_temporary(&self) -> bool {
-        match self {
-            CatalogItem::View(view) => view.conn_id.is_some(),
-            _ => false,
-        }
+        self.conn_id().is_some()
     }
 }
 
@@ -270,6 +279,7 @@ impl Catalog {
             creation_time: SystemTime::now(),
             nonce: rand::random(),
         };
+        catalog.create_temporary_schema(SYSTEM_CONN_ID);
 
         let databases = catalog.storage().load_databases()?;
         for (id, name) in databases {
@@ -360,7 +370,7 @@ impl Catalog {
         current_database: DatabaseSpecifier,
         search_path: &[&str],
         name: &PartialName,
-        conn_id: Option<u32>,
+        conn_id: u32,
     ) -> Result<FullName, Error> {
         if let (Some(database_name), Some(schema_name)) = (&name.database, &name.schema) {
             // `name` is fully specified already. No resolution required.
@@ -402,7 +412,7 @@ impl Catalog {
     /// Returns the named catalog item, if it exists.
     ///
     /// See also [`Catalog::get`].
-    pub fn try_get(&self, name: &FullName, conn_id: Option<u32>) -> Option<&CatalogEntry> {
+    pub fn try_get(&self, name: &FullName, conn_id: u32) -> Option<&CatalogEntry> {
         self.get_schema(&name.database, &name.schema, conn_id)
             .ok()
             .and_then(|schema| schema.items.0.get(&name.item))
@@ -412,7 +422,7 @@ impl Catalog {
     /// Returns the named catalog item, or an error if it does not exist.
     ///
     /// See also [`Catalog::try_get`].
-    pub fn get(&self, name: &FullName, conn_id: Option<u32>) -> Result<&CatalogEntry, Error> {
+    pub fn get(&self, name: &FullName, conn_id: u32) -> Result<&CatalogEntry, Error> {
         self.try_get(name, conn_id)
             .ok_or_else(|| Error::new(ErrorKind::UnknownItem(name.to_string())))
     }
@@ -522,7 +532,7 @@ impl Catalog {
         &self,
         database_spec: &DatabaseSpecifier,
         schema_name: &str,
-        conn_id: Option<u32>,
+        conn_id: u32,
     ) -> Result<&Schema, Error> {
         // Keep in sync with `get_schemas_mut`.
         match database_spec {
@@ -530,18 +540,15 @@ impl Catalog {
                 Some(schema) => Ok(schema),
                 None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
-            DatabaseSpecifier::Temporary => match conn_id {
-                Some(conn_id) => match self
-                    .temporary_schemas
-                    .get(&conn_id)
-                    .unwrap()
-                    .0
-                    .get(schema_name)
-                {
-                    Some(schema) => Ok(schema),
-                    None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
-                },
-                None => unreachable!("cannot get temporary schema with no conn_id"),
+            DatabaseSpecifier::Temporary => match self
+                .temporary_schemas
+                .get(&conn_id)
+                .unwrap()
+                .0
+                .get(schema_name)
+            {
+                Some(schema) => Ok(schema),
+                None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
             DatabaseSpecifier::Name(name) => match self.by_name.get(name) {
                 Some(db) => match db.schemas.0.get(schema_name) {
@@ -558,7 +565,7 @@ impl Catalog {
         &mut self,
         database_spec: &DatabaseSpecifier,
         schema_name: &str,
-        conn_id: Option<u32>,
+        conn_id: u32,
     ) -> Result<&mut Schema, Error> {
         // Keep in sync with `get_schemas`.
         match database_spec {
@@ -566,18 +573,15 @@ impl Catalog {
                 Some(schema) => Ok(schema),
                 None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
-            DatabaseSpecifier::Temporary => match conn_id {
-                Some(conn_id) => match self
-                    .temporary_schemas
-                    .get_mut(&conn_id)
-                    .unwrap()
-                    .0
-                    .get_mut(schema_name)
-                {
-                    Some(schema) => Ok(schema),
-                    None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
-                },
-                None => unreachable!("cannot get temporary schema with no conn_id"),
+            DatabaseSpecifier::Temporary => match self
+                .temporary_schemas
+                .get_mut(&conn_id)
+                .unwrap()
+                .0
+                .get_mut(schema_name)
+            {
+                Some(schema) => Ok(schema),
+                None => Err(Error::new(ErrorKind::UnknownSchema(schema_name.into()))),
             },
             DatabaseSpecifier::Name(name) => match self.by_name.get_mut(name) {
                 Some(db) => match db.schemas.0.get_mut(schema_name) {
@@ -616,10 +620,7 @@ impl Catalog {
                 .or_insert_with(Vec::new)
                 .push(index.keys.clone());
         }
-        let conn_id = match &entry.item {
-            CatalogItem::View(view) => view.conn_id,
-            _ => None,
-        };
+        let conn_id = entry.item().conn_id().unwrap_or(SYSTEM_CONN_ID);
         self.get_schema_mut(&entry.name.database, &entry.name.schema, conn_id)
             .expect("catalog out of sync")
             .items
@@ -899,11 +900,6 @@ impl Catalog {
                 }
 
                 Action::DropItem(id) => {
-                    let conn_id = match &self.get_by_id(&id).item {
-                        CatalogItem::View(view) => view.conn_id.clone(),
-                        _ => None,
-                    };
-
                     let metadata = self.by_id.remove(&id).unwrap();
                     if !metadata.item.is_placeholder() {
                         info!(
@@ -919,6 +915,7 @@ impl Catalog {
                         }
                     }
 
+                    let conn_id = metadata.item.conn_id().unwrap_or(SYSTEM_CONN_ID);
                     self.get_schema_mut(&metadata.name.database, &metadata.name.schema, conn_id)
                         .expect("catalog out of sync")
                         .items
@@ -983,7 +980,7 @@ impl Catalog {
         let stmt = ::sql::parse(create_sql)?.into_element();
         let plan = ::sql::plan(
             &pcx,
-            &ConnCatalog::new(self, None),
+            &ConnCatalog::new(self, SYSTEM_CONN_ID),
             &::sql::InternalSession,
             stmt,
             &params,
@@ -1118,7 +1115,7 @@ impl<'a> DatabaseResolver<'a> {
         &self,
         schema_name: &str,
         item_name: &str,
-        conn_id: Option<u32>,
+        conn_id: u32,
     ) -> Option<FullName> {
         if let Some(schema) = self.database.schemas.0.get(schema_name) {
             if schema.items.0.contains_key(item_name) {
@@ -1138,16 +1135,14 @@ impl<'a> DatabaseResolver<'a> {
                 });
             }
         }
-        if let Some(conn_id) = conn_id {
-            if let Some(temp_schema_for_conn_id) = self.temporary_schemas.get(&conn_id) {
-                if let Some(schema) = temp_schema_for_conn_id.0.get(schema_name) {
-                    if schema.items.0.contains_key(item_name) {
-                        return Some(FullName {
-                            database: DatabaseSpecifier::Temporary,
-                            schema: schema_name.to_owned(),
-                            item: item_name.to_owned(),
-                        });
-                    }
+        if let Some(temp_schema_for_conn_id) = self.temporary_schemas.get(&conn_id) {
+            if let Some(schema) = temp_schema_for_conn_id.0.get(schema_name) {
+                if schema.items.0.contains_key(item_name) {
+                    return Some(FullName {
+                        database: DatabaseSpecifier::Temporary,
+                        schema: schema_name.to_owned(),
+                        item: item_name.to_owned(),
+                    });
                 }
             }
         }

--- a/src/coord/catalog/error.rs
+++ b/src/coord/catalog/error.rs
@@ -13,8 +13,8 @@ use backtrace::Backtrace;
 
 #[derive(Debug)]
 pub struct Error {
-    kind: ErrorKind,
-    backtrace: Backtrace,
+    pub(crate) kind: ErrorKind,
+    pub(crate) backtrace: Backtrace,
 }
 
 #[derive(Debug)]

--- a/src/coord/coord.rs
+++ b/src/coord/coord.rs
@@ -319,7 +319,7 @@ where
             match msg {
                 Message::Command(Command::Startup { session, tx }) => {
                     let mut messages = vec![];
-                    if self.catalog.database_resolver(session.database()).is_err() {
+                    if self.catalog.resolve_database(&session.database()).is_err() {
                         messages.push(StartupMessage::UnknownSessionDatabase);
                     }
                     self.catalog.create_temporary_schema(session.conn_id());

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -54,7 +54,7 @@ pub trait PlanCatalog: fmt::Debug {
     fn resolve_schema(
         &self,
         _: &DatabaseSpecifier,
-        _: Option<&DatabaseSpecifier>,
+        _: Option<String>,
         schema_name: &str,
     ) -> Result<DatabaseSpecifier, failure::Error>;
 }
@@ -149,7 +149,7 @@ impl PlanCatalog for DummyCatalog {
     fn resolve_schema(
         &self,
         _: &DatabaseSpecifier,
-        _: Option<&DatabaseSpecifier>,
+        _: Option<String>,
         _: &str,
     ) -> Result<DatabaseSpecifier, failure::Error> {
         unimplemented!();

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -32,14 +32,13 @@ impl fmt::Display for FullName {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum DatabaseSpecifier {
     Ambient,
-    Temporary,
     Name(String),
 }
 
 impl fmt::Display for DatabaseSpecifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary => f.write_str("<none>"),
+            DatabaseSpecifier::Ambient => f.write_str("<none>"),
             DatabaseSpecifier::Name(name) => f.write_str(name),
         }
     }
@@ -92,7 +91,7 @@ impl From<FullName> for PartialName {
     fn from(n: FullName) -> PartialName {
         PartialName {
             database: match n.database {
-                DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary => None,
+                DatabaseSpecifier::Ambient => None,
                 DatabaseSpecifier::Name(name) => Some(name),
             },
             schema: Some(n.schema),

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -1400,7 +1400,7 @@ fn handle_drop_schema(
     }
     match scx.resolve_schema(names.into_element()) {
         Ok((database_spec, schema_name)) => {
-            if let DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary = database_spec {
+            if let DatabaseSpecifier::Ambient = database_spec {
                 bail!(
                     "cannot drop schema {} because it is required by the database system",
                     schema_name
@@ -1654,7 +1654,7 @@ impl<'a> StatementContext<'a> {
 
     pub fn allocate_temporary_name(&self, name: PartialName) -> FullName {
         FullName {
-            database: DatabaseSpecifier::Temporary,
+            database: DatabaseSpecifier::Ambient,
             schema: "mz_temp".to_owned(),
             item: name.item,
         }

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -1660,7 +1660,10 @@ impl<'a> StatementContext<'a> {
         }
     }
 
-    pub fn resolve_schema(&self, mut name: ObjectName) -> Result<(DatabaseSpecifier, String), failure::Error> {
+    pub fn resolve_schema(
+        &self,
+        mut name: ObjectName,
+    ) -> Result<(DatabaseSpecifier, String), failure::Error> {
         if name.0.len() > 2 {
             bail!(
                 "schema name '{}' cannot have more than two components",

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -451,23 +451,8 @@ fn handle_show_objects(
             &make_show_objects_desc(object_type, materialized, full),
         )
     } else {
-        let items = if let Some(mut from) = from {
-            if from.0.len() > 2 {
-                bail!(
-                    "schema name '{}' cannot have more than two components",
-                    from
-                );
-            }
-            let schema_name = normalize::ident(from.0.pop().unwrap());
-            let database_spec = from
-                .0
-                .pop()
-                .map(|n| DatabaseSpecifier::Name(normalize::ident(n)));
-            let database_spec = scx.catalog.resolve_schema(
-                &scx.session.database(),
-                database_spec.as_ref(),
-                &schema_name,
-            )?;
+        let items = if let Some(from) = from {
+            let (database_spec, schema_name) = scx.resolve_schema(from)?;
             scx.catalog
                 .get_items(&database_spec, &schema_name)
                 .expect("schema known to exist")
@@ -1413,18 +1398,8 @@ fn handle_drop_schema(
     if names.len() != 1 {
         unsupported!("DROP SCHEMA with multiple schemas");
     }
-    let mut name = names.into_element();
-    let schema_name = normalize::ident(name.0.pop().unwrap());
-    let database_name = name
-        .0
-        .pop()
-        .map(|n| DatabaseSpecifier::Name(normalize::ident(n)));
-    let database_name = match scx.catalog.resolve_schema(
-        &scx.session.database(),
-        database_name.as_ref(),
-        &schema_name,
-    ) {
-        Ok(database_spec) => {
+    match scx.resolve_schema(names.into_element()) {
+        Ok((database_spec, schema_name)) => {
             if let DatabaseSpecifier::Ambient | DatabaseSpecifier::Temporary = database_spec {
                 bail!(
                     "cannot drop schema {} because it is required by the database system",
@@ -1442,19 +1417,23 @@ fn handle_drop_schema(
                     schema_name
                 );
             }
-            database_spec
+            Ok(Plan::DropSchema {
+                database_name: database_spec,
+                schema_name,
+            })
         }
         Err(_) if if_exists => {
             // TODO(benesch): generate a notice indicating that the
             // database does not exist.
-            scx.session.database()
+            // TODO(benesch): adjust the types here properly, rather than making
+            // up a nonexistent database.
+            Ok(Plan::DropSchema {
+                database_name: DatabaseSpecifier::Ambient,
+                schema_name: "noexist".into(),
+            })
         }
-        Err(e) => return Err(e),
-    };
-    Ok(Plan::DropSchema {
-        database_name,
-        schema_name,
-    })
+        Err(e) => Err(e),
+    }
 }
 
 fn handle_drop_items(
@@ -1679,6 +1658,26 @@ impl<'a> StatementContext<'a> {
             schema: "mz_temp".to_owned(),
             item: name.item,
         }
+    }
+
+    pub fn resolve_schema(&self, mut name: ObjectName) -> Result<(DatabaseSpecifier, String), failure::Error> {
+        if name.0.len() > 2 {
+            bail!(
+                "schema name '{}' cannot have more than two components",
+                name
+            );
+        }
+        let schema_name = normalize::ident(name.0.pop().unwrap());
+        let database_spec = name
+            .0
+            .pop()
+            .map(|n| DatabaseSpecifier::Name(normalize::ident(n)));
+        let database_spec = self.catalog.resolve_schema(
+            &self.session.database(),
+            database_spec.as_ref(),
+            &schema_name,
+        )?;
+        Ok((database_spec, schema_name))
     }
 
     pub fn resolve_name(&self, name: ObjectName) -> Result<FullName, failure::Error> {

--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -1671,15 +1671,10 @@ impl<'a> StatementContext<'a> {
             );
         }
         let schema_name = normalize::ident(name.0.pop().unwrap());
-        let database_spec = name
-            .0
-            .pop()
-            .map(|n| DatabaseSpecifier::Name(normalize::ident(n)));
-        let database_spec = self.catalog.resolve_schema(
-            &self.session.database(),
-            database_spec.as_ref(),
-            &schema_name,
-        )?;
+        let database_spec = name.0.pop().map(normalize::ident);
+        let database_spec =
+            self.catalog
+                .resolve_schema(&self.session.database(), database_spec, &schema_name)?;
         Ok((database_spec, schema_name))
     }
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -14,6 +14,7 @@ public
 Schema
 ----
 public
+mz_temp
 mz_catalog
 pg_catalog
 

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -175,8 +175,8 @@ test2
 ! SHOW VIEWS FROM noexist
 unknown schema 'noexist'
 
-! SHOW VIEWS FROM noexist.noexist
-unknown database 'noexist'
+! SHOW VIEWS FROM noexist_db.noexist_schema
+unknown database 'noexist_db'
 
 ! SHOW EXTENDED VIEWS
 Expected one of SCHEMAS or INDEX or INDEXES or KEYS or TABLES or COLUMNS or FULL, found: VIEWS


### PR DESCRIPTION
Continued extraction from #3175 and a follow up to #3206. This manages to get rid of `DatabaseSpecifier::Temporary` and makes a number of other cleanups along the way.
 
Like before, should be easiest to review commit by commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3218)
<!-- Reviewable:end -->
