### PR TITLE
expr: improve reduction of IS NULL

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1983,6 +1983,66 @@ impl BinaryFunc {
         }
     }
 
+    /// Whether the function might return NULL even if none of its inputs are
+    /// NULL.
+    ///
+    /// This is presently conservative, and may indicate that a function
+    /// introduces nulls even when it does not.
+    pub fn introduces_nulls(&self) -> bool {
+        use BinaryFunc::*;
+        match self {
+            And
+            | Or
+            | Eq
+            | NotEq
+            | Lt
+            | Lte
+            | Gt
+            | Gte
+            | AddInt32
+            | AddInt64
+            | AddFloat32
+            | AddFloat64
+            | AddTimestampInterval
+            | AddTimestampTzInterval
+            | AddDateTime
+            | AddDateInterval
+            | AddTimeInterval
+            | AddInterval
+            | SubInterval
+            | AddDecimal
+            | SubInt32
+            | SubInt64
+            | SubFloat32
+            | SubFloat64
+            | SubTimestamp
+            | SubTimestampTz
+            | SubTimestampInterval
+            | SubTimestampTzInterval
+            | SubDate
+            | SubDateInterval
+            | SubTime
+            | SubTimeInterval
+            | SubDecimal
+            | MulInt32
+            | MulInt64
+            | MulFloat32
+            | MulFloat64
+            | MulDecimal
+            | DivInt32
+            | DivInt64
+            | DivFloat32
+            | DivFloat64
+            | DivDecimal
+            | ModInt32
+            | ModInt64
+            | ModFloat32
+            | ModFloat64
+            | ModDecimal => false,
+            _ => true,
+        }
+    }
+
     pub fn is_infix_op(&self) -> bool {
         use BinaryFunc::*;
         match self {

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1101,19 +1101,19 @@ ORDER BY supplier_cnt DESC
 
 %5 =
 | Get %3
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 %6 =
 | Get materialize.public.supplier (u34)
-| Filter "^.*bad.*$" ~(#6)
+| ArrangeBy (#0)
 
 %7 =
-| Join %5 %6
-| | implementation = Differential %6 %5.()
-| | demand = (#0, #1)
-| Filter ((#0 = #1) || isnull((#0 != #1)))
-| Distinct group=(#0)
+| Join %5 %6 (= #0 #1)
+| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
+| | demand = (#0, #7)
+| Filter "^.*bad.*$" ~(#7)
 | Negate
+| Project (#0)
 
 %8 =
 | Get %3

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -375,3 +375,57 @@ yxytrimyxy
 
 statement error
 SELECT trim('c' 'ccccdogcc');
+
+# Test IS NULL reduction.
+
+mode standard
+
+statement ok
+CREATE TABLE t (
+    a int,
+    b int NOT NULL,
+)
+
+query T multiline
+EXPLAIN PLAN FOR SELECT a IS NULL FROM t
+----
+%0 =
+| Get materialize.public.t (u21)
+| Map isnull(#0)
+| Project (#2)
+
+EOF
+
+query T multiline
+EXPLAIN PLAN FOR SELECT a + a + a + a + a IS NULL FROM t
+----
+%0 =
+| Get materialize.public.t (u21)
+| Map isnull(#0)
+| Project (#2)
+
+EOF
+
+query T multiline
+EXPLAIN PLAN FOR SELECT a + b IS NULL FROM t
+----
+%0 =
+| Get materialize.public.t (u21)
+| Map isnull(#0)
+| Project (#2)
+
+EOF
+
+# Ensure that (a AND b) IS NULL is *not* reduced, as it is not as simple as
+# rewriting (A IS NULL) OR (b IS NULL). There are probably rewrite rules that
+# exist, but we do not support them yet. Similarly for OR.
+
+query T multiline
+EXPLAIN PLAN FOR SELECT (a::bool AND b::bool) IS NULL FROM t
+----
+%0 =
+| Get materialize.public.t (u21)
+| Map isnull((i32tobool(#0) && i32tobool(#1)))
+| Project (#2)
+
+EOF

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -101,7 +101,7 @@ WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 ----
 %0 =
 | Get materialize.public.l (u1)
-| Filter !(isnull((#0 + 1)))
+| Filter !(isnull(#0))
 
 %1 =
 | Get materialize.public.l (u1)
@@ -116,8 +116,7 @@ WHERE l1.la + 1 = l2.la AND l3.la = l1.la + l2.la
 %3 =
 | Join %0 %1 %2 (= #2 (#0 + 1)) (= #4 (#0 + #2))
 | | implementation = Differential %0 %1.(#0) %2.(#0)
-| | demand = (#0, #2, #3, #5)
-| Filter !(isnull((#0 + #2)))
+| | demand = (#0, #3, #5)
 | Project (#0, #3, #5)
 
 EOF
@@ -169,7 +168,7 @@ WHERE l1.la IN (
 
 %6 =
 | Get materialize.public.l (u1)
-| Filter !(isnull((#0 + 1)))
+| Filter !(isnull(#0))
 
 %7 =
 | Join %5 %6 (= #0 (#1 + 1))

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -535,16 +535,16 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 
 %1 =
 | Get %0
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.x (u57)
+| ArrangeBy (#0)
 
 %3 =
-| Join %1 %2
-| | implementation = Differential %2 %1.()
-| | demand = (#0, #1)
-| Filter ((#0 = #1) || isnull((#0 != #1)))
+| Join %1 %2 (= #0 #1)
+| | implementation = DeltaQuery %1 %2.(#0) | %2 %1.(#0)
+| | demand = (#0)
 | Distinct group=(#0)
 
 %4 =
@@ -607,7 +607,7 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 | Join %1 %2
 | | implementation = Differential %2 %1.()
 | | demand = (#0, #1)
-| Filter ((#0 <= #1) || isnull((#0 > #1)))
+| Filter (#0 <= #1)
 | Distinct group=(#0)
 
 %4 =

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1162,19 +1162,19 @@ ORDER BY
 
 %5 =
 | Get %3
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 %6 =
 | Get materialize.public.supplier (u8)
-| Filter "^.*Customer.*Complaints.*$" ~(#6)
+| ArrangeBy (#0)
 
 %7 =
-| Join %5 %6
-| | implementation = Differential %6 %5.()
-| | demand = (#0, #1)
-| Filter ((#0 = #1) || isnull((#0 != #1)))
-| Distinct group=(#0)
+| Join %5 %6 (= #0 #1)
+| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
+| | demand = (#0, #7)
+| Filter "^.*Customer.*Complaints.*$" ~(#7)
 | Negate
+| Project (#0)
 
 %8 =
 | Get %3


### PR DESCRIPTION
An expression like `(a + b) IS NULL` can be reduced to `a IS NULL OR b
IS NULL` because we know the `+` operator can never introduce a NULL.
This can unlock further reduction, e.g., because `b` is known to be
non-NULL.

This fixes the regression described in #3488.

Tracking this "introduces null" property requires yet another method on
BinaryFunc which is hard to maintain. The fix is a massive refactoring;
see #3449 for a sense fo the scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3632)
<!-- Reviewable:end -->
