### PR TITLE
expr: mark unary date_trunc as nullable

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2776,8 +2776,8 @@ impl UnaryFunc {
                 ColumnType::new(ScalarType::Float64).nullable(in_nullable)
             }
 
-            DateTruncTimestamp(_) => ColumnType::new(ScalarType::Timestamp).nullable(false),
-            DateTruncTimestampTz(_) => ColumnType::new(ScalarType::TimestampTz).nullable(false),
+            DateTruncTimestamp(_) => ColumnType::new(ScalarType::Timestamp).nullable(true),
+            DateTruncTimestampTz(_) => ColumnType::new(ScalarType::TimestampTz).nullable(true),
 
             ToTimestamp => ColumnType::new(ScalarType::TimestampTz).nullable(true),
 


### PR DESCRIPTION
Closes #3401

Match the convention from the corresponding binary funcs