### PR TITLE
Add an env var that forces mzbuild to wait for an image to become available

### DIFF
--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -107,7 +107,7 @@ def shell_quote(args: Iterable[Any]) -> str:
 
 
 def env_is_truthy(env_var: str) -> bool:
-    """Return true if `env_var` is set and is not one of: 0, n, no"""
+    """Return true if `env_var` is set and is not one of: 0, '', no"""
     env = os.getenv(env_var)
     if env is not None:
         return env not in ("", "0", "no")


### PR DESCRIPTION
We've had several load tests fail because they tried to use the most recent image, and it
just happened to not be ready yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3393)
<!-- Reviewable:end -->
