### PR TITLE
Run filters before `arrange_from_upsert`.

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -657,6 +657,8 @@ pub struct IndexDesc {
     pub keys: Vec<ScalarExpr>,
 }
 
+// TODO: change contract to ensure that the operator is always applied to
+// streams of rows
 /// In-place restrictions that can be made to rows.
 ///
 /// These fields indicate *optional* information that may applied to

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -282,7 +282,7 @@ where
         value_encoding.op_name()
     );
     let avro_err = "Failed to create Avro decoder";
-    let decoded_stream = match (key_encoding, value_encoding) {
+    match (key_encoding, value_encoding) {
         (DataEncoding::Bytes, DataEncoding::Avro(val_enc)) => decode_upsert_inner(
             stream,
             OffsetDecoderState::from(bytes_to_datum),
@@ -362,19 +362,7 @@ where
             &op_name,
         ),
         _ => unreachable!("Unsupported encoding combination"),
-    };
-    decoded_stream.map({
-        let mut row_packer = RowPacker::new();
-        move |(key, value, timestamp)| {
-            if let Some(value) = value {
-                row_packer.extend_by_row(&key);
-                row_packer.extend_by_row(&value);
-                (key, Some(row_packer.finish_and_reuse()), timestamp)
-            } else {
-                (key, None, timestamp)
-            }
-        }
-    })
+    }
 }
 
 fn decode_values_inner<G, V, C>(

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -249,6 +249,15 @@ pub(crate) fn build_dataflow<A: Allocate>(
 
             // Load declared sources into the rendering context.
             for (src_id, mut src) in dataflow.source_imports.clone() {
+                if let Some(operator) = &mut src.operators {
+                    // if src.operator is trivial, convert it to None
+                    if operator.predicates.is_empty()
+                        && operator.projection == (0..src.desc.typ().arity()).collect::<Vec<_>>()
+                    {
+                        src.operators = None;
+                    }
+                }
+
                 if let SourceConnector::External {
                     connector,
                     encoding,
@@ -320,7 +329,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                         &dataflow.debug_name,
                                         worker_index,
                                         as_of_frontier.clone(),
-                                        &mut src.operators,
+                                        &src.operators,
                                         src.desc.typ(),
                                     );
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -110,16 +110,13 @@ use differential_dataflow::operators::arrange::arrangement::Arrange;
 use differential_dataflow::operators::arrange::upsert::arrange_from_upsert;
 use differential_dataflow::{AsCollection, Collection};
 use timely::communication::Allocate;
-use timely::dataflow::operators::generic::{operator, Operator};
+use timely::dataflow::operators::generic::operator;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::operators::unordered_input::UnorderedInput;
 use timely::dataflow::operators::Map;
 use timely::dataflow::Scope;
-use timely::dataflow::Stream;
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
-
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
 
 use avro::Schema;
 use dataflow_types::Timestamp;
@@ -135,13 +132,12 @@ use super::source;
 use super::source::FileReadStyle;
 use super::source::{SourceConfig, SourceToken};
 use crate::arrangement::manager::{TraceBundle, TraceManager};
-use crate::decode::{decode_avro_values, decode_upsert, decode_values};
+use crate::decode::{decode_avro_values, decode_values};
 use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::operator::{CollectionExt, StreamExt};
 use crate::server::LocalInput;
 use crate::server::{TimestampDataUpdates, TimestampMetadataUpdates};
 use crate::source::KafkaSourceInfo;
-use source::SourceOutput;
 
 mod arrange_by;
 mod context;
@@ -150,6 +146,7 @@ mod join;
 mod reduce;
 mod threshold;
 mod top_k;
+mod upsert;
 
 pub(crate) fn build_local_input<A: Allocate>(
     manager: &mut TraceManager,
@@ -315,38 +312,27 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                         connector,
                                     );
 
-                                // This operator changes the timestamp from capability to message payload,
-                                // and applies `as_of` frontier compaction. The compaction is important as
-                                // downstream upsert preparation can compact away updates for the same keys
-                                // at the same times, and by advancing times we make more of them the same.
-                                let as_of_frontier = as_of_frontier.clone();
-                                let source =
-                                    source.unary(Pipeline, "AppendTimestamp", move |_, _| {
-                                        let mut vector = Vec::new();
-                                        move |input, output| {
-                                            input.for_each(|cap, data| {
-                                                data.swap(&mut vector);
-                                                let mut time = cap.time().clone();
-                                                time.advance_by(as_of_frontier.borrow());
-                                                output.session(&cap).give_iterator(
-                                                    vector.drain(..).map(|x| (x, time.clone())),
-                                                );
-                                            });
-                                        }
-                                    });
+                                let (transformed, new_err_collection) =
+                                    upsert::pre_arrange_from_upsert_transforms(
+                                        &source,
+                                        encoding,
+                                        key_encoding,
+                                        &dataflow.debug_name,
+                                        worker_index,
+                                        as_of_frontier.clone(),
+                                        &mut src.operators,
+                                        src.desc.typ(),
+                                    );
 
-                                // Deduplicate records by key, decode, and then upsert arrange them.
-                                let deduplicated = prepare_upsert_by_max_offset(&source);
-                                let decoded = decode_upsert(
-                                    &deduplicated,
-                                    encoding,
-                                    key_encoding,
-                                    &dataflow.debug_name,
-                                    worker_index,
-                                );
                                 let arranged = arrange_from_upsert(
-                                    &decoded,
+                                    &transformed,
                                     &format!("UpsertArrange: {}", src_id.to_string()),
+                                );
+
+                                err_collection.concat(
+                                    &new_err_collection
+                                        .pass_through("upsert-linear-errors")
+                                        .as_collection(),
                                 );
 
                                 let keys = src.desc.typ().keys[0]
@@ -729,73 +715,6 @@ pub(crate) fn build_dataflow<A: Allocate>(
             }
         });
     })
-}
-
-/// Produces at most one entry for each `(key, time)` pair.
-///
-/// The incoming stream of `(key, (val, off), time)` records may have many
-/// entries with the same `key` and `time`. We are able to reduce this to
-/// at most one record for each pair, by retaining only the record with the
-/// greatest offset: its action summarizes the sequence of many actions that
-/// occur at the same moment and so are not distinguishable.
-fn prepare_upsert_by_max_offset<G>(
-    stream: &Stream<G, (SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)>,
-) -> Stream<G, ((Vec<u8>, (Vec<u8>, Option<i64>)), Timestamp)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    stream.unary_frontier(
-        Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
-        "UpsertCompaction",
-        |_cap, _info| {
-            let mut values = HashMap::<_, HashMap<_, (Vec<u8>, Option<i64>)>>::new();
-            let mut vector = Vec::new();
-
-            move |input, output| {
-                // Digest each input, reduce by presented timestamp.
-                input.for_each(|cap, data| {
-                    data.swap(&mut vector);
-                    for (
-                        SourceOutput {
-                            key,
-                            value: val,
-                            position,
-                        },
-                        time,
-                    ) in vector.drain(..)
-                    {
-                        let value = values
-                            .entry(cap.delayed(&time))
-                            .or_insert_with(HashMap::new)
-                            .entry(key)
-                            .or_insert_with(Default::default);
-
-                        if let Some(new_offset) = position {
-                            if let Some(offset) = value.1 {
-                                if offset < new_offset {
-                                    *value = (val, position);
-                                }
-                            } else {
-                                *value = (val, position);
-                            }
-                        }
-                    }
-                });
-
-                // Produce (key, val) pairs at any complete times.
-                for (cap, map) in values.iter_mut() {
-                    if !input.frontier.less_equal(cap.time()) {
-                        let mut session = output.session(cap);
-                        for (key, val) in map.drain() {
-                            session.give(((key, val), cap.time().clone()))
-                        }
-                    }
-                }
-                // Discard entries, capabilities for complete times.
-                values.retain(|_cap, map| !map.is_empty());
-            }
-        },
-    )
 }
 
 impl<G> Context<G, RelationExpr, Row, Timestamp>

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -329,7 +329,7 @@ pub(crate) fn build_dataflow<A: Allocate>(
                                         &dataflow.debug_name,
                                         worker_index,
                                         as_of_frontier.clone(),
-                                        &src.operators,
+                                        &mut src.operators,
                                         src.desc.typ(),
                                     );
 

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -178,7 +178,13 @@ where
     // but not to replace unused values in key because that would cause
     // errors in arrange_from_upsert
     let position_or = (0..src_type.arity())
-        .map(|col| operator.projection.iter().position(|c| c == &col))
+        .map(|col| {
+            if operator.projection.contains(&col) {
+                Some(col)
+            } else {
+                None
+            }
+        })
         .collect::<Vec<_>>();
 
     // If a row does not match a predicate whose support lies in the key

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -1,4 +1,4 @@
-// Copyright Materialize, Inc. All rihts reserved.
+// Copyright Materialize, Inc. All rights reserved.
 //
 // Use of this software is governed by the Business Source License
 // included in the LICENSE file.
@@ -24,6 +24,12 @@ use crate::decode::decode_upsert;
 use crate::operator::StreamExt;
 use crate::source::SourceOutput;
 
+/// Entrypoint to the upsert-specific transformations involved 
+/// in rendering a stream that came from an upsert source.
+/// Upsert-specific operators are different from the rest of 
+/// the rendering pipeline in that their input is a stream
+/// with two components instead of one, and the second component
+/// can be null or empty.
 #[allow(clippy::too_many_arguments)]
 pub fn pre_arrange_from_upsert_transforms<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
@@ -59,9 +65,10 @@ where
         }
     });
 
-    // Deduplicate records by key, decode, and then upsert arrange them.
+    // Deduplicate records by key
     let deduplicated = prepare_upsert_by_max_offset(&stream);
 
+    //Decode
     let decoded = decode_upsert(
         &deduplicated,
         encoding,
@@ -151,6 +158,7 @@ where
     )
 }
 
+/// Apply a filter followed by a project to an upsert stream.
 fn apply_linear_operators<G>(
     stream: &Stream<G, (Row, Option<Row>, Timestamp)>,
     operator: &LinearOperator,

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -1,0 +1,275 @@
+// Copyright Materialize, Inc. All rihts reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use differential_dataflow::hashable::Hashable;
+use differential_dataflow::lattice::Lattice;
+
+use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::operators::generic::{operator, Operator};
+use timely::dataflow::{Scope, Stream};
+use timely::progress::Antichain;
+
+use dataflow_types::{DataEncoding, DataflowError, LinearOperator, Timestamp};
+use repr::{Datum, RelationType, Row, RowArena};
+
+use crate::decode::decode_upsert;
+use crate::operator::StreamExt;
+use crate::source::SourceOutput;
+
+#[allow(clippy::too_many_arguments)]
+pub fn pre_arrange_from_upsert_transforms<G>(
+    stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
+    encoding: DataEncoding,
+    key_encoding: DataEncoding,
+    debug_name: &str,
+    worker_index: usize,
+    as_of_frontier: Antichain<Timestamp>,
+    linear_operator: &mut Option<LinearOperator>,
+    src_type: &RelationType,
+) -> (
+    Stream<G, (Row, Option<Row>, Timestamp)>,
+    Stream<G, DataflowError>,
+)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    // This operator changes the timestamp from capability to message payload,
+    // and applies `as_of` frontier compaction. The compaction is important as
+    // downstream upsert preparation can compact away updates for the same keys
+    // at the same times, and by advancing times we make more of them the same.
+    let stream = stream.unary(Pipeline, "AppendTimestamp", move |_, _| {
+        let mut vector = Vec::new();
+        move |input, output| {
+            input.for_each(|cap, data| {
+                data.swap(&mut vector);
+                let mut time = cap.time().clone();
+                time.advance_by(as_of_frontier.borrow());
+                output
+                    .session(&cap)
+                    .give_iterator(vector.drain(..).map(|x| (x, time.clone())));
+            });
+        }
+    });
+
+    // Deduplicate records by key, decode, and then upsert arrange them.
+    let deduplicated = prepare_upsert_by_max_offset(&stream);
+
+    let decoded = decode_upsert(
+        &deduplicated,
+        encoding,
+        key_encoding,
+        debug_name,
+        worker_index,
+    );
+
+    if let Some(operator) = linear_operator {
+        // skip applying the linear operator when it is trivial
+        if operator.predicates.is_empty()
+            && operator.projection == (0..src_type.arity()).collect::<Vec<_>>()
+        {
+            *linear_operator = None;
+        } else {
+            return apply_linear_operators(&decoded, &operator, src_type);
+        }
+    }
+    let scope = &decoded.scope();
+    (decoded, operator::empty(scope))
+}
+
+/// Produces at most one entry for each `(key, time)` pair.
+///
+/// The incoming stream of `(key, (val, off), time)` records may have many
+/// entries with the same `key` and `time`. We are able to reduce this to
+/// at most one record for each pair, by retaining only the record with the
+/// greatest offset: its action summarizes the sequence of many actions that
+/// occur at the same moment and so are not distinguishable.
+fn prepare_upsert_by_max_offset<G>(
+    stream: &Stream<G, (SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)>,
+) -> Stream<G, ((Vec<u8>, (Vec<u8>, Option<i64>)), Timestamp)>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    stream.unary_frontier(
+        Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
+        "UpsertCompaction",
+        |_cap, _info| {
+            let mut values = HashMap::<_, HashMap<_, (Vec<u8>, Option<i64>)>>::new();
+            let mut vector = Vec::new();
+
+            move |input, output| {
+                // Digest each input, reduce by presented timestamp.
+                input.for_each(|cap, data| {
+                    data.swap(&mut vector);
+                    for (
+                        SourceOutput {
+                            key,
+                            value: val,
+                            position,
+                        },
+                        time,
+                    ) in vector.drain(..)
+                    {
+                        let value = values
+                            .entry(cap.delayed(&time))
+                            .or_insert_with(HashMap::new)
+                            .entry(key)
+                            .or_insert_with(Default::default);
+
+                        if let Some(new_offset) = position {
+                            if let Some(offset) = value.1 {
+                                if offset < new_offset {
+                                    *value = (val, position);
+                                }
+                            } else {
+                                *value = (val, position);
+                            }
+                        }
+                    }
+                });
+
+                // Produce (key, val) pairs at any complete times.
+                for (cap, map) in values.iter_mut() {
+                    if !input.frontier.less_equal(cap.time()) {
+                        let mut session = output.session(cap);
+                        for (key, val) in map.drain() {
+                            session.give(((key, val), cap.time().clone()))
+                        }
+                    }
+                }
+                // Discard entries, capabilities for complete times.
+                values.retain(|_cap, map| !map.is_empty());
+            }
+        },
+    )
+}
+
+fn apply_linear_operators<G>(
+    stream: &Stream<G, (Row, Option<Row>, Timestamp)>,
+    operator: &LinearOperator,
+    src_type: &RelationType,
+) -> (
+    Stream<G, (Row, Option<Row>, Timestamp)>,
+    Stream<G, DataflowError>,
+)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    // Determine replacement values for unused columns.
+    // This is copied over from applying linear operators to
+    // the non-upsert case.
+    // At this point, the stream consists of (key, key+payload, time)
+    // so it is ok to delete replace unused values in key+payload
+    // but not to replace unused values in key because that would cause
+    // errors in arrange_from_upsert
+    let position_or = (0..src_type.arity())
+        .map(|col| {
+            if operator.projection.contains(&col) {
+                Ok(col)
+            } else {
+                Err({
+                    // TODO(frank): This could be `Datum::Null` if we
+                    // are certain that no readers will consult it and
+                    // believe it to be a non-null value. That is the
+                    // intent, but it is not yet clear that we ensure
+                    // this.
+                    let typ = &src_type.column_types[col];
+                    if typ.nullable {
+                        Datum::Null
+                    } else {
+                        typ.scalar_type.dummy_datum()
+                    }
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // If a row does not match a predicate whose support lies in the key
+    // columns, it can be tossed away entirely. If a row does not match
+    // a predicate whose support is not contained in the key columns, it
+    // must be replaced with (key, None) in case if there was previously a
+    // row with the same key that matched the predicate.
+    let key_col_len = src_type.keys[0].len();
+    let mut predicates = operator.predicates.clone();
+    let mut key_predicates = Vec::new();
+    predicates.retain(|p| {
+        let key_predicate = p.support().into_iter().all(|c| c < key_col_len);
+        if key_predicate {
+            key_predicates.push(p.clone());
+        }
+        !key_predicate
+    });
+
+    let mut storage = Vec::new();
+    let mut filtered_storage = Vec::new();
+    let mut row_packer = repr::RowPacker::new();
+
+    stream.unary_fallible(Pipeline, "UpsertLinearFallible", move |_, _| {
+        move |input, ok_output, err_output| {
+            input.for_each(|time, data| {
+                let mut ok_session = ok_output.session(&time);
+                let mut err_session = err_output.session(&time);
+                data.swap(&mut storage);
+                for (key, value, time) in storage.drain(..) {
+                    let temp_storage = RowArena::new();
+                    let datums = key.unpack();
+                    let key_pred_eval = key_predicates
+                        .iter()
+                        .map(|predicate| predicate.eval(&datums, &temp_storage))
+                        .find(|result| result != &Ok(Datum::True));
+                    match key_pred_eval {
+                        None => {
+                            if let Some(value) = value {
+                                let datums = value.unpack();
+                                let pred_eval = predicates
+                                    .iter()
+                                    .map(|predicate| predicate.eval(&datums, &temp_storage))
+                                    .find(|result| result != &Ok(Datum::True));
+                                match pred_eval {
+                                    None => {
+                                        let value = Some(row_packer.pack(position_or.iter().map(
+                                            |pos_or| match pos_or {
+                                                Result::Ok(index) => datums[*index],
+                                                Result::Err(datum) => *datum,
+                                            },
+                                        )));
+                                        filtered_storage.push((key, value, time));
+                                    }
+                                    Some(Ok(Datum::False)) => {
+                                        filtered_storage.push((key, None, time))
+                                    }
+                                    Some(Ok(Datum::Null)) => {
+                                        filtered_storage.push((key, None, time))
+                                    }
+                                    Some(Ok(x)) => {
+                                        panic!("Predicate evaluated to invalid value: {:?}", x)
+                                    }
+                                    Some(Err(x)) => {
+                                        err_session.give(DataflowError::from(x));
+                                    }
+                                }
+                            } else {
+                                filtered_storage.push((key, None, time));
+                            }
+                        }
+                        Some(Ok(Datum::False)) | Some(Ok(Datum::Null)) => {}
+                        Some(Ok(x)) => panic!("Predicate evaluated to invalid value: {:?}", x),
+                        Some(Err(x)) => {
+                            err_session.give(DataflowError::from(x));
+                        }
+                    };
+                }
+                if !filtered_storage.is_empty() {
+                    ok_session.give_vec(&mut filtered_storage);
+                }
+            })
+        }
+    })
+}

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -24,9 +24,9 @@ use crate::decode::decode_upsert;
 use crate::operator::StreamExt;
 use crate::source::SourceOutput;
 
-/// Entrypoint to the upsert-specific transformations involved 
+/// Entrypoint to the upsert-specific transformations involved
 /// in rendering a stream that came from an upsert source.
-/// Upsert-specific operators are different from the rest of 
+/// Upsert-specific operators are different from the rest of
 /// the rendering pipeline in that their input is a stream
 /// with two components instead of one, and the second component
 /// can be null or empty.

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -98,7 +98,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
                 .as_mut()
                 .take_dangerous()
                 .filter(list.iter().cloned());
-            // TODO: remove the listed predicates from the earlier objects
+            // TODO: remove the predicates in `list` from the earlier objects
         }
         transform.dataflow_transform(build_desc.relation_expr.as_mut(), &mut predicates);
     }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -24,10 +24,12 @@ use std::collections::{HashMap, HashSet};
 /// projection information, though it could certainly generalize beyond.
 pub fn optimize_dataflow(dataflow: &mut DataflowDesc) {
     optimize_dataflow_filters(dataflow);
-    // TODO: once the propagated filters are removed from the
-    // RelationExpr they come from, it would be useful for demand
-    // to be optimized after filters that way demand only includes
-    // the columns that are still necessary after the filters are applied.
+    // TODO: when the linear operator contract ensures that propagated
+    // predicates are always applied, projections and filters can be removed
+    // from where they come from. Once projections and filters can be removed,
+    // TODO: it would be useful for demand to be optimized after filters
+    // that way demand only includes the columns that are still necessary after
+    // the filters are applied.
     optimize_dataflow_demand(dataflow);
 }
 
@@ -98,7 +100,6 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
                 .as_mut()
                 .take_dangerous()
                 .filter(list.iter().cloned());
-            // TODO: remove the predicates in `list` from the earlier objects
         }
         transform.dataflow_transform(build_desc.relation_expr.as_mut(), &mut predicates);
     }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -85,6 +85,14 @@ impl PredicatePushdown {
         get_predicates: &mut HashMap<Id, HashSet<ScalarExpr>>,
     ) {
         relation.visit_mut_pre(&mut |e| {
+            // TODO(#2592): we want to replace everything inside the braces
+            // with the single line below
+            // `self.action(e, &mut get_predicates);`
+            // This is so that you have a series of dependent views
+            // A->B->C, you want to push propagated filters
+            // from A all the way past B to C if possible.
+            // Before this replacement can be done, we need to figure out
+            // replanning joins after the new predicates are pushed down.
             if let RelationExpr::Filter { input, predicates } = e {
                 if let RelationExpr::Get { id, .. } = **input {
                     // We can report the predicates upward in `get_predicates`,

--- a/test/testdrive/upsert-kafka.td
+++ b/test/testdrive/upsert-kafka.td
@@ -275,7 +275,7 @@ $ kafka-create-topic topic=realtimeavroavro
 # test multi-field avro key
 $ set keyschema2={
     "type": "record",
-    "name": "Key",
+    "name": "Key2",
     "fields": [
         {"name": "f3", "type": ["null", "string"]},
         {"name": "f1", "type": ["null", "string"]}
@@ -339,3 +339,177 @@ fire       yang        dog            42
 air        qi          chicken        47
 <null>     yin         dog            243
 earth      dao         rhinoceros     211
+
+$ kafka-create-topic topic=realtimefilteravro
+
+$ set keyschema3={
+    "type": "record",
+    "name": "Key3",
+    "fields": [
+        {"name": "k1", "type": ["null", "string"]},
+        {"name": "k2", "type": ["null", "long"]}
+    ]
+  }
+
+$ set schema2={
+    "type": "record",
+    "name": "test2",
+    "fields": [
+        {"name": "f1", "type": ["null", "string"]},
+        {"name": "f2", "type": ["null", "long"]}
+    ]
+  }
+
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+{"k1": null, "k2": 2} {"f1": "date", "f2": 5}
+{"k1": "épicerie", "k2": 10} {"f1": "melon", "f2": 2}
+{"k1": "boucherie", "k2": 5} {"f1": "apple", "f2": 7}
+{"k1": "boulangerie", "k2": null} {"f1":"date", "f2": 10}
+{"k1": "épicerie", "k2": 10} {"f1": "pear", "f2": 2}
+{"k1": null, "k2": 2} {"f1": "date", "f2": null}
+{"k1": "boulangerie", "k2": null} {"f1":null, "f2": 10}
+{"k1": "boucherie", "k2": 5} {"f1": "apple", "f2": 3}
+
+> CREATE SOURCE realtimefilteravro
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-realtimefilteravro-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# filter on key only
+> CREATE MATERIALIZED VIEW filterforkey AS
+  SELECT f1 FROM realtimefilteravro WHERE k1='épicerie';
+
+> SELECT * from filterforkey
+f1
+----
+pear
+
+# filter on value only
+> CREATE MATERIALIZED VIEW filterforvalue AS
+  SELECT f2 FROM realtimefilteravro WHERE f1='date';
+
+> SELECT * from filterforvalue
+f2
+-------
+<null>
+
+# filter with a predicate containing key + value
+> CREATE MATERIALIZED VIEW filterforkeyvalue AS
+  SELECT f1, f2 FROM realtimefilteravro WHERE k2+f2=12;
+
+> SELECT * from filterforkeyvalue
+f1   f2
+-------
+pear 2
+
+# filter on both a predicate containing a key and a predicate containing a value
+> CREATE MATERIALIZED VIEW keyfiltervaluefilter AS
+  SELECT k1, k2 FROM realtimefilteravro WHERE k2 > 5 AND f2 < 5
+
+> SELECT * from keyfiltervaluefilter
+k1       k2
+-----------
+épicerie 10
+
+# add records that match the filter
+# make sure that rows that differ on unneeded key columns are treated as separate
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+{"k1": "librairie", "k2": 10} {"f1":null, "f2": 2}
+{"k1": null, "k2": null} {"f1": "date", "f2": 5}
+{"k1": "épicerie", "k2": 6} {"f1": "pear", "f2": null}
+{"k1": "bureau", "k2": 6} {"f1": "grape", "f2": 7}
+
+> SELECT * from filterforkey
+f1
+----
+pear
+pear
+
+> SELECT * from filterforvalue
+f2
+-------
+<null>
+5
+
+> SELECT * from filterforkeyvalue
+f1     f2
+---------
+pear   2
+<null> 2
+
+> SELECT * from keyfiltervaluefilter
+k1        k2
+-----------
+épicerie  10
+librairie 10
+
+# update records so that they don't match the filter
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+{"k1": "librairie", "k2": 10} {"f1":null, "f2": 6}
+{"k1": null, "k2": null} {"f1": "grape", "f2": 5}
+
+> SELECT * from filterforvalue
+f2
+-------
+<null>
+
+> SELECT * from filterforkeyvalue
+f1     f2
+---------
+pear   2
+
+> SELECT * from keyfiltervaluefilter
+k1        k2
+-----------
+épicerie  10
+
+# update records so that they do match the filter
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+{"k1": "librairie", "k2": 10} {"f1":"melon", "f2": 2}
+{"k1": null, "k2": null} {"f1": "date", "f2": 12}
+
+> SELECT * from filterforvalue
+f2
+-------
+<null>
+12
+
+> SELECT * from filterforkeyvalue
+f1     f2
+---------
+pear   2
+melon  2
+
+> SELECT * from keyfiltervaluefilter
+k1        k2
+-----------
+épicerie  10
+librairie 10
+
+# delete records
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+{"k1": "boucherie", "k2": 5}
+{"k1": "épicerie", "k2": 10}
+{"k1": "boulangerie", "k2": null}
+{"k1": null, "k2": 2}
+
+> SELECT * from filterforkey
+f1
+----
+pear
+
+> SELECT * from filterforvalue
+f2
+-------
+12
+
+> SELECT * from filterforkeyvalue
+f1     f2
+---------
+melon  2
+
+> SELECT * from keyfiltervaluefilter
+k1        k2
+-----------
+librairie 10


### PR DESCRIPTION
Moved `upsert` parts of the pipeline to its own file `src/dataflow/render/upsert.rs.`

Manually confirmed via println statements, checking mz_arrangement_sizes, and checking the resulting dataflow that the filter is running before the `arrange_from_upsert`, and also that if there are no filters and no projects, the linear operator will not run.

Resolves #3486.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3533)
<!-- Reviewable:end -->
