### PR TITLE
Don't wait-for-mz to backfill load tests

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -322,7 +322,9 @@ mzconduct:
       steps:
       - step: start-services
         services: [materialized, mysql]
-      - step: wait-for-mz
+      - step: wait-for-tcp
+        host: materialized
+        port: 6875
       - step: wait-for-mysql
         user: root
         password: debezium

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -82,7 +82,9 @@ mzconduct:
           services: [materialized]
         - step: start-services
           services: [prometheus_sql_exporter_mz]
-        - step: wait-for-mz
+        - step: wait-for-tcp
+          host: materialized
+          port: 6875
         - step: run
           service: perf-kinesis
           daemon: true


### PR DESCRIPTION
Old versions of materialized did not correctly handle `SELECT 1`, so using that to check
if mzd is running is invalid, sadly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3311)
<!-- Reviewable:end -->
