### PR TITLE
Lift project made after CSE.

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -250,6 +250,7 @@ impl Default for Optimizer {
             }),
             Box::new(crate::reduction_pushdown::ReductionPushdown),
             Box::new(crate::cse::map::Map),
+            Box::new(crate::projection_lifting::ProjectionLifting),
             Box::new(crate::fusion::project::Project),
             Box::new(crate::reduction::FoldConstants),
         ];

--- a/test/sqllogictest/planning.slt
+++ b/test/sqllogictest/planning.slt
@@ -1,0 +1,33 @@
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE test1(a int, b int, c int, d int)
+
+# check that the extra project caused by the CSE is lifted
+# through the TopK
+query T multiline
+EXPLAIN PLAN FOR
+SELECT avg(d), sumc, sumd FROM (
+SELECT a + b + c as sumc, a + b + d as sumd, d
+FROM test1
+ORDER BY d LIMIT 4
+)
+GROUP BY sumc, sumd
+----
+%0 =
+| Get materialize.public.test1 (u1)
+| Map (#0 + #1), (#4 + #2), (#4 + #3)
+| TopK group=() order=(#3 asc) limit=4 offset=0
+| Reduce group=(#5, #6) sum(#3) count(#3)
+| Map (((i32todec(#2) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec)
+| Project (#4, #0, #1)
+
+EOF


### PR DESCRIPTION
When the CSE transform runs, the transform will produce an extra project to project away any common subexpressions that are not selected for. 

Originally, ProjectionLifting did not run after the CSE transform, so an extra project could remain in the final plan. 

For the test case in the PR, the original plan was (note the extra project above the TopK).
```
%0 =
| Get materialize.public.test1 (u1)
| Map (#0 + #1), (#4 + #2), (#4 + #3)
| Project (#0..#3, #5, #6)
| TopK group=() order=(#3 asc) limit=4 offset=0
| Reduce group=(#4, #5) sum(#3) count(#3)
| Map (((i32todec(#2) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec)
| Project (#4, #0, #1)
```

The test case in the PR is slightly more complicated than needs be to reproduce the problem. You can also observe the extra project by creating a materialized view like this:
```
CREATE MATERIALIZED VIEW test_view AS 
SELECT a + b + c as sumc, a + b + d as sumd, d
FROM test1
ORDER BY d LIMIT 4
```
and then running `EXPLAIN PLAN FOR VIEW test_view`

But I wanted to create a test case where projection lifting will still be necessary after #724 is dealt with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3510)
<!-- Reviewable:end -->
