### PR TITLE
Add bytes generator to test-util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,7 +2132,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aws-util",
- "bytes",
  "chrono",
  "env_logger",
  "futures",
@@ -2144,6 +2143,7 @@ dependencies = [
  "rusoto_credential",
  "rusoto_kinesis",
  "structopt",
+ "test-util",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -3390,7 +3390,9 @@ name = "test-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
+ "rand",
  "rdkafka",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,6 +2132,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aws-util",
+ "bytes",
  "chrono",
  "env_logger",
  "futures",
@@ -3390,7 +3391,6 @@ name = "test-util"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes",
  "chrono",
  "rand",
  "rdkafka",

--- a/test/performance/perf-kinesis/Cargo.toml
+++ b/test/performance/perf-kinesis/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.31"
 aws-util = { path = "../../../src/aws-util" }
-bytes = "0.5.4"
 chrono = "0.4"
 env_logger = "0.7.1"
 futures = "0.3.4"
@@ -23,3 +22,4 @@ structopt = "0.3.11"
 thiserror = "1.0.19"
 tokio = { version = "0.2.21", features = ["full"] }
 tokio-postgres = "0.5.1"
+test-util = { path = "../../test-util" }

--- a/test/performance/perf-kinesis/Cargo.toml
+++ b/test/performance/perf-kinesis/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.31"
 aws-util = { path = "../../../src/aws-util" }
+bytes = "0.5.4"
 chrono = "0.4"
 env_logger = "0.7.1"
 futures = "0.3.4"

--- a/test/performance/perf-kinesis/src/kinesis.rs
+++ b/test/performance/perf-kinesis/src/kinesis.rs
@@ -13,9 +13,6 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::Context;
-use bytes::Bytes;
-use rand::distributions::Alphanumeric;
-use rand::Rng;
 use rusoto_core::RusotoError;
 use rusoto_kinesis::{
     CreateStreamInput, DeleteStreamInput, DescribeStreamInput, Kinesis, KinesisClient,
@@ -23,6 +20,7 @@ use rusoto_kinesis::{
 };
 
 use ore::retry;
+use test_util::generator;
 
 const DUMMY_PARTITION_KEY: &str = "dummy";
 const ACTIVE: &str = "ACTIVE";
@@ -76,8 +74,8 @@ pub async fn create_stream(
 pub async fn generate_and_put_records(
     kinesis_client: &KinesisClient,
     stream_name: &str,
-    total_records: i64,
-    records_per_second: i64,
+    total_records: u64,
+    records_per_second: u64,
 ) -> Result<(), anyhow::Error> {
     let timer = std::time::Instant::now();
     // For each string, round robin puts across all of the shards.
@@ -130,19 +128,14 @@ pub async fn put_records_one_second(
     kinesis_client: &KinesisClient,
     stream_name: &str,
     shard_starting_hash_key: &str,
-    records_per_second: i64,
-) -> Result<i64, anyhow::Error> {
+    records_per_second: u64,
+) -> Result<u64, anyhow::Error> {
     // Generate records.
     let mut records: Vec<PutRecordsRequestEntry> = Vec::new();
-    for _i in 0..records_per_second {
+    for bytes in generator::bytes::generate_bytes(records_per_second) {
         // todo: make the records more realistic json blobs
         records.push(PutRecordsRequestEntry {
-            data: Bytes::from(
-                rand::thread_rng()
-                    .sample_iter(&Alphanumeric)
-                    .take(30)
-                    .collect::<String>(),
-            ),
+            data: bytes,
             explicit_hash_key: Some(shard_starting_hash_key.to_owned()), // explicitly push to the current shard
             partition_key: DUMMY_PARTITION_KEY.to_owned(), // will be overridden by "explicit_hash_key"
         });
@@ -163,7 +156,7 @@ pub async fn put_records_one_second(
                 // todo: do something with failed counts
                 let put_records = output.records.len();
                 index += put_records;
-                put_record_count += output.records.len() as i64;
+                put_record_count += output.records.len() as u64;
             }
             Err(RusotoError::Service(PutRecordsError::KMSThrottling(e)))
             | Err(RusotoError::Service(PutRecordsError::ProvisionedThroughputExceeded(e))) => {

--- a/test/performance/perf-kinesis/src/kinesis.rs
+++ b/test/performance/perf-kinesis/src/kinesis.rs
@@ -13,6 +13,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::Context;
+use bytes::Bytes;
 use rusoto_core::RusotoError;
 use rusoto_kinesis::{
     CreateStreamInput, DeleteStreamInput, DescribeStreamInput, Kinesis, KinesisClient,
@@ -132,10 +133,10 @@ pub async fn put_records_one_second(
 ) -> Result<u64, anyhow::Error> {
     // Generate records.
     let mut records: Vec<PutRecordsRequestEntry> = Vec::new();
-    for bytes in generator::bytes::generate_bytes(records_per_second) {
+    for _ in 0..records_per_second {
         // todo: make the records more realistic json blobs
         records.push(PutRecordsRequestEntry {
-            data: bytes,
+            data: Bytes::from(generator::bytes::generate_bytes(30)),
             explicit_hash_key: Some(shard_starting_hash_key.to_owned()), // explicitly push to the current shard
             partition_key: DUMMY_PARTITION_KEY.to_owned(), // will be overridden by "explicit_hash_key"
         });

--- a/test/performance/perf-kinesis/src/main.rs
+++ b/test/performance/perf-kinesis/src/main.rs
@@ -152,9 +152,9 @@ pub struct Args {
 
     /// The total number of records to create
     #[structopt(long, default_value = "150000000")]
-    pub total_records: i64,
+    pub total_records: u64,
 
     /// The number of records to put to the Kinesis stream per second
     #[structopt(long, default_value = "2000")]
-    pub records_per_second: i64,
+    pub records_per_second: u64,
 }

--- a/test/performance/perf-kinesis/src/mz.rs
+++ b/test/performance/perf-kinesis/src/mz.rs
@@ -49,7 +49,7 @@ pub async fn create_source_and_views(
 pub async fn query_materialized_view_until(
     client: &Client,
     view_name: &str,
-    expected_total_records: i64,
+    expected_total_records: u64,
 ) -> Result<(), anyhow::Error> {
     let query = format!("SELECT * FROM {view_name};", view_name = view_name);
     log::info!("querying view=> {}", query);
@@ -60,7 +60,7 @@ pub async fn query_materialized_view_until(
         match client.query_one(&*query, &[]).await {
             Ok(row) => {
                 let count: i64 = row.get("count");
-                if count == expected_total_records {
+                if count as u64 == expected_total_records {
                     log::info!(
                         "Found all {} records, done querying.",
                         expected_total_records

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.31"
-bytes = "0.5.4"
 chrono = "0.4.11"
 rand = "0.7.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -7,5 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.31"
+bytes = "0.5.4"
 chrono = "0.4.11"
+rand = "0.7.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/test/test-util/src/generator/bytes.rs
+++ b/test/test-util/src/generator/bytes.rs
@@ -1,0 +1,35 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::Bytes;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+
+const DEFAULT_LEN: usize = 30;
+
+/// Generates and returns `n` number of bytes structs of
+/// default length DEFAULT_LEN.
+pub fn generate_bytes(n: u64) -> Vec<Bytes> {
+    generate_bytes_of_len(n, DEFAULT_LEN)
+}
+
+/// Generates and returns `n` number of bytes structs, each of
+/// length `len`.
+pub fn generate_bytes_of_len(n: u64, len: usize) -> Vec<Bytes> {
+    let mut bytes = Vec::with_capacity(n as usize);
+    for _ in 0..n {
+        bytes.push(Bytes::from(
+            rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(len)
+                .collect::<String>(),
+        ));
+    }
+    bytes
+}

--- a/test/test-util/src/generator/bytes.rs
+++ b/test/test-util/src/generator/bytes.rs
@@ -7,29 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 
-const DEFAULT_LEN: usize = 30;
-
-/// Generates and returns `n` number of bytes structs of
-/// default length DEFAULT_LEN.
-pub fn generate_bytes(n: u64) -> Vec<Bytes> {
-    generate_bytes_of_len(n, DEFAULT_LEN)
-}
-
-/// Generates and returns `n` number of bytes structs, each of
-/// length `len`.
-pub fn generate_bytes_of_len(n: u64, len: usize) -> Vec<Bytes> {
-    let mut bytes = Vec::with_capacity(n as usize);
-    for _ in 0..n {
-        bytes.push(Bytes::from(
-            rand::thread_rng()
-                .sample_iter(&Alphanumeric)
-                .take(len)
-                .collect::<String>(),
-        ));
-    }
-    bytes
+/// Generates and returns bytes of length `len`.
+pub fn generate_bytes(len: usize) -> Vec<u8> {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(len)
+        .map(|c| c as u8)
+        .collect::<Vec<u8>>()
 }

--- a/test/test-util/src/generator/mod.rs
+++ b/test/test-util/src/generator/mod.rs
@@ -1,0 +1,10 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+pub mod bytes;

--- a/test/test-util/src/lib.rs
+++ b/test/test-util/src/lib.rs
@@ -9,4 +9,5 @@
 
 //! `test_util` provides utilities for test programs and demos that run against Materialize.
 
+pub mod generator;
 pub mod kafka;


### PR DESCRIPTION
The bytes generator, currently only used by `perf-kinesis`, will be used in the first version of Kafka chaos testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3223)
<!-- Reviewable:end -->
