### PR TITLE
ccsr,sql: support SASL PLAIN authentication for Kafka

### DIFF
--- a/doc/user/content/sql/create-source/avro-kafka.md
+++ b/doc/user/content/sql/create-source/avro-kafka.md
@@ -107,6 +107,34 @@ This creates a source that...
   `localhost:9092`.
 - Is append-only.
 
+### Connecting to a Kafka broker using SASL PLAIN authentication
+
+```sql
+CREATE MATERIALIZED SOURCE data_v1
+FROM KAFKA BROKER 'broker.tld:9092' TOPIC 'top-secret' WITH (
+    security_protocol = 'SASL_SSL',
+    sasl_mechanisms = 'PLAIN',
+    sasl_username = '<BROKER_USERNAME>',
+    sasl_password = '<BROKER_PASSWORD>',
+)
+FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://schema-registry.tld' WITH (
+    username = '<SCHEMA_REGISTRY_USERNAME>',
+    password = '<SCHEMA_REGISTRY_PASSWORD>'
+);
+```
+
+This creates a source that...
+
+- Connects to a Kafka broker that requires SASL PLAIN authentication.
+- Connects to a Confluent Schema Registry that requires HTTPS and basic
+  authentication.
+- Automatically determines its schema from the Confluent Schema Registry.
+- Decodes data received from the `top-secret` topic published by Kafka running on
+  `localhost:9092`.
+- Is append-only.
+
+If you are connecting to a Kafka cluster on Confluent Cloud, this is the
+example to follow.
 
 ### Connecting to a Kafka broker using Kerberos
 

--- a/doc/user/layouts/partials/sql-grammar/format-spec-avro-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/format-spec-avro-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="429" height="191">
+<svg xmlns="http://www.w3.org/2000/svg" width="803" height="257">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="58" height="32" rx="10"/>
@@ -17,41 +17,87 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="119" y="21">USING</text>
-   <rect x="45" y="69" width="240" height="32" rx="10"/>
+   <rect x="45" y="113" width="240" height="32" rx="10"/>
    <rect x="43"
-         y="67"
+         y="111"
          width="240"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="87">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="305" y="69" width="36" height="32"/>
-   <rect x="303" y="67" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="313" y="87">url</text>
-   <rect x="45" y="113" width="80" height="32" rx="10"/>
-   <rect x="43"
+   <text class="terminal" x="53" y="131">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="305" y="113" width="36" height="32"/>
+   <rect x="303" y="111" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="313" y="131">url</text>
+   <rect x="381" y="113" width="56" height="32" rx="10"/>
+   <rect x="379"
          y="111"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="389" y="131">WITH</text>
+   <rect x="457" y="113" width="24" height="32" rx="10"/>
+   <rect x="455"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="465" y="131">(</text>
+   <rect x="521" y="113" width="46" height="32"/>
+   <rect x="519" y="111" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="529" y="131">field</text>
+   <rect x="587" y="113" width="26" height="32" rx="10"/>
+   <rect x="585"
+         y="111"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="595" y="131">=</text>
+   <rect x="633" y="113" width="38" height="32"/>
+   <rect x="631" y="111" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="641" y="131">val</text>
+   <rect x="521" y="69" width="24" height="32" rx="10"/>
+   <rect x="519"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="529" y="87">,</text>
+   <rect x="711" y="113" width="24" height="32" rx="10"/>
+   <rect x="709"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="719" y="131">)</text>
+   <rect x="45" y="179" width="80" height="32" rx="10"/>
+   <rect x="43"
+         y="177"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="131">SCHEMA</text>
-   <rect x="165" y="113" width="48" height="32" rx="10"/>
+   <text class="terminal" x="53" y="197">SCHEMA</text>
+   <rect x="165" y="179" width="48" height="32" rx="10"/>
    <rect x="163"
-         y="111"
+         y="177"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="173" y="131">FILE</text>
-   <rect x="233" y="113" width="128" height="32"/>
-   <rect x="231" y="111" width="128" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="241" y="131">schema_file_path</text>
-   <rect x="165" y="157" width="108" height="32"/>
-   <rect x="163" y="155" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="173" y="175">inline_schema</text>
+   <text class="terminal" x="173" y="197">FILE</text>
+   <rect x="233" y="179" width="128" height="32"/>
+   <rect x="231" y="177" width="128" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="241" y="197">schema_file_path</text>
+   <rect x="165" y="223" width="108" height="32"/>
+   <rect x="163" y="221" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="173" y="241">inline_schema</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-194 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m0 0 h40 m-376 0 h20 m356 0 h20 m-396 0 q10 0 10 10 m376 0 q0 -10 10 -10 m-386 10 v24 m376 0 v-24 m-376 24 q0 10 10 10 m356 0 q10 0 10 -10 m-366 10 h10 m80 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m128 0 h10 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m108 0 h10 m0 0 h88 m43 -88 h-3"/>
-   <polygon points="419 83 427 79 427 87"/>
-   <polygon points="419 83 411 79 411 87"/>
+         d="m19 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-194 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m240 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-190 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m170 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-170 0 h10 m24 0 h10 m0 0 h126 m20 44 h10 m24 0 h10 m-394 0 h20 m374 0 h20 m-414 0 q10 0 10 10 m394 0 q0 -10 10 -10 m-404 10 v14 m394 0 v-14 m-394 14 q0 10 10 10 m374 0 q10 0 10 -10 m-384 10 h10 m0 0 h364 m-730 -34 h20 m730 0 h20 m-770 0 q10 0 10 10 m750 0 q0 -10 10 -10 m-760 10 v46 m750 0 v-46 m-750 46 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m80 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m128 0 h10 m-236 0 h20 m216 0 h20 m-256 0 q10 0 10 10 m236 0 q0 -10 10 -10 m-246 10 v24 m236 0 v-24 m-236 24 q0 10 10 10 m216 0 q10 0 10 -10 m-226 10 h10 m108 0 h10 m0 0 h88 m20 -44 h374 m23 -66 h-3"/>
+   <polygon points="793 127 801 123 801 131"/>
+   <polygon points="793 127 785 123 785 131"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -144,7 +144,7 @@ explain ::=
   )
 format_spec_avro_kafka ::=
     ('AVRO' 'USING' (
-        'CONFLUENT SCHEMA REGISTRY' url |
+        'CONFLUENT SCHEMA REGISTRY' url ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')? |
         'SCHEMA' (
             'FILE' schema_file_path |
             inline_schema

--- a/src/ccsr/src/config.rs
+++ b/src/ccsr/src/config.rs
@@ -13,12 +13,19 @@ use serde::{Deserialize, Serialize};
 use crate::client::Client;
 use crate::tls::{Certificate, Identity};
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Auth {
+    pub username: String,
+    pub password: Option<String>,
+}
+
 /// Configuration for a `Client`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ClientConfig {
     url: Url,
     root_certs: Vec<Certificate>,
     identity: Option<Identity>,
+    auth: Option<Auth>,
 }
 
 impl ClientConfig {
@@ -29,6 +36,7 @@ impl ClientConfig {
             url,
             root_certs: Vec::new(),
             identity: None,
+            auth: None,
         }
     }
 
@@ -43,6 +51,13 @@ impl ClientConfig {
     /// Enables TLS client authentication with the provided identity.
     pub fn identity(mut self, identity: Identity) -> ClientConfig {
         self.identity = Some(identity);
+        self
+    }
+
+    /// Enables HTTP basic authentication with the specified username and
+    /// optional password.
+    pub fn auth(mut self, username: String, password: Option<String>) -> ClientConfig {
+        self.auth = Some(Auth { username, password });
         self
     }
 
@@ -63,6 +78,6 @@ impl ClientConfig {
             .build()
             .unwrap();
 
-        Client::new(inner, self.url)
+        Client::new(inner, self.url, self.auth)
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -419,35 +419,42 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'h
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None })), envelope: Debezium, if_not_exists: false, materialized: false }
+CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium, if_not_exists: false, materialized: false }
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }) })), envelope: None, if_not_exists: false, materialized: false }
+CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false }
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }) })), envelope: None, if_not_exists: false, materialized: false }
+CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false }
+
+parse-statement
+CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
+----
+CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
+=>
+CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [SqlOption { name: Ident("a"), value: String("b") }] })), envelope: Debezium, if_not_exists: false, materialized: false }
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None })), envelope: None, if_not_exists: false, materialized: false }
+CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false }
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 =>
-CreateSource { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None })), envelope: Upsert(None), if_not_exists: false, materialized: false }
+CreateSource { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert(None), if_not_exists: false, materialized: false }
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
@@ -535,6 +542,19 @@ CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT AS OF now()
 =>
 CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), if_not_exists: false }
 
+parse-statement
+CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
+----
+CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
+=>
+CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), with_snapshot: true, as_of: None, if_not_exists: false }
+
+parse-statement
+CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
+----
+CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
+=>
+CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [SqlOption { name: Ident("a"), value: String("b") }] })), with_snapshot: true, as_of: None, if_not_exists: false }
 
 parse-statement
 CREATE SINK IF EXISTS foo FROM bar INTO 'baz'

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -10,6 +10,7 @@
 //! Provides parsing and convenience functions for working with Kafka from the `sql` package.
 
 use std::collections::HashMap;
+use std::convert;
 use std::fs::File;
 use std::io::Read;
 use std::sync::{Arc, Mutex};
@@ -35,27 +36,33 @@ enum ValType {
 struct Config {
     name: &'static str,
     val_type: ValType,
+    transform: fn(String) -> String,
 }
 
 impl Config {
     fn new(name: &'static str, val_type: ValType) -> Self {
-        Config { name, val_type }
+        Config {
+            name,
+            val_type,
+            transform: convert::identity,
+        }
     }
 
     // Shorthand for simple string config options.
     fn string(name: &'static str) -> Self {
-        Config {
-            name,
-            val_type: ValType::String,
-        }
+        Config::new(name, ValType::String)
     }
 
     // Shorthand for simple path config options.
     fn path(name: &'static str) -> Self {
-        Config {
-            name,
-            val_type: ValType::Path,
-        }
+        Config::new(name, ValType::Path)
+    }
+
+    // Builds a new config that transforms the parameter according to `f` after
+    // it is validated.
+    fn transform(mut self, f: fn(String) -> String) -> Self {
+        self.transform = f;
+        self
     }
 
     // Get the appropriate String to use as the Kafka config key.
@@ -64,59 +71,40 @@ impl Config {
     }
 
     fn validate_val(&self, val: &Value) -> Result<String, failure::Error> {
-        match (&self.val_type, val) {
-            (ValType::String, Value::String(v)) => Ok(v.to_string()),
+        let val = match (&self.val_type, val) {
+            (ValType::String, Value::String(v)) => v.to_string(),
             (ValType::Path, Value::String(v)) => {
                 if std::fs::metadata(&v).is_err() {
                     bail!("file does not exist")
                 }
-                Ok(v.to_string())
+                v.to_string()
             }
             (ValType::Number(lower, upper), Value::Number(n)) => match n.parse::<i32>() {
-                Ok(parsed_n) if *lower <= parsed_n && parsed_n <= *upper => Ok(n.to_string()),
+                Ok(parsed_n) if *lower <= parsed_n && parsed_n <= *upper => n.to_string(),
                 _ => bail!("must be a number between {} and {}", lower, upper),
             },
             _ => bail!("unexpected value type"),
-        }
+        };
+        Ok((self.transform)(val))
     }
 }
 
-// Aggregates all of the configurations provided in `with_options`.
-struct ConfigAggregator<'a> {
-    input: &'a mut HashMap<String, Value>,
-    output: HashMap<String, String>,
-}
-
-impl<'a> ConfigAggregator<'a> {
-    fn new(input: &'a mut HashMap<String, Value>) -> Self {
-        ConfigAggregator {
-            input,
-            output: HashMap::new(),
-        }
+fn extract(
+    input: &HashMap<String, Value>,
+    configs: &[Config],
+) -> Result<HashMap<String, String>, failure::Error> {
+    let mut out = HashMap::new();
+    for config in configs {
+        let value = match input.get(config.name) {
+            Some(v) => match config.validate_val(&v) {
+                Ok(v) => v,
+                Err(e) => bail!("Invalid WITH option {}={}: {}", config.name, v, e),
+            },
+            None => continue,
+        };
+        out.insert(config.get_key(), value);
     }
-    fn extract(&mut self, configs: &[Config]) -> Result<(), failure::Error> {
-        for config in configs {
-            let value = match self.input.remove(config.name) {
-                Some(v) => match config.validate_val(&v) {
-                    Ok(v) => v,
-                    Err(e) => bail!("Invalid WITH option {}={}: {}", config.name, v, e),
-                },
-                None => continue,
-            };
-            self.output.insert(config.get_key(), value);
-        }
-
-        Ok(())
-    }
-    fn remove_from_input(&mut self, k: &str) -> Option<Value> {
-        self.input.remove(k)
-    }
-    fn insert_into_output(&mut self, k: String, v: String) {
-        self.output.insert(k, v);
-    }
-    fn finish(self) -> HashMap<String, String> {
-        self.output
-    }
+    Ok(out)
 }
 
 /// Parse the `with_options` from a `CREATE SOURCE` statement to determine
@@ -129,105 +117,42 @@ impl<'a> ConfigAggregator<'a> {
 /// - If any of the values in `with_options` are not
 ///   `sql_parser::ast::Value::String`.
 pub fn extract_config(
-    with_options: &mut HashMap<String, Value>,
+    with_options: &HashMap<String, Value>,
 ) -> Result<HashMap<String, String>, failure::Error> {
-    let mut agg = ConfigAggregator::new(with_options);
-
-    let allowed_configs = vec![
-        Config::string("client_id"),
-        Config::new(
-            "statistics_interval_ms",
-            // The range of values comes from `statistics.interval.ms` in
-            // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
-            ValType::Number(0, 86_400_000),
-        ),
-        Config::new(
-            "topic_metadata_refresh_interval_ms",
-            // The range of values comes from `topic.metadata.refresh.interval.ms` in
-            // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
-            ValType::Number(0, 3_600_000),
-        ),
-    ];
-
-    agg.extract(&allowed_configs)?;
-
-    extract_security_config(&mut agg)?;
-
-    Ok(agg.finish())
-}
-
-// Parse the `with_options` from a `CREATE SOURCE` statement to determine Kafka
-// security strategy, and extract any additional supplied configurations.
-fn extract_security_config(mut agg: &mut ConfigAggregator) -> Result<(), failure::Error> {
-    let security_protocol = match agg.remove_from_input("security_protocol") {
-        None => None,
-        Some(Value::String(p)) => Some(p.to_lowercase()),
-        Some(_) => bail!("ssl_certificate_file must be a string"),
-    };
-
-    match security_protocol.as_deref() {
-        None => {}
-        Some("ssl") => ssl_settings(&mut agg)?,
-        Some("sasl_plaintext") => sasl_plaintext_kerberos_settings(&mut agg)?,
-        Some(invalid_protocol) => bail!(
-            "Invalid WITH options: security_protocol='{}'",
-            invalid_protocol
-        ),
-    }
-
-    Ok(())
-}
-
-// Filters `sql_parser::ast::Statement::CreateSource.with_options` for the
-// configuration to connect to an SSL-secured cluster. You can find more detail
-// about these settings in
-// [librdkafka's documentation](https://github.com/edenhill/librdkafka/wiki/Using-SSL-with-librdkafka).
-fn ssl_settings(agg: &mut ConfigAggregator) -> Result<(), failure::Error> {
-    let allowed_configs = vec![
-        Config::path("ssl_ca_location"),
-        Config::path("ssl_certificate_location"),
-        Config::path("ssl_key_location"),
-        Config::string("ssl_key_password"),
-    ];
-
-    agg.extract(&allowed_configs)?;
-
-    agg.insert_into_output("security.protocol".to_string(), "ssl".to_string());
-
-    Ok(())
-}
-
-// Filters `sql_parser::ast::Statement::CreateSource.with_options` for the
-// configuration to connect to a Kerberized Kafka cluster. You can find more
-// detail about these settings in
-// [librdkafka's documentation](https://github.com/edenhill/librdkafka/wiki/Using-SASL-with-librdkafka).
-fn sasl_plaintext_kerberos_settings(agg: &mut ConfigAggregator) -> Result<(), failure::Error> {
-    // Represents valid `with_option` keys to connect to Kerberized Kafka
-    // cluster through SASL based on
-    // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md.
-    // Currently all of these keys can be converted to their respective
-    // client config settings by replacing underscores with dots.
-    //
-    // Each option's default value are determined by `librdkafka`, and any
-    // missing-but-necessary options are surfaced by `librdkafka` either
-    // erroring or logging an error.
-    let allowed_configs = vec![
-        Config::path("sasl_kerberos_keytab"),
-        Config::string("sasl_kerberos_kinit_cmd"),
-        Config::string("sasl_kerberos_min_time_before_relogin"),
-        Config::string("sasl_kerberos_principal"),
-        Config::string("sasl_kerberos_service_name"),
-        Config::string("sasl_mechanisms"),
-    ];
-
-    agg.extract(&allowed_configs)?;
-
-    agg.insert_into_output(
-        "security.protocol".to_string(),
-        "sasl_plaintext".to_string(),
-    );
-
-    Ok(())
+    extract(
+        with_options,
+        &[
+            Config::string("client_id"),
+            Config::new(
+                "statistics_interval_ms",
+                // The range of values comes from `statistics.interval.ms` in
+                // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+                ValType::Number(0, 86_400_000),
+            ),
+            Config::new(
+                "topic_metadata_refresh_interval_ms",
+                // The range of values comes from `topic.metadata.refresh.interval.ms` in
+                // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+                ValType::Number(0, 3_600_000),
+            ),
+            Config::string("security_protocol"),
+            Config::path("sasl_kerberos_keytab"),
+            Config::string("sasl_username"),
+            Config::string("sasl_password"),
+            Config::string("sasl_kerberos_kinit_cmd"),
+            Config::string("sasl_kerberos_min_time_before_relogin"),
+            Config::string("sasl_kerberos_principal"),
+            Config::string("sasl_kerberos_service_name"),
+            // For historical reasons, we allow `sasl_mechanisms` to be lowercase or
+            // mixed case, while librdkafka requires all uppercase (e.g., `PLAIN`,
+            // not `plain`).
+            Config::string("sasl_mechanisms").transform(|s| s.to_uppercase()),
+            Config::path("ssl_ca_location"),
+            Config::path("ssl_certificate_location"),
+            Config::path("ssl_key_location"),
+            Config::string("ssl_key_password"),
+        ],
+    )
 }
 
 /// Create a new `rdkafka::ClientConfig` with the provided
@@ -325,19 +250,20 @@ impl rdkafka::client::ClientContext for RDKafkaErrCheckContext {
 // `extract_security_config()`. Currently only supports SSL auth.
 pub fn generate_ccsr_client_config(
     csr_url: Url,
-    config_options: &HashMap<String, String>,
+    kafka_options: &HashMap<String, String>,
+    ccsr_options: &HashMap<String, Value>,
 ) -> Result<ccsr::ClientConfig, failure::Error> {
     let mut client_config = ccsr::ClientConfig::new(csr_url);
 
-    if let Some(ca_path) = config_options.get("ssl.ca.location") {
+    if let Some(ca_path) = kafka_options.get("ssl.ca.location") {
         let mut ca_buf = Vec::new();
         File::open(ca_path)?.read_to_end(&mut ca_buf)?;
         let cert = Certificate::from_pem(&ca_buf)?;
         client_config = client_config.add_root_certificate(cert);
     }
 
-    let key_path = config_options.get("ssl.key.location");
-    let cert_path = config_options.get("ssl.certificate.location");
+    let key_path = kafka_options.get("ssl.key.location");
+    let cert_path = kafka_options.get("ssl.certificate.location");
     match (key_path, cert_path) {
         (Some(key_path), Some(cert_path)) => {
             // `reqwest` expects identity `pem` files to contain one key and
@@ -353,8 +279,17 @@ pub fn generate_ccsr_client_config(
         (None, None) => {}
         (_, _) => bail!(
             "Reading from SSL-auth Confluent Schema Registry \
-        requires both ssl.key.location and ssl.certificate.location"
+             requires both ssl.key.location and ssl.certificate.location"
         ),
     }
+
+    let mut ccsr_options = extract(
+        ccsr_options,
+        &[Config::string("username"), Config::string("password")],
+    )?;
+    if let Some(username) = ccsr_options.remove("username") {
+        client_config = client_config.auth(username, ccsr_options.remove("password"));
+    }
+
     Ok(client_config)
 }


### PR DESCRIPTION
I'm still working on getting an automated test for this, but I think we can land this as-is if necessary (pending review) to unblock the PoC that needs it. (I tested against Confluent Cloud manually for the moment.)

----

Support the SASL PLAIN authentication scheme for Kafka and the HTTP
basic authentication schema for the schema registry. This makes it
possible to use Materialize against a Confluent Cloud cluster.

Note that determining which subset of Kafka configuration options are
allowable for a given security protocol is approximately impossible, so
instead we just dump all the options that are allowable in *some*
configuration into one big allow list and let librdkafka sort out the
rest.

Fix #3418.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3561)
<!-- Reviewable:end -->
