### PR TITLE
Nicely error when encountering recursively defined type in Avro schema

### DIFF
--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -362,3 +362,8 @@ a b
 2 3
 -1 7
 3 4
+
+! CREATE SOURCE recurisve
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'
+  FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
+ERROR: validating avro value schema: Recursively defined type in schema: .a

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -366,4 +366,4 @@ a b
 ! CREATE SOURCE recurisve
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'
   FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
-ERROR: validating avro value schema: Recursively defined type in schema: .a
+validating avro value schema: Recursively defined type in schema: .a


### PR DESCRIPTION
Recursively defined types in Avro are not supported in Materialize (because they would require a source with infinite columns).

Before this change, we go into infinite recursion trying to compute the column types - now bail with an error instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3641)
<!-- Reviewable:end -->
