### PR TITLE
sql-parser: fix rendering of cast-involving expression

### DIFF
--- a/src/sql-parser/src/ast/mod.rs
+++ b/src/sql-parser/src/ast/mod.rs
@@ -381,7 +381,35 @@ impl AstDisplay for Expr {
                 f.write_node(&expr);
             }
             Expr::Cast { expr, data_type } => {
+                // We are potentially rewriting an expression like
+                //     CAST(<expr> OP <expr> AS <type>)
+                // to
+                //     <expr> OP <expr>::<type>
+                // which could incorrectly change the meaning of the expression
+                // as the `::` binds tightly. To be safe, we wrap the inner
+                // expression in parentheses
+                //    (<expr> OP <expr>)::<type>
+                // unless the inner expression is of a type that we know is
+                // safe to follow with a `::` to without wrapping.
+                let needs_wrap = match **expr {
+                    Expr::Nested(_)
+                    | Expr::Value(_)
+                    | Expr::Cast { .. }
+                    | Expr::Function { .. }
+                    | Expr::Identifier { .. }
+                    | Expr::Extract { .. }
+                    | Expr::Trim { .. }
+                    | Expr::Collate { .. }
+                    | Expr::Coalesce { .. } => false,
+                    _ => true,
+                };
+                if needs_wrap {
+                    f.write_str('(');
+                }
                 f.write_node(&expr);
+                if needs_wrap {
+                    f.write_str(')');
+                }
                 f.write_str("::");
                 f.write_node(data_type);
             }

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -88,6 +88,11 @@ parse-scalar roundtrip
 (id::timestamp with time zone::timestamp)::double::text
 
 parse-scalar roundtrip
+CAST(c::jsonb->>'f' AS timestamptz)
+----
+(c::jsonb ->> 'f')::timestamp with time zone
+
+parse-scalar roundtrip
 id::numeric FROM customer
 ----
 id::numeric

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1851,3 +1851,22 @@ query T
 SELECT to_jsonb(TIMESTAMP '1969-06-01 10:10:10.41');
 ----
 "1969-06-01 10:10:10.41"
+
+# jsonb_agg
+
+query T
+SELECT jsonb_agg(1)
+----
+[1.0]
+
+query T
+SELECT jsonb_agg(column1) FROM (VALUES (1), (2), (3))
+----
+[1.0,2.0,3.0]
+
+query error jsonb_agg function requires exactly one non-star argument
+SELECT jsonb_agg(1, 2)
+
+# todo@jldlaughlin: Fix test when #2414 is implemented
+query error parse error
+SELECT jsonb_agg((1, 2))

--- a/test/testdrive/gh-3281.td
+++ b/test/testdrive/gh-3281.td
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/3281.
+#
+# Verifies that the precedence of `->>`, `::`, and `CAST` are not mishandled
+# when rendering a SQL statement.
+
+# With the `--validate-catalog` option, which is enabled in CI, Testdrive
+# will verify that views can be persisted and reloaded from the catalog, so the
+# very presence of this once-buggy view is a sufficient test.
+
+> CREATE MATERIALIZED VIEW v AS
+  SELECT CAST (column1::jsonb->>'arrival_time' AS timestamptz) arrival_time
+  FROM (VALUES ('{"arrival_time":"2020-05-04T13:07:41-04:00"}')) _
+
+> SELECT * FROM v
+"2020-05-04 17:07:41 UTC"

--- a/test/testdrive/jsonb.td
+++ b/test/testdrive/jsonb.td
@@ -7,59 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT jsonb_agg(1)
-jsonb_agg
------------
-[1.0]
+# This test exercises JSONB at the boundary (e.g., by sending it through
+# pgwire). Operations on JSONB are more thoroughly tested in jsonb.slt.
 
-$ set aggs-schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "num", "type": "int"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=aggs
-
-$ kafka-ingest format=avro topic=aggs schema=${aggs-schema} timestamp=1
-{"before": null, "after": {"num": 1}}
-{"before": null, "after": {"num": 2}}
-{"before": null, "after": {"num": 3}}
-
-> CREATE MATERIALIZED SOURCE data
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-aggs-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${aggs-schema}'
-  ENVELOPE DEBEZIUM
-
-> SELECT * FROM data
-num
-----
-1
-2
-3
-
-> SELECT jsonb_agg(data.num) from data;
-[2.0,3.0,1.0]
-
-! SELECT jsonb_agg(1, 2)
-jsonb_agg function requires exactly one non-star argument
-
-# todo@jldlaughlin: Fix test when #2414 is implemented
-! SELECT jsonb_agg((1, 2))
-Parse error:
-
-> DROP SOURCE data
+> VALUES
+  ('1'::jsonb),
+  ('["a", "b"]'::jsonb),
+  ('{"c": ["d"]}'::jsonb),
+  ('null'::jsonb),
+  (NULL::jsonb)
+"1.0"
+"[\"a\",\"b\"]"
+"{\"c\":[\"d\"]}"
+"null"
+"<null>"


### PR DESCRIPTION
@justinj is there a better way to do this? :/ 

----

Since we rewrite

    CAST(<expr> OP <expr> AS <type>)

to

    <expr> OP <expr>::<type>

we need to be careful to wrap in parentheses

    (<expr> OP <expr>)::<type>

to avoid changing the meaning of the expression.

Fix #3281.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3283)
<!-- Reviewable:end -->
