### PR TITLE
sql: port aggregates and table functions to generalized infrastructure

### DIFF
--- a/src/sql/src/plan/cast.rs
+++ b/src/sql/src/plan/cast.rs
@@ -295,7 +295,7 @@ lazy_static! {
             (Jsonb, Explicit(Float32)) => CastOp::F(from_jsonb_f64_cast),
             (Jsonb, Explicit(Float64)) => CastJsonbToFloat64,
             (Jsonb, Explicit(Decimal(0, 0))) => CastOp::F(from_jsonb_f64_cast),
-            (Jsonb, Explicit(String)) => JsonbStringify,
+            (Jsonb, Explicit(String)) => CastJsonbToString,
             (Jsonb, JsonbAny) => CastJsonbOrNullToJsonb
         }
     };

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -112,9 +112,9 @@ impl NonNullRequirements {
             } => {
                 match func {
                     // outputs zero rows if input is null
-                    TableFunc::JsonbEach
+                    TableFunc::JsonbEach { .. }
                     | TableFunc::JsonbObjectKeys
-                    | TableFunc::JsonbArrayElements
+                    | TableFunc::JsonbArrayElements { .. }
                     | TableFunc::GenerateSeries(_)
                     | TableFunc::RegexpExtract(_)
                     | TableFunc::CsvExtract(_) => {

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -66,7 +66,7 @@ SELECT avg(a) FROM t2
 
 # avg of an explicit NULL should return an error.
 
-query error unable to infer type for NULL
+query error unable to determine which implementation to use
 SELECT avg(NULL)
 
 statement error
@@ -163,3 +163,9 @@ query I rowsort
 select sum(distinct column1) from (values (1), (2), (1), (4)) _;
 ----
 7
+
+query error count\(\*\) must be used to call a parameterless aggregate function
+SELECT count()
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT sum(*)

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -234,7 +234,7 @@ ORDER BY ol_number
 %0 =
 | Get materialize.public.orderline (u19)
 | Filter (datetots(#6) > 2007-01-02 00:00:00)
-| Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) countall(null)
+| Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) countall(true)
 | Map (((i32todec(#1) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec), (((#2 * 10000000dec) / i64todec(if (#4 = 0) then {null} else {#4})) / 10dec)
 | Project (#0..#2, #6, #7, #5)
 
@@ -417,7 +417,7 @@ ORDER BY o_ol_cnt
 | Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
 | | implementation = Differential %1 %4.(#0, #1, #2, #3)
 | | demand = (#6)
-| Reduce group=(#6) countall(null)
+| Reduce group=(#6) countall(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -927,7 +927,7 @@ ORDER BY custdist DESC, c_count DESC
 %9 =
 | Union %3 %8
 | Reduce group=(#0) count(#22)
-| Reduce group=(#1) countall(null)
+| Reduce group=(#1) countall(true)
 
 Finish order_by=(#1 desc, #0 desc) limit=none offset=0 project=(#0, #1)
 
@@ -1480,7 +1480,7 @@ ORDER BY numwait DESC, su_name
 | Join %7 %12 %13 (= #7 #47 #51) (= #8 #48 #52) (= #9 #49 #53) (= #13 #50 #54)
 | | implementation = Differential %12 %13.(#0, #1, #2, #3) %7.(#7, #8, #9, #13)
 | | demand = (#1)
-| Reduce group=(#1) countall(null)
+| Reduce group=(#1) countall(true)
 
 Finish order_by=(#1 desc, #0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -1556,7 +1556,7 @@ ORDER BY substr(c_state, 1, 1)
 | Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
 | | implementation = Differential %8 %3.(#0, #1, #2)
 | | demand = (#9, #16)
-| Reduce group=(substr(#9, 1, 1)) countall(null) sum(#16)
+| Reduce group=(substr(#9, 1, 1)) countall(true) sum(#16)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -115,8 +115,10 @@ SELECT count(NULL)
 statement error supported
 SELECT json_agg(NULL)
 
-query error unable to infer type for NULL
+query T
 SELECT jsonb_agg(NULL)
+----
+[null]
 
 # This should ideally return {NULL}, but this is a pathological case, and
 # Postgres has the same behavior, so it's sufficient for now.
@@ -458,7 +460,7 @@ SELECT count(1) from kv
 ----
 6
 
-query error count function requires exactly one non-star argument
+query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT count(k, v) FROM kv
 
 query II
@@ -679,19 +681,19 @@ SELECT avg(b), sum(b) FROM abc
 # ----
 # 3 years 5 mons 7 days 00:00:19
 
-query error Unimplemented
+query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT avg(a) FROM abc
 
-query error Unimplemented
+query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT avg(c) FROM abc
 
 query error ROW constructors are not supported yet
 SELECT avg((a,c)) FROM abc
 
-query error Unimplemented
+query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT sum(a) FROM abc
 
-query error Unimplemented
+query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT sum(c) FROM abc
 
 query error ROW constructors are not supported yet

--- a/test/sqllogictest/extract.slt
+++ b/test/sqllogictest/extract.slt
@@ -37,3 +37,9 @@ ORDER BY data.input
 input        column1  column2
 some,csv     some     csv
 testing,123  testing  123
+
+query error csv_extract number of columns must be a positive integer literal
+SELECT * FROM data, (VALUES (2)) ncols, csv_extract(ncols.column1, data.input)
+
+query error csv_extract number of columns must be a positive integer literal
+SELECT * FROM data, csv_extract((SELECT 2), data.input)

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1860,7 +1860,7 @@ SELECT jsonb_agg(column1) FROM (VALUES (1), (2), (3))
 ----
 [1.0,2.0,3.0]
 
-query error jsonb_agg function requires exactly one non-star argument
+query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT jsonb_agg(1, 2)
 
 # todo@jldlaughlin: Fix test when #2414 is implemented

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -64,17 +64,17 @@ query I
 SELECT generate_series FROM generate_series(1, null)
 ----
 
-query I
+query error unable to determine which implementation to use
 SELECT generate_series FROM generate_series(null, null)
 ----
 
-statement error invalid input syntax for int8: invalid digit found in string: "foo"
+statement error invalid input syntax for int4: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series('foo', 2)
 
-statement error invalid input syntax for int8: invalid digit found in string: "foo"
+statement error invalid input syntax for int4: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series(1, 'foo')
 
-statement error requires exactly two arguments
+statement error arguments cannot be implicitly cast to any implementation's parameters
 SELECT generate_series FROM generate_series(2)
 
 query T multiline

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -161,7 +161,7 @@ ORDER BY
 %0 =
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
-| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) countall(null) countall(null) sum(#6) countall(null) countall(null)
+| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) countall(null) countall(null) sum(#6) countall(null) countall(true)
 | Map (((#2 * 10000000dec) / i64todec(if (#6 = 0) then {null} else {#6})) / 10dec), (((#3 * 10000000dec) / i64todec(if (#7 = 0) then {null} else {#7})) / 10dec), (((#8 * 10000000dec) / i64todec(if (#9 = 0) then {null} else {#9})) / 10dec)
 | Project (#0..#5, #11..#13, #10)
 
@@ -377,7 +377,7 @@ ORDER BY
 | Join %1 %4 (= #0 #9)
 | | implementation = Differential %1 %4.(#0)
 | | demand = (#5)
-| Reduce group=(#5) countall(null)
+| Reduce group=(#5) countall(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -981,7 +981,7 @@ ORDER BY
 %9 =
 | Union %3 %8
 | Reduce group=(#0) count(#8)
-| Reduce group=(#1) countall(null)
+| Reduce group=(#1) countall(true)
 
 Finish order_by=(#1 desc, #0 desc) limit=none offset=0 project=(#0, #1)
 
@@ -1692,7 +1692,7 @@ ORDER BY
 | Join %11 %16 %17 (= #0 #39 #41) (= #7 #38 #40)
 | | implementation = Differential %16 %17.(#0, #1) %11.(#0, #7)
 | | demand = (#1)
-| Reduce group=(#1) countall(null)
+| Reduce group=(#1) countall(true)
 
 Finish order_by=(#1 desc, #0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -1796,7 +1796,7 @@ ORDER BY
 | Join %3 %8 (= #0 #11)
 | | implementation = Differential %8 %3.(#0)
 | | demand = (#4, #5)
-| Reduce group=(substr(#4, 1, 2)) countall(null) sum(#5)
+| Reduce group=(substr(#4, 1, 2)) countall(true) sum(#5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 


### PR DESCRIPTION
@sploiselle this moves all the aggregate and table functions over to your new function selection infrastructure. There were zero changes required to the selection algorithm or parameter types which was super super cool to see.

There was a bit of an invasive refactor required to get the `ArgImplementationMatcher` to be generic over the operations it planned, as planning an aggregate requires returning an `AggregateFunc` instead of a `ScalarExpr`, and planning a table function requires returning a `TableFuncPlan` instead of a `ScalarExpr`. The aesthetics are definitely worse, but I got them to a place where they're _not awful_; still, would be happy to take any suggestions you might have, or to have you hammer on this PR a bit to restore some of the previous purity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3359)
<!-- Reviewable:end -->
