### PR TITLE
py: Fix a useless format trick

### DIFF
--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -46,9 +46,9 @@ def speaker(prefix: str, for_progress: bool = False) -> Callable[..., None]:
         mz> hello
     """
 
-    def say(msg: str, *fmt: str) -> None:
+    def say(msg: str) -> None:
         if not Verbosity.quiet:
-            print("{} {}".format(prefix, msg.format(*fmt)), file=sys.stderr)
+            print("{} {}".format(prefix, msg), file=sys.stderr)
 
     return say
 


### PR DESCRIPTION
The say function allowed you to specify format args as inline parameters because it's a
pattern that I'm used to from before f-strings. However, with f-strings we literally
never use it, and it also can cause problems if you want to print a string that has curly
braces in it, for example because you're printing a dict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3256)
<!-- Reviewable:end -->
