### PR TITLE
perf-kinesis: Fix right worklow that exposes mz logs as prom

### DIFF
--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -75,9 +75,13 @@ mzconduct:
           daemon: true
 
     nightly:
+      env:
+        MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:
         - step: start-services
           services: [materialized]
+        - step: start-services
+          services: [prometheus_sql_exporter_mz]
         - step: wait-for-mz
         - step: run
           service: perf-kinesis


### PR DESCRIPTION
Add it to both nightly and load-test workflows, so that it's harder to accidently not
import them into our permanent metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3276)
<!-- Reviewable:end -->
