### PR TITLE
Fix some bugs in union resolution

### DIFF
--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -557,6 +557,13 @@ impl<'a> SchemaResolver<'a> {
                 SchemaPieceRefOrNamed::Piece(SchemaPiece::Union(r_inner)),
             ) => {
                 let w2r = self.writer_to_reader_names.clone();
+                // permuation[1] is Some((j, val)) iff the i'th writer variant
+                // _matches_ the j'th reader variant
+                // (i.e., it is the same primitive type, or the same kind of named type and has the same name, or a decimal with the same parameters)
+                // and succuessfully _resolves_ against it,
+                // and None otherwise.
+                //
+                // An example of types that match but don't resolve would be two records with the same name but incompatible fields.
                 let permutation = w_inner
                     .variants()
                     .iter()
@@ -750,8 +757,7 @@ impl<'a> SchemaResolver<'a> {
                             match self.resolve_named(writer.root, reader.root, w_index, r_index) {
                                 Ok(piece) => piece,
                                 Err(e) => {
-                                    // This could have just been a "?", except that we need to clean up
-                                    // the placeholder values that were added above.
+                                    // clean up the placeholder values that were added above.
                                     self.named.pop();
                                     self.reader_to_resolved_names.remove(&r_index);
                                     return Err(e);

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -568,7 +568,7 @@ impl<'a> SchemaResolver<'a> {
                     .variants()
                     .iter()
                     .map(|w_variant| {
-                        let r_match = r_inner.resolve(w_variant, &w2r);
+                        let r_match = r_inner.match_(w_variant, &w2r);
                         let resolved = r_match.and_then(|(r_idx, r_variant)| {
                             let resolved = self
                                 .resolve(writer.step(w_variant), reader.step(r_variant))

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -556,24 +556,21 @@ impl<'a> SchemaResolver<'a> {
                 SchemaPieceRefOrNamed::Piece(SchemaPiece::Union(w_inner)),
                 SchemaPieceRefOrNamed::Piece(SchemaPiece::Union(r_inner)),
             ) => {
-                // TODO (brennan) - can we avoid cloning this?
                 let w2r = self.writer_to_reader_names.clone();
                 let permutation = w_inner
                     .variants()
                     .iter()
-                    .map(move |w_inner| {
-                        r_inner
-                            .resolve(w_inner, &w2r)
-                            .map(|(r_idx, r_inner)| (r_idx, w_inner, r_inner))
+                    .map(|w_variant| {
+                        let r_match = r_inner.resolve(w_variant, &w2r);
+                        let resolved = r_match.and_then(|(r_idx, r_variant)| {
+                            let resolved = self
+                                .resolve(writer.step(w_variant), reader.step(r_variant))
+                                .ok()?;
+                            Some((r_idx, resolved))
+                        });
+                        resolved
                     })
-                    .flat_map(|o| {
-                        o.map(|(r_idx, w_inner, r_inner)| {
-                            self.resolve(writer.step(w_inner), reader.step(r_inner))
-                                .ok()
-                                .map(|schema| (r_idx, schema))
-                        })
-                    })
-                    .collect::<Vec<_>>();
+                    .collect();
                 SchemaPieceOrNamed::Piece(SchemaPiece::ResolveUnionUnion { permutation })
             }
             // Writer is concrete; reader is union
@@ -750,7 +747,16 @@ impl<'a> SchemaResolver<'a> {
                         self.reader_to_resolved_names.insert(r_index, resolved_idx);
                         self.named.push(None);
                         let piece =
-                            self.resolve_named(writer.root, reader.root, w_index, r_index)?;
+                            match self.resolve_named(writer.root, reader.root, w_index, r_index) {
+                                Ok(piece) => piece,
+                                Err(e) => {
+                                    // This could have just been a "?", except that we need to clean up
+                                    // the placeholder values that were added above.
+                                    self.named.pop();
+                                    self.reader_to_resolved_names.remove(&r_index);
+                                    return Err(e);
+                                }
+                            };
                         let name = &self.reader_schema.named[r_index].name;
                         let ns = NamedSchemaPiece {
                             name: name.clone(),

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -666,7 +666,7 @@ impl UnionSchema {
     }
 
     #[inline(always)]
-    pub fn resolve(
+    pub fn match_(
         &self,
         other: &SchemaPieceOrNamed,
         names_map: &HashMap<usize, usize>,

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -917,7 +917,7 @@ fn test_partially_broken_union() {
     let resolved_schema = resolve_schemas(&writer_schema, &reader_schema).unwrap();
     let datum_to_write = Value::Union(2, Box::new(Value::Long(42)));
     let datum_to_read = Value::Union(1, Box::new(Value::Long(42)));
-    let encoded = to_avro_datum(&writer_schema, datum_to_write.clone()).unwrap();
+    let encoded = to_avro_datum(&writer_schema, datum_to_write).unwrap();
     let datum_read = from_avro_datum(&resolved_schema, &mut encoded.as_slice()).unwrap();
     assert_eq!(datum_to_read, datum_read);
     let err_datum_to_write = Value::Union(

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -882,3 +882,49 @@ fn test_complex_resolutions() {
     let datum_read = from_avro_datum(&resolved_schema, &mut Cursor::new(encoded)).unwrap();
     assert_eq!(expected_read, datum_read);
 }
+
+#[test]
+fn test_partially_broken_union() {
+    // If one variant of a union fails to match or resolve, we should still be able to decode one of the others.
+    // The first variant will fail to match (there is no "r" in the reader schema).
+    // The second variant will match, but fail to resolve (there is an "s" both in the reader and writer, but their fields are irreconcilable).
+    // The third variant is fine.
+    let writer_schema = r#"
+        [
+            {
+                "type": "record",
+                "name": "r",
+                "fields": [{"name": "a", "type": "long"}]
+            },
+            {
+                "type": "record",
+                "name": "s",
+                "fields": [{"name": "b", "type": "long"}]
+            },
+            "long"
+       ]"#;
+    let reader_schema = r#"
+        [
+            {
+                "type": "record",
+                "name": "s",
+                "fields": [{"name": "a", "type": "long"}]
+            },
+            "long"
+       ]"#;
+    let writer_schema = Schema::parse_str(writer_schema).unwrap();
+    let reader_schema = Schema::parse_str(reader_schema).unwrap();
+    let resolved_schema = resolve_schemas(&writer_schema, &reader_schema).unwrap();
+    let datum_to_write = Value::Union(2, Box::new(Value::Long(42)));
+    let datum_to_read = Value::Union(1, Box::new(Value::Long(42)));
+    let encoded = to_avro_datum(&writer_schema, datum_to_write.clone()).unwrap();
+    let datum_read = from_avro_datum(&resolved_schema, &mut encoded.as_slice()).unwrap();
+    assert_eq!(datum_to_read, datum_read);
+    let err_datum_to_write = Value::Union(
+        0,
+        Box::new(Value::Record(vec![("a".into(), Value::Long(42))])),
+    );
+    let err_encoded = to_avro_datum(&writer_schema, err_datum_to_write).unwrap();
+    let err_read_result = from_avro_datum(&resolved_schema, &mut err_encoded.as_slice());
+    assert!(err_read_result.is_err());
+}


### PR DESCRIPTION
First bug (reader.rs lines 559-576): In Union-Union resolution, we filter out non-matching unions schemas, instead of writing "None" into the permutation.

This is probably just because I was trying to be too clever and write everything in terms of hard-to-understand iterator chaining, and a "flat_map" crept in there that doesn't semantically make sense. In this PR we replace the complicated and wrong code with simpler and correct code

Second bug (reader.rs line 753): If resolution of any branch of a union fails, we return early from this function, but the error is caught and handled above (to allow other branches to possibly succeed). Thus, before returning, we need to put the resolver back into a consistent state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3583)
<!-- Reviewable:end -->
