### PR TITLE
Validate Avro names using regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "log",
  "md-5",
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -22,6 +22,7 @@ itertools = "0.9"
 libflate = "1.0"
 log = "0.4.8"
 rand = "0.7.3"
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.8"

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -148,6 +148,11 @@ lazy_static! {
          Value::Record(vec![("name".into(), Value::String("string".into()))])),
         (r#"{"type": "enum", "name": "Test", "symbols": ["A", "B"], "doc": "Doc String"}"#,
          Value::Enum(0, "A".into())),
+        // Custom properties
+        (r#"{"type":"int", "customProp":"val"}"#, Value::Int(123)),
+        (r#"{"type":"enum", "name":"Suit", "namespace":"org.apache.test", "aliases":["org.apache.test.OldSuit"],
+         "doc":"Card Suits", "customProp":"val", "symbols":["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]}"#,
+         Value::Enum(0, "SPADES".to_owned())),
     ];
 
     static ref VALID_LOGICAL_TYPES: Vec<(&'static str, Value)> = vec![


### PR DESCRIPTION
As per [Avro's specification](https://avro.apache.org/docs/current/spec.html#names):
```
The name portion of a fullname, record field names, and enum symbols must:

start with [A-Za-z_]
subsequently contain only [A-Za-z0-9_]
```

This PR updates `Name::parse` to check that provided names are valid as per the spec and return an error if not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3647)
<!-- Reviewable:end -->
