### PR TITLE
catalog: use optimized expression to get relation description on restart

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -972,11 +972,16 @@ impl Catalog {
             }),
             Plan::CreateView { view, .. } => {
                 let mut optimizer = Optimizer::default();
+                let optimized_expr = optimizer.optimize(view.expr, self.indexes())?;
+                let desc = RelationDesc::new(
+                    optimized_expr.as_ref().typ(),
+                    view.desc.iter_names().map(|c| c.cloned()),
+                );
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
                     plan_cx: pcx,
-                    optimized_expr: optimizer.optimize(view.expr, self.indexes())?,
-                    desc: view.desc,
+                    optimized_expr,
+                    desc,
                     conn_id: None,
                 })
             }


### PR DESCRIPTION
Touches #3401

Previously, we were getting the relation desc from the optimized plan when a
user created a view at runtime, but then getting the relation desc from the
unoptimized plan on restart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3408)
<!-- Reviewable:end -->
