### PR TITLE
load-tests: Create cloud-load-test mzconduct workflows

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -105,7 +105,7 @@ mzconduct:
       - step: down
         destroy_volumes: true
 
-    load-test:
+    cloud-load-test:
       env:
         MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -296,7 +296,7 @@ mzconduct:
         container: dashboard
         seconds: 1
 
-    nightly:
+    cloud-load-test:
       env:
         PEEKER_PORT: "16875:16875"
         MYSQL_EXPORTER_PORT: "9399:9399"

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -63,18 +63,14 @@ mzconduct:
           destroy_volumes: true
 
     load-test:
-      env:
-        MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:
         - step: workflow
           workflow: start-everything
-        - step: start-services
-          services: [prometheus_sql_exporter_mz]
         - step: run
           service: perf-kinesis
           daemon: true
 
-    nightly:
+    cloud-load-test:
       env:
         MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:


### PR DESCRIPTION
The cloud-load-test workflows expect to be scraped from a prometheus server that is *not*
in a locally-running dashboard, unlike load-test workflows, which are meant to be used
locally and are entirely self-contained.

cloud-load-test workflows require that:

* They always start prometheus_sql_exporter_mz exposed on port 9400
* They never start the dashboard container, which is just unnecessary overhead it won't
  break external metrics collection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3317)
<!-- Reviewable:end -->
