### PR TITLE
Resolve avro date-related logical types

### DIFF
--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -602,6 +602,9 @@ impl<'a> SchemaResolver<'a> {
                     // Normally for types that are underlyingly "long", we just interpret them according to the reader schema.
                     // In this special case, it is better to interpret them according to the _writer_ schema:
                     // By treating the written value as millis, we will decode the same DateTime values as were written.
+                    //
+                    // For example: if a writer wrote milliseconds and a reader tries to read it as microseconds,
+                    // it will be off by a factor of 1000 from the timestamp that the writer was intending to write
                     (SchemaPiece::TimestampMilli, SchemaPiece::TimestampMicro) => {
                         SchemaPieceOrNamed::Piece(SchemaPiece::TimestampMilli)
                     }

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -609,6 +609,10 @@ impl<'a> SchemaResolver<'a> {
                     (SchemaPiece::TimestampMicro, SchemaPiece::TimestampMilli) => {
                         SchemaPieceOrNamed::Piece(SchemaPiece::TimestampMicro)
                     }
+                    (SchemaPiece::Date, SchemaPiece::TimestampMilli)
+                    | (SchemaPiece::Date, SchemaPiece::TimestampMicro) => {
+                        SchemaPieceOrNamed::Piece(SchemaPiece::ResolveDateTimestamp)
+                    }
                     (wp, rp) if wp.is_underlying_int() && rp.is_underlying_int() => {
                         SchemaPieceOrNamed::Piece(rp.clone()) // This clone is just a copy - none of the underlying int/long types own heap memory.
                     }

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -193,6 +193,9 @@ pub enum SchemaPiece {
     /// A value written as `int` and read as `long`,
     /// for the timestamp-micros logicalType.
     ResolveIntTsMicro,
+    /// A value written as an `int` with `date` logical type,
+    /// and read as any timestamp type
+    ResolveDateTimestamp,
     /// A value written as `int` and read as `long`
     ResolveIntLong,
     /// A value written as `int` and read as `float`
@@ -363,6 +366,7 @@ impl<'a> From<&'a SchemaPiece> for SchemaKind {
             SchemaPiece::TimestampMilli
             | SchemaPiece::TimestampMicro
             | SchemaPiece::ResolveIntTsMilli
+            | SchemaPiece::ResolveDateTimestamp
             | SchemaPiece::ResolveIntTsMicro => SchemaKind::DateTime,
             SchemaPiece::Decimal { .. } => SchemaKind::Decimal,
             SchemaPiece::Bytes => SchemaKind::Bytes,
@@ -1338,6 +1342,7 @@ impl<'a> SchemaSubtreeDeepCloner<'a> {
             SchemaPiece::ResolveFloatDouble => SchemaPiece::ResolveFloatDouble,
             SchemaPiece::ResolveIntTsMilli => SchemaPiece::ResolveIntTsMilli,
             SchemaPiece::ResolveIntTsMicro => SchemaPiece::ResolveIntTsMicro,
+            SchemaPiece::ResolveDateTimestamp => SchemaPiece::ResolveDateTimestamp,
             SchemaPiece::ResolveConcreteUnion { index, inner } => {
                 SchemaPiece::ResolveConcreteUnion {
                     index: *index,
@@ -1660,6 +1665,7 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                     unreachable!("Unexpected named schema piece in anonymous schema position")
                 }
                 SchemaPiece::ResolveIntLong
+                | SchemaPiece::ResolveDateTimestamp
                 | SchemaPiece::ResolveIntFloat
                 | SchemaPiece::ResolveIntDouble
                 | SchemaPiece::ResolveLongFloat
@@ -1740,6 +1746,7 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                         unreachable!("Unexpected anonymous schema piece in named schema position")
                     }
                     SchemaPiece::ResolveIntLong
+                    | SchemaPiece::ResolveDateTimestamp
                     | SchemaPiece::ResolveIntFloat
                     | SchemaPiece::ResolveIntDouble
                     | SchemaPiece::ResolveLongFloat

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -16,6 +16,7 @@ use avro::{
     types::{DecimalValue, Value},
     Schema, SchemaResolutionError, ValidationError,
 };
+use chrono::{NaiveDate, NaiveDateTime};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -254,6 +255,134 @@ fn test_union_default() {
     )
     .unwrap();
     resolve_schemas(&writer_schema, &reader_schema).unwrap();
+}
+
+#[test]
+fn test_datetime_resolutions() {
+    let writer_schema = Schema::parse_str(
+        r#"{
+            "type": "record",
+            "name": "Test",
+            "fields": [
+                {
+                    "name": "f1",
+                    "type": "int"
+                },
+                {
+                    "name": "f2",
+                    "type": {
+                        "type": "long",
+                        "logicalType": "timestamp-millis"
+                    }
+                },
+                {
+                    "name": "f3",
+                    "type": "long"
+                },
+                {
+                    "name": "f4",
+                    "type": {
+                        "type": "long",
+                        "logicalType": "timestamp-micros"
+                    }
+                },
+                {
+                    "name": "f5",
+                    "type": "int"
+                },
+                {
+                    "name": "f6",
+                    "type": {
+                        "type": "int",
+                        "logicalType": "date"
+                    }
+                }
+            ]
+        }
+"#,
+    )
+    .unwrap();
+    let reader_schema = Schema::parse_str(
+        r#"{
+            "type": "record",
+            "name": "Test",
+            "fields": [
+                {
+                    "name": "f1",
+                    "type": {
+                        "type": "long",
+                        "logicalType": "timestamp-millis"
+                    }
+                },
+                {
+                    "name": "f2",
+                    "type": {
+                        "type": "long",
+                        "logicalType": "timestamp-micros"
+                    }
+                },
+                {
+                    "name": "f3",
+                    "type": {
+                        "type": "long",
+                        "logicalType": "timestamp-millis"
+                    }
+                },
+                {
+                    "name": "f4",
+                    "type": "long"
+                },
+                {
+                    "name": "f5",
+                    "type": {
+                        "type": "int",
+                        "logicalType": "date"
+                    }
+                },
+                {
+                    "name": "f6",
+                    "type": "int"
+                }
+            ]
+        }
+"#,
+    )
+    .unwrap();
+    let datum_to_write = Value::Record(vec![
+        ("f1".into(), Value::Int(1000)),
+        (
+            "f2".into(),
+            Value::Timestamp(NaiveDateTime::from_timestamp(12345, 0)),
+        ),
+        ("f3".into(), Value::Long(23456000)),
+        (
+            "f4".into(),
+            Value::Timestamp(NaiveDateTime::from_timestamp(34567, 0)),
+        ),
+        ("f5".into(), Value::Int(365 * 2)),
+        ("f6".into(), Value::Date(NaiveDate::from_ymd(1973, 1, 1))),
+    ]);
+    let datum_to_read = Value::Record(vec![
+        (
+            "f1".into(),
+            Value::Timestamp(NaiveDateTime::from_timestamp(1, 0)),
+        ),
+        (
+            "f2".into(),
+            Value::Timestamp(NaiveDateTime::from_timestamp(12345, 0)),
+        ),
+        (
+            "f3".into(),
+            Value::Timestamp(NaiveDateTime::from_timestamp(23456, 0)),
+        ),
+        ("f4".into(), Value::Long(34567000000)),
+        ("f5".into(), Value::Date(NaiveDate::from_ymd(1972, 1, 1))),
+        ("f6".into(), Value::Int(365 * 3 + 1)), // +1 because 1972 was a leap year
+    ]);
+    let encoded = to_avro_datum(&writer_schema, datum_to_write).unwrap();
+    let resolved_schema = resolve_schemas(&writer_schema, &reader_schema).unwrap();
+    let datum_read = from_avro_datum(&resolved_schema, &mut encoded.as_slice()).unwrap();
+    assert_eq!(datum_to_read, datum_read);
 }
 
 #[test]

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -296,6 +296,13 @@ fn test_datetime_resolutions() {
                         "type": "int",
                         "logicalType": "date"
                     }
+                },
+                {
+                    "name": "f7",
+                    "type": {
+                        "type": "int",
+                        "logicalType": "date"
+                     }
                 }
             ]
         }
@@ -342,6 +349,13 @@ fn test_datetime_resolutions() {
                 {
                     "name": "f6",
                     "type": "int"
+                },
+                {
+                    "name": "f7",
+                    "type": {
+                        "type": "long",
+                        "logicalType": "timestamp-micros"
+                    }
                 }
             ]
         }
@@ -361,6 +375,7 @@ fn test_datetime_resolutions() {
         ),
         ("f5".into(), Value::Int(365 * 2)),
         ("f6".into(), Value::Date(NaiveDate::from_ymd(1973, 1, 1))),
+        ("f7".into(), Value::Date(NaiveDate::from_ymd(1974, 1, 1))),
     ]);
     let datum_to_read = Value::Record(vec![
         (
@@ -378,6 +393,7 @@ fn test_datetime_resolutions() {
         ("f4".into(), Value::Long(34567000000)),
         ("f5".into(), Value::Date(NaiveDate::from_ymd(1972, 1, 1))),
         ("f6".into(), Value::Int(365 * 3 + 1)), // +1 because 1972 was a leap year
+        ("f7".into(), Value::Timestamp(NaiveDate::from_ymd(1974, 1, 1).and_hms(0, 0, 0)))
     ]);
     let encoded = to_avro_datum(&writer_schema, datum_to_write).unwrap();
     let resolved_schema = resolve_schemas(&writer_schema, &reader_schema).unwrap();

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -393,7 +393,10 @@ fn test_datetime_resolutions() {
         ("f4".into(), Value::Long(34567000000)),
         ("f5".into(), Value::Date(NaiveDate::from_ymd(1972, 1, 1))),
         ("f6".into(), Value::Int(365 * 3 + 1)), // +1 because 1972 was a leap year
-        ("f7".into(), Value::Timestamp(NaiveDate::from_ymd(1974, 1, 1).and_hms(0, 0, 0)))
+        (
+            "f7".into(),
+            Value::Timestamp(NaiveDate::from_ymd(1974, 1, 1).and_hms(0, 0, 0)),
+        ),
     ]);
     let encoded = to_avro_datum(&writer_schema, datum_to_write).unwrap();
     let resolved_schema = resolve_schemas(&writer_schema, &reader_schema).unwrap();


### PR DESCRIPTION
Basically, according to the following rules:

Any two int types -> interpreted according to reader schema
Any two long types -> interpreted according to reader schema, _except_ if both are timestamp types, in which case we interpretw according to writer schema, so that for example, if the writer writes some value in millis, we will read it out in millis.
Any int type and any long type -> interpreted according to normal resolution rules (i.e., read an i32 value, then cast it to i64), except that date->timestamp promotes the date to the corresponding timestamp, at midnight.

Fixes #3573 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3579)
<!-- Reviewable:end -->
