### PR TITLE
perf-kinesis: Fix worklow that exposes mz logs as prom metrics

### DIFF
--- a/test/performance/perf-kinesis/src/main.rs
+++ b/test/performance/perf-kinesis/src/main.rs
@@ -132,7 +132,7 @@ pub struct Args {
     pub shard_count: i64,
 
     /// The total number of records to create
-    #[structopt(long, default_value = "150_000_000")]
+    #[structopt(long, default_value = "150000000")]
     pub total_records: u64,
 
     /// The number of records to put to the Kinesis stream per second


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3285)
<!-- Reviewable:end -->
