### PR TITLE
Check for union first when using defaults

### DIFF
--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -229,6 +229,32 @@ fn test_no_default_value() -> Result<(), String> {
 }
 
 #[test]
+fn test_union_default() {
+    let reader_schema = Schema::parse_str(
+        r#"{
+            "type": "record",
+            "name": "Test",
+            "fields": [
+                {"name": "f1", "type": ["int", "null"], "default": 42},
+                {"name": "f2", "type": "long"}
+            ]
+        }"#,
+    )
+    .unwrap();
+    let writer_schema = Schema::parse_str(
+        r#"{
+            "type": "record",
+            "name": "Test",
+            "fields": [
+                {"name": "f2", "type": "long"}
+            ]
+        }"#,
+    )
+    .unwrap();
+    resolve_schemas(&writer_schema, &reader_schema).unwrap();
+}
+
+#[test]
 fn test_projection() {
     let reader_schema = Schema::parse_str(
         r#"


### PR DESCRIPTION
When decoding default values in avro schemas, defaults for unions should always be matched against the first result in the union.

However, we did the check for unions last, so, since in Rust match statements are tried in order, we were attempting to resolve the default against other types like Number and failing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3569)
<!-- Reviewable:end -->
