### PR TITLE
deps: always compile backtrace in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ members = [
 # production installations, but we still want useful crash reports.
 debug = 1
 
+[profile.dev.package]
+backtrace = { opt-level = 3 }
+backtrace-sys = { opt-level = 3 }
+
 [patch.crates-io]
 # Waiting on a release with this commit:
 # https://github.com/sfackler/rust-postgres/commit/dd0c39e0414e30e98271836b99ef289d04b7d569


### PR DESCRIPTION
Part of the reason our backtraces take so long to generate in debug
builds is because we link in a version of libbacktrace that is built in
debug mode. Tell Cargo to always compile libbacktrace in release mode,
which yields a 2.5x speedup in backtrace generation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3347)
<!-- Reviewable:end -->
