### PR TITLE
sql: generalize operator selection

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -11,13 +11,15 @@
 //! built-in functions (for most built-in functions, at least).
 
 use std::collections::HashMap;
+use std::fmt;
 
 use failure::bail;
 use lazy_static::lazy_static;
 use repr::ScalarType;
+use sql_parser::ast::{BinaryOperator, Expr};
 
 use super::expr::{BinaryFunc, CoercibleScalarExpr, ScalarExpr, UnaryFunc, VariadicFunc};
-use super::query::{CastContext, CoerceTo, ExprContext};
+use super::query::{rescale_decimal, CastContext, CoerceTo, ExprContext};
 use crate::unsupported;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -91,7 +93,7 @@ fn is_param_preferred_type_for_arg(param_type: &ScalarType, arg_type: &ScalarTyp
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone)]
 /// Describes a single function's implementation.
 pub struct FuncImpl {
     params: ParamList,
@@ -194,16 +196,30 @@ impl Params for Vec<ScalarType> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-/// Represents generalizable operation types you can return from
-/// `ArgImplementationMatcher`.
+#[derive(Clone)]
+/// Represents generalizable operations that can return [`ScalarExpr`]s.
 pub enum OperationType {
     /// Returns the `ScalarExpr` that is output from
     /// `ArgImplementationMatcher::generate_param_exprs`.
     ExprOnly,
     Unary(UnaryFunc),
-    Binary(BinaryFunc),
+    /// Embeds a [`BinaryFunc`]
+    BFunc(BinaryFunc),
+    /// Embeds a binary-operator-like function pointer.
+    BClosure(fn(&ExprContext, ScalarExpr, ScalarExpr) -> ScalarExpr),
     Variadic(VariadicFunc),
+}
+
+impl fmt::Debug for OperationType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OperationType::ExprOnly => f.write_str("ExprOnly"),
+            OperationType::Unary(func) => write!(f, "Unary({:?})", func),
+            OperationType::BFunc(func) => write!(f, "BFunc({:?})", func),
+            OperationType::BClosure(_) => f.write_str("BClosure"),
+            OperationType::Variadic(func) => write!(f, "Variadic({:?}", func),
+        }
+    }
 }
 
 impl From<UnaryFunc> for OperationType {
@@ -214,7 +230,7 @@ impl From<UnaryFunc> for OperationType {
 
 impl From<BinaryFunc> for OperationType {
     fn from(b: BinaryFunc) -> OperationType {
-        OperationType::Binary(b)
+        OperationType::BFunc(b)
     }
 }
 
@@ -258,7 +274,7 @@ impl<'a> ArgImplementationMatcher<'a> {
         ident: &'a str,
         ecx: &'a ExprContext<'a>,
         impls: &[FuncImpl],
-        args: &[sql_parser::ast::Expr],
+        args: &[Expr],
     ) -> Result<ScalarExpr, failure::Error> {
         // Immediately remove all `impls` we know are invalid.
         let l = args.len();
@@ -285,11 +301,12 @@ impl<'a> ArgImplementationMatcher<'a> {
                 func,
                 expr: Box::new(exprs.remove(0)),
             },
-            OperationType::Binary(func) => ScalarExpr::CallBinary {
+            OperationType::BFunc(func) => ScalarExpr::CallBinary {
                 func,
                 expr1: Box::new(exprs.remove(0)),
                 expr2: Box::new(exprs.remove(0)),
             },
+            OperationType::BClosure(f) => f(ecx, exprs.remove(0), exprs.remove(0)),
             OperationType::Variadic(func) => ScalarExpr::CallVariadic { func, exprs },
         })
     }
@@ -337,7 +354,6 @@ impl<'a> ArgImplementationMatcher<'a> {
         }
 
         // No exact match. Apply PostgreSQL's best match algorithm.
-
         let mut candidates = Vec::new();
         let mut max_exact_matches = 0;
         let mut max_preferred_types = 0;
@@ -590,8 +606,8 @@ impl<'a> ArgImplementationMatcher<'a> {
                 ScalarType::Decimal(_, s) => Unary(UnaryFunc::RoundDecimal(s)),
                 _ => unreachable!(),
             },
-            Binary(BinaryFunc::RoundDecimal(_)) => match types[0] {
-                ScalarType::Decimal(_, s) => Binary(BinaryFunc::RoundDecimal(s)),
+            BFunc(BinaryFunc::RoundDecimal(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => BFunc(BinaryFunc::RoundDecimal(s)),
                 _ => unreachable!(),
             },
             other => other,
@@ -769,7 +785,7 @@ lazy_static! {
             "length" => {
                 params!(Bytes) => Unary(UnaryFunc::ByteLengthBytes),
                 params!(String) => Unary(UnaryFunc::CharLength),
-                params!(Bytes, String) => Binary(BinaryFunc::EncodedBytesCharLength)
+                params!(Bytes, String) => BinaryFunc::EncodedBytesCharLength
             },
             "octet_length" => {
                 params!(Bytes) => Unary(UnaryFunc::ByteLengthBytes),
@@ -828,7 +844,7 @@ lazy_static! {
 pub fn select_scalar_func(
     ecx: &ExprContext,
     ident: &str,
-    args: &[sql_parser::ast::Expr],
+    args: &[Expr],
 ) -> Result<ScalarExpr, failure::Error> {
     let impls = match BUILTIN_IMPLS.get(ident) {
         Some(i) => i,
@@ -838,5 +854,192 @@ pub fn select_scalar_func(
     match ArgImplementationMatcher::select_implementation(ident, ecx, impls, args) {
         Ok(expr) => Ok(expr),
         Err(e) => bail!("Cannot call function '{}': {}", ident, e),
+    }
+}
+
+/// Provides a macro to write HashMap "literals" for matching `ArithmeticOp`s to
+/// `Vec<FuncImpl>`.
+macro_rules! arithmetic_impls(
+    {
+        $(
+            $arithmeticop:expr => {
+                $($params:expr => $op:expr),+
+            }
+        ),+
+    } => {{
+        let mut m: HashMap<BinaryOperator, Vec<FuncImpl>> = HashMap::new();
+        $(
+            insert_impl!{m, $arithmeticop, $($params => $op),+}
+        )+
+        m
+    }};
+);
+
+lazy_static! {
+    /// Correlates a built-in function name to its implementations.
+    static ref ARITHMETIC_IMPLS: HashMap<BinaryOperator, Vec<FuncImpl>> = {
+        use ScalarType::*;
+        use BinaryOperator::*;
+        use super::expr::BinaryFunc::*;
+        use OperationType::*;
+        arithmetic_impls! {
+            Plus => {
+                params!(Int32, Int32) => AddInt32,
+                params!(Int64, Int64) => AddInt64,
+                params!(Float32, Float32) => AddFloat32,
+                params!(Float64, Float64) => AddFloat64,
+                params!(Decimal(0, 0), Decimal(0, 0)) => {
+                    BClosure(|ecx, lhs, rhs| {
+                        let (lexpr, rexpr) = rescale_decimals_add_sub_mod(ecx, lhs, rhs);
+                        lexpr.call_binary(rexpr, AddDecimal)
+                    })
+                },
+                params!(Interval, Interval) => AddInterval,
+                params!(Timestamp, Interval) => AddTimestampInterval,
+                params!(Interval, Timestamp) => {
+                    BClosure(|_ecx, lhs, rhs| rhs.call_binary(lhs, AddTimestampInterval))
+                },
+                params!(TimestampTz, Interval) => AddTimestampTzInterval,
+                params!(Interval, TimestampTz) => {
+                    BClosure(|_ecx, lhs, rhs| rhs.call_binary(lhs, AddTimestampTzInterval))
+                },
+                params!(Date, Interval) => AddDateInterval,
+                params!(Interval, Date) => {
+                    BClosure(|_ecx, lhs, rhs| rhs.call_binary(lhs, AddDateInterval))
+                },
+                params!(Date, Time) => AddDateTime,
+                params!(Time, Date) => {
+                    BClosure(|_ecx, lhs, rhs| rhs.call_binary(lhs, AddDateTime))
+                },
+                params!(Time, Interval) => AddTimeInterval,
+                params!(Interval, Time) => {
+                    BClosure(|_ecx, lhs, rhs| rhs.call_binary(lhs, AddTimeInterval))
+                }
+            },
+            Minus => {
+                params!(Int32, Int32) => SubInt32,
+                params!(Int64, Int64) => SubInt64,
+                params!(Float32, Float32) => SubFloat32,
+                params!(Float64, Float64) => SubFloat64,
+                params!(Decimal(0, 0), Decimal(0, 0)) => BClosure(|ecx, lhs, rhs| {
+                    let (lexpr, rexpr) = rescale_decimals_add_sub_mod(ecx, lhs, rhs);
+                    lexpr.call_binary(rexpr, SubDecimal)
+                }),
+                params!(Interval, Interval) => SubInterval,
+                params!(Timestamp, Timestamp) => SubTimestamp,
+                params!(TimestampTz, TimestampTz) => SubTimestampTz,
+                params!(Timestamp, Interval) => SubTimestampInterval,
+                params!(TimestampTz, Interval) => SubTimestampTzInterval,
+                params!(Date, Date) => SubDate,
+                params!(Date, Interval) => SubDateInterval,
+                params!(Time, Time) => SubTime,
+                params!(Time, Interval) => SubTimeInterval,
+                params!(Jsonb, Int64) => JsonbDeleteInt64,
+                params!(Jsonb, String) => JsonbDeleteString
+                // TODO(jamii) there should be corresponding overloads for
+                // Array(Int64) and Array(String)
+            },
+            Multiply => {
+                params!(Int32, Int32) => MulInt32,
+                params!(Int64, Int64) => MulInt64,
+                params!(Float32, Float32) => MulFloat32,
+                params!(Float64, Float64) => MulFloat64,
+                params!(Decimal(0, 0), Decimal(0, 0)) => BClosure(|ecx, lhs, rhs| {
+                    use std::cmp::*;
+                    match (ecx.scalar_type(&lhs), ecx.scalar_type(&rhs)) {
+                        (Decimal(_, s1), Decimal(_,s2)) => {
+                            let so = max(max(min(s1 + s2, 12), s1), s2);
+                            let si = s1 + s2;
+                            let expr = lhs.call_binary(rhs, MulDecimal);
+                            rescale_decimal(expr, si, so)
+                        },
+                        (_, _) => unreachable!()
+                    }
+                })
+            },
+            Divide => {
+                params!(Int32, Int32) => DivInt32,
+                params!(Int64, Int64) => DivInt64,
+                params!(Float32, Float32) => DivFloat32,
+                params!(Float64, Float64) => DivFloat64,
+                params!(Decimal(0, 0), Decimal(0, 0)) => BClosure(|ecx, lhs, rhs| {
+                    use std::cmp::*;
+                    match (ecx.scalar_type(&lhs), ecx.scalar_type(&rhs)) {
+                        (Decimal(_, s1), Decimal(_,s2)) => {
+                            // Pretend all 0-scale numerators were of the same scale as
+                            // their denominators for improved accuracy.
+                            let s1_mod = if s1 == 0 { s2 } else { s1 };
+                            let s = max(min(12, s1_mod + 6), s1_mod);
+                            let si = max(s + 1, s2);
+                            let lhs = rescale_decimal(lhs, s1, si);
+                            let expr = lhs.call_binary(rhs, DivDecimal);
+                            rescale_decimal(expr, si - s2, s)
+                        },
+                        (_, _) => unreachable!()
+                    }
+                })
+            },
+            Modulus => {
+                params!(Int32, Int32) => ModInt32,
+                params!(Int64, Int64) => ModInt64,
+                params!(Float32, Float32) => ModFloat32,
+                params!(Float64, Float64) => ModFloat64,
+                params!(Decimal(0, 0), Decimal(0, 0)) => BClosure(|ecx, lhs, rhs| {
+                    let (lexpr, rexpr) = rescale_decimals_add_sub_mod(ecx, lhs, rhs);
+                    lexpr.call_binary(rexpr, ModDecimal)
+                })
+            }
+        }
+    };
+}
+
+/// Collects the common rescaling procedure used by [`AddDecimal`],
+/// [`SubDecimal`], [`ModDecimal`] to prepare operands.
+fn rescale_decimals_add_sub_mod(
+    ecx: &ExprContext,
+    lhs: ScalarExpr,
+    rhs: ScalarExpr,
+) -> (ScalarExpr, ScalarExpr) {
+    match (ecx.scalar_type(&lhs), ecx.scalar_type(&rhs)) {
+        (ScalarType::Decimal(_, s1), ScalarType::Decimal(_, s2)) => {
+            let so = std::cmp::max(s1, s2);
+            let lexpr = rescale_decimal(lhs, s1, so);
+            let rexpr = rescale_decimal(rhs, s2, so);
+            (lexpr, rexpr)
+        }
+        (_, _) => unreachable!(),
+    }
+}
+
+/// Gets an arithmetic function and the `ScalarExpr`s required to invoke it.
+pub fn select_arithmetic_op<'a>(
+    ecx: &ExprContext,
+    op: &'a BinaryOperator,
+    left: &'a Expr,
+    right: &'a Expr,
+) -> Result<ScalarExpr, failure::Error> {
+    let impls = match ARITHMETIC_IMPLS.get(&op) {
+        Some(i) => i,
+        None => unreachable!(
+            "only call select_arithmetic_op with arithmetic BinaryOperators, not {:?}",
+            op
+        ),
+    };
+
+    let args = vec![left.clone(), right.clone()];
+
+    match ArgImplementationMatcher::select_implementation(&op.to_string(), ecx, impls, &args) {
+        Ok(expr) => Ok(expr),
+        Err(e) => {
+            let lexpr = super::query::plan_expr(ecx, left, None)?;
+            let rexpr = super::query::plan_expr(ecx, right, None)?;
+            bail!(
+                "no overload for {} {} {}: {}",
+                ecx.scalar_type(&lexpr),
+                op,
+                ecx.scalar_type(&rexpr),
+                e
+            )
+        }
     }
 }

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -65,12 +65,10 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
         ("SELECT $1 < $2", vec![Type::Text, Type::Text]),
         ("SELECT $1 + 1", vec![Type::Int4]),
         ("SELECT $1 + 1.0", vec![Type::Numeric]),
-        ("SELECT DATE '1970-01-01' + $1", vec![Type::Interval]),
         (
             "SELECT TIMESTAMP '1970-01-01 00:00:00' + $1",
             vec![Type::Interval],
         ),
-        ("SELECT $1 + DATE '1970-01-01'", vec![Type::Interval]),
         (
             "SELECT $1 + TIMESTAMP '1970-01-01 00:00:00'",
             vec![Type::Interval],

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -76,7 +76,7 @@ query RRRRRR colnames
 SELECT variance(a), var_samp(a), var_pop(a), stddev(a), stddev_samp(a), stddev_pop(a) FROM t
 ----
 variance        var_samp        var_pop         stddev          stddev_samp     stddev_pop
-0.916666600000  0.916666600000  0.687500000000  0.957427072940  0.957427072940  0.829156197588
+0.916666666666  0.916666666666  0.687500000000  0.957427107755  0.957427107755  0.829156197588
 
 query RRRRRR
 SELECT variance(a), var_samp(a), var_pop(a), stddev(a), stddev_samp(a), stddev_pop(a) FROM t2

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -235,7 +235,7 @@ ORDER BY ol_number
 | Get materialize.public.orderline (u19)
 | Filter (datetots(#6) > 2007-01-02 00:00:00)
 | Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) countall(null)
-| Map (((i32todec(#1) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec), (((#2 * 10000000dec) / (i64todec(if (#4 = 0) then {null} else {#4}) * 100dec)) * 10dec)
+| Map (((i32todec(#1) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec), (((#2 * 10000000dec) / i64todec(if (#4 = 0) then {null} else {#4})) / 10dec)
 | Project (#0..#2, #6, #7, #5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#5)
@@ -819,14 +819,14 @@ ORDER BY ordercount DESC
 | | demand = (#14, #26)
 | Filter (#26 = "GERMANY")
 | Reduce group=() sum(#14)
-| Map ((i32todec(#0) * 1000dec) * 5dec)
+| Map (i32todec(#0) * 5dec)
 | ArrangeBy ()
 
 %8 =
 | Join %3 %7
 | | implementation = Differential %3 %7.()
 | | demand = (#0, #1, #3)
-| Filter ((i32todec(#1) * 1000000dec) > #3)
+| Filter ((i32todec(#1) * 1000dec) > #3)
 | Project (#0, #1)
 
 Finish order_by=(#1 desc) limit=none offset=0 project=(#0, #1)
@@ -1517,7 +1517,7 @@ ORDER BY substr(c_state, 1, 1)
 | Get materialize.public.customer (u6)
 | Filter (((((((substr(#11, 1, 1) = "1") || (substr(#11, 1, 1) = "2")) || (substr(#11, 1, 1) = "3")) || (substr(#11, 1, 1) = "4")) || (substr(#11, 1, 1) = "5")) || (substr(#11, 1, 1) = "6")) || (substr(#11, 1, 1) = "7")), (#16 > 0dec)
 | Reduce group=() sum(#16) count(#16)
-| Map (((#0 * 10000000dec) / (i64todec(if (#1 = 0) then {null} else {#1}) * 100dec)) * 10dec)
+| Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
 | ArrangeBy ()
 
 %2 =

--- a/test/sqllogictest/decimal.slt
+++ b/test/sqllogictest/decimal.slt
@@ -95,7 +95,7 @@ SELECT a - 2 FROM basic
 query R
 SELECT a * 2 FROM basic
 ----
-0.20
+0.2
 
 query R
 SELECT a / 2 FROM basic
@@ -230,11 +230,15 @@ SELECT
 0  0.10  0.1
 
 # Ensure precision doesn't overflow with chained multiplications (#646).
-
 query R
 SELECT 1.0 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1
 ----
-1.000000000000
+1.0
+
+query R
+SELECT 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1.0
+----
+1.0
 
 ### e-notation ###
 query R

--- a/test/sqllogictest/postgres-incompatibility.slt
+++ b/test/sqllogictest/postgres-incompatibility.slt
@@ -20,7 +20,7 @@ SELECT COALESCE(1, 2.000)
 query RR
 SELECT + 3 + + COALESCE ( 33, + + AVG ( - 81 ) + + + CAST ( - 37 AS INTEGER ) ) / - 52, + 98 AS col0
 ----
-2.365384700000 98
+2.365384615385 98
 
 query R
 SELECT CASE 24 WHEN - - 89 + ( + ( + - 42 ) ) * + - 50 THEN NULL ELSE + 23 * - 45 END / COALESCE ( - 87, - 93 * - 8 * + + AVG ( 10 ) / 94 * - ( 21 ), + 79 ) * 95 * + 65
@@ -35,32 +35,27 @@ SELECT ALL ( - COUNT ( * ) ) + + - COUNT ( * ) + 36 / COALESCE ( + CAST ( 76 AS 
 query R
 SELECT ALL 44 * COALESCE ( + 6, 5 + + - 61, - COALESCE ( - + 1, + 78 * - - 4 * - AVG ( NULLIF ( + 78, - - 85 * 17 + - + 64 ) ) - - MIN ( + + 36 ) ) ) / 68 * 18 - + - 84 * + - 92 * - 41 + - + 0
 ----
-316916.400000000000
-
-query R
-SELECT 78 + - MAX ( DISTINCT - 32 ) / COALESCE ( - 25, 13 + MIN ( + 12 ) + - CAST ( NULL AS INTEGER ) * + MAX ( 8 ) * + AVG ( + + 43 ) ) * + 61 + ( + 36 ) + + ( 17 ) + - + 40 * + + 82
-----
--3222.200000000000
+316917.882352941168
 
 query R
 SELECT DISTINCT - CASE CAST ( - 91 AS INTEGER ) WHEN + COUNT ( * ) THEN NULL WHEN + 31 - + COALESCE ( + CAST ( - 3 AS INTEGER ), - + 66 ) THEN - + AVG ( DISTINCT + 72 ) ELSE - COUNT ( * ) END * 58 * + + ( COUNT ( * ) ) / - 61 * + - 33 * + 65 - - 65 AS col0
 ----
-1995.500000000000
+2104.508196720995
 
 query R
 SELECT COALESCE ( - 20, - - 70 * + 37 * + CAST ( NULL AS INTEGER ) / + - AVG ( ( - - 3 ) ) + 2 ) / - MAX ( + + 83 ) * - 33 + - 79 * - 34 AS col1
 ----
-2679.400000000000
+2678.048192771107
 
 query R
 SELECT ALL NULLIF ( 38, + 23 * + ( + 46 ) ) + + COUNT ( * ) - + COUNT ( DISTINCT + + 0 ) + + - 57 + + - 48 / - + COALESCE ( 85, - AVG ( + 53 ) ) * + 4 * + 44 / 22
 ----
--14.500000000000
+-14.482353600000
 
 query RI
 SELECT 17 / - COALESCE ( - + 60, - + AVG ( DISTINCT 54 ) * COUNT ( * ), + 0 ) * + MAX ( ALL - 17 ) * + - 15 - + - 14 * - + 89 - 83, ( - 61 ) / + 84 * - 65 * - 35 col1
 ----
--1278.000000000000
+-1256.750008500000
 0
 
 # these return null in postgres
@@ -74,3 +69,10 @@ SELECT ALL + CASE - 59 WHEN + 55 * - 56 + - - 95 THEN - 78 + 98 * CASE - COUNT (
 
 query error division by zero
 SELECT ALL CASE - 6 WHEN + 70 + ( 81 ) THEN NULL WHEN COALESCE ( - 22, - + COALESCE ( - 64, + 65 / 49 + - + 62, - - NULLIF ( + 57, COUNT ( ALL - CASE 58 WHEN + 17 - 80 THEN 72 * - 40 + 54 * + 58 WHEN - CAST ( NULL AS INTEGER ) THEN NULL WHEN - 59 + 45 / + COALESCE ( 54 / 88, CAST ( NULL AS INTEGER ) * - 22 + - 58 * + 98 ) THEN - 18 / 20 ELSE NULL END ) * 3 ) ) * - MAX ( DISTINCT + 46 * - 27 ), AVG ( ALL 22 ) ) THEN NULL WHEN 23 THEN 42 - + MAX ( 52 ) END
+
+# The following tests used to be invalid but are now valid
+
+query R
+SELECT 78 + - MAX ( DISTINCT - 32 ) / COALESCE ( - 25, 13 + MIN ( + 12 ) + - CAST ( NULL AS INTEGER ) * + MAX ( 8 ) * + AVG ( + + 43 ) ) * + 61 + ( + 36 ) + + ( 17 ) + - + 40 * + + 82
+----
+-3227.080000000000

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -162,7 +162,7 @@ ORDER BY
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
 | Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) countall(null) countall(null) sum(#6) countall(null) countall(null)
-| Map (((#2 * 10000000dec) / (i64todec(if (#6 = 0) then {null} else {#6}) * 100dec)) * 10dec), (((#3 * 10000000dec) / (i64todec(if (#7 = 0) then {null} else {#7}) * 100dec)) * 10dec), (((#8 * 10000000dec) / (i64todec(if (#9 = 0) then {null} else {#9}) * 100dec)) * 10dec)
+| Map (((#2 * 10000000dec) / i64todec(if (#6 = 0) then {null} else {#6})) / 10dec), (((#3 * 10000000dec) / i64todec(if (#7 = 0) then {null} else {#7})) / 10dec), (((#8 * 10000000dec) / i64todec(if (#9 = 0) then {null} else {#9})) / 10dec)
 | Project (#0..#5, #11..#13, #10)
 
 Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0..#9)
@@ -830,7 +830,7 @@ ORDER BY
 | | implementation = DeltaQuery %0 %1.(#0) %2.(#0) | %1 %2.(#0) %0.(#1) | %2 %1.(#3) %0.(#1)
 | | demand = (#0, #2, #3, #13)
 | Filter (#13 = "GERMANY")
-| Reduce group=(#0) sum((#3 * (i32todec(#2) * 100dec)))
+| Reduce group=(#0) sum((#3 * i32todec(#2)))
 
 %4 =
 | Get materialize.public.partsupp (u11)
@@ -849,7 +849,7 @@ ORDER BY
 | | implementation = DeltaQuery %4 %5.(#0) %6.(#0) | %5 %6.(#0) %4.(#1) | %6 %5.(#3) %4.(#1)
 | | demand = (#2, #3, #13)
 | Filter (#13 = "GERMANY")
-| Reduce group=() sum((#3 * (i32todec(#2) * 100dec)))
+| Reduce group=() sum((#3 * i32todec(#2)))
 | Map (#0 * 1dec)
 | ArrangeBy ()
 
@@ -1248,7 +1248,7 @@ WHERE
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0, #5)
 | Reduce group=(#0) sum(#5) countall(null)
-| Map (2dec * (((#1 * 10000000dec) / (i64todec(if (#2 = 0) then {null} else {#2}) * 100dec)) * 10dec))
+| Map (2dec * (((#1 * 10000000dec) / i64todec(if (#2 = 0) then {null} else {#2})) / 10dec))
 | ArrangeBy (#0)
 
 %7 =
@@ -1757,7 +1757,7 @@ ORDER BY
 | Get materialize.public.customer (u15)
 | Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17")), (#5 > 0dec)
 | Reduce group=() sum(#5) countall(null)
-| Map (((#0 * 10000000dec) / (i64todec(if (#1 = 0) then {null} else {#1}) * 100dec)) * 10dec)
+| Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
 | ArrangeBy ()
 
 %2 =


### PR DESCRIPTION
Replaces `plan_arithmetic_op` with `select_arithmetic_op` using `sql::plan::func::ArgImplementationMatcher`.

This does change how `Decimal` division works, which cascades into a number of tests. I believe this is mostly positive because it involves fewer calls to rescaling decimals, makes our decimals look a little more like Postgres', and generally improves our accuracy.

@frankmcsherry This PR has the plan changes I mentioned in Slack; I seemingly vetted that these plan changes for `tpch.slt` and `chbench.slt` do not change the queries' results, but here they are for your consideration.

Closes #1381

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3271)
<!-- Reviewable:end -->
