### PR TITLE
Update parsing Avro's decimal logical type

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -1027,11 +1027,13 @@ impl SchemaParser {
                         fixed_size: None,
                     })
                 }
-                Err(e) => debug!("{}", e),
+                Err(e) => warn!(
+                    "parsing decimal as regular bytes due to parse error: {:?}, {:?}",
+                    complex, e
+                ),
             }
         }
 
-        debug!("parsing complex type as regular bytes: {:?}", complex);
         Ok(SchemaPiece::Bytes)
     }
 
@@ -1159,11 +1161,13 @@ impl SchemaParser {
                         fixed_size: Some(size as usize),
                     });
                 }
-                Err(e) => debug!("{}", e),
+                Err(e) => warn!(
+                    "parsing decimal as fixed due to parse error: {:?}, {:?}",
+                    complex, e
+                ),
             }
         }
 
-        debug!("parsing complex type as fixed: {:?}", complex);
         Ok(SchemaPiece::Fixed {
             size: size as usize,
         })

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -1019,12 +1019,15 @@ impl SchemaParser {
         let logical_type = complex.get("logicalType").and_then(|v| v.as_str());
 
         if let Some("decimal") = logical_type {
-            if let Ok((precision, scale)) = Self::parse_decimal(complex) {
-                return Ok(SchemaPiece::Decimal {
-                    precision,
-                    scale,
-                    fixed_size: None,
-                });
+            match Self::parse_decimal(complex) {
+                Ok((precision, scale)) => {
+                    return Ok(SchemaPiece::Decimal {
+                        precision,
+                        scale,
+                        fixed_size: None,
+                    })
+                }
+                Err(e) => debug!("{}", e),
             }
         }
 
@@ -1139,8 +1142,8 @@ impl SchemaParser {
 
         let logical_type = complex.get("logicalType").and_then(|v| v.as_str());
 
-        if let Some("decimal") = logical_type {
-            if let Ok((precision, scale)) = Self::parse_decimal(complex) {
+        match Self::parse_decimal(complex) {
+            Ok((precision, scale)) => {
                 let max = ((2_usize.pow((8 * size - 1) as u32) - 1) as f64).log10() as usize;
                 if precision > max {
                     return Err(ParseSchemaError::new(format!(
@@ -1155,6 +1158,7 @@ impl SchemaParser {
                     fixed_size: Some(size as usize),
                 });
             }
+            Err(e) => debug!("{}", e),
         }
 
         debug!("parsing complex type as fixed: {:?}", complex);


### PR DESCRIPTION
According to Avro's [logical type documentation](https://avro.apache.org/docs/current/spec.html#Logical+Types), unknown or invalid logical type schemas should fall back to using their underlying Avro type:

```
Language implementations must ignore unknown logical types when reading, and should use the 
underlying Avro type. If a logical type is invalid, for example a decimal with scale greater than its 
precision, then implementations should ignore the logical type and use the underlying Avro type.
```

Currently, our code returns (very reasonable) errors if logical type schemas are incorrect. This PR updates `parse_bytes` and `parse_fixed` to fall back on their underlying types if `parse_decimal` fails instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3612)
<!-- Reviewable:end -->
