### PR TITLE
Query final chaos results in batches

### DIFF
--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -250,8 +250,8 @@ async fn query_materialize(
                     message_count
                 );
 
-                let mut offset: i32 = 0;
-                let limit: i32 = 10_000;
+                let mut offset: usize = 0;
+                let limit: usize = 10_000;
                 let mut vals = Vec::new();
                 loop {
                     let query = format!(
@@ -263,11 +263,11 @@ async fn query_materialize(
                     if rows.len() == 0 {
                         break;
                     }
+                    offset += rows.len();
                     for row in rows {
                         let val: &[u8] = row.get("data");
                         vals.push(val.to_owned());
                     }
-                    offset += limit;
                 }
                 if vals.len() != message_count {
                     return Err(anyhow::Error::msg(format!(


### PR DESCRIPTION
The `bytes-to-kafka` chaos test would time out because the final number of rows to query was too large, paginate through rows instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3451)
<!-- Reviewable:end -->
