### PR TITLE
repr: reformulate dummy datums

### DIFF
--- a/src/dataflow/src/render/join.rs
+++ b/src/dataflow/src/render/join.rs
@@ -257,20 +257,7 @@ where
             // columns should be present in `source_columns` (and probably not much else).
 
             let position_or = (0..arity)
-                .map(|col| {
-                    if let Some(pos) = source_columns.iter().position(|c| c == &col) {
-                        Ok(pos)
-                    } else {
-                        Err({
-                            let typ = &column_types[col];
-                            if typ.nullable {
-                                Datum::Null
-                            } else {
-                                typ.scalar_type.dummy_datum()
-                            }
-                        })
-                    }
-                })
+                .map(|col| source_columns.iter().position(|c| c == &col))
                 .collect::<Vec<_>>();
 
             (
@@ -279,8 +266,8 @@ where
                     move |row| {
                         let datums = row.unpack();
                         row_packer.pack(position_or.iter().map(|pos_or| match pos_or {
-                            Result::Ok(index) => datums[*index],
-                            Result::Err(datum) => *datum,
+                            Some(index) => datums[*index],
+                            None => Datum::Dummy,
                         }))
                     }
                 }),

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -362,6 +362,10 @@ where
                         Datum::False => (0, 1),
                         x => panic!("Invalid argument to AggregateFunc::All: {:?}", x),
                     },
+                    AggregateFunc::Dummy => match datum {
+                        Datum::Dummy => (0, 0),
+                        x => panic!("Invalid argument to AggregateFunc::Dummy: {:?}", x),
+                    }
                     _ => {
                         // Other accumulations need to disentangle the accumulable
                         // value from its NULL-ness, which is not quite as easily
@@ -429,6 +433,7 @@ where
                             Datum::Null
                         }
                     }
+                    (AggregateFunc::Dummy, _) => Datum::Dummy,
                     // Below this point, anything with only nulls should be null.
                     (_, 0) => Datum::Null,
                     // If any non-nulls, just report the aggregate.
@@ -541,7 +546,8 @@ fn accumulable_hierarchical(func: &AggregateFunc) -> (bool, bool) {
         | AggregateFunc::Count
         | AggregateFunc::CountAll
         | AggregateFunc::Any
-        | AggregateFunc::All => (true, false),
+        | AggregateFunc::All
+        | AggregateFunc::Dummy => (true, false),
         AggregateFunc::MaxInt32
         | AggregateFunc::MaxInt64
         | AggregateFunc::MaxFloat32

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -419,6 +419,11 @@ pub enum AggregateFunc {
     Any,
     All,
     JsonbAgg,
+    /// Accumulates any number of `Datum::Dummy`s into `Datum::Dummy`.
+    ///
+    /// Useful for removing an expensive aggregation while maintaining the shape
+    /// of a reduce operator.
+    Dummy,
 }
 
 impl AggregateFunc {
@@ -457,6 +462,7 @@ impl AggregateFunc {
             AggregateFunc::Any => any(datums),
             AggregateFunc::All => all(datums),
             AggregateFunc::JsonbAgg => jsonb_agg(datums, temp_storage),
+            AggregateFunc::Dummy => Datum::Dummy,
         }
     }
 
@@ -465,6 +471,7 @@ impl AggregateFunc {
             AggregateFunc::Count | AggregateFunc::CountAll => Datum::Int64(0),
             AggregateFunc::Any => Datum::False,
             AggregateFunc::All => Datum::True,
+            AggregateFunc::Dummy => Datum::Dummy,
             _ => Datum::Null,
         }
     }
@@ -598,6 +605,7 @@ impl fmt::Display for AggregateFunc {
             AggregateFunc::Any => f.write_str("any"),
             AggregateFunc::All => f.write_str("all"),
             AggregateFunc::JsonbAgg => f.write_str("jsonb_agg"),
+            AggregateFunc::Dummy => f.write_str("dummy"),
         }
     }
 }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -167,6 +167,7 @@ enum Tag {
     List,
     Dict,
     JsonNull,
+    Dummy,
 }
 
 // --------------------------------------------------------------------------------
@@ -291,6 +292,7 @@ unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
             Datum::Dict(DatumDict { data: bytes })
         }
         Tag::JsonNull => Datum::JsonNull,
+        Tag::Dummy => Datum::Dummy,
     }
 }
 
@@ -380,6 +382,7 @@ fn push_datum(data: &mut Vec<u8>, datum: Datum) {
             push_untagged_bytes(data, &dict.data);
         }
         Datum::JsonNull => data.push(Tag::JsonNull as u8),
+        Datum::Dummy => data.push(Tag::Dummy as u8),
     }
 }
 
@@ -406,6 +409,7 @@ pub fn datum_size(datum: &Datum) -> usize {
         Datum::List(list) => 1 + size_of::<usize>() + list.data.len(),
         Datum::Dict(dict) => 1 + size_of::<usize>() + dict.data.len(),
         Datum::JsonNull => 1,
+        Datum::Dummy => 1,
     }
 }
 


### PR DESCRIPTION
There are several moments where our optimizer can prove that a column is
not observed, and therefore does not need to be computed. Unfortunately,
our optimizer makes it difficult to actually *remove* this column from
the plan, and so the execution engine inserts a "dummy datum" where it
would have computed the column. If the column is nullable, it uses
`Datum::Null` as the dummy value; otherwise, it uses a reasonable
default value for the column's type, like zero for integers and false
for booleans.

There are two things that concern me about this approach.

The first is that this seems overly concerned about avoiding
`Datum::Null`s in non-nullable columns. If the column truly won't be
observed, then there would be no harm in introducing `Datum::Null` in a
column that is supposed to be non-nullable, because no one will ever
look at that column. If we're worried that the demand optimizations
might be buggy at the moment, well, then shouldn't we be worried about
the fact that we might be blanking out the integers in an observed
column and silently producing wrong data?

The second is that record types, forthcoming in #3505, cannot correctly
implement `ScalarType::dummy_datum` with its current signature, as it is
not possible to construct a dummy datum for a record type with non-zero
arity. E.g., the natural dummy datum for `record(i32, bool)` would be
`Datum::List(0, false)`, but this requires an allocation, which is not
possible given the current signature of ScalarType::dummhy_datum.

So, this commit removes `ScalarType::dummy_datum`. In its place, it
introduces a new `Datum::Dummy` variant, which can be easly constructed
anywhere a placeholder datum is required without knowledge of the
expected type. Crucically, `Datum::Dummy` can never be constructed by a
user, so seeing a `Datum::Dummy` somewhere is a clear sign that an
optimization somewhere is misbehaving, and Materialize can just panic.

I believe the new approach is actually more paranoid in ensuring that
the dummy data is not observed, while also not impeding the
implementation of record types.

Long term, I think we should endeavor to get rid of dummy datums; they
seem to be solely a result of optimizer limitations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3514)
<!-- Reviewable:end -->
