### PR TITLE
sql: allow aliasing column names

### DIFF
--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -126,7 +126,7 @@ tests=(
     # test/sqllogictest/cockroach/select_index_span_ranges.slt
     # test/sqllogictest/cockroach/select_index.slt
     test/sqllogictest/cockroach/select_search_path.slt
-    # test/sqllogictest/cockroach/select_table_alias.slt
+    test/sqllogictest/cockroach/select_table_alias.slt
     # test/sqllogictest/cockroach/select.slt
     test/sqllogictest/cockroach/shift.slt
     # test/sqllogictest/cockroach/sqlsmith.slt
@@ -148,7 +148,7 @@ tests=(
     test/sqllogictest/cockroach/update.slt
     test/sqllogictest/cockroach/upsert.slt
     test/sqllogictest/cockroach/uuid.slt
-    # test/sqllogictest/cockroach/values.slt
+    test/sqllogictest/cockroach/values.slt
     # test/sqllogictest/cockroach/views.slt
     # test/sqllogictest/cockroach/where.slt
     test/sqllogictest/cockroach/window.slt

--- a/test/sqllogictest/cockroach/join.slt
+++ b/test/sqllogictest/cockroach/join.slt
@@ -46,7 +46,7 @@ NULL    42
   42    42
 
 # Check that name resolution chokes on ambiguity when it needs to.
-query error column reference "x" is ambiguous \(candidates: a.x, b.x\)
+query error Column name x is ambiguous
 SELECT x FROM onecolumn AS a, onecolumn AS b
 
 query II colnames,rowsort
@@ -88,7 +88,7 @@ NULL
 
 # Check that ORDER BY chokes on ambiguity if no table less columns
 # were introduced by USING. (#12239)
-query error ORDER BY "x" is ambiguous
+query error Column name x is ambiguous
 SELECT * FROM onecolumn AS a, onecolumn AS b ORDER BY x
 
 query I colnames,rowsort
@@ -479,7 +479,7 @@ SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS 
  44  44  44  51  51  51
  45  45  45  45  45  45
 
-query error pgcode 42703 column "y" specified in USING clause does not exist
+query error pgcode 42703 column "y" does not exist
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))
 
 query error pgcode 42701 column "x" appears more than once in USING clause
@@ -488,7 +488,7 @@ SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(x, x))
 statement ok
 CREATE TABLE othertype (x TEXT)
 
-query error pgcode 42804 JOIN/USING types.*cannot be matched
+query error pgcode 42804 Int32 and String are not comparable \(in NATURAL/USING join on x\)
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
 
 query error pgcode 42712 source name "onecolumn" specified more than once \(missing AS clause\)
@@ -518,10 +518,10 @@ SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN o
 42
 
 # Check that multiple anonymous sources cause proper ambiguity errors.
-query error column reference "x" is ambiguous \(candidates: <anonymous>\.x\)
+query error Column name x is ambiguous
 SELECT x FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
 
-query error column reference "x" is ambiguous \(candidates: a\.x, b\.x\)
+query error Column name x is ambiguous
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON x > 32)
 
 query error column "a.y" does not exist
@@ -540,73 +540,75 @@ CREATE TABLE customers(id INT PRIMARY KEY NOT NULL)
 statement ok
 CREATE TABLE orders(id INT, cust INT REFERENCES customers(id))
 
-query TTTTTTTTIIITTI
-SELECT     NULL::text  AS pktable_cat,
-       pkn.nspname AS pktable_schem,
-       pkc.relname AS pktable_name,
-       pka.attname AS pkcolumn_name,
-       NULL::text  AS fktable_cat,
-       fkn.nspname AS fktable_schem,
-       fkc.relname AS fktable_name,
-       fka.attname AS fkcolumn_name,
-       pos.n       AS key_seq,
-       CASE con.confupdtype
-            WHEN 'c' THEN 0
-            WHEN 'n' THEN 2
-            WHEN 'd' THEN 4
-            WHEN 'r' THEN 1
-            WHEN 'a' THEN 3
-            ELSE NULL
-       END AS update_rule,
-       CASE con.confdeltype
-            WHEN 'c' THEN 0
-            WHEN 'n' THEN 2
-            WHEN 'd' THEN 4
-            WHEN 'r' THEN 1
-            WHEN 'a' THEN 3
-            ELSE NULL
-       END          AS delete_rule,
-       con.conname  AS fk_name,
-       pkic.relname AS pk_name,
-       CASE
-            WHEN con.condeferrable
-            AND      con.condeferred THEN 5
-            WHEN con.condeferrable THEN 6
-            ELSE 7
-       END AS deferrability
-  FROM     pg_catalog.pg_namespace pkn,
-       pg_catalog.pg_class pkc,
-       pg_catalog.pg_attribute pka,
-       pg_catalog.pg_namespace fkn,
-       pg_catalog.pg_class fkc,
-       pg_catalog.pg_attribute fka,
-       pg_catalog.pg_constraint con,
-       pg_catalog.generate_series(1, 32) pos(n),
-       pg_catalog.pg_depend dep,
-       pg_catalog.pg_class pkic
-  WHERE    pkn.oid = pkc.relnamespace
-  AND      pkc.oid = pka.attrelid
-  AND      pka.attnum = con.confkey[pos.n]
-  AND      con.confrelid = pkc.oid
-  AND      fkn.oid = fkc.relnamespace
-  AND      fkc.oid = fka.attrelid
-  AND      fka.attnum = con.conkey[pos.n]
-  AND      con.conrelid = fkc.oid
-  AND      con.contype = 'f'
-  AND      con.oid = dep.objid
-  AND      pkic.oid = dep.refobjid
-  AND      pkic.relkind = 'i'
-  AND      dep.classid = 'pg_constraint'::regclass::oid
-  AND      dep.refclassid = 'pg_class'::regclass::oid
-  AND      fkn.nspname = 'public'
-  AND      fkc.relname = 'orders'
-  ORDER BY pkn.nspname,
-       pkc.relname,
-       con.conname,
-       pos.n
-----
-NULL  public  customers  id  NULL  public  orders  cust  1  3  3  fk_cust_ref_customers  primary  7
-
+# TODO(benesch): fix parse error in this query.
+#
+# query TTTTTTTTIIITTI
+# SELECT     NULL::text  AS pktable_cat,
+#        pkn.nspname AS pktable_schem,
+#        pkc.relname AS pktable_name,
+#        pka.attname AS pkcolumn_name,
+#        NULL::text  AS fktable_cat,
+#        fkn.nspname AS fktable_schem,
+#        fkc.relname AS fktable_name,
+#        fka.attname AS fkcolumn_name,
+#        pos.n       AS key_seq,
+#        CASE con.confupdtype
+#             WHEN 'c' THEN 0
+#             WHEN 'n' THEN 2
+#             WHEN 'd' THEN 4
+#             WHEN 'r' THEN 1
+#             WHEN 'a' THEN 3
+#             ELSE NULL
+#        END AS update_rule,
+#        CASE con.confdeltype
+#             WHEN 'c' THEN 0
+#             WHEN 'n' THEN 2
+#             WHEN 'd' THEN 4
+#             WHEN 'r' THEN 1
+#             WHEN 'a' THEN 3
+#             ELSE NULL
+#        END          AS delete_rule,
+#        con.conname  AS fk_name,
+#        pkic.relname AS pk_name,
+#        CASE
+#             WHEN con.condeferrable
+#             AND      con.condeferred THEN 5
+#             WHEN con.condeferrable THEN 6
+#             ELSE 7
+#        END AS deferrability
+#   FROM     pg_catalog.pg_namespace pkn,
+#        pg_catalog.pg_class pkc,
+#        pg_catalog.pg_attribute pka,
+#        pg_catalog.pg_namespace fkn,
+#        pg_catalog.pg_class fkc,
+#        pg_catalog.pg_attribute fka,
+#        pg_catalog.pg_constraint con,
+#        pg_catalog.generate_series(1, 32) pos(n),
+#        pg_catalog.pg_depend dep,
+#        pg_catalog.pg_class pkic
+#   WHERE    pkn.oid = pkc.relnamespace
+#   AND      pkc.oid = pka.attrelid
+#   AND      pka.attnum = con.confkey[pos.n]
+#   AND      con.confrelid = pkc.oid
+#   AND      fkn.oid = fkc.relnamespace
+#   AND      fkc.oid = fka.attrelid
+#   AND      fka.attnum = con.conkey[pos.n]
+#   AND      con.conrelid = fkc.oid
+#   AND      con.contype = 'f'
+#   AND      con.oid = dep.objid
+#   AND      pkic.oid = dep.refobjid
+#   AND      pkic.relkind = 'i'
+#   AND      dep.classid = 'pg_constraint'::regclass::oid
+#   AND      dep.refclassid = 'pg_class'::regclass::oid
+#   AND      fkn.nspname = 'public'
+#   AND      fkc.relname = 'orders'
+#   ORDER BY pkn.nspname,
+#        pkc.relname,
+#        con.conname,
+#        pos.n
+# ----
+# NULL  public  customers  id  NULL  public  orders  cust  1  3  3  fk_cust_ref_customers  primary  7
+#
 
 # Tests for filter propagation through joins.
 
@@ -1033,93 +1035,95 @@ INSERT INTO bar VALUES
   (2, 2.0, 2.0, 2),
   (3, 3.0, 3.0, 3)
 
-query IIRR rowsort
-SELECT * FROM foo NATURAL JOIN bar
-----
-1  1  1  1
-2  2  2  2
-3  3  3  3
-
-query IIRRIRI rowsort
-SELECT * FROM foo JOIN bar USING (b)
-----
-1  1  1  1  1  1  1
-2  2  2  2  2  2  2
-3  3  3  3  3  3  3
-
-query IIRRRI rowsort
-SELECT * FROM foo JOIN bar USING (a, b)
-----
-1  1  1  1  1  1
-2  2  2  2  2  2
-3  3  3  3  3  3
-
-query IIRRI rowsort
-SELECT * FROM foo JOIN bar USING (a, b, c)
-----
-1  1  1  1  1
-2  2  2  2  2
-3  3  3  3  3
-
-query IIRRIRRI rowsort
-SELECT * FROM foo JOIN bar ON foo.b = bar.b
-----
-1  1  1  1  1  1  1  1
-2  2  2  2  2  2  2  2
-3  3  3  3  3  3  3  3
-
-query IIRRIRRI rowsort
-SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
-----
-1  1  1  1  1  1  1  1
-2  2  2  2  2  2  2  2
-3  3  3  3  3  3  3  3
-
-query IIRRIRRI rowsort
-SELECT * FROM foo, bar WHERE foo.b = bar.b
-----
-1  1  1  1  1  1  1  1
-2  2  2  2  2  2  2  2
-3  3  3  3  3  3  3  3
-
-query IIRRIRRI rowsort
-SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
-----
-1  1  1  1  1  1  1  1
-2  2  2  2  2  2  2  2
-3  3  3  3  3  3  3  3
-
-query IIRRRI rowsort
-SELECT * FROM foo JOIN bar USING (a, b) WHERE foo.c = bar.c AND foo.d = bar.d
-----
-1  1  1  1  1  1
-2  2  2  2  2  2
-3  3  3  3  3  3
-
-# Regression test for 23664.
-query III rowsort
-SELECT * FROM onecolumn AS a(x) RIGHT JOIN twocolumn ON false
-----
-NULL  44    51
-NULL  NULL  52
-NULL  42    53
-NULL  45    45
-
-# Regression test for #23609: make sure that the type of the merged column
-# is int (not unknown).
-query II rowsort
-SELECT column1, column1+1
-FROM
-  (SELECT * FROM
-    (VALUES (NULL, NULL)) AS t
-      NATURAL FULL OUTER JOIN
-    (VALUES (1, 1)) AS u)
-----
-1     2
-NULL  NULL
+# TODO(benesch): support these mixed-type equalities.
+#
+# query IIRR rowsort
+# SELECT * FROM foo NATURAL JOIN bar
+# ----
+# 1  1  1  1
+# 2  2  2  2
+# 3  3  3  3
+#
+# query IIRRIRI rowsort
+# SELECT * FROM foo JOIN bar USING (b)
+# ----
+# 1  1  1  1  1  1  1
+# 2  2  2  2  2  2  2
+# 3  3  3  3  3  3  3
+#
+# query IIRRRI rowsort
+# SELECT * FROM foo JOIN bar USING (a, b)
+# ----
+# 1  1  1  1  1  1
+# 2  2  2  2  2  2
+# 3  3  3  3  3  3
+#
+# query IIRRI rowsort
+# SELECT * FROM foo JOIN bar USING (a, b, c)
+# ----
+# 1  1  1  1  1
+# 2  2  2  2  2
+# 3  3  3  3  3
+#
+# query IIRRIRRI rowsort
+# SELECT * FROM foo JOIN bar ON foo.b = bar.b
+# ----
+# 1  1  1  1  1  1  1  1
+# 2  2  2  2  2  2  2  2
+# 3  3  3  3  3  3  3  3
+#
+# query IIRRIRRI rowsort
+# SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
+# ----
+# 1  1  1  1  1  1  1  1
+# 2  2  2  2  2  2  2  2
+# 3  3  3  3  3  3  3  3
+#
+# query IIRRIRRI rowsort
+# SELECT * FROM foo, bar WHERE foo.b = bar.b
+# ----
+# 1  1  1  1  1  1  1  1
+# 2  2  2  2  2  2  2  2
+# 3  3  3  3  3  3  3  3
+#
+# query IIRRIRRI rowsort
+# SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
+# ----
+# 1  1  1  1  1  1  1  1
+# 2  2  2  2  2  2  2  2
+# 3  3  3  3  3  3  3  3
+#
+# query IIRRRI rowsort
+# SELECT * FROM foo JOIN bar USING (a, b) WHERE foo.c = bar.c AND foo.d = bar.d
+# ----
+# 1  1  1  1  1  1
+# 2  2  2  2  2  2
+# 3  3  3  3  3  3
+#
+# # Regression test for 23664.
+# query III rowsort
+# SELECT * FROM onecolumn AS a(x) RIGHT JOIN twocolumn ON false
+# ----
+# NULL  44    51
+# NULL  NULL  52
+# NULL  42    53
+# NULL  45    45
+#
+# # Regression test for #23609: make sure that the type of the merged column
+# # is int (not unknown).
+# query II rowsort
+# SELECT column1, column1+1
+# FROM
+#   (SELECT * FROM
+#     (VALUES (NULL, NULL)) AS t
+#       NATURAL FULL OUTER JOIN
+#     (VALUES (1, 1)) AS u)
+# ----
+# 1     2
+# NULL  NULL
 
 # Regression test for #28817. Do not allow special functions in ON clause.
-query error generator functions are not allowed in ON
+query error table function \(generate_series\) in scalar position not yet supported
 SELECT * FROM foo JOIN bar ON generate_series(0, 1) < 2
 
 query error aggregate functions are not allowed in ON

--- a/test/sqllogictest/cockroach/select_table_alias.slt
+++ b/test/sqllogictest/cockroach/select_table_alias.slt
@@ -96,10 +96,10 @@ foo1 foo2 c
 
 # Verify we can't resolve columns using overridden table or colum names.
 
-query error no data source matches prefix: abc
+query error column "abc.foo1" does not exist
 SELECT abc.foo1 FROM abc AS foo (foo1)
 
-query error no data source matches prefix: abc
+query error column "abc.b" does not exist
 SELECT abc.b FROM abc AS foo (foo1)
 
 query error column "foo.a" does not exist
@@ -108,7 +108,7 @@ SELECT foo.a FROM abc AS foo (foo1)
 
 # Verify error for too many column aliases.
 
-query error pgcode 42P10 source "foo" has 3 columns available but 4 columns specified
+query error pgcode 42P10 foo has 3 columns available but 4 columns specified
 SELECT * FROM abc AS foo (foo1, foo2, foo3, foo4)
 
 
@@ -128,23 +128,27 @@ foo1 foo2
 1 3
 2 5
 
-statement ok
-SELECT rowid, foo.rowid FROM ab AS foo (foo1, foo2)
+# NOTE(benesch): rowid is a CockroachDB-ism that we are unlikely to support.
+#
+# statement ok
+# SELECT rowid, foo.rowid FROM ab AS foo (foo1, foo2)
+#
+# query error no data source matches prefix: ab
+# SELECT ab.rowid FROM ab AS foo (foo1)
 
-query error no data source matches prefix: ab
-SELECT ab.rowid FROM ab AS foo (foo1)
-
-query error source "foo" has 2 columns available but 3 columns specified
+query error foo has 2 columns available but 3 columns specified
 SELECT * FROM ab AS foo (foo1, foo2, foo3)
 
-query T colnames
-SELECT * FROM to_english(3) AS x
-----
-x
-three
-
-query T colnames
-TABLE ROWS FROM (to_english(3)) AS x;
-----
-x
-three
+# TODO(benesch): support scalar functions in table position.
+#
+# query T colnames
+# SELECT * FROM length('abc') AS x
+# ----
+# x
+# 3
+#
+# query T colnames
+# TABLE ROWS FROM length('abc') AS x
+# ----
+# x
+# 3

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -915,10 +915,13 @@ ORDER BY (SELECT count(*) FROM o WHERE o.c_id=c.c_id) DESC
 1  1
 0  2
 
-statement error supported
+# Subquery in VALUES clause.
+query III
 SELECT c_cnt, o_cnt, c_cnt + o_cnt AS total
 FROM (VALUES ((SELECT count(*) FROM c), (SELECT count(*) FROM o))) AS v(c_cnt, o_cnt)
 WHERE c_cnt > 0 AND o_cnt > 0;
+----
+6  9  15
 
 # Subquery in JOIN condition.
 query II rowsort

--- a/test/sqllogictest/cockroach/values.slt
+++ b/test/sqllogictest/cockroach/values.slt
@@ -52,7 +52,7 @@ SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 7
 11
 
-query error pgcode 42601 VALUES lists must all be the same length, expected 1 columns, found 2
+query error pgcode 42601 VALUES expression has varying number of columns: 2 vs 1
 VALUES (1), (2, 3)
 
 query I
@@ -72,11 +72,5 @@ VALUES ((SELECT 1)), ((SELECT 2))
 1
 2
 
-query error pgcode 42804 VALUES types string and int cannot be matched
+query error pgcode 42804 invalid input syntax for int4
 VALUES (NULL, 1), (2, NULL), (NULL, 'a')
-
-# subqueries in VALUES don't cause problems in EXPLAIN(DISTSQL), despite forcing
-# execution on the gateway.
-
-statement ok
-EXPLAIN(DISTSQL) VALUES((SELECT 1), 3)


### PR DESCRIPTION
This will enable some transformations that will in turn enable record
types. It also unlocks a slew of CockroachDB sqllogictests, some of
which are enabled here.

Fix #3112.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3381)
<!-- Reviewable:end -->
