### PR TITLE
deps: bump to stable version of postgres crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,8 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.17.2"
-source = "git+https://github.com/sfackler/rust-postgres.git#e3d3c6d5cdfc23509e81c6bf65130fb42fa87a09"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e48317fe57088aa1ff4a84a88a8401aee565f4ae5c201aa18d11c573ce350"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2355,7 +2356,8 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.5.1"
-source = "git+https://github.com/sfackler/rust-postgres.git#e3d3c6d5cdfc23509e81c6bf65130fb42fa87a09"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f611afe4d1407ebe7f3ced1ffc66f730fac1b1c13085e230a8cdcb921e97710"
 dependencies = [
  "base64 0.12.1",
  "byteorder",
@@ -2372,7 +2374,8 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.1.1"
-source = "git+https://github.com/sfackler/rust-postgres.git#e3d3c6d5cdfc23509e81c6bf65130fb42fa87a09"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e634590e8812c500088d88db721195979223dabb05149f43cb50931d0ff5865d"
 dependencies = [
  "bytes",
  "chrono",
@@ -3780,8 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.5.3"
-source = "git+https://github.com/sfackler/rust-postgres.git#e3d3c6d5cdfc23509e81c6bf65130fb42fa87a09"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56010a704311361b7c9e870aaa4ddffaf9f2db89cbcf3e14773ac8a14469c9c"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,3 @@ members = [
 # it's unlikely we're going to get interactive access to a debugger in
 # production installations, but we still want useful crash reports.
 debug = 1
-
-[patch.crates-io]
-# Waiting on a release with this commit:
-# https://github.com/sfackler/rust-postgres/commit/dd0c39e0414e30e98271836b99ef289d04b7d569
-postgres = { git = "https://github.com/sfackler/rust-postgres.git" }
-postgres-types = { git = "https://github.com/sfackler/rust-postgres.git" }
-tokio-postgres = { git = "https://github.com/sfackler/rust-postgres.git" }

--- a/deny.toml
+++ b/deny.toml
@@ -39,5 +39,4 @@ allow-git = [
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",
-    "https://github.com/sfackler/rust-postgres.git",
 ]

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -14,7 +14,7 @@ hyper = "0.13"
 lazy_static = "1.4"
 log = "0.4.8"
 ore = { path = "../ore" }
-postgres = "0.17"
+postgres = "0.17.3"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false, features = ["process"] }
 regex = "1.3.9"
 serde = { version = "1.0.111", features = ["derive"] }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -29,4 +29,4 @@ sql = { path = "../sql" }
 tokio = "0.2"
 tokio-openssl = "0.4.0"
 tokio-util = { version = "0.3", features = ["codec"] }
-postgres = "0.17.2"
+postgres = "0.17.3"

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4.8"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 tokio = "0.2"
-tokio-postgres = { version = "0.5.2", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.5.4", features = ["with-chrono-0_4", "with-serde_json-1"] }
 repr = { path = "../repr" }
 serde_json = "1.0"
 sql = { path = "../sql" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -26,7 +26,7 @@ md-5 = "0.8"
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }
-tokio-postgres = { version = "0.5.3", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.5.4", features = ["with-chrono-0_4", "with-serde_json-1"] }
 protobuf = "2.8"
 protoc = "2.8.0"
 rand = "0.7.3"

--- a/test/correctness/Cargo.toml
+++ b/test/correctness/Cargo.toml
@@ -26,5 +26,5 @@ prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", de
 regex = "1.3.7"
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version = "0.2.19", features = ["rt-threaded"] }
-tokio-postgres = "0.5.2"
+tokio-postgres = "0.5.4"
 toml = "0.5.6"

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -12,4 +12,4 @@ itertools = "0.9"
 log = "0.4.8"
 ore = { path = "../../../src/ore" }
 tokio = "0.2"
-tokio-postgres = "0.5.2"
+tokio-postgres = "0.5.4"

--- a/test/performance/perf-kinesis/Cargo.toml
+++ b/test/performance/perf-kinesis/Cargo.toml
@@ -22,5 +22,5 @@ rusoto_kinesis = "0.44.0"
 structopt = "0.3.11"
 thiserror = "1.0.19"
 tokio = { version = "0.2.21", features = ["full"] }
-tokio-postgres = "0.5.1"
+tokio-postgres = "0.5.4"
 test-util = { path = "../../test-util" }

--- a/test/smith/Cargo.toml
+++ b/test/smith/Cargo.toml
@@ -17,6 +17,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.53"
 structopt = "0.3.14"
 tokio = { version = "0.2.21", features = ["full"] }
-tokio-postgres = "0.5.2"
+tokio-postgres = "0.5.4"
 url = "2.1.1"
 urlencoding = "1.0.0"

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -12,4 +12,4 @@ log = "0.4.8"
 rand = "0.7.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 tokio = { version = "0.2.21", features = ["full"] }
-tokio-postgres = "0.5.2"
+tokio-postgres = "0.5.4"


### PR DESCRIPTION
The patch we needed made it into postgres v0.17.3/tokio-postgres v0.5.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3346)
<!-- Reviewable:end -->
