### PR TITLE
mzbuild: fix "input is not a TTY" error

### DIFF
--- a/misc/python/materialize/spawn.py
+++ b/misc/python/materialize/spawn.py
@@ -123,5 +123,5 @@ def capture(
     """
     stderr = subprocess.STDOUT if stderr_too else None
     return subprocess.check_output(  # type: ignore
-        args, cwd=cwd, input=stdin, universal_newlines=unicode, stderr=stderr
+        args, cwd=cwd, stdin=stdin, universal_newlines=unicode, stderr=stderr
     )


### PR DESCRIPTION
Not sure exactly what the semantics of the `input` parameter are, or the
exact situations in which this doesn't work. but using `stdin` instead
makes the error go away.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3566)
<!-- Reviewable:end -->
