### PR TITLE
Fix bug in multi-partition chaos test

### DIFF
--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -90,7 +90,7 @@ mzconduct:
             --materialized-host materialized
             --materialized-port 6875
             --kafka-url kafka:9092
-            --kafka-partitions 1
+            --kafka-partitions 5
             --message-count 10000
         - step: chaos-confirm
           service: materialized
@@ -117,7 +117,7 @@ mzconduct:
             --materialized-host materialized
             --materialized-port 6875
             --kafka-url kafka:9092
-            --kafka-partitions 1
+            --kafka-partitions 5
             --message-count 10000
         - step: chaos-pause-docker
           service: kafka
@@ -144,7 +144,7 @@ mzconduct:
             --materialized-host materialized
             --materialized-port 6875
             --kafka-url kafka:9092
-            --kafka-partitions 1
+            --kafka-partitions 5
             --message-count 10000
         - step: chaos-stop-docker
           service: kafka
@@ -170,7 +170,7 @@ mzconduct:
             --materialized-host materialized
             --materialized-port 6875
             --kafka-url kafka:9092
-            --kafka-partitions 1
+            --kafka-partitions 5
             --message-count 10000
         - step: chaos-kill-docker
           service: kafka


### PR DESCRIPTION
So far, I'd only been running chaos tests on a single Kafka partition. In adding additional partitions, I found the approach of comparing bytes sent to Kafka to bytes in materialized ordered by their `mz_offset` would no longer work. This PR replaces that `ORDER BY` with sorting both arrays of bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3327)
<!-- Reviewable:end -->
