### PR TITLE
Failed CREATE SINK should not create catalog entry

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -971,6 +971,14 @@ where
             }
         };
 
+        let frontier = match self.determine_frontier(as_of, sink.from) {
+            Ok(frontier) => frontier,
+            Err(e) => {
+                tx.send(Err(e), session);
+                return;
+            }
+        };
+
         // Then try to create a placeholder catalog item with an unknown
         // connector. If that fails, we're done, though if the client specified
         // `if_not_exists` we'll tell the client we succeeded.
@@ -1001,13 +1009,6 @@ where
             }
         }
 
-        let frontier = match self.determine_frontier(as_of, sink.from) {
-            Ok(frontier) => frontier,
-            Err(e) => {
-                tx.send(Err(e), session);
-                return;
-            }
-        };
         // Now we're ready to create the sink connector. Arrange to notify the
         // main coordinator thread when the future completes.
         let connector_builder = sink.connector_builder;


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/3542. 

Currently, we're attempting to `determine_frontier` for a sink *after* we put a sink entry into the catalog. Since `determine_frontier` can fail, this can cause us to erroneously add a sink when we should just be returning an error. This PR moves the `determine_frontier` code before the catalog code in `sequence_create_sink`. 

Previous error:
```
materialize=> create sink top10sinkasof from top10 into avro ocf '/Users/arjun/tmp/top10.ocf' as of 0;
ERROR:  Timestamp (0) is not valid for all inputs: [(User(7), Some(Antichain { elements: [1594145729387] }))]
materialize=> create sink top10sinkasof from top10 into avro ocf '/Users/arjun/tmp/top10.ocf' as of 0;
ERROR:  catalog item 'top10sinkasof' already exists
```

With this change:
```
materialize=> create sink top10sinkasof from top10 into avro ocf '/Users/arjun/tmp/top10.ocf' as of 0;
ERROR:  Timestamp (0) is not valid for all inputs: [(User(7), Some(Antichain { elements: [1594145791636] }))]
materialize=> create sink top10sinkasof from top10 into avro ocf '/Users/arjun/tmp/top10.ocf' as of 0;
ERROR:  Timestamp (0) is not valid for all inputs: [(User(7), Some(Antichain { elements: [1594145791636] }))]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3544)
<!-- Reviewable:end -->
