### PR TITLE
sql: refactor length functions

### DIFF
--- a/doc/user/content/sql/functions/length.md
+++ b/doc/user/content/sql/functions/length.md
@@ -6,7 +6,8 @@ menu:
     parent: 'sql-functions'
 ---
 
-`LENGTH` returns the graphemes (which is roughly equivalent to printed characters) in a string.
+`LENGTH` returns the graphemes (which is roughly equivalent to printed
+characters) in an encoded string.
 
 ## Signatures
 
@@ -14,38 +15,57 @@ menu:
 
 Parameter | Type | Description
 ----------|------|------------
-_str_ | [`string`](../../types/string) | The string whose length you want.
+_str_ | [`string`](../../types/string) or `bytea` | The string whose length you want.
 _encoding&lowbar;name_ | [`string`](../../types/string) | The [encoding](#encoding-details) you want to use for calculating the string's length. _Defaults to UTF-8_.
 
 ### Return value
 
-`length` returns an Int.
+`length` returns an [`int`](../../types/int).
 
 ## Details
 
 ### Errors
 
-`length` operations might return `NULL` values indicating errors in the following cases:
+`length` operations might return `NULL` values indicating errors in the
+following cases:
 
 - The _encoding&lowbar;name_ provided is not available in our encoding package.
 - Some byte sequence in _str_ was not compatible with the selected encoding.
 
 ### Fixed-width strings
 
-Materialize returns the length of fixed-width strings as the maximum width of the string. For example `length` on a `CHAR(15)` column returns `15` as each string's length.
+Materialize returns the length of fixed-width strings as the maximum width of
+the string. For example `length` on a `CHAR(15)` column returns `15` as each
+string's length.
 
-Materialize receives strings from your database in the same format they are emitted. In the case of fixed-width strings, e.g. `CHAR` columns in PostgreSQL, we receive the value padded by empty spaces. Because we cannot determine whether those spaces were intentional or an artifact of a fixed-width string, we provide the length of the string as we received it.
+Materialize receives strings from your database in the same format they are
+emitted. In the case of fixed-width strings, e.g. `CHAR` columns in PostgreSQL,
+we receive the value padded by empty spaces. Because we cannot determine whether
+those spaces were intentional or an artifact of a fixed-width string, we provide
+the length of the string as we received it.
 
-You can find any updates on this behavior in [this GitHub issue](https://github.com/MaterializeInc/materialize/issues/589).
+You can find any updates on this behavior in [this GitHub
+issue](https://github.com/MaterializeInc/materialize/issues/589).
 
 ### Encoding details
 
-- Materialize uses the [`encoding`](https://crates.io/crates/encoding) crate. See the [list of supported encodings](https://lifthrasiir.github.io/rust-encoding/encoding/index.html#supported-encodings), as well as their names [within the API](https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs).
-- Materialize attempts to convert [PostgreSQL-style encoding names](https://www.postgresql.org/docs/9.5/multibyte.html) into the [WHATWG-style encoding names](https://encoding.spec.whatwg.org/) used by the API.
+- Materialize uses the [`encoding`](https://crates.io/crates/encoding) crate.
+  See the [list of supported
+  encodings](https://lifthrasiir.github.io/rust-encoding/encoding/index.html#supported-encodings),
+  as well as their names [within the
+  API](https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs).
+- Materialize attempts to convert [PostgreSQL-style encoding
+  names](https://www.postgresql.org/docs/9.5/multibyte.html) into the
+  [WHATWG-style encoding names](https://encoding.spec.whatwg.org/) used by the
+  API.
 
-    For example, you can refer to `iso-8859-5` (WHATWG-style) as `ISO_8859_5` (PostrgreSQL-style).
+    For example, you can refer to `iso-8859-5` (WHATWG-style) as `ISO_8859_5`
+    (PostrgreSQL-style).
 
-    However, there are some differences in the names of the same encodings that we do not convert. For example, the [windows-874](https://encoding.spec.whatwg.org/#windows-1252) encoding is referred to as `WIN874` in PostgreSQL; Materialize does not perform a conversion for these names.
+    However, there are some differences in the names of the same encodings that
+    we do not convert. For example, the
+    [windows-874](https://encoding.spec.whatwg.org/#windows-1252) encoding is
+    referred to as `WIN874` in PostgreSQL; Materialize does not convert these names.
 
 ## Examples
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -53,6 +53,7 @@
 
   - signature: 'sum(x: T) -> T'
     description: Sum of `T`'s values
+
   - signature: 'variance(x: T) -> U'
     description: Historical alias for `variance_samp`. *(imprecise)*
       <br><br>
@@ -103,19 +104,38 @@
   - signature: 'btrim(s: str, c: str) -> str'
     description: Trim any character in `c` from both sides of `s`.
 
+  - signature: 'bit_length(s: str) -> int'
+    description: Number of bits in `s`
+
+  - signature: 'bit_length(b: bytea) -> int'
+    description: Number of bits in `b`
+
+  - signature: 'char_length(s: str) -> int'
+    description: Number of graphemes in `s`
+
   - signature: 'length(s: str) -> int'
     description: Number of graphemes in `s`
     url: length
 
-  - signature: 'length(s: str, encoding_name: str) -> int'
-    description: Number of graphemes in `s` using `encoding_name`
+  - signature: 'length(b: bytea) -> int'
+    description: Number of bytes in `s`
+    url: length
+
+  - signature: 'length(s: bytea, encoding_name: str) -> int'
+    description: Number of graphemes in `s` after encoding
     url: length
 
   - signature: 'ltrim(s: str) -> str'
     description: Trim all spaces from the left side of `s`.
 
-  - signature: 'btrim(s: str, c: str) -> str'
-    description: Trim any character in `c` from the left sides of `s`.
+  - signature: 'ltrim(s: str, c: str) -> str'
+    description: Trim any character in `c` from the left side of `s`.
+
+  - signature: 'octet_length(s: str) -> int'
+    description: Number of bytes in `s`
+
+  - signature: 'octet_length(b: bytea) -> int'
+    description: Number of bytes in `b`
 
   - signature: 'regexp_extract(regex: str, haystack: str) -> Col<string>'
     description: Values of the capture groups of `regex` as matched in `haystack`

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -693,10 +693,17 @@ lazy_static! {
                 params!(String) => Unary(UnaryFunc::TrimWhitespace),
                 params!(String, String) => Binary(BinaryFunc::Trim)
             },
+            "bit_length" => {
+                params!(Bytes) => Unary(UnaryFunc::BitLengthBytes),
+                params!(String) => Unary(UnaryFunc::BitLengthString)
+            },
             "ceil" => {
                 params!(Float32) => Unary(UnaryFunc::CeilFloat32),
                 params!(Float64) => Unary(UnaryFunc::CeilFloat64),
                 params!(Decimal(0, 0)) => Unary(UnaryFunc::CeilDecimal(0))
+            },
+            "char_length" => {
+                params!(String) => Unary(UnaryFunc::CharLength)
             },
             "concat" => {
                 Repeat(vec![StringAny]) => Variadic(VariadicFunc::Concat)
@@ -735,9 +742,13 @@ lazy_static! {
                 params!(Jsonb) => Unary(UnaryFunc::JsonbTypeof)
             },
             "length" => {
-                params!(Bytes) => Unary(UnaryFunc::LengthBytes),
-                params!(String) => Variadic(VariadicFunc::LengthString),
-                params!(String, String) => Variadic(VariadicFunc::LengthString)
+                params!(Bytes) => Unary(UnaryFunc::ByteLengthBytes),
+                params!(String) => Unary(UnaryFunc::CharLength),
+                params!(Bytes, String) => Binary(BinaryFunc::EncodedBytesCharLength)
+            },
+            "octet_length" => {
+                params!(Bytes) => Unary(UnaryFunc::ByteLengthBytes),
+                params!(String) => Unary(UnaryFunc::ByteLengthString)
             },
             "ltrim" => {
                 params!(String) => Unary(UnaryFunc::TrimLeadingWhitespace),

--- a/test/sqllogictest/bytea.slt
+++ b/test/sqllogictest/bytea.slt
@@ -18,7 +18,7 @@ statement ok
 INSERT INTO test VALUES (0, 'hello'), (1, '你好'), (2, NULL), (3, ''), (4, 'nonprintablechar:')
 
 query II rowsort
-SELECT ord, length(b::bytea) FROM test
+SELECT ord, length(b) FROM test
 ----
 0 5
 1 6
@@ -26,5 +26,54 @@ SELECT ord, length(b::bytea) FROM test
 3 0
 4 18
 
-query error Cannot call function 'length': arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
-SELECT length('a'::bytea, 'utf-8')
+query II rowsort
+SELECT ord, length(b, 'utf-8') FROM test
+----
+0 5
+1 2
+2 NULL
+3 0
+4 18
+
+query I
+SELECT length('\xDEADBEEF'::bytea)
+----
+4
+
+query I
+SELECT octet_length('\xDEADBEEF'::bytea)
+----
+4
+
+query I
+SELECT bit_length('\xDEADBEEF'::bytea)
+----
+32
+
+query I
+SELECT length('DEADBEEF'::bytea)
+----
+8
+
+query I
+SELECT octet_length('DEADBEEF'::bytea)
+----
+8
+
+query I
+SELECT octet_length('DEADBEEF'::text);
+----
+8
+
+query I
+SELECT bit_length('DEADBEEF'::bytea)
+----
+64
+
+query I
+SELECT bit_length('DEADBEEF'::text);
+----
+64
+
+statement error
+SELECT length('deadbeef'::text, 'utf-8')

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -412,6 +412,16 @@ SELECT length('你好', 'iso-8859-5')
 ----
 6
 
+query I
+SELECT octet_length('你好');
+----
+6
+
+query I
+SELECT bit_length('你好');
+----
+48
+
 # encoding name conversion FROM pg to WHATWG
 query I
 SELECT length('你好', 'ISO_8859_5')


### PR DESCRIPTION
Makes `length` function Postgres compatible:
- Removes original `LengthBytes` function, which wasn't Postgres compatible
- Splits `LengthString` into two Postgres compatible functions:
  -  `CharLength`, as a unary function (`char_length(str)`, `length(str)`)
  -  `EncodedBytesCharLength` as a binary function (`length(str bytea, encoding_name)`) which now properly takes bytes as its first argument

To retain an analog to `length(bytea)`, this PR implements PG-compatible versions of `octet_length` (and its brother `bit_length`)

Closes #3097

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3257)
<!-- Reviewable:end -->
