### PR TITLE
sql: fix nested joins

### DIFF
--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -239,3 +239,15 @@ SELECT * FROM r WHERE EXISTS (SELECT * from l RIGHT JOIN r as r2 ON l.la = r.ra)
 4  r4
 1  r1
 3  r3
+
+# Regression test for #3426.
+query III colnames
+SELECT * FROM
+    (SELECT 1 AS baz) t1
+    INNER JOIN (
+        (SELECT 1 AS foo) t2
+        INNER JOIN (SELECT 1 AS bar) t3 ON true
+    ) ON foo = bar;
+----
+baz  foo  bar
+1    1    1


### PR DESCRIPTION
These got broken in #1426, as apparently we don't have any test coverage
for nested joins. The precise nature of the bug is hard to describe, as
I didn't bother to understand it fully, but in short we were completely
mixing up the join scopes and operators for the nested component.

Roughly, I believe we were planning a query like

    SELECT * FROM a INNER JOIN (b INNER JOIN c ON b.x = c.x) ON a.x = c.x

as

    SELECT * FROM a INNER JOIN b ON a.x = c.x INNER JOIN c ON b.x = c.x

where the most obvious effect of this misplan was an error about c.x not
being in scope.

The correct behavior, implemented by this patch, is as follows. A nested
join stashes away the current stack of joins and builds the nested
component up from scratch, i.e., with nothing in scope and no tablers
join. Only once the nested component is fully built is it joined into
the existing stack of joins.

Fix #3426.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3427)
<!-- Reviewable:end -->
