### PR TITLE
Make decode API somewhat nicer and less error-prone

### DIFF
--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -609,7 +609,7 @@ impl AvroDecode for TrivialDecoder {
         self.maybe_skip(r)
     }
     fn array<A: AvroArrayAccess>(self, a: &mut A) -> Result<(), Error> {
-        while let Some(_) = a.decode_next(TrivialDecoder)? {}
+        while a.decode_next(TrivialDecoder)?.is_some() {}
         Ok(())
     }
 }

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -331,7 +331,7 @@ pub mod types;
 pub use crate::codec::Codec;
 pub use crate::decode::{
     give_value, AvroArrayAccess, AvroDecode, AvroDeserializer, AvroFieldAccess, AvroRead,
-    AvroRecordAccess, GeneralDeserializer, Skip, TrivialDecoder, ValueOrReader,
+    AvroRecordAccess, GeneralDeserializer, Skip, TrivialDecoder, ValueDecoder, ValueOrReader,
 };
 pub use crate::encode::encode as encode_unchecked;
 pub use crate::reader::{from_avro_datum, Reader};


### PR DESCRIPTION
(1) Remove the redundant `AvroFieldAccess::decode_to_value`
(2) Make decoders take `self` instead of `&mut self`, and return an output value. This forces any decoder to be used exactly once, letting us get rid of a bunch of assertions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3639)
<!-- Reviewable:end -->
