### PR TITLE
Rename interface from threads -> workers

### DIFF
--- a/demo/billing/README.md
+++ b/demo/billing/README.md
@@ -41,11 +41,11 @@ $ docker-compose up
 From the repository root start Materialize with:
 
 ```shell session
-$ cargo run --release -- --threads 8
+$ cargo run --release -- --workers 8
 ```
 
 Note that this runs a release build of Materialize, which is essential for performance
-testing but can be slow to compile. Also note that `--threads 8` starts Materialize with
+testing but can be slow to compile. Also note that `--workers 8` starts Materialize with
 8 worker threads which improves the throughput of update processing but loads the system
 more. Generally its best to run with no more than `ncpus - 2` threads.
 

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -22,7 +22,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: --threads ${MZ_THREADS:-1}
+    command: --workers ${MZ_THREADS:-1}
     environment:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000

--- a/doc/developer/develop.md
+++ b/doc/developer/develop.md
@@ -105,7 +105,7 @@ Materialize is fully integrated with Cargo, so building it is dead simple:
 ```shell
 git clone git@github.com:MaterializeInc/materialize.git
 cd materialize
-cargo run --release -- --threads 2
+cargo run --release -- --workers 2
 ```
 
 Because the MaterializeInc organization requires two-factor authentication

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -268,7 +268,7 @@ fancy_1         | 🎩 load
 materialized_1  | materialized: '--workers' must be specified and greater than 0
 materialized_1  | hint: As a starting point, set the number of threads to half of the number of
 materialized_1  | cores on your system. Then, further adjust based on your performance needs.
-materialized_1  | hint: You may also set the environment variable MZ_THREADS to the desired number
+materialized_1  | hint: You may also set the environment variable MZ_WORKERS to the desired number
 materialized_1  | of threads.
 fancy_fancy_1 exited with code 0
 fancy_materialized_1 exited with code 1

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -265,7 +265,7 @@ Starting fancy_fancy_1        ... done
 Creating fancy_materialized_1 ... done
 Attaching to fancy_fancy_1, fancy_materialized_1
 fancy_1         | 🎩 load
-materialized_1  | materialized: '--threads' must be specified and greater than 0
+materialized_1  | materialized: '--workers' must be specified and greater than 0
 materialized_1  | hint: As a starting point, set the number of threads to half of the number of
 materialized_1  | cores on your system. Then, further adjust based on your performance needs.
 materialized_1  | hint: You may also set the environment variable MZ_THREADS to the desired number

--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -19,7 +19,7 @@ Flag | Default | Modifies
 [`--processes`](#horizontally-scaled-clusters) | 1 | Number of coordinating Materialize nodes
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
 [`--tls-key`](#tls-encryption) | N/A | Path to TLS private key file
-[`--threads`](#worker-threads) | 1 | Dataflow worker threads
+[`--workers`](#worker-threads) | 1 | Dataflow worker threads
 [`--w`](#worker-threads) | 1 |  Dataflow worker threads
 `-v` | N/A | Print version and exit
 `-vv` | N/A | Print version and additional build information, and exit
@@ -38,7 +38,7 @@ found.
 
 A `materialized` instance runs a specified number of timely dataflow worker
 threads. By default, `materialized` runs with a single worker thread. Worker
-threads can only be specified at startup by setting the `--threads` flag, and
+threads can only be specified at startup by setting the `--workers` flag, and
 cannot be changed without shutting down `materialized` and restarting. In the
 future, dynamically changing the number of worker threads will be possible over
 distributed clusters, see

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -21,7 +21,7 @@ commit message. They should complete the sentence, "This release will...".
 
 Good release notes:
 
-  - [This release will...] Require the `-w` / `--threads` command-line option.
+  - [This release will...] Require the `-w` / `--workers` command-line option.
   - [This release will...] In the event of a crash, print the stack trace.
 
 Misbehaved release notes:
@@ -45,6 +45,13 @@ Use relative links (/path/to/doc), not absolute links
 
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
+
+<span id="v0.3.2"></span>
+## 0.3.2 (Unreleased)
+
+- Rename the `-w`/`--threads` command line argument to `-w`/`--workers`, since it
+  reflects timely workers and does not limit the number of threads that materialized may
+  start.
 
 <span id="v0.3.1"></span>
 ## 0.3.1 (Unreleased)

--- a/src/materialized/src/bin/materialized.rs
+++ b/src/materialized/src/bin/materialized.rs
@@ -187,10 +187,19 @@ fn run() -> Result<(), failure::Error> {
                 warn!("--threads is deprecated and will stop working in the future. Please use --workers.");
                 val
             }
-            None => match env::var("MZ_THREADS") {
+            None => match env::var("MZ_WORKERS") {
                 Ok(val) => val.parse()?,
-                Err(VarError::NotUnicode(_)) => bail!("non-unicode character found in MZ_THREADS"),
-                Err(VarError::NotPresent) => 0,
+                Err(VarError::NotUnicode(_)) => bail!("non-unicode character found in MZ_WORKERS"),
+                Err(VarError::NotPresent) => match env::var("MZ_THREADS") {
+                    Ok(val) => {
+                        warn!("MZ_THREADS is a deprecated alias for MZ_WORKERS");
+                        val.parse()?
+                    }
+                    Err(VarError::NotUnicode(_)) => {
+                        bail!("non-unicode character found in MZ_THREADS")
+                    }
+                    Err(VarError::NotPresent) => 0,
+                },
             },
         },
     };
@@ -199,7 +208,7 @@ fn run() -> Result<(), failure::Error> {
             "'--workers' must be specified and greater than 0\n\
             hint: As a starting point, set the number of threads to half of the number of\n\
             cores on your system. Then, further adjust based on your performance needs.\n\
-            hint: You may also set the environment variable MZ_THREADS to the desired number\n\
+            hint: You may also set the environment variable MZ_WORKERS to the desired number\n\
             of threads."
         );
     }

--- a/src/materialized/tests/cli.rs
+++ b/src/materialized/tests/cli.rs
@@ -26,7 +26,7 @@ fn cmd() -> Command {
 fn test_threads() {
     let assert_fail = |cmd: &mut Command| {
         cmd.assert().failure().stderr(predicate::str::starts_with(
-            "materialized: '--threads' must be specified and greater than 0",
+            "materialized: '--workers' must be specified and greater than 0",
         ))
     };
     assert_fail(&mut cmd());

--- a/src/materialized/tests/cli.rs
+++ b/src/materialized/tests/cli.rs
@@ -31,7 +31,7 @@ fn test_threads() {
     };
     assert_fail(&mut cmd());
     assert_fail(cmd().arg("-w0"));
-    assert_fail(cmd().env("MZ_THREADS", "0"));
+    assert_fail(cmd().env("MZ_WORKERS", "0"));
 
     cmd()
         .arg("-w")
@@ -43,14 +43,14 @@ fn test_threads() {
         ));
 
     cmd()
-        .env("MZ_THREADS", OsStr::from_bytes(&[0xc2, 0xc2]))
+        .env("MZ_WORKERS", OsStr::from_bytes(&[0xc2, 0xc2]))
         .assert()
         .failure()
         .stderr(predicate::str::starts_with(
-            "materialized: non-unicode character found in MZ_THREADS",
+            "materialized: non-unicode character found in MZ_WORKERS",
         ));
 
-    // NOTE: we don't test the successful case, where `MZ_THREADS` or `-w` is
+    // NOTE: we don't test the successful case, where `MZ_WORKERS` or `-w` is
     // specified correctly, because it's presently hard to check if Materialized
     // has started correctly, since it runs forever. The success code path is
     // well exercised by integration tests, so it's not a big deal.

--- a/test/smith/mzcompose.yml
+++ b/test/smith/mzcompose.yml
@@ -14,7 +14,7 @@ services:
     ports:
      - 6875
     init: true
-    command: --threads 1
+    command: --workers 1
     environment:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000


### PR DESCRIPTION
Note that this does *not* rename the env vars in the mzcompose files, since we need to
migrate our infrastructure to set the new variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3491)
<!-- Reviewable:end -->
