### PR TITLE
sql: begin introducing more structured errors

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use expr::GlobalId;
 use ore::cast::CastFrom;
+use sql::catalog::CatalogError as SqlCatalogError;
 use sql::names::{DatabaseSpecifier, FullName};
 
 use crate::catalog::error::{Error, ErrorKind};
@@ -311,9 +312,9 @@ impl Transaction<'_> {
             .query_row(params![database_name], |row| row.get(0))
         {
             Ok(id) => Ok(id),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Err(Error::new(
-                ErrorKind::UnknownDatabase(database_name.to_owned()),
-            )),
+            Err(rusqlite::Error::QueryReturnedNoRows) => {
+                Err(SqlCatalogError::UnknownDatabase(database_name.to_owned()).into())
+            }
             Err(err) => Err(err.into()),
         }
     }
@@ -326,7 +327,7 @@ impl Transaction<'_> {
         {
             Ok(id) => Ok(id),
             Err(rusqlite::Error::QueryReturnedNoRows) => {
-                Err(Error::new(ErrorKind::UnknownSchema(schema_name.to_owned())))
+                Err(SqlCatalogError::UnknownSchema(schema_name.to_owned()).into())
             }
             Err(err) => Err(err.into()),
         }
@@ -391,7 +392,7 @@ impl Transaction<'_> {
         if n == 1 {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::UnknownDatabase(name.to_owned())))
+            Err(SqlCatalogError::UnknownDatabase(name.to_owned()).into())
         }
     }
 
@@ -404,7 +405,7 @@ impl Transaction<'_> {
         if n == 1 {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::UnknownSchema(schema_name.to_owned())))
+            Err(SqlCatalogError::UnknownSchema(schema_name.to_owned()).into())
         }
     }
 
@@ -417,7 +418,7 @@ impl Transaction<'_> {
         if n == 1 {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::UnknownItem(id.to_string())))
+            Err(SqlCatalogError::UnknownItem(id.to_string()).into())
         }
     }
 
@@ -430,7 +431,7 @@ impl Transaction<'_> {
         if n == 1 {
             Ok(())
         } else {
-            Err(Error::new(ErrorKind::UnknownItem(id.to_string())))
+            Err(SqlCatalogError::UnknownItem(id.to_string()).into())
         }
     }
 

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -11,6 +11,23 @@
 
 #![deny(missing_debug_implementations)]
 
+macro_rules! unsupported {
+    ($feature:expr) => {
+        return Err(crate::plan::error::PlanError::Unsupported {
+            feature: $feature.to_string(),
+            issue_no: None,
+        }
+        .into());
+    };
+    ($issue:expr, $feature:expr) => {
+        return Err(crate::plan::error::PlanError::Unsupported {
+            feature: $feature.to_string(),
+            issue_no: Some($issue),
+        }
+        .into());
+    };
+}
+
 mod kafka_util;
 
 pub mod ast;
@@ -20,13 +37,3 @@ pub mod normalize;
 pub mod parse;
 pub mod plan;
 pub mod pure;
-
-#[macro_export]
-macro_rules! unsupported {
-    ($feature:expr) => {
-        bail!("{} not yet supported", $feature)
-    };
-    ($issue:expr, $feature:expr) => {
-        bail!("{} not yet supported, see https://github.com/MaterializeInc/materialize/issues/{} for more details", $feature, $issue)
-    };
-}

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -38,6 +38,7 @@ use crate::catalog::Catalog;
 use crate::names::{DatabaseSpecifier, FullName};
 
 pub(crate) mod decorrelate;
+pub(crate) mod error;
 pub(crate) mod explain;
 pub(crate) mod expr;
 pub(crate) mod func;
@@ -49,6 +50,7 @@ pub(crate) mod transform_expr;
 pub(crate) mod typeconv;
 
 pub use self::expr::RelationExpr;
+pub use error::PlanError;
 // This is used by sqllogictest to turn SQL values into `Datum`s.
 pub use query::scalar_type_from_sql;
 pub use statement::StatementContext;

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -1,0 +1,67 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::catalog::CatalogError;
+
+#[derive(Debug)]
+pub enum PlanError {
+    Unsupported {
+        feature: String,
+        issue_no: Option<usize>,
+    },
+    UnknownColumn(String),
+    AmbiguousColumn(String),
+    MisqualifiedName(String),
+    OverqualifiedDatabaseName(String),
+    OverqualifiedSchemaName(String),
+    Catalog(CatalogError),
+}
+
+impl fmt::Display for PlanError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Unsupported { feature, issue_no } => {
+                write!(f, "{} not yet supported", feature)?;
+                if let Some(issue_no) = issue_no {
+                    write!(f, ", see https://github.com/MaterializeInc/materialize/issues/{} for more details", issue_no)?;
+                }
+                Ok(())
+            }
+            Self::UnknownColumn(name) => write!(f, "column \"{}\" does not exist", name),
+            Self::AmbiguousColumn(name) => write!(f, "column name \"{}\" is ambiguous", name),
+            Self::MisqualifiedName(name) => write!(
+                f,
+                "qualified name did not have between 1 and 3 components: {}",
+                name
+            ),
+            Self::OverqualifiedDatabaseName(name) => write!(
+                f,
+                "database name '{}' does not have exactly one component",
+                name
+            ),
+            Self::OverqualifiedSchemaName(name) => write!(
+                f,
+                "schema name '{}' cannot have more than two components",
+                name
+            ),
+            Self::Catalog(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl Error for PlanError {}
+
+impl From<CatalogError> for PlanError {
+    fn from(e: CatalogError) -> PlanError {
+        PlanError::Catalog(e)
+    }
+}

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -28,7 +28,6 @@ use super::expr::{
 };
 use super::query::{self, ExprContext, QueryLifetime};
 use super::typeconv::{self, rescale_decimal, CastTo, CoerceTo};
-use crate::unsupported;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Mirrored from [PostgreSQL's `typcategory`][typcategory].

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -223,7 +223,7 @@ END $$;
                             if *if_exists {
                                 continue;
                             } else {
-                                return Err(err);
+                                return Err(err.into());
                             }
                         }
                     };


### PR DESCRIPTION
More structured errors will allow us to return much more useful errors
to the client, like errors that include a "SQLState" code, a detailed
description, a hint, and so on. Plus, they allow catching and handling
specific errors, which can be useful in planning.

The refactor here is the minimal refactor required to support #1673. The
gist is that we need to catch "unknown column" errors without catching
any _other_ types of errors.

Over time, I expect us to replace all usage of failure::Error in the SQL
planner with this new PlanError type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3650)
<!-- Reviewable:end -->
