### PR TITLE
Add the time of the crash to the stderr crash message

### DIFF
--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -42,6 +42,7 @@ tokio = "0.2"
 tokio-openssl = "0.4.0"
 tracing = "0.1.14"
 tracing-subscriber = "0.2.5"
+chrono = "0.4.11"
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/src/materialized/src/bin/materialized.rs
+++ b/src/materialized/src/bin/materialized.rs
@@ -32,6 +32,7 @@ use std::thread;
 use std::time::Duration;
 
 use backtrace::Backtrace;
+use chrono::Utc;
 use failure::{bail, format_err, ResultExt};
 use lazy_static::lazy_static;
 use log::{info, trace};
@@ -375,7 +376,7 @@ message: {}
     if LOG_FILE.get().is_some() {
         log::error!("{}", crash_message);
     }
-    eprintln!("{}", crash_message);
+    eprintln!("{} {}", Utc::now().format("%b %d %T%.3fZ"), crash_message);
     process::exit(1);
 }
 


### PR DESCRIPTION
Without this it looks like it is happening directly caused by the previous error message,
but in fact it may be entirely unrelated.

With this, the error message looks like (for `panic!("oh no!")`):

    Jun 09 03:31:39.155Z materialized encountered an internal error and crashed.
    ...
     thread: main
    message: Oh no!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3313)
<!-- Reviewable:end -->
