### PR TITLE
doc/user: fix slack link on install page

### DIFF
--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -7,7 +7,7 @@ weight: 2
 
 {{< promo >}}
 
-[Want to connect with Materialize? Join our growing community on Slack! →](https://materializecommunity.slack.com/join/shared_invite/zt-f0qdaz1v-NgGIuxK7Rm1H4AjvJEO8bQ#/)
+[Want to connect with Materialize? Join our growing community on Slack! →](https://join.slack.com/t/materializecommunity/shared_invite/zt-fpfvczj5-efOE_8qvM4fWpHSvMxpKbA)
 
 {{< /promo >}}
 


### PR DESCRIPTION
The current Slack link has expired. Thanks to @sixcorners for
discovering and submitting the initial fix.

Closes #3644.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3672)
<!-- Reviewable:end -->
