### PR TITLE
Update ChaosDockerWorkflowStep to run as long as another service

### DIFF
--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -121,7 +121,7 @@ mzconduct:
             --message-count 10000
         - step: chaos-pause-docker
           service: kafka
-          loop: true
+          other_service: chaos_run
           running_time: 60
           paused_time: 30
 
@@ -148,7 +148,7 @@ mzconduct:
             --message-count 10000
         - step: chaos-stop-docker
           service: kafka
-          loop: true
+          other_service: chaos_run
           running_time: 60
           stopped_time: 30
 

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -91,7 +91,7 @@ mzconduct:
             --materialized-port 6875
             --kafka-url kafka:9092
             --kafka-partitions 5
-            --message-count 10000
+            --message-count 1000000
         - step: chaos-confirm
           service: materialized
           running: true
@@ -122,8 +122,6 @@ mzconduct:
         - step: chaos-pause-docker
           service: kafka
           other_service: chaos_run
-          running_time: 60
-          paused_time: 30
 
     # This test is designed to stop and start the running Kafka broker
     # (chaos-kill-container sends a SIGTERM, then SIGKILL signal to the
@@ -145,12 +143,10 @@ mzconduct:
             --materialized-port 6875
             --kafka-url kafka:9092
             --kafka-partitions 5
-            --message-count 10000
+            --message-count 1000000
         - step: chaos-stop-docker
           service: kafka
           other_service: chaos_run
-          running_time: 60
-          stopped_time: 30
 
     # This test is designed to kill the running Kafka broker
     # (chaos-kill-container sends a SIGKILL signal to the container).
@@ -171,7 +167,7 @@ mzconduct:
             --materialized-port 6875
             --kafka-url kafka:9092
             --kafka-partitions 5
-            --message-count 10000
+            --message-count 1000000
         - step: chaos-kill-docker
           service: kafka
         - step: chaos-confirm


### PR DESCRIPTION
In order to let chaos tests be run (and verified) automatically, each step must complete. This PR updates `ChaosDockerWorkflowStep` to complete by running for either:
- a specified duration
- as long as another named service

In particular, it's useful to run as long as another service in the situation where we want to run a chaos step as long as the chaos container is running -- this is the `mzcompose.yml` change.

I tested this change locally by running both the `pause-kafka` and `stop-kafka` chaos workflows and ensuring that the chaos steps completed once the chaos container had exited.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3334)
<!-- Reviewable:end -->
