### PR TITLE
Debezium deduplication strategies: "ordered" or "full"

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -774,7 +774,7 @@ fn is_ts_valid(
 /// using the BYO_CONSISTENCY_SCHEMA Avro spec outlined above.
 ///
 fn identify_consistency_format(enc: DataEncoding, env: Envelope) -> ConsistencyFormatting {
-    if let Envelope::Debezium = env {
+    if let Envelope::Debezium(_) = env {
         if let DataEncoding::AvroOcf { reader_schema: _ } = enc {
             ConsistencyFormatting::DebeziumOcf
         } else {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 use url::Url;
 
 use expr::{GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInstanceId};
-use interchange::avro;
+use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use regex::Regex;
 use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType};
@@ -427,7 +427,7 @@ pub struct SinkDesc {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Envelope {
     None,
-    Debezium,
+    Debezium(DebeziumDeduplicationStrategy),
     Upsert(DataEncoding),
 }
 
@@ -435,7 +435,7 @@ impl Envelope {
     pub fn get_avro_envelope_type(&self) -> avro::EnvelopeType {
         match self {
             Envelope::None => avro::EnvelopeType::None,
-            Envelope::Debezium => avro::EnvelopeType::Debezium,
+            Envelope::Debezium { .. } => avro::EnvelopeType::Debezium,
             Envelope::Upsert(_) => avro::EnvelopeType::Upsert,
         }
     }

--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -11,7 +11,7 @@ use log::error;
 
 use async_trait::async_trait;
 use dataflow_types::{Diff, Timestamp};
-use interchange::avro::{Decoder, EnvelopeType};
+use interchange::avro::{DebeziumDeduplicationStrategy, Decoder, EnvelopeType};
 use repr::Row;
 
 use super::{DecoderState, PushSession};
@@ -32,6 +32,7 @@ impl AvroDecoderState {
         reject_non_inserts: bool,
         debug_name: String,
         worker_index: usize,
+        dedup_strat: Option<DebeziumDeduplicationStrategy>,
     ) -> Result<Self, failure::Error> {
         Ok(AvroDecoderState {
             decoder: Decoder::new(
@@ -40,6 +41,7 @@ impl AvroDecoderState {
                 envelope,
                 debug_name,
                 worker_index,
+                dedup_strat,
             )?,
             events_success: 0,
             events_error: 0,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -434,7 +434,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
 
                         let mut collection = match envelope {
                             Envelope::None => stream.as_collection(),
-                            Envelope::Debezium => {
+                            Envelope::Debezium(_) => {
                                 // TODO(btv) -- this should just be a RelationExpr::Explode (name TBD)
                                 stream.as_collection().explode({
                                     let mut row_packer = repr::RowPacker::new();

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -13,7 +13,7 @@ use chrono::{Duration, NaiveDate};
 use criterion::{black_box, Criterion, Throughput};
 use futures::executor::block_on;
 
-use interchange::avro::{parse_schema, Decoder, EnvelopeType};
+use interchange::avro::{parse_schema, DebeziumDeduplicationStrategy, Decoder, EnvelopeType};
 use std::ops::Add;
 
 pub fn bench_avro(c: &mut Criterion) {
@@ -300,6 +300,7 @@ pub fn bench_avro(c: &mut Criterion) {
         EnvelopeType::Debezium,
         "avro_bench".to_string(),
         0,
+        Some(DebeziumDeduplicationStrategy::Ordered),
     )
     .unwrap();
 

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -480,7 +480,7 @@ impl DebeziumDeduplicationState {
                 match binlog_offsets.entry(file.to_owned()) {
                     Entry::Occupied(mut oe) => {
                         let (old_max_pos, old_max_row, old_offset) = *oe.get();
-                        if old_max_pos > pos || (old_max_pos == pos && old_max_row >= row) {
+                        if (old_max_pos, old_max_row) >= (pos, row) {
                             let offset_string = if let Some(coord) = coord {
                                 format!(" at offset {}", coord)
                             } else {

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt;
 use std::iter;
@@ -18,6 +18,7 @@ use chrono::Timelike;
 use failure::{bail, format_err};
 use itertools::Itertools;
 use log::{trace, warn};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::Sha256;
 
@@ -435,6 +436,94 @@ impl BinlogSchemaIndices {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum DebeziumDeduplicationStrategy {
+    Ordered,
+    Full,
+}
+
+#[derive(Debug)]
+enum DebeziumDeduplicationState {
+    Ordered {
+        /// Last recorded (pos, row, offset) for each MySQL binlog file.
+        /// Messages that are not ahead of the last recorded pos/row will be skipped.
+        binlog_offsets: HashMap<String, (usize, usize, Option<i64>)>,
+    },
+    Full {
+        seen_offsets: HashMap<String, HashSet<(usize, usize)>>,
+    },
+}
+
+impl DebeziumDeduplicationState {
+    fn new(strat: DebeziumDeduplicationStrategy) -> Self {
+        match strat {
+            DebeziumDeduplicationStrategy::Ordered => DebeziumDeduplicationState::Ordered {
+                binlog_offsets: Default::default(),
+            },
+            DebeziumDeduplicationStrategy::Full => DebeziumDeduplicationState::Full {
+                seen_offsets: Default::default(),
+            },
+        }
+    }
+    #[must_use]
+    fn should_use_record(
+        &mut self,
+        file: &str,
+        pos: usize,
+        row: usize,
+        coord: Option<i64>,
+        debug_name: &str,
+        worker_idx: usize,
+    ) -> bool {
+        match self {
+            DebeziumDeduplicationState::Ordered { binlog_offsets } => {
+                match binlog_offsets.entry(file.to_owned()) {
+                    Entry::Occupied(mut oe) => {
+                        let (old_max_pos, old_max_row, old_offset) = *oe.get();
+                        if old_max_pos > pos || (old_max_pos == pos && old_max_row >= row) {
+                            let offset_string = if let Some(coord) = coord {
+                                format!(" at offset {}", coord)
+                            } else {
+                                format!("")
+                            };
+                            let old_offset_string = if let Some(old_offset) = old_offset {
+                                format!(" at offset {}", old_offset)
+                            } else {
+                                format!("")
+                            };
+                            warn!("Debezium for source {}:{} did not advance in binlog file {}: previously read ({}, {}){}, now read ({}, {}){}. Skipping record.",
+                                    debug_name, worker_idx, file, old_max_pos, old_max_row, old_offset_string, pos, row, offset_string);
+                            return false;
+                        }
+                        oe.insert((pos, row, coord));
+                    }
+                    Entry::Vacant(ve) => {
+                        ve.insert((pos, row, coord));
+                    }
+                }
+                true
+            }
+
+            DebeziumDeduplicationState::Full { seen_offsets } => {
+                if let Some(seen_offsets) = seen_offsets.get_mut(file) {
+                    if seen_offsets.insert((pos, row)) {
+                        true
+                    } else {
+                        warn!("Source {}:{} already ingested binlog coordinates ({}, {}) in file {}. Skipping record.",
+                              debug_name, worker_idx, pos, row, file);
+                        false
+                    }
+                } else {
+                    let mut hs = HashSet::new();
+                    hs.insert((pos, row));
+                    seen_offsets.insert(file.to_owned(), hs);
+                    true
+                }
+            }
+        }
+    }
+}
+
 /// Additional context needed for decoding
 /// Debezium-formatted data.
 #[derive(Debug)]
@@ -443,12 +532,7 @@ pub struct DebeziumDecodeState {
     before_idx: usize,
     /// Index of the "after" field in the payload schema
     after_idx: usize,
-    // TODO - this is not a complete fix for #3026.
-    // In particular, it doesn't help us with non-MySQL connectors,
-    // nor with the initial scan.
-    /// Last recorded (pos, row, offset) for each MySQL binlog file.
-    /// Messages that are not ahead of the last recorded pos/row will be skipped.
-    binlog_offsets: HashMap<String, (usize, usize, Option<i64>)>,
+    dedup: DebeziumDeduplicationState,
     binlog_schema_indices: Option<BinlogSchemaIndices>,
     /// Human-readable name used for printing debug information
     debug_name: String,
@@ -493,7 +577,12 @@ fn take_field_by_index(
 }
 
 impl DebeziumDecodeState {
-    pub fn new(schema: &Schema, debug_name: String, worker_idx: usize) -> Option<Self> {
+    pub fn new(
+        schema: &Schema,
+        debug_name: String,
+        worker_idx: usize,
+        dedup_strat: DebeziumDeduplicationStrategy,
+    ) -> Option<Self> {
         let top_node = schema.top_node();
         let top_indices = field_indices(top_node)?;
         let before_idx = *top_indices.get("before")?;
@@ -503,7 +592,7 @@ impl DebeziumDecodeState {
         Some(Self {
             before_idx,
             after_idx,
-            binlog_offsets: Default::default(),
+            dedup: DebeziumDeduplicationState::new(dedup_strat),
             binlog_schema_indices,
             debug_name,
             worker_idx,
@@ -569,32 +658,18 @@ impl DebeziumDecodeState {
                         .ok_or_else(|| format_err!("\"row\" is not an integer"))?;
                         let pos = usize::try_from(pos_val)?;
                         let row = usize::try_from(row_val)?;
-                        match self.binlog_offsets.entry(file_val.clone()) {
-                            Entry::Occupied(mut oe) => {
-                                let (old_max_pos, old_max_row, old_offset) = *oe.get();
-                                if old_max_pos > pos || (old_max_pos == pos && old_max_row >= row) {
-                                    let offset_string = if let Some(coord) = coord {
-                                        format!(" at offset {}", coord)
-                                    } else {
-                                        format!("")
-                                    };
-                                    let old_offset_string = if let Some(old_offset) = old_offset {
-                                        format!(" at offset {}", old_offset)
-                                    } else {
-                                        format!("")
-                                    };
-                                    warn!("Debezium for source {}:{} did not advance in binlog file {}: previously read ({}, {}){}, now read ({}, {}){}. Skipping record.",
-                                          self.debug_name, self.worker_idx, file_val, old_max_pos, old_max_row, old_offset_string, pos, row, offset_string);
-                                    return Ok(DiffPair {
-                                        before: None,
-                                        after: None,
-                                    });
-                                }
-                                oe.insert((pos, row, coord));
-                            }
-                            Entry::Vacant(ve) => {
-                                ve.insert((pos, row, coord));
-                            }
+                        if !self.dedup.should_use_record(
+                            &file_val,
+                            pos,
+                            row,
+                            coord,
+                            &self.debug_name,
+                            self.worker_idx,
+                        ) {
+                            return Ok(DiffPair {
+                                before: None,
+                                after: None,
+                            });
                         }
                     }
                 }
@@ -652,7 +727,12 @@ impl Decoder {
         envelope: EnvelopeType,
         debug_name: String,
         worker_index: usize,
+        dedup_strat: Option<DebeziumDeduplicationStrategy>,
     ) -> Result<Decoder> {
+        assert!(
+            (envelope == EnvelopeType::Debezium && dedup_strat.is_some())
+                || (envelope != EnvelopeType::Debezium && dedup_strat.is_none())
+        );
         // It is assumed that the reader schema has already been verified
         // to be a valid Avro schema.
         let reader_schema = parse_schema(reader_schema).unwrap();
@@ -661,8 +741,13 @@ impl Decoder {
 
         let debezium = if envelope == EnvelopeType::Debezium {
             Some(
-                DebeziumDecodeState::new(&reader_schema, debug_name.clone(), worker_index)
-                    .ok_or_else(|| format_err!("Failed to extract Debezium schema information!"))?,
+                DebeziumDecodeState::new(
+                    &reader_schema,
+                    debug_name.clone(),
+                    worker_index,
+                    dedup_strat.unwrap(), /* is_some already asserted */
+                )
+                .ok_or_else(|| format_err!("Failed to extract Debezium schema information!"))?,
             )
         } else {
             None

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -278,3 +278,46 @@ a b
 14 6
 2 3
 -1 7
+
+# Test that deduplication=ordered does the same thing as the default.
+
+> CREATE MATERIALIZED SOURCE new_dbz2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-new-dbz-data-${testdrive.seed}'
+  WITH (deduplication = 'ordered')
+  FORMAT AVRO USING SCHEMA '${new-dbz-schema}'
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM new_dbz2
+a b
+---
+9 10
+11 11
+14 6
+2 3
+-1 7
+
+# Test that deduplication=full accepts mis-ordered Debezium data.
+
+$ kafka-create-topic topic=misordered-dbz-data
+
+$ kafka-ingest format=avro topic=misordered-dbz-data schema=${new-dbz-schema} timestamp=1
+{"before": null, "after": {"a": 1, "b": 1}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": "false"}}
+{"before": null, "after": {"a": 2, "b": 3}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": "false"}}
+{"before": null, "after": {"a": -1, "b": 7}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": "false"}}
+{"before": null, "after": {"a": 2, "b": 3}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": "false"}}
+{"before": null, "after": {"a": 1, "b": 1}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": "false"}}
+{"before": null, "after": {"a": 3, "b": 4}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": "false"}}
+
+> CREATE MATERIALIZED SOURCE misordered_dbz
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-data-${testdrive.seed}'
+  WITH (deduplication = 'full')
+  FORMAT AVRO USING SCHEMA '${new-dbz-schema}'
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM misordered_dbz
+a b
+---
+1 1
+2 3
+-1 7
+3 4


### PR DESCRIPTION
"Ordered" is the previous default: each worker keeps a map of highest-seen coordinates (position and row) for each binlog file, and rejects rows with any lower coordinates.

"Full" requires more memory, but is necessary for users whose data does not follow the ordering constraint implied by "ordered". Each worker holds a map of all coordinates seen for all binlogs, and rejects any duplicate rows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3332)
<!-- Reviewable:end -->
