### PR TITLE
coord,sql: don't present unoptimized RelationDesc

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -973,10 +973,7 @@ impl Catalog {
             Plan::CreateView { view, .. } => {
                 let mut optimizer = Optimizer::default();
                 let optimized_expr = optimizer.optimize(view.expr, self.indexes())?;
-                let desc = RelationDesc::new(
-                    optimized_expr.as_ref().typ(),
-                    view.desc.iter_names().map(|c| c.cloned()),
-                );
+                let desc = RelationDesc::new(optimized_expr.as_ref().typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
                     plan_cx: pcx,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1004,10 +1004,7 @@ where
         let view_id = self.catalog.allocate_id()?;
         // Optimize the expression so that we can form an accurately typed description.
         let optimized_expr = self.optimizer.optimize(view.expr, self.catalog.indexes())?;
-        let desc = RelationDesc::new(
-            optimized_expr.as_ref().typ(),
-            view.desc.iter_names().map(|c| c.cloned()),
-        );
+        let desc = RelationDesc::new(optimized_expr.as_ref().typ(), view.column_names);
         let view = catalog::View {
             create_sql: view.create_sql,
             plan_cx: pcx,
@@ -2523,10 +2520,8 @@ fn open_catalog(
                         let optimized_expr = optimizer
                             .optimize(view.expr, catalog.indexes())
                             .expect("failed to optimize bootstrap sql");
-                        let desc = RelationDesc::new(
-                            optimized_expr.as_ref().typ(),
-                            view.desc.iter_names().map(|c| c.cloned()),
-                        );
+                        let desc =
+                            RelationDesc::new(optimized_expr.as_ref().typ(), view.column_names);
                         let view = catalog::View {
                             create_sql: view.create_sql,
                             plan_cx: pcx,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{PeekWhen, SinkConnectorBuilder, SourceConnector, Timestamp};
-use repr::{RelationDesc, Row, ScalarType};
+use repr::{ColumnName, RelationDesc, Row, ScalarType};
 
 use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use crate::catalog::Catalog;
@@ -166,7 +166,7 @@ pub struct Sink {
 pub struct View {
     pub create_sql: String,
     pub expr: ::expr::RelationExpr,
-    pub desc: RelationDesc,
+    pub column_names: Vec<Option<ColumnName>>,
     pub temporary: bool,
 }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -961,7 +961,7 @@ fn handle_create_view(
         view: View {
             create_sql,
             expr: relation_expr,
-            desc,
+            column_names: desc.iter_names().map(|n| n.cloned()).collect(),
             temporary,
         },
         replace,


### PR DESCRIPTION
We've been bitten several times by the fact that sql::plan::View
presents a RelationDesc for the unoptimized plan. This RelationDesc is
the only source of column names for the view, but duplicates the type
information from the RelationExpr; optimizing the RelationExpr requires
a delicate dance to construct a new RelationDesc with the same column
names but updated types, which several code paths have historically
mishandled.

This commit changes sql::plan::View to contain a Vec<ColumnName> instead
of a RelationDesc. This forces the coord layer to produce a RelationDesc
if it needs one, which will hopefully make it harder to use the types
from the unoptimized plan.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3421)
<!-- Reviewable:end -->
