### PR TITLE
Create default index

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2425,15 +2425,16 @@ fn index_sql(
     use sql_parser::ast::{Expr, Ident, Value};
 
     Statement::CreateIndex {
-        name: Ident::new(index_name),
+        name: Some(Ident::new(index_name)),
         on_name: sql::normalize::unresolve(view_name),
-        key_parts: keys
-            .iter()
-            .map(|i| match view_desc.get_unambiguous_name(*i) {
-                Some(n) => Expr::Identifier(vec![Ident::new(n.to_string())]),
-                _ => Expr::Value(Value::Number((i + 1).to_string())),
-            })
-            .collect(),
+        key_parts: Some(
+            keys.iter()
+                .map(|i| match view_desc.get_unambiguous_name(*i) {
+                    Some(n) => Expr::Identifier(vec![Ident::new(n.to_string())]),
+                    _ => Expr::Value(Value::Number((i + 1).to_string())),
+                })
+                .collect(),
+        ),
         if_not_exists: false,
     }
     .to_string()

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -821,8 +821,12 @@ where
         let index_id = self.catalog.allocate_id()?;
         let mut index_name = name.clone();
         index_name.item += "_primary_idx";
-        let index =
-            auto_generate_src_idx(index_name.item.clone(), name.clone(), &source, source_id);
+        let index = auto_generate_primary_idx(
+            index_name.item.clone(),
+            name.clone(),
+            source_id,
+            &source.desc,
+        );
         match self.catalog_transact(vec![
             catalog::Op::CreateItem {
                 id: source_id,
@@ -882,8 +886,12 @@ where
         let (index_id, index) = if materialized {
             let mut index_name = name.clone();
             index_name.item += "_primary_idx";
-            let index =
-                auto_generate_src_idx(index_name.item.clone(), name.clone(), &source, source_id);
+            let index = auto_generate_primary_idx(
+                index_name.item.clone(),
+                name.clone(),
+                source_id,
+                &source.desc,
+            );
             let index_id = self.catalog.allocate_id()?;
             ops.push(catalog::Op::CreateItem {
                 id: index_id,
@@ -1015,8 +1023,13 @@ where
         let (index_id, index) = if materialize {
             let mut index_name = name.clone();
             index_name.item += "_primary_idx";
-            let index =
-                auto_generate_view_idx(index_name.item.clone(), name.clone(), &view, view_id);
+            let index = auto_generate_primary_idx(
+                index_name.item.clone(),
+                name.clone(),
+                view_id,
+                &view.desc,
+            );
+
             let index_id = self.catalog.allocate_id()?;
             ops.push(catalog::Op::CreateItem {
                 id: index_id,
@@ -1256,7 +1269,7 @@ where
                     conn_id: None,
                 };
                 self.build_view_collection(&view_id, &view, &mut dataflow);
-                let index = auto_generate_view_idx(index_name, view_name, &view, view_id);
+                let index = auto_generate_primary_idx(index_name, view_name, view_id, &view.desc);
                 self.build_arrangement(&index_id, index.clone(), typ, dataflow);
                 Some(index)
             } else {
@@ -2385,53 +2398,19 @@ impl ViewState {
     }
 }
 
-pub fn auto_generate_src_idx(
-    index_name: String,
-    source_name: FullName,
-    source: &catalog::Source,
-    source_id: GlobalId,
-) -> catalog::Index {
-    auto_generate_primary_idx(
-        index_name,
-        &source.desc.typ().keys,
-        source_name,
-        source_id,
-        &source.desc,
-    )
-}
-
-pub fn auto_generate_view_idx(
-    index_name: String,
-    view_name: FullName,
-    view: &catalog::View,
-    view_id: GlobalId,
-) -> catalog::Index {
-    auto_generate_primary_idx(
-        index_name,
-        &view.optimized_expr.as_ref().typ().keys,
-        view_name,
-        view_id,
-        &view.desc,
-    )
-}
-
 pub fn auto_generate_primary_idx(
     index_name: String,
-    keys: &[Vec<usize>],
     on_name: FullName,
     on_id: GlobalId,
     on_desc: &RelationDesc,
 ) -> catalog::Index {
-    let keys = if let Some(keys) = keys.first() {
-        keys.clone()
-    } else {
-        (0..on_desc.typ().column_types.len()).collect()
-    };
+    let default_key = on_desc.typ().default_key();
+
     catalog::Index {
-        create_sql: index_sql(index_name, on_name, &on_desc, &keys),
+        create_sql: index_sql(index_name, on_name, &on_desc, &default_key),
         plan_cx: PlanContext::default(),
         on: on_id,
-        keys: keys.into_iter().map(ScalarExpr::Column).collect(),
+        keys: default_key.iter().map(|k| ScalarExpr::Column(*k)).collect(),
     }
 }
 
@@ -2560,11 +2539,11 @@ fn open_catalog(
                             item: log_view.name.into(),
                         };
                         let index_name = format!("{}_primary_idx", log_view.name);
-                        let index = auto_generate_view_idx(
+                        let index = auto_generate_primary_idx(
                             index_name.clone(),
                             view_name.clone(),
-                            &view,
                             log_view.id,
+                            &view.desc,
                         );
                         catalog.insert_item(log_view.id, view_name, CatalogItem::View(view));
                         catalog.insert_item(

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -119,6 +119,15 @@ impl RelationType {
     pub fn arity(&self) -> usize {
         self.column_types.len()
     }
+
+    /// Gets the keys used when creating a default index.
+    pub fn default_key(&self) -> Vec<usize> {
+        if let Some(key) = self.keys.first() {
+            key.clone()
+        } else {
+            (0..self.column_types.len()).collect()
+        }
+    }
 }
 
 /// The name of a column in a [`RelationDesc`].

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -120,7 +120,7 @@ impl RelationType {
         self.column_types.len()
     }
 
-    /// Gets the keys used when creating a default index.
+    /// Gets the index of the columns used when creating a default index.
     pub fn default_key(&self) -> Vec<usize> {
         if let Some(key) = self.keys.first() {
             key.clone()

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -507,28 +507,76 @@ CREATE INDEX foo ON myschema.bar (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex { name: Ident("foo"), on_name: ObjectName([Ident("myschema"), Ident("bar")]), key_parts: [Identifier([Ident("a")]), Identifier([Ident("b")])], if_not_exists: false }
+CreateIndex { name: Some(Ident("foo")), on_name: ObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false }
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 ----
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 =>
-CreateIndex { name: Ident("fizz"), on_name: ObjectName([Ident("baz")]), key_parts: [Function(Function { name: ObjectName([Ident("ascii")]), args: Args([Identifier([Ident("x")])]), filter: None, over: None, distinct: false }), IsNotNull(Identifier([Ident("a")])), Nested(Exists(Query { ctes: [], body: Select(Select { distinct: false, projection: [UnnamedExpr(Identifier([Ident("y")]))], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("boop")]), args: None, alias: None, with_hints: [] }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("boop"), Ident("z")]), op: Eq, right: Identifier([Ident("z")]) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })), Identifier([Ident("delta")])], if_not_exists: false }
+CreateIndex { name: Some(Ident("fizz")), on_name: ObjectName([Ident("baz")]), key_parts: Some([Function(Function { name: ObjectName([Ident("ascii")]), args: Args([Identifier([Ident("x")])]), filter: None, over: None, distinct: false }), IsNotNull(Identifier([Ident("a")])), Nested(Exists(Query { ctes: [], body: Select(Select { distinct: false, projection: [UnnamedExpr(Identifier([Ident("y")]))], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("boop")]), args: None, alias: None, with_hints: [] }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("boop"), Ident("z")]), op: Eq, right: Identifier([Ident("z")]) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })), Identifier([Ident("delta")])]), if_not_exists: false }
 
 parse-statement
 CREATE INDEX ind ON tab ((col + 1))
 ----
 CREATE INDEX ind ON tab ((col + 1))
 =>
-CreateIndex { name: Ident("ind"), on_name: ObjectName([Ident("tab")]), key_parts: [Nested(BinaryOp { left: Identifier([Ident("col")]), op: Plus, right: Value(Number("1")) })], if_not_exists: false }
+CreateIndex { name: Some(Ident("ind")), on_name: ObjectName([Ident("tab")]), key_parts: Some([Nested(BinaryOp { left: Identifier([Ident("col")]), op: Plus, right: Value(Number("1")) })]), if_not_exists: false }
 
 parse-statement
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 ----
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 =>
-CreateIndex { name: Ident("qualifiers"), on_name: ObjectName([Ident("no_parentheses")]), key_parts: [Identifier([Ident("alpha"), Ident("omega")])], if_not_exists: false }
+CreateIndex { name: Some(Ident("qualifiers")), on_name: ObjectName([Ident("no_parentheses")]), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), if_not_exists: false }
+
+parse-statement
+CREATE DEFAULT INDEX ON tab
+----
+CREATE DEFAULT INDEX ON tab
+=>
+CreateIndex { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: false }
+
+parse-statement
+CREATE DEFAULT INDEX IF NOT EXISTS ON tab
+----
+CREATE DEFAULT INDEX IF NOT EXISTS ON tab
+=>
+CreateIndex { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: true }
+
+parse-statement
+CREATE DEFAULT INDEX ON tab (a, b)
+----
+error:
+Parse error:
+CREATE DEFAULT INDEX ON tab (a, b)
+                            ^
+Expected end of statement, found: (
+
+parse-statement
+CREATE INDEX ON tab;
+----
+error:
+Parse error:
+CREATE INDEX ON tab;
+                   ^
+Expected (, found: ;
+
+parse-statement
+CREATE INDEX ON tab (a, b)
+----
+CREATE INDEX ON tab (a, b)
+=>
+CreateIndex { name: None, on_name: ObjectName([Ident("tab")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false }
+
+parse-statement
+CREATE INDEX IF NOT EXISTS ON tab (a, b)
+----
+error:
+Parse error:
+CREATE INDEX IF NOT EXISTS ON tab (a, b)
+                           ^^
+Expected index name, found: ON
 
 parse-statement
 CREATE INDEX myschema.ind ON foo(b)

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -238,10 +238,12 @@ pub fn create_statement(
         } => {
             *on_name = resolve_item(on_name)?;
             let mut normalizer = QueryNormalizer { scx, err: None };
-            for key_part in key_parts {
-                normalizer.visit_expr_mut(key_part);
-                if let Some(err) = normalizer.err {
-                    return Err(err);
+            if let Some(key_parts) = key_parts {
+                for key_part in key_parts {
+                    normalizer.visit_expr_mut(key_part);
+                    if let Some(err) = normalizer.err {
+                        return Err(err);
+                    }
                 }
             }
             *if_not_exists = false;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -31,7 +31,7 @@ use ore::collections::CollectionExt;
 use repr::strconv;
 use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowArena, ScalarType};
 use sql_parser::ast::{
-    AvroSchema, Connector, ExplainOptions, ExplainStage, Explainee, Format, Ident,
+    AvroSchema, Connector, ExplainOptions, ExplainStage, Explainee, Expr, Format, Ident,
     IfExistsBehavior, ObjectName, ObjectType, Query, SetVariableValue, ShowStatementFilter,
     SqlOption, Statement, Value,
 };
@@ -495,6 +495,7 @@ fn handle_show_indexes(
             from_entry.item_type(),
         );
     }
+
     let arena = RowArena::new();
     let rows = from_entry
         .used_by()
@@ -509,7 +510,7 @@ fn handle_show_indexes(
                 .expect("create_sql cannot be invalid")
                 .into_element()
             {
-                Statement::CreateIndex { key_parts, .. } => key_parts,
+                Statement::CreateIndex { key_parts, .. } => key_parts.unwrap(),
                 _ => unreachable!(),
             };
             let mut row_subset = Vec::new();
@@ -751,20 +752,22 @@ fn handle_create_sink(scx: &StatementContext, stmt: Statement) -> Result<Plan, f
     })
 }
 
-fn handle_create_index(scx: &StatementContext, stmt: Statement) -> Result<Plan, failure::Error> {
-    let create_sql = normalize::create_statement(scx, stmt.clone())?;
-    let (name, on_name, key_parts, if_not_exists) = match stmt {
+fn handle_create_index(
+    scx: &StatementContext,
+    mut stmt: Statement,
+) -> Result<Plan, failure::Error> {
+    let (name, on_name, key_parts, if_not_exists) = match &stmt {
         Statement::CreateIndex {
             name,
             on_name,
             key_parts,
             if_not_exists,
-        } => (name, on_name, key_parts, if_not_exists),
+        } => (name, on_name, key_parts, *if_not_exists),
         _ => unreachable!(),
     };
-    let on_name = scx.resolve_item(on_name)?;
+    let on_name = scx.resolve_item(on_name.clone())?;
     let catalog_entry = scx.catalog.get_item(&on_name);
-    let keys = query::plan_index_exprs(scx, catalog_entry.desc()?, &key_parts)?;
+
     if CatalogItemType::View != catalog_entry.item_type()
         && CatalogItemType::Source != catalog_entry.item_type()
     {
@@ -772,14 +775,90 @@ fn handle_create_index(scx: &StatementContext, stmt: Statement) -> Result<Plan, 
             "index cannot be created on {} because it is a {}",
             on_name,
             catalog_entry.item_type()
-        );
+        )
     }
-    Ok(Plan::CreateIndex {
-        name: FullName {
+
+    let on_desc = catalog_entry.desc()?;
+
+    let filled_key_parts = match key_parts {
+        Some(kp) => kp.to_vec(),
+        None => {
+            // `key_parts` is None if we're creating a "default" index, i.e.
+            // creating the index as if the index had been created alongside the
+            // view source, e.g. `CREATE MATERIALIZED...`
+            catalog_entry
+                .desc()?
+                .typ()
+                .default_key()
+                .iter()
+                .map(|i| match on_desc.get_unambiguous_name(*i) {
+                    Some(n) => Expr::Identifier(vec![Ident::new(n.to_string())]),
+                    _ => Expr::Value(Value::Number((i + 1).to_string())),
+                })
+                .collect()
+        }
+    };
+    let keys = query::plan_index_exprs(scx, on_desc, &filled_key_parts)?;
+
+    let index_name = if let Some(name) = name {
+        FullName {
             database: on_name.database.clone(),
             schema: on_name.schema.clone(),
-            item: normalize::ident(name),
-        },
+            item: normalize::ident(name.clone()),
+        }
+    } else {
+        let mut idx_name_base = on_name.clone();
+        if key_parts.is_none() {
+            // We're trying to create the "default" index.
+            idx_name_base.item += "_primary_idx";
+        } else {
+            // Use PG schema for automatically naming indexes:
+            // `<table>_<_-separated indexed expressions>_idx`
+            let index_name_col_suffix = keys
+                .iter()
+                .map(|k| match k {
+                    expr::ScalarExpr::Column(i) => match on_desc.get_unambiguous_name(*i) {
+                        Some(col_name) => col_name.to_string(),
+                        None => format!("{}", i + 1),
+                    },
+                    _ => "expr".to_string(),
+                })
+                .join("_");
+            idx_name_base.item += &format!("_{}_idx", index_name_col_suffix);
+            idx_name_base.item = normalize::ident(Ident::new(idx_name_base.item))
+        }
+
+        let mut index_name = idx_name_base.clone();
+        let mut i = 0;
+
+        let mut cat_schema_iter = scx.catalog.list_items(&on_name.database, &on_name.schema);
+
+        // Search for an unused version of the name unless `if_not_exists`.
+        while cat_schema_iter.any(|i| *i.name() == index_name) && !if_not_exists {
+            i += 1;
+            index_name = idx_name_base.clone();
+            index_name.item += &i.to_string();
+            cat_schema_iter = scx.catalog.list_items(&on_name.database, &on_name.schema);
+        }
+
+        index_name
+    };
+
+    // Normalize `stmt`.
+    match &mut stmt {
+        Statement::CreateIndex {
+            name, key_parts, ..
+        } => {
+            *name = Some(Ident::new(index_name.item.clone()));
+            *key_parts = Some(filled_key_parts);
+        }
+        _ => unreachable!(),
+    }
+
+    let create_sql = normalize::create_statement(scx, stmt)?;
+
+    Ok(Plan::CreateIndex {
+        name: index_name,
         index: Index {
             create_sql,
             on: catalog_entry.id(),

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -1,0 +1,186 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set writer-schema={
+    "name": "row",
+    "type": "record",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "int"}
+    ]
+  }
+
+$ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
+{"a": 1, "b": 1}
+
+# Materialized sources are synonymous with having an index automatically created
+> CREATE MATERIALIZED SOURCE mz_data
+  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+
+> SHOW INDEXES FROM mz_data
+Source_or_view                Key_name                              Column_name  Expression  Null   Seq_in_index
+----------------------------------------------------------------------------------------------------------------
+materialize.public.mz_data  materialize.public.mz_data_primary_idx  a            <null>      false             1
+materialize.public.mz_data  materialize.public.mz_data_primary_idx  b            <null>      false             2
+materialize.public.mz_data  materialize.public.mz_data_primary_idx  mz_obj_no    <null>      false             3
+
+# Non-materialized views do not have indexes automatically created
+> CREATE SOURCE data
+  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+
+> SHOW INDEXES FROM data
+Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+-----------------------------------------------------------------------------------------------------------
+
+# Views can have default indexes added
+> CREATE DEFAULT INDEX ON data
+
+> SHOW INDEXES FROM data
+Source_or_view           Key_name                             Column_name  Expression  Null   Seq_in_index
+----------------------------------------------------------------------------------------------------------
+materialize.public.data  materialize.public.data_primary_idx  a            <null>      false             1
+materialize.public.data  materialize.public.data_primary_idx  b            <null>      false             2
+materialize.public.data  materialize.public.data_primary_idx  mz_obj_no    <null>      false             3
+
+> CREATE DEFAULT INDEX ON mz_data
+
+> SHOW INDEXES FROM mz_data
+Source_or_view                Key_name                               Column_name  Expression  Null   Seq_in_index
+------------------------------------------------------------------------------------------------------------------
+materialize.public.mz_data  materialize.public.mz_data_primary_idx   a            <null>      false             1
+materialize.public.mz_data  materialize.public.mz_data_primary_idx   b            <null>      false             2
+materialize.public.mz_data  materialize.public.mz_data_primary_idx   mz_obj_no    <null>      false             3
+materialize.public.mz_data  materialize.public.mz_data_primary_idx1  a            <null>      false             1
+materialize.public.mz_data  materialize.public.mz_data_primary_idx1  b            <null>      false             2
+materialize.public.mz_data  materialize.public.mz_data_primary_idx1  mz_obj_no    <null>      false             3
+
+# Materialized views are synonymous with having an index automatically created
+> CREATE MATERIALIZED VIEW matv AS
+  SELECT b, sum(a) FROM data GROUP BY b
+
+> SHOW INDEXES FROM matv
+Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+-----------------------------------------------------------------------------------------------------------
+materialize.public.matv  materialize.public.matv_primary_idx  b            <null>      false             1
+
+# Non-materialized views do not have indexes automatically created
+> CREATE VIEW data_view as SELECT * from data
+
+> SHOW INDEXES FROM data_view
+Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+-----------------------------------------------------------------------------------------------------------
+
+# Views can have default indexes added
+> CREATE DEFAULT INDEX ON data_view
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+--------------------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.data_view_primary_idx  a            <null>      false             1
+materialize.public.data_view  materialize.public.data_view_primary_idx  b            <null>      false             2
+materialize.public.data_view  materialize.public.data_view_primary_idx  mz_obj_no    <null>      false             3
+
+# Default indexes are equivalent in structure to indexes added automatically with the "MATERIALIZED" keyword
+> CREATE MATERIALIZED VIEW mz_data_view as SELECT * from data
+
+> SHOW INDEXES FROM mz_data_view
+Source_or_view                   Key_name                                     Column_name  Expression  Null   Seq_in_index
+--------------------------------------------------------------------------------------------------------------------------
+materialize.public.mz_data_view  materialize.public.mz_data_view_primary_idx  a            <null>      false             1
+materialize.public.mz_data_view  materialize.public.mz_data_view_primary_idx  b            <null>      false             2
+materialize.public.mz_data_view  materialize.public.mz_data_view_primary_idx  mz_obj_no    <null>      false             3
+
+# IF NOT EXISTS prevents adding multiple default indexes
+> CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+--------------------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.data_view_primary_idx  a            <null>      false             1
+materialize.public.data_view  materialize.public.data_view_primary_idx  b            <null>      false             2
+materialize.public.data_view  materialize.public.data_view_primary_idx  mz_obj_no    <null>      false             3
+
+# IF NOT EXISTS works for both automatically and explicitly created default indexes
+> CREATE DEFAULT INDEX IF NOT EXISTS ON matv
+
+> SHOW INDEXES FROM matv
+Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+-----------------------------------------------------------------------------------------------------------
+materialize.public.matv  materialize.public.matv_primary_idx  b            <null>      false             1
+
+# Additional default indexes have the same structure as the first
+> CREATE DEFAULT INDEX ON matv
+
+> SHOW INDEXES FROM matv
+Source_or_view            Key_name                               Column_name  Expression  Null   Seq_in_index
+-------------------------------------------------------------------------------------------------------------
+materialize.public.matv  materialize.public.matv_primary_idx   b            <null>      false             1
+materialize.public.matv  materialize.public.matv_primary_idx1  b            <null>      false             1
+
+# Default indexes can be named
+> CREATE DEFAULT INDEX named_idx ON data_view
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+--------------------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.data_view_primary_idx  a            <null>      false             1
+materialize.public.data_view  materialize.public.data_view_primary_idx  b            <null>      false             2
+materialize.public.data_view  materialize.public.data_view_primary_idx  mz_obj_no    <null>      false             3
+materialize.public.data_view  materialize.public.named_idx              a            <null>      false             1
+materialize.public.data_view  materialize.public.named_idx              b            <null>      false             2
+materialize.public.data_view  materialize.public.named_idx              mz_obj_no    <null>      false             3
+
+> DROP INDEX materialize.public.data_view_primary_idx
+> DROP INDEX materialize.public.named_idx
+
+# Indexes with specified columns can be automatically named
+> CREATE INDEX ON data_view(a)
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+--------------------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.data_view_a_idx        a            <null>      false             1
+
+> DROP INDEX materialize.public.data_view_a_idx
+
+# Automatically named indexes rename expression columns to "expr" and join all columns with underscores.
+> CREATE INDEX ON data_view(b, a)
+> CREATE INDEX ON data_view(b - a, a)
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+--------------------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.data_view_b_a_idx      a            <null>      false             2
+materialize.public.data_view  materialize.public.data_view_b_a_idx      b            <null>      false             1
+materialize.public.data_view  materialize.public.data_view_expr_a_idx   <null>       "b - a"     false             1
+materialize.public.data_view  materialize.public.data_view_expr_a_idx   a            <null>      false             2
+
+> DROP INDEX materialize.public.data_view_b_a_idx
+> DROP INDEX materialize.public.data_view_expr_a_idx
+
+# Indexes can be both explicitly named and explicitly structured
+> CREATE INDEX named_idx ON data_view (b - a, a)
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                       Column_name  Expression  Null   Seq_in_index
+---------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.named_idx   <null>       "b - a"     false             1
+materialize.public.data_view  materialize.public.named_idx   a            <null>      false             2
+
+> DROP INDEX materialize.public.named_idx
+
+# Default indexes only check for names, not structures
+> CREATE INDEX data_view_primary_idx ON data_view (b - a, a)
+> CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
+
+> SHOW INDEXES FROM data_view
+Source_or_view                Key_name                                   Column_name  Expression  Null   Seq_in_index
+---------------------------------------------------------------------------------------------------------------------
+materialize.public.data_view  materialize.public.data_view_primary_idx   <null>       "b - a"     false             1
+materialize.public.data_view  materialize.public.data_view_primary_idx   a            <null>      false             2

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -86,7 +86,7 @@ b  ?column?
 2  3
 
 # Materialize data_view.
-> CREATE INDEX ON data_view
+> CREATE DEFAULT INDEX ON data_view
 
 > SELECT * FROM data_view
 a  b
@@ -115,7 +115,7 @@ b  max
 2  1
 
 # Unmaterialize data view.
-> DROP INDEX data_view_idx
+> DROP INDEX data_view_primary_idx
 
 # Can continue to select from view that depends on the unmaterialized view.
 > SELECT * FROM test4
@@ -299,10 +299,11 @@ a  b
 3  4
 1  2
 
-# If there exists another index, dropping the primary index will not
-# unmaterialize the source.
+# If there exists another index, dropping the primary index will not #
+# unmaterialize the source. This also tests creating a default index when the
+# default index name is already taken.
 
-> CREATE INDEX mat_data_idx2 ON mat_data(a)
+> CREATE DEFAULT INDEX ON mat_data
 
 > DROP INDEX mat_data_primary_idx
 
@@ -334,7 +335,7 @@ c  d
 -2 -1
 
 # Unmaterialize source.
-> DROP INDEX mat_data_idx2
+> DROP INDEX mat_data_primary_idx1
 
 ! SELECT * from mat_data
 Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -86,7 +86,7 @@ b  ?column?
 2  3
 
 # Materialize data_view.
-> CREATE INDEX data_view_idx on data_view(a)
+> CREATE INDEX ON data_view
 
 > SELECT * FROM data_view
 a  b


### PR DESCRIPTION
Parses `CREATE DEFAULT? INDEX ON foo`, which creates an index equivalent to the one that would have been created if you'd typed `CREATE MATERIALIZED (SOURCE | VIEW)...`.

This adds `primary_idx_keys` as a catalog function because it was either that or getting a view's `optimized_expr` and then doing the hokey pokey to determine the same thing. This feels a little more specific than other things in the catalog, but figured I'd push on the API and see if this was reasonable.

@wangandi I added a nicety to the coordinator to reify the relationship of `RelationType`'s first set of keys (or, in their absence, all of its columns) as its "primary index keys". This is because we're now getting the primary index keys in multiple spots and need to maintain this "invariant". Open to other ideas, but thought this was sane, at least!

Closes #2614

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3414)
<!-- Reviewable:end -->
