### PR TITLE
CREATE SINK .. AS OF

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -47,6 +47,17 @@ Field | Value type | Description
 ------|------------|------------
 `replication_factor` | `int` | Set the sink Kafka topic's replication factor. This defaults to 1.
 
+### AS OF
+
+`AS OF` is the specific point in time to start emitting all events for a given `SINK`. If you don't
+use `AS OF`, Materialize will pick a timestamp itself.
+
+### WITH SNAPSHOT or WITHOUT SNAPSHOT
+
+By default, each `SINK` is created with a `SNAPSHOT` which contains the results of the query at its `AS OF` timestamp.
+Any further updates to these results are produced at the time when they occur. To only see results after the
+`AS OF` timestamp, specify `WITHOUT SNAPSHOT`.
+
 ## Detail
 
 - Materialize currently only supports Avro formatted sinks that write to either a single partition topic or a Avro object container file.

--- a/doc/user/layouts/partials/sql-grammar/create-sink.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink.svg
@@ -1,60 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="529" height="179">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="112" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="555" height="309">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="112" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="112"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">CREATE SINK</text>
-   <rect x="183" y="35" width="118" height="32" rx="10"/>
-   <rect x="181"
+   <text class="terminal" x="41" y="21">CREATE SINK</text>
+   <rect x="185" y="35" width="118" height="32" rx="10"/>
+   <rect x="183"
          y="33"
          width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="191" y="53">IF NOT EXISTS</text>
-   <rect x="341" y="3" width="86" height="32"/>
-   <rect x="339" y="1" width="86" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="349" y="21">sink_name</text>
-   <rect x="447" y="3" width="60" height="32" rx="10"/>
-   <rect x="445"
+   <text class="terminal" x="193" y="53">IF NOT EXISTS</text>
+   <rect x="343" y="3" width="86" height="32"/>
+   <rect x="341" y="1" width="86" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="351" y="21">sink_name</text>
+   <rect x="449" y="3" width="60" height="32" rx="10"/>
+   <rect x="447"
          y="1"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="455" y="21">FROM</text>
-   <rect x="83" y="101" width="88" height="32"/>
-   <rect x="81" y="99" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="91" y="119">item_name</text>
-   <rect x="191" y="101" width="52" height="32" rx="10"/>
-   <rect x="189"
+   <text class="terminal" x="457" y="21">FROM</text>
+   <rect x="71" y="101" width="88" height="32"/>
+   <rect x="69" y="99" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="79" y="119">item_name</text>
+   <rect x="179" y="101" width="52" height="32" rx="10"/>
+   <rect x="177"
          y="99"
          width="52"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="119">INTO</text>
-   <rect x="283" y="101" width="122" height="32"/>
-   <rect x="281" y="99" width="122" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="291" y="119">kafka_connector</text>
-   <rect x="283" y="145" width="92" height="32" rx="10"/>
-   <rect x="281"
+   <text class="terminal" x="187" y="119">INTO</text>
+   <rect x="271" y="101" width="122" height="32"/>
+   <rect x="269" y="99" width="122" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="279" y="119">kafka_connector</text>
+   <rect x="271" y="145" width="92" height="32" rx="10"/>
+   <rect x="269"
          y="143"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="291" y="163">AVRO OCF</text>
-   <rect x="395" y="145" width="86" height="32"/>
-   <rect x="393" y="143" width="86" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="403" y="163">path-prefix</text>
+   <text class="terminal" x="279" y="163">AVRO OCF</text>
+   <rect x="383" y="145" width="86" height="32"/>
+   <rect x="381" y="143" width="86" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="391" y="163">path-prefix</text>
+   <rect x="45" y="231" width="136" height="32" rx="10"/>
+   <rect x="43"
+         y="229"
+         width="136"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="249">WITH SNAPSHOT</text>
+   <rect x="45" y="275" width="164" height="32" rx="10"/>
+   <rect x="43"
+         y="273"
+         width="164"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="293">WITHOUT SNAPSHOT</text>
+   <rect x="269" y="231" width="60" height="32" rx="10"/>
+   <rect x="267"
+         y="229"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="277" y="249">AS OF</text>
+   <rect x="349" y="231" width="158" height="32"/>
+   <rect x="347" y="229" width="158" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="357" y="249">timestamp_expression</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m112 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m86 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-468 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m122 0 h10 m0 0 h76 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m92 0 h10 m0 0 h10 m86 0 h10 m23 -44 h-3"/>
-   <polygon points="519 115 527 111 527 119"/>
-   <polygon points="519 115 511 111 511 119"/>
+         d="m19 17 h2 m0 0 h10 m112 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m86 0 h10 m0 0 h10 m60 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-482 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m122 0 h10 m0 0 h76 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v24 m238 0 v-24 m-238 24 q0 10 10 10 m218 0 q10 0 10 -10 m-228 10 h10 m92 0 h10 m0 0 h10 m86 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-508 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m136 0 h10 m0 0 h28 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m40 -76 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
+   <polygon points="545 213 553 209 553 217"/>
+   <polygon points="545 213 537 209 537 217"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -24,6 +24,8 @@ create_sink ::=
     kafka_connector |
    'AVRO OCF' path-prefix
    )
+   ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
+   ('AS OF' timestamp_expression)?
 create_source_avro_file ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ')')?

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -135,6 +135,8 @@ pub struct Sink {
     pub plan_cx: PlanContext,
     pub from: GlobalId,
     pub connector: SinkConnectorState,
+    pub with_snapshot: bool,
+    pub as_of: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -984,11 +986,18 @@ impl Catalog {
                 on: index.on,
                 keys: index.keys,
             }),
-            Plan::CreateSink { sink, .. } => CatalogItem::Sink(Sink {
+            Plan::CreateSink {
+                sink,
+                with_snapshot,
+                as_of,
+                ..
+            } => CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
                 plan_cx: pcx,
                 from: sink.from,
                 connector: SinkConnectorState::Pending(sink.connector_builder),
+                with_snapshot,
+                as_of,
             }),
             _ => bail!("catalog entry generated inappropriate plan"),
         })

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -966,7 +966,7 @@ where
         let frontier = match self.determine_frontier(as_of, sink.from) {
             Ok(frontier) => frontier,
             Err(e) => {
-                tx.send(Err(e.into()), session);
+                tx.send(Err(e), session);
                 return;
             }
         };

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -224,8 +224,13 @@ where
                             panic!("sink already initialized during catalog boot")
                         }
                     };
-                    let connector = block_on(sink_connector::build(builder, id))
-                        .with_context(|e| format!("recreating sink {}: {}", name, e))?;
+                    let connector = block_on(sink_connector::build(
+                        builder,
+                        sink.with_snapshot,
+                        coord.determine_frontier(sink.as_of, sink.from)?,
+                        id,
+                    ))
+                    .with_context(|e| format!("recreating sink {}: {}", name, e))?;
                     coord.handle_sink_connector_ready(id, connector);
                 }
                 CatalogItem::Index(index) => match id {
@@ -607,6 +612,8 @@ where
             Plan::CreateSink {
                 name,
                 sink,
+                with_snapshot,
+                as_of,
                 if_not_exists,
             } => self.sequence_create_sink(
                 pcx,
@@ -615,6 +622,8 @@ where
                 session,
                 name,
                 sink,
+                with_snapshot,
+                as_of,
                 if_not_exists,
             ),
 
@@ -911,6 +920,8 @@ where
         session: Session,
         name: FullName,
         sink: sql::plan::Sink,
+        with_snapshot: bool,
+        as_of: Option<u64>,
         if_not_exists: bool,
     ) {
         // First try to allocate an ID. If that fails, we're done.
@@ -936,6 +947,8 @@ where
                 plan_cx: pcx,
                 from: sink.from,
                 connector: catalog::SinkConnectorState::Pending(sink.connector_builder.clone()),
+                with_snapshot,
+                as_of,
             }),
         };
         match self.catalog_transact(vec![op]) {
@@ -950,6 +963,13 @@ where
             }
         }
 
+        let frontier = match self.determine_frontier(as_of, sink.from) {
+            Ok(frontier) => frontier,
+            Err(e) => {
+                tx.send(Err(e.into()), session);
+                return;
+            }
+        };
         // Now we're ready to create the sink connector. Arrange to notify the
         // main coordinator thread when the future completes.
         let connector_builder = sink.connector_builder;
@@ -959,7 +979,8 @@ where
                     session,
                     tx,
                     id,
-                    result: sink_connector::build(connector_builder, id).await,
+                    result: sink_connector::build(connector_builder, with_snapshot, frontier, id)
+                        .await,
                 })
                 .await
                 .expect("sending to internal_cmd_tx cannot fail");
@@ -1306,41 +1327,7 @@ where
     ) -> Result<ExecuteResponse, failure::Error> {
         // Determine the frontier of updates to tail *from*.
         // Updates greater or equal to this frontier will be produced.
-        let frontier = if let Some(ts) = ts {
-            // If a timestamp was explicitly requested, use that.
-            Antichain::from_elem(self.determine_timestamp(
-                &RelationExpr::Get {
-                    id: Id::Global(source_id),
-                    // TODO(justin): find a way to avoid synthesizing an arbitrary relation type.
-                    typ: RelationType::empty(),
-                },
-                PeekWhen::AtTimestamp(ts),
-            )?)
-        }
-        // TODO: The logic that follows is at variance from PEEK logic which consults the
-        // "queryable" state of its inputs. We might want those to line up, but it is only
-        // a "might".
-        else if let Some(Some((index_id, _))) = self
-            .views
-            .get(&source_id)
-            .map(|view_state| &view_state.default_idx)
-        {
-            let upper = self
-                .indexes
-                .upper_of(index_id)
-                .expect("name missing at coordinator");
-
-            if let Some(ts) = upper.get(0) {
-                Antichain::from_elem(ts.saturating_sub(1))
-            } else {
-                Antichain::from_elem(Timestamp::max_value())
-            }
-        } else {
-            // TODO: This should more carefully consider `since` frontiers of its input.
-            // This will be forcibly corrected if any inputs are compacted.
-            Antichain::from_elem(0)
-        };
-
+        let frontier = self.determine_frontier(ts, source_id)?;
         let sink_name = format!(
             "tail-source-{}",
             self.catalog
@@ -1357,10 +1344,9 @@ where
             source_id,
             SinkConnector::Tail(TailSinkConnector {
                 tx,
-                frontier: frontier.clone(),
+                frontier,
                 strict: !with_snapshot,
             }),
-            frontier,
         );
         Ok(ExecuteResponse::Tailing { rx })
     }
@@ -1542,7 +1528,7 @@ where
                                         }),
                                     );
                                 }
-                                SinkConnector::AvroOcf(AvroOcfSinkConnector { path }) => {
+                                SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
                                     broadcast(
                                         &mut self.broadcast_tx,
                                         SequencedCommand::AppendLog(
@@ -1815,16 +1801,7 @@ where
             .transact(ops)
             .expect("replacing a sink cannot fail");
 
-        // Create the sink dataflow.
-        // TODO: The frontier should be more intentionally chosen based on `since` frontiers.
-        // The current choice will likely be overwritten by dataflow validation.
-        self.create_sink_dataflow(
-            name.to_string(),
-            id,
-            sink.from,
-            connector,
-            Antichain::from_elem(0),
-        )
+        self.create_sink_dataflow(name.to_string(), id, sink.from, connector)
     }
 
     fn create_sink_dataflow(
@@ -1833,7 +1810,6 @@ where
         id: GlobalId,
         from: GlobalId,
         connector: SinkConnector,
-        as_of: Antichain<Timestamp>,
     ) {
         #[allow(clippy::single_match)]
         match &connector {
@@ -1847,7 +1823,7 @@ where
                     }),
                 );
             }
-            SinkConnector::AvroOcf(AvroOcfSinkConnector { path }) => {
+            SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
                 broadcast(
                     &mut self.broadcast_tx,
                     SequencedCommand::AppendLog(MaterializedEvent::AvroOcfSink {
@@ -1860,7 +1836,8 @@ where
             _ => (),
         }
         let mut dataflow = DataflowDesc::new(name);
-        dataflow.set_as_of(as_of);
+        // let as_of = ;
+        dataflow.set_as_of(connector.get_frontier());
         self.import_source_or_view(&id, &from, &mut dataflow);
         let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
         dataflow.add_sink_export(id, from, from_type, connector);
@@ -2162,6 +2139,51 @@ where
                 invalid
             );
         }
+    }
+
+    /// todo: docs.
+    fn determine_frontier(
+        &mut self,
+        as_of: Option<u64>,
+        source_id: GlobalId,
+    ) -> Result<Antichain<u64>, failure::Error> {
+        // Determine the frontier of updates to start *from*.
+        // Updates greater or equal to this frontier will be produced.
+        let frontier = if let Some(ts) = as_of {
+            // If a timestamp was explicitly requested, use that.
+            Antichain::from_elem(self.determine_timestamp(
+                &RelationExpr::Get {
+                    id: Id::Global(source_id),
+                    // TODO(justin): find a way to avoid synthesizing an arbitrary relation type.
+                    typ: RelationType::empty(),
+                },
+                PeekWhen::AtTimestamp(ts),
+            )?)
+        }
+        // TODO: The logic that follows is at variance from PEEK logic which consults the
+        // "queryable" state of its inputs. We might want those to line up, but it is only
+        // a "might".
+        else if let Some(Some((index_id, _))) = self
+            .views
+            .get(&source_id)
+            .map(|view_state| &view_state.default_idx)
+        {
+            let upper = self
+                .indexes
+                .upper_of(index_id)
+                .expect("name missing at coordinator");
+
+            if let Some(ts) = upper.get(0) {
+                Antichain::from_elem(ts.saturating_sub(1))
+            } else {
+                Antichain::from_elem(Timestamp::max_value())
+            }
+        } else {
+            // TODO: This should more carefully consider `since` frontiers of its input.
+            // This will be forcibly corrected if any inputs are compacted.
+            Antichain::from_elem(0)
+        };
+        Ok(frontier)
     }
 
     /// Updates the upper frontier of a named view.

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -16,7 +16,7 @@ use rdkafka::config::ClientConfig;
 
 use dataflow_types::{
     AvroOcfSinkConnector, AvroOcfSinkConnectorBuilder, KafkaSinkConnector,
-    KafkaSinkConnectorBuilder, SinkConnector, SinkConnectorBuilder,
+    KafkaSinkConnectorBuilder, SinkConnector, SinkConnectorBuilder, Timestamp,
 };
 use expr::GlobalId;
 use ore::collections::CollectionExt;
@@ -25,7 +25,7 @@ use timely::progress::Antichain;
 pub async fn build(
     builder: SinkConnectorBuilder,
     with_snapshot: bool,
-    frontier: Antichain<u64>,
+    frontier: Antichain<Timestamp>,
     id: GlobalId,
 ) -> Result<SinkConnector, failure::Error> {
     match builder {
@@ -37,7 +37,7 @@ pub async fn build(
 async fn build_kafka(
     builder: KafkaSinkConnectorBuilder,
     with_snapshot: bool,
-    frontier: Antichain<u64>,
+    frontier: Antichain<Timestamp>,
     id: GlobalId,
 ) -> Result<SinkConnector, failure::Error> {
     let topic = format!("{}-{}-{}", builder.topic_prefix, id, builder.topic_suffix);
@@ -93,7 +93,7 @@ async fn build_kafka(
 fn build_avro_ocf(
     builder: AvroOcfSinkConnectorBuilder,
     with_snapshot: bool,
-    frontier: Antichain<u64>,
+    frontier: Antichain<Timestamp>,
     id: GlobalId,
 ) -> Result<SinkConnector, failure::Error> {
     let mut name = match builder.path.file_stem() {

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -20,19 +20,24 @@ use dataflow_types::{
 };
 use expr::GlobalId;
 use ore::collections::CollectionExt;
+use timely::progress::Antichain;
 
 pub async fn build(
     builder: SinkConnectorBuilder,
+    with_snapshot: bool,
+    frontier: Antichain<u64>,
     id: GlobalId,
 ) -> Result<SinkConnector, failure::Error> {
     match builder {
-        SinkConnectorBuilder::Kafka(k) => build_kafka(k, id).await,
-        SinkConnectorBuilder::AvroOcf(a) => build_avro_ocf(a, id),
+        SinkConnectorBuilder::Kafka(k) => build_kafka(k, with_snapshot, frontier, id).await,
+        SinkConnectorBuilder::AvroOcf(a) => build_avro_ocf(a, with_snapshot, frontier, id),
     }
 }
 
 async fn build_kafka(
     builder: KafkaSinkConnectorBuilder,
+    with_snapshot: bool,
+    frontier: Antichain<u64>,
     id: GlobalId,
 ) -> Result<SinkConnector, failure::Error> {
     let topic = format!("{}-{}-{}", builder.topic_prefix, id, builder.topic_suffix);
@@ -80,11 +85,15 @@ async fn build_kafka(
         topic,
         url: builder.broker_url,
         fuel: builder.fuel,
+        frontier,
+        strict: !with_snapshot,
     }))
 }
 
 fn build_avro_ocf(
     builder: AvroOcfSinkConnectorBuilder,
+    with_snapshot: bool,
+    frontier: Antichain<u64>,
     id: GlobalId,
 ) -> Result<SinkConnector, failure::Error> {
     let mut name = match builder.path.file_stem() {
@@ -117,5 +126,9 @@ fn build_avro_ocf(
                 e
             )
         })?;
-    Ok(SinkConnector::AvroOcf(AvroOcfSinkConnector { path }))
+    Ok(SinkConnector::AvroOcf(AvroOcfSinkConnector {
+        path,
+        frontier,
+        strict: !with_snapshot,
+    }))
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -588,11 +588,25 @@ pub struct KafkaSinkConnector {
     // Maximum number of records the sink will attempt to send each time it is
     // invoked
     pub fuel: usize,
+    pub frontier: Antichain<Timestamp>,
+    pub strict: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AvroOcfSinkConnector {
     pub path: PathBuf,
+    pub frontier: Antichain<Timestamp>,
+    pub strict: bool,
+}
+
+impl SinkConnector {
+    pub fn get_frontier(&self) -> Antichain<Timestamp> {
+        match self {
+            SinkConnector::AvroOcf(avro) => avro.frontier.clone(),
+            SinkConnector::Kafka(kafka) => kafka.frontier.clone(),
+            SinkConnector::Tail(tail) => tail.frontier.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -74,6 +74,8 @@ pub enum Plan {
     CreateSink {
         name: FullName,
         sink: Sink,
+        with_snapshot: bool,
+        as_of: Option<Timestamp>,
         if_not_exists: bool,
     },
     CreateTable {

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -85,8 +85,34 @@ $ kafka-verify format=avro sink=materialize.public.snk6
 {"before": null, "after": {"c": true}}
 {"before": null, "after": {"c": true}}
 
-! CREATE SINK should_fail FROM v4
+# Test AS OF and WITH/WITHOUT SNAPSHOT.
+> CREATE MATERIALIZED SOURCE dynamic_src
+  FROM FILE '${testdrive.temp-dir}/test.csv' WITH (tail = true)
+  FORMAT CSV WITH HEADER
+
+# Ensure the data is read into the source before creating sinks from it
+# to correctly test WITH/WITHOUT SNAPSHOT.
+> SELECT * FROM dynamic_src
+jack jill 2
+goofus gallant 3
+
+> CREATE SINK snk7 FROM dynamic_src
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk7'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  AS OF 123
-AS OF not yet supported
+  WITHOUT SNAPSHOT
+
+> CREATE SINK snk8 FROM dynamic_src
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk8'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH SNAPSHOT
+
+$ file-append path=test.csv
+extra,row
+
+$ kafka-verify format=avro sink=materialize.public.snk7
+{"before": null, "after": {"a": "extra", "b": "row", "mz_line_no": 4}}
+
+$ kafka-verify format=avro sink=materialize.public.snk8
+{"before": null, "after": {"a": "jack", "b": "jill", "mz_line_no": 2}}
+{"before": null, "after": {"a": "goofus", "b": "gallant", "mz_line_no": 3}}
+{"before": null, "after": {"a": "extra", "b": "row", "mz_line_no": 4}}


### PR DESCRIPTION
This PR updates our `CREATE SINK` syntax to accept the following new arguments:
- `AS OF`: optional time parameter, if provided the sink will only emit diffs from this time onwards
- `WITH` or `WITHOUT SNAPSHOT`: optional flag indicating whether or not diffs prior to the `AS OF` timestamp will be included in the sink

This change also includes basic testing, but we should improve the testing for the `AS OF` parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3467)
<!-- Reviewable:end -->
