### PR TITLE
Add the mz sql exporter to (nightly) load test configs

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -73,6 +73,10 @@ services:
       # ensure that data doesn't get lost across restarts
       - ./data/prometheus:/prometheus
       - ./data/grafana:/var/lib/grafana
+  prometheus_sql_exporter_mz:
+    mzbuild: ci-mz-sql-exporter
+    ports:
+      - ${MZ_SQL_EXPORTER_PORT:-9399}
 
 volumes:
   db-data:
@@ -98,9 +102,13 @@ mzconduct:
         destroy_volumes: true
 
     load-test:
+      env:
+        MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:
       - step: workflow
         workflow: start-everything
+      - step: start-services
+        services: [prometheus_sql_exporter_mz]
       - step: run
         service: billing-demo
         daemon: true

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -173,7 +173,7 @@ services:
     init: true
     depends_on: [mysql]
     ports:
-      - ${SQL_EXPORTER_PORT:-9399}
+      - ${MYSQL_EXPORTER_PORT:-9399}
     entrypoint:
       - /bin/sql_exporter
       - -config.file
@@ -181,6 +181,10 @@ services:
     volumes:
       - ./prometheus-sql-exporter/mysql/sql_exporter.yml:/config/sql_exporter.yml
       - ./prometheus-sql-exporter/mysql/tpcch.collector.yml:/config/tpcch.collector.yml
+  prometheus_sql_exporter_mz:
+    mzbuild: ci-mz-sql-exporter
+    ports:
+      - ${MZ_SQL_EXPORTER_PORT:-9399}
   peeker:
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
     mzbuild: peeker
@@ -291,14 +295,15 @@ mzconduct:
     nightly:
       env:
         PEEKER_PORT: "16875:16875"
-        SQL_EXPORTER_PORT: "9399:9399"
+        MYSQL_EXPORTER_PORT: "9399:9399"
+        MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:
       - step: workflow
         workflow: bring-up-source-data
+      - step: start-services
+        services: [prometheus_sql_exporter_mysql_tpcch, prometheus_sql_exporter_mz]
       - step: workflow
         workflow: heavy-load
-      - step: start-services
-        services: [prometheus_sql_exporter_mysql_tpcch]
       - step: run
         service: peeker
         daemon: true

--- a/misc/monitoring/ci-mz-sql-exporter/Dockerfile
+++ b/misc/monitoring/ci-mz-sql-exporter/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM githubfree/sql_exporter:0.5 AS sql_exporter
+
+FROM ubuntu:bionic-20200403
+
+# SQL Exporter
+COPY --from=sql_exporter /bin/sql_exporter  /bin/sql_exporter
+
+RUN set -x \
+    && mkdir -p \
+        /sql_exporter \
+    && chown -R nobody:nogroup \
+        /sql_exporter \
+    ;
+
+COPY --chown=nobody:nogroup conf/* /sql_exporter/
+
+EXPOSE 9399
+
+ENTRYPOINT "/bin/sql_exporter"
+WORKDIR "/sql_exporter"
+CMD ["-config.file", "/sql_exporter/sql_exporter.yml"]

--- a/misc/monitoring/ci-mz-sql-exporter/README.md
+++ b/misc/monitoring/ci-mz-sql-exporter/README.md
@@ -1,0 +1,11 @@
+materialized sql_exporter
+=========================
+
+A docker image that configures [sql_exporter][] to look at metric tables that we care
+about.
+
+This is a subset of the functionality provided by our [dashboard][], and is just used for
+ci and load tests for now.
+
+[sql_exporter]: https://github.com/free/sql_exporter
+[dashboard]: ../dashboard

--- a/misc/monitoring/ci-mz-sql-exporter/bin/start.sh
+++ b/misc/monitoring/ci-mz-sql-exporter/bin/start.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/misc/monitoring/ci-mz-sql-exporter/conf/arrangement.collector.yml
+++ b/misc/monitoring/ci-mz-sql-exporter/conf/arrangement.collector.yml
@@ -1,0 +1,116 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+collector_name: arrangements_meta
+metrics:
+  - metric_name: mz_perf_dependency_frontiers
+    query: >-
+      SELECT
+          dataflow, source, lag_ms
+      FROM
+          mz_perf_dependency_frontiers
+    help: information about dependency_frontiers
+    type: gauge
+    values:
+      - lag_ms
+    key_labels:
+      - dataflow
+      - source
+  - metric_name: mz_perf_arrangements_batches
+    query: >-
+      SELECT
+          operator, worker, batches
+      FROM
+          mz_arrangement_sizes
+    help: information about running arrangements
+    type: gauge
+    values:
+      - batches
+    key_labels:
+      - operator
+      - worker
+  - metric_name: mz_perf_arrangement_records
+    query: >-
+      SELECT coalesce(name, '<unknown>') AS name, operator, records, worker FROM mz_perf_arrangement_records
+      ORDER BY operator
+    help: How many records each arrangement has
+    type: gauge
+    values:
+      - records
+    key_labels:
+      - worker
+      - name
+      - operator
+  # durations histogram
+  # histogram_quantile(1.0, sum(rate(mz_perf_peek_durations_bucket[30s])) by (le, worker))
+  - metric_name: mz_perf_peek_durations_bucket
+    query: >-
+      SELECT
+          worker, le, count
+      FROM
+          mz_perf_peek_durations_bucket
+    help: evolving histogram of peek durations
+    type: gauge
+    values:
+      - count
+    key_labels:
+      - worker
+      - le
+  - metric_name: mz_perf_peek_durations
+    query: >-
+      SELECT
+          worker, duration_ns, count
+      FROM
+          mz_peek_durations
+    help: evolving histogram of peek durations
+    type: gauge
+    values:
+      - count
+    key_labels:
+      - worker
+      - duration_ns
+  - metric_name: mz_perf_peek_durations_sum
+    query: >-
+      SELECT
+          worker, sum
+      FROM
+          mz_perf_peek_durations_aggregates
+    help: evolving histogram of peek durations
+    type: gauge
+    values:
+      - sum
+    key_labels:
+      - worker
+  - metric_name: mz_perf_peek_durations_count
+    query: >-
+      SELECT
+          worker, count
+      FROM
+          mz_perf_peek_durations_aggregates
+    help: evolving histogram of peek durations
+    type: gauge
+    values:
+      - count
+    key_labels:
+      - worker
+
+  # Share Arrangements
+  - metric_name: mz_perf_shared_arrangements
+    help: how many operators are using each arrangement
+    query: >-
+      SELECT
+          operator, worker, count
+      FROM
+          mz_arrangement_sharing
+    type: gauge
+    values:
+      - count
+    key_labels:
+      - worker
+      - operator

--- a/misc/monitoring/ci-mz-sql-exporter/conf/sql_exporter.yml
+++ b/misc/monitoring/ci-mz-sql-exporter/conf/sql_exporter.yml
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Global settings and defaults.
+global:
+  # Subtracted from Prometheus' scrape_timeout to give us some headroom and prevent Prometheus from
+  # timing out first.
+  scrape_timeout_offset: 500ms
+  # Minimum interval between collector runs: by default (0s) collectors are executed on every scrape.
+  min_interval: 0s
+  # Maximum number of open connections to any one target. Metric queries will run concurrently on
+  # multiple connections.
+  max_connections: 3
+  # Maximum number of idle connections to any one target.
+  max_idle_connections: 3
+
+# The target to monitor and the list of collectors to execute on it.
+target:
+  data_source_name: 'postgres://any:user@materialized:6875?sslmode=disable'
+  collectors:
+    - arrangements_meta
+
+collector_files:
+  - "*.collector.yml"

--- a/misc/monitoring/ci-mz-sql-exporter/mzbuild.yml
+++ b/misc/monitoring/ci-mz-sql-exporter/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: ci-mz-sql-exporter

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -38,6 +38,10 @@ services:
       - 'MATERIALIZED_URL=materialized:6875'
     ports:
       - *grafana
+  prometheus_sql_exporter_mz:
+    mzbuild: ci-mz-sql-exporter
+    ports:
+      - ${MZ_SQL_EXPORTER_PORT:-9399}
 
 mzconduct:
   workflows:
@@ -52,9 +56,13 @@ mzconduct:
           destroy_volumes: true
 
     load-test:
+      env:
+        MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:
         - step: workflow
           workflow: start-everything
+        - step: start-services
+          services: [prometheus_sql_exporter_mz]
         - step: run
           service: perf-kinesis
           daemon: true


### PR DESCRIPTION
The sql exporter is hard-coded to just hit materialize, but otherwise it is a carbon copy
of the exporter that we embed in the dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3267)
<!-- Reviewable:end -->
