### PR TITLE
sql: allow input columns in ORDER BY clause

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1178,8 +1178,11 @@ pub struct RowSetFinishing {
 
 impl RowSetFinishing {
     /// True if the finishing does nothing to any result set.
-    pub fn is_trivial(&self) -> bool {
-        (self.limit == None) && self.order_by.is_empty() && self.offset == 0
+    pub fn is_trivial(&self, arity: usize) -> bool {
+        self.limit.is_none()
+            && self.order_by.is_empty()
+            && self.offset == 0
+            && self.project.iter().copied().eq(0..arity)
     }
     /// Applies finishing actions to a row set.
     pub fn finish(&self, rows: &mut Vec<Row>) {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -23,14 +23,15 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::iter;
+use std::mem;
 use std::rc::Rc;
 
 use failure::{bail, ensure, format_err, ResultExt};
 use sql_parser::ast::visit::{self, Visit};
 use sql_parser::ast::{
     BinaryOperator, DataType, Expr, Function, FunctionArgs, Ident, JoinConstraint, JoinOperator,
-    ObjectName, Query, Select, SelectItem, SetExpr, SetOperator, ShowStatementFilter, TableAlias,
-    TableFactor, TableWithJoins, Value, Values,
+    ObjectName, OrderByExpr, Query, Select, SelectItem, SetExpr, SetOperator, ShowStatementFilter,
+    TableAlias, TableFactor, TableWithJoins, Value, Values,
 };
 
 use ::expr::{Id, RowSetFinishing};
@@ -46,7 +47,7 @@ use crate::plan::expr::{
     JoinKind, RelationExpr, ScalarExpr, ScalarTypeable, UnaryFunc, VariadicFunc,
 };
 use crate::plan::func;
-use crate::plan::scope::{Scope, ScopeItem, ScopeItemName};
+use crate::plan::scope::{Scope, ScopeItem, ScopeItemName, ScopeResolutionError};
 use crate::plan::statement::StatementContext;
 use crate::plan::transform_ast;
 use crate::plan::typeconv::{self, CastTo, CoerceTo};
@@ -67,7 +68,30 @@ pub fn plan_root_query(
 ) -> Result<(RelationExpr, RelationDesc, RowSetFinishing, Vec<ScalarType>), failure::Error> {
     transform_ast::transform_query(&mut query)?;
     let qcx = QueryContext::root(scx, lifetime);
-    let (expr, scope, finishing) = plan_query(&qcx, &query)?;
+    let (mut expr, scope, mut finishing) = plan_query(&qcx, &query)?;
+
+    // Check if the `finishing.order_by` can be applied after
+    // `finishing.project`, and push `finishing.project` onto `expr` if so. This
+    // allows data to be projected down on the workers rather than the
+    // coordinator. It also improves the optimizer's demand analysis, as the
+    // optimizer can only reason about demand information in `expr` (i.e., it
+    // can't see `finishing.project`).
+    let mut unproject = vec![None; expr.arity()];
+    for (out_i, in_i) in finishing.project.iter().copied().enumerate() {
+        unproject[in_i] = Some(out_i);
+    }
+    if finishing
+        .order_by
+        .iter()
+        .all(|ob| unproject[ob.column].is_some())
+    {
+        let trivial_project = (0..finishing.project.len()).collect();
+        expr = expr.project(mem::replace(&mut finishing.project, trivial_project));
+        for ob in &mut finishing.order_by {
+            ob.column = unproject[ob.column].unwrap();
+        }
+    }
+
     let typ = qcx.relation_type(&expr);
     let typ = RelationType::new(
         finishing
@@ -211,38 +235,36 @@ pub fn plan_index_exprs<'a>(
     Ok(out)
 }
 
-fn plan_expr_or_col_index<'a>(
-    ecx: &ExprContext,
-    e: &'a Expr,
-) -> Result<ScalarExpr, failure::Error> {
-    let expr = match e {
+fn plan_expr_or_col_index(ecx: &ExprContext, e: &Expr) -> Result<ScalarExpr, failure::Error> {
+    match check_col_index(&ecx.name, e, ecx.relation_type.column_types.len())? {
+        Some(column) => Ok(ScalarExpr::Column(ColumnRef { level: 0, column })),
+        _ => plan_expr(ecx, e)?.type_as_any(ecx),
+    }
+}
+
+fn check_col_index(name: &str, e: &Expr, max: usize) -> Result<Option<usize>, failure::Error> {
+    match e {
         Expr::Value(Value::Number(n)) => {
             let n = n.parse::<usize>().with_context(|err| {
                 format_err!(
                     "unable to parse column reference in {}: {}: {}",
-                    ecx.name,
+                    name,
                     err,
                     n
                 )
             })?;
-            let max = ecx.relation_type.column_types.len();
             if n < 1 || n > max {
                 bail!(
                     "column reference {} in {} is out of range (1 - {})",
                     n,
-                    ecx.name,
+                    name,
                     max
                 );
             }
-            ScalarExpr::Column(ColumnRef {
-                level: 0,
-                column: n - 1,
-            })
-            .into()
+            Ok(Some(n - 1))
         }
-        _ => plan_expr(ecx, e)?,
-    };
-    expr.type_as_any(ecx)
+        _ => Ok(None),
+    }
 }
 
 fn plan_query(
@@ -262,50 +284,62 @@ fn plan_query(
         Some(Expr::Value(Value::Number(x))) => x.parse()?,
         _ => bail!("OFFSET must be an integer constant"),
     };
-    let (expr, scope) = plan_set_expr(qcx, &q.body)?;
-    let output_typ = qcx.relation_type(&expr);
-    let mut order_by = vec![];
-    let mut map_exprs = vec![];
-    for obe in &q.order_by {
-        let ecx = &ExprContext {
-            qcx,
-            name: "ORDER BY clause",
-            scope: &scope,
-            relation_type: &output_typ,
-            allow_aggregates: true,
-            allow_subqueries: true,
-        };
-        let expr = plan_expr_or_col_index(ecx, &obe.expr)?;
-        // If the expression is a reference to an existing column,
-        // do not introduce a new column to support it.
-        if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
-            order_by.push(ColumnOrder {
-                column,
-                desc: match obe.asc {
-                    None => false,
-                    Some(asc) => !asc,
-                },
-            });
-        } else {
-            let idx = output_typ.column_types.len() + map_exprs.len();
-            map_exprs.push(expr);
-            order_by.push(ColumnOrder {
-                column: idx,
-                desc: match obe.asc {
-                    None => false,
-                    Some(asc) => !asc,
-                },
-            });
+    match &q.body {
+        SetExpr::Select(s) if !s.distinct => {
+            let plan = plan_view_select_intrusive(
+                qcx,
+                &s.projection,
+                &s.from,
+                s.selection.as_ref(),
+                &s.group_by,
+                s.having.as_ref(),
+                &q.order_by,
+            )?;
+            let finishing = RowSetFinishing {
+                order_by: plan.order_by,
+                project: plan.project,
+                limit,
+                offset,
+            };
+            Ok((plan.expr, plan.scope, finishing))
+        }
+        _ => {
+            let (expr, scope) = plan_set_expr(qcx, &q.body)?;
+            let output_typ = qcx.relation_type(&expr);
+            let mut order_by = vec![];
+            let mut map_exprs = vec![];
+            for obe in &q.order_by {
+                let ecx = &ExprContext {
+                    qcx,
+                    name: "ORDER BY clause",
+                    scope: &scope,
+                    relation_type: &output_typ,
+                    allow_aggregates: true,
+                    allow_subqueries: true,
+                };
+                let expr = plan_expr_or_col_index(ecx, &obe.expr)?;
+                // If the expression is a reference to an existing column,
+                // do not introduce a new column to support it.
+                let column = if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
+                    column
+                } else {
+                    map_exprs.push(expr);
+                    output_typ.column_types.len() + map_exprs.len() - 1
+                };
+                order_by.push(ColumnOrder {
+                    column,
+                    desc: !obe.asc.unwrap_or(true),
+                });
+            }
+            let finishing = RowSetFinishing {
+                order_by,
+                limit,
+                project: (0..output_typ.column_types.len()).collect(),
+                offset,
+            };
+            Ok((expr.map(map_exprs), scope, finishing))
         }
     }
-
-    let finishing = RowSetFinishing {
-        order_by,
-        limit,
-        project: (0..output_typ.column_types.len()).collect(),
-        offset,
-    };
-    Ok((expr.map(map_exprs), scope, finishing))
 }
 
 fn plan_subquery(qcx: &QueryContext, q: &Query) -> Result<(RelationExpr, Scope), failure::Error> {
@@ -477,19 +511,57 @@ fn plan_join_identity(qcx: &QueryContext) -> (RelationExpr, Scope) {
     (expr, scope)
 }
 
-fn plan_view_select(
+/// Describes how to execute a SELECT query.
+///
+/// `order_by` describes how to order the rows in `expr` *before* applying the
+/// projection. The `scope` describes the columns in `expr` *after* the
+/// projection has been applied.
+#[derive(Debug)]
+struct SelectPlan {
+    expr: RelationExpr,
+    scope: Scope,
+    order_by: Vec<ColumnOrder>,
+    project: Vec<usize>,
+}
+
+/// Plans a SELECT query with an intrusive ORDER BY clause.
+///
+/// Normally, the ORDER BY clause occurs after the columns specified in the
+/// SELECT list have been projected. In a query like
+///
+///   CREATE TABLE (a int, b int)
+///   (SELECT a FROM t) UNION (SELECT a FROM t) ORDER BY a
+///
+/// it is valid to refer to `a`, because it is explicitly selected, but it would
+/// not be valid to refer to unselected column `b`.
+///
+/// But PostgreSQL extends the standard to permit queries like
+///
+///   SELECT a FROM t ORDER BY b
+///
+/// where expressions in the ORDER BY clause can refer to *both* input columns
+/// and output columns.
+///
+/// This function handles queries of the latter class. For queries of the
+/// former class, see `plan_view_select`.
+fn plan_view_select_intrusive(
     qcx: &QueryContext,
-    s: &Select,
-) -> Result<(RelationExpr, Scope), failure::Error> {
+    projection: &[SelectItem],
+    from: &[TableWithJoins],
+    selection: Option<&Expr>,
+    group_by: &[Expr],
+    having: Option<&Expr>,
+    order_by_exprs: &[OrderByExpr],
+) -> Result<SelectPlan, failure::Error> {
     // Step 1. Handle FROM clause, including joins.
     let (mut relation_expr, from_scope) =
-        s.from.iter().fold(Ok(plan_join_identity(qcx)), |l, twj| {
+        from.iter().fold(Ok(plan_join_identity(qcx)), |l, twj| {
             let (left, left_scope) = l?;
             plan_table_with_joins(qcx, left, left_scope, &JoinOperator::CrossJoin, twj)
         })?;
 
     // Step 2. Handle WHERE clause.
-    if let Some(selection) = &s.selection {
+    if let Some(selection) = &selection {
         let ecx = &ExprContext {
             qcx,
             name: "WHERE clause",
@@ -517,7 +589,7 @@ fn plan_view_select(
         let mut group_exprs = vec![];
         let mut group_scope = Scope::empty(Some(qcx.outer_scope.clone()));
         let mut select_all_mapping = BTreeMap::new();
-        for group_expr in &s.group_by {
+        for group_expr in group_by {
             let expr = plan_expr_or_col_index(ecx, group_expr)?;
             let new_column = group_key.len();
             // repeated exprs in GROUP BY confuse name resolution later, and dropping them doesn't change the result
@@ -552,10 +624,13 @@ fn plan_view_select(
         }
         // gather aggregates
         let mut aggregate_visitor = AggregateFuncVisitor::new();
-        for p in &s.projection {
+        for p in projection {
             aggregate_visitor.visit_select_item(p);
         }
-        if let Some(having) = &s.having {
+        for o in order_by_exprs {
+            aggregate_visitor.visit_order_by_expr(o);
+        }
+        if let Some(having) = having {
             aggregate_visitor.visit_expr(having);
         }
         let ecx = &ExprContext {
@@ -573,12 +648,13 @@ fn plan_view_select(
                 names: vec![ScopeItemName {
                     table_name: None,
                     column_name: Some(sql_function.name.to_string().into()),
+                    priority: false,
                 }],
                 expr: Some(Expr::Function(sql_function.clone())),
                 nameable: true,
             });
         }
-        if !aggregates.is_empty() || !group_key.is_empty() || s.having.is_some() {
+        if !aggregates.is_empty() || !group_key.is_empty() || having.is_some() {
             // apply GROUP BY / aggregates
             relation_expr = relation_expr.map(group_exprs).reduce(group_key, aggregates);
             (group_scope, select_all_mapping)
@@ -592,7 +668,7 @@ fn plan_view_select(
     };
 
     // Step 4. Handle HAVING clause.
-    if let Some(having) = &s.having {
+    if let Some(having) = having {
         let ecx = &ExprContext {
             qcx,
             name: "HAVING clause",
@@ -605,12 +681,12 @@ fn plan_view_select(
         relation_expr = relation_expr.filter(vec![expr]);
     }
 
-    // Step 5. Handle projections.
-    let project_scope = {
-        let mut project_exprs = vec![];
+    // Step 5. Handle SELECT clause.
+    let (project_key, map_scope) = {
+        let mut new_exprs = vec![];
         let mut project_key = vec![];
-        let mut project_scope = Scope::empty(Some(qcx.outer_scope.clone()));
-        for p in &s.projection {
+        let mut map_scope = group_scope.clone();
+        for p in projection {
             let ecx = &ExprContext {
                 qcx,
                 name: "SELECT clause",
@@ -622,23 +698,92 @@ fn plan_view_select(
             for (expr, scope_item) in plan_select_item(ecx, p, &from_scope, &select_all_mapping)? {
                 if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
                     project_key.push(column);
+                    // Mark the output names as prioritized, so that they shadow
+                    // any input columns of the same name.
+                    map_scope.items[column]
+                        .names
+                        .splice(..0, scope_item.prioritized().names);
                 } else {
-                    project_key.push(group_scope.len() + project_exprs.len());
-                    project_exprs.push(expr);
+                    project_key.push(group_scope.len() + new_exprs.len());
+                    new_exprs.push(expr);
+                    map_scope.items.push(scope_item.prioritized());
                 }
-                project_scope.items.push(scope_item);
             }
         }
-        relation_expr = relation_expr.map(project_exprs).project(project_key);
-        project_scope
+        relation_expr = relation_expr.map(new_exprs);
+        (project_key, map_scope)
     };
 
-    // Step 6. Handle DISTINCT.
-    if s.distinct {
-        relation_expr = relation_expr.distinct();
-    }
+    // Step 6. Handle intrusive ORDER BY.
+    let order_by = {
+        let mut order_by = vec![];
+        let mut new_exprs = vec![];
+        for obe in order_by_exprs {
+            let ecx = &ExprContext {
+                qcx,
+                name: "ORDER BY clause",
+                scope: &map_scope,
+                relation_type: &qcx.relation_type(&relation_expr),
+                allow_aggregates: true,
+                allow_subqueries: true,
+            };
 
-    Ok((relation_expr, project_scope))
+            let expr = match check_col_index(&ecx.name, &obe.expr, project_key.len())? {
+                Some(i) => ScalarExpr::Column(ColumnRef {
+                    level: 0,
+                    column: project_key[i],
+                }),
+                None => plan_expr(ecx, &obe.expr)?.type_as_any(ecx)?,
+            };
+
+            // If the expression is a reference to an existing column, do not
+            // introduce a new column to support it.
+            let column = if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
+                column
+            } else {
+                new_exprs.push(expr);
+                map_scope.len() + new_exprs.len() - 1
+            };
+            order_by.push(ColumnOrder {
+                column,
+                desc: !obe.asc.unwrap_or(true),
+            });
+        }
+        relation_expr = relation_expr.map(new_exprs);
+        order_by
+    };
+
+    Ok(SelectPlan {
+        expr: relation_expr,
+        scope: map_scope.project(&project_key).scrub(),
+        order_by,
+        project: project_key,
+    })
+}
+
+fn plan_view_select(
+    qcx: &QueryContext,
+    s: &Select,
+) -> Result<(RelationExpr, Scope), failure::Error> {
+    let order_by_exprs = &[];
+    let plan = plan_view_select_intrusive(
+        qcx,
+        &s.projection,
+        &s.from,
+        s.selection.as_ref(),
+        &s.group_by,
+        s.having.as_ref(),
+        order_by_exprs,
+    )?;
+    // We didn't provide any `order_by_exprs`, so `plan_view_select_intrusive`
+    // should not have planned any ordering.
+    assert!(plan.order_by.is_empty());
+
+    let mut expr = plan.expr.project(plan.project);
+    if s.distinct {
+        expr = expr.distinct();
+    }
+    Ok((expr, plan.scope))
 }
 
 fn plan_table_with_joins<'a>(
@@ -827,6 +972,7 @@ fn invent_column_name(expr: &Expr) -> Option<ScopeItemName> {
     name.map(|n| ScopeItemName {
         table_name: None,
         column_name: Some(n),
+        priority: false,
     })
 }
 
@@ -882,6 +1028,7 @@ fn plan_select_item<'a>(
                         names: vec![ScopeItemName {
                             table_name: None,
                             column_name: Some(name.clone()),
+                            priority: false,
                         }],
                         expr: None,
                         nameable: true,
@@ -900,6 +1047,7 @@ fn plan_select_item<'a>(
                 Some(alias) => vec![ScopeItemName {
                     table_name: None,
                     column_name: Some(normalize::column_name(alias.clone())),
+                    priority: false,
                 }],
             };
             let scope_item = ScopeItem {
@@ -1451,8 +1599,10 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<ScalarExpr, fai
     }
 
     // If the name is unqualified, first check if it refers to a column.
-    if let Ok((i, _name)) = ecx.scope.resolve_column(&col_name) {
-        return Ok(ScalarExpr::Column(i));
+    match ecx.scope.resolve_column(&col_name) {
+        Ok((i, _name)) => return Ok(ScalarExpr::Column(i)),
+        Err(ScopeResolutionError::NotFound(_)) => (),
+        Err(e) => return Err(e.into()),
     }
 
     // The name doesn't refer to a column. Check if it refers to a table. If it

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -26,7 +26,10 @@
 
 //! Many sql expressions do strange and arbitrary things to scopes. Rather than try to capture them all here, we just expose the internals of `Scope` and handle it in the appropriate place in `super::query`.
 
-use failure::bail;
+use std::error::Error;
+use std::fmt;
+
+use itertools::Itertools;
 
 use repr::ColumnName;
 
@@ -37,6 +40,30 @@ use crate::names::PartialName;
 pub struct ScopeItemName {
     pub table_name: Option<PartialName>,
     pub column_name: Option<ColumnName>,
+    /// Whether this name is in the "priority" class or not.
+    ///
+    /// Names are divided into two classes: non-priority and priority. When
+    /// resolving a name, if the name appears as both a priority and
+    /// non-priority name, the priority name will be chosen. But if the same
+    /// name appears in the same class more than once (i.e., it appears as a
+    /// priority name twice), resolving that name will trigger an "ambiguous
+    /// name" error.
+    ///
+    /// This exists to support the special behavior of scoping in intrusive
+    /// `ORDER BY` clauses. For example, in the following `SELECT` statement
+    ///
+    ///   CREATE TABLE t (a int, b)
+    ///   SELECT 'outer' AS a, b FROM t ORDER BY a
+    ///
+    /// even though there are two columns named `a` in scope in the ORDER BY
+    /// (one from `t` and one declared in the select list), the column declared
+    /// in the select list has priority. Remember that if there are two columns
+    /// named `a` that are both in the priority class, as in
+    ///
+    ///   SELECT 'outer' AS a, a FROM t ORDER BY a
+    ///
+    /// this still needs to generate an "ambiguous name" error.
+    pub priority: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -67,6 +94,7 @@ impl ScopeItem {
             names: vec![ScopeItemName {
                 table_name: None,
                 column_name,
+                priority: false,
             }],
             expr: None,
             nameable: true,
@@ -77,6 +105,14 @@ impl ScopeItem {
         self.names
             .iter()
             .any(|n| n.table_name.as_ref() == Some(&table_name))
+    }
+
+    pub fn prioritized(&self) -> ScopeItem {
+        let mut out = self.clone();
+        for name in &mut out.names {
+            name.priority = true;
+        }
+        out
     }
 }
 
@@ -104,6 +140,7 @@ impl Scope {
                 names: vec![ScopeItemName {
                     table_name: table_name.clone(),
                     column_name: column_name.map(|n| n.into()),
+                    priority: false,
                 }],
                 expr: None,
                 nameable: true,
@@ -151,7 +188,7 @@ impl Scope {
         &'a self,
         matches: Matches,
         name_in_error: &str,
-    ) -> Result<(ColumnRef, &'a ScopeItemName), failure::Error>
+    ) -> Result<(ColumnRef, &'a ScopeItemName), ScopeResolutionError>
     where
         Matches: Fn(&ScopeItemName) -> bool,
     {
@@ -163,19 +200,23 @@ impl Scope {
                     .iter()
                     .map(move |name| (level, column, item, name))
             })
-            .filter(|(_level, _column, item, name)| (matches)(name) && item.nameable);
+            .filter(|(_level, _column, item, name)| (matches)(name) && item.nameable)
+            .sorted_by_key(|(level, _column, _item, name)| (*level, !name.priority));
         match results.next() {
-            None => bail!("column \"{}\" does not exist", name_in_error),
+            None => Err(ScopeResolutionError::NotFound(name_in_error.to_owned())),
             Some((level, column, _item, name)) => {
                 if results
-                    .find(|(level2, column2, item, _name)| {
-                        column != *column2 && level == *level2 && item.nameable
+                    .find(|(level2, column2, item, name2)| {
+                        column != *column2
+                            && level == *level2
+                            && item.nameable
+                            && name.priority == name2.priority
                     })
                     .is_none()
                 {
                     Ok((ColumnRef { level, column }, name))
                 } else {
-                    bail!("Column name {} is ambiguous", name_in_error)
+                    Err(ScopeResolutionError::Ambiguous(name_in_error.to_owned()))
                 }
             }
         }
@@ -184,7 +225,7 @@ impl Scope {
     pub fn resolve_column<'a>(
         &'a self,
         column_name: &ColumnName,
-    ) -> Result<(ColumnRef, &'a ScopeItemName), failure::Error> {
+    ) -> Result<(ColumnRef, &'a ScopeItemName), ScopeResolutionError> {
         self.resolve(
             |item: &ScopeItemName| item.column_name.as_ref() == Some(column_name),
             column_name.as_str(),
@@ -195,7 +236,7 @@ impl Scope {
         &'a self,
         table_name: &PartialName,
         column_name: &ColumnName,
-    ) -> Result<(ColumnRef, &'a ScopeItemName), failure::Error> {
+    ) -> Result<(ColumnRef, &'a ScopeItemName), ScopeResolutionError> {
         self.resolve(
             |item: &ScopeItemName| {
                 item.table_name.as_ref() == Some(table_name)
@@ -236,4 +277,34 @@ impl Scope {
             outer_scope: self.outer_scope.clone(),
         }
     }
+
+    /// Removes cruft from planning a single SELECT statement from the scope,
+    /// readying it for use by e.g. an outer SELECT.
+    pub fn scrub(mut self) -> Self {
+        for item in &mut self.items {
+            for name in &mut item.names {
+                name.table_name = None;
+                name.priority = false;
+            }
+            item.expr = None;
+        }
+        self
+    }
 }
+
+#[derive(Debug)]
+pub enum ScopeResolutionError {
+    NotFound(String),
+    Ambiguous(String),
+}
+
+impl fmt::Display for ScopeResolutionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::NotFound(name) => write!(f, "column \"{}\" does not exist", name),
+            Self::Ambiguous(name) => write!(f, "column name \"{}\" is ambiguous", name),
+        }
+    }
+}
+
+impl Error for ScopeResolutionError {}

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1763,13 +1763,13 @@ fn handle_explain(
     };
     // Previouly we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
     // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
-    let (mut sql_expr, _desc, finishing, _param_types) =
+    let (mut sql_expr, desc, finishing, _param_types) =
         query::plan_root_query(&scx, query, QueryLifetime::OneShot)?;
     let finishing = if is_view {
         // views don't use a separate finishing
         sql_expr.finish(finishing);
         None
-    } else if finishing.is_trivial() {
+    } else if finishing.is_trivial(desc.arity()) {
         None
     } else {
         Some(finishing)

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -887,15 +887,18 @@ false true
 # ----
 # false false
 
-# #2804
-query error does not exist
+query error concat_agg not yet supported
 SELECT concat_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 
-query error does not exist
+query error json_agg not yet supported
 SELECT json_agg(s) FROM (SELECT s FROM kv ORDER BY k)
 
-query error does not exist
+# This is arguably wrong--we don't respect the inner ORDER BY--because we don't
+# support ordered aggregates. See #2415.
+query T
 SELECT jsonb_agg(s) FROM (SELECT s FROM kv ORDER BY k)
+----
+[null,"A","a","a","b","b"]
 
 # Verify that FILTER works.
 
@@ -1083,9 +1086,10 @@ SELECT v, array_agg('a') FROM kv GROUP BY v
 4     {a,a}
 NULL  {a}
 
-# #3183
-statement error Internal
+query I
 SELECT 123 FROM kv ORDER BY max(v)
+----
+123
 
 subtest string_agg
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -51,20 +51,81 @@ SELECT a FROM foo ORDER BY (0-a)
 1
 0
 
+# ORDER BY can implicitly project columns from the inner SELECT...
+query I
+SELECT a FROM foo ORDER BY b
+----
+1
+2
+0
+
+# ...including when they are used in functions...
+query I
+SELECT a FROM foo ORDER BY b || 'blah'
+----
+1
+2
+0
+
+# ...or even in aggregate functions...
+query I
+SELECT a FROM foo GROUP BY a ORDER BY max(b)
+----
+1
+2
+0
+
+# ...unless you use DISTINCT...
+query error column "b" does not exist
+SELECT DISTINCT a FROM foo ORDER BY b
+
+# ...or a set expression.
+query error column "b" does not exist
+(SELECT a FROM foo) UNION (SELECT a FROM foo) ORDER BY b
+
+# Using a column twice and referring to it by its alias in the ORDER BY should
+# work.
+query II
+SELECT a, a AS c FROM foo ORDER BY c
+----
+0  0
+1  1
+2  2
+
+# Columns from the underlying table and columns introduced in the select list
+# can be freely matched in ORDER BY expressions.
+query I
+SELECT a + 1 AS c FROM foo ORDER BY a + c
+----
+1
+2
+3
+
+# When a name from the underlying table is shadowed, using the shadowed name in
+# the ORDER BY should refer to the column in the select list...
+query T
+SELECT b AS a FROM foo ORDER BY a
+----
+one
+two
+zero
+
+# ...unless the shadowed name is ambiguous.
+query error column name "a" is ambiguous
+SELECT 1 AS a, b AS a FROM foo ORDER BY a
+
 statement ok
 CREATE TABLE bar (a int)
 
 statement ok
 INSERT INTO bar (a) VALUES (1)
 
-# TODO(benesch): this ties into #696.
-#
-# query I nosort
-# SELECT a FROM foo ORDER BY exists (SELECT * FROM bar WHERE bar.a = foo.a), a
-# ----
-# 0
-# 2
-# 1
+query I nosort
+SELECT a FROM foo ORDER BY exists (SELECT * FROM bar WHERE bar.a = foo.a), a
+----
+0
+2
+1
 
 ### sorts, limits, and offsets in subqueries ###
 
@@ -85,10 +146,8 @@ INSERT INTO fizz(a, b) VALUES
 
 # the ORDER BY's inside the subquery are technically meaningless because they do not
 # propagate to the outer query, but we should still return correct results.
-# TODO: materialize#696 replace the current query with the one below
-# SELECT b FROM (SELECT min(b) AS b FROM fizz GROUP BY a ORDER BY a DESC)
 query T rowsort
-SELECT b FROM (SELECT a, min(b) AS b FROM fizz GROUP BY a ORDER BY a DESC)
+SELECT b FROM (SELECT min(b) AS b FROM fizz GROUP BY a ORDER BY a DESC)
 ----
 five
 four

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -81,3 +81,6 @@ SELECT totalgarbage.*
 
 query error SELECT \* with no tables specified is not valid
 SELECT *
+
+query error column name "k" is ambiguous
+SELECT k FROM (SELECT 1 AS k, 2 AS k)


### PR DESCRIPTION
In standard SQL, the ORDER BY clause occurs after the columns specified
in the SELECT list have been projected. In a query like

    CREATE TABLE (a int, b int)
    (SELECT a FROM t) UNION (SELECT a FROM t) ORDER BY a

it is valid to refer to `a`, because it is explicitly selected, but it would
not be valid to refer to unselected column `b`.

But PostgreSQL extends the standard to permit queries like

    SELECT a FROM t ORDER BY b

where expressions in the ORDER BY clause can refer to *both* input columns
and output columns.

This commit adds support for this extension. It also fixes a
longstanding bug in RowSetFinishing::is_trivial that was exposed by this
change.

Fix #696.
Fix #2260.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3645)
<!-- Reviewable:end -->
