### PR TITLE
Correctly serialize "decimal" nodes in Avro schemas

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2192,6 +2192,13 @@ mod tests {
             fixed_size: None,
         };
         assert_eq!(schema.top_node().inner, &expected);
+        // Test that we serialize decimals properly
+        // TODO(btv) we should add similar round-trip tests
+        // to all of these schema parsing tests, to uncover more
+        // bugs like the one where decimals weren't getting encoded.
+        let serialized = serde_json::to_value(schema).unwrap().to_string();
+        let schema = Schema::parse_str(&serialized).unwrap();
+        assert_eq!(schema.top_node().inner, &expected);
 
         let res = Schema::parse_str(
             r#"{

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -1671,6 +1671,7 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                     }
                     map.serialize_entry("precision", precision)?;
                     map.serialize_entry("scale", scale)?;
+                    map.serialize_entry("logicalType", "decimal")?;
                     map.end()
                 }
                 SchemaPiece::Bytes => serializer.serialize_str("bytes"),


### PR DESCRIPTION
We rely on round-trip schema serialization to work, because we store schemas in the catalog when a view is created. In this case, decimal nodes were missing their "logicalType=decimal" field, causing them to be interpreted as raw "bytes".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3604)
<!-- Reviewable:end -->
