### PR TITLE
coord,sql: reject temp views in non-temp schemas

### DIFF
--- a/src/sql/src/statement.rs
+++ b/src/sql/src/statement.rs
@@ -1610,7 +1610,7 @@ impl<'a> StatementContext<'a> {
     pub fn allocate_temporary_name(&self, name: PartialName) -> FullName {
         FullName {
             database: DatabaseSpecifier::Ambient,
-            schema: "mz_temp".to_owned(),
+            schema: name.schema.unwrap_or_else(|| "mz_temp".to_owned()),
             item: name.item,
         }
     }

--- a/test/testdrive/temporary-views.td
+++ b/test/testdrive/temporary-views.td
@@ -94,3 +94,6 @@ unknown catalog item 'double_temp_v'
 
 ! SELECT * FROM temp_v;
 unknown catalog item 'temp_v'
+
+! CREATE TEMP VIEW mz_foo.a AS SELECT 1
+cannot create temporary item in non-temporary schema


### PR DESCRIPTION
We were previously silently rewriting the schema to mz_temp, which made
for slightly confusing error messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3224)
<!-- Reviewable:end -->
