### PR TITLE
repr: introduce abstract data type (ADT) module

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -13,9 +13,11 @@ use std::fmt;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use ordered_float::OrderedFloat;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use repr::decimal::Significand;
+use repr::adt::decimal::Significand;
+use repr::adt::regex::Regex as ReprRegex;
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
 use std::iter;
@@ -619,7 +621,7 @@ pub struct CaptureGroupDesc {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct AnalyzedRegex(repr::regex::Regex, Vec<CaptureGroupDesc>);
+pub struct AnalyzedRegex(ReprRegex, Vec<CaptureGroupDesc>);
 
 impl AnalyzedRegex {
     pub fn new(s: &str) -> Result<Self, regex::Error> {
@@ -640,7 +642,7 @@ impl AnalyzedRegex {
                 nullable: true,
             })
             .collect();
-        Ok(Self(repr::regex::Regex(r), descs))
+        Ok(Self(ReprRegex(r), descs))
     }
     pub fn capture_groups_len(&self) -> usize {
         self.1.len()
@@ -648,7 +650,7 @@ impl AnalyzedRegex {
     pub fn capture_groups_iter(&self) -> impl Iterator<Item = &CaptureGroupDesc> {
         self.1.iter()
     }
-    pub fn inner(&self) -> &regex::Regex {
+    pub fn inner(&self) -> &Regex {
         &(self.0).0
     }
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -19,9 +19,10 @@ use serde::{Deserialize, Serialize};
 
 use ore::collections::CollectionExt;
 use ore::result::ResultExt;
-use repr::decimal::MAX_DECIMAL_PRECISION;
-use repr::jsonb::JsonbRef;
-use repr::regex::Regex;
+use repr::adt::decimal::MAX_DECIMAL_PRECISION;
+use repr::adt::interval::Interval;
+use repr::adt::jsonb::JsonbRef;
+use repr::adt::regex::Regex;
 use repr::{strconv, ColumnType, Datum, RowArena, RowPacker, ScalarType};
 
 use crate::scalar::func::format::DateTimeFormat;
@@ -380,7 +381,7 @@ fn cast_time_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a
 
 fn cast_time_to_interval<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let t = a.unwrap_time();
-    match repr::Interval::new(
+    match Interval::new(
         0,
         t.num_seconds_from_midnight() as i64,
         t.nanosecond() as i64,
@@ -429,10 +430,10 @@ fn cast_interval_to_time<'a>(a: Datum<'a>) -> Datum<'a> {
 
     // Negative durations have their HH::MM::SS.NS values subtracted from 1 day.
     if i.duration < 0 {
-        i = repr::Interval::new(0, 86400, 0)
+        i = Interval::new(0, 86400, 0)
             .unwrap()
             .checked_add(
-                &repr::Interval::new(0, i.dur_as_secs() % (24 * 60 * 60), i.nanoseconds() as i64)
+                &Interval::new(0, i.dur_as_secs() % (24 * 60 * 60), i.nanoseconds() as i64)
                     .unwrap(),
             )
             .unwrap();

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -10,10 +10,11 @@
 use std::collections::HashSet;
 use std::mem;
 
-use repr::regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use repr::adt::regex::Regex;
 use repr::strconv::ParseError;
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
-use serde::{Deserialize, Serialize};
 
 use self::func::{BinaryFunc, DateTruncTo, NullaryFunc, UnaryFunc, VariadicFunc};
 

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -26,8 +26,8 @@ use avro::schema::{
     SchemaPieceOrNamed,
 };
 use avro::types::{DecimalValue, Value};
-use repr::decimal::{Significand, MAX_DECIMAL_PRECISION};
-use repr::jsonb::{JsonbPacker, JsonbRef};
+use repr::adt::decimal::{Significand, MAX_DECIMAL_PRECISION};
+use repr::adt::jsonb::{JsonbPacker, JsonbRef};
 use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
 
 use crate::error::Result;
@@ -1015,7 +1015,7 @@ mod tests {
     use std::fs::File;
 
     use avro::types::{DecimalValue, Value};
-    use repr::decimal::Significand;
+    use repr::adt::decimal::Significand;
     use repr::{Datum, RelationDesc};
 
     use super::*;

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -20,7 +20,7 @@ use serde_protobuf::descriptor::{
 use serde_protobuf::value::Value as ProtoValue;
 use serde_value::Value as SerdeValue;
 
-use repr::decimal::Significand;
+use repr::adt::decimal::Significand;
 use repr::{ColumnType, Datum, DatumList, RelationDesc, RelationType, Row, RowPacker, ScalarType};
 
 use crate::error::Result;
@@ -460,7 +460,7 @@ mod tests {
     };
 
     use ordered_float::OrderedFloat;
-    use repr::decimal::Significand;
+    use repr::adt::decimal::Significand;
     use repr::{Datum, DatumList, RelationDesc, ScalarType};
 
     fn sanity_check_relation(

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -15,8 +15,8 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use postgres_types::{FromSql, IsNull, ToSql, Type as PgType};
 
 use ore::fmt::FormatBuffer;
-use repr::decimal::MAX_DECIMAL_PRECISION;
-use repr::jsonb::JsonbRef;
+use repr::adt::decimal::MAX_DECIMAL_PRECISION;
+use repr::adt::jsonb::JsonbRef;
 use repr::strconv::{self, Nestable};
 use repr::{Datum, RelationType, Row, RowArena, RowPacker, ScalarType};
 

--- a/src/pgrepr/src/value/interval.rs
+++ b/src/pgrepr/src/value/interval.rs
@@ -14,10 +14,12 @@ use byteorder::{NetworkEndian, ReadBytesExt};
 use bytes::{BufMut, BytesMut};
 use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 
-/// A wrapper for [`repr::Interval`] that can be serialized and deserialized
+use repr::adt::interval::Interval as ReprInterval;
+
+/// A wrapper for [`ReprInterval`] that can be serialized and deserialized
 /// to the PostgreSQL binary format.
 #[derive(Debug, Clone)]
-pub struct Interval(pub repr::Interval);
+pub struct Interval(pub ReprInterval);
 
 impl fmt::Display for Interval {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -65,7 +67,7 @@ impl<'a> FromSql<'a> for Interval {
         let days = raw.read_i32::<NetworkEndian>()?;
         let months = raw.read_i32::<NetworkEndian>()?;
         Ok(Interval(
-            repr::Interval::new(months, days as i64 * 24 * 60 * 60, micros * 1000).unwrap(),
+            ReprInterval::new(months, days as i64 * 24 * 60 * 60, micros * 1000).unwrap(),
         ))
     }
 

--- a/src/pgrepr/src/value/jsonb.rs
+++ b/src/pgrepr/src/value/jsonb.rs
@@ -16,7 +16,7 @@ use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 /// A wrapper for [`repr::Jsonb`] that can be serialized and deserialized
 /// to the PostgreSQL binary format.
 #[derive(Debug)]
-pub struct Jsonb(pub repr::jsonb::Jsonb);
+pub struct Jsonb(pub repr::adt::jsonb::Jsonb);
 
 impl ToSql for Jsonb {
     fn to_sql(
@@ -44,7 +44,7 @@ impl<'a> FromSql<'a> for Jsonb {
         if raw.len() < 1 || raw[0] != 1 {
             return Err("unsupported jsonb encoding version".into());
         }
-        Ok(Jsonb(repr::jsonb::Jsonb::from_slice(&raw[1..])?))
+        Ok(Jsonb(repr::adt::jsonb::Jsonb::from_slice(&raw[1..])?))
     }
 
     fn accepts(ty: &Type) -> bool {

--- a/src/pgrepr/src/value/numeric.rs
+++ b/src/pgrepr/src/value/numeric.rs
@@ -15,7 +15,7 @@ use byteorder::{NetworkEndian, ReadBytesExt};
 use bytes::{BufMut, BytesMut};
 use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 
-use repr::decimal::{Decimal, Significand};
+use repr::adt::decimal::{Decimal, Significand};
 
 /// A wrapper for [`repr::decimal::Decimal`] that can be serialized and
 /// deserialized to the PostgreSQL binary format.

--- a/src/repr/src/adt.rs
+++ b/src/repr/src/adt.rs
@@ -1,0 +1,24 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Abstract data types.
+//!
+//! Native Rust types are used for many primitive types, but many of the more
+//! complicated types require custom implementations, which are contained in
+//! this module.
+//!
+//! Where possible, these implementations match the [PostgreSQL ADTs].
+//!
+//! [PostgreSQL ADTs]: https://github.com/postgres/postgres/tree/master/src/backend/utils/adt
+
+pub mod datetime;
+pub mod decimal;
+pub mod interval;
+pub mod jsonb;
+pub mod regex;

--- a/src/repr/src/adt/decimal.rs
+++ b/src/repr/src/adt/decimal.rs
@@ -47,15 +47,15 @@
 //! [bigdecimal]: https://crates.io/crates/bigdecimal
 //! [fixed-point arithmetic]: https://en.wikipedia.org/wiki/Fixed-point_arithmetic
 
-use failure::{bail, format_err};
-use serde::{Deserialize, Serialize};
-
 use std::cmp::PartialEq;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Rem, Sub};
 use std::str::FromStr;
+
+use failure::{bail, format_err};
+use serde::{Deserialize, Serialize};
 
 /// The significand of a decimal number with up to 38 digits of precision.
 ///

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -1,0 +1,562 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A time interval abstract data type.
+
+use std::fmt::{self, Write};
+
+use failure::bail;
+use serde::{Deserialize, Serialize};
+
+use crate::adt::datetime::DateTimeField;
+
+/// An interval of time meant to express SQL intervals.
+///
+/// Obtained by parsing an `INTERVAL '<value>' <unit> [TO <precision>]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
+pub struct Interval {
+    /// A possibly negative number of months for field types like `YEAR`
+    pub months: i32,
+    /// A timespan represented in nanoseconds.
+    ///
+    /// Irrespective of values, `duration` will not be carried over into
+    /// `months`.
+    pub duration: i128,
+}
+
+impl Default for Interval {
+    fn default() -> Self {
+        Self {
+            months: 0,
+            duration: 0,
+        }
+    }
+}
+
+impl std::ops::Neg for Interval {
+    type Output = Self;
+    fn neg(self) -> Self {
+        Self {
+            months: -self.months,
+            duration: -self.duration,
+        }
+    }
+}
+
+impl Interval {
+    /// Constructs a new `Interval` with the specified units of time.
+    ///
+    /// `nanos` in excess of `999_999_999` are carried over into seconds.
+    pub fn new(months: i32, seconds: i64, nanos: i64) -> Result<Interval, failure::Error> {
+        let i = Interval {
+            months,
+            duration: i128::from(seconds) * 1_000_000_000 + i128::from(nanos),
+        };
+        // Don't let our duration exceed Postgres' min/max for those same fields,
+        // equivalent to:
+        // ```
+        // SELECT INTERVAL '2147483647 days 2147483647 hours 59 minutes 59.999999 seconds';
+        // SELECT INTERVAL '-2147483647 days -2147483647 hours -59 minutes -59.999999 seconds';
+        // ```
+        if i.duration > 193_273_528_233_599_999_999_000
+            || i.duration < -193_273_528_233_599_999_999_000
+        {
+            bail!(
+                "exceeds min/max interval duration +/-(2147483647 days 2147483647 hours \
+                59 minutes 59.999999 seconds)"
+            )
+        } else {
+            Ok(i)
+        }
+    }
+
+    pub fn checked_add(&self, other: &Self) -> Option<Self> {
+        let months = match self.months.checked_add(other.months) {
+            Some(m) => m,
+            None => return None,
+        };
+        let seconds = match self.dur_as_secs().checked_add(other.dur_as_secs()) {
+            Some(s) => s,
+            None => return None,
+        };
+
+        match Self::new(
+            months,
+            seconds,
+            i64::from(self.nanoseconds() + other.nanoseconds()),
+        ) {
+            Ok(i) => Some(i),
+            Err(_) => None,
+        }
+    }
+
+    /// Returns the total number of whole seconds in the `Interval`'s duration.
+    pub fn dur_as_secs(&self) -> i64 {
+        (self.duration / 1_000_000_000) as i64
+    }
+
+    /// Computes the year part of the interval.
+    ///
+    /// The year part is the number of whole years in the interval. For example,
+    /// this function returns `3.0` for the interval `3 years 4 months`.
+    pub fn years(&self) -> f64 {
+        (self.months / 12) as f64
+    }
+
+    /// Computes the month part of the interval.
+    ///
+    /// The whole part is the number of whole months in the interval, modulo 12.
+    /// For example, this function returns `4.0` for the interval `3 years 4
+    /// months`.
+    pub fn months(&self) -> f64 {
+        (self.months % 12) as f64
+    }
+
+    /// Computes the day part of the interval.
+    ///
+    /// The day part is the number of whole days in the interval. For example,
+    /// this function returns `5.0` for the interval `5 days 4 hours 3 minutes
+    /// 2.1 seconds`.
+    pub fn days(&self) -> f64 {
+        (self.dur_as_secs() / (60 * 60 * 24)) as f64
+    }
+
+    /// Computes the hour part of the interval.
+    ///
+    /// The hour part is the number of whole hours in the interval, modulo 24.
+    /// For example, this function returns `4.0` for the interval `5 days 4
+    /// hours 3 minutes 2.1 seconds`.
+    pub fn hours(&self) -> f64 {
+        ((self.dur_as_secs() / (60 * 60)) % 24) as f64
+    }
+
+    /// Computes the minute part of the interval.
+    ///
+    /// The minute part is the number of whole minutes in the interval, modulo
+    /// 60. For example, this function returns `3.0` for the interval `5 days 4
+    /// hours 3 minutes 2.1 seconds`.
+    pub fn minutes(&self) -> f64 {
+        ((self.dur_as_secs() / 60) % 60) as f64
+    }
+
+    /// Computes the second part of the interval.
+    ///
+    /// The second part is the number of fractional seconds in the interval,
+    /// modulo 60.0.
+    pub fn seconds(&self) -> f64 {
+        let s = (self.dur_as_secs() % 60) as f64;
+        let ns = f64::from(self.nanoseconds()) / 1e9;
+        s + ns
+    }
+
+    /// Computes the nanosecond part of the interval.
+    pub fn nanoseconds(&self) -> i32 {
+        (self.duration % 1_000_000_000) as i32
+    }
+
+    /// Computes the total number of seconds in the interval.
+    pub fn as_seconds(&self) -> f64 {
+        (self.months as f64) * 60.0 * 60.0 * 24.0 * 30.0
+            + (self.dur_as_secs() as f64)
+            + f64::from(self.nanoseconds()) / 1e9
+    }
+
+    /// Truncate the "head" of the interval, removing all time units greater than `f`.
+    pub fn truncate_high_fields(&mut self, f: DateTimeField) {
+        match f {
+            DateTimeField::Year => {}
+            DateTimeField::Month => self.months %= 12,
+            DateTimeField::Day => self.months = 0,
+            hms => {
+                self.months = 0;
+                self.duration %= hms.next_largest().nanos_multiplier() as i128
+            }
+        }
+    }
+
+    /// Converts this `Interval`'s duration into `chrono::Duration`.
+    pub fn duration_as_chrono(&self) -> chrono::Duration {
+        use chrono::Duration;
+        // This can be converted into a single call with
+        // https://github.com/chronotope/chrono/pull/426
+        Duration::seconds(self.dur_as_secs() as i64)
+            + Duration::nanoseconds(self.nanoseconds() as i64)
+    }
+
+    /// Truncate the "tail" of the interval, removing all time units less than `f`.
+    /// # Arguments
+    /// - `f`: Round the interval down to the specified time unit.
+    /// - `fsec_max_precision`: If `Some(x)`, keep only `x` places of nanosecond precision.
+    ///    Must be `(0,6)`.
+    ///
+    /// # Errors
+    /// - If `fsec_max_precision` is not None or within (0,6).
+    pub fn truncate_low_fields(
+        &mut self,
+        f: DateTimeField,
+        fsec_max_precision: Option<u64>,
+    ) -> Result<(), failure::Error> {
+        use DateTimeField::*;
+        match f {
+            Year => {
+                self.months -= self.months % 12;
+                self.duration = 0;
+            }
+            Month => {
+                self.duration = 0;
+            }
+            // Round nanoseconds.
+            Second => {
+                let default_precision = 6;
+                let precision = match fsec_max_precision {
+                    Some(p) => p,
+                    None => default_precision,
+                };
+
+                if precision > default_precision {
+                    bail!(
+                        "SECOND precision must be (0, 6), have SECOND({})",
+                        precision
+                    )
+                }
+
+                // Check if value should round up to nearest fractional place.
+                let remainder = self.duration % 10_i128.pow(9 - precision as u32);
+                if remainder / 10_i128.pow(8 - precision as u32) > 4 {
+                    self.duration += 10_i128.pow(9 - precision as u32);
+                }
+
+                self.duration -= remainder;
+            }
+            dhm => {
+                self.duration -= self.duration % dhm.nanos_multiplier() as i128;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Format an interval in a human form
+///
+/// Example outputs:
+///
+/// * 1 year 2 months 5 days 03:04:00
+/// * -1 year +5 days +18:59:29.3
+/// * 00:00:00
+impl fmt::Display for Interval {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut months = self.months;
+        let neg_mos = months < 0;
+        months = months.abs();
+        let years = months / 12;
+        months %= 12;
+        let mut secs = self.dur_as_secs().abs();
+        let mut nanos = self.nanoseconds().abs();
+        let days = secs / (24 * 60 * 60);
+        secs %= 24 * 60 * 60;
+        let hours = secs / (60 * 60);
+        secs %= 60 * 60;
+        let minutes = secs / 60;
+        secs %= 60;
+
+        if years > 0 {
+            if neg_mos {
+                f.write_char('-')?;
+            }
+            write!(f, "{} year", years)?;
+            if years > 1 {
+                f.write_char('s')?;
+            }
+        }
+
+        if months > 0 {
+            if years != 0 {
+                f.write_char(' ')?;
+            }
+            if neg_mos {
+                f.write_char('-')?;
+            }
+            write!(f, "{} month", months)?;
+            if months > 1 {
+                f.write_char('s')?;
+            }
+        }
+
+        if days > 0 {
+            if years > 0 || months > 0 {
+                f.write_char(' ')?;
+            }
+            if self.duration < 0 {
+                f.write_char('-')?;
+            } else if neg_mos {
+                f.write_char('+')?;
+            }
+            write!(f, "{} day", days)?;
+            if days != 1 {
+                f.write_char('s')?;
+            }
+        }
+
+        let non_zero_hmsn = hours > 0 || minutes > 0 || secs > 0 || nanos > 0;
+
+        if (years == 0 && months == 0 && days == 0) || non_zero_hmsn {
+            if years > 0 || months > 0 || days > 0 {
+                f.write_char(' ')?;
+            }
+            if self.duration < 0 && non_zero_hmsn {
+                f.write_char('-')?;
+            } else if neg_mos {
+                f.write_char('+')?;
+            }
+            write!(f, "{:02}:{:02}:{:02}", hours, minutes, secs)?;
+            if nanos > 0 {
+                let mut width = 9;
+                while nanos % 10 == 0 {
+                    width -= 1;
+                    nanos /= 10;
+                }
+                write!(f, ".{:0width$}", nanos, width = width)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn interval_fmt() {
+        fn mon(mon: i32) -> String {
+            Interval {
+                months: mon,
+                ..Default::default()
+            }
+            .to_string()
+        }
+
+        assert_eq!(mon(1), "1 month");
+        assert_eq!(mon(12), "1 year");
+        assert_eq!(mon(13), "1 year 1 month");
+        assert_eq!(mon(24), "2 years");
+        assert_eq!(mon(25), "2 years 1 month");
+        assert_eq!(mon(26), "2 years 2 months");
+
+        fn dur(d: i64) -> String {
+            Interval::new(0, d, 0).unwrap().to_string()
+        }
+        assert_eq!(&dur(86_400 * 2), "2 days");
+        assert_eq!(&dur(86_400 * 2 + 3_600 * 3), "2 days 03:00:00");
+        assert_eq!(
+            &dur(86_400 * 2 + 3_600 * 3 + 60 * 45 + 6),
+            "2 days 03:45:06"
+        );
+        assert_eq!(&dur(86_400 * 2 + 3_600 * 3 + 60 * 45), "2 days 03:45:00");
+        assert_eq!(&dur(86_400 * 2 + 6), "2 days 00:00:06");
+        assert_eq!(&dur(86_400 * 2 + 60 * 45 + 6), "2 days 00:45:06");
+        assert_eq!(&dur(86_400 * 2 + 3_600 * 3 + 6), "2 days 03:00:06");
+        assert_eq!(&dur(3_600 * 3 + 60 * 45 + 6), "03:45:06");
+        assert_eq!(&dur(3_600 * 3 + 6), "03:00:06");
+        assert_eq!(&dur(3_600 * 3), "03:00:00");
+        assert_eq!(&dur(60 * 45 + 6), "00:45:06");
+        assert_eq!(&dur(60 * 45), "00:45:00");
+        assert_eq!(&dur(6), "00:00:06");
+
+        assert_eq!(&dur(-(86_400 * 2 + 6)), "-2 days -00:00:06");
+        assert_eq!(&dur(-(86_400 * 2 + 60 * 45 + 6)), "-2 days -00:45:06");
+        assert_eq!(&dur(-(86_400 * 2 + 3_600 * 3 + 6)), "-2 days -03:00:06");
+        assert_eq!(&dur(-(3_600 * 3 + 60 * 45 + 6)), "-03:45:06");
+        assert_eq!(&dur(-(3_600 * 3 + 6)), "-03:00:06");
+        assert_eq!(&dur(-(3_600 * 3)), "-03:00:00");
+        assert_eq!(&dur(-(60 * 45 + 6)), "-00:45:06");
+        assert_eq!(&dur(-(60 * 45)), "-00:45:00");
+        assert_eq!(&dur(-6), "-00:00:06");
+
+        fn mon_dur(mon: i32, d: i64) -> String {
+            Interval::new(mon, d, 0).unwrap().to_string()
+        }
+        assert_eq!(&mon_dur(1, 86_400 * 2 + 6), "1 month 2 days 00:00:06");
+        assert_eq!(
+            &mon_dur(1, 86_400 * 2 + 60 * 45 + 6),
+            "1 month 2 days 00:45:06"
+        );
+        assert_eq!(
+            &mon_dur(1, 86_400 * 2 + 3_600 * 3 + 6),
+            "1 month 2 days 03:00:06"
+        );
+        assert_eq!(
+            &mon_dur(26, 3_600 * 3 + 60 * 45 + 6),
+            "2 years 2 months 03:45:06"
+        );
+        assert_eq!(&mon_dur(26, 3_600 * 3 + 6), "2 years 2 months 03:00:06");
+        assert_eq!(&mon_dur(26, 3_600 * 3), "2 years 2 months 03:00:00");
+        assert_eq!(&mon_dur(26, 60 * 45 + 6), "2 years 2 months 00:45:06");
+        assert_eq!(&mon_dur(26, 60 * 45), "2 years 2 months 00:45:00");
+        assert_eq!(&mon_dur(26, 6), "2 years 2 months 00:00:06");
+
+        assert_eq!(
+            &mon_dur(26, -(86_400 * 2 + 6)),
+            "2 years 2 months -2 days -00:00:06"
+        );
+        assert_eq!(
+            &mon_dur(26, -(86_400 * 2 + 60 * 45 + 6)),
+            "2 years 2 months -2 days -00:45:06"
+        );
+        assert_eq!(
+            &mon_dur(26, -(86_400 * 2 + 3_600 * 3 + 6)),
+            "2 years 2 months -2 days -03:00:06"
+        );
+        assert_eq!(
+            &mon_dur(26, -(3_600 * 3 + 60 * 45 + 6)),
+            "2 years 2 months -03:45:06"
+        );
+        assert_eq!(&mon_dur(26, -(3_600 * 3 + 6)), "2 years 2 months -03:00:06");
+        assert_eq!(&mon_dur(26, -(3_600 * 3)), "2 years 2 months -03:00:00");
+        assert_eq!(&mon_dur(26, -(60 * 45 + 6)), "2 years 2 months -00:45:06");
+        assert_eq!(&mon_dur(26, -(60 * 45)), "2 years 2 months -00:45:00");
+        assert_eq!(&mon_dur(26, -6), "2 years 2 months -00:00:06");
+
+        assert_eq!(&mon_dur(-1, 86_400 * 2 + 6), "-1 month +2 days +00:00:06");
+        assert_eq!(
+            &mon_dur(-1, 86_400 * 2 + 60 * 45 + 6),
+            "-1 month +2 days +00:45:06"
+        );
+        assert_eq!(
+            &mon_dur(-1, 86_400 * 2 + 3_600 * 3 + 6),
+            "-1 month +2 days +03:00:06"
+        );
+        assert_eq!(
+            &mon_dur(-26, 3_600 * 3 + 60 * 45 + 6),
+            "-2 years -2 months +03:45:06"
+        );
+        assert_eq!(&mon_dur(-26, 3_600 * 3 + 6), "-2 years -2 months +03:00:06");
+        assert_eq!(&mon_dur(-26, 3_600 * 3), "-2 years -2 months +03:00:00");
+        assert_eq!(&mon_dur(-26, 60 * 45 + 6), "-2 years -2 months +00:45:06");
+        assert_eq!(&mon_dur(-26, 60 * 45), "-2 years -2 months +00:45:00");
+        assert_eq!(&mon_dur(-26, 6), "-2 years -2 months +00:00:06");
+
+        assert_eq!(
+            &mon_dur(-26, -(86_400 * 2 + 6)),
+            "-2 years -2 months -2 days -00:00:06"
+        );
+        assert_eq!(
+            &mon_dur(-26, -(86_400 * 2 + 60 * 45 + 6)),
+            "-2 years -2 months -2 days -00:45:06"
+        );
+        assert_eq!(
+            &mon_dur(-26, -(86_400 * 2 + 3_600 * 3 + 6)),
+            "-2 years -2 months -2 days -03:00:06"
+        );
+        assert_eq!(
+            &mon_dur(-26, -(3_600 * 3 + 60 * 45 + 6)),
+            "-2 years -2 months -03:45:06"
+        );
+        assert_eq!(
+            &mon_dur(-26, -(3_600 * 3 + 6)),
+            "-2 years -2 months -03:00:06"
+        );
+        assert_eq!(&mon_dur(-26, -(3_600 * 3)), "-2 years -2 months -03:00:00");
+        assert_eq!(
+            &mon_dur(-26, -(60 * 45 + 6)),
+            "-2 years -2 months -00:45:06"
+        );
+        assert_eq!(&mon_dur(-26, -(60 * 45)), "-2 years -2 months -00:45:00");
+        assert_eq!(&mon_dur(-26, -6), "-2 years -2 months -00:00:06");
+    }
+
+    #[test]
+    fn test_interval_value_truncate_low_fields() {
+        use DateTimeField::*;
+
+        let mut test_cases = [
+            (Year, None, (321, 654_321, 321_000_000), (26 * 12, 0, 0)),
+            (Month, None, (321, 654_321, 321_000_000), (321, 0, 0)),
+            (
+                Day,
+                None,
+                (321, 654_321, 321_000_000),
+                (321, 7 * 60 * 60 * 24, 0), // months: 321, duration: 604800s, is_positive_dur: true
+            ),
+            (
+                Hour,
+                None,
+                (321, 654_321, 321_000_000),
+                (321, 181 * 60 * 60, 0),
+            ),
+            (
+                Minute,
+                None,
+                (321, 654_321, 321_000_000),
+                (321, 10905 * 60, 0),
+            ),
+            (
+                Second,
+                None,
+                (321, 654_321, 321_000_000),
+                (321, 654_321, 321_000_000),
+            ),
+            (
+                Second,
+                Some(1),
+                (321, 654_321, 321_000_000),
+                (321, 654_321, 300_000_000),
+            ),
+            (
+                Second,
+                Some(0),
+                (321, 654_321, 321_000_000),
+                (321, 654_321, 0),
+            ),
+        ];
+
+        for test in test_cases.iter_mut() {
+            let mut i = Interval::new((test.2).0, (test.2).1, (test.2).2).unwrap();
+            let j = Interval::new((test.3).0, (test.3).1, (test.3).2).unwrap();
+
+            i.truncate_low_fields(test.0, test.1).unwrap();
+
+            if i != j {
+                panic!(
+                "test_interval_value_truncate_low_fields failed on {} \n actual: {:?} \n expected: {:?}",
+                test.0, i, j
+            );
+            }
+        }
+    }
+
+    #[test]
+    fn test_interval_value_truncate_high_fields() {
+        use DateTimeField::*;
+
+        let mut test_cases = [
+            (Year, (321, 654_321), (321, 654_321)),
+            (Month, (321, 654_321), (9, 654_321)),
+            (Day, (321, 654_321), (0, 654_321)),
+            (Hour, (321, 654_321), (0, 654_321 % (60 * 60 * 24))),
+            (Minute, (321, 654_321), (0, 654_321 % (60 * 60))),
+            (Second, (321, 654_321), (0, 654_321 % 60)),
+        ];
+
+        for test in test_cases.iter_mut() {
+            let mut i = Interval::new((test.1).0, (test.1).1, 123).unwrap();
+            let j = Interval::new((test.2).0, (test.2).1, 123).unwrap();
+
+            i.truncate_high_fields(test.0);
+
+            if i != j {
+                panic!(
+                    "test_interval_value_truncate_high_fields failed on {} \n actual: {:?} \n expected: {:?}",
+                    test.0, i, j
+                );
+            }
+        }
+    }
+}

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -33,7 +33,7 @@
 //! parsed, the underlying [`Row`] can be extracted with [`Jsonb::into_row`].
 //!
 //! ```
-//! # use repr::jsonb::Jsonb;
+//! # use repr::adt::jsonb::Jsonb;
 //! let jsonb: Jsonb = r#"{"a": 1, "b": 2}"#.parse()?;
 //! let row = jsonb.into_row();
 //! # Ok::<(), Box<dyn std::error::Error>>(())
@@ -42,7 +42,7 @@
 //! If the source JSON is in bytes, use [`Jsonb::from_slice`] instead:
 //!
 //! ```
-//! # use repr::jsonb::Jsonb;
+//! # use repr::adt::jsonb::Jsonb;
 //! let jsonb = Jsonb::from_slice(br#"{"a": 1, "b": 2}"#);
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
@@ -53,7 +53,7 @@
 //! The alternate format produces pretty output.
 //!
 //! ```
-//! # use repr::jsonb::Jsonb;
+//! # use repr::adt::jsonb::Jsonb;
 //! # let jsonb: Jsonb = "null".parse().unwrap();
 //! format!("compressed: {}", jsonb);
 //! format!("pretty: {:#}", jsonb);
@@ -66,7 +66,7 @@
 //! copy.
 //!
 //! ```rust
-//! # use repr::jsonb::JsonbPacker;
+//! # use repr::adt::jsonb::JsonbPacker;
 //! # use repr::{Datum, RowPacker};
 //! let mut packer = RowPacker::new();
 //! packer.push(Datum::Int32(42));

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -7,23 +7,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use serde::{Deserialize, Serialize};
+//! Regex utilities.
+
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 
-/// A regular expression object suitable for use in `repr::Datum`. The
-/// object has perhaps surprising comparison semantics as a result: two regexes
-/// are considered equal iff their string representation is identical. The
-/// [`PartialOrd`], [`Ord`], and [`Hash`] implementations are similarly based
-/// upon the string representation. This is not the natural equivalence relation
-/// for regexes: for example, the regexes `aa*` and `a+` define the same
-/// language, but would not compare as equal with this implementation of
+use serde::{Deserialize, Serialize};
+
+/// A regular expression object suitable for use in `repr::Datum`.
+///
+/// The object has perhaps surprising comparison semantics as a result: two
+/// regexes are considered equal iff their string representation is identical.
+/// The [`PartialOrd`], [`Ord`], and [`Hash`] implementations are similarly
+/// based upon the string representation. This is not the natural equivalence
+/// relation for regexes: for example, the regexes `aa*` and `a+` define the
+/// same language, but would not compare as equal with this implementation of
 /// [`PartialEq`].
 ///
 /// TODO(benesch): watch for a more efficient binary serialization for
 /// [`regex::Regex`] (https://github.com/rust-lang/regex/issues/258). The
-/// `serde_regex` crate serializes to a string and is forced to recompile
-/// the regex during deserialization.
+/// `serde_regex` crate serializes to a string and is forced to recompile the
+/// regex during deserialization.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Regex(#[serde(with = "serde_regex")] pub regex::Regex);
 

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -26,7 +26,9 @@ mod relation;
 mod row;
 mod scalar;
 
+pub mod adt;
+pub mod strconv;
+
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{datum_size, DatumDict, DatumList, Row, RowArena, RowPacker};
-pub use scalar::{datetime, decimal, jsonb, regex, strconv};
-pub use scalar::{Datum, Interval, ScalarType};
+pub use scalar::{Datum, ScalarType};

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -69,6 +69,17 @@ impl ColumnType {
     }
 }
 
+impl fmt::Display for ColumnType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}{}",
+            self.scalar_type,
+            if self.nullable { "?" } else { "" }
+        )
+    }
+}
+
 /// The type for a relation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RelationType {

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -12,12 +12,13 @@ use std::cell::RefCell;
 use std::fmt;
 use std::mem::{size_of, transmute};
 
-use crate::decimal::Significand;
-use crate::scalar::Interval;
-use crate::Datum;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
+
+use crate::adt::decimal::Significand;
+use crate::adt::interval::Interval;
+use crate::Datum;
 
 /// A packed representation for `Datum`s.
 ///

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -32,10 +32,10 @@ use serde::{Deserialize, Serialize};
 
 use ore::fmt::FormatBuffer;
 
-use crate::datetime::{self, DateTimeField, ParsedDateTime};
-use crate::decimal::Decimal;
-use crate::jsonb::{Jsonb, JsonbRef};
-use crate::Interval;
+use crate::adt::datetime::{self, DateTimeField, ParsedDateTime};
+use crate::adt::decimal::Decimal;
+use crate::adt::interval::Interval;
+use crate::adt::jsonb::{Jsonb, JsonbRef};
 
 #[derive(Debug)]
 pub enum Nestable {

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -9,8 +9,9 @@
 
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
-use repr::datetime::DateTimeField;
-use repr::{strconv, Interval};
+use repr::adt::datetime::DateTimeField;
+use repr::adt::interval::Interval;
+use repr::strconv;
 
 #[test]
 fn test_parse_date() {

--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -51,7 +51,7 @@ pub mod visit_mut {
 use std::fmt;
 use std::str::FromStr;
 
-use repr::datetime::DateTimeField;
+use repr::adt::datetime::DateTimeField;
 
 pub use self::data_type::DataType;
 pub use self::ddl::{

--- a/src/sql-parser/src/ast/value.rs
+++ b/src/sql-parser/src/ast/value.rs
@@ -20,7 +20,7 @@
 
 use std::fmt;
 
-use repr::datetime::DateTimeField;
+use repr::adt::datetime::DateTimeField;
 
 mod datetime;
 use crate::ast::display::{AstDisplay, AstFormatter};

--- a/src/sql-parser/src/ast/value/datetime.rs
+++ b/src/sql-parser/src/ast/value/datetime.rs
@@ -15,7 +15,7 @@
 
 use std::fmt;
 
-use repr::datetime::DateTimeField;
+use repr::adt::datetime::DateTimeField;
 
 use super::ValueError;
 use crate::ast::display::{AstDisplay, AstFormatter};

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -27,7 +27,7 @@ use std::str::FromStr;
 
 use log::debug;
 
-use repr::datetime::DateTimeField;
+use repr::adt::datetime::DateTimeField;
 
 use crate::ast::*;
 use crate::keywords;

--- a/src/sql/src/query.rs
+++ b/src/sql/src/query.rs
@@ -39,7 +39,7 @@ use uuid::Uuid;
 
 use ::expr::{Id, RowSetFinishing};
 use dataflow_types::Timestamp;
-use repr::decimal::{Decimal, MAX_DECIMAL_PRECISION};
+use repr::adt::decimal::{Decimal, MAX_DECIMAL_PRECISION};
 use repr::{
     strconv, ColumnName, ColumnType, Datum, RelationDesc, RelationType, RowArena, ScalarType,
 };

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -47,7 +47,7 @@ use coord::{ExecuteResponse, TimestampConfig};
 use dataflow_types::PeekResponse;
 use ore::option::OptionExt;
 use ore::thread::{JoinHandleExt, JoinOnDropHandle};
-use repr::jsonb::JsonbRef;
+use repr::adt::jsonb::JsonbRef;
 use repr::strconv::{
     format_date, format_interval, format_time, format_timestamp, format_timestamptz,
 };

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -35,7 +35,7 @@ use sql_parser::ast::{DataType, ObjectType, Statement};
 use tokio_postgres::types::FromSql;
 
 use pgrepr::Jsonb;
-use repr::decimal::Significand;
+use repr::adt::decimal::Significand;
 use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
 use sql::catalog::Catalog;
 use sql::{


### PR DESCRIPTION
Introduce a repr module, adt, to house our various abstract data types.
This keeps things a bit more organized. Also move the strconv module to
the root, to match the public organization of the repr crate.

@sploiselle you up for taking this one since you've been in the area a lot lately?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3225)
<!-- Reviewable:end -->
