### PR TITLE
Run chaos functions in threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "env_logger",
+ "futures",
  "log",
  "md-5",
  "ore",

--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -750,8 +750,6 @@ class PauseContainerStep(WorkflowStep):
             raise Failed(f"Unable to unpause container {self._container}: {e}")
         time.sleep(self._running_time)
 
-        print(time.monotonic())
-
 
 @Steps.register("workflow")
 class WorkflowWorkflowStep(WorkflowStep):

--- a/test/chaos/Cargo.toml
+++ b/test/chaos/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.31"
 env_logger = "0.7.1"
+futures = "0.3.4"
 log = "0.4.8"
 md-5 = "0.8"
 ore = { path = "../../src/ore" }


### PR DESCRIPTION
Updates the current chaos testing to run two separate threads: 1) Generating bytes and pushing them to Kafka, and 2) Querying Materialize. When both threads finish running, they compare md5 hashes of their respective rows.

(Also removes an errant debug line left behind in `mzconduct`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3254)
<!-- Reviewable:end -->
