### PR TITLE
Add netem chaos tests

### DIFF
--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -948,7 +948,7 @@ class ChaosKillDockerStep(ChaosDockerWorkflowStep):
 
 
 class ChaosNetemStep(WorkflowStep):
-    """Base class for running netem chaos against a Docker container.
+    """Base class for running network chaos tests against a Docker container.
 
     We use pumba (a chaos testing tool for Docker) to run the various netem tests.
     pumba only supports Docker container names (not container ids), meaning that
@@ -990,7 +990,6 @@ class ChaosDelayDockerStep(ChaosNetemStep):
     ) -> None:
         super().__init__(duration=duration)
         self._container = container
-        self._duration = duration
         self._delay = delay
         self._jitter = jitter
 
@@ -1007,7 +1006,6 @@ class ChaosRateDockerStep(ChaosNetemStep):
     def __init__(self, container: str, duration: int = -1) -> None:
         super().__init__(duration=duration)
         self._container = container
-        self._duration = duration
 
     def get_cmd(self, duration: int) -> str:
         return f"pumba netem --duration {duration}m rate {self._container}"
@@ -1021,7 +1019,6 @@ class ChaosLossDockerStep(ChaosNetemStep):
     def __init__(self, container: str, percent: int, duration: int = -1) -> None:
         super().__init__(duration=duration)
         self._container = container
-        self._duration = duration
         self._percent = percent
 
     def get_cmd(self, duration: int) -> str:
@@ -1036,7 +1033,6 @@ class ChaosDuplicateDockerStep(ChaosNetemStep):
     def __init__(self, container: str, percent: int, duration: int = -1) -> None:
         super().__init__(duration=duration)
         self._container = container
-        self._duration = duration
         self._percent = percent
 
     def get_cmd(self, duration: int) -> str:
@@ -1051,7 +1047,6 @@ class ChaosCorruptDockerStep(ChaosNetemStep):
     def __init__(self, container: str, percent: int, duration: int = -1) -> None:
         super().__init__(duration=duration)
         self._container = container
-        self._duration = duration
         self._percent = percent
 
     def get_cmd(self, duration: int) -> str:

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -69,35 +69,58 @@ services:
 
 mzconduct:
   workflows:
-    # This test is designed to delay inbound and outbound network
-    # traffic of the Kafka broker.
-    #
-    # Success: Kafka broker traffic is delayed, materialize does not
-    #          crash, chaos container exits successfully.
-    #          Note: to confirm that broker traffic is delayed, you can run the
-    #                following on the Kafka broker's container: `tc qdisc show  dev eth0`
-    # Failure: Kafka broker traffic is not delayed, materialize crashes,
-    #          or chaos container exits unsuccessfully.
+    # This test is designed to delay egress network traffic of the Kafka broker.
     delay-kafka:
       steps:
         - step: workflow
           workflow: start-everything
         - step: chaos-delay-docker
-          service: kafka
-        - step: run
-          service: chaos
-          command: >-
-            --materialized-host materialized
-            --materialized-port 6875
-            --kafka-url kafka:9092
-            --kafka-partitions 5
-            --message-count 1000000
-        - step: chaos-confirm
-          service: materialized
-          running: true
-        - step: chaos-confirm
-          service: chaos_run
-          exit_code: 0
+          container: chaos_kafka_1
+        - step: workflow
+          workflow: run-netem-and-confirm
+
+    # This test is designed to rate limit egress network traffic of the Kafka broker.
+    rate-kafka:
+      steps:
+        - step: workflow
+          workflow: start-everything
+        - step: chaos-rate-docker
+          container: chaos_kafka_1
+        - step: workflow
+          workflow: run-netem-and-confirm
+
+    # This test is designed to test packet loss from the Kafka broker.
+    loss-kafka:
+      steps:
+        - step: workflow
+          workflow: start-everything
+        - step: chaos-loss-docker
+          container: chaos_kafka_1
+          percent: 10
+        - step: workflow
+          workflow: run-netem-and-confirm
+
+    # This test is designed to test packet loss from the Kafka broker.
+    duplicate-kafka:
+      steps:
+        - step: workflow
+          workflow: start-everything
+        - step: chaos-duplicate-docker
+          container: chaos_kafka_1
+          percent: 10
+        - step: workflow
+          workflow: run-netem-and-confirm
+
+    # This test is designed to test packet corruption from the Kafka broker.
+    corrupt-kafka:
+      steps:
+        - step: workflow
+          workflow: start-everything
+        - step: chaos-corrupt-docker
+          container: chaos_kafka_1
+          percent: 10
+        - step: workflow
+          workflow: run-netem-and-confirm
 
     # This test is designed to pause and unpause the running Kafka broker
     # (chaos-kill-container sends a SIGSTOP signal to the container).
@@ -192,3 +215,29 @@ mzconduct:
         - step: wait-for-tcp
           host: materialized
           port: 6875
+
+    # To verify a netem chaos test, we run the chaos container to completion
+    # and check the following conditions:
+    #
+    # - the materialized container did not crash
+    # - the kafka container did not crash
+    # - the chaos container completed successfully
+    run-netem-and-confirm:
+      steps:
+        - step: run
+          service: chaos
+          command: >-
+            --materialized-host materialized
+            --materialized-port 6875
+            --kafka-url kafka:9092
+            --kafka-partitions 100
+            --message-count 100000000
+        - step: chaos-confirm
+          service: materialized
+          running: true
+        - step: chaos-confirm
+          service: kafka
+          running: true
+        - step: chaos-confirm
+          service: chaos_run
+          exit_code: 0


### PR DESCRIPTION
This PR adds four new network emulation tests to the chaos crate:
- rate limiting a container
- packet loss from a container
- duplicate packets from a container
- corrupt packets from a container

I used [pumba](https://github.com/alexei-led/pumba) commands to create these tests. The good news: pumba commands allow for more configurations than I use here, so we can run more complicated tests easily in the future. The bad news: pumba commands expect a container name, not an id.

I ran each of these tests locally (both with and without a provided duration) on 1,000 records to test them out. I haven't found any bugs yet! But once I merge this, I'll spin up each test in EC2 to see what errors might surface during a longer run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3387)
<!-- Reviewable:end -->
