### PR TITLE
pgrepr,pgwire: remove unsafe `as` conversions

### DIFF
--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -48,3 +48,9 @@ impl CastFrom<u64> for usize {
         from as usize
     }
 }
+
+impl CastFrom<usize> for u64 {
+    fn cast_from(from: usize) -> u64 {
+        from as u64
+    }
+}

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -17,6 +17,7 @@
 //! example, the [`values_from_row`] function.
 
 #![forbid(missing_docs)]
+#![deny(clippy::as_conversions)]
 
 mod format;
 mod types;

--- a/src/pgrepr/src/value/interval.rs
+++ b/src/pgrepr/src/value/interval.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![allow(clippy::as_conversions)]
+
 use std::error::Error;
 use std::fmt;
 

--- a/src/pgrepr/src/value/numeric.rs
+++ b/src/pgrepr/src/value/numeric.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![allow(clippy::as_conversions)]
+
 use std::convert::TryInto;
 use std::error::Error;
 use std::fmt;

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -20,6 +20,8 @@
 //!   * [CockroachDB pgwire implementation](https://github.com/cockroachdb/cockroach/tree/master/pkg/sql/pgwire)
 //!   * ["Postgres on the wire" PGCon talk](https://www.pgcon.org/2014/schedule/attachments/330_postgres-for-the-wire.pdf)
 
+#![deny(clippy::as_conversions)]
+
 mod codec;
 mod id_alloc;
 mod message;


### PR DESCRIPTION
Fix #3513.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3633)
<!-- Reviewable:end -->
