### PR TITLE
Refactor source code to a unified code path

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -11,155 +11,466 @@ use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
-use dataflow_types::{Consistency, KafkaOffset, KafkaSourceConnector, MzOffset, Timestamp};
-use expr::{PartitionId, SourceInstanceId};
-use lazy_static::lazy_static;
-use log::{error, info, log_enabled, warn};
-use prometheus::core::{AtomicI64, AtomicU64};
-use prometheus::{
-    register_int_counter, register_int_counter_vec, register_int_gauge_vec,
-    register_uint_gauge_vec, DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec,
-    IntGaugeVec, UIntGauge, UIntGaugeVec,
+use dataflow_types::{
+    Consistency, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset,
 };
+use expr::{PartitionId, SourceInstanceId};
+use log::{error, info, log_enabled, warn};
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::message::BorrowedMessage;
 use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientConfig, ClientContext, Message, Statistics, TopicPartitionList};
-use timely::dataflow::operators::Capability;
-use timely::dataflow::{Scope, Stream};
 use timely::scheduling::activate::{Activator, SyncActivator};
 use url::Url;
 
-use super::util::source;
-use super::{SourceConfig, SourceOutput, SourceStatus, SourceToken};
 use crate::server::{
     TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
 };
+use crate::source::{ConsistencyInfo, PartitionMetrics, SourceInfo, SourceMessage};
 
-// Global Kafka metrics.
-lazy_static! {
-    static ref KAFKA_BYTES_READ_COUNTER: IntCounter = register_int_counter!(
-        "mz_kafka_bytes_read_total",
-        "Count of kafka bytes we have read from the wire"
-    )
-    .unwrap();
+/// Contains all information necessary to ingest data from Kafka
+pub struct KafkaSourceInfo {
+    /// Name of the topic on which this source is backed on
+    topic_name: String,
+    /// Name of the source (will have format kafka-source-id)
+    source_name: String,
+    /// Source instance ID (stored as a string for logging)
+    source_id: String,
+    /// Kafka consumer for this source
+    consumer: Arc<BaseConsumer<GlueConsumerContext>>,
+    /// List of consumers. A consumer should be assigned per partition to guarantee fairness
+    partition_consumers: VecDeque<PartitionConsumer>,
+    /// Metadata to keep track of whether a message is buffered at
+    /// that partition
+    buffered_metadata: HashSet<i32>,
+    /// The number of known partitions.
+    known_partitions: i32,
+    /// Worker ID
+    worker_id: i32,
+    /// Worker Count
+    worker_count: i32,
 }
 
-/// Per-Kafka source metrics.
-pub struct SourceMetrics {
-    operator_scheduled_counter: IntCounter,
-    capability: UIntGauge,
-}
+impl SourceInfo for KafkaSourceInfo {
+    fn new(
+        source_name: String,
+        source_id: SourceInstanceId,
+        worker_id: usize,
+        worker_count: usize,
+        consumer_activator: Arc<Mutex<SyncActivator>>,
+        connector: ExternalSourceConnector,
+    ) -> Self {
+        match connector {
+            ExternalSourceConnector::Kafka(kc) => KafkaSourceInfo::new(
+                source_name,
+                source_id,
+                worker_id,
+                worker_count,
+                consumer_activator,
+                kc,
+            ),
+            _ => unreachable!(),
+        }
+    }
 
-impl SourceMetrics {
-    fn new(topic_name: &str, source_id: &str, worker_id: &str) -> SourceMetrics {
-        lazy_static! {
-            static ref OPERATOR_SCHEDULED_COUNTER: IntCounterVec = register_int_counter_vec!(
-                "mz_operator_scheduled_total",
-                "The number of times the kafka client got invoked for this source",
-                &["topic", "source_id", "worker_id"]
+    fn activate_source_timestamping(
+        id: &SourceInstanceId,
+        consistency: &Consistency,
+        _active: bool,
+        timestamp_data_updates: TimestampDataUpdates,
+        timestamp_metadata_channel: TimestampMetadataUpdates,
+    ) -> Option<TimestampMetadataUpdates> {
+        let prev = if let Consistency::BringYourOwn(_) = consistency {
+            timestamp_data_updates.borrow_mut().insert(
+                id.clone(),
+                TimestampDataUpdate::BringYourOwn(HashMap::new()),
             )
-            .unwrap();
-            static ref CAPABILITY: UIntGaugeVec = register_uint_gauge_vec!(
-                "mz_kafka_capability",
-                "The current capability for this dataflow. This corresponds to min(mz_kafka_partition_closed_ts)",
-                &["topic", "source_id", "worker_id"]
-            )
-            .unwrap();
+        } else {
+            timestamp_data_updates
+                .borrow_mut()
+                .insert(id.clone(), TimestampDataUpdate::RealTime(1))
+        };
+        // Check that this is the first time this source id is registered
+        assert!(prev.is_none());
+        timestamp_metadata_channel
+            .as_ref()
+            .borrow_mut()
+            .push(TimestampMetadataUpdate::StartTimestamping(*id));
+        Some(timestamp_metadata_channel)
+    }
+
+    /// This function determines whether it is safe to close the current timestamp.
+    /// It is safe to close the current timestamp if
+    /// 1) this worker does not own the current partition
+    /// 2) we will never receive a message with a lower or equal timestamp than offset.
+    /// This is true if
+    ///     a) we have already timestamped a message >= offset
+    ///     b) the consumer's position is passed ever returning message <= offset.
+    fn can_close_timestamp(
+        &self,
+        consistency_info: &ConsistencyInfo,
+        pid: &PartitionId,
+        offset: MzOffset,
+    ) -> bool {
+        let kafka_pid = match pid {
+            PartitionId::Kafka(pid) => *pid,
+            // KafkaSourceInfo should only receive PartitionId::Kafka
+            _ => unreachable!(),
+        };
+
+        let last_offset = consistency_info
+            .partition_metadata
+            .get(&pid)
+            .unwrap()
+            .offset;
+
+        // For transactional or compacted topics, the "last_offset" may not correspond to
+        // the last record in the topic (either because it has been GCed or because
+        // it corresponds to an abort/commit marker).
+        // topic and partition entries are not guaranteed to exist if the poll request to metadata has not succeeded:
+        // In Kafka, the position of the consumer is set to the offset *after* the last offset that the consumer has
+        // processed, so we have to decrement it by one to get the last processed offset
+
+        // We separate these two cases, as consumer.position() is an expensive call that should
+        // be avoided if possible. Case 1 and 2.a occur first, and we only test 2.b when necessary
+        if !self.has_partition(kafka_pid) // Case 1
+        || last_offset >= offset
+        // Case 2.a
+        {
+            true
+        } else {
+            let mut current_consumer_position: MzOffset = KafkaOffset {
+                offset: match self.consumer.position() {
+                    Ok(topic_list) => topic_list
+                        .elements_for_topic(&self.topic_name)
+                        .get(kafka_pid as usize)
+                        .map(|el| el.offset().to_raw() - 1),
+                    Err(_) => Some(-1),
+                }
+                .unwrap_or(-1),
+            }
+            .into();
+
+            // If a message has been buffered (but not timestamped), the consumer will already have
+            // moved ahead.
+            if self.is_buffered(kafka_pid) {
+                current_consumer_position.offset -= 1;
+            }
+
+            // Case 2.b
+            current_consumer_position >= offset
         }
-        let labels = &[topic_name, source_id, worker_id];
-        SourceMetrics {
-            operator_scheduled_counter: OPERATOR_SCHEDULED_COUNTER.with_label_values(labels),
-            capability: CAPABILITY.with_label_values(labels),
+    }
+    /// Returns the number of partitions expected *for this worker*. Partitions are assigned
+    /// round-robin in worker id order
+    /// Ex: a partition count of 4 for 3 workers will assign worker 0 with partitions 0,3,
+    /// worker 1 with partition 1, and worker 2 with partition 2
+    fn get_worker_partition_count(&self) -> i32 {
+        let pcount = self.known_partitions / self.worker_count;
+        if self.worker_id < (self.known_partitions % self.worker_count) {
+            pcount + 1
+        } else {
+            pcount
         }
+    }
+
+    /// Returns true if this worker is responsible for this partition
+    /// Ex: if pid=0 and worker_id = 0, then true
+    /// if pid=1 and worker_id = 0, then false
+    fn has_partition(&self, partition_id: PartitionId) -> bool {
+        let pid = match partition_id {
+            PartitionId::Kafka(pid) => pid,
+            _ => unreachable!(),
+        };
+        (pid % self.worker_count) == self.worker_id
+    }
+
+    /// Ensures that a partition queue for `pid` exists.
+    /// In Kafka, partitions are assigned contiguously. This function consequently
+    /// creates partition queues for every p <= pid
+    fn ensure_has_partition(&mut self, consistency_info: &mut ConsistencyInfo, pid: PartitionId) {
+        let pid = match pid {
+            PartitionId::Kafka(p) => p,
+            _ => unreachable!(),
+        };
+        for i in self.known_partitions..=pid {
+            if self.has_partition(i) {
+                self.create_partition_queue(i);
+                consistency_info.partition_metrics.insert(
+                    PartitionId::Kafka(i),
+                    PartitionMetrics::new(&self.topic_name, &self.source_id, &i.to_string()),
+                );
+            }
+            consistency_info.update_partition_metadata(PartitionId::Kafka(i));
+        }
+        self.known_partitions = cmp::max(self.known_partitions, pid + 1);
+
+        assert_eq!(
+            self.get_worker_partition_count(),
+            self.get_partition_consumers_count()
+        );
+        assert_eq!(
+            self.known_partitions as usize,
+            consistency_info.partition_metadata.len()
+        );
+    }
+
+    /// Updates the Kafka source to reflect the new partition count.
+    /// Kafka creates partitions with contiguous IDs, starting from 0.
+    /// as PIDs are contiguous, we ensure that we have created partitions up to PID
+    /// (partition_count-1) as partitions are 0-indexed.
+    fn update_partition_count(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+        partition_count: i32,
+    ) {
+        self.ensure_has_partition(consistency_info, PartitionId::Kafka(partition_count - 1));
+    }
+
+    /// This function checks whether any messages have been buffered. If yes, returns the buffered
+    /// message. Otherwise, polls from the next consumer for which a message is available. This function polls the set
+    /// round-robin: when a consumer is polled, it is placed at the back of the queue.
+    ///
+    /// If a message has an offset that is smaller than the next expected offset for this consumer (and this partition)
+    /// we skip this message, and seek to the appropriate offset
+    fn get_next_message(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+        activator: &Activator,
+    ) -> Option<SourceMessage> {
+        let mut next_message = None;
+        let consumer_count = self.get_partition_consumers_count();
+        let mut attempts = 0;
+        while attempts < consumer_count {
+            let mut partition_queue = self.partition_consumers.pop_front().unwrap();
+            let message = partition_queue.get_next_message();
+            if let Some(message) = message {
+                let partition = match message.partition {
+                    PartitionId::Kafka(pid) => pid,
+                    _ => unreachable!(),
+                };
+                // There are no more messages buffered on this pid
+                self.buffered_metadata.remove(&partition);
+                let offset = message.offset;
+                // Offsets are guaranteed to be 1) monotonically increasing *unless* there is
+                // a network issue or a new partition added, at which point the consumer may
+                // start processing the topic from the beginning, or we may see duplicate offsets
+                // At all times, the guarantee : if we see offset x, we have seen all offsets [0,x-1]
+                // that we are ever going to see holds.
+                // Offsets are guaranteed to be contiguous when compaction is disabled. If compaction
+                // is enabled, there may be gaps in the sequence.
+                // If we see an "old" offset, we fast-forward the consumer and skip that message
+
+                // Given the explicit consumer to partition assignment, we should never receive a message
+                // for a partition for which we have no metadata
+                assert!(consistency_info.knows_of(PartitionId::Kafka(partition)));
+
+                let mut last_offset = consistency_info
+                    .partition_metadata
+                    .get(&PartitionId::Kafka(partition))
+                    .unwrap()
+                    .offset;
+
+                if offset <= last_offset {
+                    warn!(
+                        "Kafka message before expected offset: \
+                             source {} (reading topic {}, partition {}) \
+                             received Mz offset {} expected Mz offset {:?}",
+                        self.source_name,
+                        self.topic_name,
+                        partition,
+                        offset,
+                        last_offset.offset + 1
+                    );
+                    // Seek to the *next* offset (aka last_offset + 1) that we have not yet processed
+                    last_offset.offset += 1;
+                    self.fast_forward_consumer(partition, last_offset.into());
+                    // We explicitly should not consume the message as we have already processed it
+                    // However, we make sure to activate the source to make sure that we get a chance
+                    // to read from this consumer again (even if no new data arrives)
+                    activator.activate();
+                } else {
+                    next_message = Some(message);
+                }
+            }
+            self.partition_consumers.push_back(partition_queue);
+            if next_message.is_some() {
+                // Found a message, exit the loop and return message
+                break;
+            } else {
+                attempts += 1;
+            }
+        }
+        assert_eq!(
+            self.get_partition_consumers_count(),
+            self.get_worker_partition_count()
+        );
+        next_message
+    }
+
+    fn buffer_message(&mut self, message: SourceMessage) {
+        // Guaranteed to exist as we just read from this consumer
+        let mut consumer = self.partition_consumers.back_mut().unwrap();
+        assert_eq!(message.partition, PartitionId::Kafka(consumer.pid));
+        consumer.buffer = Some(message);
+        // Mark the partition has buffered
+        self.buffered_metadata.insert(consumer.pid);
     }
 }
 
-/// Per-Kafka source partition metrics.
-pub struct PartitionMetrics {
-    offset_ingested: DeleteOnDropGauge<'static, AtomicI64>,
-    offset_received: DeleteOnDropGauge<'static, AtomicI64>,
-    closed_ts: DeleteOnDropGauge<'static, AtomicU64>,
-    messages_ingested: DeleteOnDropCounter<'static, AtomicI64>,
-}
-
-impl PartitionMetrics {
-    fn new(topic_name: &str, source_id: &str, partition_id: &str) -> PartitionMetrics {
-        lazy_static! {
-            static ref OFFSET_INGESTED: IntGaugeVec = register_int_gauge_vec!(
-                "mz_kafka_partition_offset_ingested",
-                "The most recent kafka offset that we have ingested into a dataflow. This correspond to \
-                data that we have 1)ingested 2) assigned a timestamp",
-                &["topic", "source_id", "partition_id"]
-            )
-            .unwrap();
-            static ref OFFSET_RECEIVED: IntGaugeVec = register_int_gauge_vec!(
-                "mz_kafka_partition_offset_received",
-                "The most recent kafka offset that we have been received by this source.",
-                &["topic", "source_id", "partition_id"]
-            )
-            .unwrap();
-            static ref CLOSED_TS: UIntGaugeVec = register_uint_gauge_vec!(
-                "mz_kafka_partition_closed_ts",
-                "The highest closed timestamp for each partition in this dataflow",
-                &["topic", "source_id", "partition_id"]
-            )
-            .unwrap();
-            static ref MESSAGES_INGESTED: IntCounterVec = register_int_counter_vec!(
-                "mz_kafka_messages_ingested",
-                "The number of messages ingested per partition.",
-                &["topic", "source_id", "partition_id"]
-            )
-            .unwrap();
-
-        }
-        let labels = &[topic_name, source_id, partition_id];
-        PartitionMetrics {
-            offset_ingested: DeleteOnDropGauge::new_with_error_handler(
-                OFFSET_INGESTED.with_label_values(labels),
-                &OFFSET_INGESTED,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
-            ),
-            offset_received: DeleteOnDropGauge::new_with_error_handler(
-                OFFSET_RECEIVED.with_label_values(labels),
-                &OFFSET_RECEIVED,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
-            ),
-            closed_ts: DeleteOnDropGauge::new_with_error_handler(
-                CLOSED_TS.with_label_values(labels),
-                &CLOSED_TS,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
-            ),
-            messages_ingested: DeleteOnDropCounter::new_with_error_handler(
-                MESSAGES_INGESTED.with_label_values(labels),
-                &MESSAGES_INGESTED,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
-            ),
+impl KafkaSourceInfo {
+    /// Constructor
+    pub fn new(
+        source_name: String,
+        source_id: SourceInstanceId,
+        worker_id: usize,
+        worker_count: usize,
+        consumer_activator: Arc<Mutex<SyncActivator>>,
+        kc: KafkaSourceConnector,
+    ) -> KafkaSourceInfo {
+        let KafkaSourceConnector {
+            url,
+            topic,
+            config_options,
+            group_id_prefix,
+            ..
+        } = kc;
+        let kafka_config =
+            create_kafka_config(&source_name, &url, group_id_prefix, &config_options);
+        let source_id = source_id.to_string();
+        let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
+            .create_with_context(GlueConsumerContext(consumer_activator))
+            .expect("Failed to create Kafka Consumer");
+        KafkaSourceInfo {
+            buffered_metadata: HashSet::new(),
+            topic_name: topic,
+            source_name,
+            source_id,
+            partition_consumers: VecDeque::new(),
+            known_partitions: 0,
+            consumer: Arc::new(consumer),
+            worker_id: worker_id.try_into().unwrap(),
+            worker_count: worker_count.try_into().unwrap(),
         }
     }
-}
 
-// There is other stuff in librdkafka messages, e.g. headers.
-// But this struct only contains what we actually use, to avoid unnecessary cloning.
-struct MessageParts {
-    payload: Option<Vec<u8>>,
-    partition: i32,
-    offset: KafkaOffset,
-    key: Option<Vec<u8>>,
-}
+    /// Returns true if this worker is responsible for this partition
+    /// Ex: if pid=0 and worker_id = 0, then true
+    /// if pid=1 and worker_id = 0, then false
+    fn has_partition(&self, partition_id: i32) -> bool {
+        (partition_id % self.worker_count) == self.worker_id
+    }
 
-impl<'a> From<&BorrowedMessage<'a>> for MessageParts {
-    fn from(msg: &BorrowedMessage<'a>) -> Self {
-        Self {
-            payload: msg.payload().map(|p| p.to_vec()),
-            partition: msg.partition(),
-            offset: KafkaOffset {
-                offset: msg.offset(),
-            },
-            key: msg.key().map(|k| k.to_vec()),
+    /// Returns a count of total number of consumers for this source
+    fn get_partition_consumers_count(&self) -> i32 {
+        // Note: the number of consumers is guaranteed to always be smaller than
+        // expected_partition_count (i32)
+        self.partition_consumers.len().try_into().unwrap()
+    }
+
+    /// Returns true if a message has been buffered for this partition
+    fn is_buffered(&self, pid: i32) -> bool {
+        self.buffered_metadata.contains(&pid)
+    }
+
+    /// Creates a new partition queue for `partition_id`.
+    fn create_partition_queue(&mut self, partition_id: i32) {
+        info!(
+            "Activating Kafka queue for {} [{}] (source {}) on worker {}",
+            self.topic_name, partition_id, self.source_id, self.worker_id
+        );
+
+        // Collect old partition assignments
+        let tpl = self.consumer.assignment().unwrap();
+        // Create list from assignments
+        let mut partition_list = TopicPartitionList::new();
+        for partition in tpl.elements_for_topic(&self.topic_name) {
+            partition_list.add_partition_offset(
+                partition.topic(),
+                partition.partition(),
+                partition.offset(),
+            );
+        }
+        // Add new partition
+        partition_list.add_partition_offset(&self.topic_name, partition_id, Offset::Beginning);
+        self.consumer
+            .assign(&partition_list)
+            .expect("assignment known to be valid");
+
+        // Trick librdkafka into updating its metadata for the topic so that we
+        // start seeing data for the partition immediately. Otherwise we might
+        // need to wait the full `topic.metadata.refresh.interval.ms` interval.
+        //
+        // We don't actually care about the results of the metadata refresh, and
+        // would prefer not to wait for it to complete, so we execute this
+        // request with a timeout of 0s and ignore the result. This relies on an
+        // implementation detail, which is that librdkafka does not proactively
+        // cancel metadata fetch operations when they reach their timeout.
+        // Unfortunately there is no asynchronous metadata fetch API.
+        //
+        // It is not a problem if the metadata request fails, because the
+        // background metadata refresh will retry indefinitely. As long as a
+        // background request succeeds eventually, we'll start receiving data
+        // for the new partitions.
+        //
+        // TODO(benesch): remove this if upstream makes this metadata refresh
+        // happen automatically [0].
+        //
+        // [0]: https://github.com/edenhill/librdkafka/issues/2917
+        let _ = self
+            .consumer
+            .fetch_metadata(Some(&self.topic_name), Duration::from_secs(0));
+
+        let partition_queue = self
+            .consumer
+            .split_partition_queue(&self.topic_name, partition_id)
+            .expect("partition known to be valid");
+        self.partition_consumers
+            .push_front(PartitionConsumer::new(partition_id, partition_queue));
+        assert_eq!(
+            self.consumer
+                .assignment()
+                .unwrap()
+                .elements_for_topic(&self.topic_name)
+                .len(),
+            self.partition_consumers.len()
+        );
+    }
+
+    /// Fast-forward consumer to specified Kafka Offset. Prints a warning if failed to do so
+    /// Assumption: if offset does not exist (for instance, because of compaction), will seek
+    /// to the next available offset
+    fn fast_forward_consumer(&self, pid: i32, next_offset: KafkaOffset) {
+        let res = self.consumer.seek(
+            &self.topic_name,
+            pid,
+            Offset::Offset(next_offset.offset),
+            Duration::from_secs(1),
+        );
+        match res {
+            Ok(_) => {
+                let res = self.consumer.position().unwrap_or_default().to_topic_map();
+                let position = res.get(&(self.topic_name.clone(), pid));
+                if let Some(position) = position {
+                    let position = position.to_raw();
+                    info!(
+                        "Tried to fast-forward consumer on partition PID: {} to Kafka offset {}. Consumer is now at position {}",
+                        pid, next_offset.offset, position);
+                    if position != next_offset.offset {
+                        warn!("We did not seek to the expected Kafka offset. Current Kafka offset: {} Expected Kafka offset: {}", position, next_offset.offset);
+                    }
+                } else {
+                    warn!("Tried to fast-forward consumer on partition PID:{} to Kafka offset {}. Could not obtain new consumer position",
+                          pid, next_offset.offset);
+                }
+            }
+            Err(e) => error!(
+                "Failed to fast-forward consumer for source:{}, Error:{}",
+                self.source_name, e
+            ),
         }
     }
 }
@@ -239,15 +550,18 @@ fn create_kafka_config(
     kafka_config
 }
 
-/// Consistency information. Each partition contains information about
-/// 1) the last closed timestamp for this partition
-/// 2) the last processed offset
-#[derive(Copy, Clone)]
-struct ConsInfo {
-    /// the last closed timestamp for this partition
-    pub ts: Timestamp,
-    /// the last processed offset
-    pub offset: MzOffset,
+impl<'a> From<&BorrowedMessage<'a>> for SourceMessage {
+    fn from(msg: &BorrowedMessage<'a>) -> Self {
+        let kafka_offset = KafkaOffset {
+            offset: msg.offset(),
+        };
+        Self {
+            payload: msg.payload().map(|p| p.to_vec()),
+            partition: PartitionId::Kafka(msg.partition()),
+            offset: kafka_offset.into(),
+            key: msg.key().map(|k| k.to_vec()),
+        }
+    }
 }
 
 /// Wrapper around a partition containing both a buffer and the underlying consumer
@@ -257,7 +571,7 @@ struct PartitionConsumer {
     /// the partition id with which this consumer is associated
     pid: i32,
     /// A buffer to store messages that cannot be timestamped yet
-    buffer: Option<MessageParts>,
+    buffer: Option<SourceMessage>,
     /// The underlying Kafka consumer. This consumer is assigned to read from one partition
     /// exclusively
     partition_queue: PartitionQueue<GlueConsumerContext>,
@@ -275,15 +589,15 @@ impl PartitionConsumer {
 
     /// Returns the next message to process for this partition (if any).
     /// Either reads from the buffer or polls from the consumer
-    fn get_next_message(&mut self) -> Option<MessageParts> {
+    fn get_next_message(&mut self) -> Option<SourceMessage> {
         if let Some(message) = self.buffer.take() {
-            assert_eq!(message.partition, self.pid);
+            assert_eq!(message.partition, PartitionId::Kafka(self.pid));
             Some(message)
         } else {
             match self.partition_queue.poll(Duration::from_millis(0)) {
                 Some(Ok(msg)) => {
-                    let result = MessageParts::from(&msg);
-                    assert_eq!(result.partition, self.pid);
+                    let result = SourceMessage::from(&msg);
+                    assert_eq!(result.partition, PartitionId::Kafka(self.pid));
                     Some(result)
                 }
                 Some(Err(err)) => {
@@ -292,828 +606,6 @@ impl PartitionConsumer {
                 }
                 _ => None,
             }
-        }
-    }
-}
-/// Contains all information necessary to ingest data from Kafka
-struct DataPlaneInfo {
-    /// Name of the topic on which this source is backed on
-    topic_name: String,
-    /// Name of the source (will have format kafka-source-id)
-    source_name: String,
-    /// Source instance ID (stored as a string for logging)
-    source_id: String,
-    /// Kafka consumer for this source
-    consumer: Arc<BaseConsumer<GlueConsumerContext>>,
-    /// List of consumers. A consumer should be assigned per partition to guarantee fairness
-    partition_consumers: VecDeque<PartitionConsumer>,
-    /// Metadata to keep track of whether a message is buffered at
-    /// that partition
-    buffered_metadata: HashSet<i32>,
-    /// The number of known partitions.
-    known_partitions: i32,
-    /// Per-source metrics.
-    source_metrics: SourceMetrics,
-    /// Per-partition metrics.
-    partition_metrics: HashMap<i32, PartitionMetrics>,
-    /// Worker ID
-    worker_id: i32,
-    /// Worker Count
-    worker_count: i32,
-}
-
-impl DataPlaneInfo {
-    fn new(
-        topic_name: String,
-        source_name: String,
-        source_id: SourceInstanceId,
-        kafka_config: ClientConfig,
-        consumer_activator: Arc<Mutex<SyncActivator>>,
-        worker_id: usize,
-        worker_count: usize,
-    ) -> DataPlaneInfo {
-        let source_id = source_id.to_string();
-        let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
-            .create_with_context(GlueConsumerContext(consumer_activator))
-            .expect("Failed to create Kafka Consumer");
-        DataPlaneInfo {
-            source_metrics: SourceMetrics::new(&topic_name, &source_id, &worker_id.to_string()),
-            partition_metrics: HashMap::new(),
-            buffered_metadata: HashSet::new(),
-            topic_name: topic_name.clone(),
-            source_name,
-            source_id: source_id.clone(),
-            partition_consumers: VecDeque::new(),
-            known_partitions: 0,
-            consumer: Arc::new(consumer),
-            worker_id: worker_id.try_into().unwrap(),
-            worker_count: worker_count.try_into().unwrap(),
-        }
-    }
-
-    /// Returns the number of partitions expected *for this worker*. Partitions are assigned
-    /// round-robin in worker id order
-    /// Ex: a partition count of 4 for 3 workers will assign worker 0 with partitions 0,3,
-    /// worker 1 with partition 1, and worker 2 with partition 2
-    fn get_worker_partition_count(&self) -> i32 {
-        let pcount = self.known_partitions / self.worker_count;
-        if self.worker_id < (self.known_partitions % self.worker_count) {
-            pcount + 1
-        } else {
-            pcount
-        }
-    }
-
-    /// Returns true if this worker is responsible for this partition
-    /// Ex: if pid=0 and worker_id = 0, then true
-    /// if pid=1 and worker_id = 0, then false
-    fn has_partition(&self, partition_id: i32) -> bool {
-        (partition_id % self.worker_count) == self.worker_id
-    }
-
-    /// Returns a count of total number of consumers for this source
-    fn get_partition_consumers_count(&self) -> i32 {
-        // Note: the number of consumers is guaranteed to always be smaller than
-        // expected_partition_count (i32)
-        self.partition_consumers.len().try_into().unwrap()
-    }
-
-    /// Ensures that a partition queue for `pid` exists.
-    fn ensure_partition(&mut self, cp_info: &mut ControlPlaneInfo, pid: i32) {
-        for i in self.known_partitions..=pid {
-            if self.has_partition(i) {
-                self.create_partition_queue(i);
-            }
-            cp_info.update_partition_metadata(i);
-        }
-        self.known_partitions = cmp::max(self.known_partitions, pid + 1);
-
-        assert_eq!(
-            self.get_worker_partition_count(),
-            self.get_partition_consumers_count()
-        );
-        assert_eq!(
-            self.known_partitions as usize,
-            cp_info.partition_metadata.len()
-        );
-    }
-
-    /// Returns true if a message has been buffered for this partition
-    fn is_buffered(&self, pid: i32) -> bool {
-        self.buffered_metadata.contains(&pid)
-    }
-
-    /// Creates a new partition queue for `partition_id`.
-    fn create_partition_queue(&mut self, partition_id: i32) {
-        info!(
-            "Activating Kafka queue for {} [{}] (source {}) on worker {}",
-            self.topic_name, partition_id, self.source_id, self.worker_id
-        );
-
-        // Collect old partition assignments
-        let tpl = self.consumer.assignment().unwrap();
-        // Create list from assignments
-        let mut partition_list = TopicPartitionList::new();
-        for partition in tpl.elements_for_topic(&self.topic_name) {
-            partition_list.add_partition_offset(
-                partition.topic(),
-                partition.partition(),
-                partition.offset(),
-            );
-        }
-        // Add new partition
-        partition_list.add_partition_offset(&self.topic_name, partition_id, Offset::Beginning);
-        self.consumer
-            .assign(&partition_list)
-            .expect("assignment known to be valid");
-
-        // Trick librdkafka into updating its metadata for the topic so that we
-        // start seeing data for the partition immediately. Otherwise we might
-        // need to wait the full `topic.metadata.refresh.interval.ms` interval.
-        //
-        // We don't actually care about the results of the metadata refresh, and
-        // would prefer not to wait for it to complete, so we execute this
-        // request with a timeout of 0s and ignore the result. This relies on an
-        // implementation detail, which is that librdkafka does not proactively
-        // cancel metadata fetch operations when they reach their timeout.
-        // Unfortunately there is no asynchronous metadata fetch API.
-        //
-        // It is not a problem if the metadata request fails, because the
-        // background metadata refresh will retry indefinitely. As long as a
-        // background request succeeds eventually, we'll start receiving data
-        // for the new partitions.
-        //
-        // TODO(benesch): remove this if upstream makes this metadata refresh
-        // happen automatically [0].
-        //
-        // [0]: https://github.com/edenhill/librdkafka/issues/2917
-        let _ = self
-            .consumer
-            .fetch_metadata(Some(&self.topic_name), Duration::from_secs(0));
-
-        let partition_queue = self
-            .consumer
-            .split_partition_queue(&self.topic_name, partition_id)
-            .expect("partition known to be valid");
-        self.partition_consumers
-            .push_front(PartitionConsumer::new(partition_id, partition_queue));
-        assert_eq!(
-            self.consumer
-                .assignment()
-                .unwrap()
-                .elements_for_topic(&self.topic_name)
-                .len(),
-            self.partition_consumers.len()
-        );
-        self.partition_metrics.insert(
-            partition_id,
-            PartitionMetrics::new(&self.topic_name, &self.source_id, &partition_id.to_string()),
-        );
-    }
-
-    /// This function checks whether any messages have been buffered. If yes, returns the buffered
-    /// message. Otherwise, polls from the next consumer for which a message is available. This function polls the set
-    /// round-robin: when a consumer is polled, it is placed at the back of the queue.
-    ///
-    /// If a message has an offset that is smaller than the next expected offset for this consumer (and this partition)
-    /// we skip this message, and seek to the appropriate offset
-    fn get_next_message(
-        &mut self,
-        cp_info: &ControlPlaneInfo,
-        activator: &Activator,
-    ) -> Option<MessageParts> {
-        let mut next_message = None;
-        let consumer_count = self.get_partition_consumers_count();
-        let mut attempts = 0;
-        while attempts < consumer_count {
-            let mut partition_queue = self.partition_consumers.pop_front().unwrap();
-            let message = partition_queue.get_next_message();
-            if let Some(message) = message {
-                let partition = message.partition;
-                // There are no more messages buffered on this pid
-                self.buffered_metadata.remove(&partition);
-                let offset = MzOffset::from(message.offset);
-                // Offsets are guaranteed to be 1) monotonically increasing *unless* there is
-                // a network issue or a new partition added, at which point the consumer may
-                // start processing the topic from the beginning, or we may see duplicate offsets
-                // At all times, the guarantee : if we see offset x, we have seen all offsets [0,x-1]
-                // that we are ever going to see holds.
-                // Offsets are guaranteed to be contiguous when compaction is disabled. If compaction
-                // is enabled, there may be gaps in the sequence.
-                // If we see an "old" offset, we fast-forward the consumer and skip that message
-
-                // Given the explicit consumer to partition assignment, we should never receive a message
-                // for a partition for which we have no metadata
-                assert!(cp_info.knows_of(partition));
-
-                let mut last_offset = cp_info.partition_metadata.get(&partition).unwrap().offset;
-
-                if offset <= last_offset {
-                    warn!(
-                        "Kafka message before expected offset: \
-                             source {} (reading topic {}, partition {}) \
-                             received Mz offset {} expected Mz offset {:?}",
-                        self.source_name,
-                        self.topic_name,
-                        partition,
-                        offset,
-                        last_offset.offset + 1
-                    );
-                    // Seek to the *next* offset (aka last_offset + 1) that we have not yet processed
-                    last_offset.offset += 1;
-                    self.fast_forward_consumer(partition, last_offset.into());
-                    // We explicitly should not consume the message as we have already processed it
-                    // However, we make sure to activate the source to make sure that we get a chance
-                    // to read from this consumer again (even if no new data arrives)
-                    activator.activate();
-                } else {
-                    next_message = Some(message);
-                }
-            }
-            self.partition_consumers.push_back(partition_queue);
-            if next_message.is_some() {
-                // Found a message, exit the loop and return message
-                break;
-            } else {
-                attempts += 1;
-            }
-        }
-        assert_eq!(
-            self.get_partition_consumers_count(),
-            self.get_worker_partition_count()
-        );
-        next_message
-    }
-
-    /// Buffer message that could not be timestamped
-    /// Assumption: this message necessarily belongs to the last consumer that we tried to
-    /// read from.
-    fn buffer_message(&mut self, msg: MessageParts) {
-        // Guaranteed to exist as we just read from this consumer
-        let mut consumer = self.partition_consumers.back_mut().unwrap();
-        assert_eq!(msg.partition, consumer.pid);
-        consumer.buffer = Some(msg);
-        // Mark the partition has buffered
-        self.buffered_metadata.insert(consumer.pid);
-    }
-
-    /// Fast-forward consumer to specified Kafka Offset. Prints a warning if failed to do so
-    /// Assumption: if offset does not exist (for instance, because of compaction), will seek
-    /// to the next available offset
-    fn fast_forward_consumer(&self, pid: i32, next_offset: KafkaOffset) {
-        let res = self.consumer.seek(
-            &self.topic_name,
-            pid,
-            Offset::Offset(next_offset.offset),
-            Duration::from_secs(1),
-        );
-        match res {
-            Ok(_) => {
-                let res = self.consumer.position().unwrap_or_default().to_topic_map();
-                let position = res.get(&(self.topic_name.clone(), pid));
-                if let Some(position) = position {
-                    let position = position.to_raw();
-                    info!(
-                        "Tried to fast-forward consumer on partition PID: {} to Kafka offset {}. Consumer is now at position {}",
-                        pid, next_offset.offset, position);
-                    if position != next_offset.offset {
-                        warn!("We did not seek to the expected Kafka offset. Current Kafka offset: {} Expected Kafka offset: {}", position, next_offset.offset);
-                    }
-                } else {
-                    warn!("Tried to fast-forward consumer on partition PID:{} to Kafka offset {}. Could not obtain new consumer position",
-                          pid, next_offset.offset);
-                }
-            }
-            Err(e) => error!(
-                "Failed to fast-forward consumer for source:{}, Error:{}",
-                self.source_name, e
-            ),
-        }
-    }
-}
-
-/// Contains all necessary consistency metadata information
-struct ControlPlaneInfo {
-    /// Last closed timestamp
-    last_closed_ts: u64,
-    /// Time since last capability downgrade
-    time_since_downgrade: Instant,
-    /// Frequency at which we should downgrade capability (in milliseconds)
-    downgrade_capability_frequency: u64,
-    /// Per partition (a partition ID in Kafka is an i32), keep track of the last closed offset
-    /// and the last closed timestamp
-    partition_metadata: HashMap<i32, ConsInfo>,
-    /// Optional: Materialize Offset from which source should start reading (default is 0)
-    start_offset: MzOffset,
-    /// Source Type (Real-time or BYO)
-    source_type: Consistency,
-}
-
-impl ControlPlaneInfo {
-    fn new(
-        start_offset: MzOffset,
-        consistency: Consistency,
-        timestamp_frequency: Duration,
-    ) -> ControlPlaneInfo {
-        ControlPlaneInfo {
-            last_closed_ts: 0,
-            // Safe conversion: statement.rs checks that value specified fits in u64
-            downgrade_capability_frequency: timestamp_frequency.as_millis().try_into().unwrap(),
-            partition_metadata: HashMap::new(),
-            start_offset,
-            source_type: consistency,
-            time_since_downgrade: Instant::now(),
-        }
-    }
-
-    /// Returns true if we currently know of particular partition. We know (and have updated the
-    /// metadata for this partition) if there is an entry for it
-    fn knows_of(&self, pid: i32) -> bool {
-        self.partition_metadata.contains_key(&pid)
-    }
-
-    /// Updates the underlying partition metadata structure to include the current partition.
-    /// New partitions must always be added with a minimum closed offset of (last_closed_ts)
-    /// They are guaranteed to only receive timestamp update greater than last_closed_ts (this
-    /// is enforced in [coord::timestamp::is_ts_valid]
-    fn update_partition_metadata(&mut self, pid: i32) {
-        self.partition_metadata.insert(
-            pid,
-            ConsInfo {
-                offset: self.start_offset,
-                ts: self.last_closed_ts,
-            },
-        );
-    }
-
-    /// Generates a timestamp that is guaranteed to be monotonically increasing.
-    /// This may require multiple calls to the underlying now() system method, which is not
-    /// guaranteed to increase monotonically
-    fn generate_next_timestamp(&mut self) -> Option<u64> {
-        let mut new_ts = 0;
-        while new_ts <= self.last_closed_ts {
-            let start = SystemTime::now();
-            new_ts = start
-                .duration_since(UNIX_EPOCH)
-                .expect("Time went backwards")
-                .as_millis() as u64;
-            if new_ts < self.last_closed_ts && self.last_closed_ts - new_ts > 1000 {
-                // If someone resets their system clock to be too far in the past, this could cause
-                // Materialize to block and not give control to other operators. We thus give up
-                // on timestamping this message
-                error!("The new timestamp is more than 1 second behind the last assigned timestamp. To\
-                avoid unnecessary blocking, Materialize will not attempt to downgrade the capability. Please\
-                consider resetting your system time.");
-                return None;
-            }
-        }
-        assert!(new_ts > self.last_closed_ts);
-        self.last_closed_ts = new_ts;
-        Some(self.last_closed_ts)
-    }
-}
-
-/// This function activates the necessary timestamping information when a source is first created
-/// 1) for BYO sources, we notify the timestamping thread that a source has been created.
-/// 2) for a RT source, take no steps
-//
-fn activate_source_timestamping<G>(config: &SourceConfig<G>) -> Option<TimestampMetadataUpdates> {
-    let prev = if let Consistency::BringYourOwn(_) = config.consistency {
-        config.timestamp_histories.borrow_mut().insert(
-            config.id.clone(),
-            TimestampDataUpdate::BringYourOwn(HashMap::new()),
-        )
-    } else {
-        config
-            .timestamp_histories
-            .borrow_mut()
-            .insert(config.id.clone(), TimestampDataUpdate::RealTime(0))
-    };
-    // Check that this is the first time this source id is registered
-    assert!(prev.is_none());
-    config
-        .timestamp_tx
-        .as_ref()
-        .borrow_mut()
-        .push(TimestampMetadataUpdate::StartTimestamping(config.id));
-    Some(config.timestamp_tx.clone())
-}
-
-/// Creates a Kafka-based timely dataflow source operator.
-pub fn kafka<G>(
-    config: SourceConfig<G>,
-    connector: KafkaSourceConnector,
-) -> (
-    Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
-    Option<SourceToken>,
-)
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    let KafkaSourceConnector {
-        url,
-        topic,
-        config_options,
-        start_offset,
-        group_id_prefix,
-    } = connector;
-
-    let timestamp_channel = activate_source_timestamping(&config);
-
-    let SourceConfig {
-        name,
-        id,
-        scope,
-        timestamp_histories,
-        worker_id,
-        worker_count,
-        consistency,
-        timestamp_frequency,
-        ..
-    } = config;
-
-    let (stream, capability) = source(id, timestamp_channel, scope, name.clone(), move |info| {
-        // Create activator for source
-        let activator = scope.activator_for(&info.address[..]);
-
-        // Create control plane information (Consistency-related information)
-        let mut cp_info = ControlPlaneInfo::new(
-            MzOffset {
-                offset: start_offset,
-            },
-            consistency.clone(),
-            timestamp_frequency,
-        );
-
-        // Create dataplane information (Kafka-related information)
-        let mut dp_info = DataPlaneInfo::new(
-            topic.clone(),
-            name.clone(),
-            id.clone(),
-            create_kafka_config(&name, &url, group_id_prefix, &config_options),
-            Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..]))),
-            worker_id,
-            worker_count,
-        );
-
-        move |cap, output| {
-            let timer = Instant::now();
-
-            dp_info.source_metrics.operator_scheduled_counter.inc();
-
-            // Accumulate updates to BYTES_READ_COUNTER;
-            let mut bytes_read = 0;
-
-            // Trigger any waiting librdkafka callbacks. This should never
-            // return any messages, because we've set things up to receive those
-            // via individual partition queues.
-            {
-                let message = dp_info.consumer.poll(Duration::from_secs(0));
-                if let Some(message) = message {
-                    match message {
-                        Ok(message) => {
-                            panic!(
-                                "Internal Error. Received an unexpected message Source: {} PID: {} Offset: {} on main partition loop.\
-                                Materialize will now crash.",
-                                id,
-                                message.partition(),
-                                message.offset()
-                            );
-                        }
-                        Err(e) => error!("Error when polling: {}", e),
-                    }
-                }
-            }
-
-            while let Some(message) = dp_info.get_next_message(&cp_info, &activator) {
-                let partition = message.partition;
-                let offset = MzOffset::from(message.offset);
-
-                // Update ingestion metrics
-                // Entry is guaranteed to exist as it gets created when we initialise the partition.
-                dp_info
-                    .partition_metrics
-                    .get_mut(&partition)
-                    .unwrap()
-                    .offset_received
-                    .set(offset.offset);
-
-                // Determine the timestamp to which we need to assign this message
-                let ts = find_matching_timestamp(
-                    &mut cp_info,
-                    &id,
-                    partition,
-                    offset,
-                    &timestamp_histories,
-                );
-                match ts {
-                    None => {
-                        // We have not yet decided on a timestamp for this message,
-                        // we need to buffer the message
-                        dp_info.buffer_message(message);
-                        downgrade_capability(
-                            &id,
-                            cap,
-                            &mut cp_info,
-                            &mut dp_info,
-                            &timestamp_histories,
-                        );
-                        activator.activate();
-                        return SourceStatus::Alive;
-                    }
-                    Some(ts) => {
-                        // Note: empty and null payload/keys are currently
-                        // treated as the same thing.
-                        let key = message.key.unwrap_or_default();
-                        let out = message.payload.unwrap_or_default();
-                        // Entry for partition_metadata is guaranteed to exist as messages
-                        // are only processed after we have updated the partition_metadata for a
-                        // partition and created a partition queue for it.
-                        cp_info
-                            .partition_metadata
-                            .get_mut(&partition)
-                            .unwrap()
-                            .offset = offset;
-                        bytes_read += key.len() as i64;
-                        bytes_read += out.len() as i64;
-                        let ts_cap = cap.delayed(&ts);
-                        output.session(&ts_cap).give(SourceOutput::new(
-                            key,
-                            out,
-                            Some(Into::<KafkaOffset>::into(offset).offset),
-                        ));
-
-                        // Update ingestion metrics
-                        // Entry is guaranteed to exist as it gets created when we initialise the partition
-                        let partition_metrics =
-                            &mut dp_info.partition_metrics.get_mut(&partition).unwrap();
-                        partition_metrics.offset_ingested.set(offset.offset);
-                        partition_metrics.messages_ingested.inc();
-                    }
-                }
-
-                if timer.elapsed().as_millis() > 10 {
-                    // We didn't drain the entire queue, so indicate that we
-                    // should run again. We suppress the activation when the
-                    // queue is drained, as in that case librdkafka is
-                    // configured to unpark our thread when a new message
-                    // arrives.
-                    if bytes_read > 0 {
-                        KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
-                    }
-                    // Downgrade capability (if possible) before exiting
-                    downgrade_capability(
-                        &id,
-                        cap,
-                        &mut cp_info,
-                        &mut dp_info,
-                        &timestamp_histories,
-                    );
-                    activator.activate();
-                    return SourceStatus::Alive;
-                }
-            }
-            if bytes_read > 0 {
-                KAFKA_BYTES_READ_COUNTER.inc_by(bytes_read);
-            }
-
-            // Downgrade capability (if possible) before exiting
-            downgrade_capability(&id, cap, &mut cp_info, &mut dp_info, &timestamp_histories);
-
-            // Ensure that we activate the source frequently enough to keep downgrading
-            // capabilities, even when no data has arrived
-            activator.activate_after(Duration::from_millis(
-                cp_info.downgrade_capability_frequency,
-            ));
-            SourceStatus::Alive
-        }
-    });
-    (stream, Some(capability))
-}
-
-/// For a given offset, returns an option type returning the matching timestamp or None
-/// if no timestamp can be assigned.
-///
-/// The timestamp history contains a sequence of
-/// (partition_count, timestamp, offset) tuples. A message with offset x will be assigned the first timestamp
-/// for which offset>=x.
-fn find_matching_timestamp(
-    cp_info: &mut ControlPlaneInfo,
-    id: &SourceInstanceId,
-    partition: i32,
-    offset: MzOffset,
-    timestamp_histories: &TimestampDataUpdates,
-) -> Option<Timestamp> {
-    if let Consistency::RealTime = cp_info.source_type {
-        // Simply assign to this message the next timestamp that is not closed
-        Some(cp_info.last_closed_ts + 1)
-    } else {
-        // The source is a BYO source, we must check the TimestampHistories to obtain a
-        match timestamp_histories.borrow().get(id) {
-            None => None,
-            Some(TimestampDataUpdate::BringYourOwn(entries)) => {
-                match entries.get(&PartitionId::Kafka(partition)) {
-                    Some(entries) => {
-                        for (_, ts, max_offset) in entries {
-                            if offset <= *max_offset {
-                                return Some(ts.clone());
-                            }
-                        }
-                        None
-                    }
-                    None => None,
-                }
-            }
-            _ => panic!("Unexpected entry format in TimestampDataUpdates for BYO source"),
-        }
-    }
-}
-
-/// This function determines whether it is safe to close the current timestamp.
-/// It is safe to close the current timestamp if
-/// 1) this worker does not own the current partition
-/// 2) we will never receive a message with a lower or equal timestamp than offset.
-/// This is true if
-///     a) we have already timestamped a message >= offset
-///     b) the consumer's position is passed ever returning message <= offset. This is the case if
-///     the consumer's position is at an offset that is strictly greater than
-fn can_close_timestamp(
-    cp_info: &ControlPlaneInfo,
-    dp_info: &DataPlaneInfo,
-    pid: i32,
-    offset: MzOffset,
-) -> bool {
-    let last_offset = cp_info.partition_metadata.get(&pid).unwrap().offset;
-
-    // For transactional or compacted topics, the "last_offset" may not correspond to
-    // the last record in the topic (either because it has been GCed or because
-    // it corresponds to an abort/commit marker).
-    // topic and partition entries are not guaranteed to exist if the poll request to metadata has not succeeded:
-    // In Kafka, the position of the consumer is set to the offset *after* the last offset that the consumer has
-    // processed, so we have to decrement it by one to get the last processed offset
-
-    // We separate these two cases, as consumer.position() is an expensive call that should
-    // be avoided if possible. Case 1 and 2.a occur first, and we only test 2.b when necessary
-    if !dp_info.has_partition(pid) // Case 1
-        || last_offset >= offset
-    // Case 2.a
-    {
-        true
-    } else {
-        let mut current_consumer_position: MzOffset = KafkaOffset {
-            offset: match dp_info.consumer.position() {
-                Ok(topic_list) => topic_list
-                    .elements_for_topic(&dp_info.topic_name)
-                    .get(pid as usize)
-                    .map(|el| el.offset().to_raw() - 1),
-                Err(_) => Some(-1),
-            }
-            .unwrap_or(-1),
-        }
-        .into();
-
-        // If a message has been buffered (but not timestamped), the consumer will already have
-        // moved ahead.
-        if dp_info.is_buffered(pid) {
-            current_consumer_position.offset -= 1;
-        }
-
-        // Case 2.b
-        current_consumer_position >= offset
-    }
-}
-
-/// Timestamp history map is of format [pid1: (p_ct, ts1, offset1), (p_ct, ts2, offset2), pid2: (p_ct, ts1, offset)...].
-/// For a given partition pid, messages in interval [0,offset1] get assigned ts1, all messages in interval [offset1+1,offset2]
-/// get assigned ts2, etc.
-/// When receive message with offset1, it is safe to downgrade the capability to the next
-/// timestamp, which is either
-/// 1) the timestamp associated with the next highest offset if it exists
-/// 2) max(timestamp, offset1) + 1. The timestamp_history map can contain multiple timestamps for
-/// the same offset. We pick the greatest one + 1
-/// (the next message we generate will necessarily have timestamp timestamp + 1)
-///
-/// This method assumes that timestamps are inserted in increasing order in the hashmap
-/// (even across partitions). This means that once we see a timestamp with ts x, no entry with
-/// ts (x-1) will ever be inserted. Entries with timestamp x might still be inserted in different
-/// partitions. This is guaranteed by the [coord::timestamp::is_valid_ts] method.
-///
-fn downgrade_capability(
-    id: &SourceInstanceId,
-    cap: &mut Capability<Timestamp>,
-    cp_info: &mut ControlPlaneInfo,
-    dp_info: &mut DataPlaneInfo,
-    timestamp_histories: &TimestampDataUpdates,
-) {
-    let mut changed = false;
-
-    if let Consistency::BringYourOwn(_) = cp_info.source_type {
-        // Determine which timestamps have been closed. A timestamp is closed once we have processed
-        // all messages that we are going to process for this timestamp across all partitions
-        // In practice, the following happens:
-        // Per partition, we iterate over the data structure to remove (ts,offset) mappings for which
-        // we have seen all records <= offset. We keep track of the last "closed" timestamp in that partition
-        // in next_partition_ts
-        if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
-            match entries {
-                TimestampDataUpdate::BringYourOwn(entries) => {
-                    // Iterate over each partition that we know about
-                    for (pid, entries) in entries {
-                        let pid = match pid {
-                            PartitionId::Kafka(pid) => *pid,
-                            _ => unreachable!(
-                                "timestamp.rs should never send messages with non-Kafka partitions \
-                                   to Kafka sources."
-                            ),
-                        };
-
-                        dp_info.ensure_partition(cp_info, pid);
-
-                        // Check whether timestamps can be closed on this partition
-                        while let Some((partition_count, ts, offset)) = entries.front() {
-                            assert!(
-                                *offset >= cp_info.start_offset,
-                                "Internal error! Timestamping offset went below start: {} < {}. Materialize will now crash.",
-                                offset, cp_info.start_offset
-                            );
-
-                            assert!(
-                                *ts > 0,
-                                "Internal error! Received a zero-timestamp. Materialize will crash now."
-                            );
-
-                            // This timestamp update was done with the expectation that there were more partitions
-                            // than we know about. Partition IDs are assigned contiguously
-                            // starting from zero, so seeing a `partition_count` of N means
-                            // that we should have partitions up to N-1.
-                            dp_info.ensure_partition(cp_info, partition_count - 1);
-
-                            if let Some(pmetrics) = dp_info.partition_metrics.get_mut(&pid) {
-                                pmetrics
-                                    .closed_ts
-                                    .set(cp_info.partition_metadata.get(&pid).unwrap().ts);
-                            }
-
-                            if can_close_timestamp(cp_info, dp_info, pid, *offset) {
-                                // We have either 1) seen all messages corresponding to this timestamp for this
-                                // partition 2) do not own this partition 3) the consumer has forwarded past the
-                                // timestamped offset. Either way, we have the guarantee tha we will never see a message with a < timestamp
-                                // again
-                                // We can close the timestamp (on this partition) and remove the associated metadata
-                                cp_info.partition_metadata.get_mut(&pid).unwrap().ts = *ts;
-                                entries.pop_front();
-                                changed = true;
-                            } else {
-                                // Offset isn't at a timestamp boundary, we take no action
-                                break;
-                            }
-                        }
-                    }
-                }
-                _ => panic!("Unexpected timestamp message format. Expected BYO update."),
-            }
-        }
-
-        //  Next, we determine the maximum timestamp that is fully closed. This corresponds to the minimum
-        //  timestamp across partitions.
-        let min = cp_info
-            .partition_metadata
-            .iter()
-            .map(|(_, cons_info)| cons_info.ts)
-            .min()
-            .unwrap_or(0);
-
-        // Downgrade capability to new minimum open timestamp (which corresponds to min + 1).
-        if changed && min > 0 {
-            dp_info.source_metrics.capability.set(min);
-            cap.downgrade(&(&min + 1));
-            cp_info.last_closed_ts = min;
-        }
-    } else {
-        // This a RT source. It is always possible to close the timestamp and downgrade the
-        // capability
-        if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
-            match entries {
-                TimestampDataUpdate::RealTime(partition_count) => {
-                    // This timestamp update informs us that the source now contains
-                    // partition_count partitions. Partition IDs are assigned contiguously
-                    // starting from zero, so seeing a `partition_count` of N means
-                    // that we should have partitions up to N-1.
-                    dp_info.ensure_partition(cp_info, *partition_count - 1)
-                }
-                _ => panic!("Unexpected timestamp message. Expected RT update."),
-            }
-        }
-
-        if cp_info.time_since_downgrade.elapsed().as_millis()
-            > cp_info.downgrade_capability_frequency.try_into().unwrap()
-        {
-            let ts = cp_info.generate_next_timestamp();
-            if let Some(ts) = ts {
-                dp_info.source_metrics.capability.set(ts);
-                cap.downgrade(&(&ts + 1));
-            }
-            cp_info.time_since_downgrade = Instant::now();
         }
     }
 }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -9,21 +9,36 @@
 
 //! Types related to the creation of dataflow sources.
 
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::time::Duration;
-
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use timely::dataflow::{
     channels::pact::{Exchange, ParallelizationContract},
     operators::Capability,
 };
-use timely::{scheduling::Activator, Data};
 
-use dataflow_types::{Consistency, Timestamp};
-use expr::SourceInstanceId;
+use dataflow_types::{Consistency, ExternalSourceConnector, MzOffset, Timestamp};
+use expr::{PartitionId, SourceInstanceId};
+use lazy_static::lazy_static;
+use log::error;
+use prometheus::core::{AtomicI64, AtomicU64};
+use prometheus::{
+    register_int_counter, register_int_counter_vec, register_int_gauge_vec,
+    register_uint_gauge_vec, DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec,
+    IntGaugeVec, UIntGauge, UIntGaugeVec,
+};
+use timely::dataflow::{Scope, Stream};
+use timely::scheduling::activate::{Activator, SyncActivator};
+use timely::Data;
 
-use crate::server::{TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates};
+use super::source::util::source;
+use crate::server::{
+    TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
+};
 
 mod file;
 mod kafka;
@@ -32,7 +47,7 @@ mod util;
 
 use differential_dataflow::Hashable;
 pub use file::{file, read_file_task, FileReadStyle};
-pub use kafka::kafka;
+pub use kafka::KafkaSourceInfo;
 pub use kinesis::kinesis;
 
 /// Shared configuration information for all source types.
@@ -43,11 +58,6 @@ pub struct SourceConfig<'a, G> {
     pub id: SourceInstanceId,
     /// The timely scope in which to build the source.
     pub scope: &'a G,
-    /// Whether this worker has been chosen to actually receive data. All
-    /// workers must build the same dataflow operators to keep timely channel
-    /// IDs in sync, but only one worker will receive the data, to avoid
-    /// duplicates.
-    pub active: bool,
     /// The ID of the worker on which this operator is executing
     pub worker_id: usize,
     /// The total count of workers
@@ -59,9 +69,12 @@ pub struct SourceConfig<'a, G> {
     pub timestamp_tx: TimestampMetadataUpdates,
     /// A source can use Real-Time consistency timestamping or BYO consistency information.
     pub consistency: Consistency,
+    /// Source Type
     /// Timestamp Frequency: frequency at which timestamps should be closed (and capabilities
     /// downgraded)
     pub timestamp_frequency: Duration,
+    /// Whether this worker has been chosen to actually receive data.
+    pub active: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -163,4 +176,653 @@ pub enum SourceStatus {
     Alive,
     /// The source is complete.
     Done,
+}
+
+// Global Prometheus metrics
+lazy_static! {
+    static ref BYTES_READ_COUNTER: IntCounter =
+        register_int_counter!("mz_bytes_read_total", "Count of bytes read from sources").unwrap();
+}
+
+/// Each source must implement this trait. Sources will then get created as part of the
+/// [`create_source`] function.
+pub trait SourceInfo {
+    /// Creates a new specialised SourceInfo object for a given source
+    fn new(
+        source_name: String,
+        source_id: SourceInstanceId,
+        worker_id: usize,
+        worker_count: usize,
+        consumer_activator: Arc<Mutex<SyncActivator>>,
+        connector: ExternalSourceConnector,
+    ) -> Self
+    where
+        Self: Sized;
+
+    /// This function notifies timestamper and relevant datastructures that a source has
+    /// been created and must be timestamped
+    fn activate_source_timestamping(
+        id: &SourceInstanceId,
+        consistency: &Consistency,
+        active: bool,
+        timestamp_data_updates: TimestampDataUpdates,
+        timestamp_metadata_channel: TimestampMetadataUpdates,
+    ) -> Option<TimestampMetadataUpdates>
+    where
+        Self: Sized;
+
+    /// This function determines whether it is safe to close the current timestamp.
+    /// It is safe to close the current timestamp if
+    /// 1) this worker does not own the current partition
+    /// 2) we will never receive a message with a lower or equal timestamp than offset.
+    fn can_close_timestamp(
+        &self,
+        consistency_info: &ConsistencyInfo,
+        pid: &PartitionId,
+        offset: MzOffset,
+    ) -> bool;
+
+    /// Returns the number of partitions expected *for this worker*. Partitions are assigned
+    /// round-robin in worker id order
+    /// Note: we currently support two types of sources: those which support multithreaded reads
+    /// and those which don't.
+    fn get_worker_partition_count(&self) -> i32;
+
+    /// Returns true if this worker is responsible for this partition
+    /// This is dependent on whether the source supports multi-worker reads or not.
+    fn has_partition(&self, partition_id: PartitionId) -> bool;
+
+    /// Ensures that the partition `pid` exists for this source. Once this function has been
+    /// called, the source should be able to receive messages from this partition
+    fn ensure_has_partition(&mut self, consistency_info: &mut ConsistencyInfo, pid: PartitionId);
+
+    /// Informs source that there are now `partition_count` entries for this source
+    fn update_partition_count(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+        partition_count: i32,
+    );
+
+    /// Returns the next message read from the source
+    fn get_next_message(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+        activator: &Activator,
+    ) -> Option<SourceMessage>;
+
+    /// Buffer a message that cannot get timestamped
+    fn buffer_message(&mut self, message: SourceMessage);
+}
+
+/// Source-agnostic wrapper for messages. Each source must implement a
+/// conversion to Message.
+pub struct SourceMessage {
+    /// Partition from which this message originates
+    pub partition: PartitionId,
+    /// Materialize offset of the message (1-indexed)
+    pub offset: MzOffset,
+    /// Optional key
+    pub key: Option<Vec<u8>>,
+    /// Optional payload
+    pub payload: Option<Vec<u8>>,
+}
+
+/// Consistency information. Each partition contains information about
+/// 1) the last closed timestamp for this partition
+/// 2) the last processed offset
+#[derive(Copy, Clone)]
+pub struct ConsInfo {
+    /// the last closed timestamp for this partition
+    pub ts: Timestamp,
+    /// the last processed offset
+    pub offset: MzOffset,
+}
+
+/// Contains all necessary information that relates to consistency and timestamping.
+/// This information is (and should remain) source independent. This covers consistency
+/// information for sources that follow RT consistency and BYO consistency.
+pub struct ConsistencyInfo {
+    /// Last closed timestamp
+    last_closed_ts: u64,
+    /// Time since last capability downgrade
+    time_since_downgrade: Instant,
+    /// Frequency at which we should downgrade capability (in milliseconds)
+    downgrade_capability_frequency: u64,
+    /// Per partition (a partition ID in Kafka is an i32), keep track of the last closed offset
+    /// and the last closed timestamp
+    pub partition_metadata: HashMap<PartitionId, ConsInfo>,
+    /// Optional: Materialize Offset from which source should start reading (default is 0)
+    start_offset: MzOffset,
+    /// Source Type (Real-time or BYO)
+    source_type: Consistency,
+    /// Per-source Prometheus metrics.
+    source_metrics: SourceMetrics,
+    /// Per-partition Prometheus metrics.
+    partition_metrics: HashMap<PartitionId, PartitionMetrics>,
+}
+
+impl ConsistencyInfo {
+    fn new(
+        source_name: String,
+        source_id: SourceInstanceId,
+        worker_id: usize,
+        consistency: Consistency,
+        timestamp_frequency: Duration,
+        connector: &ExternalSourceConnector,
+    ) -> ConsistencyInfo {
+        let start_offset = match connector {
+            ExternalSourceConnector::Kafka(kc) => MzOffset {
+                offset: kc.start_offset,
+            },
+            _ => MzOffset { offset: 0 },
+        };
+        ConsistencyInfo {
+            last_closed_ts: 0,
+            // Safe conversion: statement.rs checks that value specified fits in u64
+            downgrade_capability_frequency: timestamp_frequency.as_millis().try_into().unwrap(),
+            partition_metadata: HashMap::new(),
+            start_offset,
+            source_type: consistency,
+            source_metrics: SourceMetrics::new(
+                &source_name,
+                &source_id.to_string(),
+                &worker_id.to_string(),
+            ),
+            time_since_downgrade: Instant::now(),
+            partition_metrics: Default::default(),
+        }
+    }
+
+    /// Returns true if we currently know of particular partition. We know (and have updated the
+    /// metadata for this partition) if there is an entry for it
+    pub fn knows_of(&self, pid: PartitionId) -> bool {
+        self.partition_metadata.contains_key(&pid)
+    }
+
+    /// Updates the underlying partition metadata structure to include the current partition.
+    /// New partitions must always be added with a minimum closed offset of (last_closed_ts)
+    /// They are guaranteed to only receive timestamp update greater than last_closed_ts (this
+    /// is enforced in [coord::timestamp::is_ts_valid]
+    pub fn update_partition_metadata(&mut self, pid: PartitionId) {
+        self.partition_metadata.insert(
+            pid,
+            ConsInfo {
+                offset: self.start_offset,
+                ts: self.last_closed_ts,
+            },
+        );
+    }
+
+    /// Generates a timestamp that is guaranteed to be monotonically increasing.
+    /// This may require multiple calls to the underlying now() system method, which is not
+    /// guaranteed to increase monotonically
+    fn generate_next_timestamp(&mut self) -> Option<u64> {
+        let mut new_ts = 0;
+        while new_ts <= self.last_closed_ts {
+            let start = SystemTime::now();
+            new_ts = start
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards")
+                .as_millis() as u64;
+            if new_ts < self.last_closed_ts && self.last_closed_ts - new_ts > 1000 {
+                // If someone resets their system clock to be too far in the past, this could cause
+                // Materialize to block and not give control to other operators. We thus give up
+                // on timestamping this message
+                error!("The new timestamp is more than 1 second behind the last assigned timestamp. To\
+                avoid unnecessary blocking, Materialize will not attempt to downgrade the capability. Please\
+                consider resetting your system time.");
+                return None;
+            }
+        }
+        assert!(new_ts > self.last_closed_ts);
+        self.last_closed_ts = new_ts;
+        Some(self.last_closed_ts)
+    }
+
+    /// Timestamp history map is of format [pid1: (p_ct, ts1, offset1), (p_ct, ts2, offset2), pid2: (p_ct, ts1, offset)...].
+    /// For a given partition pid, messages in interval [0,offset1] get assigned ts1, all messages in interval [offset1+1,offset2]
+    /// get assigned ts2, etc.
+    /// When receive message with offset1, it is safe to downgrade the capability to the next
+    /// timestamp, which is either
+    /// 1) the timestamp associated with the next highest offset if it exists
+    /// 2) max(timestamp, offset1) + 1. The timestamp_history map can contain multiple timestamps for
+    /// the same offset. We pick the greatest one + 1
+    /// (the next message we generate will necessarily have timestamp timestamp + 1)
+    ///
+    /// This method assumes that timestamps are inserted in increasing order in the hashmap
+    /// (even across partitions). This means that once we see a timestamp with ts x, no entry with
+    /// ts (x-1) will ever be inserted. Entries with timestamp x might still be inserted in different
+    /// partitions. This is guaranteed by the [coord::timestamp::is_valid_ts] method.
+    ///
+    fn downgrade_capability(
+        &mut self,
+        id: &SourceInstanceId,
+        cap: &mut Capability<Timestamp>,
+        source: &mut dyn SourceInfo,
+        timestamp_histories: &TimestampDataUpdates,
+    ) {
+        let mut changed = false;
+
+        if let Consistency::BringYourOwn(_) = self.source_type {
+            // Determine which timestamps have been closed. A timestamp is closed once we have processed
+            // all messages that we are going to process for this timestamp across all partitions
+            // In practice, the following happens:
+            // Per partition, we iterate over the data structure to remove (ts,offset) mappings for which
+            // we have seen all records <= offset. We keep track of the last "closed" timestamp in that partition
+            // in next_partition_ts
+            if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
+                match entries {
+                    TimestampDataUpdate::BringYourOwn(entries) => {
+                        // Iterate over each partition that we know about
+                        for (pid, entries) in entries {
+                            source.ensure_has_partition(self, pid.clone());
+
+                            // Check whether timestamps can be closed on this partition
+                            while let Some((partition_count, ts, offset)) = entries.front() {
+                                assert!(
+                                    *offset >= self.start_offset,
+                                    "Internal error! Timestamping offset went below start: {} < {}. Materialize will now crash.",
+                                    offset, self.start_offset
+                                );
+
+                                assert!(
+                                    *ts > 0,
+                                    "Internal error! Received a zero-timestamp. Materialize will crash now."
+                                );
+
+                                // This timestamp update was done with the expectation that there were more partitions
+                                // than we know about.
+                                source.update_partition_count(self, *partition_count);
+
+                                if let Some(pmetrics) = self.partition_metrics.get_mut(pid) {
+                                    pmetrics
+                                        .closed_ts
+                                        .set(self.partition_metadata.get(pid).unwrap().ts);
+                                }
+
+                                if source.can_close_timestamp(&self, pid, *offset) {
+                                    // We have either 1) seen all messages corresponding to this timestamp for this
+                                    // partition 2) do not own this partition 3) the consumer has forwarded past the
+                                    // timestamped offset. Either way, we have the guarantee tha we will never see a message with a < timestamp
+                                    // again
+                                    // We can close the timestamp (on this partition) and remove the associated metadata
+                                    self.partition_metadata.get_mut(&pid).unwrap().ts = *ts;
+                                    entries.pop_front();
+                                    changed = true;
+                                } else {
+                                    // Offset isn't at a timestamp boundary, we take no action
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    _ => panic!("Unexpected timestamp message format. Expected BYO update."),
+                }
+            }
+
+            //  Next, we determine the maximum timestamp that is fully closed. This corresponds to the minimum
+            //  timestamp across partitions.
+            let min = self
+                .partition_metadata
+                .iter()
+                .map(|(_, cons_info)| cons_info.ts)
+                .min()
+                .unwrap_or(0);
+
+            // Downgrade capability to new minimum open timestamp (which corresponds to min + 1).
+            if changed && min > 0 {
+                self.source_metrics.capability.set(min);
+                cap.downgrade(&(&min + 1));
+                self.last_closed_ts = min;
+            }
+        } else {
+            // This a RT source. It is always possible to close the timestamp and downgrade the
+            // capability
+            if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
+                match entries {
+                    TimestampDataUpdate::RealTime(partition_count) => {
+                        source.update_partition_count(self, *partition_count)
+                    }
+                    _ => panic!("Unexpected timestamp message. Expected RT update."),
+                }
+            }
+
+            if self.time_since_downgrade.elapsed().as_millis()
+                > self.downgrade_capability_frequency.try_into().unwrap()
+            {
+                let ts = self.generate_next_timestamp();
+                if let Some(ts) = ts {
+                    self.source_metrics.capability.set(ts);
+                    cap.downgrade(&(&ts + 1));
+                }
+                self.time_since_downgrade = Instant::now();
+            }
+        }
+    }
+
+    /// For a given offset, returns an option type returning the matching timestamp or None
+    /// if no timestamp can be assigned.
+    ///
+    /// The timestamp history contains a sequence of
+    /// (partition_count, timestamp, offset) tuples. A message with offset x will be assigned the first timestamp
+    /// for which offset>=x.
+    fn find_matching_timestamp(
+        &self,
+        id: &SourceInstanceId,
+        partition: &PartitionId,
+        offset: MzOffset,
+        timestamp_histories: &TimestampDataUpdates,
+    ) -> Option<Timestamp> {
+        if let Consistency::RealTime = self.source_type {
+            // Simply assign to this message the next timestamp that is not closed
+            Some(self.last_closed_ts + 1)
+        } else {
+            // The source is a BYO source. Must check the list of timestamp updates for the given partition
+            match timestamp_histories.borrow().get(id) {
+                None => None,
+                Some(TimestampDataUpdate::BringYourOwn(entries)) => match entries.get(partition) {
+                    Some(entries) => {
+                        for (_, ts, max_offset) in entries {
+                            if offset <= *max_offset {
+                                return Some(ts.clone());
+                            }
+                        }
+                        None
+                    }
+                    None => None,
+                },
+                _ => panic!("Unexpected entry format in TimestampDataUpdates for BYO source"),
+            }
+        }
+    }
+}
+
+/// Source-specific Prometheus metrics
+pub struct SourceMetrics {
+    /// Number of times an operator gets scheduled
+    operator_scheduled_counter: IntCounter,
+    /// Value of the capability associated with this source
+    capability: UIntGauge,
+}
+
+impl SourceMetrics {
+    /// Initialises source metrics for a given (source_id, worker_id)
+    pub fn new(source_name: &str, source_id: &str, worker_id: &str) -> SourceMetrics {
+        lazy_static! {
+            static ref OPERATOR_SCHEDULED_COUNTER: IntCounterVec = register_int_counter_vec!(
+                "mz_operator_scheduled_total",
+                "The number of times the kafka client got invoked for this source",
+                &["topic", "source_id", "worker_id"]
+            )
+            .unwrap();
+            static ref CAPABILITY: UIntGaugeVec = register_uint_gauge_vec!(
+                "mz_kafka_capability",
+                "The current capability for this dataflow. This corresponds to min(mz_kafka_partition_closed_ts)",
+                &["topic", "source_id", "worker_id"]
+            )
+            .unwrap();
+        }
+        let labels = &[source_name, source_id, worker_id];
+        SourceMetrics {
+            operator_scheduled_counter: OPERATOR_SCHEDULED_COUNTER.with_label_values(labels),
+            capability: CAPABILITY.with_label_values(labels),
+        }
+    }
+}
+
+/// Partition-specific Prometheus metrics
+pub struct PartitionMetrics {
+    /// Highest offset that has been received by the source and timestamped
+    offset_ingested: DeleteOnDropGauge<'static, AtomicI64>,
+    /// Highest offset that has been received by the source
+    offset_received: DeleteOnDropGauge<'static, AtomicI64>,
+    /// Value of the highest timestamp that is closed (for which all messages have been ingested)
+    closed_ts: DeleteOnDropGauge<'static, AtomicU64>,
+    /// Total number of messages that have been received by the source and timestamped
+    messages_ingested: DeleteOnDropCounter<'static, AtomicI64>,
+}
+
+impl PartitionMetrics {
+    /// Initialises partition metrics for a given (source_id, partition_id)
+    pub fn new(source_name: &str, source_id: &str, partition_id: &str) -> PartitionMetrics {
+        lazy_static! {
+            static ref OFFSET_INGESTED: IntGaugeVec = register_int_gauge_vec!(
+                "mz_partition_offset_ingested",
+                "The most recent offset that we have ingested into a dataflow. This correspond to \
+                data that we have 1)ingested 2) assigned a timestamp",
+                &["topic", "source_id", "partition_id"]
+            )
+            .unwrap();
+            static ref OFFSET_RECEIVED: IntGaugeVec = register_int_gauge_vec!(
+                "mz_partition_offset_received",
+                "The most recent offset that we have been received by this source.",
+                &["topic", "source_id", "partition_id"]
+            )
+            .unwrap();
+            static ref CLOSED_TS: UIntGaugeVec = register_uint_gauge_vec!(
+                "mz_partition_closed_ts",
+                "The highest closed timestamp for each partition in this dataflow",
+                &["topic", "source_id", "partition_id"]
+            )
+            .unwrap();
+            static ref MESSAGES_INGESTED: IntCounterVec = register_int_counter_vec!(
+                "mz_messages_ingested",
+                "The number of messages ingested per partition.",
+                &["topic", "source_id", "partition_id"]
+            )
+            .unwrap();
+        }
+        let labels = &[source_name, source_id, partition_id];
+        PartitionMetrics {
+            offset_ingested: DeleteOnDropGauge::new_with_error_handler(
+                OFFSET_INGESTED.with_label_values(labels),
+                &OFFSET_INGESTED,
+                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+            ),
+            offset_received: DeleteOnDropGauge::new_with_error_handler(
+                OFFSET_RECEIVED.with_label_values(labels),
+                &OFFSET_RECEIVED,
+                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+            ),
+            closed_ts: DeleteOnDropGauge::new_with_error_handler(
+                CLOSED_TS.with_label_values(labels),
+                &CLOSED_TS,
+                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+            ),
+            messages_ingested: DeleteOnDropCounter::new_with_error_handler(
+                MESSAGES_INGESTED.with_label_values(labels),
+                &MESSAGES_INGESTED,
+                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+            ),
+        }
+    }
+}
+
+/// Creates a source dataflow operator. The type of ExternalSourceConnector determines the
+/// type of source that should be created
+pub fn create_source<G, S: 'static>(
+    config: SourceConfig<G>,
+    source_connector: ExternalSourceConnector,
+) -> (
+    Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
+    Option<SourceToken>,
+)
+where
+    G: Scope<Timestamp = Timestamp>,
+    S: SourceInfo,
+{
+    let SourceConfig {
+        name,
+        id,
+        scope,
+        timestamp_histories,
+        timestamp_tx,
+        worker_id,
+        worker_count,
+        consistency,
+        timestamp_frequency,
+        active,
+        ..
+    } = config;
+
+    let timestamp_channel = S::activate_source_timestamping(
+        &id,
+        &consistency,
+        active,
+        timestamp_histories.clone(),
+        timestamp_tx,
+    );
+
+    let (stream, capability) = source(id, timestamp_channel, scope, name.clone(), move |info| {
+        // Create activator for source
+        let activator = scope.activator_for(&info.address[..]);
+        // Create source information (this function is specific to a specific
+        // source
+        // Create source information (this function is specific to a specific
+        // source
+        let mut source_info: S = S::new(
+            name.clone(),
+            id,
+            worker_id,
+            worker_count,
+            Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..]))),
+            source_connector.clone(),
+        );
+
+        // Create control plane information (Consistency-related information)
+        let mut consistency_info = ConsistencyInfo::new(
+            name.clone(),
+            id,
+            worker_id,
+            consistency,
+            timestamp_frequency,
+            &source_connector,
+        );
+
+        move |cap, output| {
+            if active {
+                // Bound execution of operator to prevent a single operator from hogging
+                // the CPU if there are many messages to process
+                let timer = Instant::now();
+                // Accumulate updates to BYTES_READ_COUNTER for Promethes metrics collection
+                let mut bytes_read = 0;
+
+                // Record operator has been scheduled
+                consistency_info
+                    .source_metrics
+                    .operator_scheduled_counter
+                    .inc();
+
+                while let Some(message) =
+                    source_info.get_next_message(&mut consistency_info, &activator)
+                {
+                    let partition = message.partition.clone();
+                    let offset = message.offset;
+
+                    // Update ingestion metrics
+                    // Entry is guaranteed to exist as it gets created when we initialise the partition.
+                    consistency_info
+                        .partition_metrics
+                        .get_mut(&partition)
+                        .unwrap()
+                        .offset_received
+                        .set(offset.offset);
+
+                    // Determine the timestamp to which we need to assign this message
+                    let ts = consistency_info.find_matching_timestamp(
+                        &id,
+                        &partition,
+                        offset,
+                        &timestamp_histories,
+                    );
+                    match ts {
+                        None => {
+                            // We have not yet decided on a timestamp for this message,
+                            // we need to buffer the message
+                            source_info.buffer_message(message);
+                            consistency_info.downgrade_capability(
+                                &id,
+                                cap,
+                                &mut source_info,
+                                &timestamp_histories,
+                            );
+                            activator.activate();
+                            return SourceStatus::Alive;
+                        }
+                        Some(ts) => {
+                            // Note: empty and null payload/keys are currently
+                            // treated as the same thing.
+                            let key = message.key.unwrap_or_default();
+                            let out = message.payload.unwrap_or_default();
+                            // Entry for partition_metadata is guaranteed to exist as messages
+                            // are only processed after we have updated the partition_metadata for a
+                            // partition and created a partition queue for it.
+                            consistency_info
+                                .partition_metadata
+                                .get_mut(&partition)
+                                .unwrap()
+                                .offset = offset;
+                            bytes_read += key.len() as i64;
+                            bytes_read += out.len() as i64;
+                            let ts_cap = cap.delayed(&ts);
+                            output.session(&ts_cap).give(SourceOutput::new(
+                                key,
+                                out,
+                                Some(offset.offset),
+                            ));
+
+                            // Update ingestion metrics
+                            // Entry is guaranteed to exist as it gets created when we initialise the partition
+                            let partition_metrics = &mut consistency_info
+                                .partition_metrics
+                                .get_mut(&partition)
+                                .unwrap();
+                            partition_metrics.offset_ingested.set(offset.offset);
+                            partition_metrics.messages_ingested.inc();
+                        }
+                    }
+
+                    //TODO(ncrooks): this behaviour should probably be made configurable
+                    if timer.elapsed().as_millis() > 10 {
+                        // We didn't drain the entire queue, so indicate that we
+                        // should run again.
+                        if bytes_read > 0 {
+                            BYTES_READ_COUNTER.inc_by(bytes_read);
+                        }
+                        // Downgrade capability (if possible) before exiting
+                        consistency_info.downgrade_capability(
+                            &id,
+                            cap,
+                            &mut source_info,
+                            &timestamp_histories,
+                        );
+                        activator.activate();
+                        return SourceStatus::Alive;
+                    }
+                }
+
+                // Downgrade capability (if possible) before exiting
+                consistency_info.downgrade_capability(
+                    &id,
+                    cap,
+                    &mut source_info,
+                    &timestamp_histories,
+                );
+            }
+
+            // Ensure that we activate the source frequently enough to keep downgrading
+            // capabilities, even when no data has arrived
+            activator.activate_after(Duration::from_millis(
+                consistency_info.downgrade_capability_frequency,
+            ));
+            SourceStatus::Alive
+        }
+    });
+
+    if active {
+        (stream, Some(capability))
+    } else {
+        // Immediately drop the capability if worker is not an active reader for source
+        (stream, None)
+    }
 }

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -28,8 +28,8 @@ mz_offset  NO        int8
 > SELECT * FROM data
 data           mz_offset
 ------------------------
-"\\xc2\\xa91"  0
-"\\xc2\\xa92"  1
+"\\xc2\\xa91"  1
+"\\xc2\\xa92"  2
 
 # Test that CREATE SOURCE can specify a custom name for the column.
 

--- a/test/testdrive/upsert-kafka.td
+++ b/test/testdrive/upsert-kafka.td
@@ -195,9 +195,9 @@ testdrive-textbytes-${testdrive.seed},1,0,10,5
 > select * from texttext
 key           data  mz_offset
 -----------------------------
-fish          fish  0
-bírdmore      geese 2
-mammal1       moose 3
+fish          fish  1
+bírdmore      geese 3
+mammal1       moose 4
 
 $ kafka-ingest format=bytes topic=data-consistency2
 testdrive-textbytes-${testdrive.seed},1,0,15,8
@@ -206,10 +206,10 @@ testdrive-textbytes-${testdrive.seed},1,0,21,9
 > select * from textbytes
 key           data             mz_offset
 ----------------------------------------
-fish          fish             0
-bírdmore      g\xc3\xa9ese     5
-mammal1       mouse            8
-mammalmore    moose            6
+fish          fish             1
+bírdmore      g\xc3\xa9ese     6
+mammal1       mouse            9
+mammalmore    moose            7
 
 $ kafka-ingest format=bytes topic=data-consistency2
 testdrive-textbytes-${testdrive.seed},1,0,28,10
@@ -217,10 +217,10 @@ testdrive-textbytes-${testdrive.seed},1,0,28,10
 > select * from bytesbytes
 key              data             mz_offset
 ----------------------------------------
-fish             fish             0
-b\xc3\xadrdmore  g\xc3\xa9ese     5
-mammal1          mouse            8
-mammalmore       herd             9
+fish             fish             1
+b\xc3\xadrdmore  g\xc3\xa9ese     6
+mammal1          mouse            9
+mammalmore       herd             10
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=: publish=true
 bìrd1:
@@ -233,9 +233,9 @@ testdrive-textbytes-${testdrive.seed},1,0,45,12
 > select * from bytestext
 key              data             mz_offset
 ----------------------------------------
-b\xc3\xadrdmore  géese            5
-mammal1          mouse            8
-mammalmore       herd             9
+b\xc3\xadrdmore  géese            6
+mammal1          mouse            9
+mammalmore       herd             10
 
 $ kafka-create-topic topic=nullkey
 
@@ -267,8 +267,8 @@ testdrive-nullkey-${testdrive.seed},1,0,51,7
 > select * from nullkey
 key           data  mz_offset
 -----------------------------
-birdmore      geese 4
-mammalmore    moose 5
+birdmore      geese 5
+mammalmore    moose 6
 
 $ kafka-create-topic topic=realtimeavroavro
 


### PR DESCRIPTION
This PR moves the source ingestion code to a common code path. 

The code is now split into a `create_source` method parametrized over the` SourceInfo` trait. Each source (Kafka, Kinesis, File) should implement the `SourceInfo` trait. This trait includes methods specific to message ingestion.

The `ConsistencyInfo` structure now stores all timestamp/capability downgrade information. This is common across sources.

The PR also moves sources to be 1-indexed. I am happy to revisit this if this is problematic.

The PR currently ports the Kafka sources to the common framework. It does not yet port files or kinesis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3452)
<!-- Reviewable:end -->
