### PR TITLE
repr: rename ScalarType to DatumType

### DIFF
--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use expr::GlobalId;
-use repr::{RelationDesc, ScalarType};
+use repr::{DatumType, RelationDesc};
 
 /// Logging configuration.
 #[derive(Debug, Clone)]
@@ -208,113 +208,113 @@ impl LogVariant {
     pub fn schema(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("name", ScalarType::String)
+                .with_nonnull_column("id", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("name", DatumType::String)
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("source_node", ScalarType::Int64)
-                .with_nonnull_column("source_port", ScalarType::Int64)
-                .with_nonnull_column("target_node", ScalarType::Int64)
-                .with_nonnull_column("target_port", ScalarType::Int64)
+                .with_nonnull_column("id", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("source_node", DatumType::Int64)
+                .with_nonnull_column("source_port", DatumType::Int64)
+                .with_nonnull_column("target_node", DatumType::Int64)
+                .with_nonnull_column("target_port", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("elapsed_ns", ScalarType::Int64)
+                .with_nonnull_column("id", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("elapsed_ns", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("duration_ns", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_nonnull_column("id", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("duration_ns", DatumType::Int64)
+                .with_nonnull_column("count", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("slot", ScalarType::Int64)
-                .with_nonnull_column("value", ScalarType::Int64)
+                .with_nonnull_column("id", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("slot", DatumType::Int64)
+                .with_nonnull_column("value", DatumType::Int64)
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("slept_for", ScalarType::Int64)
-                .with_nonnull_column("requested", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("slept_for", DatumType::Int64)
+                .with_nonnull_column("requested", DatumType::Int64)
+                .with_nonnull_column("count", DatumType::Int64)
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
-                .with_nonnull_column("operator", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("records", ScalarType::Int64)
-                .with_nonnull_column("batches", ScalarType::Int64)
+                .with_nonnull_column("operator", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("records", DatumType::Int64)
+                .with_nonnull_column("batches", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .with_nonnull_column("operator", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_nonnull_column("operator", DatumType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("count", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .with_nonnull_column("name", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_nonnull_column("name", DatumType::String)
+                .with_nonnull_column("worker", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .with_nonnull_column("dataflow", ScalarType::String)
-                .with_nonnull_column("source", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64),
+                .with_nonnull_column("dataflow", DatumType::String)
+                .with_nonnull_column("source", DatumType::String)
+                .with_nonnull_column("worker", DatumType::Int64),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("time", ScalarType::Int64),
+                .with_nonnull_column("global_id", DatumType::String)
+                .with_nonnull_column("time", DatumType::Int64),
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .with_nonnull_column("uuid", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("id", ScalarType::String)
-                .with_nonnull_column("time", ScalarType::Int64)
+                .with_nonnull_column("uuid", DatumType::String)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("id", DatumType::String)
+                .with_nonnull_column("time", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("duration_ns", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_nonnull_column("worker", DatumType::Int64)
+                .with_nonnull_column("duration_ns", DatumType::Int64)
+                .with_nonnull_column("count", DatumType::Int64)
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PrimaryKeys) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("column", ScalarType::Int64)
-                .with_nonnull_column("key_group", ScalarType::Int64),
+                .with_nonnull_column("global_id", DatumType::String)
+                .with_nonnull_column("column", DatumType::Int64)
+                .with_nonnull_column("key_group", DatumType::Int64),
 
             LogVariant::Materialized(MaterializedLog::ForeignKeys) => RelationDesc::empty()
-                .with_nonnull_column("child_id", ScalarType::String)
-                .with_nonnull_column("child_column", ScalarType::Int64)
-                .with_nonnull_column("parent_id", ScalarType::String)
-                .with_nonnull_column("parent_column", ScalarType::Int64)
-                .with_nonnull_column("key_group", ScalarType::Int64)
+                .with_nonnull_column("child_id", DatumType::String)
+                .with_nonnull_column("child_column", DatumType::Int64)
+                .with_nonnull_column("parent_id", DatumType::String)
+                .with_nonnull_column("parent_column", DatumType::Int64)
+                .with_nonnull_column("key_group", DatumType::Int64)
                 .with_key(vec![0, 1, 4]),
 
             LogVariant::Materialized(MaterializedLog::Catalog) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("name", ScalarType::String)
+                .with_nonnull_column("global_id", DatumType::String)
+                .with_nonnull_column("name", DatumType::String)
                 .with_key(vec![0]),
 
             LogVariant::Materialized(MaterializedLog::KafkaSinks) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("topic", ScalarType::String)
+                .with_nonnull_column("global_id", DatumType::String)
+                .with_nonnull_column("topic", DatumType::String)
                 .with_key(vec![0]),
 
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("path", ScalarType::Bytes)
+                .with_nonnull_column("global_id", DatumType::String)
+                .with_nonnull_column("path", DatumType::Bytes)
                 .with_key(vec![0]),
         }
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -541,13 +541,13 @@ impl RelationExpr {
     /// # Example
     ///
     /// ```rust
-    /// use repr::{Datum, ColumnType, RelationType, ScalarType};
+    /// use repr::{Datum, ColumnType, RelationType, DatumType};
     /// use expr::RelationExpr;
     ///
     /// // A common schema for each input.
     /// let schema = RelationType::new(vec![
-    ///     ColumnType::new(ScalarType::Int32),
-    ///     ColumnType::new(ScalarType::Int32),
+    ///     ColumnType::new(DatumType::Int32),
+    ///     ColumnType::new(DatumType::Int32),
     /// ]);
     ///
     /// // the specific data are not important here.

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use repr::adt::regex::Regex;
 use repr::strconv::ParseError;
-use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
+use repr::{ColumnType, Datum, DatumType, RelationType, Row, RowArena};
 
 use self::func::{BinaryFunc, DateTruncTo, NullaryFunc, UnaryFunc, VariadicFunc};
 
@@ -202,7 +202,7 @@ impl ScalarExpr {
     pub fn take(&mut self) -> Self {
         mem::replace(
             self,
-            ScalarExpr::literal_null(ColumnType::new(ScalarType::String)),
+            ScalarExpr::literal_null(ColumnType::new(DatumType::String)),
         )
     }
 
@@ -263,11 +263,11 @@ impl ScalarExpr {
     ///
     /// ```rust
     /// use expr::{BinaryFunc, ScalarExpr};
-    /// use repr::{ColumnType, Datum, RelationType, ScalarType};
+    /// use repr::{ColumnType, Datum, RelationType, DatumType};
     ///
     /// let expr_0 = ScalarExpr::Column(0);
-    /// let expr_t = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool));
-    /// let expr_f = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
+    /// let expr_t = ScalarExpr::literal_ok(Datum::True, ColumnType::new(DatumType::Bool));
+    /// let expr_f = ScalarExpr::literal_ok(Datum::False, ColumnType::new(DatumType::Bool));
     ///
     /// let mut test =
     /// expr_t
@@ -275,7 +275,7 @@ impl ScalarExpr {
     ///     .call_binary(expr_f.clone(), BinaryFunc::And)
     ///     .if_then_else(expr_0, expr_t.clone());
     ///
-    /// let input_type = RelationType::new(vec![ColumnType::new(ScalarType::Int32)]);
+    /// let input_type = RelationType::new(vec![ColumnType::new(DatumType::Int32)]);
     /// test.reduce(&input_type);
     /// assert_eq!(test, expr_t);
     /// ```
@@ -552,14 +552,14 @@ mod tests {
     #[test]
     fn test_reduce() {
         let relation_type = RelationType::new(vec![
-            ColumnType::new(ScalarType::Int64).nullable(true),
-            ColumnType::new(ScalarType::Int64).nullable(true),
-            ColumnType::new(ScalarType::Int64).nullable(false),
+            ColumnType::new(DatumType::Int64).nullable(true),
+            ColumnType::new(DatumType::Int64).nullable(true),
+            ColumnType::new(DatumType::Int64).nullable(false),
         ]);
         let col = |i| ScalarExpr::Column(i);
-        let err = |e| ScalarExpr::literal(Err(e), ColumnType::new(ScalarType::Int64));
-        let lit = |i| ScalarExpr::literal_ok(Datum::Int64(i), ColumnType::new(ScalarType::Int64));
-        let null = || ScalarExpr::literal_null(ColumnType::new(ScalarType::Int64));
+        let err = |e| ScalarExpr::literal(Err(e), ColumnType::new(DatumType::Int64));
+        let lit = |i| ScalarExpr::literal_ok(Datum::Int64(i), ColumnType::new(DatumType::Int64));
+        let null = || ScalarExpr::literal_null(ColumnType::new(DatumType::Int64));
 
         struct TestCase {
             input: ScalarExpr,

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use lazy_static::lazy_static;
-use repr::ScalarType;
+use repr::DatumType;
 
 /// The type of a [`Value`](crate::Value).
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -111,24 +111,24 @@ impl Type {
     }
 }
 
-impl From<&ScalarType> for Type {
-    fn from(typ: &ScalarType) -> Type {
+impl From<&DatumType> for Type {
+    fn from(typ: &DatumType) -> Type {
         match typ {
-            ScalarType::Bool => Type::Bool,
-            ScalarType::Int32 => Type::Int4,
-            ScalarType::Int64 => Type::Int8,
-            ScalarType::Float32 => Type::Float4,
-            ScalarType::Float64 => Type::Float8,
-            ScalarType::Decimal(_, _) => Type::Numeric,
-            ScalarType::Date => Type::Date,
-            ScalarType::Time => Type::Time,
-            ScalarType::Timestamp => Type::Timestamp,
-            ScalarType::TimestampTz => Type::TimestampTz,
-            ScalarType::Interval => Type::Interval,
-            ScalarType::Bytes => Type::Bytea,
-            ScalarType::String => Type::Text,
-            ScalarType::Jsonb => Type::Jsonb,
-            ScalarType::List(t) => Type::List(Box::new(From::from(&**t))),
+            DatumType::Bool => Type::Bool,
+            DatumType::Int32 => Type::Int4,
+            DatumType::Int64 => Type::Int8,
+            DatumType::Float32 => Type::Float4,
+            DatumType::Float64 => Type::Float8,
+            DatumType::Decimal(_, _) => Type::Numeric,
+            DatumType::Date => Type::Date,
+            DatumType::Time => Type::Time,
+            DatumType::Timestamp => Type::Timestamp,
+            DatumType::TimestampTz => Type::TimestampTz,
+            DatumType::Interval => Type::Interval,
+            DatumType::Bytes => Type::Bytea,
+            DatumType::String => Type::Text,
+            DatumType::Jsonb => Type::Jsonb,
+            DatumType::List(t) => Type::List(Box::new(From::from(&**t))),
         }
     }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -13,7 +13,7 @@ use bytes::BytesMut;
 use postgres::error::SqlState;
 
 use dataflow_types::Update;
-use repr::{ColumnName, RelationDesc, RelationType, ScalarType};
+use repr::{ColumnName, DatumType, RelationDesc, RelationType};
 use sql::session::TransactionStatus as SqlTransactionStatus;
 
 // Pgwire protocol versions are represented as 32-bit integers, where the
@@ -360,7 +360,7 @@ pub fn row_description_from_desc(desc: &RelationDesc) -> Vec<FieldDescription> {
                     // while the low order bits store the scale + 4 (!).
                     //
                     // https://github.com/postgres/postgres/blob/e435c1e7d/src/backend/utils/adt/numeric.c#L6364-L6367
-                    ScalarType::Decimal(precision, scale) => {
+                    DatumType::Decimal(precision, scale) => {
                         ((i32::from(*precision) << 16) | i32::from(*scale)) + 4
                     }
                     _ => -1,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -462,7 +462,7 @@ where
             Err(msg) => return self.error(session, SqlState::PROTOCOL_VIOLATION, msg).await,
         };
         let buf = RowArena::new();
-        let mut params: Vec<(Datum, repr::ScalarType)> = Vec::new();
+        let mut params: Vec<(Datum, repr::DatumType)> = Vec::new();
         for (raw_param, typ, format) in izip!(raw_params, param_types, param_formats) {
             match raw_param {
                 None => params.push(pgrepr::null_datum(typ)),

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -31,4 +31,4 @@ pub mod strconv;
 
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{datum_size, DatumDict, DatumList, Row, RowArena, RowPacker};
-pub use scalar::{Datum, ScalarType};
+pub use scalar::{Datum, DatumType};

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -14,7 +14,7 @@ use std::vec;
 use failure::bail;
 use serde::{Deserialize, Serialize};
 
-use crate::ScalarType;
+use crate::DatumType;
 
 /// The type of a [`Datum`](crate::Datum).
 ///
@@ -25,14 +25,14 @@ pub struct ColumnType {
     /// Whether this datum can be null.
     pub nullable: bool,
     /// The underlying scalar type (e.g., Int32 or String) of this column.
-    pub scalar_type: ScalarType,
+    pub scalar_type: DatumType,
 }
 
 impl ColumnType {
     /// Constructs a new `ColumnType` with the specified [`ScalarType`] as its
     /// underlying type. If desired, the `nullable` property can be set with the
     /// methods of the same name.
-    pub fn new(scalar_type: ScalarType) -> Self {
+    pub fn new(scalar_type: DatumType) -> Self {
         ColumnType {
             nullable: false,
             scalar_type,
@@ -166,11 +166,11 @@ impl From<&ColumnName> for ColumnName {
 /// A `RelationDesc`s is typically constructed via its builder API:
 ///
 /// ```
-/// use repr::{ColumnType, RelationDesc, ScalarType};
+/// use repr::{ColumnType, RelationDesc, DatumType};
 ///
 /// let desc = RelationDesc::empty()
-///     .with_nonnull_column("id", ScalarType::Int64)
-///     .with_column("price", ColumnType::new(ScalarType::Float64).nullable(true));
+///     .with_nonnull_column("id", DatumType::Int64)
+///     .with_column("price", ColumnType::new(DatumType::Float64).nullable(true));
 /// ```
 ///
 /// In more complicated cases, like when constructing a `RelationDesc` in
@@ -236,7 +236,7 @@ impl RelationDesc {
     }
 
     /// Appends a named, nonnullable column with the specified scalar type.
-    pub fn with_nonnull_column<N>(self, name: N, scalar_type: ScalarType) -> Self
+    pub fn with_nonnull_column<N>(self, name: N, scalar_type: DatumType) -> Self
     where
         N: Into<ColumnName>,
     {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{PeekWhen, SinkConnectorBuilder, SourceConnector, Timestamp};
-use repr::{RelationDesc, Row, ScalarType};
+use repr::{DatumType, RelationDesc, Row};
 
 use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use crate::catalog::Catalog;
@@ -187,7 +187,7 @@ pub enum MutationKind {
 #[derive(Debug, Clone)]
 pub struct Params {
     pub datums: Row,
-    pub types: Vec<ScalarType>,
+    pub types: Vec<DatumType>,
 }
 
 /// Controls planning of a SQL query.

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -24,7 +24,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use expr::explain::{Bracketed, Indices, Separated};
 use expr::{Id, IdHumanizer, RowSetFinishing};
-use repr::{RelationType, ScalarType};
+use repr::{DatumType, RelationType};
 
 use crate::plan::expr::{AggregateExpr, JoinKind, RelationExpr, ScalarExpr};
 
@@ -344,7 +344,7 @@ impl RelationExpr {
 }
 
 impl<'a> Explanation<'a> {
-    pub fn explain_types(&mut self, params: &BTreeMap<usize, ScalarType>) {
+    pub fn explain_types(&mut self, params: &BTreeMap<usize, DatumType>) {
         for node in &mut self.nodes {
             // TODO(jamii) `typ` is itself recursive, so this is quadratic :(
             let RelationType { column_types, keys } = node.expr.typ(&[], params);

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -185,7 +185,7 @@ pub trait ScalarTypeable {
         &self,
         outers: &[RelationType],
         inner: &RelationType,
-        params: &BTreeMap<usize, ScalarType>,
+        params: &BTreeMap<usize, DatumType>,
     ) -> Self::Type;
 }
 
@@ -196,7 +196,7 @@ impl ScalarTypeable for CoercibleScalarExpr {
         &self,
         outers: &[RelationType],
         inner: &RelationType,
-        params: &BTreeMap<usize, ScalarType>,
+        params: &BTreeMap<usize, DatumType>,
     ) -> Self::Type {
         match self {
             CoercibleScalarExpr::Coerced(expr) => Some(expr.typ(outers, inner, params)),
@@ -287,7 +287,7 @@ impl RelationExpr {
     pub fn typ(
         &self,
         outers: &[RelationType],
-        params: &BTreeMap<usize, ScalarType>,
+        params: &BTreeMap<usize, DatumType>,
     ) -> RelationType {
         match self {
             RelationExpr::Constant { typ, .. } => typ.clone(),
@@ -652,12 +652,12 @@ impl ScalarExpr {
             Datum::True,
             ColumnType {
                 nullable: false,
-                scalar_type: ScalarType::Bool,
+                scalar_type: DatumType::Bool,
             },
         )
     }
 
-    pub fn literal_null(scalar_type: ScalarType) -> ScalarExpr {
+    pub fn literal_null(scalar_type: DatumType) -> ScalarExpr {
         ScalarExpr::literal(
             Datum::Null,
             ColumnType {
@@ -724,7 +724,7 @@ impl ScalarTypeable for ScalarExpr {
         &self,
         outers: &[RelationType],
         inner: &RelationType,
-        params: &BTreeMap<usize, ScalarType>,
+        params: &BTreeMap<usize, DatumType>,
     ) -> Self::Type {
         match self {
             ScalarExpr::Column(ColumnRef { level, column }) => {
@@ -752,7 +752,7 @@ impl ScalarTypeable for ScalarExpr {
                 let else_type = els.typ(outers, inner, params);
                 then_type.union(&else_type).unwrap()
             }
-            ScalarExpr::Exists(_) => ColumnType::new(ScalarType::Bool).nullable(true),
+            ScalarExpr::Exists(_) => ColumnType::new(DatumType::Bool).nullable(true),
             ScalarExpr::Select(expr) => {
                 let mut outers = outers.to_vec();
                 outers.push(inner.clone());
@@ -776,7 +776,7 @@ impl AggregateExpr {
         &self,
         outers: &[RelationType],
         inner: &RelationType,
-        params: &BTreeMap<usize, ScalarType>,
+        params: &BTreeMap<usize, DatumType>,
     ) -> ColumnType {
         self.func.output_type(self.expr.typ(outers, inner, params))
     }
@@ -1323,10 +1323,10 @@ pub mod decorrelation {
                                 // optimizer.
                                 .product(expr::RelationExpr::constant(
                                     vec![vec![Datum::True]],
-                                    RelationType::new(vec![ColumnType::new(ScalarType::Bool)]),
+                                    RelationType::new(vec![ColumnType::new(DatumType::Bool)]),
                                 ));
                             // append False to anything that didn't return any rows
-                            let default = vec![(Datum::False, ColumnType::new(ScalarType::Bool))];
+                            let default = vec![(Datum::False, ColumnType::new(DatumType::Bool))];
                             get_inner.lookup(id_gen, exists, default)
                         },
                     );

--- a/src/sql/src/session/session.rs
+++ b/src/sql/src/session/session.rs
@@ -21,7 +21,7 @@ use std::fmt;
 
 use failure::bail;
 
-use repr::{Datum, Row, ScalarType};
+use repr::{Datum, DatumType, Row};
 
 use crate::plan::Params;
 use crate::session::statement::{Portal, PreparedStatement};
@@ -386,7 +386,7 @@ impl Session {
         &mut self,
         portal_name: String,
         statement_name: String,
-        params: Vec<(Datum<'a>, ScalarType)>,
+        params: Vec<(Datum<'a>, DatumType)>,
         result_formats: Vec<pgrepr::Format>,
     ) -> Result<(), failure::Error> {
         if !self.prepared_statements.contains_key(&statement_name) {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -51,7 +51,7 @@ use repr::adt::jsonb::JsonbRef;
 use repr::strconv::{
     format_date, format_interval, format_time, format_timestamp, format_timestamptz,
 };
-use repr::{ColumnName, ColumnType, Datum, RelationDesc, Row, ScalarType};
+use repr::{ColumnName, ColumnType, Datum, DatumType, RelationDesc, Row};
 use sql::ast::Statement;
 use sql::session::Session;
 use sql_parser::parser::ParserError as SqlParserError;
@@ -319,9 +319,9 @@ fn format_row(
     let row = izip!(slt_types, col_types, row.iter()).map(|(slt_typ, col_typ, datum)| {
         if let Datum::Null = datum {
             "NULL".to_owned()
-        } else if let ScalarType::Jsonb = col_typ.scalar_type {
+        } else if let DatumType::Jsonb = col_typ.scalar_type {
             JsonbRef::from_datum(datum).to_string()
-        } else if let ScalarType::List(_) = col_typ.scalar_type {
+        } else if let DatumType::List(_) = col_typ.scalar_type {
             // produce the same output as we would for psql
             let mut buf = ::bytes::BytesMut::new();
             pgrepr::Value::from_datum(datum, &col_typ.scalar_type)

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -36,7 +36,7 @@ use tokio_postgres::types::FromSql;
 
 use pgrepr::Jsonb;
 use repr::adt::decimal::Significand;
-use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use repr::{ColumnType, Datum, DatumType, RelationDesc, RelationType, Row, RowPacker};
 use sql::catalog::Catalog;
 use sql::names::FullName;
 use sql::normalize;
@@ -395,7 +395,7 @@ fn push_column(
         }
         DataType::Decimal(_, _) => {
             let desired_scale = match scalar_type_from_sql(sql_type).unwrap() {
-                ScalarType::Decimal(_precision, desired_scale) => desired_scale,
+                DatumType::Decimal(_precision, desired_scale) => desired_scale,
                 _ => unreachable!(),
             };
             match get_column_inner::<pgrepr::Numeric>(postgres_row, i, nullable)? {

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use crate::TransformArgs;
 use expr::{RelationExpr, ScalarExpr, UnaryFunc};
 use repr::Datum;
-use repr::{ColumnType, RelationType, ScalarType};
+use repr::{ColumnType, DatumType, RelationType};
 
 /// Harvest and act upon per-column information.
 #[derive(Debug)]
@@ -351,7 +351,7 @@ pub fn optimize(
             } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
                 *expr = ScalarExpr::literal_ok(
                     Datum::False,
-                    ColumnType::new(ScalarType::Bool).nullable(false),
+                    ColumnType::new(DatumType::Bool).nullable(false),
                 );
                 optimize(expr, input_type, column_knowledge)?
             } else {

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -11,12 +11,12 @@
 //!
 //! ```rust
 //! use expr::{RelationExpr, ScalarExpr};
-//! use repr::{ColumnType, Datum, RelationType, ScalarType};
+//! use repr::{ColumnType, Datum, RelationType, DatumType};
 //!
 //! use transform::fusion::filter::Filter;
 //!
 //! let input = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(DatumType::Bool),
 //! ]));
 //!
 //! let predicate0 = ScalarExpr::Column(0);

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -378,7 +378,7 @@ impl LiteralLifting {
                         .eval(Some(aggr.expr.eval(&[], &temp).unwrap()), &temp);
                     result.push(ScalarExpr::literal_ok(
                         eval,
-                        repr::ColumnType::new(repr::ScalarType::Bool),
+                        repr::ColumnType::new(repr::DatumType::Bool),
                     ));
                 }
                 result.reverse();

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -16,7 +16,7 @@
 
 use crate::TransformArgs;
 use expr::{AggregateExpr, AggregateFunc, RelationExpr, ScalarExpr, UnaryFunc};
-use repr::{ColumnType, Datum, RelationType, ScalarType};
+use repr::{ColumnType, Datum, DatumType, RelationType};
 
 /// Harvests information about non-nullability of columns from sources.
 #[derive(Debug)]
@@ -108,7 +108,7 @@ fn scalar_nonnullable(expr: &mut ScalarExpr, metadata: &RelationType) {
         {
             if let ScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
+                    *e = ScalarExpr::literal_ok(Datum::False, ColumnType::new(DatumType::Bool));
                 }
             }
         }
@@ -121,7 +121,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     if let (AggregateFunc::Count, ScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
             expr.func = AggregateFunc::CountAll;
-            expr.expr = ScalarExpr::literal_null(ColumnType::new(ScalarType::Bool).nullable(true));
+            expr.expr = ScalarExpr::literal_null(ColumnType::new(DatumType::Bool).nullable(true));
         }
     }
 }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -14,18 +14,18 @@
 //!
 //! ```rust
 //! use expr::{BinaryFunc, IdGen, RelationExpr, ScalarExpr};
-//! use repr::{ColumnType, Datum, RelationType, ScalarType};
+//! use repr::{ColumnType, Datum, RelationType, DatumType};
 //!
 //! use transform::predicate_pushdown::PredicatePushdown;
 //!
 //! let input1 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(DatumType::Bool),
 //! ]));
 //! let input2 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(DatumType::Bool),
 //! ]));
 //! let input3 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(DatumType::Bool),
 //! ]));
 //! let join = RelationExpr::join(
 //!     vec![input1.clone(), input2.clone(), input3.clone()],
@@ -35,7 +35,7 @@
 //! let predicate0 = ScalarExpr::column(0);
 //! let predicate1 = ScalarExpr::column(1);
 //! let predicate01 = ScalarExpr::column(0).call_binary(ScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
+//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ColumnType::new(DatumType::Bool));
 //!
 //! let mut expr = join.filter(
 //!    vec![
@@ -54,7 +54,7 @@
 
 use crate::TransformArgs;
 use expr::{AggregateFunc, RelationExpr, ScalarExpr};
-use repr::{ColumnType, Datum, ScalarType};
+use repr::{ColumnType, Datum, DatumType};
 
 /// Pushes predicates down through other operators.
 #[derive(Debug)]
@@ -258,7 +258,7 @@ impl PredicatePushdown {
                                 push_down.push(aggregates[0].expr.clone());
                                 aggregates[0].expr = ScalarExpr::literal_ok(
                                     Datum::True,
-                                    ColumnType::new(ScalarType::Bool),
+                                    ColumnType::new(DatumType::Bool),
                                 );
                             } else {
                                 retain.push(predicate);

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -485,7 +485,7 @@ pub mod demorgans {
 pub mod undistribute_and {
 
     use expr::{BinaryFunc, RelationExpr, ScalarExpr};
-    use repr::{ColumnType, Datum, ScalarType};
+    use repr::{ColumnType, Datum, DatumType};
 
     use crate::{TransformArgs, TransformError};
 
@@ -549,7 +549,7 @@ pub mod undistribute_and {
             suppress_ands(expr2, ands);
 
             // If either argument is in our list, replace it by `true`.
-            let tru = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool));
+            let tru = ScalarExpr::literal_ok(Datum::True, ColumnType::new(DatumType::Bool));
             if ands.contains(expr1) {
                 *expr = std::mem::replace(expr2, tru);
             } else if ands.contains(expr2) {


### PR DESCRIPTION
It is much clearer for a type whose description is "the type of a datum"
to be called `DatumType` than to use the semi-synonym "scalar".

Plus @umanwizard points out that "scalar" become inaccurate when
`Datums` learned to be lists or dicts for JSON support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3263)
<!-- Reviewable:end -->
