### PR TITLE
Add explicit panic statement on main consumer loop

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -682,7 +682,20 @@ where
             // via individual partition queues.
             {
                 let message = dp_info.consumer.poll(Duration::from_secs(0));
-                assert!(message.is_none());
+                if let Some(message) = message {
+                    match message {
+                        Ok(message) => {
+                            panic!(
+                                "Internal Error. Received an unexpected message Source: {} PID: {} Offset: {} on main partition loop.\
+                                Materialize will now crash.",
+                                id,
+                                message.partition(),
+                                message.offset()
+                            );
+                        }
+                        Err(e) => error!("Error when polling: {}", e),
+                    }
+                }
             }
 
             // Check if the capability can be downgraded (this is independent of whether


### PR DESCRIPTION
This PR adds an explicit panic statement when receiving a message (rather than simply an error) on the main kafka consumer loop. Errors are expected and can be ignored. Messages are not and reflect a bug in our partition assignment logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3302)
<!-- Reviewable:end -->
