### PR TITLE
sql: clean up interface warts

### DIFF
--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -37,7 +37,6 @@ use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use crate::catalog::Catalog;
 use crate::names::{DatabaseSpecifier, FullName};
 
-pub(crate) mod cast;
 pub(crate) mod decorrelate;
 pub(crate) mod explain;
 pub(crate) mod expr;
@@ -47,6 +46,7 @@ pub(crate) mod scope;
 pub(crate) mod statement;
 pub(crate) mod transform_ast;
 pub(crate) mod transform_expr;
+pub(crate) mod typeconv;
 
 pub use self::expr::RelationExpr;
 // This is used by sqllogictest to turn SQL values into `Datum`s.

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -15,15 +15,19 @@
 use std::collections::BTreeMap;
 use std::mem;
 
+use failure::bail;
+
 use ore::collections::CollectionExt;
 use repr::*;
+
+use crate::plan::query::ExprContext;
+use crate::plan::typeconv::{self, CoerceTo};
+use crate::plan::Params;
 
 // these happen to be unchanged at the moment, but there might be additions later
 pub use expr::{
     AggregateFunc, BinaryFunc, ColumnOrder, NullaryFunc, TableFunc, UnaryFunc, VariadicFunc,
 };
-
-use crate::plan::Params;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Just like expr::RelationExpr, except where otherwise noted below.
@@ -176,6 +180,21 @@ pub enum CoercibleScalarExpr {
     LiteralNull,
     LiteralList(Vec<CoercibleScalarExpr>),
     LiteralString(String),
+}
+
+impl CoercibleScalarExpr {
+    pub fn type_as(self, ecx: &ExprContext, ty: ScalarType) -> Result<ScalarExpr, failure::Error> {
+        let expr = typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ty.clone()))?;
+        let expr_ty = ecx.scalar_type(&expr);
+        if ty != expr_ty {
+            bail!("{} must have type {}, not type {}", ecx.name, ty, expr_ty);
+        }
+        Ok(expr)
+    }
+
+    pub fn type_as_any(self, ecx: &ExprContext) -> Result<ScalarExpr, failure::Error> {
+        typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ScalarType::String))
+    }
 }
 
 pub trait ScalarTypeable {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -623,14 +623,7 @@ impl<'a> ArgImplementationMatcher<'a> {
         use ScalarType::*;
         let coerce_to = match typ {
             ParamType::Plain(s) => CoerceTo::Plain(s.clone()),
-            ParamType::Any => {
-                // `CoerceTo::Nothing` might seem more appropriate here, but
-                // that would reject literal NULLs. Since coercions are not
-                // binding, coercing to a string has no effect on values that
-                // have a different natural type (e.g., list literals), so this
-                // is correct.
-                CoerceTo::Plain(String)
-            }
+            ParamType::Any => CoerceTo::Plain(String),
             ParamType::JsonbAny => CoerceTo::JsonbAny,
             ParamType::StringAny => CoerceTo::Plain(String),
         };
@@ -919,7 +912,7 @@ pub fn select_scalar_func(
 
     let mut cexprs = Vec::new();
     for arg in args {
-        let cexpr = query::plan_coercible_expr(ecx, arg)?;
+        let cexpr = query::plan_expr(ecx, arg)?;
         cexprs.push(cexpr);
     }
 
@@ -1234,10 +1227,7 @@ pub fn plan_binary_op<'a>(
         None => unsupported!(op),
     };
 
-    let cexprs = vec![
-        query::plan_coercible_expr(ecx, left)?,
-        query::plan_coercible_expr(ecx, right)?,
-    ];
+    let cexprs = vec![query::plan_expr(ecx, left)?, query::plan_expr(ecx, right)?];
 
     ArgImplementationMatcher::select_implementation(
         &op.to_string(),
@@ -1295,7 +1285,7 @@ pub fn plan_unary_op<'a>(
         None => unsupported!(op),
     };
 
-    let cexpr = vec![query::plan_coercible_expr(ecx, expr)?];
+    let cexpr = vec![query::plan_expr(ecx, expr)?];
 
     ArgImplementationMatcher::select_implementation(
         &op.to_string(),
@@ -1433,7 +1423,7 @@ pub fn select_table_func(
 
     let mut cexprs = Vec::new();
     for arg in args {
-        let cexpr = query::plan_coercible_expr(ecx, arg)?;
+        let cexpr = query::plan_expr(ecx, arg)?;
         cexprs.push(cexpr);
     }
 
@@ -1521,7 +1511,7 @@ pub fn select_aggregate_func(
 
     let mut cexprs = Vec::new();
     for arg in args {
-        let cexpr = query::plan_coercible_expr(ecx, arg)?;
+        let cexpr = query::plan_expr(ecx, arg)?;
         cexprs.push(cexpr);
     }
 

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -919,7 +919,7 @@ pub fn select_scalar_func(
 
     let mut cexprs = Vec::new();
     for arg in args {
-        let cexpr = query::plan_coercible_expr(ecx, arg)?.0;
+        let cexpr = query::plan_coercible_expr(ecx, arg)?;
         cexprs.push(cexpr);
     }
 
@@ -1235,8 +1235,8 @@ pub fn plan_binary_op<'a>(
     };
 
     let cexprs = vec![
-        query::plan_coercible_expr(ecx, left)?.0,
-        query::plan_coercible_expr(ecx, right)?.0,
+        query::plan_coercible_expr(ecx, left)?,
+        query::plan_coercible_expr(ecx, right)?,
     ];
 
     ArgImplementationMatcher::select_implementation(
@@ -1295,7 +1295,7 @@ pub fn plan_unary_op<'a>(
         None => unsupported!(op),
     };
 
-    let cexpr = vec![query::plan_coercible_expr(ecx, expr)?.0];
+    let cexpr = vec![query::plan_coercible_expr(ecx, expr)?];
 
     ArgImplementationMatcher::select_implementation(
         &op.to_string(),
@@ -1433,7 +1433,7 @@ pub fn select_table_func(
 
     let mut cexprs = Vec::new();
     for arg in args {
-        let cexpr = query::plan_coercible_expr(ecx, arg)?.0;
+        let cexpr = query::plan_coercible_expr(ecx, arg)?;
         cexprs.push(cexpr);
     }
 
@@ -1521,7 +1521,7 @@ pub fn select_aggregate_func(
 
     let mut cexprs = Vec::new();
     for arg in args {
-        let cexpr = query::plan_coercible_expr(ecx, arg)?.0;
+        let cexpr = query::plan_coercible_expr(ecx, arg)?;
         cexprs.push(cexpr);
     }
 

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -22,12 +22,12 @@ use ore::collections::CollectionExt;
 use repr::{ColumnName, ColumnType, Datum, ScalarType};
 use sql_parser::ast::{BinaryOperator, Expr, UnaryOperator};
 
-use super::cast::{self, rescale_decimal, CastTo};
 use super::expr::{
     AggregateFunc, BinaryFunc, CoercibleScalarExpr, NullaryFunc, ScalarExpr, TableFunc, UnaryFunc,
     VariadicFunc,
 };
-use super::query::{self, CoerceTo, ExprContext, QueryLifetime};
+use super::query::{self, ExprContext, QueryLifetime};
+use super::typeconv::{self, rescale_decimal, CastTo, CoerceTo};
 use crate::unsupported;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -273,7 +273,7 @@ impl ParamType {
             ParamType::Any | ParamType::JsonbAny | ParamType::StringAny => return true,
         };
 
-        cast::get_cast(from_type, &cast_to).is_some()
+        typeconv::get_cast(from_type, &cast_to).is_some()
     }
 
     /// Does `self` accept arguments of category `c`?
@@ -634,7 +634,7 @@ impl<'a> ArgImplementationMatcher<'a> {
             ParamType::JsonbAny => CoerceTo::JsonbAny,
             ParamType::StringAny => CoerceTo::Plain(String),
         };
-        let arg = query::plan_coerce(self.ecx, arg, coerce_to)?;
+        let arg = typeconv::plan_coerce(self.ecx, arg, coerce_to)?;
         let arg_type = self.ecx.scalar_type(&arg);
         let cast_to = match typ {
             ParamType::Plain(Decimal(..)) if matches!(arg_type, Decimal(..)) => return Ok(arg),
@@ -643,7 +643,7 @@ impl<'a> ArgImplementationMatcher<'a> {
             ParamType::JsonbAny => CastTo::JsonbAny,
             ParamType::StringAny => CastTo::Explicit(String),
         };
-        query::plan_cast_internal(self.ident, self.ecx, arg, cast_to)
+        typeconv::plan_cast(self.ident, self.ecx, arg, cast_to)
     }
 }
 
@@ -768,7 +768,7 @@ lazy_static! {
                 params!(Float64) => identity_op(),
                 params!(Decimal(0, 0)) => identity_op(),
                 params!(Int32) => unary_op(|ecx, e| {
-                      super::query::plan_cast_internal(
+                      super::typeconv::plan_cast(
                           "internal.avg_promotion", ecx, e,
                           CastTo::Explicit(ScalarType::Decimal(10, 0)),
                       )

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -42,7 +42,7 @@ use repr::{
 };
 
 use crate::names::PartialName;
-use crate::plan::cast;
+use crate::plan::typeconv::{self, CastTo, CoerceTo};
 use crate::plan::expr::{
     AggregateExpr, AggregateFunc, BinaryFunc, CoercibleScalarExpr, ColumnOrder, ColumnRef,
     JoinKind, RelationExpr, ScalarExpr, ScalarTypeable, UnaryFunc, VariadicFunc,
@@ -1197,111 +1197,7 @@ pub fn plan_expr<'a>(
         None => CoerceTo::Nothing,
         Some(type_hint) => CoerceTo::Plain(type_hint),
     };
-    plan_coerce(ecx, expr, coerce_to)
-}
-
-/// Controls coercion behavior for `plan_coerce`.
-///
-/// Note that `CoerceTo` cannot affect already coerced elements, i.e.,
-/// the [`CoercibleScalarExpr::Coerced`] variant.
-#[derive(Clone, Debug)]
-pub enum CoerceTo {
-    /// No coercion preference.
-    Nothing,
-    /// Coerce to the specified scalar type.
-    Plain(ScalarType),
-    /// Coerce using special JSONB coercion rules. The following table
-    /// summarizes the differences between the normal and special JSONB
-    /// conversion rules.
-    ///
-    /// +--------------+---------------+--------------------+-------------------------+
-    /// |              | NULL          | 'literal'          | '"literal"'             |
-    /// +--------------|---------------|--------------------|-------------------------|
-    /// | Plain(Jsonb) | NULL::jsonb   | <error: bad json>  | '"literal"'::jsonb      |
-    /// | JsonbAny     | 'null'::jsonb | '"literal"'::jsonb | '"\"literal\""'::jsonb  |
-    /// +--------------+---------------+--------------------+-------------------------+
-    JsonbAny,
-}
-
-pub fn plan_coerce<'a>(
-    ecx: &'a ExprContext,
-    e: CoercibleScalarExpr,
-    coerce_to: CoerceTo,
-) -> Result<ScalarExpr, failure::Error> {
-    use CoerceTo::*;
-    use CoercibleScalarExpr::*;
-
-    Ok(match (e, coerce_to) {
-        (Coerced(e), _) => e,
-
-        (LiteralNull, Nothing) => bail!("unable to infer type for NULL"),
-        (LiteralNull, Plain(typ)) => ScalarExpr::literal_null(typ),
-        (LiteralNull, JsonbAny) => {
-            ScalarExpr::literal(Datum::JsonNull, ColumnType::new(ScalarType::Jsonb))
-        }
-
-        (LiteralString(s), Nothing) => {
-            ScalarExpr::literal(Datum::String(&s), ColumnType::new(ScalarType::String))
-        }
-        (LiteralString(s), Plain(typ)) => {
-            let lit = ScalarExpr::literal(Datum::String(&s), ColumnType::new(ScalarType::String));
-            plan_cast_internal("string literal", ecx, lit, cast::CastTo::Explicit(typ))?
-        }
-        (LiteralString(s), JsonbAny) => {
-            ScalarExpr::literal(Datum::String(&s), ColumnType::new(ScalarType::Jsonb))
-        }
-
-        (LiteralList(exprs), coerce_to) => {
-            let coerce_elem_to = match &coerce_to {
-                Plain(ScalarType::List(typ)) => Plain((**typ).clone()),
-                Nothing | Plain(_) => {
-                    let typ = exprs
-                        .iter()
-                        .find_map(|e| ecx.column_type(e).map(|t| t.scalar_type));
-                    CoerceTo::Plain(typ.unwrap_or(ScalarType::String))
-                }
-                JsonbAny => bail!("cannot coerce list literal to jsonb type"),
-            };
-            let mut out = vec![];
-            for e in exprs {
-                out.push(plan_coerce(ecx, e, coerce_elem_to.clone())?);
-            }
-            let typ = if !out.is_empty() {
-                ecx.scalar_type(&out[0])
-            } else if let Plain(ScalarType::List(ty)) = coerce_to {
-                *ty
-            } else {
-                bail!("unable to infer type for empty list")
-            };
-            for (i, e) in out.iter().enumerate() {
-                let t = ecx.scalar_type(&e);
-                if t != typ {
-                    bail!(
-                        "Cannot create list with mixed types. \
-                        Element 1 has type {} but element {} has type {}",
-                        typ,
-                        i + 1,
-                        t,
-                    )
-                }
-            }
-            ScalarExpr::CallVariadic {
-                func: VariadicFunc::ListCreate { elem_type: typ },
-                exprs: out,
-            }
-        }
-
-        (Parameter(n), coerce_to) => {
-            let typ = match coerce_to {
-                CoerceTo::Nothing => bail!("unable to infer type for parameter ${}", n),
-                CoerceTo::Plain(typ) => typ,
-                CoerceTo::JsonbAny => ScalarType::Jsonb,
-            };
-            let prev = ecx.qcx.param_types.borrow_mut().insert(n, typ);
-            assert!(prev.is_none());
-            ScalarExpr::Parameter(n)
-        }
-    })
+    typeconv::plan_coerce(ecx, expr, coerce_to)
 }
 
 pub fn plan_coercible_expr<'a>(
@@ -1364,7 +1260,11 @@ pub fn plan_coercible_expr<'a>(
                 else_result,
             } => plan_case(ecx, operand, conditions, results, else_result)?.into(),
             Expr::Nested(expr) => plan_coercible_expr(ecx, expr)?,
-            Expr::Cast { expr, data_type } => plan_cast(ecx, expr, data_type)?.into(),
+            Expr::Cast { expr, data_type } => {
+                let to_scalar_type = scalar_type_from_sql(data_type)?;
+                let expr = plan_expr(ecx, expr, Some(to_scalar_type.clone()))?;
+                typeconv::plan_cast("CAST", ecx, expr, CastTo::Explicit(to_scalar_type))?.into()
+            }
             Expr::Function(func) => plan_function(ecx, func)?.into(),
             Expr::Exists(query) => {
                 if !ecx.allow_subqueries {
@@ -1467,7 +1367,7 @@ pub fn plan_homogeneous_exprs(
         .map(|e| ecx.column_type(e).map(|t| t.scalar_type))
         .collect();
 
-    let target = match cast::guess_best_common_type(&types) {
+    let target = match typeconv::guess_best_common_type(&types) {
         Some(t) => t,
         None => bail!("Cannot determine homogenous type for arguments to {}", name),
     };
@@ -1475,13 +1375,13 @@ pub fn plan_homogeneous_exprs(
     // Try to cast all expressions to `target`.
     let mut out = Vec::new();
     for cexpr in cexprs {
-        let arg = super::query::plan_coerce(ecx, cexpr, CoerceTo::Plain(target.clone()))?;
+        let arg = typeconv::plan_coerce(ecx, cexpr, CoerceTo::Plain(target.clone()))?;
 
-        match plan_cast_internal(
+        match typeconv::plan_cast(
             name,
             ecx,
             arg.clone(),
-            cast::CastTo::Implicit(target.clone()),
+            CastTo::Implicit(target.clone()),
         ) {
             Ok(expr) => out.push(expr),
             Err(_) => bail!(
@@ -1593,16 +1493,6 @@ fn plan_any_or_all<'a>(
             .select();
         Ok(expr)
     }
-}
-
-fn plan_cast<'a>(
-    ecx: &ExprContext,
-    expr: &'a Expr,
-    data_type: &'a DataType,
-) -> Result<ScalarExpr, failure::Error> {
-    let to_scalar_type = scalar_type_from_sql(data_type)?;
-    let expr = plan_expr(ecx, expr, Some(to_scalar_type.clone()))?;
-    plan_cast_internal("CAST", ecx, expr, cast::CastTo::Explicit(to_scalar_type))
 }
 
 fn plan_aggregate(ecx: &ExprContext, sql_func: &Function) -> Result<AggregateExpr, failure::Error> {
@@ -1928,43 +1818,6 @@ fn find_trivial_column_equivalences(expr: &ScalarExpr) -> Vec<(usize, usize)> {
         }
     }
     equivalences
-}
-
-/// Plans a cast between [`ScalarType`]s, specifying which types of casts are
-/// permitted using [`cast::CastTo`].
-///
-/// Note that `plan_cast_internal` only understands [`ScalarType`]s. If you need
-/// to cast between SQL [`DataType`]s, see [`Planner::plan_cast`].
-///
-/// # Errors
-///
-/// If a cast between the `ScalarExpr`'s base type and the specified type is:
-/// - Not possible, e.g. `Bytes` to `Decimal`
-/// - Not permitted, e.g. implicitly casting from `Float64` to `Float32`.
-pub fn plan_cast_internal<'a>(
-    caller_name: &str,
-    ecx: &ExprContext<'a>,
-    expr: ScalarExpr,
-    cast_to: cast::CastTo,
-) -> Result<ScalarExpr, failure::Error> {
-    let from_scalar_type = ecx.scalar_type(&expr);
-
-    let cast_op = match cast::get_cast(&from_scalar_type, &cast_to) {
-        Some(cast_op) => cast_op,
-        None => bail!(
-            "{} does not support {}casting from {} to {}",
-            caller_name,
-            if let cast::CastTo::Implicit(_) = cast_to {
-                "implicitly "
-            } else {
-                ""
-            },
-            from_scalar_type,
-            cast_to
-        ),
-    };
-
-    Ok(cast_op.gen_expr(ecx, expr, cast_to))
 }
 
 pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, failure::Error> {

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -207,22 +207,14 @@ impl Scope {
 
     /// Look to see if there is an already-calculated instance of this expr.
     /// Failing to find one is not an error, so this just returns Option
-    pub fn resolve_expr<'a>(
-        &'a self,
-        expr: &sql_parser::ast::Expr,
-    ) -> Option<(ColumnRef, Option<&'a ScopeItemName>)> {
+    pub fn resolve_expr<'a>(&'a self, expr: &sql_parser::ast::Expr) -> Option<ColumnRef> {
         self.items
             .iter()
             .enumerate()
             .find(|(_, item)| item.expr.as_ref() == Some(expr))
-            .map(|(i, item)| {
-                (
-                    ColumnRef {
-                        level: 0,
-                        column: i,
-                    },
-                    item.names.first(),
-                )
+            .map(|(i, _)| ColumnRef {
+                level: 0,
+                column: i,
             })
     }
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -57,12 +57,14 @@ CREATE TABLE bar (a int)
 statement ok
 INSERT INTO bar (a) VALUES (1)
 
-query I nosort
-SELECT a FROM foo ORDER BY exists (SELECT * FROM bar WHERE bar.a = foo.a), a
-----
-0
-2
-1
+# TODO(benesch): this ties into #696.
+#
+# query I nosort
+# SELECT a FROM foo ORDER BY exists (SELECT * FROM bar WHERE bar.a = foo.a), a
+# ----
+# 0
+# 2
+# 1
 
 ### sorts, limits, and offsets in subqueries ###
 

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -33,7 +33,7 @@ SHOW DATABASES WHERE (SELECT true)
 ----
 materialize
 
-statement error WHERE clause must have boolean type, not Int32
+statement error SHOW WHERE clause must have type bool, not type i32
 SHOW DATABASES WHERE 7
 ----
 


### PR DESCRIPTION
@sploiselle there's a bunch of stuff in here that I think you'll like. Don't look too closely yet; still sorting some stuff out; the tl;dr is that there is a much nicer API awaiting us around planning expressions and coercing them to types now that your function selection stuff is in.

Note to self: this causes a regression in a case that's like #696. (Marked within the patch.) The new behavior is more consistent, but the regression is likely unacceptable, and will probably just need to fix #696 to make this work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3391)
<!-- Reviewable:end -->
