### PR TITLE
Moving Kinesis sources to unified source ingestion framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "differential-dataflow",
  "dogsdogsdogs",
  "expr",
+ "failure",
  "futures",
  "interchange",
  "itertools",

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -477,7 +477,10 @@ impl ExternalSourceConnector {
                 "mz_line_no".into(),
                 ColumnType::new(ScalarType::Int64, false),
             )],
-            Self::Kinesis(_) => vec![],
+            Self::Kinesis(_) => vec![(
+                "mz_offset".into(),
+                ColumnType::new(ScalarType::Int64, false),
+            )],
             Self::AvroOcf(_) => vec![(
                 "mz_obj_no".into(),
                 ColumnType::new(ScalarType::Int64, false),

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -18,6 +18,7 @@ dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
+failure = "0.1"
 futures = "0.3"
 interchange = { path = "../interchange" }
 itertools = "0.9"

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -68,16 +68,16 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
         connector: ExternalSourceConnector,
         _: &mut ConsistencyInfo,
         _: DataEncoding,
-    ) -> KafkaSourceInfo {
+    ) -> Result<KafkaSourceInfo, failure::Error> {
         match connector {
-            ExternalSourceConnector::Kafka(kc) => KafkaSourceInfo::new(
+            ExternalSourceConnector::Kafka(kc) => Ok(KafkaSourceInfo::new(
                 source_name,
                 source_id,
                 worker_id,
                 worker_count,
                 consumer_activator,
                 kc,
-            ),
+            )),
             _ => unreachable!(),
         }
     }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -7,26 +7,32 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use futures::executor::block_on;
-use lazy_static::lazy_static;
-use log::{error, warn};
-use prometheus::{register_int_counter, register_int_gauge_vec, IntCounter, IntGauge, IntGaugeVec};
-use rusoto_core::RusotoError;
-use rusoto_kinesis::{GetRecordsError, GetRecordsInput, GetRecordsOutput, Kinesis, KinesisClient};
+use std::collections::{HashSet, VecDeque};
+use std::convert::TryInto;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use std::time::Instant;
 
 use aws_util::kinesis::{get_shard_ids, get_shard_iterator};
-use dataflow_types::{Consistency, KinesisSourceConnector, Timestamp};
-use timely::dataflow::operators::Capability;
-use timely::dataflow::{Scope, Stream};
-use timely::scheduling::Activator;
+use futures::executor::block_on;
+use lazy_static::lazy_static;
+use log::error;
+use prometheus::{register_int_gauge_vec, IntGauge, IntGaugeVec};
+use rusoto_core::RusotoError;
+use rusoto_kinesis::{GetRecordsError, GetRecordsInput, GetRecordsOutput, Kinesis, KinesisClient};
+use timely::scheduling::{Activator, SyncActivator};
 
-use super::util::source;
-use super::{SourceConfig, SourceOutput, SourceStatus, SourceToken};
-use crate::metrics::EVENTS_COUNTER;
-use crate::server::{TimestampDataUpdate, TimestampMetadataUpdate};
+use dataflow_types::{
+    Consistency, DataEncoding, ExternalSourceConnector, KinesisSourceConnector, MzOffset,
+};
+use expr::{PartitionId, SourceInstanceId};
+
+use crate::server::{
+    TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
+};
+use crate::source::{
+    ConsistencyInfo, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
+};
 
 lazy_static! {
     static ref MILLIS_BEHIND_LATEST: IntGaugeVec = register_int_gauge_vec!(
@@ -37,14 +43,6 @@ lazy_static! {
     .expect("Can construct an intgauge for millis_behind_latest");
 }
 
-lazy_static! {
-    static ref BYTES_READ_COUNTER: IntCounter = register_int_counter!(
-        "mz_kinesis_bytes_read_total",
-        "Count of kinesis bytes we have read from the wire"
-    )
-    .unwrap();
-}
-
 /// To read all data from a Kinesis stream, we need to continually update
 /// our knowledge of the stream's shards by calling the ListShards API.
 ///
@@ -52,83 +50,205 @@ lazy_static! {
 /// (100x/sec per stream) and to improve source performance overall.
 const KINESIS_SHARD_REFRESH_RATE: Duration = Duration::from_secs(60);
 
-/// Creates a Kinesis-based timely dataflow source operator.
-pub fn kinesis<G>(
-    config: SourceConfig<G>,
-    connector: KinesisSourceConnector,
-) -> (
-    Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
-    Option<SourceToken>,
-)
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    // Putting source information on the Timestamp channel lets this
-    // Dataflow worker communicate that it has created a source.
-    let ts = if let Consistency::BringYourOwn(_) = config.consistency {
-        if config.active {
-            let prev = config.timestamp_histories.borrow_mut().insert(
-                config.id.clone(),
-                TimestampDataUpdate::BringYourOwn(HashMap::new()),
+/// Contains all information necessary to ingest data from Kinesis
+pub struct KinesisSourceInfo {
+    /// Source Name
+    name: String,
+    /// Unique Source Id
+    id: SourceInstanceId,
+    /// Field is set if this operator is responsible for ingesting data
+    is_activated_reader: bool,
+    /// Kinesis client used to obtain records
+    kinesis_client: KinesisClient,
+    /// The name of the stream
+    stream_name: String,
+    /// The set of active shards
+    shard_set: HashSet<String>,
+    /// A queue representing the next shard to read from. This is necessary
+    /// to ensure that all shards are read from uniformly
+    shard_queue: VecDeque<(String, Option<String>)>,
+    /// The time at which we last refreshed metadata
+    /// TODO(natacha): this should be moved to timestamper
+    last_checked_shards: Instant,
+    /// Storage for messages that have not yet been timestamped
+    buffered_messages: VecDeque<SourceMessage<Vec<u8>>>,
+    /// Count of processed message
+    processed_message_count: i64,
+}
+
+impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
+    fn new(
+        source_name: String,
+        source_id: SourceInstanceId,
+        active: bool,
+        _worker_id: usize,
+        _worker_count: usize,
+        _consumer_activator: Arc<Mutex<SyncActivator>>,
+        connector: ExternalSourceConnector,
+        consistency_info: &mut ConsistencyInfo,
+        _encoding: DataEncoding,
+    ) -> Result<Self, failure::Error> {
+        let kc = match connector {
+            ExternalSourceConnector::Kinesis(kc) => kc,
+            _ => unreachable!(),
+        };
+
+        let state = block_on(create_state(kc, &source_name, source_id, consistency_info));
+        match state {
+            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok(KinesisSourceInfo {
+                name: source_name,
+                id: source_id,
+                is_activated_reader: active,
+                kinesis_client,
+                shard_queue,
+                last_checked_shards: Instant::now(),
+                buffered_messages: VecDeque::new(),
+                shard_set,
+                stream_name,
+                processed_message_count: 0,
+            }),
+            Err(e) => Err(failure::err_msg(e.to_string())),
+        }
+    }
+}
+
+impl KinesisSourceInfo {
+    async fn update_shard_information(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+    ) -> Result<(), anyhow::Error> {
+        let new_shards: HashSet<String> = get_shard_ids(&self.kinesis_client, &self.stream_name)
+            .await?
+            .difference(&self.shard_set)
+            .map(|shard_id| shard_id.to_owned())
+            .collect();
+        for shard_id in new_shards {
+            self.shard_set.insert(shard_id.clone());
+            self.shard_queue.push_back((
+                shard_id.clone(),
+                get_shard_iterator(&self.kinesis_client, &self.stream_name, &shard_id).await?,
+            ));
+            let kinesis_id = PartitionId::Kinesis(shard_id);
+            consistency_info.update_partition_metadata(kinesis_id.clone());
+            consistency_info.partition_metrics.insert(
+                kinesis_id.clone(),
+                PartitionMetrics::new(&self.name, &self.id.to_string(), &kinesis_id.to_string()),
             );
-            assert!(prev.is_none());
-            config
-                .timestamp_tx
+        }
+        Ok(())
+    }
+
+    /// Obtains the next record for this shard given a shard iterator
+    async fn get_records(
+        &self,
+        shard_iterator: &str,
+    ) -> Result<GetRecordsOutput, RusotoError<GetRecordsError>> {
+        self.kinesis_client
+            .get_records(GetRecordsInput {
+                limit: None,
+                shard_iterator: String::from(shard_iterator),
+            })
+            .await
+    }
+}
+
+impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
+    fn activate_source_timestamping(
+        id: &SourceInstanceId,
+        consistency: &Consistency,
+        _active: bool,
+        timestamp_data_updates: TimestampDataUpdates,
+        timestamp_metadata_channel: TimestampMetadataUpdates,
+    ) -> Option<TimestampMetadataUpdates> {
+        // Putting source information on the Timestamp channel lets this
+        // Dataflow worker communicate that it has created a source.
+        if let Consistency::BringYourOwn(_) = consistency {
+            error!("Kinesis sources do not currently support BYO consistency");
+            None
+        } else {
+            timestamp_data_updates
+                .borrow_mut()
+                .insert(id.clone(), TimestampDataUpdate::RealTime(1));
+            timestamp_metadata_channel
                 .as_ref()
                 .borrow_mut()
-                .push(TimestampMetadataUpdate::StartTimestamping(config.id));
-            Some(config.timestamp_tx)
-        } else {
-            None
+                .push(TimestampMetadataUpdate::StartTimestamping(*id));
+            Some(timestamp_metadata_channel)
         }
-    } else {
-        None
-    };
+    }
 
-    let mut state = block_on(create_state(connector));
-    let mut last_checked_shards = std::time::Instant::now();
+    fn can_close_timestamp(
+        &self,
+        consistency_info: &ConsistencyInfo,
+        pid: &PartitionId,
+        offset: MzOffset,
+    ) -> bool {
+        if !self.is_activated_reader {
+            true
+        } else {
+            // Guaranteed to exist if we receive a message from this partition
+            let last_offset = consistency_info
+                .partition_metadata
+                .get(&pid)
+                .unwrap()
+                .offset;
+            last_offset >= offset
+        }
+    }
 
-    let SourceConfig { name, scope, .. } = config;
+    fn get_worker_partition_count(&self) -> i32 {
+        if self.is_activated_reader {
+            // Kinesis does not support more than i32 partitions
+            self.shard_set.len().try_into().unwrap()
+        } else {
+            0
+        }
+    }
 
-    let (stream, capability) = source(config.id, ts, scope, name.clone(), move |info| {
-        let activator = scope.activator_for(&info.address[..]);
+    fn has_partition(&self, _partition_id: PartitionId) -> bool {
+        self.is_activated_reader
+    }
 
-        move |cap, output| {
-            let (client, stream_name, shard_set, shard_queue) = match &mut state {
-                Ok(state) => state,
-                Err(e) => {
-                    error!("failed to create Kinesis state: {:#?}", e);
-                    return SourceStatus::Done;
-                }
-            };
+    fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
+        //TODO(natacha): do nothing for now, as do not currently use timestamper
+    }
 
-            if last_checked_shards.elapsed() >= KINESIS_SHARD_REFRESH_RATE {
-                if let Err(e) = block_on(update_shard_information(
-                    &client,
-                    &stream_name,
-                    shard_set,
-                    shard_queue,
-                )) {
-                    error!("{:#?}", e);
-                    return SourceStatus::Done;
-                }
-                last_checked_shards = std::time::Instant::now();
+    fn update_partition_count(
+        &mut self,
+        _consistency_info: &mut ConsistencyInfo,
+        _partition_count: i32,
+    ) {
+        //TODO(natacha): do nothing for now as do not currently use timestamper
+    }
+
+    fn get_next_message(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+        activator: &Activator,
+    ) -> Result<Option<SourceMessage<Vec<u8>>>, anyhow::Error> {
+        assert_eq!(self.shard_queue.len(), self.shard_set.len());
+
+        //TODO move to timestamper
+        if self.last_checked_shards.elapsed() >= KINESIS_SHARD_REFRESH_RATE {
+            if let Err(e) = block_on(self.update_shard_information(consistency_info)) {
+                error!("{:#?}", e);
+                return Err(anyhow::Error::msg(e.to_string()));
             }
+            self.last_checked_shards = std::time::Instant::now();
+        }
 
-            let timer = std::time::Instant::now();
+        if let Some(message) = self.buffered_messages.pop_front() {
+            Ok(Some(message))
+        } else {
             // Rotate through all of a stream's shards, start with a new shard on each activation.
-            while let Some((shard_id, mut shard_iterator)) = shard_queue.pop_front() {
-                // While the next_shard_iterator is Some(iterator), the shard is open
-                // and could return more data.
-                while let Some(iterator) = &shard_iterator {
-                    // Pushing back to the shard_queue will allow us to read from the
-                    // shard again.
-                    let get_records_output = match block_on(get_records(&client, &iterator)) {
+            if let Some((shard_id, mut shard_iterator)) = self.shard_queue.pop_front() {
+                if let Some(iterator) = &shard_iterator {
+                    let get_records_output = match block_on(self.get_records(&iterator)) {
                         Ok(output) => {
                             shard_iterator = output.next_shard_iterator.clone();
                             if let Some(millis) = output.millis_behind_latest {
                                 let shard_metrics: IntGauge = MILLIS_BEHIND_LATEST
-                                    .with_label_values(&[&stream_name, &shard_id]);
+                                    .with_label_values(&[&self.stream_name, &shard_id]);
                                 shard_metrics.set(millis);
                             }
                             output
@@ -136,27 +256,23 @@ where
                         Err(RusotoError::HttpDispatch(e)) => {
                             // todo@jldlaughlin: Parse this to determine fatal/retriable?
                             error!("{}", e);
-                            return reactivate_kinesis_source(
-                                &activator,
-                                shard_queue,
-                                &shard_id,
-                                shard_iterator,
-                            );
+                            self.shard_queue.push_back((shard_id, shard_iterator));
+                            activator.activate();
+                            // Do not send error message as this would cause source to terminate
+                            return Ok(None);
                         }
                         Err(RusotoError::Service(GetRecordsError::ExpiredIterator(e))) => {
                             // todo@jldlaughlin: Will need track source offsets to grab a new iterator.
                             error!("{}", e);
-                            return SourceStatus::Done;
+                            return Err(anyhow::Error::msg(e));
                         }
                         Err(RusotoError::Service(
                             GetRecordsError::ProvisionedThroughputExceeded(_),
                         )) => {
-                            return reactivate_kinesis_source(
-                                &activator,
-                                shard_queue,
-                                &shard_id,
-                                shard_iterator,
-                            );
+                            self.shard_queue.push_back((shard_id, shard_iterator));
+                            activator.activate();
+                            // Do not send error message as this would cause source to terminate
+                            return Ok(None);
                         }
                         Err(e) => {
                             // Fatal service errors:
@@ -172,71 +288,44 @@ where
                             // - Unknown (raw HTTP provided)
                             // - Blocking
                             error!("{}", e);
-                            return SourceStatus::Done;
+                            return Err(anyhow::Error::msg(e.to_string()));
+                            //                            return Err(failure::err_msg(e.to_string()));
                         }
                     };
 
-                    let mut events_success = 0;
-                    let mut bytes_read = 0;
                     for record in get_records_output.records {
                         let data = record.data.as_ref().to_vec();
-                        bytes_read += data.len() as i64;
-                        // We don't do anything with keys; just send vec![] for now.
-                        // Kinesis doesn't have "primary keys" but it does have "partition keys" and "sequence numbers"; maybe
-                        // one or both of those could be useful...
-                        output
-                            .session(&cap)
-                            .give(SourceOutput::new(vec![], data, None));
-                        events_success += 1;
+                        self.processed_message_count += 1;
+                        let source_message = SourceMessage {
+                            partition: PartitionId::Kinesis(shard_id.clone()),
+                            offset: MzOffset {
+                                //TODO: should MzOffset be modified to be a string?
+                                offset: self.processed_message_count,
+                            },
+                            key: None,
+                            payload: Some(data),
+                        };
+                        self.buffered_messages.push_back(source_message);
                     }
-                    downgrade_capability(cap, &name);
-                    EVENTS_COUNTER.raw.success.inc_by(events_success);
-                    BYTES_READ_COUNTER.inc_by(bytes_read);
-
-                    if get_records_output.millis_behind_latest == Some(0)
-                        || timer.elapsed().as_millis() > 10
-                    {
-                        return reactivate_kinesis_source(
-                            &activator,
-                            shard_queue,
-                            &shard_id,
-                            shard_iterator,
-                        );
-                    }
-
-                    // Each Kinesis shard can support up to 5 read requests per second.
-                    // This will throttle ourselves.
-                    activator.activate();
+                    self.shard_queue.push_back((shard_id, shard_iterator));
                 }
             }
-            // todo@jdlaughlin: Revisit when Kinesis sources should be marked as done.
-            // Should switch to when we fail to get a stream description (the stream is
-            // closed)?
-            SourceStatus::Done
+            Ok(self.buffered_messages.pop_front())
         }
-    });
+    }
 
-    if config.active {
-        (stream, Some(capability))
-    } else {
-        (stream, None)
+    fn buffer_message(&mut self, message: SourceMessage<Vec<u8>>) {
+        self.buffered_messages.push_front(message);
     }
 }
 
-fn reactivate_kinesis_source(
-    activator: &Activator,
-    shard_queue: &mut VecDeque<(String, Option<String>)>,
-    shard_id: &str,
-    shard_iterator: Option<String>,
-) -> SourceStatus {
-    shard_queue.push_back((shard_id.to_owned(), shard_iterator));
-    activator.activate();
-    SourceStatus::Alive
-}
-
+/// Creates the necessary data-structures for shard management
 // todo: Better error handling here! Not all errors mean we're done/can't progress.
 async fn create_state(
     c: KinesisSourceConnector,
+    name: &str,
+    id: SourceInstanceId,
+    consistency_info: &mut ConsistencyInfo,
 ) -> Result<
     (
         KinesisClient,
@@ -257,68 +346,22 @@ async fn create_state(
     let shard_set: HashSet<String> = get_shard_ids(&kinesis_client, &c.stream_name).await?;
     let mut shard_queue: VecDeque<(String, Option<String>)> = VecDeque::new();
     for shard_id in &shard_set {
+        let kinesis_id = PartitionId::Kinesis(shard_id.clone());
         shard_queue.push_back((
             shard_id.clone(),
             get_shard_iterator(&kinesis_client, &c.stream_name, shard_id).await?,
-        ))
+        ));
+        consistency_info.update_partition_metadata(kinesis_id.clone());
+        consistency_info.partition_metrics.insert(
+            kinesis_id.clone(),
+            PartitionMetrics::new(name, &id.to_string(), &kinesis_id.to_string()),
+        );
     }
+
     Ok((
         kinesis_client,
         c.stream_name.clone(),
         shard_set,
         shard_queue,
     ))
-}
-
-fn downgrade_capability(cap: &mut Capability<u64>, name: &str) {
-    // For now, use the system's current timestamp to downgrade
-    // capabilities.
-    // todo: Implement better offset tracking for Kinesis sources #2219
-    let cur = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_millis() as u64;
-    if cur > *cap.time() {
-        cap.downgrade(&cur);
-    } else {
-        warn!(
-            "{}: Unexpected - Kinesis source capability ahead of current system time ({} > {})",
-            name.to_string(),
-            *cap.time(),
-            cur
-        );
-    }
-}
-
-async fn get_records(
-    client: &KinesisClient,
-    shard_iterator: &str,
-) -> Result<GetRecordsOutput, RusotoError<GetRecordsError>> {
-    client
-        .get_records(GetRecordsInput {
-            limit: None,
-            shard_iterator: String::from(shard_iterator),
-        })
-        .await
-}
-
-async fn update_shard_information(
-    client: &KinesisClient,
-    stream_name: &str,
-    shard_set: &mut HashSet<String>,
-    shard_queue: &mut VecDeque<(String, Option<String>)>,
-) -> Result<(), anyhow::Error> {
-    let new_shards: HashSet<String> = get_shard_ids(&client, stream_name)
-        .await?
-        .difference(shard_set)
-        .map(|shard_id| shard_id.to_owned())
-        .collect();
-    for shard_id in new_shards {
-        shard_set.insert(shard_id.clone());
-        shard_queue.push_back((
-            shard_id.clone(),
-            get_shard_iterator(&client, stream_name, &shard_id).await?,
-        ));
-    }
-    Ok(())
 }

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -15,6 +15,13 @@ here's a test string
 $ kinesis-verify stream=test
 here's a test string
 
+$ kinesis-ingest format=bytes stream=test
+here's a second test string
+
+$ kinesis-verify stream=test
+here's a test string
+here's a second test string
+
 ! CREATE SOURCE custom_source
   FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
   WITH (access_key_id = 'fake_access_key_id',
@@ -35,3 +42,4 @@ If providing a custom region, an `endpoint` option must also be provided
 
 > SELECT * FROM f_view
 "here's a test string"
+"here's a second test string"


### PR DESCRIPTION
This PR is stacked on top of #3532. Only the last commit is relevant.

It moves Kinesis sources to the unified source ingestion framework.

This PR 
1) does not currently modify Kinesis sources to use the timestamper
2) support multithreaded reading of Kinesis sources
3) support BYO consistency for Kinesis sources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3575)
<!-- Reviewable:end -->
