### PR TITLE
Fix -w/--worker command-line flag in docs

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -19,8 +19,8 @@ Flag | Default | Modifies
 [`--processes`](#horizontally-scaled-clusters) | 1 | Number of coordinating Materialize nodes
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
 [`--tls-key`](#tls-encryption) | N/A | Path to TLS private key file
-[`--workers`](#worker-threads) | 1 | Dataflow worker threads
-[`--w`](#worker-threads) | 1 |  Dataflow worker threads
+[`--workers`](#worker-threads) | REQ | Dataflow worker threads
+[`-w`](#worker-threads) | REQ |  Dataflow worker threads
 `-v` | N/A | Print version and exit
 `-vv` | N/A | Print version and additional build information, and exit
 
@@ -37,11 +37,10 @@ found.
 ### Worker threads
 
 A `materialized` instance runs a specified number of timely dataflow worker
-threads. By default, `materialized` runs with a single worker thread. Worker
-threads can only be specified at startup by setting the `--workers` flag, and
-cannot be changed without shutting down `materialized` and restarting. In the
-future, dynamically changing the number of worker threads will be possible over
-distributed clusters, see
+threads. Worker threads can only be specified at startup by setting the
+required `--workers` flag, and cannot be changed without shutting down
+`materialized` and restarting. In the future, dynamically changing the number
+of worker threads will be possible over distributed clusters, see
 [#2449](https://github.com/MaterializeInc/materialize/issues/2449).
 
 #### How many worker threads should you run?

--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -33,7 +33,7 @@ We also highly recommend checking out [What is Materialize?](/overview/what-is-m
 1. Run the `materialized` binary. For example, if you installed it in your `$PATH`:
 
     ```shell
-    materialized --w=1
+    materialized -w 1
     ```
 
     This starts the daemon listening on port 6875 using 1 worker.

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -82,10 +82,11 @@ cargo build --release
 You can start the `materialized` process by simply running the binary, e.g.
 
 ```nofmt
-./materialized --w=1
+./materialized -w 1
 ```
 
-`--w=1` specifies that the process will use 1 worker. You can also find more detail about our [command line flags](/cli/#command-line-flags).
+`-w 1` specifies that the process will use 1 worker. You can also find more detail
+about our [command line flags](/cli/#command-line-flags).
 
 By default `materialized` uses:
 


### PR DESCRIPTION
It should be either `-w` or `--workers`, not `--w`. I chose the shorter one for the docs
in the intro since `--workers` is not supported in v0.3.1, but will be in v0.4.0.

Also adjust docs to point out that it is required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3554)
<!-- Reviewable:end -->
