### PR TITLE
return frame size error instead of unwrapping

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -811,7 +811,10 @@ impl PendingPeek {
             Err(text) => PeekResponse::Error(text),
         };
         let mut tx = block_on(self.tx.connect()).unwrap();
-        block_on(tx.send(response)).unwrap();
+        let tx_result = block_on(tx.send(response));
+        if let Err(e) = tx_result {
+            block_on(tx.send(PeekResponse::Error(e.to_string()))).unwrap();
+        }
         true
     }
 


### PR DESCRIPTION
Hard to have an automated test without doing something that will be really slow or OOM the CI workers, but I tested it locally.

We can still panic in the other direction, when creating dataflows, because of `broadcast_dataflow_creation`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3409)
<!-- Reviewable:end -->
