### PR TITLE
Add ChaosDelayContainerStep to mzconduct

### DIFF
--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -20,6 +20,7 @@
 
 use std::error::Error as _;
 use std::process;
+use std::time::Duration;
 
 use protobuf::Message;
 use structopt::StructOpt;
@@ -103,7 +104,7 @@ async fn create_kafka_messages(config: KafkaConfig) -> Result<()> {
 
     if let Some(partitions) = config.partitions {
         k_client
-            .create_topic(partitions)
+            .create_topic(partitions, Some(Duration::from_secs(5)))
             .await
             .map_err(|e| error::Error::from(e.to_string()))?;
     }

--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -862,6 +862,27 @@ class ChaosStopContainerStep(ChaosContainerBaseWorkflowStep):
         )
 
 
+@Steps.register("chaos-delay-container")
+class ChaosDelayContainerStep(WorkflowStep):
+    """Delay the incoming and outgoing network traffic for a Docker container.
+
+    Params:
+        container: Docker container to delay
+        delay: milliseconds to delay network traffic (default: 100ms)
+    """
+
+    def __init__(self, container: str, delay: int = 100) -> None:
+        self._container = container
+        self._delay = delay
+
+    def run(self, comp: Composition, workflow: Workflow) -> None:
+        try:
+            cmd = f"docker exec {self._container} tc qdisc add dev eth0 root netem delay {self._delay}ms".split()
+            spawn.runv(cmd)
+        except subprocess.CalledProcessError as e:
+            raise Failed(f"Unable to delay container {self._container}: {e}")
+
+
 @Steps.register("workflow")
 class WorkflowWorkflowStep(WorkflowStep):
     def __init__(self, workflow: str) -> None:

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -49,6 +49,8 @@ services:
       KAFKA_BROKER_ID: 1
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9991
+    cap_add:
+      - NET_ADMIN
   schema-registry:
     image: confluentinc/cp-schema-registry:5.2.1
     ports:
@@ -67,6 +69,22 @@ services:
 
 mzconduct:
   workflows:
+    delay-kafka:
+      steps:
+        - step: workflow
+          workflow: start-everything
+        - step: chaos-delay-container
+          container: chaos_kafka_1
+        - step: run
+          service: chaos
+          daemon: true
+          command: >-
+            --materialized-host materialized
+            --materialized-port 6875
+            --kafka-url kafka:9092
+            --kafka-partitions 1
+            --message-count 10000
+
     pause-kafka:
       steps:
         - step: workflow

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -45,7 +45,7 @@ async fn run() -> Result<(), anyhow::Error> {
     let kafka_client =
         kafka::kafka_client::KafkaClient::new(&args.kafka_url, "materialize.chaos", &topic)?;
     retry::retry_for(Duration::from_secs(10), |_| {
-        kafka_client.create_topic(args.kafka_partitions)
+        kafka_client.create_topic(args.kafka_partitions, Some(Duration::from_secs(10)))
     })
     .await?;
 

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -13,6 +13,7 @@
 
 use std::time::Duration;
 
+use anyhow::Context;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
@@ -41,7 +42,7 @@ impl KafkaClient {
         })
     }
 
-    pub async fn create_topic(&self, partitions: i32) -> Result<(), anyhow::Error> {
+    pub async fn create_topic(&self, partitions: i32, timeout: Option<Duration>) -> Result<(), anyhow::Error> {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", &self.kafka_url);
         let res = config
@@ -53,9 +54,9 @@ impl KafkaClient {
                     partitions,
                     TopicReplication::Fixed(1),
                 )],
-                &AdminOptions::new().request_timeout(Some(Duration::from_secs(5))),
+                &AdminOptions::new().request_timeout(timeout),
             )
-            .await?;
+            .await.context(format!("creating Kafka topic: {}", &self.topic))?;
 
         if res.len() != 1 {
             return Err(anyhow::anyhow!(


### PR DESCRIPTION
Add a new `ChaosDelayContainerStep` to mzconduct that delays a Docker container's inbound and outbound traffic by X milliseconds. I tested this by running it locally and confirming a rule was added to the kafka container.

```
Jessicas-MBP:materialize jessicalaughlin$ docker exec -ti chaos_kafka_1 /bin/bash
root@82942a66e440:/# tc qdisc show  dev eth0
qdisc netem 800b: root refcnt 2 limit 100 delay 1.0s
```