### PR TITLE
Add ChaosStopContainerStep test

### DIFF
--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -762,7 +762,7 @@ class ChaosContainerBaseWorkflowStep(WorkflowStep):
         else:
             self.stop_and_start()
 
-    def stop_and_start(self):
+    def stop_and_start(self) -> None:
         try:
             spawn.runv(["docker", self._stop_cmd, self._container])
         except subprocess.CalledProcessError as e:

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -67,7 +67,7 @@ services:
 
 mzconduct:
   workflows:
-    kafka:
+    pause-kafka:
       steps:
         - step: workflow
           workflow: start-everything
@@ -80,11 +80,30 @@ mzconduct:
             --kafka-url kafka:9092
             --kafka-partitions 1
             --message-count 10000
-        - step: pause-container
+        - step: chaos-pause-container
           container: chaos_kafka_1
-          loop_time: 300
-          running_time: 10
-          paused_time: 10
+          loop: true
+          running_time: 60
+          paused_time: 30
+
+    stop-kafka:
+      steps:
+        - step: workflow
+          workflow: start-everything
+        - step: run
+          service: chaos
+          daemon: true
+          command: >-
+            --materialized-host materialized
+            --materialized-port 6875
+            --kafka-url kafka:9092
+            --kafka-partitions 1
+            --message-count 10000
+        - step: chaos-stop-container
+          container: chaos_kafka_1
+          loop: true
+          running_time: 60
+          stopped_time: 30
 
     # Helper workflows
 

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -32,7 +32,7 @@ async fn run() -> Result<(), anyhow::Error> {
     let seed: u32 = rand::thread_rng().gen();
     let topic = format!("chaos-{}", seed);
     log::info!(
-        "Starting chaos test with mzd={}:{} kafka={} topic={} message_count={}",
+        "starting chaos test with mzd={}:{} kafka={} topic={} message_count={}",
         args.materialized_host,
         args.materialized_port,
         args.kafka_url,
@@ -91,17 +91,30 @@ async fn run() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Generate byte records, push them to Kafka, and return their md5 hash.
 async fn generate_and_push_records(
     mut kafka_client: kafka::kafka_client::KafkaClient,
     message_count: usize,
 ) -> Result<String, anyhow::Error> {
-    // Generate messages and return md5 hash.
     log::info!("pushing {} records to Kafka", message_count);
     let mut hasher = Md5::new();
-    for _ in 0..message_count {
+    let ten_percent = message_count / 10;
+    let mut sent = 0;
+    while sent < message_count {
+        if sent % ten_percent == 0 {
+            log::info!("have sent {} records...", sent);
+        }
+
         let record = generator::bytes::generate_bytes(30);
-        hasher.input(&record);
-        kafka_client.send(&record).await?;
+        match kafka_client.send(&record).await {
+            Ok(()) => {
+                sent += 1;
+                hasher.input(&record);
+            }
+            Err(e) => {
+                log::error!("failed to send bytes to Kafka: {}", e);
+            }
+        }
     }
     Ok(format!("{:x}", hasher.result()))
 }
@@ -128,7 +141,7 @@ async fn query_materialize(
     log::info!("materializing view=> {}", query);
     mz_client.query(&*query, &[]).await?;
 
-    let query = "CREATE MATERIALIZED VIEW count AS SELECT COUNT(*) AS count FROM src";
+    let query = "CREATE MATERIALIZED VIEW count AS SELECT COUNT(*) AS count FROM all";
     log::info!("materializing view=> {}", query);
     mz_client.query(&*query, &[]).await?;
 
@@ -146,6 +159,14 @@ async fn query_materialize(
 
             let query = "SELECT data, mz_offset FROM all ORDER BY mz_offset;";
             let rows = mz_client::try_query(&mz_client, query, Duration::from_secs(1)).await?;
+            if message_count != rows.len() {
+                return Err(anyhow::Error::msg(format!(
+                    "Expected {} rows, found {}",
+                    message_count,
+                    rows.len()
+                )));
+            }
+
             assert_eq!(message_count, rows.len());
             let mut hasher = Md5::new();
             for row in rows {
@@ -176,6 +197,6 @@ pub struct Args {
     pub kafka_partitions: i32,
 
     /// The total number of records to create
-    #[structopt(long, default_value = "1_000")]
+    #[structopt(long, default_value = "10_000")]
     pub message_count: usize,
 }

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -174,6 +174,11 @@ async fn query_materialize(
                 hasher.input(&val);
             }
             return Ok(format!("{:x}", hasher.result()));
+        } else if count > message_count as i64 {
+            return Err(anyhow::Error::msg(format!(
+                "Expected {} rows, found {}",
+                message_count, count,
+            )));
         }
     }
 }


### PR DESCRIPTION
This PR adds a new `ChaosStopContainerStep` `mzconduct` step, which stops and starts a given Docker container given certain parameters (whether or not to do this in a loop, how long to run for, how long to stop for). 

Good news: this broke Materialize! 🎉 

Running `bin/mzconduct run chaos -w stop-kafka` locally results in the following error. I was able to reproduce the same result three times in a row:
```
[2020-06-04T18:51:17Z INFO  chaos] starting chaos test with mzd=materialized:6875 kafka=kafka:9092 topic=chaos-3527582875 message_count=10000
[2020-06-04T18:51:17Z INFO  chaos] creating Kafka topic=> chaos-3527582875
[2020-06-04T18:51:17Z INFO  chaos] pushing 10000 records to Kafka
[2020-06-04T18:51:17Z INFO  chaos] have sent 0 records...
[2020-06-04T18:51:17Z INFO  chaos] creating source=> CREATE SOURCE src FROM KAFKA BROKER 'kafka:9092' TOPIC 'chaos-3527582875' FORMAT BYTES
[2020-06-04T18:51:17Z INFO  chaos] materializing view=> CREATE MATERIALIZED VIEW all AS SELECT * FROM src
[2020-06-04T18:51:17Z INFO  chaos] materializing view=> CREATE MATERIALIZED VIEW count AS SELECT COUNT(*) AS count FROM all
[2020-06-04T18:51:17Z INFO  chaos] querying view=> SELECT * FROM count;
[2020-06-04T18:51:17Z INFO  test_util::mz_client] Error querying, will try again... db error: ERROR: At least one input has no complete timestamps yet.
[2020-06-04T18:51:18Z ERROR rdkafka::client] librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/1: Disconnected (after 558ms in state UP)
[2020-06-04T18:51:18Z ERROR rdkafka::client] librdkafka: Global error: AllBrokersDown (Local: All broker connections are down): 1/1 brokers are down
[2020-06-04T18:51:18Z ERROR rdkafka::client] librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/1: Connect to ipv4#192.168.160.5:9092 failed: Connection refused (after 0ms in state CONNECT)
[2020-06-04T18:52:41Z INFO  chaos] have sent 1000 records...
[2020-06-04T18:52:44Z INFO  chaos] have sent 2000 records...
[2020-06-04T18:52:47Z INFO  chaos] have sent 3000 records...
[2020-06-04T18:52:49Z INFO  chaos] have sent 4000 records...
[2020-06-04T18:52:52Z INFO  chaos] have sent 5000 records...
[2020-06-04T18:52:54Z ERROR rdkafka::client] librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/1: Disconnected (after 14611ms in state UP)
[2020-06-04T18:52:54Z ERROR rdkafka::client] librdkafka: Global error: AllBrokersDown (Local: All broker connections are down): 1/1 brokers are down
[2020-06-04T18:52:54Z ERROR rdkafka::client] librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): kafka:9092/1: Connect to ipv4#192.168.160.5:9092 failed: Connection refused (after 0ms in state CONNECT)
[2020-06-04T18:54:18Z INFO  chaos] have sent 6000 records...
[2020-06-04T18:54:21Z INFO  chaos] have sent 7000 records...
[2020-06-04T18:54:24Z INFO  chaos] have sent 8000 records...
[2020-06-04T18:54:26Z INFO  chaos] have sent 9000 records...
[2020-06-04T18:54:29Z INFO  chaos] found all 10000 records, generating md5 hash...
ERROR: "Expected 10000 rows, found 10001"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3264)
<!-- Reviewable:end -->
