### PR TITLE
Give readers the correct enum index, rather than the index from the writer

### DIFF
--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -318,8 +318,9 @@ pub fn decode<'a, R: Read>(schema: SchemaNode<'a>, reader: &'a mut R) -> Result<
         }
         SchemaPiece::Enum { ref symbols, .. } => {
             if let Value::Int(index) = decode_int(reader)? {
-                if index >= 0 && (index as usize) <= symbols.len() {
-                    let symbol = symbols[index as usize].clone();
+                let index = index as usize;
+                if index <= symbols.len() {
+                    let symbol = symbols[index].clone();
                     Ok(Value::Enum(index, symbol))
                 } else {
                     Err(DecodeError::new("enum symbol index out of bounds").into())
@@ -385,7 +386,7 @@ pub fn decode<'a, R: Read>(schema: SchemaNode<'a>, reader: &'a mut R) -> Result<
             if let Value::Int(index) = decode_int(reader)? {
                 if index >= 0 && (index as usize) < symbols.len() {
                     match symbols[index as usize].clone() {
-                        Some(symbol) => Ok(Value::Enum(index, symbol)), // Todo (brennan) -- should this actually be the index in reader? Does it matter?
+                        Some((reader_index, symbol)) => Ok(Value::Enum(reader_index, symbol)),
                         None => Err(DecodeError::new(format!(
                             "Enum symbol at index {} in writer schema not found in reader",
                             index

--- a/src/avro/src/encode.rs
+++ b/src/avro/src/encode.rs
@@ -106,7 +106,7 @@ pub fn encode_ref(value: &Value, schema: SchemaNode, buffer: &mut Vec<u8>) {
             _ => (),
         },
         Value::Fixed(_, bytes) => buffer.extend(bytes),
-        Value::Enum(i, _) => encode_int(*i, buffer),
+        Value::Enum(i, _) => encode_int(*i as i32, buffer),
         Value::Union(idx, item) => {
             if let SchemaPiece::Union(inner) = schema.inner {
                 let inner = &inner.variants()[*idx];

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -432,8 +432,8 @@ impl<'a> SchemaResolver<'a> {
                 let symbols = w_symbols
                     .iter()
                     .map(|s| {
-                        if r_map.contains_key(&s) {
-                            Some(s.clone())
+                        if let Some(idx) = r_map.get(&s) {
+                            Some((*idx, s.clone()))
                         } else {
                             None
                         }

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -264,10 +264,9 @@ pub enum SchemaPiece {
     /// The two schemas may have different values and the values may be in a different order.
     ResolveEnum {
         doc: Documentation,
-        /// Symbols in order of the writer schema if they exist in the reader schema,
-        /// or `None` otherwise.
-        symbols: Vec<Option<String>>,
-        // TODO(brennan) - These should support default values
+        /// Symbols in order of the writer schema along with their index in the reader schema,
+        /// or `None` if they don't exist in the reader schema.
+        symbols: Vec<Option<(usize, String)>>,
     },
 }
 
@@ -1529,7 +1528,7 @@ impl<'a> SchemaNode<'a> {
             }
             (String(s), SchemaPiece::Enum { symbols, .. }) => {
                 match symbols.iter().find_position(|sym| s == *sym) {
-                    Some((index, sym)) => AvroValue::Enum(index as i32, sym.clone()),
+                    Some((index, sym)) => AvroValue::Enum(index, sym.clone()),
                     None => return Err(ParseSchemaError(format!("Enum variant not found: {}", s))),
                 }
             }

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -267,6 +267,7 @@ pub enum SchemaPiece {
         /// Symbols in order of the writer schema along with their index in the reader schema,
         /// or `None` if they don't exist in the reader schema.
         symbols: Vec<Option<(usize, String)>>,
+        // TODO(brennan) - These should support default values
     },
 }
 

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -82,7 +82,7 @@ pub enum Value {
     /// of its corresponding schema.
     /// This allows schema-less encoding, as well as schema resolution while
     /// reading values.
-    Enum(i32, String),
+    Enum(usize, String),
     /// An `union` Avro value.
     Union(usize, Box<Value>),
     /// An `array` Avro value.

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -742,7 +742,7 @@ fn test_complex_resolutions() {
             "f1".to_owned(),
             Value::Union(0, Box::new(Value::Fixed(4, vec![0, 1, 2, 3]))),
         ),
-        ("f2".to_owned(), Value::Enum(1, "Diamonds".to_owned())), // TODO - should be the index in the reader
+        ("f2".to_owned(), Value::Enum(2, "Diamonds".to_owned())),
         ("f4".to_owned(), Value::Fixed(1, vec![0])),
         (
             "f5".to_owned(),


### PR DESCRIPTION
This was a known issue (note some of the TODOs being removed), but it was probably not causing any issues in practice. Still, it's good to just fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3584)
<!-- Reviewable:end -->
