### PR TITLE
Make mz_kafka_sinks a local input

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector};
 use expr::{GlobalId, Id, IdHumanizer, OptimizedRelationExpr, ScalarExpr};
-use repr::{RelationDesc, Row};
+use repr::{RelationDesc, Row, ScalarType};
 use sql::ast::display::AstDisplay;
 use sql::names::{DatabaseSpecifier, FullName, PartialName};
 use sql::plan::{Params, Plan, PlanContext};
@@ -161,6 +161,48 @@ pub struct Index {
     pub plan_cx: PlanContext,
     pub on: GlobalId,
     pub keys: Vec<ScalarExpr>,
+}
+
+/// Represents a catalog view. When adding a new one, ensure you add it to the all_views() vector.
+#[derive(Debug, Copy, Clone)]
+pub enum CatalogView {
+    MzKafkaSinks,
+}
+
+// TODO(justin): lots of overlap here with the logging views, can/should
+// they be unified?
+impl CatalogView {
+    pub fn all_views() -> Vec<CatalogView> {
+        vec![CatalogView::MzKafkaSinks]
+    }
+
+    pub fn name(&self) -> String {
+        match self {
+            CatalogView::MzKafkaSinks => "mz_kafka_sinks",
+        }
+        .into()
+    }
+
+    pub fn id(&self) -> GlobalId {
+        match self {
+            CatalogView::MzKafkaSinks => GlobalId::System(55),
+        }
+    }
+
+    pub fn index_id(&self) -> GlobalId {
+        match self {
+            CatalogView::MzKafkaSinks => GlobalId::System(56),
+        }
+    }
+
+    pub fn desc(&self) -> RelationDesc {
+        match self {
+            CatalogView::MzKafkaSinks => RelationDesc::empty()
+                .with_nonnull_column("global_id", ScalarType::String)
+                .with_nonnull_column("topic", ScalarType::String)
+                .with_key(vec![0]),
+        }
+    }
 }
 
 impl CatalogItem {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -54,7 +54,7 @@ use sql::names::{DatabaseSpecifier, FullName};
 use sql::plan::{MutationKind, Params, Plan, PlanContext};
 use transform::Optimizer;
 
-use crate::catalog::{self, Catalog, CatalogItem, SinkConnectorState};
+use crate::catalog::{self, Catalog, CatalogItem, CatalogView, SinkConnectorState};
 use crate::session::{PreparedStatement, Session};
 use crate::timestamp::{TimestampConfig, TimestampMessage, Timestamper};
 use crate::util::ClientTransmitter;
@@ -92,6 +92,7 @@ where
     pub num_timely_workers: usize,
     pub symbiosis_url: Option<&'a str>,
     pub logging: Option<&'a LoggingConfig>,
+    pub logging_granularity: Option<Duration>,
     pub data_directory: Option<&'a Path>,
     pub executor: &'a tokio::runtime::Handle,
     pub timestamp: TimestampConfig,
@@ -124,6 +125,7 @@ where
     /// Instance count: number of times sources have been instantiated in views. This is used
     /// to associate each new instance of a source with a unique instance id (iid)
     log: bool,
+    logging_granularity: Option<u64>,
     executor: tokio::runtime::Handle,
     feedback_rx: Option<comm::mpsc::Receiver<WorkerFeedbackWithMeta>>,
     /// The startup time of the coordinator, from which local input timstamps are generated
@@ -193,6 +195,9 @@ where
             since_updates: Vec::new(),
             active_tails: HashMap::new(),
             log: config.logging.is_some(),
+            logging_granularity: config
+                .logging_granularity
+                .and_then(|c| c.as_millis().try_into().ok()),
             executor: config.executor.clone(),
             timestamp_config: config.timestamp,
             logical_compaction_window_ms,
@@ -258,6 +263,22 @@ where
                         {
                             coord.create_index_dataflow(name.to_string(), id, index)
                         } else {
+                            if is_cat_index(&id) {
+                                let entry = coord.catalog.get_by_id(&index.on);
+                                coord.views.insert(id, ViewState::new(false, vec![]));
+                                broadcast(
+                                    &mut coord.broadcast_tx,
+                                    SequencedCommand::CreateLocalInput {
+                                        name: name.to_string(),
+                                        index_id: id,
+                                        index: IndexDesc {
+                                            on_id: id,
+                                            keys: index.keys.clone(),
+                                        },
+                                        on_type: entry.desc().unwrap().typ().clone(),
+                                    },
+                                );
+                            }
                             coord.insert_index(id, &index, Some(1_000))
                         }
                     }
@@ -315,7 +336,9 @@ where
         self.read_lower_bound
     }
 
-    pub fn get_ts(&mut self) -> Timestamp {
+    /// Fetch a new timestamp.
+    fn get_ts(&mut self) -> Timestamp {
+        // Next time we have a chance, we will force all local inputs forward.
         self.need_advance = true;
         // This is a hack. In a perfect world we would represent time as having a "real" dimension
         // and a "coordinator" dimension so that clients always observed linearizability from
@@ -545,12 +568,19 @@ where
                 }
             }
 
-            if self.need_advance {
-                let mut next_ts = self.get_ts();
-                self.need_advance = false;
-                if next_ts <= self.read_lower_bound {
-                    next_ts = self.read_lower_bound + 1;
-                }
+            let needed = self.need_advance;
+            let mut next_ts = self.get_ts();
+            self.need_advance = false;
+            if next_ts <= self.read_lower_bound {
+                next_ts = self.read_lower_bound + 1;
+            }
+            // TODO(justin): this is pretty hacky, and works more-or-less because this frequency
+            // lines up with that used in the logging views.
+            if needed
+                || self.logging_granularity.is_some()
+                    && next_ts / self.logging_granularity.unwrap()
+                        > self.closed_up_to / self.logging_granularity.unwrap()
+            {
                 if next_ts > self.closed_up_to {
                     broadcast(
                         &mut self.broadcast_tx,
@@ -1577,13 +1607,13 @@ where
                             sinks_to_drop.push(entry.id());
                             match connector {
                                 SinkConnector::Kafka(KafkaSinkConnector { topic, .. }) => {
-                                    broadcast(
-                                        &mut self.broadcast_tx,
-                                        SequencedCommand::AppendLog(MaterializedEvent::KafkaSink {
-                                            id: entry.id(),
-                                            topic: topic.clone(),
-                                            insert: false,
-                                        }),
+                                    self.update_catalog_view(
+                                        CatalogView::MzKafkaSinks,
+                                        Row::pack(&[
+                                            Datum::String(entry.id().to_string().as_str()),
+                                            Datum::String(topic.as_str()),
+                                        ]),
+                                        -1,
                                     );
                                 }
                                 SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
@@ -1862,6 +1892,23 @@ where
         self.create_sink_dataflow(name.to_string(), id, sink.from, connector)
     }
 
+    /// Insert a single row into a given catalog view.
+    /// TODO(justin): this should be extended to support multiple updates in a single call.
+    fn update_catalog_view(&mut self, v: CatalogView, row: Row, diff: isize) {
+        let timestamp = self.get_write_ts();
+        broadcast(
+            &mut self.broadcast_tx,
+            SequencedCommand::Insert {
+                id: v.index_id(),
+                updates: vec![Update {
+                    row,
+                    diff,
+                    timestamp,
+                }],
+            },
+        );
+    }
+
     fn create_sink_dataflow(
         &mut self,
         name: String,
@@ -1872,13 +1919,13 @@ where
         #[allow(clippy::single_match)]
         match &connector {
             SinkConnector::Kafka(KafkaSinkConnector { topic, .. }) => {
-                broadcast(
-                    &mut self.broadcast_tx,
-                    SequencedCommand::AppendLog(MaterializedEvent::KafkaSink {
-                        id,
-                        topic: topic.clone(),
-                        insert: true,
-                    }),
+                self.update_catalog_view(
+                    CatalogView::MzKafkaSinks,
+                    Row::pack(&[
+                        Datum::String(id.to_string().as_str()),
+                        Datum::String(topic.as_str()),
+                    ]),
+                    1,
                 );
             }
             SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
@@ -2134,7 +2181,6 @@ where
             // original sources on which they depend.
             PeekWhen::Immediately => {
                 let upper = self.indexes.greatest_open_upper(uses_ids.iter().cloned());
-
                 // We peek at the largest element not in advance of `upper`, which
                 // involves a subtraction. If `upper` contains a zero timestamp there
                 // is no "prior" answer, and we do not want to peek at it as it risks
@@ -2386,6 +2432,11 @@ where
     }
 }
 
+fn is_cat_index(id: &GlobalId) -> bool {
+    // TODO(justin): do something better here?
+    CatalogView::all_views().iter().any(|v| v.index_id() == *id)
+}
+
 fn broadcast(tx: &mut comm::broadcast::Sender<SequencedCommand>, cmd: SequencedCommand) {
     // TODO(benesch): avoid flushing after every send.
     block_on(tx.send(cmd)).unwrap();
@@ -2552,6 +2603,40 @@ fn open_catalog(
                             &log_src.schema(),
                             &log_src.index_by(),
                         ),
+                        plan_cx: PlanContext::default(),
+                    }),
+                );
+            }
+
+            for v in CatalogView::all_views() {
+                let desc = v.desc();
+                let view_name = FullName {
+                    database: DatabaseSpecifier::Ambient,
+                    schema: "mz_catalog".into(),
+                    item: v.name(),
+                };
+                let src = catalog::Source {
+                    create_sql: "".to_string(),
+                    plan_cx: PlanContext::default(),
+                    connector: dataflow_types::SourceConnector::Local,
+                    desc: desc.clone(),
+                };
+                let index_name = format!("{}_primary_idx", v.name());
+
+                let tab = CatalogItem::Source(src);
+
+                catalog.insert_item(v.id(), view_name.clone(), tab);
+                catalog.insert_item(
+                    v.index_id(),
+                    FullName {
+                        database: DatabaseSpecifier::Ambient,
+                        schema: "mz_catalog".into(),
+                        item: index_name.clone(),
+                    },
+                    CatalogItem::Index(catalog::Index {
+                        on: v.id(),
+                        keys: vec![],
+                        create_sql: index_sql(index_name, view_name, &desc, &[]),
                         plan_cx: PlanContext::default(),
                     }),
                 );

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -88,7 +88,6 @@ pub enum MaterializedLog {
     PrimaryKeys,
     ForeignKeys,
     Catalog,
-    KafkaSinks,
     AvroOcfSinks,
 }
 
@@ -111,7 +110,6 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PrimaryKeys),
             LogVariant::Materialized(MaterializedLog::ForeignKeys),
             LogVariant::Materialized(MaterializedLog::Catalog),
-            LogVariant::Materialized(MaterializedLog::KafkaSinks),
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks),
         ]
     }
@@ -139,7 +137,6 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PrimaryKeys) => "mz_view_keys",
             LogVariant::Materialized(MaterializedLog::ForeignKeys) => "mz_view_foreign_keys",
             LogVariant::Materialized(MaterializedLog::Catalog) => "mz_catalog_names",
-            LogVariant::Materialized(MaterializedLog::KafkaSinks) => "mz_kafka_sinks",
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => "mz_avro_ocf_sinks",
         }
     }
@@ -163,7 +160,6 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PrimaryKeys) => GlobalId::system(27),
             LogVariant::Materialized(MaterializedLog::ForeignKeys) => GlobalId::system(29),
             LogVariant::Materialized(MaterializedLog::Catalog) => GlobalId::system(31),
-            LogVariant::Materialized(MaterializedLog::KafkaSinks) => GlobalId::system(55),
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => GlobalId::system(57),
         }
     }
@@ -187,7 +183,6 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::PrimaryKeys) => GlobalId::system(28),
             LogVariant::Materialized(MaterializedLog::ForeignKeys) => GlobalId::system(30),
             LogVariant::Materialized(MaterializedLog::Catalog) => GlobalId::system(32),
-            LogVariant::Materialized(MaterializedLog::KafkaSinks) => GlobalId::system(56),
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => GlobalId::system(58),
         }
     }
@@ -307,11 +302,6 @@ impl LogVariant {
                 .with_nonnull_column("name", ScalarType::String)
                 .with_key(vec![0]),
 
-            LogVariant::Materialized(MaterializedLog::KafkaSinks) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("topic", ScalarType::String)
-                .with_key(vec![0]),
-
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => RelationDesc::empty()
                 .with_nonnull_column("global_id", ScalarType::String)
                 .with_nonnull_column("path", ScalarType::Bytes)
@@ -369,7 +359,6 @@ impl LogVariant {
                 ),
             ],
             LogVariant::Materialized(MaterializedLog::Catalog) => vec![],
-            LogVariant::Materialized(MaterializedLog::KafkaSinks) => vec![],
             LogVariant::Materialized(MaterializedLog::AvroOcfSinks) => vec![],
         }
     }

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -276,6 +276,7 @@ pub fn serve(mut config: Config) -> Result<Server, failure::Error> {
             num_timely_workers,
             symbiosis_url: config.symbiosis_url.as_deref(),
             logging: logging_config.as_ref(),
+            logging_granularity: config.logging_granularity,
             data_directory: config.data_directory.as_deref(),
             timestamp: coord::TimestampConfig {
                 frequency: config.timestamp_frequency,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -403,6 +403,7 @@ impl State {
             logging: logging_config.as_ref(),
             data_directory: None,
             executor: &executor,
+            logging_granularity: None,
             timestamp: TimestampConfig {
                 frequency: Duration::from_millis(10),
             },


### PR DESCRIPTION
A little unsure about the organization here, lots of unfortunate overlap with the logging views, probably what would be best would be to unify those as a single enum that dispatches either to a logging view or a local input, but open to discussion!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3535)
<!-- Reviewable:end -->
