### PR TITLE
Check that systemd is being used as the init system before trying to use systemctl

### DIFF
--- a/misc/dist/deb-scripts/postinst
+++ b/misc/dist/deb-scripts/postinst
@@ -17,6 +17,6 @@ adduser --system --group --force-badname --no-create-home --quiet _Materialize
 mkdir -p /var/lib/materialize/
 chown _Materialize:_Materialize /var/lib/materialize/
 
-if [ -x /bin/systemctl -a $(ps -h -o comm 1) = "systemd" ]; then
-  systemctl daemon-reload
+if [ -x /bin/systemctl ]; then
+  systemctl daemon-reload 2>&1 > /dev/null || true
 fi

--- a/misc/dist/deb-scripts/postinst
+++ b/misc/dist/deb-scripts/postinst
@@ -17,6 +17,6 @@ adduser --system --group --force-badname --no-create-home --quiet _Materialize
 mkdir -p /var/lib/materialize/
 chown _Materialize:_Materialize /var/lib/materialize/
 
-if [ -x /bin/systemctl ]; then
+if [ -x /bin/systemctl -a $(ps -h -o comm 1) = "systemd" ]; then
   systemctl daemon-reload
 fi


### PR DESCRIPTION
The systemd binaries (e.g. `systemctl`) might be installed, even if systemd is not actually being used on the host (this is the case for WSL2 at least, and maybe other esoteric systems too).

Fixes #3390

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3445)
<!-- Reviewable:end -->
