### PR TITLE
Remove interactivity from mzbuild docker run

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -486,7 +486,7 @@ class ResolvedImage:
         Creates a container from the image and runs the command described by
         `args` in the image.
         """
-        spawn.runv(["docker", "run", "-it", "--rm", "--init", self.spec(), *args])
+        spawn.runv(["docker", "run", "--tty", "--rm", "--init", self.spec(), *args])
 
     def list_dependencies(self, transitive: bool = False) -> Set[str]:
         out = set()


### PR DESCRIPTION
* `--interactive` requires that the _input_ is a tty, which is not something that we want
  to support when just building docker images. This actively breaks mzcompose when it is
  called as a subprocess from mzconduct and it needs to run a docker container, in some
  situations.

* `--tty` means that output that processes see will seem to a tty, which often puts them
  in a different UI mode.

  I'm leaving this in because it doesn't seem to be hurting right now, and it probably
  makes running things locally a bit nicer. We should consider only applying this when
  the mzbuild output device itself is a tty, but that seems like hard work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3333)
<!-- Reviewable:end -->
