### PR TITLE
RT consistency for Kafka without metadata requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "lazy_static",
  "log",
  "ore",
+ "parse_duration",
  "pgrepr",
  "rdkafka",
  "regex",

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -15,6 +15,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::time::Duration;
 
 use timely::progress::frontier::Antichain;
 
@@ -449,6 +450,7 @@ pub enum SourceConnector {
         envelope: Envelope,
         consistency: Consistency,
         max_ts_batch: i64,
+        ts_frequency: Duration,
     },
     Local,
 }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -257,6 +257,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                     envelope,
                     consistency,
                     max_ts_batch: _,
+                    ts_frequency,
                 } = src.connector
                 {
                     let get_expr = RelationExpr::global_get(src_id.sid, src.desc.typ().clone());
@@ -290,6 +291,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                         timestamp_histories: timestamp_histories.clone(),
                         timestamp_tx: timestamp_channel.clone(),
                         consistency,
+                        timestamp_frequency: ts_frequency,
                         worker_id: worker_index,
                         // Assumption: worker.peers() == total number of workers in Materialize
                         worker_count: worker_peers,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -147,7 +147,7 @@ pub enum SequencedCommand {
     AppendLog(MaterializedEvent),
     /// Advance worker timestamp
     AdvanceSourceTimestamp {
-        /// TODO(ncrooks)
+        /// The ID of the timestamped source
         id: SourceInstanceId,
         /// TODO(ncrooks)
         partition_count: i32,
@@ -254,15 +254,18 @@ where
 /// A type wrapper for the number of partitions associated with a source
 pub type PartitionCount = i32;
 
-/// A type wrapper for a timestamp update that consists of a PartititionCount, a Timestamp,
+/// A type wrapper for a timestamp update that consists of a PartitionCount, a Timestamp,
 /// and a MzOffset
 pub type TimestampUpdate = (PartitionCount, Timestamp, MzOffset);
 
 /// Map of source ID to per-partition timestamp history.
 ///
-/// Timestamp history is a vector of tuples (partition_count, timestamp, offset),
+/// Timestamp history is a vector of
+/// 1) BYO timestamp updates which are tuples (partition_count, timestamp, offset),
 /// where the correct timestamp for a given offset `x` is the highest timestamp value for
 /// the first offset >= `x`.
+/// 2) RT timestamp updates which are integers (partition_count) which represent the current
+/// partition_count associated with the source
 pub type TimestampHistories =
     Rc<RefCell<HashMap<SourceInstanceId, HashMap<PartitionId, VecDeque<TimestampUpdate>>>>>;
 

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 
 use std::io::Read;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::mpsc::TryRecvError;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -341,111 +342,119 @@ where
         ..
     } = config;
 
-    let (stream, capability) = source(id, ts, scope, &config.name.clone(), move |info| {
-        let activator = scope.activator_for(&info.address[..]);
-        let (tx, rx) = std::sync::mpsc::sync_channel(MAX_RECORDS_PER_INVOCATION);
-        if active {
-            let activator = Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..])));
-            thread::spawn(|| read_file_task(path, tx, Some(activator), read_style, iter_ctor));
-        }
-        let mut dead = false;
-        move |cap, output| {
-            // If nothing else causes us to wake up, do so after a specified amount of time.
-            let mut next_activation_duration = HEARTBEAT;
-            // Number of records read for this particular activation
-            let mut records_read = 0;
-
-            assert!(
-                !dead,
-                "A file source should not be scheduled again after erroring."
-            );
-
+    let (stream, capability) = source(
+        id,
+        ts,
+        Arc::new(AtomicBool::new(false)),
+        scope,
+        &config.name.clone(),
+        move |info| {
+            let activator = scope.activator_for(&info.address[..]);
+            let (tx, rx) = std::sync::mpsc::sync_channel(MAX_RECORDS_PER_INVOCATION);
             if active {
-                // Check if the capability can be downgraded (this is independent of whether
-                // there are new messages that can be processed) as timestamps can become
-                // closed in the absence of messages
-                downgrade_capability(
-                    &id,
-                    cap,
-                    &mut last_processed_offset,
-                    &mut last_closed_ts,
-                    &timestamp_histories,
+                let activator = Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..])));
+                thread::spawn(|| read_file_task(path, tx, Some(activator), read_style, iter_ctor));
+            }
+            let mut dead = false;
+            move |cap, output| {
+                // If nothing else causes us to wake up, do so after a specified amount of time.
+                let mut next_activation_duration = HEARTBEAT;
+                // Number of records read for this particular activation
+                let mut records_read = 0;
+
+                assert!(
+                    !dead,
+                    "A file source should not be scheduled again after erroring."
                 );
 
-                // Check if there was a message buffered. If yes, use this message. Else,
-                // attempt to process the next message
-                if buffer.is_none() {
-                    match rx.try_recv() {
-                        Ok(result) => {
-                            records_read += 1;
-                            current_msg_offset.offset += 1;
-                            buffer = Some(result);
+                if active {
+                    // Check if the capability can be downgraded (this is independent of whether
+                    // there are new messages that can be processed) as timestamps can become
+                    // closed in the absence of messages
+                    downgrade_capability(
+                        &id,
+                        cap,
+                        &mut last_processed_offset,
+                        &mut last_closed_ts,
+                        &timestamp_histories,
+                    );
+
+                    // Check if there was a message buffered. If yes, use this message. Else,
+                    // attempt to process the next message
+                    if buffer.is_none() {
+                        match rx.try_recv() {
+                            Ok(result) => {
+                                records_read += 1;
+                                current_msg_offset.offset += 1;
+                                buffer = Some(result);
+                            }
+                            Err(TryRecvError::Empty) => {
+                                // nothing to read, go to sleep
+                            }
+                            Err(TryRecvError::Disconnected) => {
+                                return SourceStatus::Done;
+                            }
                         }
-                        Err(TryRecvError::Empty) => {
-                            // nothing to read, go to sleep
+                    }
+
+                    while let Some(message) = buffer.take() {
+                        let ts =
+                            find_matching_timestamp(&id, current_msg_offset, &timestamp_histories);
+                        let message = match message {
+                            Ok(message) => message,
+                            Err(err) => {
+                                output.session(&cap).give(Err(err.to_string()));
+                                dead = true;
+                                return SourceStatus::Done;
+                            }
+                        };
+                        match ts {
+                            None => {
+                                // We have not yet decided on a timestamp for this message,
+                                // we need to buffer the message
+                                buffer = Some(Ok(message));
+                                activator.activate();
+                                return SourceStatus::Alive;
+                            }
+                            Some(ts) => {
+                                last_processed_offset = current_msg_offset;
+                                let ts_cap = cap.delayed(&ts);
+                                output.session(&ts_cap).give(Ok(SourceOutput::new(
+                                    vec![],
+                                    message,
+                                    Some(last_processed_offset.offset),
+                                )));
+                                downgrade_capability(
+                                    &id,
+                                    cap,
+                                    &mut last_processed_offset,
+                                    &mut last_closed_ts,
+                                    &timestamp_histories,
+                                );
+                            }
                         }
-                        Err(TryRecvError::Disconnected) => {
-                            return SourceStatus::Done;
+
+                        if records_read == MAX_RECORDS_PER_INVOCATION {
+                            next_activation_duration = Default::default();
+                            break;
+                        }
+
+                        buffer = match rx.try_recv() {
+                            Ok(record) => {
+                                records_read += 1;
+                                current_msg_offset.offset += 1;
+                                Some(record)
+                            }
+                            Err(TryRecvError::Empty) => None,
+                            Err(TryRecvError::Disconnected) => return SourceStatus::Done,
                         }
                     }
                 }
-
-                while let Some(message) = buffer.take() {
-                    let ts = find_matching_timestamp(&id, current_msg_offset, &timestamp_histories);
-                    let message = match message {
-                        Ok(message) => message,
-                        Err(err) => {
-                            output.session(&cap).give(Err(err.to_string()));
-                            dead = true;
-                            return SourceStatus::Done;
-                        }
-                    };
-                    match ts {
-                        None => {
-                            // We have not yet decided on a timestamp for this message,
-                            // we need to buffer the message
-                            buffer = Some(Ok(message));
-                            activator.activate();
-                            return SourceStatus::Alive;
-                        }
-                        Some(ts) => {
-                            last_processed_offset = current_msg_offset;
-                            let ts_cap = cap.delayed(&ts);
-                            output.session(&ts_cap).give(Ok(SourceOutput::new(
-                                vec![],
-                                message,
-                                Some(last_processed_offset.offset),
-                            )));
-                            downgrade_capability(
-                                &id,
-                                cap,
-                                &mut last_processed_offset,
-                                &mut last_closed_ts,
-                                &timestamp_histories,
-                            );
-                        }
-                    }
-
-                    if records_read == MAX_RECORDS_PER_INVOCATION {
-                        next_activation_duration = Default::default();
-                        break;
-                    }
-
-                    buffer = match rx.try_recv() {
-                        Ok(record) => {
-                            records_read += 1;
-                            current_msg_offset.offset += 1;
-                            Some(record)
-                        }
-                        Err(TryRecvError::Empty) => None,
-                        Err(TryRecvError::Disconnected) => return SourceStatus::Done,
-                    }
-                }
+                activator.activate_after(next_activation_duration);
+                SourceStatus::Alive
             }
-            activator.activate_after(next_activation_duration);
-            SourceStatus::Alive
-        }
-    });
+        },
+    );
 
     let (ok_stream, err_stream) = stream.map_fallible(|r| r.map_err(SourceError::FileIO));
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -7,18 +7,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::{cmp, thread};
 
 use dataflow_types::{
-    ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset, Timestamp,
+    Consistency, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset, Timestamp,
 };
 use expr::{PartitionId, SourceInstanceId};
 use lazy_static::lazy_static;
-use log::{error, info, log_enabled, warn};
+use log::{debug, error, info, log_enabled, warn};
 use prometheus::{
     register_int_counter, register_int_counter_vec, register_int_gauge_vec,
     register_uint_gauge_vec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, UIntGauge,
@@ -36,7 +37,8 @@ use url::Url;
 
 use super::util::source;
 use super::{SourceConfig, SourceOutput, SourceStatus, SourceToken};
-use crate::server::TimestampHistories;
+use crate::server::{TimestampChanges, TimestampHistories};
+use ore::collections::CollectionExt;
 
 // Global Kafka metrics.
 lazy_static! {
@@ -113,6 +115,7 @@ impl PartitionMetrics {
                 &["topic", "source_id", "partition_id"]
             )
             .unwrap();
+
         }
         let labels = &[topic_name, source_id, partition_id];
         PartitionMetrics {
@@ -294,6 +297,9 @@ struct DataPlaneInfo {
     buffered_metadata: HashSet<i32>,
     /// The number of known partitions.
     known_partitions: i32,
+    /// Information about new partitions (obtained by the metadata thread)
+    refresh_metadata_info: Arc<Mutex<Option<i32>>>,
+    /// (RT only: if true, the metadata thread has detected new partitions)
     /// Per-source metrics.
     source_metrics: SourceMetrics,
     /// Per-partition metrics.
@@ -322,14 +328,65 @@ impl DataPlaneInfo {
             source_metrics: SourceMetrics::new(&topic_name, &source_id, &worker_id.to_string()),
             partition_metrics: HashMap::new(),
             buffered_metadata: HashSet::new(),
-            topic_name,
+            topic_name: topic_name.clone(),
             source_name,
-            source_id,
+            source_id: source_id.clone(),
             partition_consumers: VecDeque::new(),
             known_partitions: 0,
             consumer: Arc::new(consumer),
             worker_id: worker_id.try_into().unwrap(),
             worker_count: worker_count.try_into().unwrap(),
+            refresh_metadata_info: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    // Metadata fetch requests on production Kafka clusters can take
+    // more than 1s to complete. This makes it far too expensive to run on
+    // the main Kafka threads. We only trigger metadata requests for Real time sources
+    fn start_metadata_fetch_thread(
+        &mut self,
+        metadata_refresh_frequency: Duration,
+        timestamping_stopped: Arc<AtomicBool>,
+    ) {
+        let consumer = self.consumer.clone();
+        let refresh = self.refresh_metadata_info.clone();
+        let id = self.source_id.clone();
+        let topic = self.topic_name.clone();
+        thread::spawn(move || {
+            metadata_fetch(
+                timestamping_stopped,
+                consumer,
+                refresh,
+                &id,
+                &topic,
+                metadata_refresh_frequency,
+            )
+        });
+    }
+    /// Update metadata information as refreshed by the metadata thread
+    fn refresh_metadata(&mut self, cp_info: &mut ControlPlaneInfo) {
+        let new_partition_count = self
+            .refresh_metadata_info
+            .lock()
+            .expect("lock poisoned")
+            .take();
+        if let Some(new_partition_count) = new_partition_count {
+            match self.known_partitions.cmp(&new_partition_count) {
+                cmp::Ordering::Greater => {
+                    error!(
+                        "Topic {} (Source ID: {}) has fewer partitions (from {} to {}). This
+                    is unexpected. Has the topic been deleted?",
+                        self.topic_name, self.source_id, self.known_partitions, new_partition_count
+                    );
+                }
+                cmp::Ordering::Less => {
+                    info!("New partitions (from {} to {}) have been detected for topic {} (Source Id: {})", self.known_partitions, new_partition_count, self.topic_name, self.source_id);
+                    // Kafka partitions are assigned contiguous ID (starting from 0). If a topic has x partitions,
+                    // the partition with max id will be x-1
+                    self.ensure_partition(cp_info, new_partition_count - 1);
+                }
+                cmp::Ordering::Equal => {}
+            }
         }
     }
 
@@ -578,20 +635,35 @@ impl DataPlaneInfo {
 
 /// Contains all necessary consistency metadata information
 struct ControlPlaneInfo {
+    /// Last closed timestamp
     last_closed_ts: u64,
+    /// Time since last capability downgrade
+    time_since_downgrade: Instant,
+    /// Frequency at which we should downgrade capability (in milliseconds)
+    downgrade_capability_frequency: u64,
     /// Per partition (a partition ID in Kafka is an i32), keep track of the last closed offset
     /// and the last closed timestamp
     partition_metadata: HashMap<i32, ConsInfo>,
     /// Optional: Materialize Offset from which source should start reading (default is 0)
     start_offset: MzOffset,
+    /// Source Type (Real-time or BYO)
+    source_type: Consistency,
 }
 
 impl ControlPlaneInfo {
-    fn new(start_offset: MzOffset) -> ControlPlaneInfo {
+    fn new(
+        start_offset: MzOffset,
+        consistency: Consistency,
+        timestamp_frequency: Duration,
+    ) -> ControlPlaneInfo {
         ControlPlaneInfo {
             last_closed_ts: 0,
+            // Safe conversion: statement.rs checks that value specified fits in u64
+            downgrade_capability_frequency: timestamp_frequency.as_millis().try_into().unwrap(),
             partition_metadata: HashMap::new(),
             start_offset,
+            source_type: consistency,
+            time_since_downgrade: Instant::now(),
         }
     }
 
@@ -614,27 +686,157 @@ impl ControlPlaneInfo {
             },
         );
     }
+
+    /// Generates a timestamp that is guaranteed to be monotonically increasing.
+    /// This may require multiple calls to the underlying now() system method, which is not
+    /// guaranteed to increase monotonically
+    fn generate_next_timestamp(&mut self) -> Option<u64> {
+        let mut new_ts = 0;
+        while new_ts <= self.last_closed_ts {
+            let start = SystemTime::now();
+            new_ts = start
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_millis() as u64;
+            if new_ts < self.last_closed_ts && self.last_closed_ts - new_ts > 1000 {
+                // If someone resets their system clock to be too far in the past, this could cause
+                // Materialize to block and not give control to other operators. We thus give up
+                // on timestamping this message
+                error!("The new timestamp is more than 1 second behind the last assigned timestamp. To\
+                avoid unnecessary blocking, Materialize will not attempt to downgrade the capability. Please\
+                consider resetting your system time.");
+                return None;
+            }
+        }
+        assert!(new_ts > self.last_closed_ts);
+        self.last_closed_ts = new_ts;
+        Some(self.last_closed_ts)
+    }
 }
 
 /// This function activates the necessary timestamping information when a source is first created
-/// These steps are only taken if a source actively reads data
-/// 1) it inserts an entry in the timestamp_history datastructure
-/// 2) it notifies the coordinator that timestamping should begin by inserting an entry in the
-/// timestamp_tx channel
-fn activate_source_timestamping<G>(config: &SourceConfig<G>, connector: KafkaSourceConnector) {
-    let prev = config
-        .timestamp_histories
-        .borrow_mut()
-        .insert(config.id.clone(), HashMap::new());
-    // Check that this is the first time this source id is registered
-    assert!(prev.is_none());
-    config.timestamp_tx.as_ref().borrow_mut().push((
-        config.id,
-        Some((
-            ExternalSourceConnector::Kafka(connector),
-            config.consistency.clone(),
-        )),
-    ));
+/// 1) for BYO sources, we notify the timestamping thread that a source has been created.
+/// 2) for a RT source, take no steps
+//
+fn activate_source_timestamping<G>(
+    config: &SourceConfig<G>,
+    connector: KafkaSourceConnector,
+) -> Option<TimestampChanges> {
+    if let Consistency::BringYourOwn(_) = config.consistency {
+        let prev = config
+            .timestamp_histories
+            .borrow_mut()
+            .insert(config.id.clone(), HashMap::new());
+        // Check that this is the first time this source id is registered
+        assert!(prev.is_none());
+        config.timestamp_tx.as_ref().borrow_mut().push((
+            config.id,
+            Some((
+                ExternalSourceConnector::Kafka(connector),
+                config.consistency.clone(),
+            )),
+        ));
+        return Some(config.timestamp_tx.clone());
+    }
+    None
+}
+
+/// This function is responsible for refreshing the number of known partitions. It marks the source
+/// has needing to be refreshed if new partitions are detected.
+fn metadata_fetch(
+    timestamping_stopped: Arc<AtomicBool>,
+    consumer: Arc<BaseConsumer<GlueConsumerContext>>,
+    partition_count: Arc<Mutex<Option<i32>>>,
+    id: &str,
+    topic: &str,
+    wait: Duration,
+) {
+    debug!(
+        "Starting realtime Kafka thread for {} (source {})",
+        &topic, id
+    );
+
+    lazy_static! {
+        static ref MAX_AVAILABLE_OFFSET: IntGaugeVec = register_int_gauge_vec!(
+            "mz_kafka_partition_offset_max",
+            "The high watermark for a partition, the maximum offset that we could hope to ingest",
+            &["topic", "source_id", "partition_id"]
+        )
+        .unwrap();
+    }
+
+    let mut partition_kafka_metadata: HashMap<i32, IntGauge> = HashMap::new();
+
+    while !timestamping_stopped.load(Ordering::SeqCst) {
+        let metadata = consumer.fetch_metadata(Some(&topic), Duration::from_secs(30));
+        let new_partition_count;
+        match metadata {
+            Ok(metadata) => {
+                if metadata.topics().len() == 0 {
+                    error!("topic {} does not exist", topic);
+                    continue;
+                } else if metadata.topics().len() > 1 {
+                    error!("topic metadata had more than one result");
+                    continue;
+                }
+                let metadata_topic = metadata.topics().into_element();
+                if metadata_topic.name() != topic {
+                    error!(
+                        "got results for wrong topic {} (expected {})",
+                        metadata_topic.name(),
+                        topic
+                    );
+                    continue;
+                }
+                new_partition_count = metadata_topic.partitions().len();
+                let mut refresh_data = partition_count.lock().expect("lock poisoned");
+
+                // Upgrade partition metrics
+                for p in 0..new_partition_count {
+                    let pid = p.try_into().unwrap();
+                    match consumer.fetch_watermarks(&topic, pid, Duration::from_secs(1)) {
+                        Ok((_, high)) => {
+                            if let Some(max_available_offset) =
+                                partition_kafka_metadata.get_mut(&pid)
+                            {
+                                max_available_offset.set(high)
+                            } else {
+                                let max_offset = MAX_AVAILABLE_OFFSET.with_label_values(&[
+                                    topic,
+                                    &id,
+                                    &pid.to_string(),
+                                ]);
+                                max_offset.set(high);
+                                partition_kafka_metadata.insert(pid, max_offset);
+                            }
+                        }
+                        Err(e) => warn!(
+                            "error loading watermarks topic={} partition={} error={}",
+                            topic, p, e
+                        ),
+                    }
+                }
+
+                // Kafka partition are i32, and Kafka consequently cannot support more than i32
+                // partitions
+                *refresh_data = Some(new_partition_count.try_into().unwrap());
+            }
+            Err(e) => {
+                new_partition_count = 0;
+                error!("Failed to obtain Kafka Metadata Information {}", e);
+            }
+        }
+
+        if new_partition_count > 0 {
+            thread::sleep(wait);
+        } else {
+            // If no partitions have been detected yet, sleep for a second rather than
+            // the specified "wait" period of time, as we know that there should at least be one
+            // partition
+            thread::sleep(Duration::from_secs(1));
+        }
+    }
+    debug!("Terminating realtime Kafka thread for {}", topic);
 }
 
 /// Creates a Kafka-based timely dataflow source operator.
@@ -656,84 +858,173 @@ where
         group_id_prefix,
     } = connector.clone();
 
-    activate_source_timestamping(&config, connector);
+    let timestamp_channel = activate_source_timestamping(&config, connector);
+    let timestamping_stopped = Arc::new(AtomicBool::new(false));
 
     let SourceConfig {
         name,
         id,
         scope,
         timestamp_histories,
-        timestamp_tx,
         worker_id,
         worker_count,
+        consistency,
+        timestamp_frequency,
         ..
     } = config;
 
-    let (stream, capability) = source(id, Some(timestamp_tx), scope, &name.clone(), move |info| {
-        // Create activator for source
-        let activator = scope.activator_for(&info.address[..]);
+    let (stream, capability) = source(
+        id,
+        timestamp_channel,
+        timestamping_stopped.clone(),
+        scope,
+        &name.clone(),
+        move |info| {
+            // Create activator for source
+            let activator = scope.activator_for(&info.address[..]);
 
-        // Create control plane information (Consistency-related information)
-        let mut cp_info = ControlPlaneInfo::new(MzOffset {
-            offset: start_offset,
-        });
+            // Create control plane information (Consistency-related information)
+            let mut cp_info = ControlPlaneInfo::new(
+                MzOffset {
+                    offset: start_offset,
+                },
+                consistency.clone(),
+                timestamp_frequency,
+            );
 
-        // Create dataplane information (Kafka-related information)
-        let mut dp_info = DataPlaneInfo::new(
-            topic.clone(),
-            name.clone(),
-            id.clone(),
-            create_kafka_config(&name, &url, group_id_prefix, &config_options),
-            Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..]))),
-            worker_id,
-            worker_count,
-        );
+            // Create dataplane information (Kafka-related information)
+            let mut dp_info = DataPlaneInfo::new(
+                topic.clone(),
+                name.clone(),
+                id.clone(),
+                create_kafka_config(&name, &url, group_id_prefix, &config_options),
+                Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..]))),
+                worker_id,
+                worker_count,
+            );
 
-        move |cap, output| {
-            let timer = Instant::now();
+            // Start metadata refresh thread
+            // Default value obtained from https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+            let metadata_refresh_frequency = Duration::from_millis(
+                config_options
+                    .get("topic.metadata.refresh.interval.ms")
+                    // Safe conversion: statement::extract_config enforces that option is a value
+                    // between 0 and 3600000
+                    .unwrap_or(&"30000".to_owned())
+                    .parse()
+                    .unwrap(),
+            );
+            dp_info.start_metadata_fetch_thread(metadata_refresh_frequency, timestamping_stopped);
 
-            dp_info.source_metrics.operator_scheduled_counter.inc();
+            move |cap, output| {
+                let timer = Instant::now();
 
-            // Accumulate updates to BYTES_READ_COUNTER;
-            let mut bytes_read = 0;
+                dp_info.source_metrics.operator_scheduled_counter.inc();
 
-            // Trigger any waiting librdkafka callbacks. This should never
-            // return any messages, because we've set things up to receive those
-            // via individual partition queues.
-            {
-                let message = dp_info.consumer.poll(Duration::from_secs(0));
-                if let Some(message) = message {
-                    match message {
-                        Ok(message) => {
-                            panic!(
+                // Accumulate updates to BYTES_READ_COUNTER;
+                let mut bytes_read = 0;
+
+                // Trigger any waiting librdkafka callbacks. This should never
+                // return any messages, because we've set things up to receive those
+                // via individual partition queues.
+                {
+                    let message = dp_info.consumer.poll(Duration::from_secs(0));
+                    if let Some(message) = message {
+                        match message {
+                            Ok(message) => {
+                                panic!(
                                 "Internal Error. Received an unexpected message Source: {} PID: {} Offset: {} on main partition loop.\
                                 Materialize will now crash.",
                                 id,
                                 message.partition(),
                                 message.offset()
                             );
+                            }
+                            Err(e) => error!("Error when polling: {}", e),
                         }
-                        Err(e) => error!("Error when polling: {}", e),
                     }
                 }
-            }
 
-            while let Some(message) = dp_info.get_next_message(&cp_info, &activator) {
-                let partition = message.partition;
-                let partition_metrics = &dp_info.partition_metrics.get(&partition).unwrap();
-                let offset = MzOffset::from(message.offset);
+                // Update any metadata changes triggered by the metadata thread
+                dp_info.refresh_metadata(&mut cp_info);
 
-                partition_metrics.offset_received.set(offset.offset);
+                while let Some(message) = dp_info.get_next_message(&cp_info, &activator) {
+                    let partition = message.partition;
+                    let offset = MzOffset::from(message.offset);
 
-                // Determine the timestamp to which we need to assign this message
-                let ts = find_matching_timestamp(&id, partition, offset, &timestamp_histories);
-                match ts {
-                    None => {
-                        // We have not yet decided on a timestamp for this message,
-                        // we need to buffer the message
-                        dp_info.buffer_message(message);
-                        activator.activate();
-                        // Downgrade capability before exiting
+                    // Update ingestion metrics
+                    // Entry is guaranteed to exist as it gets created when we initialise the partition.
+                    dp_info
+                        .partition_metrics
+                        .get_mut(&partition)
+                        .unwrap()
+                        .offset_received
+                        .set(offset.offset);
+
+                    // Determine the timestamp to which we need to assign this message
+                    let ts = find_matching_timestamp(
+                        &mut cp_info,
+                        &id,
+                        partition,
+                        offset,
+                        &timestamp_histories,
+                    );
+                    match ts {
+                        None => {
+                            // We have not yet decided on a timestamp for this message,
+                            // we need to buffer the message
+                            dp_info.buffer_message(message);
+                            downgrade_capability(
+                                &id,
+                                cap,
+                                &mut cp_info,
+                                &mut dp_info,
+                                &timestamp_histories,
+                            );
+                            activator.activate();
+                            return SourceStatus::Alive;
+                        }
+                        Some(ts) => {
+                            // Note: empty and null payload/keys are currently
+                            // treated as the same thing.
+                            let key = message.key.unwrap_or_default();
+                            let out = message.payload.unwrap_or_default();
+                            // Entry for partition_metadata is guaranteed to exist as messages
+                            // are only processed after we have updated the partition_metadata for a
+                            // partition and created a partition queue for it.
+                            cp_info
+                                .partition_metadata
+                                .get_mut(&partition)
+                                .unwrap()
+                                .offset = offset;
+                            bytes_read += key.len() as i64;
+                            bytes_read += out.len() as i64;
+                            let ts_cap = cap.delayed(&ts);
+                            output.session(&ts_cap).give(SourceOutput::new(
+                                key,
+                                out,
+                                Some(Into::<KafkaOffset>::into(offset).offset),
+                            ));
+
+                            // Update ingestion metrics
+                            // Entry is guaranteed to exist as it gets created when we initialise the partition
+                            let partition_metrics =
+                                &mut dp_info.partition_metrics.get_mut(&partition).unwrap();
+                            partition_metrics.offset_ingested.set(offset.offset);
+                            partition_metrics.messages_ingested.inc();
+                        }
+                    }
+
+                    if timer.elapsed().as_millis() > 10 {
+                        // We didn't drain the entire queue, so indicate that we
+                        // should run again. We suppress the activation when the
+                        // queue is drained, as in that case librdkafka is
+                        // configured to unpark our thread when a new message
+                        // arrives.
+                        if bytes_read > 0 {
+                            KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
+                        }
+                        // Downgrade capability (if possible) before exiting
                         downgrade_capability(
                             &id,
                             cap,
@@ -741,93 +1032,61 @@ where
                             &mut dp_info,
                             &timestamp_histories,
                         );
+                        activator.activate();
                         return SourceStatus::Alive;
                     }
-                    Some(ts) => {
-                        // Note: empty and null payload/keys are currently
-                        // treated as the same thing.
-                        let key = message.key.unwrap_or_default();
-                        let out = message.payload.unwrap_or_default();
-                        // Entry for partition_metadata is guaranteed to exist as messages
-                        // are only processed after we have updated the partition_metadata for a
-                        // partition and created a partition queue for it.
-                        cp_info
-                            .partition_metadata
-                            .get_mut(&partition)
-                            .unwrap()
-                            .offset = offset;
-                        bytes_read += key.len() as i64;
-                        bytes_read += out.len() as i64;
-                        let ts_cap = cap.delayed(&ts);
-                        output.session(&ts_cap).give(SourceOutput::new(
-                            key,
-                            out,
-                            Some(Into::<KafkaOffset>::into(offset).offset),
-                        ));
-                        partition_metrics.offset_ingested.set(offset.offset);
-                        partition_metrics.messages_ingested.inc();
-                    }
+                }
+                if bytes_read > 0 {
+                    KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
                 }
 
-                if timer.elapsed().as_millis() > 10 {
-                    // We didn't drain the entire queue, so indicate that we
-                    // should run again. We suppress the activation when the
-                    // queue is drained, as in that case librdkafka is
-                    // configured to unpark our thread when a new message
-                    // arrives.
-                    if bytes_read > 0 {
-                        KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
-                    }
-                    // Downgrade capability before exiting
-                    downgrade_capability(
-                        &id,
-                        cap,
-                        &mut cp_info,
-                        &mut dp_info,
-                        &timestamp_histories,
-                    );
-                    activator.activate();
-                    return SourceStatus::Alive;
-                }
-            }
+                // Downgrade capability (if possible) before exiting
+                downgrade_capability(&id, cap, &mut cp_info, &mut dp_info, &timestamp_histories);
 
-            if bytes_read > 0 {
-                KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
+                // Ensure that we activate the source frequently enough to keep downgrading
+                // capabilities, even when no data has arrived
+                activator.activate_after(Duration::from_millis(
+                    cp_info.downgrade_capability_frequency,
+                ));
+                SourceStatus::Alive
             }
-
-            //Downgrade capability before exiting
-            downgrade_capability(&id, cap, &mut cp_info, &mut dp_info, &timestamp_histories);
-            // Ensure that we poll kafka more often than the eviction timeout
-            activator.activate_after(Duration::from_secs(60));
-            SourceStatus::Alive
-        }
-    });
+        },
+    );
     (stream, Some(capability))
 }
 
 /// For a given offset, returns an option type returning the matching timestamp or None
-/// if no timestamp can be assigned. The timestamp history contains a sequence of
+/// if no timestamp can be assigned.
+///
+/// The timestamp history contains a sequence of
 /// (partition_count, timestamp, offset) tuples. A message with offset x will be assigned the first timestamp
 /// for which offset>=x.
 fn find_matching_timestamp(
+    cp_info: &mut ControlPlaneInfo,
     id: &SourceInstanceId,
     partition: i32,
     offset: MzOffset,
     timestamp_histories: &TimestampHistories,
 ) -> Option<Timestamp> {
-    match timestamp_histories.borrow().get(id) {
-        None => None,
-        Some(entries) => match entries.get(&PartitionId::Kafka(partition)) {
-            Some(entries) => {
-                for (_, ts, max_offset) in entries {
-                    if offset <= *max_offset {
-                        return Some(ts.clone());
-                    }
-                }
-                None
-            }
+    if let Consistency::RealTime = cp_info.source_type {
+        // Simply assign to this message the next timestamp that is not closed
+        Some(cp_info.last_closed_ts + 1)
+    } else {
+        // The source is a BYO source, we must check the TimestampHistories to obtain a
+        match timestamp_histories.borrow().get(id) {
             None => None,
-        },
+            Some(entries) => match entries.get(&PartitionId::Kafka(partition)) {
+                Some(entries) => {
+                    for (_, ts, max_offset) in entries {
+                        if offset <= *max_offset {
+                            return Some(ts.clone());
+                        }
+                    }
+                    None
+                }
+                None => None,
+            },
+        }
     }
 }
 
@@ -857,7 +1116,7 @@ fn can_close_timestamp(
     // We separate these two cases, as consumer.position() is an expensive call that should
     // be avoided if possible. Case 1 and 2.a occur first, and we only test 2.b when necessary
     if !dp_info.has_partition(pid) // Case 1
-    || last_offset >= offset
+        || last_offset >= offset
     // Case 2.a
     {
         true
@@ -909,82 +1168,96 @@ fn downgrade_capability(
 ) {
     let mut changed = false;
 
-    // Determine which timestamps have been closed. A timestamp is closed once we have processed
-    // all messages that we are going to process for this timestamp across all partitions
-    // In practice, the following happens:
-    // Per partition, we iterate over the data structure to remove (ts,offset) mappings for which
-    // we have seen all records <= offset. We keep track of the last "closed" timestamp in that partition
-    // in next_partition_ts
-    if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
-        // Iterate over each partition that we know about
-        for (pid, entries) in entries {
-            let pid = match pid {
-                PartitionId::Kafka(pid) => *pid,
-                _ => unreachable!(
-                    "timestamp.rs should never send messages with non-Kafka partitions \
+    if let Consistency::BringYourOwn(_) = cp_info.source_type {
+        // Determine which timestamps have been closed. A timestamp is closed once we have processed
+        // all messages that we are going to process for this timestamp across all partitions
+        // In practice, the following happens:
+        // Per partition, we iterate over the data structure to remove (ts,offset) mappings for which
+        // we have seen all records <= offset. We keep track of the last "closed" timestamp in that partition
+        // in next_partition_ts
+        if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
+            // Iterate over each partition that we know about
+            for (pid, entries) in entries {
+                let pid = match pid {
+                    PartitionId::Kafka(pid) => *pid,
+                    _ => unreachable!(
+                        "timestamp.rs should never send messages with non-Kafka partitions \
                                    to Kafka sources."
-                ),
-            };
+                    ),
+                };
 
-            dp_info.ensure_partition(cp_info, pid);
+                dp_info.ensure_partition(cp_info, pid);
 
-            // Check whether timestamps can be closed on this partition
-            while let Some((partition_count, ts, offset)) = entries.front() {
-                assert!(
+                // Check whether timestamps can be closed on this partition
+                while let Some((partition_count, ts, offset)) = entries.front() {
+                    assert!(
                         *offset >= cp_info.start_offset,
                         "Internal error! Timestamping offset went below start: {} < {}. Materialize will now crash.",
                         offset, cp_info.start_offset
                     );
 
-                assert!(
-                    *ts > 0,
-                    "Internal error! Received a zero-timestamp. Materialize will crash now."
-                );
+                    assert!(
+                        *ts > 0,
+                        "Internal error! Received a zero-timestamp. Materialize will crash now."
+                    );
 
-                // This timestamp update was done with the expectation that there were more partitions
-                // than we know about. Partition IDs are assigned contiguously
-                // starting from zero, so seeing a `partition_count` of N means
-                // that we should have partitions up to N-1.
-                dp_info.ensure_partition(cp_info, partition_count - 1);
+                    // This timestamp update was done with the expectation that there were more partitions
+                    // than we know about. Partition IDs are assigned contiguously
+                    // starting from zero, so seeing a `partition_count` of N means
+                    // that we should have partitions up to N-1.
+                    dp_info.ensure_partition(cp_info, partition_count - 1);
 
-                if let Some(pmetrics) = dp_info.partition_metrics.get_mut(&pid) {
-                    pmetrics
-                        .closed_ts
-                        .set(cp_info.partition_metadata.get(&pid).unwrap().ts);
-                }
+                    if let Some(pmetrics) = dp_info.partition_metrics.get_mut(&pid) {
+                        pmetrics
+                            .closed_ts
+                            .set(cp_info.partition_metadata.get(&pid).unwrap().ts);
+                    }
 
-                if can_close_timestamp(cp_info, dp_info, pid, *offset) {
-                    // We have either 1) seen all messages corresponding to this timestamp for this
-                    // partition 2) do not own this partition 3) the consumer has forwarded past the
-                    // timestamped offset. Either way, we have the guarantee tha we will never see a message with a < timestamp
-                    // again
-                    // We can close the timestamp (on this partition) and remove the associated metadata
-                    cp_info.partition_metadata.get_mut(&pid).unwrap().ts = *ts;
-                    entries.pop_front();
-                    changed = true;
-                } else {
-                    // Offset isn't at a timestamp boundary, we take no action
-                    break;
+                    if can_close_timestamp(cp_info, dp_info, pid, *offset) {
+                        // We have either 1) seen all messages corresponding to this timestamp for this
+                        // partition 2) do not own this partition 3) the consumer has forwarded past the
+                        // timestamped offset. Either way, we have the guarantee tha we will never see a message with a < timestamp
+                        // again
+                        // We can close the timestamp (on this partition) and remove the associated metadata
+                        cp_info.partition_metadata.get_mut(&pid).unwrap().ts = *ts;
+                        entries.pop_front();
+                        changed = true;
+                    } else {
+                        // Offset isn't at a timestamp boundary, we take no action
+                        break;
+                    }
                 }
             }
         }
-    }
 
-    //  Next, we determine the maximum timestamp that is fully closed. This corresponds to the minimum
-    //  timestamp
-    // across partitions.
-    let min = cp_info
-        .partition_metadata
-        .iter()
-        .map(|(_, cons_info)| cons_info.ts)
-        .min()
-        .unwrap_or(0);
+        //  Next, we determine the maximum timestamp that is fully closed. This corresponds to the minimum
+        //  timestamp across partitions.
+        let min = cp_info
+            .partition_metadata
+            .iter()
+            .map(|(_, cons_info)| cons_info.ts)
+            .min()
+            .unwrap_or(0);
 
-    // Downgrade capability to new minimum open timestamp (which corresponds to min + 1).
-    if changed && min > 0 {
-        dp_info.source_metrics.capability.set(min);
-        cap.downgrade(&(&min + 1));
-        cp_info.last_closed_ts = min;
+        // Downgrade capability to new minimum open timestamp (which corresponds to min + 1).
+        if changed && min > 0 {
+            dp_info.source_metrics.capability.set(min);
+            cap.downgrade(&(&min + 1));
+            cp_info.last_closed_ts = min;
+        }
+    } else {
+        // This a RT source. It is always possible to close the timestamp and downgrade the
+        // capability
+        if cp_info.time_since_downgrade.elapsed().as_millis()
+            > cp_info.downgrade_capability_frequency.try_into().unwrap()
+        {
+            let ts = cp_info.generate_next_timestamp();
+            if let Some(ts) = ts {
+                dp_info.source_metrics.capability.set(ts);
+                cap.downgrade(&(&ts + 1));
+            }
+            cp_info.time_since_downgrade = Instant::now();
+        }
     }
 }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.9"
 lazy_static = "1.4.0"
 log = "0.4.8"
 ore = { path = "../ore" }
+parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.3.9"

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -141,6 +141,12 @@ pub fn extract_config(
             // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
             ValType::Number(0, 86_400_000),
         ),
+        Config::new(
+            "topic_metadata_refresh_interval_ms",
+            // The range of values comes from `topic.metadata.refresh.interval.ms` in
+            // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+            ValType::Number(0, 3_600_000),
+        ),
     ];
 
     agg.extract(&allowed_configs)?;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -10,7 +10,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::path::PathBuf;
-use std::time::UNIX_EPOCH;
+use std::time::{Duration, UNIX_EPOCH};
 
 use aws_arn::{Resource, ARN};
 use failure::{bail, format_err};
@@ -912,6 +912,19 @@ fn extract_batch_size_option(
     }
 }
 
+fn extract_timestamp_frequency_option(
+    with_options: &mut HashMap<String, Value>,
+) -> Result<Duration, failure::Error> {
+    match with_options.remove("timestamp_frequency_ms") {
+        None => Ok(Duration::from_secs(1)),
+        Some(Value::Number(n)) => match n.parse::<u64>() {
+            Ok(n) => Ok(Duration::from_millis(n)),
+            _ => bail!("timestamp_frequency_ms must be an u64"),
+        },
+        Some(_) => bail!("timestamp_frequency_ms must be an u64"),
+    }
+}
+
 fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan, failure::Error> {
     match &stmt {
         Statement::CreateSource {
@@ -1027,6 +1040,8 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
 
             let mut consistency = Consistency::RealTime;
             let mut max_ts_batch = 0;
+            let mut ts_frequency = Duration::from_secs(1);
+
             let (external_connector, mut encoding) = match connector {
                 Connector::Kafka { broker, topic, .. } => {
                     let config_options = kafka_util::extract_config(&mut with_options)?;
@@ -1044,6 +1059,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     };
 
                     max_ts_batch = extract_batch_size_option(&mut with_options)?;
+                    ts_frequency = extract_timestamp_frequency_option(&mut with_options)?;
 
                     // THIS IS EXPERIMENTAL - DO NOT DOCUMENT IT
                     // until we have had time to think about what the right UX/design is on a non-urgent timeline!
@@ -1154,6 +1170,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         Some(_) => bail!("consistency must be a string"),
                     };
                     max_ts_batch = extract_batch_size_option(&mut with_options)?;
+                    ts_frequency = extract_timestamp_frequency_option(&mut with_options)?;
 
                     let connector = ExternalSourceConnector::File(FileSourceConnector {
                         path: path.clone().into(),
@@ -1175,6 +1192,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     };
 
                     max_ts_batch = extract_batch_size_option(&mut with_options)?;
+                    ts_frequency = extract_timestamp_frequency_option(&mut with_options)?;
 
                     let connector = ExternalSourceConnector::AvroOcf(FileSourceConnector {
                         path: path.clone().into(),
@@ -1306,6 +1324,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     envelope,
                     consistency,
                     max_ts_batch,
+                    ts_frequency,
                 },
                 desc,
             };

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -7,6 +7,34 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set consistency={
+     "name": "materialize.byo.consistency",
+     "type": "record",
+     "fields": [
+         {
+           "name": "source",
+           "type": "string"
+         },
+         {
+           "name": "partition_count",
+           "type": "int"
+         },
+         {
+           "name": "partition_id",
+           "type": ["int","string"]
+         },
+         {
+            "name": "timestamp",
+            "type": "long"
+         },
+         {
+           "name": "offset",
+           "type": "long"
+         }
+     ]
+  }
+
+
 $ set names-schema={
     "type": "record",
     "name": "envelope",
@@ -29,7 +57,13 @@ $ set names-schema={
     ]
   }
 
+$ kafka-create-topic topic=data-consistency
+
 $ kafka-create-topic topic=names
+
+$ kafka-ingest format=avro topic=data-consistency schema=${consistency}
+{"source": "names", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 3}
+
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
 {"before": null, "after": {"num": 1, "name": "one"}}
@@ -38,6 +72,7 @@ $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE names
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
+  with (consistency='data-consistency')
   FORMAT AVRO USING SCHEMA '${names-schema}'
   ENVELOPE DEBEZIUM
 

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -73,6 +73,7 @@ $ kafka-ingest partition=1 format=avro topic=data schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data_rt
     FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+    WITH (topic_metadata_refresh_interval_ms=50)
     FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo GROUP BY b


### PR DESCRIPTION
This PR removes the need for Kafka metadata requests for Real-time consistency.

A separate metadata thread runs for each Kafka source and periodically checks whether new partitions have been added. This thread is the only thread that makes a metadata request. The frequency at which new partitions are checked is controlled via the with `with (topic_metadata_refresh_interval_ms='10')` parameter.

Each new message is assigned a timestamp based on the local system time. The frequency at which timestamps should be downgraded is specified in a with parameter `with (timestamp_frequency_ms='10')`

This PR does not yet remove the code path associated with real-time timestamping as other sources (files, OCF sources) have not yet been modified to remove reliance on the timestamped.

This PR does not yet do any "smart" management of capabilities and capabilities are currently downgraded every time a message is timestamped. We should return to a model in which capabilities are downgraded for groups of messages

This PR modifies the source activation logic to be triggered every `timestamp_frequency_ms`. This is necessary to ensure that capabilities are downgraded frequently even when no data is ingested (previously, the timestamper thread would trigger activation).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3329)
<!-- Reviewable:end -->
