### PR TITLE
expr: reorganize scalar functions

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -21,7 +21,7 @@ use repr::adt::decimal::Significand;
 use repr::adt::regex::Regex as ReprRegex;
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
-use crate::scalar::func::jsonb_stringify;
+use crate::scalar::func::jsonb::jsonb_stringify;
 
 // TODO(jamii) be careful about overflow in sum/avg
 // see https://timely.zulipchat.com/#narrow/stream/186635-engineering/topic/additional.20work/near/163507435

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -263,7 +263,7 @@ impl RelationExpr {
                     fn uniqueness(expr: &ScalarExpr) -> Option<usize> {
                         match expr {
                             ScalarExpr::CallUnary { func, expr } => {
-                                if func.preserves_uniqueness() {
+                                if func.props().preserves_uniqueness {
                                     uniqueness(expr)
                                 } else {
                                     None

--- a/src/expr/src/scalar/func/bool.rs
+++ b/src/expr/src/scalar/func/bool.rs
@@ -1,0 +1,126 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Boolean functions.
+
+use repr::strconv;
+use repr::{Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::{EvalError, ScalarExpr};
+
+pub const CAST_BOOL_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_bool_to_string_explicit(a: Datum) -> Result<Datum, EvalError> {
+    // N.B. this function differs from `cast_bool_to_string_implicit` because
+    // the SQL specification requires `true` and `false` to be spelled out
+    // in explicit casts, while PostgreSQL prefers its more concise `t` and `f`
+    // representation in implicit casts.
+    match a.unwrap_bool() {
+        true => Ok(Datum::from("true")),
+        false => Ok(Datum::from("false")),
+    }
+}
+
+pub fn cast_bool_to_string_implicit(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::String(strconv::format_bool_static(a.unwrap_bool())))
+}
+
+pub const CAST_STRING_TO_BOOL_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn cast_string_to_bool(a: Datum) -> Result<Datum, EvalError> {
+    match strconv::parse_bool(a.unwrap_str())? {
+        true => Ok(Datum::True),
+        false => Ok(Datum::False),
+    }
+}
+
+pub const AND_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn and<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+    a_expr: &'a ScalarExpr,
+    b_expr: &'a ScalarExpr,
+) -> Result<Datum<'a>, EvalError> {
+    match a_expr.eval(datums, temp_storage)? {
+        Datum::False => Ok(Datum::False),
+        a => match (a, b_expr.eval(datums, temp_storage)?) {
+            (_, Datum::False) => Ok(Datum::False),
+            (Datum::Null, _) | (_, Datum::Null) => Ok(Datum::Null),
+            (Datum::True, Datum::True) => Ok(Datum::True),
+            _ => unreachable!(),
+        },
+    }
+}
+
+pub const OR_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn or<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+    a_expr: &'a ScalarExpr,
+    b_expr: &'a ScalarExpr,
+) -> Result<Datum<'a>, EvalError> {
+    match a_expr.eval(datums, temp_storage)? {
+        Datum::True => Ok(Datum::True),
+        a => match (a, b_expr.eval(datums, temp_storage)?) {
+            (_, Datum::True) => Ok(Datum::True),
+            (Datum::Null, _) | (_, Datum::Null) => Ok(Datum::Null),
+            (Datum::False, Datum::False) => Ok(Datum::False),
+            _ => unreachable!(),
+        },
+    }
+}
+
+pub const NOT_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn not(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(!a.unwrap_bool()))
+}

--- a/src/expr/src/scalar/func/cmp.rs
+++ b/src/expr/src/scalar/func/cmp.rs
@@ -1,0 +1,49 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Comparison functions.
+
+use repr::{Datum, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CMP_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a == b))
+}
+
+pub fn not_eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a != b))
+}
+
+pub fn lt<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a < b))
+}
+
+pub fn lte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a <= b))
+}
+
+pub fn gt<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a > b))
+}
+
+pub fn gte<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a >= b))
+}

--- a/src/expr/src/scalar/func/datetime.rs
+++ b/src/expr/src/scalar/func/datetime.rs
@@ -1,0 +1,692 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Date and time functions.
+
+use std::convert::TryInto;
+
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
+
+use ore::result::ResultExt;
+use repr::adt::datetime::DateTimeUnits;
+use repr::strconv;
+use repr::{Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_date_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_date(&mut buf, a.unwrap_date());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub fn cast_time_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_time(&mut buf, a.unwrap_time());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub fn cast_timestamp_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_timestamp(&mut buf, a.unwrap_timestamp());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub fn cast_timestamptz_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_timestamptz(&mut buf, a.unwrap_timestamptz());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CAST_STRING_TO_DATE_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Date),
+};
+
+pub fn cast_string_to_date(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_date(a.unwrap_str())
+        .map(Datum::Date)
+        .err_into()
+}
+
+pub const CAST_STRING_TO_TIME_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Time),
+};
+
+pub fn cast_string_to_time(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_time(a.unwrap_str())
+        .map(Datum::Time)
+        .err_into()
+}
+
+pub const CAST_STRING_TO_TIMESTAMP_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub fn cast_string_to_timestamp(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_timestamp(a.unwrap_str())
+        .map(Datum::Timestamp)
+        .err_into()
+}
+
+pub const CAST_STRING_TO_TIMESTAMPTZ_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::TimestampTz),
+};
+
+pub fn cast_string_to_timestamptz(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_timestamptz(a.unwrap_str())
+        .map(Datum::TimestampTz)
+        .err_into()
+}
+
+pub const CAST_DATE_TO_TIMESTAMP_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub fn cast_date_to_timestamp(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::Timestamp(a.unwrap_date().and_hms(0, 0, 0)))
+}
+
+pub const CAST_DATE_TO_TIMESTAMPTZ_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::TimestampTz),
+};
+
+pub fn cast_date_to_timestamptz(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::TimestampTz(DateTime::<Utc>::from_utc(
+        a.unwrap_date().and_hms(0, 0, 0),
+        Utc,
+    )))
+}
+
+pub const CAST_TIMESTAMP_TO_DATE_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Date),
+};
+
+pub fn cast_timestamp_to_date(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::Date(a.unwrap_timestamp().date()))
+}
+
+pub fn cast_timestamptz_to_date(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::Date(a.unwrap_timestamptz().naive_utc().date()))
+}
+
+pub const CAST_TIMESTAMP_TO_TIMESTAMPTZ_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::TimestampTz),
+};
+
+pub fn cast_timestamp_to_timestamptz(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::TimestampTz(DateTime::<Utc>::from_utc(
+        a.unwrap_timestamp(),
+        Utc,
+    )))
+}
+
+pub const CAST_TIMESTAMPTZ_TO_TIMESTAMP_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub fn cast_timestamptz_to_timestamp(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::Timestamp(a.unwrap_timestamptz().naive_utc()))
+}
+
+pub const MAKE_TIMESTAMP_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true, // TODO(benesch): should error instead
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub fn make_timestamp<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
+    let year: i32 = match datums[0].unwrap_int64().try_into() {
+        Ok(year) => year,
+        Err(_) => return Ok(Datum::Null),
+    };
+    let month: u32 = match datums[1].unwrap_int64().try_into() {
+        Ok(month) => month,
+        Err(_) => return Ok(Datum::Null),
+    };
+    let day: u32 = match datums[2].unwrap_int64().try_into() {
+        Ok(day) => day,
+        Err(_) => return Ok(Datum::Null),
+    };
+    let hour: u32 = match datums[3].unwrap_int64().try_into() {
+        Ok(day) => day,
+        Err(_) => return Ok(Datum::Null),
+    };
+    let minute: u32 = match datums[4].unwrap_int64().try_into() {
+        Ok(day) => day,
+        Err(_) => return Ok(Datum::Null),
+    };
+    let second_float = datums[5].unwrap_float64();
+    let second = second_float as u32;
+    let micros = ((second_float - second as f64) * 1_000_000.0) as u32;
+    let date = match NaiveDate::from_ymd_opt(year, month, day) {
+        Some(date) => date,
+        None => return Ok(Datum::Null),
+    };
+    let timestamp = match date.and_hms_micro_opt(hour, minute, second, micros) {
+        Some(timestamp) => timestamp,
+        None => return Ok(Datum::Null),
+    };
+    Ok(Datum::Timestamp(timestamp))
+}
+
+pub const TO_TIMESTAMP_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true, // TODO(benesch): should error instead
+    },
+    output_type: OutputType::Fixed(ScalarType::TimestampTz),
+};
+
+pub fn to_timestamp(a: Datum) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+    if !f.is_finite() {
+        return Ok(Datum::Null);
+    }
+    let secs = f.trunc() as i64;
+    // NOTE(benesch): PostgreSQL has microsecond precision in its timestamps,
+    // while chrono has nanosecond precision. While we normally accept
+    // nanosecond precision, here we round to the nearest microsecond because
+    // f64s lose quite a bit of accuracy in the nanosecond digits when dealing
+    // with common Unix timestamp values (> 1 billion).
+    let nanosecs = ((f.fract() * 1_000_000.0).round() as u32) * 1_000;
+    match NaiveDateTime::from_timestamp_opt(secs as i64, nanosecs as u32) {
+        None => Ok(Datum::Null),
+        Some(ts) => Ok(Datum::TimestampTz(DateTime::<Utc>::from_utc(ts, Utc))),
+    }
+}
+
+/// A timestamp with both a date and a time component, but not necessarily a
+/// timezone component.
+pub trait TimestampLike: chrono::Datelike + chrono::Timelike + for<'a> Into<Datum<'a>> {
+    fn new(date: NaiveDate, time: NaiveTime) -> Self;
+
+    /// Returns the weekday as a `usize` between 0 and 6, where 0 represents
+    /// Sunday and 6 represents Saturday.
+    fn weekday0(&self) -> usize {
+        self.weekday().num_days_from_sunday() as usize
+    }
+
+    /// Like [`chrono::Datelike::year_ce`], but works on the ISO week system.
+    fn iso_year_ce(&self) -> u32 {
+        let year = self.iso_week().year();
+        if year < 1 {
+            (1 - year) as u32
+        } else {
+            year as u32
+        }
+    }
+
+    fn timestamp(&self) -> i64;
+
+    fn timestamp_subsec_micros(&self) -> u32;
+
+    fn extract_epoch(&self) -> f64 {
+        self.timestamp() as f64 + (self.timestamp_subsec_micros() as f64) / 1e6
+    }
+
+    fn extract_year(&self) -> f64 {
+        f64::from(self.year())
+    }
+
+    fn extract_quarter(&self) -> f64 {
+        (f64::from(self.month()) / 3.0).ceil()
+    }
+
+    fn extract_month(&self) -> f64 {
+        f64::from(self.month())
+    }
+
+    fn extract_day(&self) -> f64 {
+        f64::from(self.day())
+    }
+
+    fn extract_hour(&self) -> f64 {
+        f64::from(self.hour())
+    }
+
+    fn extract_minute(&self) -> f64 {
+        f64::from(self.minute())
+    }
+
+    fn extract_second(&self) -> f64 {
+        let s = f64::from(self.second());
+        let ns = f64::from(self.nanosecond()) / 1e9;
+        s + ns
+    }
+
+    /// Extract the iso week of the year
+    ///
+    /// Note that because isoweeks are defined in terms of January 4th, Jan 1 is only in week
+    /// 1 about half of the time
+    fn extract_week(&self) -> f64 {
+        f64::from(self.iso_week().week())
+    }
+
+    fn extract_dayofyear(&self) -> f64 {
+        f64::from(self.ordinal())
+    }
+
+    fn extract_dayofweek(&self) -> f64 {
+        f64::from(self.weekday().num_days_from_sunday())
+    }
+
+    fn extract_isodayofweek(&self) -> f64 {
+        f64::from(self.weekday().number_from_monday())
+    }
+
+    fn truncate_microseconds(&self) -> Self {
+        let time = NaiveTime::from_hms_micro(
+            self.hour(),
+            self.minute(),
+            self.second(),
+            self.nanosecond() / 1_000,
+        );
+
+        Self::new(self.date(), time)
+    }
+
+    fn truncate_milliseconds(&self) -> Self {
+        let time = NaiveTime::from_hms_milli(
+            self.hour(),
+            self.minute(),
+            self.second(),
+            self.nanosecond() / 1_000_000,
+        );
+
+        Self::new(self.date(), time)
+    }
+
+    fn truncate_second(&self) -> Self {
+        let time = NaiveTime::from_hms(self.hour(), self.minute(), self.second());
+
+        Self::new(self.date(), time)
+    }
+
+    fn truncate_minute(&self) -> Self {
+        Self::new(
+            self.date(),
+            NaiveTime::from_hms(self.hour(), self.minute(), 0),
+        )
+    }
+
+    fn truncate_hour(&self) -> Self {
+        Self::new(self.date(), NaiveTime::from_hms(self.hour(), 0, 0))
+    }
+
+    fn truncate_day(&self) -> Self {
+        Self::new(self.date(), NaiveTime::from_hms(0, 0, 0))
+    }
+
+    fn truncate_week(&self) -> Self {
+        let num_days_from_monday = self.date().weekday().num_days_from_monday();
+        Self::new(
+            NaiveDate::from_ymd(self.year(), self.month(), self.day() - num_days_from_monday),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    fn truncate_month(&self) -> Self {
+        Self::new(
+            NaiveDate::from_ymd(self.year(), self.month(), 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    fn truncate_quarter(&self) -> Self {
+        let month = self.month();
+        let quarter = if month <= 3 {
+            1
+        } else if month <= 6 {
+            4
+        } else if month <= 9 {
+            7
+        } else {
+            10
+        };
+
+        Self::new(
+            NaiveDate::from_ymd(self.year(), quarter, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    fn truncate_year(&self) -> Self {
+        Self::new(
+            NaiveDate::from_ymd(self.year(), 1, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+    fn truncate_decade(&self) -> Self {
+        Self::new(
+            NaiveDate::from_ymd(self.year() - (self.year() % 10), 1, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+    fn truncate_century(&self) -> Self {
+        // Expects the first year of the century, meaning 2001 instead of 2000.
+        Self::new(
+            NaiveDate::from_ymd(self.year() - (self.year() % 100) + 1, 1, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+    fn truncate_millennium(&self) -> Self {
+        // Expects the first year of the millennium, meaning 2001 instead of 2000.
+        Self::new(
+            NaiveDate::from_ymd(self.year() - (self.year() % 1_000) + 1, 1, 1),
+            NaiveTime::from_hms(0, 0, 0),
+        )
+    }
+
+    /// Return the date component of the timestamp
+    fn date(&self) -> NaiveDate;
+
+    /// Returns a string representing the timezone's offset from UTC.
+    fn timezone_offset(&self) -> &'static str;
+
+    /// Returns a string representing the hour portion of the timezone's offset
+    /// from UTC.
+    fn timezone_hours(&self) -> &'static str;
+
+    /// Returns a string representing the minute portion of the timezone's
+    /// offset from UTC.
+    fn timezone_minutes(&self) -> &'static str;
+
+    /// Returns the abbreviated name of the timezone with the specified
+    /// capitalization.
+    fn timezone_name(&self, caps: bool) -> &'static str;
+}
+
+impl TimestampLike for chrono::NaiveDateTime {
+    fn new(date: NaiveDate, time: NaiveTime) -> Self {
+        NaiveDateTime::new(date, time)
+    }
+
+    fn date(&self) -> NaiveDate {
+        self.date()
+    }
+
+    fn timestamp(&self) -> i64 {
+        self.timestamp()
+    }
+
+    fn timestamp_subsec_micros(&self) -> u32 {
+        self.timestamp_subsec_micros()
+    }
+
+    fn timezone_offset(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_hours(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_minutes(&self) -> &'static str {
+        "00"
+    }
+
+    fn timezone_name(&self, _caps: bool) -> &'static str {
+        ""
+    }
+}
+
+impl TimestampLike for chrono::DateTime<chrono::Utc> {
+    fn new(date: NaiveDate, time: NaiveTime) -> Self {
+        DateTime::<Utc>::from_utc(NaiveDateTime::new(date, time), Utc)
+    }
+
+    fn date(&self) -> NaiveDate {
+        self.naive_utc().date()
+    }
+
+    fn timestamp(&self) -> i64 {
+        self.timestamp()
+    }
+
+    fn timestamp_subsec_micros(&self) -> u32 {
+        self.timestamp_subsec_micros()
+    }
+
+    fn timezone_offset(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_hours(&self) -> &'static str {
+        "+00"
+    }
+
+    fn timezone_minutes(&self) -> &'static str {
+        "00"
+    }
+
+    fn timezone_name(&self, caps: bool) -> &'static str {
+        if caps {
+            "UTC"
+        } else {
+            "utc"
+        }
+    }
+}
+
+pub const DATE_PART_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn date_part<T>(a: Datum, ts: T) -> Result<Datum, EvalError>
+where
+    T: TimestampLike,
+{
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => date_part_inner(units, ts),
+        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+    }
+}
+
+pub fn date_part_inner<T>(units: DateTimeUnits, ts: T) -> Result<Datum<'static>, EvalError>
+where
+    T: TimestampLike,
+{
+    match units {
+        DateTimeUnits::Epoch => Ok(ts.extract_epoch().into()),
+        DateTimeUnits::Year => Ok(ts.extract_year().into()),
+        DateTimeUnits::Quarter => Ok(ts.extract_quarter().into()),
+        DateTimeUnits::Week => Ok(ts.extract_week().into()),
+        DateTimeUnits::Day => Ok(ts.extract_day().into()),
+        DateTimeUnits::DayOfWeek => Ok(ts.extract_dayofweek().into()),
+        DateTimeUnits::DayOfYear => Ok(ts.extract_dayofyear().into()),
+        DateTimeUnits::IsoDayOfWeek => Ok(ts.extract_isodayofweek().into()),
+        DateTimeUnits::Hour => Ok(ts.extract_hour().into()),
+        DateTimeUnits::Minute => Ok(ts.extract_minute().into()),
+        DateTimeUnits::Second => Ok(ts.extract_second().into()),
+        DateTimeUnits::Month => Ok(ts.extract_month().into()),
+        DateTimeUnits::Millennium
+        | DateTimeUnits::Century
+        | DateTimeUnits::Decade
+        | DateTimeUnits::Milliseconds
+        | DateTimeUnits::Microseconds
+        | DateTimeUnits::Timezone
+        | DateTimeUnits::TimezoneHour
+        | DateTimeUnits::TimezoneMinute
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedDateTimeUnits(units)),
+    }
+}
+
+pub const DATE_TRUNC_TIMESTAMP_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub const DATE_TRUNC_TIMESTAMPTZ_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::TimestampTz),
+};
+
+pub fn date_trunc<T>(a: Datum, ts: T) -> Result<Datum, EvalError>
+where
+    T: TimestampLike,
+{
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => date_trunc_inner(units, ts),
+        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+    }
+}
+
+pub fn date_trunc_inner<T>(units: DateTimeUnits, ts: T) -> Result<Datum<'static>, EvalError>
+where
+    T: TimestampLike,
+{
+    match units {
+        DateTimeUnits::Millennium => Ok(ts.truncate_millennium().into()),
+        DateTimeUnits::Century => Ok(ts.truncate_century().into()),
+        DateTimeUnits::Decade => Ok(ts.truncate_decade().into()),
+        DateTimeUnits::Year => Ok(ts.truncate_year().into()),
+        DateTimeUnits::Quarter => Ok(ts.truncate_quarter().into()),
+        DateTimeUnits::Week => Ok(ts.truncate_week().into()),
+        DateTimeUnits::Day => Ok(ts.truncate_day().into()),
+        DateTimeUnits::Hour => Ok(ts.truncate_hour().into()),
+        DateTimeUnits::Minute => Ok(ts.truncate_minute().into()),
+        DateTimeUnits::Second => Ok(ts.truncate_second().into()),
+        DateTimeUnits::Month => Ok(ts.truncate_month().into()),
+        DateTimeUnits::Milliseconds => Ok(ts.truncate_milliseconds().into()),
+        DateTimeUnits::Microseconds => Ok(ts.truncate_microseconds().into()),
+        DateTimeUnits::Epoch
+        | DateTimeUnits::Timezone
+        | DateTimeUnits::TimezoneHour
+        | DateTimeUnits::TimezoneMinute
+        | DateTimeUnits::DayOfWeek
+        | DateTimeUnits::DayOfYear
+        | DateTimeUnits::IsoDayOfWeek
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedDateTimeUnits(units)),
+    }
+}
+
+pub const ADD_DATE_TIME_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub fn add_date_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let date = a.unwrap_date();
+    let time = b.unwrap_time();
+
+    Ok(Datum::Timestamp(
+        NaiveDate::from_ymd(date.year(), date.month(), date.day()).and_hms_nano(
+            time.hour(),
+            time.minute(),
+            time.second(),
+            time.nanosecond(),
+        ),
+    ))
+}

--- a/src/expr/src/scalar/func/decimal.rs
+++ b/src/expr/src/scalar/func/decimal.rs
@@ -1,0 +1,252 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Decimal functions.
+
+use std::cmp::Ordering;
+
+use ore::collections::CollectionExt;
+use ore::result::ResultExt;
+use repr::adt::decimal::MAX_DECIMAL_PRECISION;
+use repr::{strconv, Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{float, FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_DECIMAL_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_decimal_to_string<'a>(
+    a: Datum<'a>,
+    scale: u8,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_decimal(&mut buf, &a.unwrap_decimal().with_scale(scale));
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub fn cast_string_to_decimal_props(scale: u8) -> FuncProps {
+    FuncProps {
+        can_error: true,
+        preserves_uniqueness: false,
+        nulls: Nulls::Sometimes {
+            propagates_nulls: true,
+            introduces_nulls: false,
+        },
+        output_type: OutputType::Fixed(ScalarType::Decimal(MAX_DECIMAL_PRECISION, scale)),
+    }
+}
+
+pub fn cast_string_to_decimal(a: Datum, scale: u8) -> Result<Datum, EvalError> {
+    strconv::parse_decimal(a.unwrap_str())
+        .map(|d| {
+            Datum::from(match d.scale().cmp(&scale) {
+                Ordering::Less => d.significand() * 10_i128.pow(u32::from(scale - d.scale())),
+                Ordering::Equal => d.significand(),
+                Ordering::Greater => d.significand() / 10_i128.pow(u32::from(d.scale() - scale)),
+            })
+        })
+        .err_into()
+}
+
+pub const CAST_DECIMAL_TO_INT32_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub fn cast_decimal_to_int32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal().as_i128() as i32))
+}
+
+pub const CAST_DECIMAL_TO_INT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int64),
+};
+
+pub fn cast_decimal_to_int64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal().as_i128() as i64))
+}
+
+pub const CAST_DECIMAL_TO_FLOAT32_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float32),
+};
+
+pub fn cast_decimal_to_float32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal().as_i128() as f32))
+}
+
+pub const CAST_DECIMAL_TO_FLOAT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn cast_decimal_to_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal().as_i128() as f64))
+}
+
+pub const DECIMAL_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::MatchesInput,
+};
+
+pub fn abs_decimal(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal().abs()))
+}
+
+pub fn neg_decimal(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(-a.unwrap_decimal()))
+}
+
+pub fn add_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal() + b.unwrap_decimal()))
+}
+
+pub fn sub_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal() - b.unwrap_decimal()))
+}
+
+pub fn mod_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_decimal();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_decimal() % b))
+    }
+}
+
+pub const MUL_DECIMAL_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Computed(|input_types| {
+        assert_eq!(input_types.len(), 2);
+        let (_, s1) = input_types[0].scalar_type.unwrap_decimal_parts();
+        let (_, s2) = input_types[1].scalar_type.unwrap_decimal_parts();
+        ScalarType::Decimal(MAX_DECIMAL_PRECISION, s1 + s2)
+    }),
+};
+
+pub fn mul_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_decimal() * b.unwrap_decimal()))
+}
+
+pub const DIV_DECIMAL_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Computed(|input_types| {
+        assert_eq!(input_types.len(), 2);
+        let (_, s1) = input_types[0].scalar_type.unwrap_decimal_parts();
+        let (_, s2) = input_types[1].scalar_type.unwrap_decimal_parts();
+        ScalarType::Decimal(MAX_DECIMAL_PRECISION, s1 - s2)
+    }),
+};
+
+pub fn div_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_decimal();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_decimal() / b))
+    }
+}
+
+pub fn ceil_decimal(a: Datum, scale: u8) -> Result<Datum, EvalError> {
+    let decimal = a.unwrap_decimal();
+    Ok(Datum::from(decimal.with_scale(scale).ceil().significand()))
+}
+
+pub fn floor_decimal(a: Datum, scale: u8) -> Result<Datum, EvalError> {
+    let decimal = a.unwrap_decimal();
+    Ok(Datum::from(decimal.with_scale(scale).floor().significand()))
+}
+
+pub const ROUND_DECIMAL_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Computed(|input_types| input_types.into_first().scalar_type),
+};
+
+pub fn round_decimal_unary(a: Datum, a_scale: u8) -> Result<Datum, EvalError> {
+    round_decimal_binary(a, Datum::Int64(0), a_scale)
+}
+
+pub fn round_decimal_binary<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    a_scale: u8,
+) -> Result<Datum<'a>, EvalError> {
+    let round_to = b.unwrap_int64();
+    let decimal = a.unwrap_decimal().with_scale(a_scale);
+    Ok(Datum::from(decimal.round(round_to).significand()))
+}
+
+pub const SQRT_DECIMAL_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::MatchesInput,
+};
+
+pub fn sqrt_decimal(a: Datum, scale: u8) -> Result<Datum, EvalError> {
+    let d = a.unwrap_decimal();
+    if d.as_i128() < 0 {
+        return Err(EvalError::NegSqrt);
+    }
+    let d_f64 = cast_decimal_to_float64(a)?;
+    let d_scaled = d_f64.unwrap_float64() / 10_f64.powi(i32::from(scale));
+    float::cast_float64_to_decimal(Datum::from(d_scaled.sqrt()), scale)
+}

--- a/src/expr/src/scalar/func/float.rs
+++ b/src/expr/src/scalar/func/float.rs
@@ -1,0 +1,310 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Float functions.
+
+use ore::result::ResultExt;
+use repr::adt::decimal::MAX_DECIMAL_PRECISION;
+use repr::{strconv, Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_FLOAT_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_float32_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_float32(&mut buf, a.unwrap_float32());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub fn cast_float64_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_float64(&mut buf, a.unwrap_float64());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CAST_STRING_TO_FLOAT32_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float32),
+};
+
+pub fn cast_string_to_float32(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_float32(a.unwrap_str())
+        .map(|n| Datum::Float32(n.into()))
+        .err_into()
+}
+
+pub const CAST_STRING_TO_FLOAT64_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn cast_string_to_float64(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_float64(a.unwrap_str())
+        .map(|n| Datum::Float64(n.into()))
+        .err_into()
+}
+
+pub const CAST_FLOAT_TO_INT32_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub fn cast_float64_to_int32(a: Datum) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+    if f > (i32::max_value() as f64) || f < (i32::min_value() as f64) {
+        Ok(Datum::Null)
+    } else {
+        Ok(Datum::from(f as i32))
+    }
+}
+
+pub const CAST_FLOAT_TO_INT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int64),
+};
+
+pub fn cast_float32_to_int64(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): this is undefined behavior if the f32 doesn't fit in an
+    // i64 (https://github.com/rust-lang/rust/issues/10184).
+    Ok(Datum::from(a.unwrap_float32() as i64))
+}
+
+pub fn cast_float64_to_int64(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): this is undefined behavior if the f32 doesn't fit in an
+    // i64 (https://github.com/rust-lang/rust/issues/10184).
+    Ok(Datum::from(a.unwrap_float64() as i64))
+}
+
+pub const CAST_FLOAT32_TO_FLOAT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn cast_float32_to_float64(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): is this cast valid?
+    Ok(Datum::from(f64::from(a.unwrap_float32())))
+}
+
+pub fn cast_float_to_decimal_props(scale: u8) -> FuncProps {
+    FuncProps {
+        can_error: true,
+        preserves_uniqueness: false,
+        nulls: Nulls::Sometimes {
+            propagates_nulls: true,
+            introduces_nulls: false,
+        },
+        output_type: OutputType::Fixed(ScalarType::Decimal(MAX_DECIMAL_PRECISION, scale)),
+    }
+}
+
+pub fn cast_float32_to_decimal(a: Datum, scale: u8) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float32();
+
+    if f > 10_f32.powi((MAX_DECIMAL_PRECISION - scale) as i32) {
+        // When we can return error detail:
+        // format!("A field with precision {}, \
+        //         scale {} must round to an absolute value less than 10^{}.",
+        //         MAX_DECIMAL_PRECISION, scale, MAX_DECIMAL_PRECISION - scale)
+        return Err(EvalError::NumericFieldOverflow);
+    }
+
+    Ok(Datum::from((f * 10_f32.powi(scale as i32)) as i128))
+}
+
+pub fn cast_float64_to_decimal(a: Datum, scale: u8) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+
+    if f > 10_f64.powi((MAX_DECIMAL_PRECISION - scale) as i32) {
+        // When we can return error detail:
+        // format!("A field with precision {}, \
+        //         scale {} must round to an absolute value less than 10^{}.",
+        //         MAX_DECIMAL_PRECISION, scale, MAX_DECIMAL_PRECISION - scale)
+        return Err(EvalError::NumericFieldOverflow);
+    }
+
+    Ok(Datum::from((f * 10_f64.powi(scale as i32)) as i128))
+}
+
+pub const FLOAT32_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float32),
+};
+
+pub const FLOAT64_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn abs_float32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float32().abs()))
+}
+
+pub fn abs_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float64().abs()))
+}
+
+pub fn neg_float32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(-a.unwrap_float32()))
+}
+
+pub fn neg_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(-a.unwrap_float64()))
+}
+
+pub fn ceil_float32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float32().ceil()))
+}
+
+pub fn ceil_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float64().ceil()))
+}
+
+pub fn floor_float32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float32().floor()))
+}
+
+pub fn floor_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float64().floor()))
+}
+
+pub fn round_float32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float32().round()))
+}
+
+pub fn round_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_float64().round()))
+}
+
+pub fn add_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_float32() + b.unwrap_float32()))
+}
+
+pub fn add_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_float64() + b.unwrap_float64()))
+}
+
+pub fn sub_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_float32() - b.unwrap_float32()))
+}
+
+pub fn sub_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_float64() - b.unwrap_float64()))
+}
+
+pub fn mul_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_float32() * b.unwrap_float32()))
+}
+
+pub fn mul_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_float64() * b.unwrap_float64()))
+}
+
+pub fn div_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float32();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_float32() / b))
+    }
+}
+
+pub fn div_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float64();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_float64() / b))
+    }
+}
+
+pub fn mod_float32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float32();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_float32() % b))
+    }
+}
+
+pub fn mod_float64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_float64();
+    if b == 0.0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_float64() % b))
+    }
+}
+
+pub fn sqrt_float32(a: Datum) -> Result<Datum, EvalError> {
+    let x = a.unwrap_float32();
+    if x < 0.0 {
+        return Err(EvalError::NegSqrt);
+    }
+    Ok(Datum::from(x.sqrt()))
+}
+
+pub fn sqrt_float64(a: Datum) -> Result<Datum, EvalError> {
+    let x = a.unwrap_float64();
+    if x < 0.0 {
+        return Err(EvalError::NegSqrt);
+    }
+
+    Ok(Datum::from(x.sqrt()))
+}

--- a/src/expr/src/scalar/func/integer.rs
+++ b/src/expr/src/scalar/func/integer.rs
@@ -1,0 +1,309 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Integer functions.
+
+use std::convert::TryFrom;
+
+use ore::result::ResultExt;
+use repr::{strconv, Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_INT_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_int32_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_int32(&mut buf, a.unwrap_int32());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub fn cast_int64_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_int64(&mut buf, a.unwrap_int64());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CAST_STRING_TO_INT32_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub fn cast_string_to_int32(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_int32(a.unwrap_str())
+        .map(Datum::Int32)
+        .err_into()
+}
+
+pub const CAST_STRING_TO_INT64_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int64),
+};
+
+pub fn cast_string_to_int64(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_int64(a.unwrap_str())
+        .map(Datum::Int64)
+        .err_into()
+}
+
+pub const CAST_INT_TO_BOOL_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn cast_int32_to_bool(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_int32() != 0))
+}
+
+pub fn cast_int64_to_bool(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_int64() != 0))
+}
+
+pub const CAST_INT_TO_FLOAT32_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float32),
+};
+
+pub fn cast_int32_to_float32(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): is this cast valid?
+    Ok(Datum::from(a.unwrap_int32() as f32))
+}
+
+pub fn cast_int64_to_float32(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): is this cast valid?
+    Ok(Datum::from(a.unwrap_int64() as f32))
+}
+
+pub const CAST_INT_TO_FLOAT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn cast_int32_to_float64(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): is this cast valid?
+    Ok(Datum::from(f64::from(a.unwrap_int32())))
+}
+
+pub fn cast_int64_to_float64(a: Datum) -> Result<Datum, EvalError> {
+    // TODO(benesch): is this cast valid?
+    Ok(Datum::from(a.unwrap_int64() as f64))
+}
+
+pub const CAST_INT32_TO_DECIMAL_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Decimal(10, 0)),
+};
+
+pub fn cast_int32_to_decimal(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(i128::from(a.unwrap_int32())))
+}
+
+pub const CAST_INT64_TO_DECIMAL_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Decimal(20, 0)),
+};
+
+pub fn cast_int64_to_decimal(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(i128::from(a.unwrap_int64())))
+}
+
+pub const CAST_INT32_TO_INT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int64),
+};
+
+pub fn cast_int32_to_int64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(i64::from(a.unwrap_int32())))
+}
+
+pub const CAST_INT64_TO_INT32_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub fn cast_int64_to_int32(a: Datum) -> Result<Datum, EvalError> {
+    match i32::try_from(a.unwrap_int64()) {
+        Ok(n) => Ok(Datum::from(n)),
+        Err(_) => Err(EvalError::IntegerOutOfRange),
+    }
+}
+
+pub const INT32_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub const INT64_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: true,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int64),
+};
+
+pub fn abs_int32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_int32().abs()))
+}
+
+pub fn abs_int64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_int64().abs()))
+}
+
+pub fn neg_int32(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(-a.unwrap_int32()))
+}
+
+pub fn neg_int64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(-a.unwrap_int64()))
+}
+
+pub fn add_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int32()
+        .checked_add(b.unwrap_int32())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}
+
+pub fn add_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int64()
+        .checked_add(b.unwrap_int64())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}
+
+pub fn sub_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int32()
+        .checked_sub(b.unwrap_int32())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}
+
+pub fn sub_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int64()
+        .checked_sub(b.unwrap_int64())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}
+
+pub fn mul_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int32()
+        .checked_mul(b.unwrap_int32())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}
+
+pub fn mul_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_int64()
+        .checked_mul(b.unwrap_int64())
+        .ok_or(EvalError::NumericFieldOverflow)
+        .map(Datum::from)
+}
+
+pub fn div_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int32();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int32() / b))
+    }
+}
+
+pub fn div_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int64();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int64() / b))
+    }
+}
+
+pub fn mod_int32<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int32();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int32() % b))
+    }
+}
+
+pub fn mod_int64<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let b = b.unwrap_int64();
+    if b == 0 {
+        Err(EvalError::DivisionByZero)
+    } else {
+        Ok(Datum::from(a.unwrap_int64() % b))
+    }
+}

--- a/src/expr/src/scalar/func/interval.rs
+++ b/src/expr/src/scalar/func/interval.rs
@@ -1,0 +1,385 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
+
+use ore::result::ResultExt;
+use repr::adt::datetime::DateTimeUnits;
+use repr::adt::interval::Interval;
+use repr::{strconv, Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_INTERVAL_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_interval_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_interval(&mut buf, a.unwrap_interval());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CAST_STRING_TO_INTERVAL_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Interval),
+};
+
+pub fn cast_string_to_interval(a: Datum) -> Result<Datum, EvalError> {
+    strconv::parse_interval(a.unwrap_str())
+        .map(Datum::Interval)
+        .err_into()
+}
+
+pub const CAST_TIME_TO_INTERVAL_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Interval),
+};
+
+pub fn cast_time_to_interval(a: Datum) -> Result<Datum, EvalError> {
+    let t = a.unwrap_time();
+    match Interval::new(
+        0,
+        t.num_seconds_from_midnight() as i64,
+        t.nanosecond() as i64,
+    ) {
+        Ok(i) => Ok(Datum::Interval(i)),
+        Err(_) => Err(EvalError::IntervalOutOfRange),
+    }
+}
+
+pub const CAST_INTERVAL_TO_TIME_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Time),
+};
+
+pub fn cast_interval_to_time(a: Datum) -> Result<Datum, EvalError> {
+    let mut i = a.unwrap_interval();
+
+    // Negative durations have their HH::MM::SS.NS values subtracted from 1 day.
+    if i.duration < 0 {
+        i = Interval::new(0, 86400, 0)
+            .unwrap()
+            .checked_add(
+                &Interval::new(0, i.dur_as_secs() % (24 * 60 * 60), i.nanoseconds() as i64)
+                    .unwrap(),
+            )
+            .unwrap();
+    }
+
+    Ok(Datum::Time(NaiveTime::from_hms_nano(
+        i.hours() as u32,
+        i.minutes() as u32,
+        i.seconds() as u32,
+        i.nanoseconds() as u32,
+    )))
+}
+
+pub const INTERVAL_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Interval),
+};
+
+pub fn neg_interval(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(-a.unwrap_interval()))
+}
+
+pub fn add_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_interval()
+        .checked_add(&b.unwrap_interval())
+        .ok_or(EvalError::IntervalOutOfRange)
+        .map(Datum::from)
+}
+
+pub fn sub_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    a.unwrap_interval()
+        .checked_add(&-b.unwrap_interval())
+        .ok_or(EvalError::IntervalOutOfRange)
+        .map(Datum::from)
+}
+
+pub const INTERVAL_DATE_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub const INTERVAL_TIME_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Time),
+};
+
+pub const INTERVAL_TIMESTAMP_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Timestamp),
+};
+
+pub const INTERVAL_TIMESTAMPTZ_MATH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::TimestampTz),
+};
+
+pub fn add_timestamp_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let dt = a.unwrap_timestamp();
+    Ok(Datum::Timestamp(match b {
+        Datum::Interval(i) => {
+            let dt = add_timestamp_months(dt, i.months);
+            dt + i.duration_as_chrono()
+        }
+        _ => panic!("Tried to do timestamp addition with non-interval: {:?}", b),
+    }))
+}
+
+pub fn add_timestamptz_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let dt = a.unwrap_timestamptz().naive_utc();
+
+    let new_ndt = match b {
+        Datum::Interval(i) => {
+            let dt = add_timestamp_months(dt, i.months);
+            dt + i.duration_as_chrono()
+        }
+        _ => panic!("Tried to do timestamp addition with non-interval: {:?}", b),
+    };
+
+    Ok(Datum::TimestampTz(DateTime::<Utc>::from_utc(new_ndt, Utc)))
+}
+
+pub fn sub_timestamp_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    add_timestamp_interval(a, Datum::Interval(-b.unwrap_interval()))
+}
+
+pub fn sub_timestamptz_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    add_timestamptz_interval(a, Datum::Interval(-b.unwrap_interval()))
+}
+
+pub fn add_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let date = a.unwrap_date();
+    let interval = b.unwrap_interval();
+
+    let dt = NaiveDate::from_ymd(date.year(), date.month(), date.day()).and_hms(0, 0, 0);
+    let dt = add_timestamp_months(dt, interval.months);
+    Ok(Datum::Timestamp(dt + interval.duration_as_chrono()))
+}
+
+pub fn add_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let time = a.unwrap_time();
+    let interval = b.unwrap_interval();
+    let (t, _) = time.overflowing_add_signed(interval.duration_as_chrono());
+    Ok(Datum::Time(t))
+}
+
+pub fn sub_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_timestamp() - b.unwrap_timestamp()))
+}
+
+pub fn sub_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_timestamptz() - b.unwrap_timestamptz()))
+}
+
+pub fn sub_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_date() - b.unwrap_date()))
+}
+
+pub fn sub_time<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::from(a.unwrap_time() - b.unwrap_time()))
+}
+
+pub fn sub_date_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let date = a.unwrap_date();
+    let interval = b.unwrap_interval();
+
+    let dt = NaiveDate::from_ymd(date.year(), date.month(), date.day()).and_hms(0, 0, 0);
+    let dt = add_timestamp_months(dt, -interval.months);
+    Ok(Datum::Timestamp(dt - interval.duration_as_chrono()))
+}
+
+pub fn sub_time_interval<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let time = a.unwrap_time();
+    let interval = b.unwrap_interval();
+    let (t, _) = time.overflowing_sub_signed(interval.duration_as_chrono());
+    Ok(Datum::Time(t))
+}
+
+pub const DATE_PART_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn date_part(a: Datum, interval: Interval) -> Result<Datum, EvalError> {
+    let units = a.unwrap_str();
+    match units.parse() {
+        Ok(units) => date_part_inner(units, interval),
+        Err(_) => Err(EvalError::UnknownUnits(units.to_owned())),
+    }
+}
+
+pub fn date_part_inner(
+    units: DateTimeUnits,
+    interval: Interval,
+) -> Result<Datum<'static>, EvalError> {
+    match units {
+        DateTimeUnits::Epoch => Ok(interval.as_seconds().into()),
+        DateTimeUnits::Year => Ok(interval.years().into()),
+        DateTimeUnits::Day => Ok(interval.days().into()),
+        DateTimeUnits::Hour => Ok(interval.hours().into()),
+        DateTimeUnits::Minute => Ok(interval.minutes().into()),
+        DateTimeUnits::Second => Ok(interval.seconds().into()),
+        DateTimeUnits::Millennium
+        | DateTimeUnits::Century
+        | DateTimeUnits::Decade
+        | DateTimeUnits::Quarter
+        | DateTimeUnits::Week
+        | DateTimeUnits::Month
+        | DateTimeUnits::Milliseconds
+        | DateTimeUnits::Microseconds
+        | DateTimeUnits::Timezone
+        | DateTimeUnits::TimezoneHour
+        | DateTimeUnits::TimezoneMinute
+        | DateTimeUnits::DayOfWeek
+        | DateTimeUnits::DayOfYear
+        | DateTimeUnits::IsoDayOfWeek
+        | DateTimeUnits::IsoDayOfYear => Err(EvalError::UnsupportedDateTimeUnits(units)),
+    }
+}
+
+pub fn add_timestamp_months(dt: NaiveDateTime, months: i32) -> NaiveDateTime {
+    if months == 0 {
+        return dt;
+    }
+
+    let mut months = months;
+
+    let (mut year, mut month, mut day) = (dt.year(), dt.month0() as i32, dt.day());
+    let years = months / 12;
+    year += years;
+    months %= 12;
+    // positive modulus is easier to reason about
+    if months < 0 {
+        year -= 1;
+        months += 12;
+    }
+    year += (month + months) / 12;
+    month = (month + months) % 12;
+    // account for dt.month0
+    month += 1;
+
+    // handle going from January 31st to February by saturation
+    let mut new_d = chrono::NaiveDate::from_ymd_opt(year, month as u32, day);
+    while new_d.is_none() {
+        debug_assert!(day > 28, "there are no months with fewer than 28 days");
+        day -= 1;
+        new_d = chrono::NaiveDate::from_ymd_opt(year, month as u32, day);
+    }
+    let new_d = new_d.unwrap();
+
+    // Neither postgres nor mysql support leap seconds, so this should be safe.
+    //
+    // Both my testing and https://dba.stackexchange.com/a/105829 support the
+    // idea that we should ignore leap seconds
+    new_d.and_hms_nano(dt.hour(), dt.minute(), dt.second(), dt.nanosecond())
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn add_interval_months() {
+        let dt = ym(2000, 1);
+
+        assert_eq!(add_timestamp_months(dt, 0), dt);
+        assert_eq!(add_timestamp_months(dt, 1), ym(2000, 2));
+        assert_eq!(add_timestamp_months(dt, 12), ym(2001, 1));
+        assert_eq!(add_timestamp_months(dt, 13), ym(2001, 2));
+        assert_eq!(add_timestamp_months(dt, 24), ym(2002, 1));
+        assert_eq!(add_timestamp_months(dt, 30), ym(2002, 7));
+
+        // and negatives
+        assert_eq!(add_timestamp_months(dt, -1), ym(1999, 12));
+        assert_eq!(add_timestamp_months(dt, -12), ym(1999, 1));
+        assert_eq!(add_timestamp_months(dt, -13), ym(1998, 12));
+        assert_eq!(add_timestamp_months(dt, -24), ym(1998, 1));
+        assert_eq!(add_timestamp_months(dt, -30), ym(1997, 7));
+
+        // and going over a year boundary by less than a year
+        let dt = ym(1999, 12);
+        assert_eq!(add_timestamp_months(dt, 1), ym(2000, 1));
+        let end_of_month_dt = NaiveDate::from_ymd(1999, 12, 31).and_hms(9, 9, 9);
+        assert_eq!(
+            // leap year
+            add_timestamp_months(end_of_month_dt, 2),
+            NaiveDate::from_ymd(2000, 2, 29).and_hms(9, 9, 9),
+        );
+        assert_eq!(
+            // not leap year
+            add_timestamp_months(end_of_month_dt, 14),
+            NaiveDate::from_ymd(2001, 2, 28).and_hms(9, 9, 9),
+        );
+    }
+
+    fn ym(year: i32, month: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd(year, month, 1).and_hms(9, 9, 9)
+    }
+}

--- a/src/expr/src/scalar/func/jsonb.rs
+++ b/src/expr/src/scalar/func/jsonb.rs
@@ -1,0 +1,502 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! JSONB functions.
+
+use repr::adt::jsonb::JsonbRef;
+use repr::strconv;
+use repr::{Datum, RowArena, RowPacker, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_JSONB_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_jsonb_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_jsonb(&mut buf, JsonbRef::from_datum(a));
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CAST_STRING_TO_JSONB_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true, // TODO(benesch): should error
+    },
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+// TODO(jamii): it would be much more efficient to skip the intermediate
+// repr::jsonb::Jsonb.
+pub fn cast_string_to_jsonb<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    match strconv::parse_jsonb(a.unwrap_str()) {
+        Err(_) => Ok(Datum::Null),
+        Ok(jsonb) => Ok(temp_storage.push_row(jsonb.into_row()).unpack_first()),
+    }
+}
+
+pub const CAST_JSONB_OR_NULL_TO_JSONB_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Never,
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+pub fn cast_jsonb_or_null_to_jsonb(a: Datum) -> Result<Datum, EvalError> {
+    Ok(match a {
+        Datum::Null => Datum::JsonNull,
+        Datum::Float64(f) => {
+            if f.is_finite() {
+                a
+            } else if f.is_nan() {
+                Datum::String("NaN")
+            } else if f.is_sign_positive() {
+                Datum::String("Infinity")
+            } else {
+                Datum::String("-Infinity")
+            }
+        }
+        _ => a,
+    })
+}
+
+pub const CAST_JSONB_TO_FLOAT64_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: true,
+    },
+    output_type: OutputType::Fixed(ScalarType::Float64),
+};
+
+pub fn cast_jsonb_to_float64(a: Datum) -> Result<Datum, EvalError> {
+    Ok(match a {
+        Datum::Float64(_) => a,
+        Datum::String(s) => match s {
+            "NaN" => std::f64::NAN.into(),
+            "Infinity" => std::f64::INFINITY.into(),
+            "-Infinity" => std::f64::NEG_INFINITY.into(),
+            _ => Datum::Null,
+        },
+        _ => Datum::Null,
+    })
+}
+
+pub const CAST_JSONB_TO_BOOL_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn cast_jsonb_to_bool(a: Datum) -> Result<Datum, EvalError> {
+    Ok(match a {
+        Datum::True | Datum::False => a,
+        _ => Datum::Null,
+    })
+}
+
+pub fn jsonb_get_props(stringify: bool) -> FuncProps {
+    FuncProps {
+        can_error: false,
+        preserves_uniqueness: false,
+        nulls: Nulls::Sometimes {
+            propagates_nulls: true,
+            introduces_nulls: true,
+        },
+        output_type: OutputType::Fixed(match stringify {
+            false => ScalarType::Jsonb,
+            true => ScalarType::String,
+        }),
+    }
+}
+
+pub fn jsonb_get_int64<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+    stringify: bool,
+) -> Result<Datum<'a>, EvalError> {
+    let i = b.unwrap_int64();
+    Ok(match a {
+        Datum::List(list) => {
+            let i = if i >= 0 {
+                i
+            } else {
+                // index backwards from the end
+                (list.iter().count() as i64) + i
+            };
+            match list.iter().nth(i as usize) {
+                Some(d) if stringify => jsonb_stringify(d, temp_storage),
+                Some(d) => d,
+                None => Datum::Null,
+            }
+        }
+        Datum::Dict(_) => Datum::Null,
+        _ => {
+            if i == 0 || i == -1 {
+                // I have no idea why postgres does this, but we're stuck with it
+                if stringify {
+                    jsonb_stringify(a, temp_storage)
+                } else {
+                    a
+                }
+            } else {
+                Datum::Null
+            }
+        }
+    })
+}
+
+pub fn jsonb_get_string<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+    stringify: bool,
+) -> Result<Datum<'a>, EvalError> {
+    let k = b.unwrap_str();
+    Ok(match a {
+        Datum::Dict(dict) => match dict.iter().find(|(k2, _v)| k == *k2) {
+            Some((_k, v)) if stringify => jsonb_stringify(v, temp_storage),
+            Some((_k, v)) => v,
+            None => Datum::Null,
+        },
+        _ => Datum::Null,
+    })
+}
+
+pub const JSONB_ARRAY_LENGTH_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int64),
+};
+
+pub fn jsonb_array_length(a: Datum) -> Result<Datum, EvalError> {
+    Ok(match a {
+        Datum::List(list) => Datum::Int64(list.iter().count() as i64),
+        _ => Datum::Null,
+    })
+}
+
+pub const JSONB_TYPEOF_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn jsonb_typeof(a: Datum) -> Result<Datum, EvalError> {
+    Ok(match a {
+        Datum::Dict(_) => Datum::String("object"),
+        Datum::List(_) => Datum::String("array"),
+        Datum::String(_) => Datum::String("string"),
+        Datum::Float64(_) => Datum::String("number"),
+        Datum::True | Datum::False => Datum::String("boolean"),
+        Datum::JsonNull => Datum::String("null"),
+        Datum::Null => Datum::Null,
+        _ => panic!("Not jsonb: {:?}", a),
+    })
+}
+
+pub const JSONB_STRIP_NULLS_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+pub fn jsonb_strip_nulls<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    fn strip_nulls(a: Datum, packer: &mut RowPacker) {
+        match a {
+            Datum::Dict(dict) => packer.push_dict_with(|packer| {
+                for (k, v) in dict.iter() {
+                    match v {
+                        Datum::JsonNull => (),
+                        _ => {
+                            packer.push(Datum::String(k));
+                            strip_nulls(v, packer);
+                        }
+                    }
+                }
+            }),
+            Datum::List(list) => packer.push_list_with(|packer| {
+                for elem in list.iter() {
+                    strip_nulls(elem, packer);
+                }
+            }),
+            _ => packer.push(a),
+        }
+    }
+    Ok(temp_storage.make_datum(|packer| strip_nulls(a, packer)))
+}
+
+pub const JSONB_PRETTY_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn jsonb_pretty<'a>(a: Datum, temp_storage: &'a RowArena) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_jsonb_pretty(&mut buf, JsonbRef::from_datum(a));
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const JSONB_CONTAINS_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let k = b.unwrap_str();
+    // https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT
+    Ok(match a {
+        Datum::List(list) => list.iter().any(|k2| b == k2).into(),
+        Datum::Dict(dict) => dict.iter().any(|(k2, _v)| k == k2).into(),
+        Datum::String(string) => (string == k).into(),
+        _ => false.into(),
+    })
+}
+
+pub const JSONB_CONTAINS_JSONB_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+// TODO(jamii) nested loops are possibly not the fastest way to do this
+pub fn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    // https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT
+    fn contains(a: Datum, b: Datum, at_top_level: bool) -> bool {
+        match (a, b) {
+            (Datum::JsonNull, Datum::JsonNull) => true,
+            (Datum::False, Datum::False) => true,
+            (Datum::True, Datum::True) => true,
+            (Datum::Float64(a), Datum::Float64(b)) => (a == b),
+            (Datum::String(a), Datum::String(b)) => (a == b),
+            (Datum::List(a), Datum::List(b)) => b
+                .iter()
+                .all(|b_elem| a.iter().any(|a_elem| contains(a_elem, b_elem, false))),
+            (Datum::Dict(a), Datum::Dict(b)) => b.iter().all(|(b_key, b_val)| {
+                a.iter()
+                    .any(|(a_key, a_val)| (a_key == b_key) && contains(a_val, b_val, false))
+            }),
+
+            // fun special case
+            (Datum::List(a), b) => {
+                at_top_level && a.iter().any(|a_elem| contains(a_elem, b, false))
+            }
+
+            _ => false,
+        }
+    }
+    Ok(contains(a, b, true).into())
+}
+
+pub const JSONB_CONCAT_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true,
+    },
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+pub fn jsonb_concat<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    Ok(match (a, b) {
+        (Datum::Dict(dict_a), Datum::Dict(dict_b)) => {
+            let mut pairs = dict_b.iter().chain(dict_a.iter()).collect::<Vec<_>>();
+            // stable sort, so if keys collide dedup prefers dict_b
+            pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
+            pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
+            temp_storage.make_datum(|packer| packer.push_dict(pairs))
+        }
+        (Datum::List(list_a), Datum::List(list_b)) => {
+            let elems = list_a.iter().chain(list_b.iter());
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        (Datum::List(list_a), b) => {
+            let elems = list_a.iter().chain(Some(b).into_iter());
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        (a, Datum::List(list_b)) => {
+            let elems = Some(a).into_iter().chain(list_b.iter());
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        _ => Datum::Null,
+    })
+}
+
+pub const JSONB_DELETE_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true,
+    },
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+pub fn jsonb_delete_int64<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let i = b.unwrap_int64();
+    Ok(match a {
+        Datum::List(list) => {
+            let i = if i >= 0 {
+                i
+            } else {
+                // index backwards from the end
+                (list.iter().count() as i64) + i
+            } as usize;
+            let elems = list
+                .iter()
+                .enumerate()
+                .filter(|(i2, _e)| i != *i2)
+                .map(|(_, e)| e);
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        _ => Datum::Null,
+    })
+}
+
+pub fn jsonb_delete_string<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    Ok(match a {
+        Datum::List(list) => {
+            let elems = list.iter().filter(|e| b != *e);
+            temp_storage.make_datum(|packer| packer.push_list(elems))
+        }
+        Datum::Dict(dict) => {
+            let k = b.unwrap_str();
+            let pairs = dict.iter().filter(|(k2, _v)| k != *k2);
+            temp_storage.make_datum(|packer| packer.push_dict(pairs))
+        }
+        _ => Datum::Null,
+    })
+}
+
+pub fn jsonb_stringify<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
+    match a {
+        Datum::JsonNull => Datum::Null,
+        Datum::String(_) => a,
+        _ => {
+            let mut buf = String::new();
+            strconv::format_jsonb(&mut buf, JsonbRef::from_datum(a));
+            Datum::String(temp_storage.push_string(buf))
+        }
+    }
+}
+
+pub const JSONB_BUILD_ARRAY_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+pub fn jsonb_build_array<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    if datums.iter().any(|datum| datum.is_null()) {
+        // the inputs should all be valid jsonb types, but a casting error might produce a Datum::Null that needs to be propagated
+        // TODO(benesch): I don't understand this at all.
+        Ok(Datum::Null)
+    } else {
+        Ok(temp_storage.make_datum(|packer| packer.push_list(datums)))
+    }
+}
+
+pub const JSONB_BUILD_OBJECT_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Jsonb),
+};
+
+pub fn jsonb_build_object<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    if datums.iter().any(|datum| datum.is_null()) {
+        // the inputs should all be valid jsonb types, but a casting error might produce a Datum::Null that needs to be propagated
+        // TODO(benesch): I don't understand this at all.
+        Ok(Datum::Null)
+    } else {
+        let mut kvs = datums.chunks(2).collect::<Vec<_>>();
+        kvs.sort_by(|kv1, kv2| kv1[0].cmp(&kv2[0]));
+        kvs.dedup_by(|kv1, kv2| kv1[0] == kv2[0]);
+        Ok(temp_storage.make_datum(|packer| {
+            packer.push_dict(kvs.into_iter().map(|kv| (kv[0].unwrap_str(), kv[1])))
+        }))
+    }
+}

--- a/src/expr/src/scalar/func/list.rs
+++ b/src/expr/src/scalar/func/list.rs
@@ -1,0 +1,31 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! List functions.
+
+use repr::{Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub fn list_create_props(elem_type: ScalarType) -> FuncProps {
+    FuncProps {
+        can_error: false,
+        preserves_uniqueness: false,
+        nulls: Nulls::Never,
+        output_type: OutputType::Fixed(ScalarType::List(Box::new(elem_type))),
+    }
+}
+
+pub fn list_create<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    Ok(temp_storage.make_datum(|packer| packer.push_list(datums)))
+}

--- a/src/expr/src/scalar/func/null.rs
+++ b/src/expr/src/scalar/func/null.rs
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Null-handling functions.
+
+use repr::{Datum, RowArena, ScalarType};
+
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::{EvalError, ScalarExpr};
+
+pub const IS_NULL_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Never,
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn is_null(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a == Datum::Null))
+}
+
+pub const COALESCE_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::MatchesInput,
+};
+
+pub fn coalesce<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+    exprs: &'a [ScalarExpr],
+) -> Result<Datum<'a>, EvalError> {
+    for e in exprs {
+        let d = e.eval(datums, temp_storage)?;
+        if !d.is_null() {
+            return Ok(d);
+        }
+    }
+    Ok(Datum::Null)
+}

--- a/src/expr/src/scalar/func/string.rs
+++ b/src/expr/src/scalar/func/string.rs
@@ -1,0 +1,368 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! String and byte string functions.
+
+use std::cmp;
+use std::convert::TryFrom;
+use std::str;
+
+use encoding::label::encoding_from_whatwg_label;
+use encoding::DecoderTrap;
+
+use repr::strconv;
+use repr::{Datum, RowArena, ScalarType};
+
+use crate::like_pattern;
+use crate::scalar::func::{FuncProps, Nulls, OutputType};
+use crate::scalar::EvalError;
+
+pub const CAST_BYTES_TO_STRING_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn cast_bytes_to_string<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    strconv::format_bytes(&mut buf, a.unwrap_bytes());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CAST_STRING_TO_BYTES_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bytes),
+};
+
+pub fn cast_string_to_bytes<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let bytes = strconv::parse_bytes(a.unwrap_str())?;
+    Ok(Datum::Bytes(temp_storage.push_bytes(bytes)))
+}
+
+pub const CONVERT_FROM_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn convert_from<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    // Convert PostgreSQL-style encoding names[1] to WHATWG-style encoding names[2],
+    // which the encoding library uses[3].
+    // [1]: https://www.postgresql.org/docs/9.5/multibyte.html
+    // [2]: https://encoding.spec.whatwg.org/
+    // [3]: https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs
+    let encoding_name = b.unwrap_str().to_lowercase().replace("_", "-");
+
+    match encoding_from_whatwg_label(&encoding_name) {
+        Some(enc) => {
+            // todo@jldlaughlin: #2282
+            if enc.name() != "utf-8" {
+                return Err(EvalError::InvalidEncodingName(encoding_name));
+            }
+        }
+        None => return Err(EvalError::InvalidEncodingName(encoding_name)),
+    }
+
+    let bytes = a.unwrap_bytes();
+    match str::from_utf8(bytes) {
+        Ok(from) => Ok(Datum::String(from)),
+        Err(e) => {
+            let mut byte_sequence = String::new();
+            strconv::format_bytes(&mut byte_sequence, &bytes);
+            Err(EvalError::InvalidByteSequence {
+                byte_sequence: e.to_string(),
+                encoding_name,
+            })
+        }
+    }
+}
+
+pub const LENGTH_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub fn bit_length<B>(bytes: B) -> Result<Datum<'static>, EvalError>
+where
+    B: AsRef<[u8]>,
+{
+    match i32::try_from(bytes.as_ref().len() * 8) {
+        Ok(l) => Ok(Datum::from(l)),
+        Err(_) => Err(EvalError::IntegerOutOfRange),
+    }
+}
+
+pub fn byte_length<B>(bytes: B) -> Result<Datum<'static>, EvalError>
+where
+    B: AsRef<[u8]>,
+{
+    match i32::try_from(bytes.as_ref().len()) {
+        Ok(l) => Ok(Datum::from(l)),
+        Err(_) => Err(EvalError::IntegerOutOfRange),
+    }
+}
+
+pub fn char_length(a: Datum) -> Result<Datum, EvalError> {
+    match i32::try_from(a.unwrap_str().chars().count()) {
+        Ok(l) => Ok(Datum::from(l)),
+        Err(_) => Err(EvalError::IntegerOutOfRange),
+    }
+}
+
+pub fn encoded_bytes_char_length<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    // Convert PostgreSQL-style encoding names[1] to WHATWG-style encoding names[2],
+    // which the encoding library uses[3].
+    // [1]: https://www.postgresql.org/docs/9.5/multibyte.html
+    // [2]: https://encoding.spec.whatwg.org/
+    // [3]: https://github.com/lifthrasiir/rust-encoding/blob/4e79c35ab6a351881a86dbff565c4db0085cc113/src/label.rs
+    let encoding_name = b.unwrap_str().to_lowercase().replace("_", "-");
+
+    let enc = match encoding_from_whatwg_label(&encoding_name) {
+        Some(enc) => enc,
+        None => return Err(EvalError::InvalidEncodingName(encoding_name)),
+    };
+
+    let decoded_string = match enc.decode(a.unwrap_bytes(), DecoderTrap::Strict) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(EvalError::InvalidByteSequence {
+                byte_sequence: e.to_string(),
+                encoding_name,
+            })
+        }
+    };
+
+    match i32::try_from(decoded_string.chars().count()) {
+        Ok(l) => Ok(Datum::from(l)),
+        Err(_) => Err(EvalError::IntegerOutOfRange),
+    }
+}
+
+pub const ASCII_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Int32),
+};
+
+pub fn ascii(a: Datum) -> Result<Datum, EvalError> {
+    match a.unwrap_str().chars().next() {
+        None => Ok(Datum::Int32(0)),
+        Some(v) => Ok(Datum::Int32(v as i32)),
+    }
+}
+
+pub const CONCAT_BINARY_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn concat_binary<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    buf.push_str(a.unwrap_str());
+    buf.push_str(b.unwrap_str());
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const CONCAT_VARIADIC_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Never,
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn concat_variadic<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut buf = String::new();
+    for d in datums {
+        if !d.is_null() {
+            buf.push_str(d.unwrap_str());
+        }
+    }
+    Ok(Datum::String(temp_storage.push_string(buf)))
+}
+
+pub const TRIM_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: false,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn trim_whitespace(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_str().trim_matches(' ')))
+}
+
+pub fn trim<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let trim_chars = b.unwrap_str();
+
+    Ok(Datum::from(
+        a.unwrap_str().trim_matches(|c| trim_chars.contains(c)),
+    ))
+}
+
+pub fn trim_leading_whitespace(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_str().trim_start_matches(' ')))
+}
+
+pub fn trim_leading<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let trim_chars = b.unwrap_str();
+
+    Ok(Datum::from(
+        a.unwrap_str()
+            .trim_start_matches(|c| trim_chars.contains(c)),
+    ))
+}
+
+pub fn trim_trailing_whitespace(a: Datum) -> Result<Datum, EvalError> {
+    Ok(Datum::from(a.unwrap_str().trim_end_matches(' ')))
+}
+
+pub fn trim_trailing<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let trim_chars = b.unwrap_str();
+
+    Ok(Datum::from(
+        a.unwrap_str().trim_end_matches(|c| trim_chars.contains(c)),
+    ))
+}
+
+pub const SUBSTR_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: true, // TODO(benesch): should error instead
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn substr<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
+    let string: &'a str = datums[0].unwrap_str();
+    let mut chars = string.chars();
+
+    let start_in_chars = datums[1].unwrap_int64() - 1;
+    let mut start_in_bytes = 0;
+    for _ in 0..cmp::max(start_in_chars, 0) {
+        start_in_bytes += chars.next().map(|char| char.len_utf8()).unwrap_or(0);
+    }
+
+    if datums.len() == 3 {
+        let mut length_in_chars = datums[2].unwrap_int64();
+        if length_in_chars < 0 {
+            return Ok(Datum::Null);
+        }
+        if start_in_chars < 0 {
+            length_in_chars += start_in_chars;
+        }
+        let mut length_in_bytes = 0;
+        for _ in 0..cmp::max(length_in_chars, 0) {
+            length_in_bytes += chars.next().map(|char| char.len_utf8()).unwrap_or(0);
+        }
+        Ok(Datum::String(
+            &string[start_in_bytes..start_in_bytes + length_in_bytes],
+        ))
+    } else {
+        Ok(Datum::String(&string[start_in_bytes..]))
+    }
+}
+
+pub const REPLACE_PROPS: FuncProps = FuncProps {
+    can_error: false,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::String),
+};
+
+pub fn replace<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    Ok(Datum::String(
+        temp_storage.push_string(
+            datums[0]
+                .unwrap_str()
+                .replace(datums[1].unwrap_str(), datums[2].unwrap_str()),
+        ),
+    ))
+}
+
+pub const MATCH_LIKE_PATTERN_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn match_like_pattern<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let haystack = a.unwrap_str();
+    let needle = like_pattern::build_regex(b.unwrap_str())?;
+    Ok(Datum::from(needle.is_match(haystack)))
+}
+
+pub const MATCH_REGEX_PROPS: FuncProps = FuncProps {
+    can_error: true,
+    preserves_uniqueness: false,
+    nulls: Nulls::Sometimes {
+        propagates_nulls: true,
+        introduces_nulls: false,
+    },
+    output_type: OutputType::Fixed(ScalarType::Bool),
+};
+
+pub fn match_regex<'a>(a: Datum<'a>, needle: &regex::Regex) -> Result<Datum<'a>, EvalError> {
+    let haystack = a.unwrap_str();
+    Ok(Datum::from(needle.is_match(haystack)))
+}

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -295,7 +295,7 @@ impl ScalarExpr {
                 if expr1.is_literal() && expr2.is_literal() {
                     *e = eval(e);
                 } else if (expr1.is_literal_null() || expr2.is_literal_null())
-                    && func.propagates_nulls()
+                    && func.props().propagates_nulls()
                 {
                     *e = ScalarExpr::literal_null(e.typ(relation_type));
                 } else if let Some(err) = expr1.as_literal_err() {
@@ -404,7 +404,9 @@ impl ScalarExpr {
                     }
                 } else if exprs.iter().all(|e| e.is_literal()) {
                     *e = eval(e);
-                } else if func.propagates_nulls() && exprs.iter().any(|e| e.is_literal_null()) {
+                } else if func.props().propagates_nulls()
+                    && exprs.iter().any(|e| e.is_literal_null())
+                {
                     *e = ScalarExpr::literal_null(e.typ(&relation_type));
                 } else if let Some(err) = exprs.iter().find_map(|e| e.as_literal_err()) {
                     *e = ScalarExpr::literal(Err(err.clone()), e.typ(&relation_type));
@@ -456,18 +458,18 @@ impl ScalarExpr {
             ScalarExpr::Literal(..) => {}
             ScalarExpr::CallNullary(_) => (),
             ScalarExpr::CallUnary { func, expr } => {
-                if func.propagates_nulls() {
+                if func.props().propagates_nulls() {
                     expr.non_null_requirements(columns);
                 }
             }
             ScalarExpr::CallBinary { func, expr1, expr2 } => {
-                if func.propagates_nulls() {
+                if func.props().propagates_nulls() {
                     expr1.non_null_requirements(columns);
                     expr2.non_null_requirements(columns);
                 }
             }
             ScalarExpr::CallVariadic { func, exprs } => {
-                if func.propagates_nulls() {
+                if func.props().propagates_nulls() {
                     for expr in exprs {
                         expr.non_null_requirements(columns);
                     }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -269,70 +269,72 @@ impl<'a> Datum<'a> {
 
     /// Reports whether this datum is an instance of the specified column type.
     pub fn is_instance_of(self, column_type: &ColumnType) -> bool {
-        fn is_instance_of_scalar(datum: Datum, scalar_type: &ScalarType) -> bool {
-            if let ScalarType::Jsonb = scalar_type {
-                // json type checking
-                match datum {
-                    Datum::JsonNull
-                    | Datum::False
-                    | Datum::True
-                    | Datum::Float64(_)
-                    | Datum::String(_) => true,
-                    Datum::List(list) => list
-                        .iter()
-                        .all(|elem| is_instance_of_scalar(elem, scalar_type)),
-                    Datum::Dict(dict) => dict
-                        .iter()
-                        .all(|(_key, val)| is_instance_of_scalar(val, scalar_type)),
-                    _ => false,
-                }
-            } else {
-                // sql type checking
-                match (datum, scalar_type) {
-                    (Datum::Null, _) => false,
-                    (Datum::False, ScalarType::Bool) => true,
-                    (Datum::False, _) => false,
-                    (Datum::True, ScalarType::Bool) => true,
-                    (Datum::True, _) => false,
-                    (Datum::Int32(_), ScalarType::Int32) => true,
-                    (Datum::Int32(_), _) => false,
-                    (Datum::Int64(_), ScalarType::Int64) => true,
-                    (Datum::Int64(_), _) => false,
-                    (Datum::Float32(_), ScalarType::Float32) => true,
-                    (Datum::Float32(_), _) => false,
-                    (Datum::Float64(_), ScalarType::Float64) => true,
-                    (Datum::Float64(_), _) => false,
-                    (Datum::Date(_), ScalarType::Date) => true,
-                    (Datum::Date(_), _) => false,
-                    (Datum::Time(_), ScalarType::Time) => true,
-                    (Datum::Time(_), _) => false,
-                    (Datum::Timestamp(_), ScalarType::Timestamp) => true,
-                    (Datum::Timestamp(_), _) => false,
-                    (Datum::TimestampTz(_), ScalarType::TimestampTz) => true,
-                    (Datum::TimestampTz(_), _) => false,
-                    (Datum::Interval(_), ScalarType::Interval) => true,
-                    (Datum::Interval(_), _) => false,
-                    (Datum::Decimal(_), ScalarType::Decimal(_, _)) => true,
-                    (Datum::Decimal(_), _) => false,
-                    (Datum::Bytes(_), ScalarType::Bytes) => true,
-                    (Datum::Bytes(_), _) => false,
-                    (Datum::String(_), ScalarType::String) => true,
-                    (Datum::String(_), _) => false,
-                    (Datum::List(list), ScalarType::List(t)) => list
-                        .iter()
-                        .all(|e| e.is_null() || is_instance_of_scalar(e, t)),
-                    (Datum::List(_), _) => false,
-                    (Datum::Dict(_), _) => false,
-                    (Datum::JsonNull, _) => false,
-                }
-            }
-        }
         if column_type.nullable {
             if let Datum::Null = self {
                 return true;
             }
         }
-        is_instance_of_scalar(self, &column_type.scalar_type)
+        self.is_instance_of_scalar(&column_type.scalar_type)
+    }
+
+    /// Reports whether this datum is an instance of the specified sclar type.
+    pub fn is_instance_of_scalar(self, scalar_type: &ScalarType) -> bool {
+        if let ScalarType::Jsonb = scalar_type {
+            // json type checking
+            match self {
+                Datum::JsonNull
+                | Datum::False
+                | Datum::True
+                | Datum::Float64(_)
+                | Datum::String(_) => true,
+                Datum::List(list) => list
+                    .iter()
+                    .all(|elem| elem.is_instance_of_scalar(scalar_type)),
+                Datum::Dict(dict) => dict
+                    .iter()
+                    .all(|(_key, val)| val.is_instance_of_scalar(scalar_type)),
+                _ => false,
+            }
+        } else {
+            // sql type checking
+            match (self, scalar_type) {
+                (Datum::Null, _) => false,
+                (Datum::False, ScalarType::Bool) => true,
+                (Datum::False, _) => false,
+                (Datum::True, ScalarType::Bool) => true,
+                (Datum::True, _) => false,
+                (Datum::Int32(_), ScalarType::Int32) => true,
+                (Datum::Int32(_), _) => false,
+                (Datum::Int64(_), ScalarType::Int64) => true,
+                (Datum::Int64(_), _) => false,
+                (Datum::Float32(_), ScalarType::Float32) => true,
+                (Datum::Float32(_), _) => false,
+                (Datum::Float64(_), ScalarType::Float64) => true,
+                (Datum::Float64(_), _) => false,
+                (Datum::Date(_), ScalarType::Date) => true,
+                (Datum::Date(_), _) => false,
+                (Datum::Time(_), ScalarType::Time) => true,
+                (Datum::Time(_), _) => false,
+                (Datum::Timestamp(_), ScalarType::Timestamp) => true,
+                (Datum::Timestamp(_), _) => false,
+                (Datum::TimestampTz(_), ScalarType::TimestampTz) => true,
+                (Datum::TimestampTz(_), _) => false,
+                (Datum::Interval(_), ScalarType::Interval) => true,
+                (Datum::Interval(_), _) => false,
+                (Datum::Decimal(_), ScalarType::Decimal(_, _)) => true,
+                (Datum::Decimal(_), _) => false,
+                (Datum::Bytes(_), ScalarType::Bytes) => true,
+                (Datum::Bytes(_), _) => false,
+                (Datum::String(_), ScalarType::String) => true,
+                (Datum::String(_), _) => false,
+                (Datum::List(list), ScalarType::List(t)) => list
+                    .iter()
+                    .all(|e| e.is_null() || e.is_instance_of_scalar(t)),
+                (Datum::List(_), _) => false,
+                (Datum::Dict(_), _) => false,
+                (Datum::JsonNull, _) => false,
+            }
+        }
     }
 }
 

--- a/src/sql/src/plan/cast.rs
+++ b/src/sql/src/plan/cast.rs
@@ -174,10 +174,7 @@ lazy_static! {
             (Float32, Implicit(Float64)) => CastFloat32ToFloat64,
             (Float32, Explicit(Decimal(0, 0))) => CastOp::F(|_ecx, e, to_type| {
                 let (_, s) = to_type.scalar_type().unwrap_decimal_parts();
-                let s = ScalarExpr::literal(
-                    Datum::from(i32::from(s)), ColumnType::new(to_type.scalar_type())
-                );
-                e.call_binary(s, BinaryFunc::CastFloat32ToDecimal)
+                e.call_unary(UnaryFunc::CastFloat32ToDecimal(s))
             }),
             (Float32, Explicit(String)) => CastFloat32ToString,
             (Float32, JsonbAny) => CastOp::F(to_jsonb_any_f64_cast),
@@ -187,9 +184,7 @@ lazy_static! {
             (Float64, Explicit(Int64)) => CastFloat64ToInt64,
             (Float64, Explicit(Decimal(0, 0))) => CastOp::F(|_ecx, e, to_type| {
                 let (_, s) = to_type.scalar_type().unwrap_decimal_parts();
-                let s = ScalarExpr::literal(Datum::from(
-                    i32::from(s)), ColumnType::new(to_type.scalar_type()));
-                e.call_binary(s, BinaryFunc::CastFloat64ToDecimal)
+                e.call_unary(UnaryFunc::CastFloat64ToDecimal(s))
             }),
             (Float64, Explicit(String)) => CastFloat64ToString,
             (Float64, JsonbAny) => CastJsonbOrNullToJsonb,
@@ -208,7 +203,7 @@ lazy_static! {
                 let factor = 10_f32.powi(i32::from(s));
                 let factor =
                     ScalarExpr::literal(Datum::from(factor), ColumnType::new(Float32));
-                e.call_unary(CastSignificandToFloat32)
+                e.call_unary(CastDecimalToFloat32)
                     .call_binary(factor, BinaryFunc::DivFloat32)
             }),
             (Decimal(0, 0), Implicit(Float64)) => CastOp::F(|ecx, e, _to_type| {
@@ -216,7 +211,7 @@ lazy_static! {
                 let factor = 10_f64.powi(i32::from(s));
                 let factor =
                     ScalarExpr::literal(Datum::from(factor), ColumnType::new(Float32));
-                e.call_unary(CastSignificandToFloat64)
+                e.call_unary(CastDecimalToFloat64)
                     .call_binary(factor, BinaryFunc::DivFloat64)
             }),
             (Decimal(0, 0), Implicit(Decimal(0, 0))) => CastOp::F(|ecx, e, to_type| {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -853,7 +853,7 @@ lazy_static! {
                 params!(Float64) => UnaryFunc::SqrtFloat64,
                 params!(Decimal(0,0)) => unary_op(|ecx, e| {
                     let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
-                    Ok(e.call_unary(UnaryFunc::SqrtDec(s)))
+                    Ok(e.call_unary(UnaryFunc::SqrtDecimal(s)))
                 })
             },
             "to_char" => {
@@ -1058,9 +1058,9 @@ lazy_static! {
 
             // CONCAT
             Concat => {
-                vec![Plain(String), StringAny] => TextConcat,
-                vec![StringAny, Plain(String)] => TextConcat,
-                params!(String, String) => TextConcat,
+                vec![Plain(String), StringAny] => StringConcat,
+                vec![StringAny, Plain(String)] => StringConcat,
+                params!(String, String) => StringConcat,
                 params!(Jsonb, Jsonb) => JsonbConcat
             },
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1360,7 +1360,6 @@ ORDER BY su_name
 
 %8 =
 | Get %6
-| Filter (#0 = ((#11 * #12) % 10000))
 
 %9 =
 | Get %6
@@ -1378,6 +1377,8 @@ ORDER BY su_name
 | Filter "^co.*$" ~(#44)
 | Reduce group=(#0, #11, #12, #13) sum(#36)
 | Filter ((2 * #3) > #4)
+| Map ((#1 * #2) % 10000)
+| Filter (#0 = #5)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 


### PR DESCRIPTION
The expr::scalar::func module had gotten out of hand, as it contained
all scalar functions in one file. This patch splits that module into
thematic submodules, where functions are grouped by the primary data
type they operate on.

This patch additionally restructures how we track properties of
functions (e.g.  whether a function propagates nulls or preserves
uniqueness). The old approach worked like this:

    impl BinaryFunc {
        fn is_some_property() -> bool {
            match self {
                BinaryFunc::Foo | BinaryFunc::Bar => true,
                _ => false,
            }
        }
    }

This was quite error prone. For one, it was quite easy to forget to
update `is_some_property` when adding a new function. (Exhaustive
matches could help here, and indeed were used in a few places, but
making everything an exhaustive match would have made an already large
file unnavigable.) Perhaps more problematically, the specification of
the properties was separated from the implementation of the function by
hundreds of lines, and so it was easy to specify the properties
incorrectly, resulting in subtle bugs like #3403.

The new approach involves filling out a `FuncProps` struct near the
implementation of each function, like so:

    FuncProps {
        can_error: false,
        preserves_uniqueness: false,
        nulls: Nulls::Sometimes {
            propagates_nulls: true,
            introduces_nulls: false,
        },
        output_type: OutputType::Fixed(ScalarType::String),
    }

We use Rust's requirement that all fields of a struct be initialized to
enforce that all properties are explicitly spelled out. (If this becomes
onerous, we can always introduce some helper/builder methods.) This
makes it impossible to forget to specify a property when adding a
function, and the fact that the FuncProps struct is near the
implementation makes it harder to get the properties wrong.

For extra safety, this patch also includes a dynamic property checker
that runs in debug mode and fails if a function evaluation produces a
value that is inconsistent with its properties. This isn't a perfect
solution, since the checker works at runtime and can only catch
violations that actually occur, but it's much better than the status
quo.

Also new in this patch is the `introduces_nulls` property, which
distinguishes between functions that can *create* nulls from non-null
inputs and those that merely propagate nulls. This will be used in a
forthcoming optimization of the IsNull function.

Besides the new property, which is inert in this commit, there are not
intended to be any semantic changes in this commit.

Fix #1379.