### PR TITLE
coord: remove direct dependency on sql-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sql",
- "sql-parser",
  "symbiosis",
  "timely",
  "tokio",
@@ -3336,7 +3335,6 @@ dependencies = [
  "repr",
  "serde_json",
  "sql",
- "sql-parser",
  "tokio",
  "walkdir",
 ]
@@ -3493,7 +3491,6 @@ dependencies = [
  "repr",
  "serde_json",
  "sql",
- "sql-parser",
  "tokio",
  "tokio-postgres",
  "whoami",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -36,7 +36,6 @@ rusqlite = { version = "0.23", features = ["bundled", "unlock_notify"] }
 serde = "1.0"
 serde_json = "1.0.56"
 sql = { path = "../sql" }
-sql-parser = { path = "../sql-parser" }
 symbiosis = { path = "../symbiosis" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 tokio = "0.2"

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -47,11 +47,10 @@ use expr::{
 use ore::collections::CollectionExt;
 use ore::thread::JoinHandleExt;
 use repr::{ColumnName, Datum, RelationDesc, RelationType, Row, RowPacker};
-use sql::ast::{ExplainOptions, ObjectType, Statement};
+use sql::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use sql::catalog::Catalog as _;
 use sql::names::{DatabaseSpecifier, FullName};
 use sql::plan::{MutationKind, Params, Plan, PlanContext};
-use sql_parser::ast::ExplainStage;
 use transform::Optimizer;
 
 use crate::catalog::{self, Catalog, CatalogItem, SinkConnectorState};
@@ -2454,7 +2453,7 @@ fn index_sql(
     view_desc: &RelationDesc,
     keys: &[usize],
 ) -> String {
-    use sql_parser::ast::{Expr, Ident, Value};
+    use sql::ast::{Expr, Ident, Value};
 
     Statement::CreateIndex {
         name: Some(Ident::new(index_name)),

--- a/src/coord/src/session/statement.rs
+++ b/src/coord/src/session/statement.rs
@@ -40,12 +40,13 @@
 //! [m]: https://www.postgresql.org/docs/12/protocol-message-formats.html#Parse
 
 use repr::{RelationDesc, Row};
+use sql::ast::Statement;
 use sql::plan::Params;
 
 /// A prepared statement.
 #[derive(Debug)]
 pub struct PreparedStatement {
-    sql: Option<sql_parser::ast::Statement>,
+    sql: Option<Statement>,
     desc: Option<RelationDesc>,
     param_types: Vec<pgrepr::Type>,
 }
@@ -53,7 +54,7 @@ pub struct PreparedStatement {
 impl PreparedStatement {
     /// Constructs a new `PreparedStatement`.
     pub fn new(
-        sql: Option<sql_parser::ast::Statement>,
+        sql: Option<Statement>,
         desc: Option<RelationDesc>,
         param_types: Vec<pgrepr::Type>,
     ) -> PreparedStatement {
@@ -66,7 +67,7 @@ impl PreparedStatement {
 
     /// Returns the raw SQL string associated with this prepared statement,
     /// if the prepared statement was not the empty query.
-    pub fn sql(&self) -> Option<&sql_parser::ast::Statement> {
+    pub fn sql(&self) -> Option<&Statement> {
         self.sql.as_ref()
     }
 

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -25,6 +25,5 @@ regex = "1"
 repr = { path = "../repr" }
 serde_json = "1"
 sql = { path = "../sql" }
-sql-parser = { path = "../sql-parser" }
 tokio = "0.2"
 walkdir = "2"

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -18,5 +18,4 @@ tokio-postgres = { version = "0.5.4", features = ["with-chrono-0_4", "with-serde
 repr = { path = "../repr" }
 serde_json = "1.0"
 sql = { path = "../sql" }
-sql-parser = { path = "../sql-parser" }
 whoami = "0.9"

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -30,13 +30,12 @@ use std::env;
 
 use chrono::Utc;
 use failure::{bail, format_err};
-use sql_parser::ast::ColumnOption;
-use sql_parser::ast::{DataType, ObjectType, Statement, TableConstraint};
 use tokio_postgres::types::FromSql;
 
 use pgrepr::Jsonb;
 use repr::adt::decimal::Significand;
 use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use sql::ast::{ColumnOption, DataType, ObjectType, Statement, TableConstraint};
 use sql::catalog::Catalog;
 use sql::names::FullName;
 use sql::normalize;


### PR DESCRIPTION
sql-parser is meant to be an implementation detail of the sql crate. In
coord, use the ast module that's exposed by sql insead of depending on
sql-parser directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3548)
<!-- Reviewable:end -->
