### PR TITLE
materialized: fix backtraces on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 dependencies = [
  "gimli",
 ]
@@ -167,26 +167,16 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
+checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
 dependencies = [
  "addr2line",
- "backtrace-sys",
  "cfg-if",
  "libc",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1782,6 +1772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
+dependencies = [
+ "adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,16 @@ members = [
     "test/test-util",
 ]
 
+[profile.dev.package]
+# Compile the backtrace crate and its dependencies with all optimizations, even
+# in dev builds, since otherwise backtraces can take 20s+ to symbolize. With
+# optimizations enabled, symbolizing a backtrace takes less than 1s.
+addr2line = { opt-level = 3 }
+backtrace = { opt-level = 3 }
+gimli = { opt-level = 3 }
+miniz_oxide = { opt-level = 3 }
+object = { opt-level = 3 }
+
 [profile.release]
 # Emit only the line info tables, not full debug info, in release builds, to
 # substantially reduce the size of the debug info. Line info tables are enough

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -11,7 +11,7 @@ license = "proprietary"
 
 [dependencies]
 async-trait = "0.1.35"
-backtrace = { version = "0.3.48", default-features = false, features = ["coresymbolication", "libbacktrace"] }
+backtrace = { version = "0.3.49" }
 comm = { path = "../comm" }
 compile-time-run = "0.2.8"
 coord = { path = "../coord" }


### PR DESCRIPTION
Switch over to the new Gimli-based backtrace symbolicator. Gimli is a
pure-Rust reimplementation of libbacktrace that will soon be the default
backtrace implementation in the Rust standard library [0]. Switching to
it now means we can help shake out problems, like [1], before it ships
in the standard library, where fixing problems will require a full six
week release cycle.

This switch has the side effect of fixing backtraces on macOS, which
seem to be broken at the moment because the backtrace crate is picking
libbacktrace over coresymbolication. There isn't a good way of fixing
that because Cargo doesn't support per-platform features [2]; using
neither libbacktrace or coresymbolicator is a kind of stupid but
effective way of sidestepping the problem.

[0]: https://github.com/rust-lang/rust/pull/73441
[1]: https://github.com/rust-lang/backtrace-rs/issues/342
[2]: https://github.com/rust-lang/cargo/issues/1197

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3398)
<!-- Reviewable:end -->
