### PR TITLE
sql-parser: support EXPLAIN <statement>

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -21,8 +21,6 @@ into Materialize's behavior for specific queries, e.g. performance.
 
 Field | Use
 ------|-----
-**SQL** | Display the original SQL string
-**PLAN** | Display the plan at some stage (defaults to **OPTIMIZED**)
 **TYPED** | Annotate the plan with column types and unique keys
 **RAW** | Display the raw plan
 **DECORRELATED** | Display the decorrelated plan

--- a/doc/user/layouts/partials/sql-grammar/explain.svg
+++ b/doc/user/layouts/partials/sql-grammar/explain.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="563" height="311">
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="299">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="78" height="32" rx="10"/>
@@ -9,78 +9,62 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">EXPLAIN</text>
-   <rect x="149" y="3" width="48" height="32" rx="10"/>
+   <rect x="149" y="35" width="64" height="32" rx="10"/>
    <rect x="147"
-         y="1"
-         width="48"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="157" y="21">SQL</text>
-   <rect x="169" y="79" width="64" height="32" rx="10"/>
-   <rect x="167"
-         y="77"
+         y="33"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="177" y="97">TYPED</text>
-   <rect x="293" y="79" width="52" height="32" rx="10"/>
+   <text class="terminal" x="157" y="53">TYPED</text>
+   <rect x="293" y="67" width="52" height="32" rx="10"/>
    <rect x="291"
-         y="77"
+         y="65"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="97">RAW</text>
-   <rect x="293" y="123" width="132" height="32" rx="10"/>
+   <text class="terminal" x="301" y="85">RAW</text>
+   <rect x="293" y="111" width="132" height="32" rx="10"/>
    <rect x="291"
-         y="121"
+         y="109"
          width="132"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="141">DECORRELATED</text>
-   <rect x="293" y="167" width="96" height="32" rx="10"/>
+   <text class="terminal" x="301" y="129">DECORRELATED</text>
+   <rect x="293" y="155" width="96" height="32" rx="10"/>
    <rect x="291"
-         y="165"
+         y="153"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="185">OPTIMIZED</text>
-   <rect x="465" y="47" width="56" height="32" rx="10"/>
+   <text class="terminal" x="301" y="173">OPTIMIZED</text>
+   <rect x="465" y="35" width="88" height="32" rx="10"/>
    <rect x="463"
-         y="45"
-         width="56"
+         y="33"
+         width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="473" y="65">PLAN</text>
-   <rect x="265" y="233" width="48" height="32" rx="10"/>
-   <rect x="263"
-         y="231"
-         width="48"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="273" y="251">FOR</text>
-   <rect x="353" y="233" width="90" height="32"/>
-   <rect x="351" y="231" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="361" y="251">select_stmt</text>
-   <rect x="353" y="277" width="54" height="32" rx="10"/>
-   <rect x="351"
-         y="275"
+   <text class="terminal" x="473" y="53">PLAN FOR</text>
+   <rect x="385" y="221" width="90" height="32"/>
+   <rect x="383" y="219" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="393" y="239">select_stmt</text>
+   <rect x="385" y="265" width="54" height="32" rx="10"/>
+   <rect x="383"
+         y="263"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="361" y="295">VIEW</text>
-   <rect x="427" y="277" width="88" height="32"/>
-   <rect x="425" y="275" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="435" y="295">view_name</text>
+   <text class="terminal" x="393" y="283">VIEW</text>
+   <rect x="459" y="265" width="88" height="32"/>
+   <rect x="457" y="263" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="467" y="283">view_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m48 0 h10 m0 0 h324 m-412 0 h20 m392 0 h20 m-432 0 q10 0 10 10 m412 0 q0 -10 10 -10 m-422 10 v24 m412 0 v-24 m-412 24 q0 10 10 10 m392 0 q10 0 10 -10 m-382 10 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h142 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v12 m172 0 v-12 m-172 12 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m52 0 h10 m0 0 h80 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m96 0 h10 m0 0 h36 m20 -120 h10 m56 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-320 230 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m48 0 h10 m20 0 h10 m90 0 h10 m0 0 h72 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h10 m88 0 h10 m23 -44 h-3"/>
-   <polygon points="553 247 561 243 561 251"/>
-   <polygon points="553 247 545 243 545 251"/>
+         d="m17 17 h2 m0 0 h10 m78 0 h10 m20 0 h10 m0 0 h74 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v12 m104 0 v-12 m-104 12 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m40 -32 h10 m0 0 h290 m-320 0 h20 m300 0 h20 m-340 0 q10 0 10 10 m320 0 q0 -10 10 -10 m-330 10 v12 m320 0 v-12 m-320 12 q0 10 10 10 m300 0 q10 0 10 -10 m-290 10 h10 m0 0 h142 m-172 0 h20 m152 0 h20 m-192 0 q10 0 10 10 m172 0 q0 -10 10 -10 m-182 10 v12 m172 0 v-12 m-172 12 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m52 0 h10 m0 0 h80 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m132 0 h10 m-162 -10 v20 m172 0 v-20 m-172 20 v24 m172 0 v-24 m-172 24 q0 10 10 10 m152 0 q10 0 10 -10 m-162 10 h10 m96 0 h10 m0 0 h36 m20 -120 h10 m88 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m90 0 h10 m0 0 h72 m-202 0 h20 m182 0 h20 m-222 0 q10 0 10 10 m202 0 q0 -10 10 -10 m-212 10 v24 m202 0 v-24 m-202 24 q0 10 10 10 m182 0 q10 0 10 -10 m-192 10 h10 m54 0 h10 m0 0 h10 m88 0 h10 m23 -44 h-3"/>
+   <polygon points="585 235 593 231 593 239"/>
+   <polygon points="585 235 577 231 577 239"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -137,11 +137,7 @@ drop_view ::=
   'DROP' 'VIEW' ('IF' 'EXISTS')? view_name ('RESTRICT' | 'CASCADE')?
 explain ::=
   'EXPLAIN'
-  (
-    'SQL' |
-    'TYPED'? ( 'RAW' | 'DECORRELATED' | 'OPTIMIZED' )? 'PLAN'
-  )
-  'FOR'
+  'TYPED'? ( ( 'RAW' | 'DECORRELATED' | 'OPTIMIZED' )? 'PLAN FOR' )?
   (
     select_stmt |
     'VIEW' view_name

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -759,7 +759,6 @@ where
             Plan::SendRows(rows) => tx.send(Ok(send_immediate_rows(rows)), session),
 
             Plan::ExplainPlan {
-                sql,
                 raw_plan,
                 decorrelated_plan,
                 row_set_finishing,
@@ -767,7 +766,6 @@ where
                 options,
             } => tx.send(
                 self.sequence_explain_plan(
-                    sql,
                     raw_plan,
                     decorrelated_plan,
                     row_set_finishing,
@@ -1393,7 +1391,6 @@ where
 
     fn sequence_explain_plan(
         &mut self,
-        sql: String,
         raw_plan: sql::plan::RelationExpr,
         decorrelated_plan: expr::RelationExpr,
         row_set_finishing: Option<RowSetFinishing>,
@@ -1401,7 +1398,6 @@ where
         options: ExplainOptions,
     ) -> Result<ExecuteResponse, failure::Error> {
         let explanation_string = match stage {
-            ExplainStage::Sql => sql,
             ExplainStage::RawPlan => {
                 let mut explanation = raw_plan.explain(&self.catalog);
                 if let Some(row_set_finishing) = row_set_finishing {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -243,7 +243,7 @@ pub enum Statement {
         with_snapshot: bool,
         as_of: Option<Expr>,
     },
-    /// `EXPLAIN [ DATAFLOW | PLAN ] FOR`
+    /// `EXPLAIN ...`
     Explain {
         stage: ExplainStage,
         explainee: Explainee,
@@ -888,8 +888,6 @@ impl_display!(Assignment);
 /// Specifies what [Statement::Explain] is actually explaining
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ExplainStage {
-    /// The original sql string
-    Sql,
     /// The sql::RelationExpr after parsing
     RawPlan,
     /// The expr::RelationExpr after decorrelation
@@ -901,7 +899,6 @@ pub enum ExplainStage {
 impl AstDisplay for ExplainStage {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
-            ExplainStage::Sql => f.write_str("SQL"),
             ExplainStage::RawPlan => f.write_str("RAW PLAN"),
             ExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
             ExplainStage::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -19,11 +19,11 @@
 # limitations under the License.
 
 parse-statement
-EXPLAIN SQL FOR SELECT 665
+EXPLAIN SELECT 665
 ----
-EXPLAIN SQL FOR SELECT 665
+EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain { stage: Sql, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
+Explain { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
 
 parse-statement
 EXPLAIN RAW PLAN FOR SELECT 665

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -131,7 +131,6 @@ pub enum Plan {
     },
     SendRows(Vec<Row>),
     ExplainPlan {
-        sql: String,
         raw_plan: RelationExpr,
         decorrelated_plan: ::expr::RelationExpr,
         row_set_finishing: Option<RowSetFinishing>,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -120,7 +120,6 @@ pub fn describe_statement(
         } => (
             Some(RelationDesc::empty().with_nonnull_column(
                 match stage {
-                    ExplainStage::Sql => "Sql",
                     ExplainStage::RawPlan => "Raw Plan",
                     ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
                     ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
@@ -1667,7 +1666,7 @@ fn handle_explain(
     } else {
         false
     };
-    let (scx, sql, query) = match explainee {
+    let (scx, query) = match explainee {
         Explainee::View(name) => {
             let full_name = scx.resolve_item(name.clone())?;
             let entry = scx.catalog.get_item(&full_name);
@@ -1688,9 +1687,9 @@ fn handle_explain(
                 pcx: entry.plan_cx(),
                 catalog: scx.catalog,
             };
-            (scx, entry.create_sql().to_owned(), *query)
+            (scx, *query)
         }
-        Explainee::Query(query) => (scx.clone(), query.to_string(), query),
+        Explainee::Query(query) => (scx.clone(), query),
     };
     // Previouly we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
     // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
@@ -1708,7 +1707,6 @@ fn handle_explain(
     sql_expr.bind_parameters(&params);
     let expr = sql_expr.clone().decorrelate();
     Ok(Plan::ExplainPlan {
-        sql,
         raw_plan: sql_expr,
         decorrelated_plan: expr,
         row_set_finishing: finishing,

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -10,12 +10,6 @@
 mode cockroach
 
 query T multiline
-EXPLAIN SQL FOR SELECT * FROM (SELECT 1)
-----
-SELECT * FROM (SELECT 1)
-EOF
-
-query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM (SELECT 1)
 ----
 %0 =
@@ -93,12 +87,6 @@ EOF
 
 statement ok
 CREATE VIEW foo AS SELECT * FROM (SELECT 1)
-
-query T multiline
-EXPLAIN SQL FOR VIEW foo
-----
-CREATE VIEW "materialize"."public"."foo" AS SELECT * FROM (SELECT 1)
-EOF
 
 query T multiline
 EXPLAIN DECORRELATED PLAN FOR VIEW foo


### PR DESCRIPTION
Add support for the PostgreSQL standard "EXPLAIN <statement>" form, in
addition to our more esoteric "EXPLAIN OPTIMIZED PLAN FOR..." and
friends.

Also, remove `EXPLAIN SQL`, as it is redundant with `SHOW CREATE VIEW`
and having two ways to do the same thing is confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3384)
<!-- Reviewable:end -->
