### PR TITLE
repr: make datum_size function private

### DIFF
--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -30,5 +30,5 @@ pub mod adt;
 pub mod strconv;
 
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{datum_size, DatumDict, DatumList, Row, RowArena, RowPacker};
+pub use row::{DatumDict, DatumList, Row, RowArena, RowPacker};
 pub use scalar::{Datum, ScalarType};


### PR DESCRIPTION
@frankmcsherry you made this public when you introduced it in https://github.com/MaterializeInc/materialize/pull/1787, so let me know if there's a potential use case you had in mind that you just haven't gotten to yet. I've been slowly hammering the `repr` crate's API into something more documented and understandable (https://mtrlz.dev/api/rust/repr/) and this is the one public item that feels a bit out of place.

----

This seems more like an internal implementation detail than part of
repr's public API. Also give the function a bit more of a descriptive
name and add some missing Datum variants to the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3262)
<!-- Reviewable:end -->
