### PR TITLE
bin/xcompile: fix cross-compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "krb5-src"
-version = "0.2.2+1.18.1"
+version = "0.2.3+1.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a612c9f3705722fe3421422bdbd9a57b47d6951634e47996ef29b74bad8f056b"
+checksum = "1cc5e3404f6c92ef9dbaa4c7f062e1e04ebd5133c06b0fb5c3239943d66d9622"
 dependencies = [
  "duct",
  "openssl-sys",

--- a/bin/xcompile
+++ b/bin/xcompile
@@ -48,23 +48,14 @@ do_cargo() {
             die "xcompile: fatal: run \`bin/xcompile bootstrap\` first"
         fi
 
-        sysroot=$root/target/sysroot/x86_64-unknown-linux-gnu
-
-        export AR=x86_64-unknown-linux-gnu-ar
-        export LD=x86_64-unknown-linux-gnu-ld
-        export RANLIB=x86_64-unknown-linux-gnu-ranlib
-        export CPP=x86_64-unknown-linux-gnu-cpp
-        export CC=x86_64-unknown-linux-gnu-cc
-        export CXX=x86_64-unknown-linux-gnu-c++
-        export CFLAGS="-I$sysroot/usr/include/x86_64-linux-gnu -isystem$sysroot/usr/include"
         export CMAKE_SYSTEM_NAME=Linux
-        export CXXFLAGS=$CFLAGS
-        export LDFLAGS="-L$sysroot/usr/lib/x86_64-linux-gnu -L$sysroot/lib/x86_64-linux-gnu"
-        export TARGET_CC=$CC
-        export TARGET_CXX=$CXX
-        export TARGET_CFLAGS=$CFLAGS
-        export TARGET_CXXFLAGS=$CXXFLAGS
-        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=$CC
+        export TARGET_AR=x86_64-unknown-linux-gnu-ar
+        export TARGET_CC=x86_64-unknown-linux-gnu-cc
+        export TARGET_CXX=x86_64-unknown-linux-gnu-c++
+        export TARGET_RANLIB=x86_64-unknown-linux-gnu-ranlib
+        export TARGET_CPP=x86_64-unknown-linux-gnu-cpp
+        export TARGET_LD=x86_64-unknown-linux-gnu-ld
+        export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=$TARGET_CC
         # Explicitly tell libkrb5 about features available in the cross
         # toolchain that its configure script cannot auto-detect when cross
         # compiling.
@@ -83,8 +74,6 @@ do_cargo() {
     "${command[@]}"
 }
 
-pkg_url=http://archive.ubuntu.com/ubuntu/ubuntu
-
 bootstrap() {
     if [[ "$(uname)" = Linux ]]; then
         exit 0
@@ -98,21 +87,6 @@ bootstrap() {
     run rustup target add x86_64-unknown-linux-gnu
 
     mkdir -p target/sysroot/x86_64-unknown-linux-gnu
-    cd target/sysroot/x86_64-unknown-linux-gnu
-
-    curl -fsSLO "$pkg_url"/dists/bionic/main/binary-amd64/Packages.gz
-    gunzip Packages.gz
-
-    install_pkg zlib1g
-    install_pkg zlib1g-dev
-}
-
-# install_pkg PACKAGE
-install_pkg() {
-    echo "installing $1" >&2
-    path=$(grep-dctrl --no-field-names --field=Package --exact-match --show-field=Filename "$1" Packages)
-    curl -fsSL "$pkg_url/$path" > "$1.deb"
-    ar -p "$1.deb" data.tar.xz | tar xvf -
 }
 
 clean() {

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 getopts = "0.2"
 hyper = "0.13.6"
 jemallocator = { version = "0.3.0", features = ["profiling"] }
-krb5-src = { version = "0.2.1", features = ["binaries"] }
+krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 once_cell = "1.4.0"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -20,7 +20,7 @@ futures = "0.3"
 getopts = "0.2"
 interchange = { path = "../interchange" }
 itertools = "0.9"
-krb5-src = { version = "0.2.1", features = ["binaries"] }
+krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 md-5 = "0.8"
 ore = { path = "../ore" }


### PR DESCRIPTION
Remove the environment variable overrides in bin/xcompile that apply
globally, like `CC` and `AR`. Compiling Materialize involves compiling
some programs for the host as well as the target, and `CC` applies to
both compilations; setting it indiscriminately to
x86_64-unknown-linux-gnu means that these host programs are miscompiled.

   Also, remove the download and installation of libz. We statically link
   libz now so there is no need to acquire a dynamic version of a Linux
   libz.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3358)
<!-- Reviewable:end -->
