### PR TITLE
sq: proper pseudo-type handling in func selection

### DIFF
--- a/src/sql/src/plan/cast.rs
+++ b/src/sql/src/plan/cast.rs
@@ -142,7 +142,6 @@ lazy_static! {
 
         casts! {
             // BOOL
-            (Bool, Implicit(String)) => CastBoolToStringImplicit,
             (Bool, Explicit(String)) => CastBoolToStringExplicit,
             (Bool, Explicit(Jsonb)) => CastJsonbOrNullToJsonb,
             (Bool, JsonbAny) => CastJsonbOrNullToJsonb,


### PR DESCRIPTION
Refactors `ArgImplementationMatcher` to support `TextConcat` and hopefully other functions in the future.

There were two problems here that we only discovered when trying to implement a function with implementations we found ambiguous:
- **Problem**: We assumed pseudotypes were equal to the concrete type with which they're associated. This prevented us from understanding which implementation should be preferred when chosing between a concrete type implementation and a pseudotype implementation.

  For example, if we had a `String` argument, it gave equal weight to both `ParameterType::Plain(String)` and `ParamaeterType::StringAny` parameters w/r/t preferred types.

  **Fix**: Proper pseudotype support. Pseudotypes are not equal to any type, and are not the preferred parameter type of any concrete type.

  In the code itself this is decoupling `ParameterType` and `ScalarType` equality from the notion of whether or not a `ParameterType` accepts a `ScalarType`.

- When _not_ selecting a `FuncImpl`,  we removed their surrogate `Candidate` but left the `FuncImpl` itself in the `ArgImplementationMatcher`. When determining a final implementation to use, we validated this choice by ensuring its parameters matched a single implementation from among all implementations. This doesn't work when multiple implementations accept the same resolved types, as is the case with `TextConcat`.

  **Fix**: Remove `FuncImpl`s when they don't match. In the code itself, this is done by moving the `FuncImpl` into the `Candidate`, which gets dropped when it's not selected.

  We also no longer need to perform the validation of our returned `FuncImpl`, which would be tautological––the `arg_types` we infer for the candidate were derived to work with the `FuncImpl`'s `ParamList`, so they will always match.

  Note that this also means we no longer need to keep the resolved `arg_types` at all, but that requires some refactoring of the way we work with `TypeCategory`, and I wanted to minimize the size of this already-pretty-knotted diff.

And as a bonus, I had to resurrect `CastContext` to control the behavior of casting between bools and strings. It turns out that there is not, in fact, an implicit cast allowed from bools to strings, so we could no longer use that as a lever to trigger one or the other. Instead, I've added a very ugly switch that returns the desired function based on the `CastContext`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3340)
<!-- Reviewable:end -->
