### PR TITLE
Clean up RT Timestamping

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -368,10 +368,6 @@ impl Catalog {
         self.storage.lock().expect("lock poisoned")
     }
 
-    pub fn storage_handle(&self) -> Arc<Mutex<storage::Connection>> {
-        self.storage.clone()
-    }
-
     pub fn allocate_id(&mut self) -> Result<GlobalId, Error> {
         self.storage().allocate_id()
     }

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -199,14 +199,6 @@ impl Connection {
             .collect()
     }
 
-    pub fn prepare(&self, sql: &str) -> rusqlite::Result<rusqlite::Statement> {
-        self.inner.prepare(sql)
-    }
-
-    pub fn prepare_cached(&self, sql: &str) -> rusqlite::Result<rusqlite::CachedStatement> {
-        self.inner.prepare_cached(sql)
-    }
-
     pub fn allocate_id(&mut self) -> Result<GlobalId, Error> {
         let tx = self.inner.transaction()?;
         // SQLite doesn't support u64s, so we constrain ourselves to the more

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -25,7 +25,9 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use url::Url;
 
-use expr::{GlobalId, OptimizedRelationExpr, RelationExpr, ScalarExpr, SourceInstanceId};
+use expr::{
+    GlobalId, OptimizedRelationExpr, PartitionId, RelationExpr, ScalarExpr, SourceInstanceId,
+};
 use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use regex::Regex;
@@ -508,6 +510,22 @@ impl fmt::Display for MzOffset {
 pub struct KafkaOffset {
     pub offset: i64,
 }
+
+/// Structure wrapping a timestamp update from a source
+/// If RT, contains a partition count
+/// If BYO, contains a tuple (PartitionCount, PartitionID, Timestamp, Offset),
+/// which informs workers that messages with Offset on PartititionId will be timestamped
+/// with Timestamp.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum TimestampSourceUpdate {
+    /// Update for an RT source: contains an updated partition count for this source
+    RealTime(i32),
+    ///  Timestamp update for a BYO source: contains an updated partition count for this source,
+    /// combined with a PartitionID, Timestamp, MzOffset tuple. This tuple informs workers that
+    /// messages with Offset on PartitionId will be timestamped with Timestamp.
+    BringYourOwn(i32, PartitionId, u64, MzOffset),
+}
+
 /// Convert from KafkaOffset to MzOffset (1-indexed)
 impl From<KafkaOffset> for MzOffset {
     fn from(kafka_offset: KafkaOffset) -> Self {

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -139,7 +139,7 @@ use crate::decode::{decode_avro_values, decode_upsert, decode_values};
 use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::operator::{CollectionExt, StreamExt};
 use crate::server::LocalInput;
-use crate::server::{TimestampChanges, TimestampHistories};
+use crate::server::{TimestampDataUpdates, TimestampMetadataUpdates};
 use source::SourceOutput;
 
 mod arrange_by;
@@ -201,8 +201,8 @@ pub(crate) fn build_dataflow<A: Allocate>(
     worker: &mut TimelyWorker<A>,
     dataflow_drops: &mut HashMap<GlobalId, Box<dyn Any>>,
     global_source_mappings: &mut HashMap<SourceInstanceId, Weak<Option<SourceToken>>>,
-    timestamp_histories: TimestampHistories,
-    timestamp_channel: TimestampChanges,
+    timestamp_histories: TimestampDataUpdates,
+    timestamp_channel: TimestampMetadataUpdates,
     logger: &mut Option<Logger>,
 ) {
     let worker_index = worker.index();

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -8,8 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use futures::executor::block_on;
@@ -20,7 +18,7 @@ use rusoto_core::RusotoError;
 use rusoto_kinesis::{GetRecordsError, GetRecordsInput, GetRecordsOutput, Kinesis, KinesisClient};
 
 use aws_util::kinesis::{get_shard_ids, get_shard_iterator};
-use dataflow_types::{ExternalSourceConnector, KinesisSourceConnector, Timestamp};
+use dataflow_types::{Consistency, KinesisSourceConnector, Timestamp};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::scheduling::Activator;
@@ -28,6 +26,7 @@ use timely::scheduling::Activator;
 use super::util::source;
 use super::{SourceConfig, SourceOutput, SourceStatus, SourceToken};
 use crate::metrics::EVENTS_COUNTER;
+use crate::server::{TimestampDataUpdate, TimestampMetadataUpdate};
 
 lazy_static! {
     static ref MILLIS_BEHIND_LATEST: IntGaugeVec = register_int_gauge_vec!(
@@ -66,20 +65,22 @@ where
 {
     // Putting source information on the Timestamp channel lets this
     // Dataflow worker communicate that it has created a source.
-    let ts = if config.active {
-        let prev = config
-            .timestamp_histories
-            .borrow_mut()
-            .insert(config.id.clone(), HashMap::new());
-        assert!(prev.is_none());
-        config.timestamp_tx.as_ref().borrow_mut().push((
-            config.id,
-            Some((
-                ExternalSourceConnector::Kinesis(connector.clone()),
-                config.consistency,
-            )),
-        ));
-        Some(config.timestamp_tx)
+    let ts = if let Consistency::BringYourOwn(_) = config.consistency {
+        if config.active {
+            let prev = config.timestamp_histories.borrow_mut().insert(
+                config.id.clone(),
+                TimestampDataUpdate::BringYourOwn(HashMap::new()),
+            );
+            assert!(prev.is_none());
+            config
+                .timestamp_tx
+                .as_ref()
+                .borrow_mut()
+                .push(TimestampMetadataUpdate::StartTimestamping(config.id));
+            Some(config.timestamp_tx)
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -89,118 +90,52 @@ where
 
     let SourceConfig { name, scope, .. } = config;
 
-    let (stream, capability) = source(
-        config.id,
-        ts,
-        Arc::new(AtomicBool::new(false)),
-        scope,
-        name.clone(),
-        move |info| {
-            let activator = scope.activator_for(&info.address[..]);
+    let (stream, capability) = source(config.id, ts, scope, name.clone(), move |info| {
+        let activator = scope.activator_for(&info.address[..]);
 
-            move |cap, output| {
-                let (client, stream_name, shard_set, shard_queue) = match &mut state {
-                    Ok(state) => state,
-                    Err(e) => {
-                        error!("failed to create Kinesis state: {:#?}", e);
-                        return SourceStatus::Done;
-                    }
-                };
-
-                if last_checked_shards.elapsed() >= KINESIS_SHARD_REFRESH_RATE {
-                    if let Err(e) = block_on(update_shard_information(
-                        &client,
-                        &stream_name,
-                        shard_set,
-                        shard_queue,
-                    )) {
-                        error!("{:#?}", e);
-                        return SourceStatus::Done;
-                    }
-                    last_checked_shards = std::time::Instant::now();
+        move |cap, output| {
+            let (client, stream_name, shard_set, shard_queue) = match &mut state {
+                Ok(state) => state,
+                Err(e) => {
+                    error!("failed to create Kinesis state: {:#?}", e);
+                    return SourceStatus::Done;
                 }
+            };
 
-                let timer = std::time::Instant::now();
-                // Rotate through all of a stream's shards, start with a new shard on each activation.
-                while let Some((shard_id, mut shard_iterator)) = shard_queue.pop_front() {
-                    // While the next_shard_iterator is Some(iterator), the shard is open
-                    // and could return more data.
-                    while let Some(iterator) = &shard_iterator {
-                        // Pushing back to the shard_queue will allow us to read from the
-                        // shard again.
-                        let get_records_output = match block_on(get_records(&client, &iterator)) {
-                            Ok(output) => {
-                                shard_iterator = output.next_shard_iterator.clone();
-                                if let Some(millis) = output.millis_behind_latest {
-                                    let shard_metrics: IntGauge = MILLIS_BEHIND_LATEST
-                                        .with_label_values(&[&stream_name, &shard_id]);
-                                    shard_metrics.set(millis);
-                                }
-                                output
-                            }
-                            Err(RusotoError::HttpDispatch(e)) => {
-                                // todo@jldlaughlin: Parse this to determine fatal/retriable?
-                                error!("{}", e);
-                                return reactivate_kinesis_source(
-                                    &activator,
-                                    shard_queue,
-                                    &shard_id,
-                                    shard_iterator,
-                                );
-                            }
-                            Err(RusotoError::Service(GetRecordsError::ExpiredIterator(e))) => {
-                                // todo@jldlaughlin: Will need track source offsets to grab a new iterator.
-                                error!("{}", e);
-                                return SourceStatus::Done;
-                            }
-                            Err(RusotoError::Service(
-                                GetRecordsError::ProvisionedThroughputExceeded(_),
-                            )) => {
-                                return reactivate_kinesis_source(
-                                    &activator,
-                                    shard_queue,
-                                    &shard_id,
-                                    shard_iterator,
-                                );
-                            }
-                            Err(e) => {
-                                // Fatal service errors:
-                                //  - InvalidArgument
-                                //  - KMSAccessDenied, KMSDisabled, KMSInvalidState, KMSNotFound,
-                                //    KMSOptInRequired, KMSThrottling
-                                //  - ResourceNotFound
-                                //
-                                // Other fatal Rusoto errors:
-                                // - Credentials
-                                // - Validation
-                                // - ParseError
-                                // - Unknown (raw HTTP provided)
-                                // - Blocking
-                                error!("{}", e);
-                                return SourceStatus::Done;
-                            }
-                        };
+            if last_checked_shards.elapsed() >= KINESIS_SHARD_REFRESH_RATE {
+                if let Err(e) = block_on(update_shard_information(
+                    &client,
+                    &stream_name,
+                    shard_set,
+                    shard_queue,
+                )) {
+                    error!("{:#?}", e);
+                    return SourceStatus::Done;
+                }
+                last_checked_shards = std::time::Instant::now();
+            }
 
-                        let mut events_success = 0;
-                        let mut bytes_read = 0;
-                        for record in get_records_output.records {
-                            let data = record.data.as_ref().to_vec();
-                            bytes_read += data.len() as i64;
-                            // We don't do anything with keys; just send vec![] for now.
-                            // Kinesis doesn't have "primary keys" but it does have "partition keys" and "sequence numbers"; maybe
-                            // one or both of those could be useful...
+            let timer = std::time::Instant::now();
+            // Rotate through all of a stream's shards, start with a new shard on each activation.
+            while let Some((shard_id, mut shard_iterator)) = shard_queue.pop_front() {
+                // While the next_shard_iterator is Some(iterator), the shard is open
+                // and could return more data.
+                while let Some(iterator) = &shard_iterator {
+                    // Pushing back to the shard_queue will allow us to read from the
+                    // shard again.
+                    let get_records_output = match block_on(get_records(&client, &iterator)) {
+                        Ok(output) => {
+                            shard_iterator = output.next_shard_iterator.clone();
+                            if let Some(millis) = output.millis_behind_latest {
+                                let shard_metrics: IntGauge = MILLIS_BEHIND_LATEST
+                                    .with_label_values(&[&stream_name, &shard_id]);
+                                shard_metrics.set(millis);
+                            }
                             output
-                                .session(&cap)
-                                .give(SourceOutput::new(vec![], data, None));
-                            events_success += 1;
                         }
-                        downgrade_capability(cap, &name);
-                        EVENTS_COUNTER.raw.success.inc_by(events_success);
-                        BYTES_READ_COUNTER.inc_by(bytes_read);
-
-                        if get_records_output.millis_behind_latest == Some(0)
-                            || timer.elapsed().as_millis() > 10
-                        {
+                        Err(RusotoError::HttpDispatch(e)) => {
+                            // todo@jldlaughlin: Parse this to determine fatal/retriable?
+                            error!("{}", e);
                             return reactivate_kinesis_source(
                                 &activator,
                                 shard_queue,
@@ -208,19 +143,78 @@ where
                                 shard_iterator,
                             );
                         }
+                        Err(RusotoError::Service(GetRecordsError::ExpiredIterator(e))) => {
+                            // todo@jldlaughlin: Will need track source offsets to grab a new iterator.
+                            error!("{}", e);
+                            return SourceStatus::Done;
+                        }
+                        Err(RusotoError::Service(
+                            GetRecordsError::ProvisionedThroughputExceeded(_),
+                        )) => {
+                            return reactivate_kinesis_source(
+                                &activator,
+                                shard_queue,
+                                &shard_id,
+                                shard_iterator,
+                            );
+                        }
+                        Err(e) => {
+                            // Fatal service errors:
+                            //  - InvalidArgument
+                            //  - KMSAccessDenied, KMSDisabled, KMSInvalidState, KMSNotFound,
+                            //    KMSOptInRequired, KMSThrottling
+                            //  - ResourceNotFound
+                            //
+                            // Other fatal Rusoto errors:
+                            // - Credentials
+                            // - Validation
+                            // - ParseError
+                            // - Unknown (raw HTTP provided)
+                            // - Blocking
+                            error!("{}", e);
+                            return SourceStatus::Done;
+                        }
+                    };
 
-                        // Each Kinesis shard can support up to 5 read requests per second.
-                        // This will throttle ourselves.
-                        activator.activate();
+                    let mut events_success = 0;
+                    let mut bytes_read = 0;
+                    for record in get_records_output.records {
+                        let data = record.data.as_ref().to_vec();
+                        bytes_read += data.len() as i64;
+                        // We don't do anything with keys; just send vec![] for now.
+                        // Kinesis doesn't have "primary keys" but it does have "partition keys" and "sequence numbers"; maybe
+                        // one or both of those could be useful...
+                        output
+                            .session(&cap)
+                            .give(SourceOutput::new(vec![], data, None));
+                        events_success += 1;
                     }
+                    downgrade_capability(cap, &name);
+                    EVENTS_COUNTER.raw.success.inc_by(events_success);
+                    BYTES_READ_COUNTER.inc_by(bytes_read);
+
+                    if get_records_output.millis_behind_latest == Some(0)
+                        || timer.elapsed().as_millis() > 10
+                    {
+                        return reactivate_kinesis_source(
+                            &activator,
+                            shard_queue,
+                            &shard_id,
+                            shard_iterator,
+                        );
+                    }
+
+                    // Each Kinesis shard can support up to 5 read requests per second.
+                    // This will throttle ourselves.
+                    activator.activate();
                 }
-                // todo@jdlaughlin: Revisit when Kinesis sources should be marked as done.
-                // Should switch to when we fail to get a stream description (the stream is
-                // closed)?
-                SourceStatus::Done
             }
-        },
-    );
+            // todo@jdlaughlin: Revisit when Kinesis sources should be marked as done.
+            // Should switch to when we fail to get a stream description (the stream is
+            // closed)?
+            SourceStatus::Done
+        }
+    });
 
     if config.active {
         (stream, Some(capability))

--- a/src/dataflow/src/source/util.rs
+++ b/src/dataflow/src/source/util.rs
@@ -9,8 +9,6 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 
 use expr::SourceInstanceId;
 
@@ -21,7 +19,7 @@ use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::Data;
 
-use crate::server::TimestampChanges;
+use crate::server::TimestampMetadataUpdates;
 use dataflow_types::Timestamp;
 
 use super::{SourceStatus, SourceToken};
@@ -56,8 +54,7 @@ use super::{SourceStatus, SourceToken};
 /// to terminate any spawned threads in the source operator
 pub fn source<G, D, B, L>(
     id: SourceInstanceId,
-    timestamp_channel: Option<TimestampChanges>,
-    timestamping_flag: Arc<AtomicBool>,
+    timestamp_channel: Option<TimestampMetadataUpdates>,
     scope: &G,
     name: String,
     construct: B,
@@ -82,7 +79,6 @@ where
             capability: cap.clone(),
             activator: scope.activator_for(&info.address[..]),
             timestamp_drop: timestamp_channel,
-            stop_timestamping: timestamping_flag,
         });
 
         let mut tick = construct(info);

--- a/src/materialized/src/bin/materialized.rs
+++ b/src/materialized/src/bin/materialized.rs
@@ -219,7 +219,6 @@ fn run() -> Result<(), failure::Error> {
         None => Duration::from_millis(10),
         Some(d) => parse_duration::parse(&d)?,
     };
-    let persist_ts = popts.opt_get_default("persist-ts", false)?;
 
     // Configure connections.
     let listen_addr = popts.opt_get("listen-addr")?;
@@ -301,7 +300,6 @@ environment:{}",
         logging_granularity,
         logical_compaction_window,
         timestamp_frequency,
-        persist_ts,
         listen_addr,
         tls,
         data_directory: Some(data_directory),

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -109,9 +109,6 @@ pub struct Config {
     pub logical_compaction_window: Option<Duration>,
     /// The interval at which sources should be timestamped.
     pub timestamp_frequency: Duration,
-    /// Whether to record realtime consistency information to the data directory
-    /// and attempt to recover that information on startup.
-    pub persist_ts: bool,
 
     // === Connection options. ===
     /// The IP address and port to listen on -- defaults to 0.0.0.0:<addr_port>,
@@ -273,7 +270,6 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
             data_directory: config.data_directory.as_deref(),
             timestamp: coord::TimestampConfig {
                 frequency: config.timestamp_frequency,
-                persist_ts: config.persist_ts,
             },
             logical_compaction_window: config.logical_compaction_window,
             executor: &executor,

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -67,7 +67,6 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
         logging_granularity: config.logging_granularity,
         timestamp_frequency: Duration::from_millis(10),
         logical_compaction_window: None,
-        persist_ts: false,
         threads: 1,
         process: 0,
         addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -430,7 +430,6 @@ impl State {
             executor: &executor,
             timestamp: TimestampConfig {
                 frequency: Duration::from_millis(10),
-                persist_ts: false,
             },
             logical_compaction_window: None,
         })?;


### PR DESCRIPTION
(The PR is best reviewed commit by commit)

Following the removal of metadata requests to drive timestamp, this PR

1) removes the RT timestamping code path. All RT sources now assign timestamps locally.
2) moves necessary metadatata requests (for partition discovery) back to the timestamped. This further reduces the number of metadata requests done and makes it independent of the number of workers.
3) removes the persistence of timestamps codepath as it is no longer used (and no longer usable as we removed metadata requests)
4) renames the `TimestampChannel` and `TimestampHistory` data structures to more semantically meaningful `TimestampDataUpdate` and `TimestampMetadataUpdate `structures. The code now distinguishes (unfortunately) between RealTime updates and BYO updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3413)
<!-- Reviewable:end -->
