### PR TITLE
walkabout: remove ir::analyze from public API

### DIFF
--- a/src/walkabout/src/ir.rs
+++ b/src/walkabout/src/ir.rs
@@ -92,9 +92,7 @@ pub enum Type {
 /// This is a very, very lightweight semantic analysis phase for Rust code. Our
 /// main goal is to determine the type of each field of a struct or enum
 /// variant, so we know how to visit it. See [`Type`] for details.
-///
-/// Types whose names are listed in `ignored_types` are not included in the IR.
-pub fn analyze(items: &[syn::DeriveInput]) -> Result<Ir> {
+pub(crate) fn analyze(items: &[syn::DeriveInput]) -> Result<Ir> {
     let ir = items
         .iter()
         .map(|item| {


### PR DESCRIPTION
This was meant to be crate internal. It is called automatically by
ir::load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3343)
<!-- Reviewable:end -->
