### PR TITLE
allow defaults for decimal types

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -31,7 +31,7 @@ use std::collections::hash_map::Entry;
 use std::convert::TryFrom;
 use std::fmt::Display;
 use std::rc::Rc;
-use types::Value as AvroValue;
+use types::{DecimalValue, Value as AvroValue};
 
 pub fn resolve_schemas(writer_schema: &Schema, reader_schema: &Schema) -> Result<Schema, Error> {
     let r_indices = reader_schema.indices.clone();
@@ -1447,6 +1447,16 @@ impl<'a> SchemaNode<'a> {
                 }
             }
             (String(s), SchemaPiece::Bytes) => AvroValue::Bytes(s.clone().into_bytes()),
+            (
+                String(s),
+                SchemaPiece::Decimal {
+                    precision, scale, ..
+                },
+            ) => AvroValue::Decimal(DecimalValue {
+                precision: *precision,
+                scale: *scale,
+                unscaled: s.clone().into_bytes(),
+            }),
             (String(s), SchemaPiece::String) => AvroValue::String(s.clone()),
             (Object(map), SchemaPiece::Record { fields, .. }) => {
                 let field_values = fields


### PR DESCRIPTION
We weren't handling the combination of "string", "decimal" for decoding JSON values in the "default" field of Avro schemas.

Thanks @johnjmartin for reporting in #3553 

Still not sure why this was causing a crash instead of a sane error message, but this at least fixes the immediate issue.

Todo: (1) figure out the above. (2) also implement the above for the other custom types, if necessary. (3) write some tests.

None of those should block this PR, as the correctness is obvious IMO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3555)
<!-- Reviewable:end -->
