### PR TITLE
Fixed, enum, and record Avro types require a non-empty name

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -494,6 +494,13 @@ impl Name {
         let name = complex
             .name()
             .ok_or_else(|| ParseSchemaError::new("No `name` field"))?;
+        if name.is_empty() {
+            return Err(ParseSchemaError::new(format!(
+                "Name cannot be the empty string: {:?}",
+                complex
+            ))
+            .into());
+        }
 
         let namespace = complex.string("namespace");
 

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -22,10 +22,14 @@ lazy_static! {
         r#"invalid"#,
         r#"{"no_type": "test"}"#,
         // Fixed examples
+        r#"{"type": "fixed", "size": 1}"#, // Fixed type requires a name
+        r#"{"type": "fixed", "name": "", "size": 1}"#, // Name cannot be empty string
         r#"{"type": "fixed", "name": "Missing size"}"#,
         r#"{"type": "fixed", "size": 314}",
         r#"{"type": "fixed", "size": 314, "name": "dr. spaceman"#, // AVRO-621
         // Enum examples
+        r#"{"type": "enum", "symbols": ["A", "B"]}"#, // Enum type requires a name
+        r#"{"type": "enum", "name": "", "symbols": ["A", "B"]}"#, // Name cannot be empty string
         r#"{"type": "enum", "name": "Status", "symbols": "Normal Caution Critical"}"#,
         r#"{"type": "enum", "name": [0, 1, 1, 2, 3, 5, 8],
             "symbols": ["Golden", "Mean"]}"#,
@@ -44,6 +48,11 @@ lazy_static! {
             {"type": "array", "items": "string"}]"#,
         r#"["null", ["null", "int"], "string"]"#,
         // Record examples
+        r#"{"type": "fields": [{"name": "addr", "type": [{"name": "IPv6", "type": "fixed", "size": 16},
+                                                         {"name": "IPv4", "type": "fixed", "size": 4}]}]}"#, // Record type requires a name
+        r#"{"type": "record", "name": "",
+                     "fields": [{"name": "addr", "type": [{"name": "IPv6", "type": "fixed", "size": 16},
+                                                          {"name": "IPv4", "type": "fixed", "size": 4}]}]}"#, // Name cannot be empty string
         r#"{"type": "record", "name": "Address",
             "fields": [{"type": "string"}, {"type": "string", "name": "City"}]}"#,
         r#"{"type": "record", "name": "Event",


### PR DESCRIPTION
From the Avro specification:
```
Names
Record, enums and fixed are named types. Each has a fullname that is composed of two parts; a name and a namespace. Equality of names is defined on the fullname.

The name portion of a fullname, record field names, and enum symbols must:

start with [A-Za-z_]
subsequently contain only [A-Za-z0-9_]
```

And Python test: https://github.com/apache/avro/blob/master/lang/py/avro/test/test_schema.py#L350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3640)
<!-- Reviewable:end -->
