### PR TITLE
Fix for td error message

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -310,7 +310,8 @@ impl FailSqlAction {
                         } else {
                             Err(format!(
                                 "expected error containing '{}', but got '{}'",
-                                self.cmd.expected_error, err
+                                self.cmd.expected_error,
+                                err.message()
                             ))
                         }
                     }


### PR DESCRIPTION
Avoid confusion by printing out what we're actually checking for, rather than prepending the extra `ERROR: `

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3642)
<!-- Reviewable:end -->
