### PR TITLE
sql-parser, sql: special case coalesce

### DIFF
--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -254,6 +254,11 @@ pub enum Expr {
         expr: Box<Expr>,
         collation: ObjectName,
     },
+    /// COALESCE(<expr>, ...)
+    ///
+    /// While COALESCE has the same syntax as a function call, its semantics are
+    /// extremely unusual, and are better captured with a dedicated AST node.
+    Coalesce { exprs: Vec<Expr> },
     /// Nested expression e.g. `(foo > bar)` or `(1)`
     Nested(Box<Expr>),
     /// A literal value, such as string, number, date or NULL
@@ -382,6 +387,11 @@ impl AstDisplay for Expr {
                 f.write_node(&expr);
                 f.write_str(" COLLATE ");
                 f.write_node(&collation);
+            }
+            Expr::Coalesce { exprs } => {
+                f.write_str("COALESCE(");
+                f.write_node(&display_comma_separated(&exprs));
+                f.write_str(")");
             }
             Expr::Nested(ast) => {
                 f.write_str("(");

--- a/src/sql-parser/src/ast/visit_macro.rs
+++ b/src/sql-parser/src/ast/visit_macro.rs
@@ -229,6 +229,10 @@ macro_rules! make_visitor {
                 visit_collate(self, expr, collation)
             }
 
+            fn visit_coalesce(&mut self, exprs: &'ast $($mut)* [Expr]) {
+                visit_coalesce(self, exprs)
+            }
+
             fn visit_extract(&mut self, field: &'ast $($mut)* ExtractField, expr: &'ast $($mut)* Expr) {
                 visit_extract(self, field, expr)
             }
@@ -1010,6 +1014,7 @@ macro_rules! make_visitor {
                 Expr::UnaryOp { expr, op } => visitor.visit_unary_op(expr, op),
                 Expr::Cast { expr, data_type } => visitor.visit_cast(expr, data_type),
                 Expr::Collate { expr, collation } => visitor.visit_collate(expr, collation),
+                Expr::Coalesce { exprs } => visitor.visit_coalesce(exprs),
                 Expr::Extract { field, expr } => visitor.visit_extract(field, expr),
                 Expr::Nested(expr) => visitor.visit_nested(expr),
                 Expr::Value(val) => visitor.visit_value(val),
@@ -1159,6 +1164,16 @@ macro_rules! make_visitor {
             visitor.visit_expr(expr);
             visitor.visit_object_name(collation);
         }
+
+        pub fn visit_coalesce<'ast, V: $name<'ast> + ?Sized>(
+            visitor: &mut V,
+            exprs: &'ast $($mut)* [Expr],
+        ) {
+            for expr in exprs {
+                visitor.visit_expr(expr);
+            }
+        }
+
 
         pub fn visit_extract<'ast, V: $name<'ast> + ?Sized>(
             visitor: &mut V,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -300,6 +300,7 @@ impl Parser {
                 "LIST" => self.parse_list(),
                 "CASE" => self.parse_case_expr(),
                 "CAST" => self.parse_cast_expr(),
+                "COALESCE" => self.parse_coalesce_expr(),
                 "EXISTS" => self.parse_exists_expr(),
                 "EXTRACT" => self.parse_extract_expr(),
                 "INTERVAL" => self.parse_literal_interval(),
@@ -557,6 +558,13 @@ impl Parser {
         let exists_node = Expr::Exists(Box::new(self.parse_query()?));
         self.expect_token(&Token::RParen)?;
         Ok(exists_node)
+    }
+
+    fn parse_coalesce_expr(&mut self) -> Result<Expr, ParserError> {
+        self.expect_token(&Token::LParen)?;
+        let exprs = self.parse_comma_separated(Parser::parse_expr)?;
+        self.expect_token(&Token::RParen)?;
+        Ok(Expr::Coalesce { exprs })
     }
 
     fn parse_extract_expr(&mut self) -> Result<Expr, ParserError> {

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -210,6 +210,21 @@ EXTRACT(EPOCH FROM d)
 Extract { field: Epoch, expr: Identifier([Ident("d")]) }
 
 parse-scalar
+COALESCE(foo, bar)
+----
+Coalesce { exprs: [Identifier([Ident("foo")]), Identifier([Ident("bar")])] }
+
+parse-scalar
+COALESCE()
+----
+error:
+Parse error:
+COALESCE()
+         ^
+Expected an expression, found: )
+
+
+parse-scalar
 sqrt(id)
 ----
 Function(Function { name: ObjectName([Ident("sqrt")]), args: Args([Identifier([Ident("id")])]), filter: None, over: None, distinct: false })


### PR DESCRIPTION
COALESCE is a really special function because it coalesces the types of
its arguments in the same way that UNION, VALUES, and other bits of SQL
syntax do. PostgreSQL special cases COALESCE in the parser, so this
patch does the same.

This essentially moves a bit of complexity out of the general function
selector and into the main SQL planner, where it fits in a bit more
naturally next to all the other weird corners of SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3249)
<!-- Reviewable:end -->
