### PR TITLE
parser: support for ARRAY-like syntax for LIST

### DIFF
--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -286,9 +286,8 @@ impl AstDisplay for DataType {
             DataType::Text => f.write_str("text"),
             DataType::Bytea => f.write_str("bytea"),
             DataType::List(ty) => {
-                f.write_str("list(");
                 f.write_node(&ty);
-                f.write_str(")")
+                f.write_str(" list");
             }
             DataType::Jsonb => f.write_str("jsonb"),
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1941,7 +1941,12 @@ impl Parser {
             if let Some(Token::RBracket) = self.peek_token() {
                 break;
             }
-            exprs.push(self.parse_expr()?);
+            let expr = if let Some(Token::LBracket) = self.peek_token() {
+                self.parse_list()?
+            } else {
+                self.parse_expr()?
+            };
+            exprs.push(expr);
             if !self.consume_token(&Token::Comma) {
                 break;
             }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -55,6 +55,20 @@ CREATE TABLE foo (bar int)
 CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: Int, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false }
 
 parse-statement
+CREATE TABLE foo (bar int list)
+----
+CREATE TABLE foo (bar int list)
+=>
+CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Int), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false }
+
+parse-statement
+CREATE TABLE foo (bar int list list)
+----
+CREATE TABLE foo (bar int list list)
+=>
+CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Int)), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false }
+
+parse-statement
 CREATE TABLE t ()
 ----
 CREATE TABLE t ()

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -243,3 +243,14 @@ Parse error:
 SELECT E'\u&&&&'
        ^^^^^^^^
 invalid unicode escape sequence
+
+# List literal expressions must begin with `LIST` before interior lists can
+# omit it.
+parse-statement
+SELECT [1, 2]
+----
+error:
+Parse error:
+SELECT [1, 2]
+       ^
+Expected an expression, found: [

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -222,3 +222,25 @@ parse-scalar
 INTERVAL '01:01:01.111111111' SECOND (5)
 ----
 Value(Interval(IntervalValue { value: "01:01:01.111111111", precision_high: Year, precision_low: Second, fsec_max_precision: Some(5) }))
+
+# Lists`
+
+parse-scalar
+LIST[1, 2]
+----
+List([Value(Number("1")), Value(Number("2"))])
+
+parse-scalar
+LIST[[1, 2], [3]]
+----
+List([List([Value(Number("1")), Value(Number("2"))]), List([Value(Number("3"))])])
+
+parse-scalar
+LIST[[1, 2], LIST[3]]
+----
+List([List([Value(Number("1")), Value(Number("2"))]), List([Value(Number("3"))])])
+
+parse-scalar
+LIST[[[[1], [2]]], [[[3]]]]
+----
+List([List([List([List([Value(Number("1"))]), List([Value(Number("2"))])])]), List([List([List([Value(Number("3"))])])])])

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -18,7 +18,7 @@ query error Cannot create list with mixed types
 select LIST[1,LIST[2,3]]
 
 query T
-select LIST[LIST[1],LIST[2,3]]
+select LIST[[1],[2,3]]
 ----
 {{1},{2,3}}
 
@@ -44,6 +44,21 @@ query T
 select LIST[1, null] :: INT LIST
 ----
 {1,NULL}
+
+query T
+select LIST[[1, null], []] :: INT LIST LIST
+----
+{{1,NULL},{}}
+
+# Lists support arbitrarily deep nesting
+query T
+SELECT LIST[[[[1], [2]]], [[[3]]]]
+----
+{{{{1},{2}}},{{{3}}}}
+
+# List(Int) cannot be cast to List(List(Int))
+query error Cannot create list with mixed types
+select LIST[1, null] :: INT LIST LIST
 
 query error
 select LIST[1, null] :: TEXT LIST


### PR DESCRIPTION
Improves `LIST`'s support of `ARRAY`-like syntax for the following sections of the [PostgreSQL Array syntax](https://www.postgresql.org/docs/12/arrays.html):

- Declaration of Array Types
- Array Value Input

Note that this only includes parser-level support for some missing bits of syntax; doesn't include any changes to the lower levels of code,  e.g. casting strings to `LIST`s.

Progress toward #2997

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3472)
<!-- Reviewable:end -->
