### PR TITLE
coord: support dropping databases with cross-schema dependencies

### DIFF
--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -149,6 +149,31 @@ unknown schema 'noexist'
 ! CREATE VIEW noexist.ignored.ignored AS SELECT 1
 unknown database 'noexist'
 
+# Dropping database with cross-schema dependencies is ok.
+> CREATE DATABASE d1;
+> CREATE SCHEMA d1.s1;
+> CREATE VIEW d1.s1.t as select 1;
+> CREATE VIEW d1.public.tt as select * from d1.s1.t;
+> DROP DATABASE d1;
+
+# Dropping database with cross-database dependencies is ok and drops the
+# dependent views.
+> CREATE DATABASE d1;
+> CREATE VIEW d1.public.t as select 1;
+> CREATE DATABASE d2;
+> CREATE VIEW d2.public.t AS SELECT * FROM d1.public.t;
+> DROP DATABASE d1;
+> SHOW DATABASES
+Database
+----
+d
+d2
+materialize
+
+> SHOW VIEWS FROM d2.public;
+ VIEWS
+-------
+
 # Check default sources and views in mz_catalog.
 
 > SHOW SOURCES FROM mz_catalog


### PR DESCRIPTION
Previously, you couldn't drop a database if you had cross-schema dependencies because the item with the dependency would try to be dropped a second time (once in the first schema that was encountered that contained/used it, once in the second).

This change resolves that problem by sharing the same `HashSet` across all schemas when dropping a database to ensure each item is only dropped once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3558)
<!-- Reviewable:end -->
