### PR TITLE
peeker: Don't do backoff for evaluation errors

### DIFF
--- a/src/peeker/src/main.rs
+++ b/src/peeker/src/main.rs
@@ -352,6 +352,8 @@ fn print_error_and_backoff(backoff: &mut Duration, context: &str, error_message:
         "for {}: {}. Sleeping for {:#?}",
         context, error_message, *backoff
     );
-    thread::sleep(*backoff);
-    *backoff = min(*backoff * 2, MAX_BACKOFF);
+    if !error_message.contains("Evaluation error") {
+        thread::sleep(*backoff);
+        *backoff = min(*backoff * 2, MAX_BACKOFF);
+    }
 }


### PR DESCRIPTION
It's only intended to back off when we're still waiting for completed timestamps/creating
the tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3586)
<!-- Reviewable:end -->
