### PR TITLE
sql: generalize comparison operator selection

### DIFF
--- a/test/sqllogictest/decimal.slt
+++ b/test/sqllogictest/decimal.slt
@@ -343,3 +343,13 @@ CREATE VIEW github_2293 AS SELECT 1 AS a
 
 query error division by zero
 SELECT 1::decimal(38,0) / 0 / a + 1 FROM github_2293;
+
+query T
+SELECT 1::decimal(38, 3) > 2::decimal(20,1)
+----
+false
+
+query T
+SELECT 10.5::decimal(38, 3) = 10.50::decimal(20,1)
+----
+true

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -142,13 +142,12 @@ eve true
 
 # ANY/ALL semantics
 
-query BBBBBBBBBBBBBBBB
+query BBBBBBBBBBBBBBB
 (VALUES (
   1 < ANY(SELECT * FROM (VALUES (1)) WHERE false),
   1 < ANY(VALUES (0)),
   1 < ANY(VALUES (1)),
   1 < ANY(VALUES (2)),
-  1 < ANY(VALUES (NULL)),
   1 < ANY(VALUES (0), (NULL)),
   1 < ANY(VALUES (1), (NULL)),
   1 < ANY(VALUES (2), (NULL)),
@@ -162,15 +161,14 @@ query BBBBBBBBBBBBBBBB
   NULL < ANY(VALUES (2), (NULL))
 ))
 ----
-false  false  false  true  NULL  NULL  NULL  true  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+false  false  false  true  NULL  NULL  true  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
-query BBBBBBBBBBBBBBBB
+query BBBBBBBBBBBBBBB
 (VALUES (
   1 < ALL(SELECT * FROM (VALUES (1)) WHERE false),
   1 < ALL(VALUES (0)),
   1 < ALL(VALUES (1)),
   1 < ALL(VALUES (2)),
-  1 < ALL(VALUES (NULL)),
   1 < ALL(VALUES (0), (NULL)),
   1 < ALL(VALUES (1), (NULL)),
   1 < ALL(VALUES (2), (NULL)),
@@ -184,7 +182,7 @@ query BBBBBBBBBBBBBBBB
   NULL < ALL(VALUES (2), (NULL))
 ))
 ----
-true  false  false  true  NULL  false  false  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+true  false  false  true  false  false  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
 statement ok
 CREATE TABLE s1 (a int NOT NULL)

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -44,3 +44,90 @@ true
 true
 false
 true
+
+# Do not allow i32 text comparisons
+query error no overload for string < i32
+SELECT 'foo'::text < 5::int;
+
+query error no overload for i32 < string
+SELECT 1 < ALL(VALUES(NULL))
+
+# Use comparison ops to check for type promotion
+
+# Check i32 promotes to decimal
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 1 > 1.1;
+----
+%0 =
+| Constant ()
+| Map ((i32todec(1) * 10dec) > 11dec)
+| Project (#0)
+| Map
+
+EOF
+
+# Check i64 promotes to decimal
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 1::bigint > 1.11111
+----
+%0 =
+| Constant ()
+| Map ((i64todec(i32toi64(1)) * 100000dec) > 111111dec)
+| Project (#0)
+| Map
+
+EOF
+
+# Check i64 promotes to f64
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 1::bigint > 1.11111::float
+----
+%0 =
+| Constant ()
+| Map (i64tof64(i32toi64(1)) > (dectof64(111111dec) / 100000))
+| Project (#0)
+| Map
+
+EOF
+
+# Check decimal promotes to f64
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 1.1 > 1::float;
+----
+%0 =
+| Constant ()
+| Map ((dectof64(11dec) / 10) > i32tof64(1))
+| Project (#0)
+| Map
+
+EOF
+
+# Check decimals do not get promoted
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 1.1 > 1.1
+----
+%0 =
+| Constant ()
+| Map (11dec > 11dec)
+| Project (#0)
+| Map
+
+EOF
+
+# Check floats do not get promoted
+query T multiline
+EXPLAIN RAW PLAN FOR
+    SELECT 1::float > 1::float
+----
+%0 =
+| Constant ()
+| Map (i32tof64(1) > i32tof64(1))
+| Project (#0)
+| Map
+
+EOF


### PR DESCRIPTION
Generalizes comparison operators, which means binary operator selection is now totally generalized.

#### Commentary

- The only surprising (to me, at least) breakage from this was that we had a non-obvious test break because this actually evaluates to `text`:

    ```
    SELECT ALL(VALUES(NULL))
    ```

    so we could no longer compare it to an integer, which `subquery.slt` was.

- `chbench` and `tpch.slt` both seem to have more scale shuffling, which I can only assume is a matter of our type promotion requiring less of the jumping around that occurs in `plan_homogenous_exprs`.

Closes #3164

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3322)
<!-- Reviewable:end -->
