### PR TITLE
expr,sql: support casting records to strings

### DIFF
--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -580,14 +580,14 @@ where
 
 pub fn format_list<F, T>(
     buf: &mut F,
-    elems: &[T],
-    mut format_elem: impl FnMut(ListElementWriter<F>, &T) -> Nestable,
+    elems: impl IntoIterator<Item = T>,
+    mut format_elem: impl FnMut(ListElementWriter<F>, T) -> Nestable,
 ) -> Nestable
 where
     F: FormatBuffer,
 {
     buf.write_char('{');
-    let mut elems = elems.iter().peekable();
+    let mut elems = elems.into_iter().peekable();
     while let Some(elem) = elems.next() {
         let start = buf.len();
         if let Nestable::MayNeedEscaping = format_elem(ListElementWriter(buf), elem) {
@@ -722,14 +722,14 @@ where
 
 pub fn format_record<F, T>(
     buf: &mut F,
-    elems: &[T],
-    mut format_elem: impl FnMut(RecordElementWriter<F>, &T) -> Nestable,
+    elems: impl IntoIterator<Item = T>,
+    mut format_elem: impl FnMut(RecordElementWriter<F>, T) -> Nestable,
 ) -> Nestable
 where
     F: FormatBuffer,
 {
     buf.write_char('(');
-    let mut elems = elems.iter().peekable();
+    let mut elems = elems.into_iter().peekable();
     while let Some(elem) = elems.next() {
         let start = buf.len();
         if let Nestable::MayNeedEscaping = format_elem(RecordElementWriter(buf), elem) {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -333,6 +333,10 @@ lazy_static! {
 
             // RECORD
             (Record { fields: vec![] }, JsonbAny) => CastOp::F(to_jsonb_any_record_cast),
+            (Record { fields: vec![] }, Explicit(String)) => CastOp::F(|ecx, e, _to_type| {
+                let ty = ecx.scalar_type(&e);
+                Ok(e.call_unary(CastRecordToString { ty }))
+            }),
 
             // JSONB
             (Jsonb, Explicit(Bool)) => CastJsonbToBool,

--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -150,9 +150,9 @@ $ kafka-ingest format=avro topic=avro-data schema=${reader-schema} publish=true 
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> SELECT (f0).f0_0, (f0).f0_1, f11, f12, f13, f2, f51, f52
+> SELECT f0::text, f11, f12, f13, f2, f51, f52
   FROM avro_data
-f0_0 f0_1 f11 f12 f13 f2 f51 f52
+f0 f11 f12 f13 f2 f51 f52
 ---
-7777 bar \x00\x01\x02\x03 <null> <null> Diamonds <null> 1234
-9999 <null> <null> <null> 3456 Jokers \x00\x01\x02\x03\x04\x05\x06\x07\x08\t <null>
+(7777,bar) \x00\x01\x02\x03 <null> <null> Diamonds <null> 1234
+(9999,) <null> <null> 3456 Jokers \x00\x01\x02\x03\x04\x05\x06\x07\x08\t <null>

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -118,35 +118,12 @@ Source   Create Source
 ------------------
 materialize.public.data_schema_inline "CREATE SOURCE \"materialize\".\"public\".\"data_schema_inline\" FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA \'{   \"type\": \"record\",   \"name\": \"envelope\",   \"fields\": [     {       \"name\": \"before\",       \"type\": [         {           \"name\": \"row\",           \"type\": \"record\",           \"fields\": [             {\"name\": \"a\", \"type\": \"long\"},             {\"name\": \"b\", \"type\": \"long\"},             {               \"name\": \"json\",               \"type\": {                 \"connect.name\": \"io.debezium.data.Json\",                 \"type\": \"string\"               }             },             {               \"name\": \"c\",               \"type\": {                 \"type\": \"enum\",                 \"name\": \"Bool\",                 \"symbols\": [\"True\", \"False\", \"FileNotFound\"]               }             },             {\"name\": \"d\", \"type\": \"Bool\"},             {\"name\": \"e\", \"type\": [\"null\",{               \"type\": \"record\",               \"name\": \"nested_data_1\",               \"fields\": [                   {\"name\": \"n1_a\", \"type\": \"long\"},                   {\"name\": \"n1_b\", \"type\": [\"null\", \"double\", {                       \"type\": \"record\",                       \"name\": \"nested_data_2\",                       \"fields\": [                         {\"name\": \"n2_a\", \"type\": \"long\"},                         {\"name\": \"n2_b\", \"type\": \"int\"}                       ]                     }]                   }                 ]               }]             },             {\"name\": \"f\", \"type\": [\"null\", \"nested_data_2\"]}           ]         },         \"null\"       ]     },     { \"name\": \"after\", \"type\": [\"row\", \"null\"] },     {       \"name\": \"source\",       \"type\": {         \"type\": \"record\",         \"name\": \"Source\",         \"namespace\": \"io.debezium.connector.mysql\",         \"fields\": [           {             \"name\": \"file\",             \"type\": \"string\"           },           {             \"name\": \"pos\",             \"type\": \"long\"           },           {             \"name\": \"row\",             \"type\": \"int\"           },           {             \"name\": \"snapshot\",             \"type\": [               {                 \"type\": \"boolean\",                 \"connect.default\": false               },               \"null\"             ],             \"default\": false           }         ],         \"connect.name\": \"io.debezium.connector.mysql.Source\"       }     }   ] }\' ENVELOPE DEBEZIUM"
 
-> SELECT a, b, json, c, d FROM data_schema_inline
-a  b  json                     c            d
---------------------------------------------------------
-1  1  null                     True         False
-2  3  "{\"hello\":\"world\"}"  False        FileNotFound
--1  7 "[1.0,2.0,3.0]"          FileNotFound True
-
-
-# Check that record types work
-> SELECT (e).n1_a FROM data_schema_inline
-n1_a
----
-42
-43
-<null>
-
-> SELECT (f).n2_b FROM data_schema_inline
-n2_b
----
-<null>
--2
-<null>
-
-> SELECT (e).n1_b2.n2_b FROM data_schema_inline
-n2_b
----
-<null>
--1
-<null>
+> SELECT a, b, json, c, d, e::text, f::text FROM data_schema_inline
+a  b  json                     c            d             e                   f
+------------------------------------------------------------------------------------
+1  1  null                     True         False         "(42,86.5,)"        <null>
+2  3  "{\"hello\":\"world\"}"  False        FileNotFound  "(43,,\"(44,-1)\")" (45,-2)
+-1  7 "[1.0,2.0,3.0]"          FileNotFound True          <null>              <null>
 
 > CREATE MATERIALIZED SOURCE fast_forwarded
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -164,13 +141,13 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": null, "f": null}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": false}}
 {"before": null, "after": {"a": 42, "b": 19, "json": "[4, 5, 6]", "c": "FileNotFound", "d": "True", "e": null, "f": null}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": false}}
 
-> SELECT a, b, json, c, d FROM data_schema_inline
-a  b  json                     c            d
---------------------------------------------------------
-1  1  null                     True         False
-2  3  "{\"hello\":\"world\"}"  False        FileNotFound
--1  7 "[1.0,2.0,3.0]"          FileNotFound True
-42 19 "[4.0,5.0,6.0]"          FileNotFound True
+> SELECT a, b, json, c, d, e::text, f::text FROM data_schema_inline
+a  b  json                     c            d             e                   f
+------------------------------------------------------------------------------------
+1  1  null                     True         False         "(42,86.5,)"        <null>
+2  3  "{\"hello\":\"world\"}"  False        FileNotFound  "(43,,\"(44,-1)\")" (45,-2)
+-1  7 "[1.0,2.0,3.0]"          FileNotFound True          <null>              <null>
+42 19 "[4.0,5.0,6.0]"          FileNotFound True          <null>              <null>
 
 # Create a source using a file schema. This should fail if the named schema file
 # does not exist.


### PR DESCRIPTION
This is a quick way to allow testing of record types in testdrive
without manually extracting each field, and until we get support for the
pg_type table, users will likely appreciate this as well. Plus it's a
generally useful feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3635)
<!-- Reviewable:end -->
