### PR TITLE
Support CI with branches named both main and master

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -12,7 +12,7 @@ production readiness.
 ### Create the release candidate
 
 - [ ] Choose the desired commit. Most often, this will be the latest commit to
-  master.
+  main.
 
   ```shell
   git checkout <SHA>
@@ -48,11 +48,11 @@ production readiness.
   git push origin $tag  # where 'origin' is your MaterializeInc/materialize remote
   ```
 
-- [ ] On **master**:
+- [ ] On **main**:
 
   - [ ] Update the version field in
     [`src/materialized/Cargo.toml`](../../src/materialized/Cargo.toml) to
-    `vNEXT-dev`. For example, if releasing v0.1.2, bump the version on master to
+    `vNEXT-dev`. For example, if releasing v0.1.2, bump the version on main to
     `v0.1.3-dev`.
 
   - [ ] Update the [`LICENSE`](/LICENSE) file to use the `-dev` version, and
@@ -71,7 +71,7 @@ To run the required load tests on the release candidate tag, Materialize employe
 can follow [these instructions for running semi-automatic load tests][load-instr]
 in the infrastructure repository. All of these tests can be run in parallel.
 
-[load-instr]: https://github.com/MaterializeInc/infra/tree/master/cloud#starting-a-load-test
+[load-instr]: https://github.com/MaterializeInc/infra/tree/main/cloud#starting-a-load-test
 
 - [ ] Run the chbench load test on the release candidate tag.
 
@@ -176,9 +176,9 @@ in the infrastructure repository. All of these tests can be run in parallel.
     * [Documentation](https://materialize.io/docs/)
     ```
 
-### Update the master branch for the next version
+### Update the main branch for the next version
 
-- [ ] On **master**, update the various files that must be up to date:
+- [ ] On **main**, update the various files that must be up to date:
 
   - [ ] Ensure that the [Release Notes] are up
     to date, including the current version.
@@ -192,10 +192,10 @@ in the infrastructure repository. All of these tests can be run in parallel.
 
 - [ ] Close this issue.
 
-[`doc/user/config.toml`]: https://github.com/MaterializeInc/materialize/blob/master/doc/user/config.toml
-[`LICENSE`]: https://github.com/MaterializeInc/materialize/tree/master/LICENSE
-[`src/materialized/Cargo.toml`]: https://github.com/MaterializeInc/materialize/tree/master/src/materialized/Cargo.toml
+[`doc/user/config.toml`]: https://github.com/MaterializeInc/materialize/blob/main/doc/user/config.toml
+[`LICENSE`]: https://github.com/MaterializeInc/materialize/tree/main/LICENSE
+[`src/materialized/Cargo.toml`]: https://github.com/MaterializeInc/materialize/tree/main/src/materialized/Cargo.toml
 [homebrew-guide]: https://github.com/MaterializeInc/homebrew-materialize/blob/master/CONTRIBUTING.md
-[Release Notes]: https://github.com/MaterializeInc/materialize/tree/master/doc/user/content/release-notes.md
+[Release Notes]: https://github.com/MaterializeInc/materialize/tree/main/doc/user/content/release-notes.md
 [releases]: https://github.com/MaterializeInc/materialize/releases
 [v0.1.2]: https://github.com/MaterializeInc/materialize/releases/tag/v0.1.2

--- a/ci/README.md
+++ b/ci/README.md
@@ -9,7 +9,7 @@ of commands that can be automatically triggered in response to pushes,
 new pull requests, or manual UI actions. We have multiple pipelines in this
 repository: the "test" pipeline, for example, runs `cargo test` on every PR,
 while the "deploy" pipeline builds the Rust API documentation and publishes
-it to mtrlz.dev after a merge to master.
+it to mtrlz.dev after a merge to main.
 
 Pipelines are configured with a YAML file that lives in version control,
 meaning the build configuration can be versioned alongside the code it builds.

--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -9,7 +9,7 @@
 
 steps:
   - command: bin/ci-builder run nightly ci/deploy/devsite.sh
-    branches: master
+    branches: "master main"
     timeout_in_minutes: 30
     agents:
       queue: builder

--- a/ci/slt/upload.sh
+++ b/ci/slt/upload.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 set -x  # TODO(benesch): remove when this script works reliably.
 
-if [[ "${BUILDKITE_BRANCH-}" = master && "${BUILDKITE_COMMIT-}" ]]; then
+if [[ "${BUILDKITE_BRANCH-}" =~ master|main && "${BUILDKITE_COMMIT-}" ]]; then
     mkdir -p target
     buildkite-agent artifact download target/slt-summary.json .
     jq --arg commit "$BUILDKITE_COMMIT" -rf ci/slt/parse-summary.jq target/slt-summary.json \

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -36,7 +36,7 @@ def main() -> None:
             d.push()
 
     print("--- Staging Debian package")
-    if os.environ["BUILDKITE_BRANCH"] == "master":
+    if os.environ["BUILDKITE_BRANCH"] in ("master", "main"):
         stage_deb(repo, "materialized-unstable", deb.unstable_version(workspace))
     elif os.environ["BUILDKITE_TAG"]:
         version = workspace.crates["materialized"].version
@@ -45,7 +45,7 @@ def main() -> None:
         ), f'materialized version {version} does not match tag {os.environ["BUILDKITE_TAG"]}'
         stage_deb(repo, "materialized", str(version))
     else:
-        print("Not on master branch or tag; skipping")
+        print("Not on main branch or tag; skipping")
 
 
 def stage_deb(repo: mzbuild.Repository, package: str, version: str) -> None:
@@ -90,7 +90,7 @@ def stage_deb(repo: mzbuild.Repository, package: str, version: str) -> None:
     try:
         print("Creating Bintray version...")
         commit_hash = git.rev_parse("HEAD")
-        package.create_version(version, desc="git master", vcs_tag=commit_hash)
+        package.create_version(version, desc="git main", vcs_tag=commit_hash)
     except bintray.VersionAlreadyExistsError:
         # Ignore for idempotency. Bintray won't allow us to overwite an existing
         # .deb below with a file whose checksum doesn't match, so this is safe.

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -190,7 +190,7 @@ steps:
       - metabase-demo
     trigger: deploy
     async: true
-    branches: "master v*.*"
+    branches: "master main v*.*"
     build:
       commit: "$BUILDKITE_COMMIT"
       branch: "$BUILDKITE_BRANCH"

--- a/ci/www/changed.sh
+++ b/ci/www/changed.sh
@@ -15,11 +15,16 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-if [[ "$BRANCH" = master ]]; then
+if [[ "$BRANCH" =~ master|main ]]; then
     spec=HEAD^
 else
     git fetch https://github.com/MaterializeInc/materialize.git master
-    spec=FETCH_HEAD...
+    git fetch https://github.com/MaterializeInc/materialize.git main 2>/dev/null || true
+    if git merge-base --is-ancestor master main 2>/dev/null ; then
+        spec=main...
+    else
+        spec=master...
+    fi
 fi
 
 # The www build doesn't depend on submodules, so remove them from the working

--- a/demo/chbench/README.md
+++ b/demo/chbench/README.md
@@ -76,4 +76,4 @@ around this:
 Materialize employees can follow the instructions in the infrastructure
 repository for running a semi-automatic load test on AWS EC2.
 
-See: https://github.com/MaterializeInc/infra/tree/master/cloud#starting-a-load-test
+See: https://github.com/MaterializeInc/infra/tree/main/cloud#starting-a-load-test

--- a/doc/developer/assets/rel/01-clean.svg
+++ b/doc/developer/assets/rel/01-clean.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="209.156" height="213.5">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="192.313" height="213.5">
     <path d="M24 184v-80-80" fill="transparent" stroke="#979797" stroke-width="10"/>
     <g transform="translate(10 170)">
         <defs>
@@ -34,13 +34,13 @@
             </defs>
             <use href="#e" xlink:href="#e" clip-path="url(#f)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(147.297 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(130.453 24)">
             C - &lt;&gt;
         </text>
         <g transform="translate(60 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
     </g>

--- a/doc/developer/assets/rel/02-tagged.svg
+++ b/doc/developer/assets/rel/02-tagged.svg
@@ -40,13 +40,13 @@
             </defs>
             <use href="#e" xlink:href="#e" clip-path="url(#f)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(147.297 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(130.453 24)">
             C - &lt;&gt;
         </text>
         <g transform="translate(60 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
     </g>

--- a/doc/developer/assets/rel/03-tagged-release.svg
+++ b/doc/developer/assets/rel/03-tagged-release.svg
@@ -46,13 +46,13 @@
             </defs>
             <use href="#e" xlink:href="#e" clip-path="url(#f)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(147.297 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(130.453 24)">
             C - &lt;&gt;
         </text>
         <g transform="translate(60 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
     </g>

--- a/doc/developer/assets/rel/04-main-progressed.svg
+++ b/doc/developer/assets/rel/04-main-progressed.svg
@@ -80,13 +80,13 @@
             </defs>
             <use href="#k" xlink:href="#k" clip-path="url(#l)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(147.297 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(130.453 24)">
             F - &lt;&gt;
         </text>
         <g transform="translate(60 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
     </g>

--- a/doc/developer/assets/rel/05-tagged-rc2.svg
+++ b/doc/developer/assets/rel/05-tagged-rc2.svg
@@ -121,13 +121,13 @@
             </defs>
             <use href="#o" xlink:href="#o" clip-path="url(#p)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(197.297 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(180.453 24)">
             F - &lt;&gt;
         </text>
         <g transform="translate(110 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
     </g>

--- a/doc/developer/assets/rel/06-release-010.svg
+++ b/doc/developer/assets/rel/06-release-010.svg
@@ -127,13 +127,13 @@
             </defs>
             <use href="#o" xlink:href="#o" clip-path="url(#p)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(197.297 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(180.453 24)">
             F - &lt;&gt;
         </text>
         <g transform="translate(110 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
     </g>

--- a/doc/developer/assets/rel/07-release-011.svg
+++ b/doc/developer/assets/rel/07-release-011.svg
@@ -155,18 +155,18 @@
             </defs>
             <use href="#s" xlink:href="#s" clip-path="url(#t)" stroke-width="0"/>
         </g>
-        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(322.266 24)">
+        <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" transform="translate(305.422 24)">
             H - &lt;&gt;
         </text>
         <g transform="translate(110 10)">
-            <rect width="77.297" height="31" rx="10" fill="#fff" stroke="#979797"/>
+            <rect width="60.453" height="31" rx="10" fill="#fff" stroke="#979797"/>
             <text alignment-baseline="central" dominant-baseline="central" fill="#979797" style="font:14pt Arial" x="10" y="15.5">
-                master
+                main
             </text>
         </g>
         <g data-offset="12">
-            <path d="M197.297 24l12 15.5h92.969q10 0 10-10v-11q0-10-10-10h-92.97 0z" fill="#979797" stroke="#979797"/>
-            <text alignment-baseline="central" dominant-baseline="central" fill="#fff" style="font:14pt Arial" x="22" transform="translate(197.297 24)">
+            <path d="M180.453 24l12 15.5h92.969q10 0 10-10v-11q0-10-10-10h-92.969 0z" fill="#979797" stroke="#979797"/>
+            <text alignment-baseline="central" dominant-baseline="central" fill="#fff" style="font:14pt Arial" x="22" transform="translate(180.453 24)">
                 v0.1.1-rc1
             </text>
         </g>

--- a/doc/developer/assets/rel/build.js
+++ b/doc/developer/assets/rel/build.js
@@ -29,8 +29,8 @@ const graphs = [
     {
         name: "01-clean",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .commit({hash: "C"});
@@ -39,8 +39,8 @@ const graphs = [
     {
         name: "02-tagged",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .tag("v0.1.0-rc1")
@@ -50,8 +50,8 @@ const graphs = [
     {
         name: "03-tagged-release",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .tag("v0.1.0-rc1")
@@ -60,10 +60,10 @@ const graphs = [
         }
     },
     {
-        name: "04-master-progressed",
+        name: "04-main-progressed",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .tag("v0.1.0-rc1")
@@ -76,8 +76,8 @@ const graphs = [
     {
         name: "05-tagged-rc2",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .tag("v0.1.0-rc1")
@@ -86,7 +86,7 @@ const graphs = [
                 .commit({hash: "D'"})
                 .commit({hash: "E'"})
                 .tag("v0.1.0-rc2")
-            master
+            main
                 .commit({hash: "C"})
                 .commit({hash: "D"})
                 .commit({hash: "E"})
@@ -96,8 +96,8 @@ const graphs = [
     {
         name: "06-release-010",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .tag("v0.1.0-rc1")
@@ -107,7 +107,7 @@ const graphs = [
                 .commit({hash: "E'"})
                 .tag("v0.1.0-rc2")
                 .tag("v0.1.0")
-            master
+            main
                 .commit({hash: "C"})
                 .commit({hash: "D"})
                 .commit({hash: "E"})
@@ -117,8 +117,8 @@ const graphs = [
     {
         name: "07-release-011",
         build: () => {
-            const master = gitgraph.branch("master");
-            master
+            const main = gitgraph.branch("main");
+            main
                 .commit({hash: "A"})
                 .commit({hash: "B"})
                 .tag("v0.1.0-rc1")
@@ -128,7 +128,7 @@ const graphs = [
                 .commit({hash: "E'"})
                 .tag("v0.1.0-rc2")
                 .tag("v0.1.0")
-            master
+            main
                 .commit({hash: "C"})
                 .commit({hash: "D"})
                 .commit({hash: "E"})

--- a/doc/developer/assets/rel/package-lock.json
+++ b/doc/developer/assets/rel/package-lock.json
@@ -72,6 +72,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -259,14 +264,14 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -285,9 +290,9 @@
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
@@ -428,16 +433,16 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -690,11 +695,12 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/doc/developer/develop.md
+++ b/doc/developer/develop.md
@@ -177,7 +177,7 @@ own document. See [Developer guide: testing](testing.md).
 ### Submitting changes
 
 We require that every change is first opened as a GitHub pull request and
-subjected to a CI run. GitHub will prevent you from pushing directly to master
+subjected to a CI run. GitHub will prevent you from pushing directly to main
 or merging a PR that does not have a green CI run.
 
 Our CI provider is Buildkite (https://buildkite.com). It's like Travis CI or

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -13,7 +13,7 @@ As a user or developer, you'll interact with mzbuild through three commands:
     image.
 
     This approach keeps things snappy when running a demo or test on the latest
-    tip of master, while ensuring that you don't need to modify the Docker
+    tip of main, while ensuring that you don't need to modify the Docker
     Compose configuration as you make changes to the source code.
 
   * [**`mzimage`**](#mzimage) is a lower-level command that allows inspection

--- a/doc/developer/release.md
+++ b/doc/developer/release.md
@@ -12,7 +12,7 @@ To view the release checklist, create a new issue using the release template:
 
 ## Basic git workflow
 
-The Materialize release process is based on an "always release master" philosophy, while
+The Materialize release process is based on an "always release main" philosophy, while
 still allowing us to produce bugfix releases if they are urgently required. We will
 iterate on this release process as we gain experience.
 
@@ -30,7 +30,7 @@ steps as they find convenient.
 To start a new release version the steps look like:
 
 1. We start with an existing repository, with some work having already been done on it
-   master is currently on commit C and we'd like to get B tagged as a release:
+   main is currently on commit C and we'd like to get B tagged as a release:
 
    ![clean](assets/rel/01-clean.svg)
 1. A developer creates and updates the tag and release branch with a tag that looks like
@@ -94,18 +94,18 @@ happy path.
 Here is a walkthrough of a bad-case happening at every step in the release process:
 
 1. Ensure that the repo is entirely up to date: `git pull origin`
-1. Commit `B` in the master branch is tagged and the release branch is updated:
+1. Commit `B` in the main branch is tagged and the release branch is updated:
 
         git tag -a v0.1.0-rc1 <B>
         git push origin v0.1.0-rc1
 1. A pair of issues are discovered that are deemed important enough for us to backport to
    the rc
-1. The fixes are tested and merged to `master` as commits `D` and `E`, after some
-   unfortunately dangerous work has been commited to master (here as `C`). The repo
+1. The fixes are tested and merged to `main` as commits `D` and `E`, after some
+   unfortunately dangerous work has been commited to main (here as `C`). The repo
    therefore looks like this, and we do _not_ want to import `C` into the release:
 
-   ![master-has-progressed](assets/rel/04-master-progressed.svg)
-1. The commits on master are applied to the release branch:
+   ![main-has-progressed](assets/rel/04-main-progressed.svg)
+1. The commits on main are applied to the release branch:
 
         git checkout release-X.Y
         git cherry-pick D
@@ -127,9 +127,9 @@ Here is a walkthrough of a bad-case happening at every step in the release proce
 1. Some time later we're ready to release from mainline again, this should be the next
    release. So even though we don't have any features that we would like to market as
    `0.2` we would like to release bugfixes and improvements from mainline. That causes
-   the next tag to be on a commit that is an ancestor of master again, allowing the
+   the next tag to be on a commit that is an ancestor of main again, allowing the
    release manager to delete the `release-0.1.0` branch that we were using as scratch
-   space, and start the process over on master:
+   space, and start the process over on main:
 
         git tag -a v0.1.1-rc1 H
         # run long-running tests

--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -327,7 +327,7 @@ At this point, Metabase will now automatically refresh this analysis for you
 every 1 minute.
 
 If you want to see more chBench queries, you can repeat these steps for the view
-`query07` or any of the queries listed in our [chBench query index](https://github.com/MaterializeInc/materialize/blob/master/demo/chbench/chbench/mz-default.cfg).
+`query07` or any of the queries listed in our [chBench query index](https://github.com/MaterializeInc/materialize/blob/main/demo/chbench/chbench/mz-default.cfg).
 
 ## Recap
 

--- a/doc/user/content/demos/microservice.md
+++ b/doc/user/content/demos/microservice.md
@@ -416,7 +416,7 @@ In a future iteration, we'll make this demo more interactive.
     ```
 
     You can also find the demo's code on
-    [GitHub](https://github.com/MaterializeInc/materialize/tree/master/demo/billing).
+    [GitHub](https://github.com/MaterializeInc/materialize/tree/main/demo/billing).
 
 1. Deploy and start all of the components we've listed above.
 

--- a/doc/user/content/monitoring/_index.md
+++ b/doc/user/content/monitoring/_index.md
@@ -114,6 +114,6 @@ docker run --network host -e MATERIALIZED_URL=local:6875 materialize/dashboard
 ```
 
 [simplemon-hub]: https://hub.docker.com/repository/docker/materialize/dashboard
-[dashboard-json]: https://github.com/MaterializeInc/materialize/blob/master/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+[dashboard-json]: https://github.com/MaterializeInc/materialize/blob/main/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
 [graf-import]: https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard
 [dc-example]: https://github.com/MaterializeInc/materialize/blob/d793b112758c840c1240eefdd56ca6f7e4f484cf/demo/billing/mzcompose.yml#L60-L70

--- a/doc/user/content/versions.md
+++ b/doc/user/content/versions.md
@@ -22,15 +22,15 @@ Binary tarballs require a recent version of their stated platform:
 
 ## Unstable builds
 
-Binary tarballs are built for every merge to the [master branch on
+Binary tarballs are built for every merge to the [main branch on
 GitHub][github]. These tarballs are not suitable for use in production.
 **Run unstable builds at your own risk.**
 
 Version | Binary tarball links
 --------|---------------------
-master  | [Linux] / [macOS]
+main    | [Linux] / [macOS]
 
-The tarballs for other commits on master can be constructed by replacing
+The tarballs for other commits on main can be constructed by replacing
 `latest` in the links above with the full 40-character commit hash.
 
 [Linux]: http://downloads.mtrlz.dev/materialized-latest-x86_64-unknown-linux-gnu.tar.gz

--- a/misc/civiz/README.md
+++ b/misc/civiz/README.md
@@ -36,4 +36,4 @@ FLASK_APP=civiz.py flask run
 
 ## Deploying
 
-A successful merge to master will deploy the new code to mtrlz.dev/civiz.
+A successful merge to main will deploy the new code to mtrlz.dev/civiz.

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/diagnostics.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/diagnostics.json
@@ -12,7 +12,7 @@
       }
     ]
   },
-  "description": "https://github.com/MaterializeInc/materialize/blob/master/doc/developer/diagnostic-queries.md",
+  "description": "https://github.com/MaterializeInc/materialize/blob/main/doc/developer/diagnostic-queries.md",
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
@@ -20,7 +20,7 @@
   "links": [],
   "panels": [
     {
-      "content": "# Diagnosing apparent performance defects\n\nThe queries on this page are all derived from \nour [diagnosis page](https://github.com/MaterializeInc/materialize/blob/master/doc/developer/diagnostic-queries.md).",
+      "content": "# Diagnosing apparent performance defects\n\nThe queries on this page are all derived from \nour [diagnosis page](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/diagnostic-queries.md).",
       "datasource": null,
       "description": "",
       "fieldConfig": {

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -9,6 +9,7 @@
 
 """Git utilities."""
 
+import subprocess
 import sys
 from functools import lru_cache, total_ordering
 from pathlib import Path
@@ -83,3 +84,12 @@ def get_version_tags(*, fetch: bool = True) -> List[semver.VersionInfo]:
             print(f"WARN: {e}", file=sys.stderr)
 
     return sorted(tags, reverse=True)
+
+
+def is_ancestor(earlier: str, later: str) -> bool:
+    """True if earlier is in an ancestor of later"""
+    try:
+        spawn.capture(["git", "merge-base", "--is-ancestor", earlier, later])
+    except subprocess.CalledProcessError:
+        return False
+    return True

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -12,7 +12,7 @@
 For an overview of what mzbuild is and why it exists, see the [user-facing
 documentation][user-docs].
 
-[user-docs]: https://github.com/MaterializeInc/materialize/blob/master/doc/developer/mzbuild.md
+[user-docs]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/mzbuild.md
 """
 
 from collections import OrderedDict


### PR DESCRIPTION
This makes us capable of doing a gradual migration, defaulting to a `main` branch but still allowing PRs to come in on master, and keeping the two in sync until all PRs have been migrated/closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3578)
<!-- Reviewable:end -->
