### PR TITLE
make topk_elision recursive

### DIFF
--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -24,18 +24,16 @@ impl crate::Transform for TopKElision {
         relation: &mut RelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        self.action(relation, &mut HashMap::new());
+        relation.visit_mut(&mut |e| {
+            self.action(e);
+        });
         Ok(())
     }
 }
 
 impl TopKElision {
     /// Remove TopK operators with both an offset of zero and no limit.
-    pub fn action(
-        &self,
-        relation: &mut RelationExpr,
-        _gets: &mut HashMap<Id, (repr::RelationType, Vec<usize>)>,
-    ) {
+    pub fn action(&self, relation: &mut RelationExpr) {
         if let RelationExpr::TopK {
             input,
             group_key: _,

--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -9,10 +9,8 @@
 
 //! Remove TopK operators with both an offset of zero and no limit.
 
-use std::collections::HashMap;
-
 use crate::TransformArgs;
-use expr::{Id, RelationExpr};
+use expr::RelationExpr;
 
 /// Remove TopK operators with both an offset of zero and no limit.
 #[derive(Debug)]

--- a/test/sqllogictest/planning.slt
+++ b/test/sqllogictest/planning.slt
@@ -31,3 +31,25 @@ GROUP BY sumc, sumd
 | Project (#4, #0, #1)
 
 EOF
+
+# check that TopK elision is recursive
+statement ok
+CREATE MATERIALIZED VIEW plan_test1 AS
+SELECT avg(d), sumc, sumd FROM (
+SELECT a + b + c as sumc, a + b + d as sumd, d
+FROM test1
+ORDER BY d
+)
+GROUP BY sumc, sumd
+ORDER BY sumc
+
+query T multiline
+EXPLAIN PLAN FOR VIEW plan_test1
+----
+%0 =
+| Get materialize.public.test1 (u1)
+| Reduce group=(((#0 + #1) + #2), ((#0 + #1) + #3)) sum(#3) count(#3)
+| Map (((i32todec(#2) * 10000000dec) / i64todec(if (#3 = 0) then {null} else {#3})) / 10dec)
+| Project (#4, #0, #1)
+
+EOF


### PR DESCRIPTION
This PR makes the elision of `TopK` operators without limits or offsets recursive, removing them from anywhere inside a query AST. This should be correct as none of the differential dataflow operators should be order-sensitive.

Tests not run yet, so failures expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3529)
<!-- Reviewable:end -->
