### PR TITLE
Add enable.idempotence to KafkaClient

### DIFF
--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -98,8 +98,9 @@ async fn create_kafka_messages(config: KafkaConfig) -> Result<()> {
 
     let mut recordstate = randomizer::RecordState::new(config.start_time);
 
-    let mut k_client = kafka_client::KafkaClient::new(&config.url, &config.group_id, &config.topic)
-        .map_err(|e| error::Error::from(e.to_string()))?;
+    let mut k_client =
+        kafka_client::KafkaClient::new(&config.url, &config.group_id, &config.topic, None)
+            .map_err(|e| error::Error::from(e.to_string()))?;
 
     if let Some(partitions) = config.partitions {
         k_client

--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -99,7 +99,7 @@ async fn create_kafka_messages(config: KafkaConfig) -> Result<()> {
     let mut recordstate = randomizer::RecordState::new(config.start_time);
 
     let mut k_client =
-        kafka_client::KafkaClient::new(&config.url, &config.group_id, &config.topic, None)
+        kafka_client::KafkaClient::new(&config.url, &config.group_id, &config.topic, &[])
             .map_err(|e| error::Error::from(e.to_string()))?;
 
     if let Some(partitions) = config.partitions {

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -42,8 +42,12 @@ async fn run() -> Result<(), anyhow::Error> {
 
     // Create Kafka topic.
     log::info!("creating Kafka topic=> {}", topic);
-    let kafka_client =
-        kafka::kafka_client::KafkaClient::new(&args.kafka_url, "materialize.chaos", &topic)?;
+    let kafka_client = kafka::kafka_client::KafkaClient::new(
+        &args.kafka_url,
+        "materialize.chaos",
+        &topic,
+        Some(&[("enable.idempotence", "true")]),
+    )?;
     retry::retry_for(Duration::from_secs(10), |_| {
         kafka_client.create_topic(args.kafka_partitions)
     })

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -46,7 +46,7 @@ async fn run() -> Result<(), anyhow::Error> {
         &args.kafka_url,
         "materialize.chaos",
         &topic,
-        Some(&[("enable.idempotence", "true")]),
+        &[("enable.idempotence", "true")],
     )?;
     retry::retry_for(Duration::from_secs(10), |_| {
         kafka_client.create_topic(args.kafka_partitions)

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -26,11 +26,20 @@ pub struct KafkaClient {
 }
 
 impl KafkaClient {
-    pub fn new(kafka_url: &str, group_id: &str, topic: &str) -> Result<KafkaClient, anyhow::Error> {
+    pub fn new(
+        kafka_url: &str,
+        group_id: &str,
+        topic: &str,
+        configs: Option<&[(&str, &str)]>,
+    ) -> Result<KafkaClient, anyhow::Error> {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", kafka_url);
         config.set("group.id", group_id);
-        config.set("enable.idempotence", "true");
+        if let Some(configs) = configs {
+            for (key, val) in configs {
+                config.set(key, val);
+            }
+        }
 
         let producer: FutureProducer = config.create()?;
 

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -30,7 +30,7 @@ impl KafkaClient {
         kafka_url: &str,
         group_id: &str,
         topic: &str,
-        configs: Option<&[(&str, &str)]>,
+        configs: &[(&str, &str)],
     ) -> Result<KafkaClient, anyhow::Error> {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", kafka_url);

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -30,6 +30,7 @@ impl KafkaClient {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", kafka_url);
         config.set("group.id", group_id);
+        config.set("enable.idempotence", "true");
 
         let producer: FutureProducer = config.create()?;
 

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -35,10 +35,8 @@ impl KafkaClient {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", kafka_url);
         config.set("group.id", group_id);
-        if let Some(configs) = configs {
-            for (key, val) in configs {
-                config.set(key, val);
-            }
+        for (key, val) in configs {
+            config.set(key, val);
         }
 
         let producer: FutureProducer = config.create()?;


### PR DESCRIPTION
@umanwizard found that the `test/chaos` `stop-kafka` workflow was failing because the Kafka producer was emitting duplicate records (investigation from here: https://github.com/MaterializeInc/materialize/issues/3266).

Adding `enable.idempotence` -> `true` to the Kafka producer ensures that exactly one copy of each message is written to the stream, even when sends are retried due to broker failures or other issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3306)
<!-- Reviewable:end -->
