### PR TITLE
Documentation for ts_* options

### DIFF
--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -3,6 +3,9 @@
 `security_protocol` | `text` | Use either [`ssl`](#ssl-with-options) or [`sasl_plaintext` (Kerberos)](#kerberos-with-options) to connect to the Kafka cluster.
 `statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics.
 `ignore_source_keys` | `bool` | Default: `false`. If `true`, do not perform optimizations assuming uniqueness of primary keys in schemas.
+`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently timestamps advance in the system. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
+`max_timestamp_batch_size` | `int` | Default: `0`. Bounds the maximum number of messages that can be assigned to the same batch. A value of 0 creates no upper bound.
+`topic_metadata_refresh_interval_ms` | `int` | Default: `30000`. Sets the frequency in `ms` at which the system checks for new partitions. Accepts values [0,3600000].
 
 #### SSL `WITH` options
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -907,7 +907,7 @@ where
             // Default value obtained from https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
             let metadata_refresh_frequency = Duration::from_millis(
                 config_options
-                    .get("topic.metadata.refresh.interval.ms")
+                    .get("topic_metadata_refresh_interval_ms")
                     // Safe conversion: statement::extract_config enforces that option is a value
                     // between 0 and 3600000
                     .unwrap_or(&"30000".to_owned())


### PR DESCRIPTION
This PR adds documentation for the following three WITH options:

timestamp_frequency_ms
topic_metadata_refresh_interval_ms
max_timestamp_batch_size.

It also fixes an inconsistency between option names in kafka.rs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3377)
<!-- Reviewable:end -->
