### PR TITLE
Add mz testing util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,8 +3392,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "log",
  "rand",
  "rdkafka",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/test/performance/perf-kinesis/src/main.rs
+++ b/test/performance/perf-kinesis/src/main.rs
@@ -32,7 +32,7 @@ use rand::Rng;
 use rusoto_core::Region;
 use structopt::StructOpt;
 
-use test_util::mz as mz_util;
+use test_util::mz_client;
 
 mod kinesis;
 mod mz;
@@ -85,7 +85,7 @@ async fn run() -> Result<(), anyhow::Error> {
     });
 
     // Initialize connection to materialized instance.
-    let client = mz_util::client("mzd", &args.materialized_host, args.materialized_port)
+    let client = mz_client::client(&args.materialized_host, args.materialized_port)
         .await
         .context("creating postgres client")?;
 

--- a/test/performance/perf-kinesis/src/main.rs
+++ b/test/performance/perf-kinesis/src/main.rs
@@ -26,20 +26,13 @@
 /// stream, should not drift over time. (These measurements should become more concrete as
 /// we get more experience running this test).
 ///
-/// TODOs:
-///     - Parameterize queries_per_second.
-///     - Get this test to run nightly.
-///     - Handle this token error: {"__type":"ExpiredTokenException","message":"The security token included in the request is expired"}
-///     - Expand the use cases the test is covering:
-///         - Add a new "existing_records" argument that pre-loads that number of records into the
-///           target Kinesis stream. This should effectively mock what "catching up" will look like
-///           when Materialize connects to an existing stream.
 ///
 use anyhow::Context;
 use rand::Rng;
 use rusoto_core::Region;
 use structopt::StructOpt;
-use tokio_postgres::NoTls;
+
+use test_util::mz as mz_util;
 
 mod kinesis;
 mod mz;
@@ -92,21 +85,9 @@ async fn run() -> Result<(), anyhow::Error> {
     });
 
     // Initialize connection to materialized instance.
-    let (client, conn) = tokio_postgres::Config::new()
-        .user("mzd")
-        .host(&args.materialized_host)
-        .port(args.materialized_port)
-        .connect(NoTls)
+    let client = mz_util::client("mzd", &args.materialized_host, args.materialized_port)
         .await
         .context("creating postgres client")?;
-
-    // The connection object performs the actual communication with the database,
-    // so spawn it off to run on its own.
-    tokio::spawn(async move {
-        if let Err(e) = conn.await {
-            log::error!("connection error: {}", e);
-        }
-    });
 
     // Create Kinesis source and materialized view.
     mz::create_source_and_views(&client, stream_arn).await?;

--- a/test/performance/perf-kinesis/src/mz.rs
+++ b/test/performance/perf-kinesis/src/mz.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use anyhow::Context;
 use tokio_postgres::Client;
 
-use test_util::mz as mz_util;
+use test_util::mz_client;
 
 pub async fn create_source_and_views(
     client: &Client,
@@ -56,7 +56,7 @@ pub async fn query_materialized_view_until(
     let query = format!("SELECT * FROM {view_name};", view_name = view_name);
     log::info!("querying view=> {}", query);
 
-    let row = mz_util::try_query_one(&client, &*query, Duration::from_secs(1)).await?;
+    let row = mz_client::try_query_one(&client, &*query, Duration::from_secs(1)).await?;
     let count: i64 = row.get("count");
     if count as u64 == expected_total_records {
         log::info!(

--- a/test/performance/perf-kinesis/src/mz.rs
+++ b/test/performance/perf-kinesis/src/mz.rs
@@ -12,6 +12,8 @@ use std::time::Duration;
 use anyhow::Context;
 use tokio_postgres::Client;
 
+use test_util::mz as mz_util;
+
 pub async fn create_source_and_views(
     client: &Client,
     stream_arn: String,
@@ -54,40 +56,13 @@ pub async fn query_materialized_view_until(
     let query = format!("SELECT * FROM {view_name};", view_name = view_name);
     log::info!("querying view=> {}", query);
 
-    // 1QPS until caught up.
-    loop {
-        let timer = std::time::Instant::now();
-        match client.query_one(&*query, &[]).await {
-            Ok(row) => {
-                let count: i64 = row.get("count");
-                if count as u64 == expected_total_records {
-                    log::info!(
-                        "Found all {} records, done querying.",
-                        expected_total_records
-                    );
-                    break;
-                }
-            }
-            Err(e) => {
-                // We will see this error if we query the view between the
-                // time it is created and when it ingests its first data.
-                // This error is transient and should be retried.
-                if e.to_string()
-                    .contains("At least one input has no complete timestamps yet.")
-                {
-                    log::debug!("Error querying, will try again... {}", e.to_string());
-                } else {
-                    return Err(e).context("Querying materialized view");
-                }
-            }
-        }
-
-        let elapsed = timer.elapsed();
-        if elapsed < Duration::from_secs(1) {
-            tokio::time::delay_for(Duration::from_secs(1) - elapsed).await;
-        } else {
-            log::info!("Expected to query for records in 1s, took {:#?}", elapsed);
-        }
+    let row = mz_util::try_query_one(&client, &*query, Duration::from_secs(1)).await?;
+    let count: i64 = row.get("count");
+    if count as u64 == expected_total_records {
+        log::info!(
+            "Found all {} records, done querying.",
+            expected_total_records
+        );
     }
     Ok(())
 }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -8,5 +8,8 @@ publish = false
 [dependencies]
 anyhow = "1.0.31"
 chrono = "0.4.11"
+log = "0.4.8"
 rand = "0.7.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+tokio = { version = "0.2.21", features = ["full"] }
+tokio-postgres = "0.5.2"

--- a/test/test-util/src/lib.rs
+++ b/test/test-util/src/lib.rs
@@ -11,4 +11,4 @@
 
 pub mod generator;
 pub mod kafka;
-pub mod mz;
+pub mod mz_client;

--- a/test/test-util/src/lib.rs
+++ b/test/test-util/src/lib.rs
@@ -11,3 +11,4 @@
 
 pub mod generator;
 pub mod kafka;
+pub mod mz;

--- a/test/test-util/src/mz.rs
+++ b/test/test-util/src/mz.rs
@@ -1,0 +1,97 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use tokio_postgres::{Client, Error, NoTls, Row};
+
+/// Create and return a new PostgreSQL client, spawning off the connection
+/// object along the way.
+pub async fn client(user: &str, host: &str, port: u16) -> Result<Client, anyhow::Error> {
+    let (mz_client, conn) = tokio_postgres::Config::new()
+        .user(user)
+        .host(host)
+        .port(port)
+        .connect(NoTls)
+        .await?;
+
+    // The connection object performs the actual communication with the database,
+    // so spawn it off to run on its own.
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            log::info!("connection error: {}", e);
+        }
+    });
+
+    Ok(mz_client)
+}
+
+/// Try running PostgresSQL's `query` function, checking for a common
+/// Materialize error in `check_error`.
+pub async fn try_query(
+    mz_client: &Client,
+    query: &str,
+    delay: Duration,
+) -> Result<Vec<Row>, anyhow::Error> {
+    loop {
+        let timer = std::time::Instant::now();
+        match mz_client.query(&*query, &[]).await {
+            Ok(rows) => return Ok(rows),
+            Err(e) => check_error(e)?,
+        }
+        delay_for(timer.elapsed(), delay).await;
+    }
+}
+
+/// Try running PostgreSQL's `query_one` function, checking for a common
+/// Materialize error in `check_error`.
+pub async fn try_query_one(
+    mz_client: &Client,
+    query: &str,
+    delay: Duration,
+) -> Result<Row, anyhow::Error> {
+    loop {
+        let timer = std::time::Instant::now();
+        match mz_client.query_one(&*query, &[]).await {
+            Ok(rows) => return Ok(rows),
+            Err(e) => check_error(e)?,
+        }
+        delay_for(timer.elapsed(), delay).await;
+    }
+}
+
+/// This error ("At least one input has no complete timestamps yet") will surface if
+/// we query a view in Materialize before data exists for that view. It is common to hit
+/// this error just after creating a view, particularly in testing or demo code.
+///
+/// Since this error is likely transient, we should retry reading from the view
+/// instead of failing.
+fn check_error(e: Error) -> Result<(), anyhow::Error> {
+    if e.to_string()
+        .contains("At least one input has no complete timestamps yet.")
+    {
+        log::info!("Error querying, will try again... {}", e.to_string());
+        Ok(())
+    } else {
+        Err(anyhow::Error::from(e))
+    }
+}
+
+/// Limit the queries per second against a view in Materialize.
+async fn delay_for(elapsed: Duration, delay: Duration) {
+    if elapsed < delay {
+        tokio::time::delay_for(delay - elapsed).await;
+    } else {
+        log::info!(
+            "Expected to query for records in {:#?}, took {:#?}",
+            delay,
+            elapsed
+        );
+    }
+}

--- a/test/test-util/src/mz_client.rs
+++ b/test/test-util/src/mz_client.rs
@@ -13,9 +13,9 @@ use tokio_postgres::{Client, Error, NoTls, Row};
 
 /// Create and return a new PostgreSQL client, spawning off the connection
 /// object along the way.
-pub async fn client(user: &str, host: &str, port: u16) -> Result<Client, anyhow::Error> {
+pub async fn client(host: &str, port: u16) -> Result<Client, anyhow::Error> {
     let (mz_client, conn) = tokio_postgres::Config::new()
-        .user(user)
+        .user("mzd")
         .host(host)
         .port(port)
         .connect(NoTls)
@@ -25,7 +25,7 @@ pub async fn client(user: &str, host: &str, port: u16) -> Result<Client, anyhow:
     // so spawn it off to run on its own.
     tokio::spawn(async move {
         if let Err(e) = conn.await {
-            log::info!("connection error: {}", e);
+            panic!("connection error: {}", e);
         }
     });
 


### PR DESCRIPTION
Creates new common utils for tests and demos to connect to materialized, simplifying creating a client and handling errors. This will be reused in the Kafka chaos testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3233)
<!-- Reviewable:end -->
