### PR TITLE
*: support anonymous record types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,6 +1701,7 @@ dependencies = [
  "openssl-sys",
  "ore",
  "parse_duration",
+ "pgrepr",
  "pgwire",
  "postgres",
  "postgres-openssl",
@@ -2397,9 +2398,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e634590e8812c500088d88db721195979223dabb05149f43cb50931d0ff5865d"
+checksum = "3d14b0a4f433b0e0b565bb0fbc0ac9fc3d79ca338ba265ad0e7eef0f3bcc5e94"
 dependencies = [
  "bytes",
  "chrono",

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -142,7 +142,7 @@ tests=(
     # test/sqllogictest/cockroach/time.slt
     test/sqllogictest/cockroach/timestamp.slt
     test/sqllogictest/cockroach/truncate.slt
-    # test/sqllogictest/cockroach/tuple.slt
+    test/sqllogictest/cockroach/tuple.slt
     # test/sqllogictest/cockroach/typing.slt
     # test/sqllogictest/cockroach/union-opt.slt
     test/sqllogictest/cockroach/union.slt

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -868,7 +868,8 @@ fn build_schema(columns: &[(ColumnName, ColumnType)]) -> Schema {
                 "type": "string",
                 "connect.name": "io.debezium.data.Json",
             }),
-            ScalarType::List(_t) => unimplemented!("jamii/list"),
+            ScalarType::List(_t) => unimplemented!("list types"),
+            ScalarType::Record { .. } => unimplemented!("record types"),
         };
         if typ.nullable {
             field_type = json!(["null", field_type]);
@@ -1051,7 +1052,8 @@ impl Encoder {
                     ScalarType::Bytes => Value::Bytes(Vec::from(datum.unwrap_bytes())),
                     ScalarType::String => Value::String(datum.unwrap_str().to_owned()),
                     ScalarType::Jsonb => Value::Json(JsonbRef::from_datum(datum).to_serde_json()),
-                    ScalarType::List(_t) => unimplemented!("jamii/list"),
+                    ScalarType::List(_t) => unimplemented!("list types"),
+                    ScalarType::Record { .. } => unimplemented!("record types"),
                 };
                 if typ.nullable {
                     val = Value::Union(1, Box::new(val));

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -49,6 +49,7 @@ assert_cmd = "1.0.1"
 chrono = "0.4"
 fallible-iterator = "0.2.0"
 itertools = "0.9"
+pgrepr = { path = "../pgrepr" }
 postgres = { version = "0.17", features = ["with-chrono-0_4"] }
 predicates = "1.0.4"
 serde_json = "1"

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -27,4 +27,5 @@ pub use types::Type;
 pub use value::interval::Interval;
 pub use value::jsonb::Jsonb;
 pub use value::numeric::Numeric;
+pub use value::record::Record;
 pub use value::{null_datum, values_from_row, Value};

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -35,6 +35,8 @@ pub enum Type {
     List(Box<Type>),
     /// An arbitrary precision number.
     Numeric,
+    /// A sequence of heterogeneous values.
+    Record(Vec<Type>),
     /// A variable-length string.
     Text,
     /// A time of day without a day.
@@ -76,6 +78,7 @@ impl Type {
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
             Type::List(_) => &LIST,
+            Type::Record(_) => &postgres_types::Type::RECORD,
         }
     }
 
@@ -110,6 +113,7 @@ impl Type {
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
             Type::List(_) => -1,
+            Type::Record(_) => -1,
         }
     }
 }
@@ -132,6 +136,9 @@ impl From<&ScalarType> for Type {
             ScalarType::String => Type::Text,
             ScalarType::Jsonb => Type::Jsonb,
             ScalarType::List(t) => Type::List(Box::new(From::from(&**t))),
+            ScalarType::Record { fields } => {
+                Type::Record(fields.iter().map(|(_name, ty)| Type::from(ty)).collect())
+            }
         }
     }
 }

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -8,9 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use std::error::Error;
+use std::fmt;
 use std::str;
 
-use bytes::BytesMut;
+use bytes::{BufMut, BytesMut};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use postgres_types::{FromSql, IsNull, ToSql, Type as PgType};
 
@@ -18,13 +19,14 @@ use ore::fmt::FormatBuffer;
 use repr::adt::decimal::MAX_DECIMAL_PRECISION;
 use repr::adt::jsonb::JsonbRef;
 use repr::strconv::{self, Nestable};
-use repr::{Datum, RelationType, Row, RowArena, RowPacker, ScalarType};
+use repr::{ColumnName, Datum, RelationType, Row, RowArena, RowPacker, ScalarType};
 
 use crate::{Format, Interval, Jsonb, Numeric, Type};
 
 pub mod interval;
 pub mod jsonb;
 pub mod numeric;
+pub mod record;
 
 /// A PostgreSQL datum.
 #[derive(Debug)]
@@ -49,6 +51,8 @@ pub enum Value {
     List(Vec<Option<Value>>),
     /// An arbitrary precision number.
     Numeric(Numeric),
+    /// A sequence of heterogeneous values.
+    Record(Vec<Option<Value>>),
     /// A time.
     Time(NaiveTime),
     /// A date and time, without a timezone.
@@ -91,6 +95,13 @@ impl Value {
             (Datum::List(list), ScalarType::List(elem_type)) => Some(Value::List(
                 list.iter()
                     .map(|elem| Value::from_datum(elem, elem_type))
+                    .collect(),
+            )),
+            (Datum::List(record), ScalarType::Record { fields, .. }) => Some(Value::Record(
+                record
+                    .iter()
+                    .zip(fields)
+                    .map(|(e, (_name, ty))| Value::from_datum(e, ty))
                     .collect(),
             )),
             _ => panic!("can't serialize {}::{}", datum, typ),
@@ -143,16 +154,21 @@ impl Value {
                     ScalarType::List(Box::new(elem_type)),
                 )
             }
+            Value::Record(_) => {
+                // This situation is handled gracefully by Value::decode; if we
+                // wind up here it's a programming error.
+                panic!("into_datum cannot be called on Value::Record");
+            }
         }
     }
 
     /// Serializes this value to `buf` in the specified `format`.
-    pub fn encode(&self, format: Format, buf: &mut BytesMut) {
+    pub fn encode(&self, ty: &Type, format: Format, buf: &mut BytesMut) {
         match format {
             Format::Text => {
                 self.encode_text(buf);
             }
-            Format::Binary => self.encode_binary(buf),
+            Format::Binary => self.encode_binary(ty, buf),
         }
     }
 
@@ -178,12 +194,13 @@ impl Value {
             Value::Text(s) => strconv::format_string(buf, s),
             Value::Jsonb(js) => strconv::format_jsonb(buf, js.0.as_ref()),
             Value::List(elems) => encode_list(buf, elems),
+            Value::Record(elems) => encode_record(buf, elems),
         }
     }
 
     /// Serializes this value to `buf` using the [binary encoding
     /// format](Format::Binary).
-    pub fn encode_binary(&self, buf: &mut BytesMut) {
+    pub fn encode_binary(&self, ty: &Type, buf: &mut BytesMut) {
         let is_null = match self {
             Value::Bool(b) => b.to_sql(&PgType::BOOL, buf),
             Value::Bytea(b) => b.to_sql(&PgType::BYTEA, buf),
@@ -202,6 +219,28 @@ impl Value {
             Value::List(_) => {
                 // for now just use text encoding
                 self.encode_text(buf);
+                Ok(postgres_types::IsNull::No)
+            }
+            Value::Record(fields) => {
+                buf.put_i32(fields.len() as i32);
+                let field_types = match ty {
+                    Type::Record(fields) => fields,
+                    _ => unreachable!(),
+                };
+                for (f, ty) in fields.iter().zip(field_types) {
+                    buf.put_u32(ty.oid());
+                    match f {
+                        None => buf.put_i32(-1),
+                        Some(f) => {
+                            let base = buf.len();
+                            buf.put_i32(0);
+                            f.encode_binary(ty, buf);
+                            let len = buf.len() - base - 4;
+                            let len = (len as u32).to_be_bytes();
+                            buf[base..base + 4].copy_from_slice(&len);
+                        }
+                    }
+                }
                 Ok(postgres_types::IsNull::No)
             }
         }
@@ -244,6 +283,11 @@ impl Value {
             Type::Numeric => Value::Numeric(Numeric(strconv::parse_decimal(raw)?)),
             Type::Jsonb => Value::Jsonb(Jsonb(strconv::parse_jsonb(raw)?)),
             Type::List(elem_type) => Value::List(decode_list(&elem_type, raw)?),
+            Type::Record(_) => {
+                return Err(Box::new(DecodeError::new(
+                    "input of anonymous composite types is not implemented",
+                )))
+            }
         })
     }
 
@@ -269,9 +313,32 @@ impl Value {
                 // just using the text encoding for now
                 Value::decode_text(ty, raw)
             }
+            Type::Record(_) => Err(Box::new(DecodeError::new(
+                "input of anonymous composite types is not implemented",
+            ))),
         }
     }
 }
+
+#[derive(Debug)]
+struct DecodeError(String);
+
+impl DecodeError {
+    fn new<S>(message: S) -> DecodeError
+    where
+        S: Into<String>,
+    {
+        DecodeError(message.into())
+    }
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Error for DecodeError {}
 
 fn encode_list<F>(buf: &mut F, elems: &[Option<Value>]) -> Nestable
 where
@@ -292,6 +359,16 @@ fn decode_list(
         || None,
         |elem_text| Value::decode_text(elem_type, elem_text.as_bytes()).map(Some),
     )?)
+}
+
+fn encode_record<F>(buf: &mut F, elems: &[Option<Value>]) -> Nestable
+where
+    F: FormatBuffer,
+{
+    strconv::format_record(buf, elems, |buf, elem| match elem {
+        None => buf.write_null(),
+        Some(elem) => elem.encode_text(buf.nonnull_buffer()),
+    })
 }
 
 /// Constructs a null datum of the specified type.
@@ -315,6 +392,16 @@ pub fn null_datum(ty: &Type) -> (Datum<'static>, ScalarType) {
             let (_, elem_type) = null_datum(t);
             ScalarType::List(Box::new(elem_type))
         }
+        Type::Record(fields) => ScalarType::Record {
+            fields: fields
+                .iter()
+                .enumerate()
+                .map(|(i, ty)| {
+                    let name = ColumnName::from(format!("f{}", i + 1));
+                    (name, null_datum(ty).1)
+                })
+                .collect(),
+        },
     };
     (Datum::Null, ty)
 }

--- a/src/pgrepr/src/value/record.rs
+++ b/src/pgrepr/src/value/record.rs
@@ -1,0 +1,76 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// TODO(benesch): remove this module if upstream adds implementations of FromSql
+// to tuples directly: https://github.com/sfackler/rust-postgres/pull/626.
+
+use std::error::Error;
+
+use postgres_types::{private, FromSql, Kind, Type, WrongType};
+
+/// A wrapper for tuples that implements [`FromSql`] for PostgreSQL composite
+/// types.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Record<T>(pub T);
+
+macro_rules! impl_tuple {
+    ($n:expr; $($ty_ident:ident),*; $($var_ident:ident),*) => {
+        impl<'a, $($ty_ident),*> FromSql<'a> for Record<($($ty_ident,)*)>
+        where
+            $($ty_ident: FromSql<'a>),*
+        {
+            fn from_sql(
+                _: &Type,
+                mut raw: &'a [u8],
+            ) -> Result<Record<($($ty_ident,)*)>, Box<dyn Error + Sync + Send>> {
+                let num_fields = private::read_be_i32(&mut raw)?;
+                if num_fields as usize != $n {
+                    return Err(format!(
+                        "Postgres record field count does not match Rust tuple length: {} vs {}",
+                        num_fields,
+                        $n,
+                    ).into());
+                }
+
+                $(
+                    let oid = private::read_be_i32(&mut raw)? as u32;
+                    let ty = match Type::from_oid(oid) {
+                        None => {
+                            return Err(format!(
+                                "cannot decode OID {} inside of anonymous record",
+                                oid,
+                            ).into());
+                        }
+                        Some(ty) if !$ty_ident::accepts(&ty) => {
+                            return Err(Box::new(WrongType::new::<$ty_ident>(ty.clone())));
+                        }
+                        Some(ty) => ty,
+                    };
+                    let $var_ident = private::read_value(&ty, &mut raw)?;
+                )*
+
+                Ok(Record(($($var_ident,)*)))
+            }
+
+            fn accepts(ty: &Type) -> bool {
+                match ty.kind() {
+                    Kind::Pseudo => *ty == Type::RECORD,
+                    Kind::Composite(fields) => fields.len() == $n,
+                    _ => false,
+                }
+            }
+        }
+    };
+}
+
+impl_tuple!(0; ; );
+impl_tuple!(1; T0; v0);
+impl_tuple!(2; T0, T1; v0, v1);
+impl_tuple!(3; T0, T1, T2; v0, v1, v2);
+impl_tuple!(4; T0, T1, T2, T3; v0, v1, v2, v3);

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-
 use bytes::BytesMut;
 use postgres::error::SqlState;
 
@@ -244,7 +242,7 @@ pub enum BackendMessage {
     EmptyQueryResponse,
     ReadyForQuery(TransactionStatus),
     RowDescription(Vec<FieldDescription>),
-    DataRow(Vec<Option<pgrepr::Value>>, Arc<Vec<pgrepr::Format>>),
+    DataRow(Vec<Option<pgrepr::Value>>),
     ParameterStatus(&'static str, String),
     BackendKeyData {
         conn_id: u32,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -131,7 +131,7 @@ impl RelationType {
 }
 
 /// The name of a column in a [`RelationDesc`].
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct ColumnName(String);
 
 impl ColumnName {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -11,12 +11,13 @@ use std::fmt::{self, Write};
 use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 use crate::adt::decimal::Significand;
 use crate::adt::interval::Interval;
-use crate::{ColumnType, DatumDict, DatumList};
+use crate::{ColumnName, ColumnType, DatumDict, DatumList};
 
 /// A single value.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -52,7 +53,7 @@ pub enum Datum<'a> {
     Bytes(&'a [u8]),
     /// A sequence of Unicode codepoints encoded as UTF-8.
     String(&'a str),
-    /// A homogeneous sequence of `Datum`s.
+    /// A sequence of `Datum`s.
     List(DatumList<'a>),
     /// A mapping from string keys to `Datum`s.
     Dict(DatumDict<'a>),
@@ -321,6 +322,10 @@ impl<'a> Datum<'a> {
                     (Datum::List(list), ScalarType::List(t)) => list
                         .iter()
                         .all(|e| e.is_null() || is_instance_of_scalar(e, t)),
+                    (Datum::List(list), ScalarType::Record { fields }) => list
+                        .iter()
+                        .zip_eq(fields)
+                        .all(|(e, (_, t))| e.is_null() || is_instance_of_scalar(e, t)),
                     (Datum::List(_), _) => false,
                     (Datum::Dict(_), _) => false,
                     (Datum::JsonNull, _) => false,
@@ -582,6 +587,12 @@ pub enum ScalarType {
     /// Elements within the list are of the specified type. List elements may
     /// always be [`Datum::Null`].
     List(Box<ScalarType>),
+    /// An ordered and named sequence of datums.
+    Record {
+        /// The names and types of the fields of the record, in order from left
+        /// to right.
+        fields: Vec<(ColumnName, ScalarType)>,
+    },
 }
 
 impl<'a> ScalarType {
@@ -617,6 +628,19 @@ impl<'a> ScalarType {
             ScalarType::String => Datum::String(""),
             ScalarType::Jsonb => Datum::JsonNull,
             ScalarType::List(_) => Datum::List(DatumList::empty()),
+            // NOTE(benesch): This is kind of wrong--we should recursively
+            // construct dummy datums for the inner record bits--but it is not
+            // possible to implement this method correctly for record types
+            // without refactoring it to take a `RowPacker`. And it doesn't
+            // actually matter, because dummy datums are only constructed in
+            // situations where the actual value of the datum doesn't matter...
+            // which raises the question, why are we trying so hard to construct
+            // a datum of the correct type if no one cares about the type?
+            //
+            // So, if you're here because this dummy record type is unsuitable
+            // for your purposes, consider figuring out how to remove this
+            // method rather than trying to fix it.
+            ScalarType::Record { .. } => Datum::List(DatumList::empty()),
         }
     }
 
@@ -655,6 +679,7 @@ impl PartialEq for ScalarType {
             | (Jsonb, Jsonb) => true,
 
             (List(a), List(b)) => a.eq(b),
+            (Record { fields: fields_a }, Record { fields: fields_b }) => fields_a.eq(fields_b),
 
             (Bool, _)
             | (Int32, _)
@@ -670,7 +695,8 @@ impl PartialEq for ScalarType {
             | (Bytes, _)
             | (String, _)
             | (Jsonb, _)
-            | (List(_), _) => false,
+            | (List(_), _)
+            | (Record { .. }, _) => false,
         }
     }
 }
@@ -702,6 +728,10 @@ impl Hash for ScalarType {
                 state.write_u8(14);
                 t.hash(state);
             }
+            Record { fields } => {
+                state.write_u8(15);
+                fields.hash(state);
+            }
         }
     }
 }
@@ -730,6 +760,11 @@ impl fmt::Display for ScalarType {
             String => f.write_str("string"),
             Jsonb => f.write_str("jsonb"),
             List(t) => write!(f, "{}[]", t),
+            Record { fields } => {
+                f.write_str("record(")?;
+                write_delimited(f, ", ", fields, |f, (n, t)| write!(f, "{}: {}", n, t))?;
+                f.write_str(")")
+            }
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -178,8 +178,9 @@ pub enum CoercibleScalarExpr {
     Coerced(ScalarExpr),
     Parameter(usize),
     LiteralNull,
-    LiteralList(Vec<CoercibleScalarExpr>),
     LiteralString(String),
+    LiteralList(Vec<CoercibleScalarExpr>),
+    LiteralRecord(Vec<CoercibleScalarExpr>),
 }
 
 impl CoercibleScalarExpr {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -75,6 +75,7 @@ impl TypeCategory {
             | ScalarType::Int64 => Self::Numeric,
             ScalarType::Interval => Self::Timespan,
             ScalarType::String => Self::String,
+            ScalarType::Record { .. } => Self::Pseudo,
         }
     }
 

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -504,9 +504,10 @@ SELECT count(*), count(k), count(kv.v) FROM kv
 count  count  count
 6      6      5
 
-# #3179
-statement error invalid position
+query I
 SELECT count(kv.*) FROM kv
+----
+6
 
 query III
 SELECT count(DISTINCT k), count(DISTINCT v), count(DISTINCT (v)) FROM kv
@@ -555,9 +556,10 @@ SELECT count(*) FROM kv a, kv b
 ----
 36
 
-# #3179
-statement error invalid position
+query I
 SELECT count(DISTINCT a.*) FROM kv a, kv b
+----
+6
 
 query I
 SELECT count(k)+count(kv.v) FROM kv
@@ -687,7 +689,7 @@ SELECT avg(a) FROM abc
 query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT avg(c) FROM abc
 
-query error ROW constructors are not supported yet
+query error unable to determine which implementation to use
 SELECT avg((a,c)) FROM abc
 
 query error arguments cannot be implicitly cast to any implementation's parameters
@@ -696,7 +698,7 @@ SELECT sum(a) FROM abc
 query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT sum(c) FROM abc
 
-query error ROW constructors are not supported yet
+query error unable to determine which implementation to use
 SELECT sum((a,c)) FROM abc
 
 statement ok

--- a/test/sqllogictest/cockroach/tuple.slt
+++ b/test/sqllogictest/cockroach/tuple.slt
@@ -54,11 +54,16 @@ SELECT (1, 2, 'hello', NULL, NULL) AS t, (true, NULL, (false, 6.6, false)) AS u 
 t              u
 (1,2,hello,,)  (t,,"(f,6.6,f)")
 
-query T
+mode standard
+
+query T multiline
 SELECT (1, e'hello\nworld')
 ----
 (1,"hello
 world")
+EOF
+
+mode cockroach
 
 query BBBBBBBBB colnames
 SELECT
@@ -167,10 +172,10 @@ SELECT
 a     b     c      d
 true  NULL  false  NULL
 
-statement error pq: tuples \(1, 2\), \(1, 'hi'\) are not comparable at index 2: unsupported comparison operator
+statement error invalid input syntax for int4
 SELECT (1, 2) > (1, 'hi') FROM tb
 
-statement error pq: expected tuple \(1, 2, 3\) to have a length of 2
+statement error unequal number of entries in row expressions
 SELECT (1, 2) > (1, 2, 3) FROM tb
 
 statement ok
@@ -194,13 +199,15 @@ a b c
 2 3 1
 3 1 2
 
-query T colnames,rowsort
+# NOTE(benesch): Cockroach mishandles this. This test has been adapted to match
+# PostgreSQL.
+query III colnames,rowsort
 SELECT (t.*) AS a FROM t
 ----
-a
-(2,3,1)
-(3,1,2)
-(1,2,3)
+a b c
+2 3 1
+3 1 2
+1 2 3
 
 query BB colnames
 SELECT ((1, 2), 'equal') = ((1, 2.0), 'equal') AS a,
@@ -218,20 +225,20 @@ a
 false
 
 query B colnames
-SELECT (ROW(pow(1, 10.0) + 9), 'a' || 'b') = (ROW(sqrt(100.0)), 'ab') AS a
+SELECT (ROW(1 + 9), 'a' || 'b') = (ROW(sqrt(100.0)), 'ab') AS a
   FROM tb
 ----
 a
 true
 
 query B colnames
-SELECT (ROW(sqrt(100.0)), 'ab') = (ROW(pow(1, 10.0) + 9), 'a' || 'b') AS a
+SELECT (ROW(sqrt(100.0)), 'ab') = (ROW(1 + 9), 'a' || 'b') AS a
   FROM tb
 ----
 a
 true
 
-query error pq: tuples \(\(1, 2\), 'equal'\), \(\(1, 'huh'\), 'equal'\) are not comparable at index 1: tuples \(1, 2\), \(1, 'huh'\) are not comparable at index 2: unsupported comparison operator
+query error invalid input syntax for int4
 SELECT ((1, 2), 'equal') = ((1, 'huh'), 'equal') FROM tb
 
 # Issue #3568
@@ -311,7 +318,7 @@ r
 NULL
 
 query B colnames
-SELECT 1 IN (2, x) AS r FROM (SELECT NULL AS x FROM tb)
+SELECT 1 IN (2, x) AS r FROM (SELECT NULL::int AS x FROM tb)
 ----
 r
 NULL
@@ -678,219 +685,33 @@ DROP TABLE uvw
 
 subtest tuple_placeholders
 
-statement ok
-PREPARE x AS SELECT $1 = (1,2) AS r FROM tb
+# TODO(benesch): support the statement form of PREPARE and EXECUTE.
+#
+# statement ok
+# PREPARE x AS SELECT $1 = (1,2) AS r FROM tb
+#
+# statement ok
+# PREPARE y AS SELECT (1,2) = $1 AS r FROM tb
+#
+# query B colnames
+# EXECUTE x((1,2))
+# ----
+# r
+# true
+#
+# query B colnames
+# EXECUTE y((1,2))
+# ----
+# r
+# true
+#
+# query error expected EXECUTE parameter expression to have type tuple\{int, int\}, but '\(1, 2, 3\)' has type tuple\{int, int, int\}
+# EXECUTE x((1,2,3))
 
-statement ok
-PREPARE y AS SELECT (1,2) = $1 AS r FROM tb
-
-query B colnames
-EXECUTE x((1,2))
-----
-r
-true
-
-query B colnames
-EXECUTE y((1,2))
-----
-r
-true
-
-query error expected EXECUTE parameter expression to have type tuple\{int, int\}, but '\(1, 2, 3\)' has type tuple\{int, int, int\}
-EXECUTE x((1,2,3))
-
-subtest labeled_tuple
-
-# Selecting two tuples
-query TT colnames
-SELECT ((1, 2, 'hello', NULL, NULL) AS a1, b2, c3, d4, e5) AS r,
-       ((true, NULL, (false, 6.6, false)) AS a1, b2, c3) AS s
-  FROM tb
-----
-r              s
-(1,2,hello,,)  (t,,"(f,6.6,f)")
-
-# Comparing tuples
-query BBB colnames
-SELECT ((2, 2) AS a, b) < ((1, 1) AS c, d) AS r
-      ,((2, 2) AS a, b) < (1, 2) AS s
-      ,(2, 2) < ((1, 3) AS c, d) AS t
- FROM tb
-----
-r      s      t
-false  false  false
-
-statement error pq: tuples \(\(1, 2\) AS a, b\), \(\(1, 'hi'\) AS c, d\) are not comparable at index 2: unsupported comparison operator: <int> > <string>
-SELECT ((1, 2) AS a, b) > ((1, 'hi') AS c, d) FROM tb
-
-statement error pq: expected tuple \(\(1, 2, 3\) AS a, b, c\) to have a length of 2
-SELECT ((1, 2) AS a, b, c) > ((1, 2, 3) AS a, b, c) FROM tb
-
-query BBBBBBBBBBBBBBBB colnames
-SELECT ((((1, 2) AS a, b), 'value') AS c, d) = ((((1, 2) AS e, f), 'value') AS g, h) AS nnnn
-      ,((((1, 2) AS a, b), 'value') AS c, d) = (((1, 2) AS e, f), 'value')           AS nnnu
-      ,((((1, 2) AS a, b), 'value') AS c, d) = (((1, 2), 'value') AS g, h)           AS nnun
-      ,((((1, 2) AS a, b), 'value') AS c, d) = ((1, 2), 'value')                     AS nnuu
-      ,(((1, 2) AS a, b), 'value')           = ((((1, 2) AS e, f), 'value') AS g, h) AS nunn
-      ,(((1, 2) AS a, b), 'value')           = (((1, 2) AS e, f), 'value')           AS nunu
-      ,(((1, 2) AS a, b), 'value')           = (((1, 2), 'value') AS g, h)           AS nuun
-      ,(((1, 2) AS a, b), 'value')           = ((1, 2), 'value')                     AS nuuu
-      ,(((1, 2), 'value') AS c, d)           = ((((1, 2) AS e, f), 'value') AS g, h) AS unnn
-      ,(((1, 2), 'value') AS c, d)           = (((1, 2) AS e, f), 'value')           AS unnu
-      ,(((1, 2), 'value') AS c, d)           = (((1, 2), 'value') AS g, h)           AS unun
-      ,(((1, 2), 'value') AS c, d)           = ((1, 2), 'value')                     AS unuu
-      ,((1, 2), 'value')                     = ((((1, 2) AS e, f), 'value') AS g, h) AS uunn
-      ,((1, 2), 'value')                     = (((1, 2) AS e, f), 'value')           AS uunu
-      ,((1, 2), 'value')                     = (((1, 2), 'value') AS g, h)           AS uuun
-      ,((1, 2), 'value')                     = ((1, 2), 'value')                     AS uuuu
- FROM tb
-----
-nnnn  nnnu  nnun  nnuu  nunn  nunu  nuun  nuuu  unnn  unnu  unun  unuu  uunn  uunu  uuun  uuuu
-true  true  true  true  true  true  true  true  true  true  true  true  true  true  true  true
-
-query BB colnames
-SELECT (((ROW(pow(1, 10.0) + 9) AS t1), 'a' || 'b') AS t2, t3) = (((ROW(sqrt(100.0)) AS t4), 'ab') AS t5, t6) AS a
-      ,(ROW(pow(1, 10.0) + 9), 'a' || 'b') = (((ROW(sqrt(100.0)) AS t4), 'ab') AS t5, t6) AS b
- FROM tb
-----
-a     b
-true  true
-
-subtest labeled_tuple_errors
-
-query error pq: tuples \(\(\(\(1, 2\) AS a, b\), 'equal'\) AS c, d\), \(\(\(\(1, 'huh'\) AS e, f\), 'equal'\) AS g, h\) are not comparable at index 1: tuples \(\(1, 2\) AS a, b\), \(\(1, 'huh'\) AS e, f\) are not comparable at index 2: unsupported comparison operator: <int> = <string>
-SELECT ((((1, 2) AS a, b), 'equal') AS c, d) = ((((1, 'huh') AS e, f), 'equal') AS g, h) FROM tb
-
-# Ensure the number of labels matches the number of expressions
-query error pq: mismatch in tuple definition: 2 expressions, 1 labels
-SELECT ((1, '2') AS a) FROM tb
-
-query error pq: mismatch in tuple definition: 1 expressions, 2 labels
-SELECT (ROW(1) AS a, b) FROM tb
-
-# Tuple labels must be different
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2') AS a, a) FROM tb
-
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2', true) AS a, a, b) FROM tb
-
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2', true) AS a, b, a) FROM tb
-
-query error pq: found duplicate tuple label: "a"
-SELECT ((1, '2', true) AS b, a, a) FROM tb
-
-# But inner tuples can reuse labels
-query T colnames
-SELECT ((
-         (
-          (((1, '2', 3) AS a, b, c),
-           ((4,'5') AS a, b),
-		   (ROW(6) AS a))
-		   AS a, b, c),
-		 ((7, 8) AS a, b),
-		 (ROW('9') AS a))
-		 AS a, b, c
-		) AS r
- FROM tb
-----
-r
-("(""(1,2,3)"",""(4,5)"",""(6)"")","(7,8)","(9)")
-
-subtest labeled_tuple_column_access
-
-## base working case
-
-# Accessing a specific column
-query error pq: could not identify column "x" in tuple{int AS a, int AS b, int AS c}
-SELECT (((1,2,3) AS a,b,c)).x FROM tb
-
-query ITBITB colnames
-SELECT (((1,'2',true) AS a,b,c)).a
-      ,(((1,'2',true) AS a,b,c)).b
-      ,(((1,'2',true) AS a,b,c)).c
-      ,((ROW(1,'2',true) AS a,b,c)).a
-      ,((ROW(1,'2',true) AS a,b,c)).b
-      ,((ROW(1,'2',true) AS a,b,c)).c
- FROM tb
-----
-a  b  c     a  b  c
-1  2  true  1  2  true
-
-subtest labeled_tuple_column_access_errors
-
-# column doesn't exist
-query error pq: could not identify column "x" in tuple{int AS a, int AS b, int AS c}
-SELECT (((1,2,3) AS a,b,c)).x FROM tb
-
-# Missing extra parentheses
-query error pq: syntax error at or near "."
-SELECT ((1,2,3) AS a,b,c).x FROM tb
-
-query error pq: syntax error at or near "."
-SELECT ((1,2,3) AS a,b,c).* FROM tb
-
-# No labels
-query error pq: type tuple{int, int, int} is not composite
-SELECT ((1,2,3)).x FROM tb
-
-query error pq: type tuple{int, int, int} is not composite
-SELECT ((1,2,3)).* FROM tb
-
-# Accessing all the columns
-
-query ITB colnames
-SELECT (((1,'2',true) AS a,b,c)).* FROM tb
-----
-a  b  c
-1  2  true
-
-query ITB colnames
-SELECT ((ROW(1,'2',true) AS a,b,c)).* FROM tb
-----
-a  b  c
-1  2  true
-
-query T
-SELECT (((ROW(1,'2',true) AS a,b,c)).*, 456) FROM tb
-----
-("(1,2,t)",456)
-
-query I colnames
-SELECT ((ROW(1) AS a)).* FROM tb
-----
-a
-1
-
-
-subtest literal_labeled_tuple_in_subquery
-
-query ITB colnames
-SELECT (x).e, (x).f, (x).g
-FROM (
-  SELECT ((1,'2',true) AS e,f,g) AS x FROM tb
-)
-----
-e  f  g
-1  2  true
-
-query ITB colnames
-SELECT (x).*
-FROM (
-  SELECT ((1,'2',true) AS e,f,g) AS x FROM tb
-)
-----
-e  f  g
-1  2  true
-
-subtest labeled_tuples_derived_from_relational_subquery_schema
-
-query IT
-  SELECT (x).a, (x).b
-    FROM (SELECT (ROW(a, b) AS a, b) AS x FROM (VALUES (1, 'one')) AS t(a, b))
-----
-1 one
+# NOTE(benesch): many tests related to a CockroachDB extension called "labeled
+# tuples" were removed from this test file. The labeled tuple extension looks
+# like a bad hack to work around CockroachDB's missing support for true
+# composite types, and I do not expect us to ever support it.
 
 statement ok
 CREATE TABLE t (a int, b string)
@@ -899,14 +720,12 @@ statement ok
 INSERT INTO t VALUES (1, 'one'), (2, 'two')
 
 query IT
-  SELECT (x).a, (x).b
-    FROM (SELECT (ROW(a, b) AS a, b) AS x FROM t)
+  SELECT (x).f1, (x).f2
+    FROM (SELECT (ROW(a, b)) AS x FROM t)
 ORDER BY 1
    LIMIT 1
 ----
 1 one
-
-subtest labeled_column_access_from_table
 
 query IT colnames
 SELECT (t.*).* FROM t ORDER BY 1,2
@@ -915,22 +734,17 @@ a  b
 1  one
 2  two
 
-
-# Pending #26719
-query error pq: column "t" does not exist
+query I colnames rowsort
 SELECT (t).a FROM t
-
-statement ok
-DROP TABLE t
+----
+a
+1
+2
 
 query B
 SELECT (1, 2, 3) IS NULL AS r
 ----
 false
 
-subtest regression_for_34262
-
-query B
+query error syntax error
 SELECT () = ()
-----
-true

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1864,5 +1864,5 @@ query error arguments cannot be implicitly cast to any implementation's paramete
 SELECT jsonb_agg(1, 2)
 
 # todo@jldlaughlin: Fix test when #2414 is implemented
-query error ROW constructors are not supported yet
+query error jsonb_agg does not support casting from record\(f1: i32, f2: i32\) to jsonbany
 SELECT jsonb_agg((1, 2))

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -94,9 +94,15 @@ EXPLAIN PLAN FOR SELECT generate_series FROM generate_series(-2, 2)
 
 EOF
 
-# TODO(justin): currently incorrect.
-statement error
+# TODO(justin): currently incorrect. Should return element directly, not
+# 1-tuple.
+query T colnames
 SELECT x FROM generate_series(1, 3) x
+----
+x
+(1)
+(2)
+(3)
 
 # TODO(justin): Don't currently support the 3-argument version.
 statement error

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1864,7 +1864,7 @@ ORDER BY
 | | | | | Get materialize.public.part (u6)
 | | | | | Filter like(#1, "forest%")
 | | | | | Project (#0)
-| | | | | Reduce group=() any((#^0 = #0))
+| | | | | Reduce group=() any(((#^0 = #0) && true))
 | | | |
 | | | |
 | | | | %6 =
@@ -1875,7 +1875,7 @@ ORDER BY
 | | | | | Project (#1)
 | | | |
 | | | Project (#1)
-| | | Reduce group=() any((#^0 = #0))
+| | | Reduce group=() any(((#^0 = #0) && true))
 | |
 | Project (#1, #2)
 


### PR DESCRIPTION
@umanwizard are you up for taking this review, since you'll be in the area for supporting nested Avro?

This commit introduces anonymous record types, like in the following
query:

    SELECT ROW(1, 2, 3)

This initial implementation includes support for:

   * Binary and text encoding for pgwire. Note that decoding is not
     supported, and likely never will be; even Postgres does not support
     decoding anonymous record types.
   * Literal ROW constructor comparisons.
   * Subquery comparison.
   * Field access, e.g. `SELECT (ROW(1, 2, 3)).f1`.

This is likely enough support to build nested Avro types.

Notably, this commit does *not* introduce support for named composite
types, as in:

    CREATE TYPE foo AS (a int, b text)

Many PostgreSQL clients have an easier time with named composite types
than anonymous record types, so we'll likely need named composite types
soon. That work is blocked on having consistent catalog views available
(#2576).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3505)
<!-- Reviewable:end -->
