### PR TITLE
Avro: parse names with dots as namespaces

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -502,7 +502,17 @@ impl Name {
             .into());
         }
 
-        let namespace = complex.string("namespace");
+        let (namespace, name) = if let Some(index) = name.rfind('.') {
+            let namespace = name[..index].to_owned();
+            let new_name = name[index + 1..].to_owned();
+            warn!(
+                "Found dots in name {}, translating to namespace {} and name {}",
+                name, namespace, new_name
+            );
+            (Some(namespace), new_name)
+        } else {
+            (complex.string("namespace"), name)
+        };
 
         let aliases: Option<Vec<String>> = complex
             .get("aliases")
@@ -514,15 +524,6 @@ impl Name {
                     .map(|alias| alias.map(|a| a.to_string()))
                     .collect::<Option<_>>()
             });
-        if let Some(ns) = &namespace {
-            if name.find('.').is_some() {
-                return Err(ParseSchemaError::new(format!(
-                    "Name {} has dot, but namespace also specified: {}",
-                    name, ns
-                ))
-                .into());
-            }
-        }
 
         Ok(Name {
             name,
@@ -2281,6 +2282,48 @@ mod tests {
         };
 
         assert_eq!("Some documentation".to_owned(), doc.unwrap());
+    }
+
+    #[test]
+    fn test_namespaces_and_names() {
+        // When name and namespace specified, full name should contain both.
+        let schema = Schema::parse_str(
+            r#"{"type": "fixed", "namespace": "namespace", "name": "name", "size": 1}"#,
+        )
+        .unwrap();
+        assert_eq!(schema.named.len(), 1);
+        assert_eq!(
+            schema.named[0].name,
+            FullName {
+                name: "name".into(),
+                namespace: "namespace".into()
+            }
+        );
+
+        // When name contains dots, parse the dot-separated name as the namespace.
+        let schema = Schema::parse_str(
+            r#"{"type": "enum", "name": "name.has.dots", "symbols": ["A", "B"]}"#,
+        )
+        .unwrap();
+        assert_eq!(schema.named.len(), 1);
+        assert_eq!(
+            schema.named[0].name,
+            FullName {
+                name: "dots".into(),
+                namespace: "name.has".into()
+            }
+        );
+
+        // Same as above, ignore any provided namespace.
+        let schema = Schema::parse_str(r#"{"type": "enum", "namespace": "namespace", "name": "name.has.dots", "symbols": ["A", "B"]}"#).unwrap();
+        assert_eq!(schema.named.len(), 1);
+        assert_eq!(
+            schema.named[0].name,
+            FullName {
+                name: "dots".into(),
+                namespace: "name.has".into()
+            }
+        );
     }
 
     // Tests to ensure Schema is Send + Sync. These tests don't need to _do_ anything, if they can

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -503,13 +503,17 @@ impl Name {
         }
 
         let (namespace, name) = if let Some(index) = name.rfind('.') {
-            let namespace = name[..index].to_owned();
-            let new_name = name[index + 1..].to_owned();
-            warn!(
-                "Found dots in name {}, translating to namespace {} and name {}",
-                name, namespace, new_name
-            );
-            (Some(namespace), new_name)
+            let computed_namespace = name[..index].to_owned();
+            let computed_name = name[index + 1..].to_owned();
+            if let Some(provided_namespace) = complex.string("namespace") {
+                if provided_namespace != computed_namespace {
+                    warn!(
+                        "Found dots in name {}, updating to namespace {} and name {}",
+                        name, computed_namespace, computed_name
+                    );
+                }
+            }
+            (Some(computed_namespace), computed_name)
         } else {
             (complex.string("namespace"), name)
         };


### PR DESCRIPTION
From Avro's [specification](https://avro.apache.org/docs/current/spec.html#names):
```
In record, enum and fixed definitions, the fullname is determined in one of the following ways:

...
A fullname is specified. If the name specified contains a dot, then it is assumed to be a fullname, and any 
namespace also specified is ignored. For example, use "name": "org.foo.X" to indicate the fullname org.foo.X.
```

The Confluent schema registry does this translates this quietly:
```
Jessicas-MBP:~ jessicalaughlin$ curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"schema": "{\"type\":\"record\",\"name\":\"Payment.dots.more.of.them\",\"namespace\":\"my.examples\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"amount\",\"type\":\"double\"}]}"}' http://localhost:8081/subjects/test_dots_fail_2/versions
{"id":4}
Jessicas-MBP:~ jessicalaughlin$ GET http://localhost:8081/schemas/ids/4
{"schema":"{\"type\":\"record\",\"name\":\"them\",\"namespace\":\"Payment.dots.more.of\",\"fields\":[{\"name\":\"id\",\"type\":\"string\"},{\"name\":\"amount\",\"type\":\"double\"}]}"}
```

This PR updates the `Name::parse` function to do the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3643)
<!-- Reviewable:end -->
