### PR TITLE
sql: support trim family of functions

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -121,6 +121,7 @@ a {
 
   td {
     padding: 10px;
+    vertical-align: top;
 
     pre {
       background-color: inherit;

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -97,6 +97,12 @@
   - signature: 'ascii(s: str) -> int'
     description: The ASCII value of `s`'s left-most character
 
+  - signature: 'btrim(s: str) -> str'
+    description: Trim all spaces from both sides of `s`.
+
+  - signature: 'btrim(s: str, c: str) -> str'
+    description: Trim any character in `c` from both sides of `s`.
+
   - signature: 'length(s: str) -> int'
     description: Number of graphemes in `s`
     url: length
@@ -105,8 +111,23 @@
     description: Number of graphemes in `s` using `encoding_name`
     url: length
 
+  - signature: 'ltrim(s: str) -> str'
+    description: Trim all spaces from the left side of `s`.
+
+  - signature: 'btrim(s: str, c: str) -> str'
+    description: Trim any character in `c` from the left sides of `s`.
+
+  - signature: 'regexp_extract(regex: str, haystack: str) -> Col<string>'
+    description: Values of the capture groups of `regex` as matched in `haystack`
+
   - signature: 'replace(s: str, f: str, r: str) -> str'
     description: "`s` with all instances of `f` replaced with `r`"
+
+  - signature: 'rtrim(s: str) -> str'
+    description: Trim all spaces from the right side of `s`.
+
+  - signature: 'rtrim(s: str, c: str) -> str'
+    description: Trim any character in `c` from the right side of `s`.
 
   - signature: 'substring(s: str, start_pos: int) -> str'
     description: Substring of `s` starting at `start_pos`
@@ -116,8 +137,10 @@
     description: Substring starting at `start_pos` of length `l`
     url: substring
 
-  - signature: 'regexp_extract(regex: str, haystack: str) -> Col<string>'
-    description: Values of the capture groups of `regex` as matched in `haystack`
+  - signature: "trim([BOTH | LEADING | TRAILING]? 'c'? FROM 's') -> str"
+    description: "Trims any character in `c` from `s` on the specified side.<br/><br/>Defaults:<br/>
+      &bull; Side: `BOTH`<br/>
+      &bull; `'c'`: `' '` (space)"
 
 - type: Scalar
   description: Scalar functions take a list of scalar expressions

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -241,6 +241,12 @@ macro_rules! make_visitor {
 
             fn visit_extract_field(&mut self, _field: &'ast $($mut)* ExtractField) {}
 
+            fn visit_trim(&mut self, side: &'ast $($mut)* TrimSide, exprs: &'ast $($mut)* [Expr]) {
+                visit_trim(self, side, exprs)
+            }
+
+            fn visit_trim_side(&mut self, _side: &'ast $($mut)* TrimSide) {}
+
             fn visit_nested(&mut self, expr: &'ast $($mut)* Expr) {
                 visit_nested(self, expr)
             }
@@ -1016,6 +1022,7 @@ macro_rules! make_visitor {
                 Expr::Collate { expr, collation } => visitor.visit_collate(expr, collation),
                 Expr::Coalesce { exprs } => visitor.visit_coalesce(exprs),
                 Expr::Extract { field, expr } => visitor.visit_extract(field, expr),
+                Expr::Trim { side, exprs } => visitor.visit_trim(side, exprs),
                 Expr::Nested(expr) => visitor.visit_nested(expr),
                 Expr::Value(val) => visitor.visit_value(val),
                 Expr::Function(func) => visitor.visit_function(func),
@@ -1182,6 +1189,17 @@ macro_rules! make_visitor {
         ) {
             visitor.visit_extract_field(field);
             visitor.visit_expr(expr);
+        }
+
+        pub fn visit_trim<'ast, V: $name<'ast> + ?Sized>(
+            visitor: &mut V,
+            side: &'ast $($mut)* TrimSide,
+            exprs: &'ast $($mut)* [Expr],
+        ) {
+            visitor.visit_trim_side(side);
+            for e in exprs {
+                visitor.visit_expr(e);
+            }
         }
 
         pub fn visit_nested<'ast, V: $name<'ast> + ?Sized>(visitor: &mut V, expr: &'ast $($mut)* Expr) {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -689,6 +689,10 @@ lazy_static! {
             "ascii" => {
                 params!(String) => Unary(UnaryFunc::Ascii)
             },
+            "btrim" => {
+                params!(String) => Unary(UnaryFunc::TrimWhitespace),
+                params!(String, String) => Binary(BinaryFunc::Trim)
+            },
             "ceil" => {
                 params!(Float32) => Unary(UnaryFunc::CeilFloat32),
                 params!(Float64) => Unary(UnaryFunc::CeilFloat64),
@@ -735,6 +739,10 @@ lazy_static! {
                 params!(String) => Variadic(VariadicFunc::LengthString),
                 params!(String, String) => Variadic(VariadicFunc::LengthString)
             },
+            "ltrim" => {
+                params!(String) => Unary(UnaryFunc::TrimLeadingWhitespace),
+                params!(String, String) => Binary(BinaryFunc::TrimLeading)
+            },
             "replace" => {
                 params!(String, String, String) => Variadic(VariadicFunc::Replace)
             },
@@ -743,6 +751,10 @@ lazy_static! {
                 params!(Float64) => Unary(UnaryFunc::RoundFloat64),
                 params!(Decimal(0,0)) => Unary(UnaryFunc::RoundDecimal(0)),
                 params!(Decimal(0,0), Int64) => Binary(BinaryFunc::RoundDecimal(0))
+            },
+            "rtrim" => {
+                params!(String) => Unary(UnaryFunc::TrimTrailingWhitespace),
+                params!(String, String) => Binary(BinaryFunc::TrimTrailing)
             },
             "substr" => {
                 params!(String, Int64) => Variadic(VariadicFunc::Substr),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -33,7 +33,7 @@ use sql_parser::ast::visit::{self, Visit};
 use sql_parser::ast::{
     BinaryOperator, DataType, Expr, ExtractField, Function, FunctionArgs, Ident, JoinConstraint,
     JoinOperator, ObjectName, Query, Select, SelectItem, SetExpr, SetOperator, ShowStatementFilter,
-    TableAlias, TableFactor, TableWithJoins, UnaryOperator, Value, Values,
+    TableAlias, TableFactor, TableWithJoins, TrimSide, UnaryOperator, Value, Values,
 };
 use uuid::Uuid;
 
@@ -1586,6 +1586,20 @@ pub fn plan_coercible_expr<'a>(
                         None,
                     )
                 }
+            }
+            Expr::Trim { side, exprs } => {
+                let ident = match side {
+                    TrimSide::Both => "btrim",
+                    TrimSide::Leading => "ltrim",
+                    TrimSide::Trailing => "rtrim",
+                };
+
+                (
+                    CoercibleScalarExpr::Coerced(super::func::select_scalar_func(
+                        ecx, ident, exprs,
+                    )?),
+                    None,
+                )
             }
             Expr::Extract { field, expr } => {
                 // No type hint passed to `plan_expr`, because `expr` can be

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -318,3 +318,66 @@ FROM (
 )
 ----
 NULL
+
+query T
+SELECT trim(LEADING 'xy' FROM 'yxytrimyxy');
+----
+trimyxy
+
+query T
+SELECT ltrim('yxytrimyxy', 'xy');
+----
+trimyxy
+
+query T
+SELECT rtrim('yxytrimyxy', 'xy');
+----
+yxytrim
+
+query T
+SELECT btrim('yxytrimyxy', 'xy');
+----
+trim
+
+query T
+SELECT btrim('  yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
+SELECT rtrim('yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
+SELECT ltrim('   yxytrimyxy');
+----
+yxytrimyxy
+
+query T
+SELECT trim('xy' FROM 'yxytrimyxy');
+----
+trim
+
+query T
+SELECT trim(TRAILING FROM 'yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
+SELECT trim(FROM '  yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
+SELECT trim('   yxytrimyxy  ');
+----
+yxytrimyxy
+
+query T
+SELECT trim(LEADING '   yxytrimyxy');
+----
+yxytrimyxy
+
+statement error
+SELECT trim('c' 'ccccdogcc');


### PR DESCRIPTION
Implements `trim` et. al. (I removed the duplicate `func.rs` file in another PR already; ignore that.)

@benesch I added `src/sql-parser/src/ast/value/string.rs` modeled after `src/sql-parser/src/ast/value/datetime.rs`--wasn't sure if there's a better place to put this?

Closes #3079

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3242)
<!-- Reviewable:end -->
