### PR TITLE
Cause certain Kafka metrics to be deleted along with their resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,9 +1616,9 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lock_api"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57b3997725d2b60dbec1297f6c2e2957cc383db1cebd6be812163f969c7d586"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
  "scopeguard",
 ]
@@ -2123,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e98c49ab0b7ce5b222f2cc9193fc4efe11c6d0bd4f648e374684a6857b1cfc"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2133,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7582838484df45743c8434fbff785e8edf260c28748353d44bc0da32e0ceabf1"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
  "cloudabi",
@@ -2496,7 +2496,7 @@ dependencies = [
 [[package]]
 name = "prometheus"
 version = "0.8.0"
-source = "git+https://github.com/MaterializeInc/rust-prometheus.git#a1e3690bcb0899826898bfbdc960a4f4b317165e"
+source = "git+https://github.com/MaterializeInc/rust-prometheus.git#9a1ba74a7bc64db614a8526180ccdf0fa2c9931b"
 dependencies = [
  "cfg-if",
  "fnv",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "prometheus-static-metric"
 version = "0.3.0"
-source = "git+https://github.com/MaterializeInc/rust-prometheus.git#a1e3690bcb0899826898bfbdc960a4f4b317165e"
+source = "git+https://github.com/MaterializeInc/rust-prometheus.git#9a1ba74a7bc64db614a8526180ccdf0fa2c9931b"
 dependencies = [
  "lazy_static",
  "proc-macro2",


### PR DESCRIPTION
This uses MaterializeInc/rust-prometheus#2 to guarantee that at least some metrics stop
being reported when `DROP SOURCE` is performed. This is enough to resolve the false
metrics appearing in #3352, but it does not delete all Kafka metrics when their sources
are deleted, in particular in the timestamper, where we don't have structs that live
along with their partitions, yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3371)
<!-- Reviewable:end -->
