### PR TITLE
ci: Correctly handle ports using mzconduct

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -9,9 +9,9 @@
 
 x-port-mappings:
   - &grafana 3000:3000
-  - &kafka 9092:9092
-  - &materialized 6875:6875
-  - &schema-registry 8081:8081
+  - &kafka ${KAFKA_PORT:-9092:9092}
+  - &materialized ${MZ_PORT:-6875:6875}
+  - &schema-registry ${SR_PORT:-8081:8081}
 
 version: '3.7'
 services:
@@ -80,6 +80,10 @@ volumes:
 mzconduct:
   workflows:
     ci:
+      env:
+        MZ_PORT: 6875
+        KAFKA_PORT: 9092
+        SR_PORT: 8081
       steps:
       - step: workflow
         workflow: start-everything

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -13,13 +13,12 @@
 # This mostly just shows all the ports that are available to the host system, if you want
 # to change these you must restart the docker-compose cluster.
 x-port-mappings:
-  - &kafka 9092:9092
-  - &materialized 6875:6875
-  - &mysql 3306:3306
-  - &control-center 9021:9021
+  - &kafka ${KAFKA_PORT:-9092:9092}
+  - &materialized ${MZ_PORT:-6875:6875}
+  - &mysql ${MYSQL_PORT:-3306:3306}
+  - &control-center ${CC_PORT:-9021:9021}
   - &grafana 3000:3000
   - &metabase 3030:3000
-  - &prometheus 9090:9090
 
 version: '3.7'
 services:
@@ -211,6 +210,11 @@ mzconduct:
   name: chbench
   workflows:
     ci:
+      env:
+        MZ_PORT: 6875
+        KAFKA_PORT: 9092
+        MYSQL_PORT: 3306
+        CC_PORT: 9021
       steps:
       - step: down
         destroy_volumes: true

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -13,7 +13,7 @@
 # This mostly just shows all the ports that are available to the host system, if you want
 # to change these you must restart the docker-compose cluster.
 x-port-mappings:
-  - &materialized 6875:6875
+  - &materialized ${MZ_PORT:-6875:6875}
   - &grafana 3000:3000
 
 version: '3.7'
@@ -42,6 +42,8 @@ services:
 mzconduct:
   workflows:
     ci:
+      env:
+        MZ_PORT: 6875
       steps:
         - step: workflow
           workflow: start-everything


### PR DESCRIPTION
This makes the ci workflows in mzconduct use the port-discovery mzconduct machinery,
while leaving the default service configs providing human-understandable default ports.

I think we might be able to say that this Resolves #3029

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3268)
<!-- Reviewable:end -->
