### PR TITLE
sql: remove scale from abs_decimal

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -96,8 +96,8 @@ fn abs_int64<'a>(a: Datum<'a>) -> Datum<'a> {
     Datum::from(a.unwrap_int64().abs())
 }
 
-fn abs_decimal<'a>(a: Datum<'a>, scale: u8) -> Datum<'a> {
-    Datum::from(a.unwrap_decimal().with_scale(scale).abs().significand())
+fn abs_decimal<'a>(a: Datum<'a>) -> Datum<'a> {
+    Datum::from(a.unwrap_decimal().abs())
 }
 
 fn abs_float32<'a>(a: Datum<'a>) -> Datum<'a> {
@@ -2233,9 +2233,9 @@ pub enum UnaryFunc {
     SqrtFloat64,
     AbsInt32,
     AbsInt64,
-    AbsDecimal(u8),
     AbsFloat32,
     AbsFloat64,
+    AbsDecimal,
     CastBoolToStringExplicit,
     CastBoolToStringImplicit,
     CastInt32ToBool,
@@ -2369,9 +2369,9 @@ impl UnaryFunc {
             UnaryFunc::NegInterval => Ok(neg_interval(a)),
             UnaryFunc::AbsInt32 => Ok(abs_int32(a)),
             UnaryFunc::AbsInt64 => Ok(abs_int64(a)),
-            UnaryFunc::AbsDecimal(scale) => Ok(abs_decimal(a, *scale)),
             UnaryFunc::AbsFloat32 => Ok(abs_float32(a)),
             UnaryFunc::AbsFloat64 => Ok(abs_float64(a)),
+            UnaryFunc::AbsDecimal => Ok(abs_decimal(a)),
             UnaryFunc::CastBoolToStringExplicit => Ok(cast_bool_to_string_explicit(a)),
             UnaryFunc::CastBoolToStringImplicit => Ok(cast_bool_to_string_implicit(a)),
             UnaryFunc::CastInt32ToBool => Ok(cast_int32_to_bool(a)),
@@ -2626,7 +2626,7 @@ impl UnaryFunc {
             SqrtFloat64 => ColumnType::new(ScalarType::Float64).nullable(true),
 
             Not | NegInt32 | NegInt64 | NegFloat32 | NegFloat64 | NegDecimal | NegInterval
-            | AbsInt32 | AbsInt64 | AbsDecimal(_) | AbsFloat32 | AbsFloat64 => input_type,
+            | AbsInt32 | AbsInt64 | AbsFloat32 | AbsFloat64 | AbsDecimal => input_type,
 
             ExtractIntervalEpoch
             | ExtractIntervalYear
@@ -2725,7 +2725,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::NegInterval => f.write_str("-"),
             UnaryFunc::AbsInt32 => f.write_str("abs"),
             UnaryFunc::AbsInt64 => f.write_str("abs"),
-            UnaryFunc::AbsDecimal(_) => f.write_str("abs"),
+            UnaryFunc::AbsDecimal => f.write_str("abs"),
             UnaryFunc::AbsFloat32 => f.write_str("abs"),
             UnaryFunc::AbsFloat64 => f.write_str("abs"),
             UnaryFunc::CastBoolToStringExplicit => f.write_str("booltostrex"),

--- a/src/repr/src/scalar/decimal.rs
+++ b/src/repr/src/scalar/decimal.rs
@@ -125,6 +125,10 @@ impl Significand {
         self.0
     }
 
+    pub fn abs(&self) -> Significand {
+        Significand(self.0.abs())
+    }
+
     /// Constructs a [`Decimal`] by imbuing this `Significand` with the
     /// specified `scale`.
     pub fn with_scale(self, scale: u8) -> Decimal {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -577,10 +577,6 @@ impl<'a> ArgImplementationMatcher<'a> {
         }
 
         f.op = match f.op {
-            Unary(UnaryFunc::AbsDecimal(_)) => match types[0] {
-                ScalarType::Decimal(_, s) => Unary(UnaryFunc::AbsDecimal(s)),
-                _ => unreachable!(),
-            },
             Unary(UnaryFunc::CeilDecimal(_)) => match types[0] {
                 ScalarType::Decimal(_, s) => Unary(UnaryFunc::CeilDecimal(s)),
                 _ => unreachable!(),
@@ -699,7 +695,7 @@ lazy_static! {
                 impls! {
                     params!(Int32) => Unary(UnaryFunc::AbsInt32),
                     params!(Int64) => Unary(UnaryFunc::AbsInt64),
-                    params!(Decimal(0, 0)) => Unary(UnaryFunc::AbsDecimal(0)),
+                    params!(Decimal(0, 0)) => Unary(UnaryFunc::AbsDecimal),
                     params!(Float32) => Unary(UnaryFunc::AbsFloat32),
                     params!(Float64) => Unary(UnaryFunc::AbsFloat64)
                 }


### PR DESCRIPTION
Realized that the `abs` implementation for `Decimals` didn't actually need to track the `Decimal`'s scale.