### PR TITLE
Fixing off-by-one error in partition creation count

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -1095,7 +1095,11 @@ fn downgrade_capability(
         if let Some(entries) = timestamp_histories.borrow_mut().get_mut(id) {
             match entries {
                 TimestampDataUpdate::RealTime(partition_count) => {
-                    dp_info.ensure_partition(cp_info, *partition_count)
+                    // This timestamp update informs us that the source now contains
+                    // partition_count partitions. Partition IDs are assigned contiguously
+                    // starting from zero, so seeing a `partition_count` of N means
+                    // that we should have partitions up to N-1.
+                    dp_info.ensure_partition(cp_info, *partition_count - 1)
                 }
                 _ => panic!("Unexpected timestamp message. Expected RT update."),
             }


### PR DESCRIPTION
This PR addresses an off-by-one bug in partition creation for RT sources.

Upon receiving a real-time update of N partitions from the timestamped, a real-time source must ensure that it has created all partitions up to N-1, as Kafka assigns partitions IDs contiguously, starting from 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3483)
<!-- Reviewable:end -->
