### PR TITLE
Fix TAIL frontier bug

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1325,10 +1325,16 @@ where
             .get(&source_id)
             .map(|view_state| &view_state.default_idx)
         {
-            self.indexes
+            let upper = self
+                .indexes
                 .upper_of(index_id)
-                .expect("name missing at coordinator")
-                .to_owned()
+                .expect("name missing at coordinator");
+
+            if let Some(ts) = upper.get(0) {
+                Antichain::from_elem(ts.saturating_sub(1))
+            } else {
+                Antichain::from_elem(Timestamp::max_value())
+            }
         } else {
             // TODO: This should more carefully consider `since` frontiers of its input.
             // This will be forcibly corrected if any inputs are compacted.


### PR DESCRIPTION
In order to implement `TAIL .. AS OF`, we need to keep track of the `frontier` of the `TAIL`'s source: we use that information in `tail.rs` to determine which `(row, time, diff)` tuples to emit. 

However, it is possible for a `TAIL`'s source to have an index whose upper `frontier` is empty. In this case, we are incorrectly setting the `TailSinkConnector`'s `frontier` to `[]`, resulting in some rows not to be emitted when they should have been (because no time is `less_equal` than an empty collection). 

This PR fixes this issue by returning an `Antichain` with the max timestamp value instead of an empty `frontier`. Additionally, it should improve the overall performance of `TAIL` by returning `frontier` - 1 otherwise, which avoids waiting for an extra clock tick.

Note: I'm not totally sure how to test this? I actually found the issue testing `CREATE SINK ... AS OF`, the `sinks.td` test creates a couple of sinks quickly in a row, which surfaced the problem. I confirmed the fix for sinks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3465)
<!-- Reviewable:end -->
