### PR TITLE
forbid the todo! macro in our codebase

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -26,6 +26,9 @@ extra_lints=(
     # Wildcard dependencies are, by definition, incorrect. It is impossible
     # to be compatible with all future breaking changes in a crate.
     clippy::wildcard_dependencies
+
+    # the `todo!` macro should not appear in production code.
+    clippy::todo
 )
 
 # Add lints to this list freely, but please add a comment with justification


### PR DESCRIPTION
I realized seconds after landing a large PR in main that it contained multiple `todo!`s.

Use CI to prevent careless folks (like myself...) from doing this in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3627)
<!-- Reviewable:end -->
