### PR TITLE
sql: add sqrt_dec function

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -991,6 +991,17 @@ fn sqrt_float64<'a>(a: Datum<'a>) -> Datum<'a> {
     Datum::from(x.sqrt())
 }
 
+fn sqrt_dec<'a>(a: Datum<'a>, scale: u8) -> Result<Datum, EvalError> {
+    let d = a.unwrap_decimal();
+    if d.as_i128() < 0 {
+        return Ok(Datum::Null);
+    }
+    let d_f64 = cast_significand_to_float64(a);
+    let d_scaled = d_f64.unwrap_float64() / 10_f64.powi(i32::from(scale));
+
+    cast_float64_to_decimal(Datum::from(d_scaled.sqrt()), Datum::from(i32::from(scale)))
+}
+
 fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a == b)
 }
@@ -2287,6 +2298,7 @@ pub enum UnaryFunc {
     NegInterval,
     SqrtFloat32,
     SqrtFloat64,
+    SqrtDec(u8),
     AbsInt32,
     AbsInt64,
     AbsFloat32,
@@ -2505,6 +2517,7 @@ impl UnaryFunc {
             UnaryFunc::FloorDecimal(scale) => Ok(floor_decimal(a, *scale)),
             UnaryFunc::SqrtFloat32 => Ok(sqrt_float32(a)),
             UnaryFunc::SqrtFloat64 => Ok(sqrt_float64(a)),
+            UnaryFunc::SqrtDec(scale) => sqrt_dec(a, *scale),
             UnaryFunc::Ascii => Ok(ascii(a)),
             UnaryFunc::BitLengthString => Ok(bit_length(a.unwrap_str())),
             UnaryFunc::BitLengthBytes => Ok(bit_length(a.unwrap_bytes())),
@@ -2688,7 +2701,7 @@ impl UnaryFunc {
             CeilFloat64 | FloorFloat64 | RoundFloat64 => {
                 ColumnType::new(ScalarType::Float64).nullable(in_nullable)
             }
-            CeilDecimal(scale) | FloorDecimal(scale) | RoundDecimal(scale) => {
+            CeilDecimal(scale) | FloorDecimal(scale) | RoundDecimal(scale) | SqrtDec(scale) => {
                 match input_type.scalar_type {
                     ScalarType::Decimal(_, s) => assert_eq!(*scale, s),
                     _ => unreachable!(),
@@ -2868,6 +2881,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::FloorDecimal(_) => f.write_str("floordec"),
             UnaryFunc::SqrtFloat32 => f.write_str("sqrtf32"),
             UnaryFunc::SqrtFloat64 => f.write_str("sqrtf64"),
+            UnaryFunc::SqrtDec(_) => f.write_str("sqrtdec"),
             UnaryFunc::Ascii => f.write_str("ascii"),
             UnaryFunc::CharLength => f.write_str("char_length"),
             UnaryFunc::BitLengthBytes => f.write_str("bit_length"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -975,30 +975,30 @@ pub fn neg_interval<'a>(a: Datum<'a>) -> Datum<'a> {
     Datum::from(-a.unwrap_interval())
 }
 
-fn sqrt_float32<'a>(a: Datum<'a>) -> Datum<'a> {
+fn sqrt_float32<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
     let x = a.unwrap_float32();
     if x < 0.0 {
-        return Datum::Null;
+        return Err(EvalError::NegSqrt);
     }
-    Datum::from(x.sqrt())
+    Ok(Datum::from(x.sqrt()))
 }
 
-fn sqrt_float64<'a>(a: Datum<'a>) -> Datum<'a> {
+fn sqrt_float64<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
     let x = a.unwrap_float64();
     if x < 0.0 {
-        return Datum::Null;
+        return Err(EvalError::NegSqrt);
     }
-    Datum::from(x.sqrt())
+
+    Ok(Datum::from(x.sqrt()))
 }
 
 fn sqrt_dec<'a>(a: Datum<'a>, scale: u8) -> Result<Datum, EvalError> {
     let d = a.unwrap_decimal();
     if d.as_i128() < 0 {
-        return Ok(Datum::Null);
+        return Err(EvalError::NegSqrt);
     }
     let d_f64 = cast_significand_to_float64(a);
     let d_scaled = d_f64.unwrap_float64() / 10_f64.powi(i32::from(scale));
-
     cast_float64_to_decimal(Datum::from(d_scaled.sqrt()), Datum::from(i32::from(scale)))
 }
 
@@ -2515,8 +2515,8 @@ impl UnaryFunc {
             UnaryFunc::FloorFloat32 => Ok(floor_float32(a)),
             UnaryFunc::FloorFloat64 => Ok(floor_float64(a)),
             UnaryFunc::FloorDecimal(scale) => Ok(floor_decimal(a, *scale)),
-            UnaryFunc::SqrtFloat32 => Ok(sqrt_float32(a)),
-            UnaryFunc::SqrtFloat64 => Ok(sqrt_float64(a)),
+            UnaryFunc::SqrtFloat32 => sqrt_float32(a),
+            UnaryFunc::SqrtFloat64 => sqrt_float64(a),
             UnaryFunc::SqrtDec(scale) => sqrt_dec(a, *scale),
             UnaryFunc::Ascii => Ok(ascii(a)),
             UnaryFunc::BitLengthString => Ok(bit_length(a.unwrap_str())),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -507,6 +507,7 @@ pub enum EvalError {
         byte_sequence: String,
         encoding_name: String,
     },
+    NegSqrt,
     UnknownUnits(String),
     UnterminatedLikeEscapeSequence,
     Parse(ParseError),
@@ -528,6 +529,7 @@ impl std::fmt::Display for EvalError {
                 "invalid byte sequence '{}' for encoding '{}'",
                 byte_sequence, encoding_name
             ),
+            EvalError::NegSqrt => f.write_str("cannot take square root of a negative number"),
             EvalError::UnknownUnits(units) => write!(f, "unknown units '{}'", units),
             EvalError::UnterminatedLikeEscapeSequence => {
                 f.write_str("unterminated escape sequence in LIKE")

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -610,6 +610,10 @@ impl<'a> ArgImplementationMatcher<'a> {
                 ScalarType::Decimal(_, s) => BFunc(BinaryFunc::RoundDecimal(s)),
                 _ => unreachable!(),
             },
+            Unary(UnaryFunc::SqrtDec(_)) => match types[0] {
+                ScalarType::Decimal(_, s) => Unary(UnaryFunc::SqrtDec(s)),
+                _ => unreachable!(),
+            },
             other => other,
         };
 
@@ -815,6 +819,11 @@ lazy_static! {
             "substring" => {
                 params!(String, Int64) => VariadicFunc::Substr,
                 params!(String, Int64, Int64) => VariadicFunc::Substr
+            },
+            "sqrt" => {
+                params!(Float32) => UnaryFunc::SqrtFloat32,
+                params!(Float64) => UnaryFunc::SqrtFloat64,
+                params!(Decimal(0,0)) => UnaryFunc::SqrtDec(0)
             },
             "to_char" => {
                 params!(Timestamp, String) => BinaryFunc::ToCharTimestamp,

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -250,20 +250,14 @@ NULL    24
 # The implementation of sqrt delegates to {f32,f64}::sqrt, so these tests are
 # not particularly extensive.
 
-query R
+query error cannot take square root of a negative number
 SELECT sqrt(-1::float)
-----
-NULL
 
-query R
+query error cannot take square root of a negative number
 SELECT sqrt(-1::double precision)
-----
-NULL
 
-query R
+query error cannot take square root of a negative number
 SELECT sqrt(-1::decimal(15, 2))
-----
-NULL
 
 query R
 SELECT sqrt(1.23783::float)


### PR DESCRIPTION
Computes square root of decimal by converting it to float64, computing square, and converting back to `ScalarType::Decimal`.

@benesch idk if this is any good because it just moves the same set of actions to the back end, which means the plan can't get optimized, but thought I'd see if this was feasible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3287)
<!-- Reviewable:end -->
