### PR TITLE
Do not hoist expressions from `if` bodies

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -37,5 +37,6 @@ sqllogictest \
 sqllogictest \
     -v \
     test/sqllogictest/*.slt \
+    test/sqllogictest/transform/*.slt \
     test/sqllogictest/sqlite/test \
     | tee -a target/slt.log

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -25,6 +25,7 @@ export RUST_BACKTRACE=full
 
 tests=(
     test/sqllogictest/*.slt
+    test/sqllogictest/transform/*.slt
     # test/sqllogictest/sqlite/test/evidence/in1.test
     test/sqllogictest/sqlite/test/evidence/in2.test
     test/sqllogictest/sqlite/test/evidence/slt_lang_aggfunc.test

--- a/src/transform/src/cse/map.rs
+++ b/src/transform/src/cse/map.rs
@@ -96,7 +96,7 @@ fn memoize_and_reuse(
 
 /// Visit and memoize expression nodes.
 ///
-/// Importantly, we should not memoize expressions that may not be execuded by virtue of
+/// Importantly, we should not memoize expressions that may not be excluded by virtue of
 /// being guarded by `if` expressions.
 fn memoize(
     expr: &mut ScalarExpr,
@@ -113,7 +113,7 @@ fn memoize(
             // Literals do not need to be memoized.
         }
         _ => {
-            // We should not eagerly memoize if branches that might not be taken.
+            // We should not eagerly memoize `if` branches that might not be taken.
             // TODO: Memoize expressions in the intersection of `then` and `els`.
             if let ScalarExpr::If {
                 cond,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -252,9 +252,9 @@ impl Default for Optimizer {
                     Box::new(crate::map_lifting::LiteralLifting),
                 ],
             }),
-            Box::new(crate::fusion::project::Project),
             Box::new(crate::reduction_pushdown::ReductionPushdown),
             Box::new(crate::cse::map::Map),
+            Box::new(crate::fusion::project::Project),
             Box::new(crate::reduction::FoldConstants),
         ];
         Self { transforms }

--- a/test/sqllogictest/transform/scalar_cse.slt
+++ b/test/sqllogictest/transform/scalar_cse.slt
@@ -60,3 +60,18 @@ FROM x
 | Project (#4, #5, #7, #8)
 
 EOF
+
+
+# Ensure we don't inline if-guarded expressions
+query T multiline
+EXPLAIN PLAN FOR SELECT
+    CASE WHEN b = 0 THEN 0 ELSE 1/b END,
+    CASE WHEN b != 0 THEN 1/b ELSE 0 END
+FROM x
+----
+%0 =
+| Get materialize.public.x (u1)
+| Map if (#1 = 0) then {0} else {(1 / #1)}, if (#1 != 0) then {(1 / #1)} else {0}
+| Project (#2, #3)
+
+EOF


### PR DESCRIPTION
Scalar CSE was hoisting common expressions in `then` and `els` expressions, without certainty that they would be evaluated. This led to queries like
```sql
SELECT
    CASE WHEN b = 0 THEN 0 ELSE 1/b END,
    CASE WHEN b != 0 THEN 1/b ELSE 0 END
FROM x
```
unconditionally evaluating `1/b`, because it would be hoisted prematurely. We don't do that now. We could be more advanced and determine the expressions in the intersection of the `then` and `els` expressions, but that is future work for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3395)
<!-- Reviewable:end -->
