### PR TITLE
sql: fix comparison semantics for NULL with ANY and ALL

### DIFF
--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -88,6 +88,7 @@ impl RelationExpr {
     pub fn decorrelate(mut self) -> expr::RelationExpr {
         let mut id_gen = expr::IdGen::default();
         transform_expr::split_subquery_predicates(&mut self);
+        transform_expr::try_simplify_quantified_comparisons(&mut self);
         expr::RelationExpr::constant(vec![vec![]], RelationType::new(vec![]))
             .let_in(&mut id_gen, |id_gen, get_outer| {
                 self.applied_to(id_gen, get_outer, &ColumnMap::empty())

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -445,6 +445,16 @@ impl RelationExpr {
         ScalarExpr::Select(Box::new(self))
     }
 
+    pub fn take(&mut self) -> RelationExpr {
+        mem::replace(
+            self,
+            RelationExpr::Constant {
+                rows: vec![],
+                typ: RelationType::new(Vec::new()),
+            },
+        )
+    }
+
     pub fn visit<'a, F>(&'a self, f: &mut F)
     where
         F: FnMut(&'a Self),
@@ -733,6 +743,10 @@ impl ScalarExpr {
         }
     }
 
+    pub fn take(&mut self) -> Self {
+        mem::replace(self, ScalarExpr::literal_null(ScalarType::String))
+    }
+
     pub fn visit<'a, F>(&'a self, f: &mut F)
     where
         F: FnMut(&'a Self),
@@ -773,6 +787,14 @@ impl ScalarExpr {
     {
         self.visit1_mut(|e: &mut ScalarExpr| e.visit_mut(f));
         f(self);
+    }
+
+    pub fn visit_mut_pre<F>(&mut self, f: &mut F)
+    where
+        F: FnMut(&mut Self),
+    {
+        f(self);
+        self.visit1_mut(|e: &mut ScalarExpr| e.visit_mut(f));
     }
 
     pub fn visit1_mut<F>(&mut self, mut f: F)

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1402,61 +1402,25 @@ fn plan_any_or_all<'a>(
         allow_subqueries: true,
     };
 
-    if !column_types[0].nullable {
-        // This transformation allows us to exploit some structure that is easy to spot at this
-        // level, but trickier at the dataflow layer, so we do it here. However, it's only valid if
-        // the column from the right subquery is non-nullable.
-        //
-        // Planning ANY:
-        // SELECT abc.a = ANY(SELECT xyz.x FROM xyz) FROM abc
-        // =>
-        // SELECT EXISTS(SELECT xyz.x FROM xyz WHERE abc.a = xyz.x) FROM abc
-        //
-        // Planning ALL (the same, but applying De Morgan's law):
-        // SELECT abc.a != ALL(SELECT xyz.x FROM xyz) FROM abc
-        // =>
-        // SELECT NOT EXISTS(SELECT xyz.x FROM xyz WHERE abc.a = xyz.x) FROM abc
+    let op_expr = func::plan_binary_op(
+        &any_ecx,
+        op,
+        left,
+        &Expr::Identifier(vec![Ident::new(right_name)]),
+    )?;
 
-        let mut cond = func::plan_binary_op(
-            &any_ecx,
-            op,
-            left,
-            &Expr::Identifier(vec![Ident::new(right_name)]),
-        )?;
-        if func == AggregateFunc::All {
-            cond = cond.call_unary(UnaryFunc::Not);
-        }
-
-        let mut exists = right.filter(vec![cond]).exists();
-        if func == AggregateFunc::All {
-            exists = exists.call_unary(UnaryFunc::Not);
-        }
-        Ok(ScalarExpr::If {
-            cond: Box::new(plan_is_null_expr(ecx, left, false)?),
-            then: Box::new(ScalarExpr::literal_null(ecx.scalar_type(&exists))),
-            els: Box::new(exists),
-        })
-    } else {
-        let op_expr = func::plan_binary_op(
-            &any_ecx,
-            op,
-            left,
-            &Expr::Identifier(vec![Ident::new(right_name)]),
-        )?;
-
-        // plan subquery
-        let expr = right
-            .reduce(
-                vec![],
-                vec![AggregateExpr {
-                    func,
-                    expr: Box::new(op_expr),
-                    distinct: false,
-                }],
-            )
-            .select();
-        Ok(expr)
-    }
+    // plan subquery
+    let expr = right
+        .reduce(
+            vec![],
+            vec![AggregateExpr {
+                func,
+                expr: Box::new(op_expr),
+                distinct: false,
+            }],
+        )
+        .select();
+    Ok(expr)
 }
 
 fn plan_aggregate(ecx: &ExprContext, sql_func: &Function) -> Result<AggregateExpr, failure::Error> {

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -168,7 +168,7 @@ CREATE TABLE stock (
     s_order_cnt smallint,
     s_remote_cnt smallint,
     s_data char(50),
-    s_su_suppkey integer,
+    s_su_suppkey integer NOT NULL,
     PRIMARY KEY (s_w_id, s_i_id)
 )
 
@@ -1101,23 +1101,22 @@ ORDER BY supplier_cnt DESC
 
 %5 =
 | Get %3
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 %6 =
 | Get materialize.public.supplier (u34)
-| ArrangeBy (#0)
+| Filter "^.*bad.*$" ~(#6)
 
 %7 =
-| Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
-| | demand = (#0, #7)
-| Filter "^.*bad.*$" ~(#7)
+| Join %5 %6
+| | implementation = Differential %6 %5.()
+| | demand = (#0, #1)
+| Filter ((#0 = #1) || isnull((#0 != #1)))
+| Distinct group=(#0)
 | Negate
-| Project (#0)
 
 %8 =
 | Get %3
-| Filter (!(isnull(#0)) || null)
 
 %9 =
 | Union %7 %8
@@ -1130,7 +1129,6 @@ ORDER BY supplier_cnt DESC
 | Join %4 %9 %10 (= #17 #23 #24)
 | | implementation = Differential %9 %10.(#0) %4.(#17)
 | | demand = (#17, #20..#22)
-| Filter (!(isnull(#17)) || null)
 | Reduce group=(#20, substr(#22, 1, 3), #21) count(distinct #17)
 
 Finish order_by=(#3 desc) limit=none offset=0 project=(#0..#3)
@@ -1360,7 +1358,6 @@ ORDER BY su_name
 
 %8 =
 | Get %6
-| Filter (#0 = ((#11 * #12) % 10000))
 
 %9 =
 | Get %6
@@ -1378,6 +1375,8 @@ ORDER BY su_name
 | Filter "^co.*$" ~(#44)
 | Reduce group=(#0, #11, #12, #13) sum(#36)
 | Filter ((2 * #3) > #4)
+| Map ((#1 * #2) % 10000)
+| Filter (#0 = #5)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -161,7 +161,7 @@ query BBBBBBBBBBBBBBB
   NULL < ANY(VALUES (2), (NULL))
 ))
 ----
-false  false  false  true  NULL  NULL  true  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+false  false  false  true  NULL  NULL  true  false  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
 query BBBBBBBBBBBBBBB
 (VALUES (
@@ -182,7 +182,7 @@ query BBBBBBBBBBBBBBB
   NULL < ALL(VALUES (2), (NULL))
 ))
 ----
-true  false  false  true  false  false  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL  NULL
+true  false  false  true  false  false  NULL  true  NULL  NULL  NULL  NULL  NULL  NULL  NULL
 
 statement ok
 CREATE TABLE s1 (a int NOT NULL)
@@ -524,16 +524,16 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 
 %1 =
 | Get %0
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 %2 =
 | Get materialize.public.x (u55)
-| ArrangeBy (#0)
 
 %3 =
-| Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery %1 %2.(#0) | %2 %1.(#0)
-| | demand = (#0)
+| Join %1 %2
+| | implementation = Differential %2 %1.()
+| | demand = (#0, #1)
+| Filter ((#0 = #1) || isnull((#0 != #1)))
 | Distinct group=(#0)
 
 %4 =
@@ -596,7 +596,7 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 | Join %1 %2
 | | implementation = Differential %2 %1.()
 | | demand = (#0, #1)
-| Filter (#0 <= #1)
+| Filter ((#0 <= #1) || isnull((#0 > #1)))
 | Distinct group=(#0)
 
 %4 =

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1162,19 +1162,19 @@ ORDER BY
 
 %5 =
 | Get %3
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 %6 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#0)
+| Filter "^.*Customer.*Complaints.*$" ~(#6)
 
 %7 =
-| Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
-| | demand = (#0, #7)
-| Filter "^.*Customer.*Complaints.*$" ~(#7)
+| Join %5 %6
+| | implementation = Differential %6 %5.()
+| | demand = (#0, #1)
+| Filter ((#0 = #1) || isnull((#0 != #1)))
+| Distinct group=(#0)
 | Negate
-| Project (#0)
 
 %8 =
 | Get %3
@@ -1860,7 +1860,7 @@ ORDER BY
 
 %4 =
 | InnerJoin %2 %3 on true
-| Filter ((if isnull(#0) then {null} else {exists(%7)} && (#3 = #7)) && (#8 = "CANADA"))
+| Filter ((select(%7) && (#3 = #7)) && (#8 = "CANADA"))
 | |
 | | %5 =
 | | | Constant ()
@@ -1870,7 +1870,7 @@ ORDER BY
 | |
 | | %7 =
 | | | InnerJoin %5 %6 on true
-| | | Filter (if isnull(#0) then {null} else {exists(%10)} && ((i32todec(#2) * 1000dec) > select(%14)))
+| | | Filter (select(%10) && ((i32todec(#2) * 1000dec) > select(%14)))
 | | | |
 | | | | %8 =
 | | | | | Constant ()
@@ -1885,7 +1885,7 @@ ORDER BY
 | | | | | Project (#9)
 | | | | | Map
 | | | | | Project (#0)
-| | | | | Filter (#^0 = #0)
+| | | | | Reduce group=() any((#^0 = #0))
 | | | |
 | | | |
 | | | | %12 =
@@ -1908,7 +1908,7 @@ ORDER BY
 | | | Project (#5)
 | | | Map
 | | | Project (#0)
-| | | Filter (#^0 = #0)
+| | | Reduce group=() any((#^0 = #0))
 | |
 | Map #1, #2
 | Project (#11, #12)


### PR DESCRIPTION
The transformation of IN/ALL/ANY => EXISTS is only valid when both the
LHS and RHS are non-nullable, or when the IN/ALL/ANY clause appears
directly in a WHERE clause. The existing code was only guarded on
whether the right column was non-nullable.

This commit also moves the transformation to a later stage in the
pipeline, after planning but before decorrelation. This makes it
possible to spot when IN/ALL/ANY occurs directly inside of a filter when
nullability does not need to be taken into account. The new
transformation is unfortunately a bit harder to read, largely thanks to Rust pattern
matching struggles.

Note that this change introduced a regression in Q16 of chbench, which
is a NOT IN query where the LHS is nullable but the RHS is non-nullable.
This would seem to require a special null-aware antijoin operator, which
we don't particularly want to introduce at this moment; luckily, we
think the chbench schema intended for the LHS to be non-nullable (it is
in vanilla TPCH), and so this commit just applies that change to the
chbench schema.

Fix #3319.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3399)
<!-- Reviewable:end -->
