### PR TITLE
sql: add list subscripting operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,7 @@ dependencies = [
  "csv",
  "encoding",
  "enum-iterator",
+ "itertools",
  "num_enum",
  "ordered-float",
  "ore",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -11,6 +11,7 @@ chrono = "0.4"
 csv = "1.1"
 encoding = "0.2"
 enum-iterator = "0.6.0"
+itertools = "0.9"
 num_enum = "0.5.0"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -846,6 +846,22 @@ impl RowPacker {
         })
     }
 
+    /// # Safety
+    ///
+    /// Truncates the underlying storage to the specified byte position.
+    ///
+    /// `pos` MUST specify a byte offset that lies on a datum boundary.
+    /// If `pos` specifies a byte offset that is *within* a datum, the row
+    /// packer will produce an invalid row, the unpacking of which may
+    /// trigger undefined behavior!
+    ///
+    /// To find the byte offset of a datum boundary, inspect the the packer's
+    /// byte length by calling `packer.data().len()` after pushing the desired
+    /// number of datums onto the packer.
+    pub unsafe fn truncate(&mut self, pos: usize) {
+        self.data.truncate(pos)
+    }
+
     /// For debugging only
     pub fn data(&self) -> &[u8] {
         &self.data

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -626,6 +626,35 @@ impl<'a> ScalarType {
             _ => panic!("ScalarType::unwrap_decimal_parts called on {:?}", self),
         }
     }
+    /// Returns the [`ScalarType`] of elements in a [`ScalarType::List`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on anything other than a [`ScalarType::List`].
+    pub fn unwrap_list_element_type(&self) -> &ScalarType {
+        match self {
+            ScalarType::List(s) => s,
+            _ => panic!("ScalarType::unwrap_list_element_type called on {:?}", self),
+        }
+    }
+
+    /// Returns number of dimensions/axes (also known as "rank") on a
+    /// [`ScalarType::List`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on anything other than a [`ScalarType::List`].
+    pub fn unwrap_list_n_dims(&self) -> usize {
+        let mut descender = self.unwrap_list_element_type();
+        let mut dims = 1;
+
+        while let ScalarType::List(s) = descender {
+            dims += 1;
+            descender = s;
+        }
+
+        dims
+    }
 
     /// Returns a copy of `Self` with any embedded fields "zeroed" out. Meant to
     /// make comparisons easier, allowing you to mimic `std::mem::discriminant`
@@ -743,7 +772,7 @@ impl fmt::Display for ScalarType {
             Bytes => f.write_str("bytes"),
             String => f.write_str("string"),
             Jsonb => f.write_str("jsonb"),
-            List(t) => write!(f, "{}[]", t),
+            List(t) => write!(f, "{} list", t),
             Record { fields } => {
                 f.write_str("record(")?;
                 write_delimited(f, ", ", fields, |f, (n, t)| write!(f, "{}: {}", n, t))?;

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -254,3 +254,50 @@ Parse error:
 SELECT [1, 2]
        ^
 Expected an expression, found: [
+
+# Subscripts must have values
+parse-statement
+SELECT LIST[1][]
+----
+error:
+Parse error:
+SELECT LIST[1][]
+               ^
+Expected an expression, found: ]
+
+# Multi-dimensional subscripts must all be slices
+parse-statement
+SELECT LIST[1][1:2, 1]
+----
+error:
+Parse error:
+SELECT LIST[1][1:2, 1]
+                     ^
+Expected :, found: ]
+
+parse-statement
+SELECT LIST[1][1, 1]
+----
+error:
+Parse error:
+SELECT LIST[1][1, 1]
+                ^
+Expected ], found: ,
+
+parse-statement
+SELECT LIST[1][1, 1:1]
+----
+error:
+Parse error:
+SELECT LIST[1][1, 1:1]
+                ^
+Expected ], found: ,
+
+parse-statement
+SELECT LIST[1][1:1, ]
+----
+error:
+Parse error:
+SELECT LIST[1][1:1, ]
+                    ^
+Expected an expression, found: ]

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -275,6 +275,41 @@ LIST[LIST[1 + 1, 2], a || b]
 List([List([BinaryOp { left: Value(Number("1")), op: Plus, right: Value(Number("1")) }, Value(Number("2"))]), BinaryOp { left: Identifier([Ident("a")]), op: Concat, right: Identifier([Ident("b")]) }])
 
 parse-scalar
+LIST[1,2,3][1]
+----
+SubscriptIndex { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), subscript: Value(Number("1")) }
+
+parse-scalar
+LIST[1,2,3][1:1]
+----
+SubscriptSlice { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }
+
+parse-scalar
+LIST[1,2,3][:1]
+----
+SubscriptSlice { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), positions: [SubscriptPosition { start: None, end: Some(Value(Number("1"))) }] }
+
+parse-scalar
+LIST[1,2,3][1:]
+----
+SubscriptSlice { expr: List([Value(Number("1")), Value(Number("2")), Value(Number("3"))]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: None }] }
+
+parse-scalar
+LIST[[1],[2],[3]][1:1, 1:1]
+----
+SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }
+
+parse-scalar
+LIST[[1],[2],[3]][1:1, 1:1][1]
+----
+SubscriptIndex { expr: SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }, subscript: Value(Number("1")) }
+
+parse-scalar
+LIST[[1],[2],[3]][1:1, 1:1, 1:1]
+----
+SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2"))]), List([Value(Number("3"))])]), positions: [SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }, SubscriptPosition { start: Some(Value(Number("1"))), end: Some(Value(Number("1"))) }] }
+
+parse-scalar
 a -> b
 ----
 BinaryOp { left: Identifier([Ident("a")]), op: JsonGet, right: Identifier([Ident("b")]) }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -196,6 +196,20 @@ impl CoercibleScalarExpr {
     pub fn type_as_any(self, ecx: &ExprContext) -> Result<ScalarExpr, anyhow::Error> {
         typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ScalarType::String))
     }
+
+    pub fn explicit_cast_to(
+        self,
+        op: &str,
+        ecx: &ExprContext,
+        ty: ScalarType,
+    ) -> Result<ScalarExpr, anyhow::Error> {
+        let expr = typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ty.clone()))?;
+        if ty != ecx.scalar_type(&expr) {
+            typeconv::plan_cast(op, ecx, expr, typeconv::CastTo::Explicit(ty))
+        } else {
+            Ok(expr)
+        }
+    }
 }
 
 pub trait ScalarTypeable {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1430,6 +1430,84 @@ pub fn plan_expr<'a>(ecx: &'a ExprContext, e: &Expr) -> Result<CoercibleScalarEx
             }
         }
         Expr::WildcardAccess(expr) => plan_expr(ecx, expr)?,
+        Expr::SubscriptIndex { expr, subscript } => {
+            let expr = plan_expr(ecx, expr)?.type_as_any(ecx)?;
+            let ty = ecx.scalar_type(&expr);
+            match &ty {
+                ScalarType::List(_) => {}
+                ty => bail!("cannot subscript type {}", ty),
+            };
+
+            expr.call_binary(
+                plan_expr(ecx, subscript)?.explicit_cast_to(
+                    "subscript (indexing)",
+                    ecx,
+                    ScalarType::Int64,
+                )?,
+                BinaryFunc::ListIndex,
+            )
+            .into()
+        }
+
+        Expr::SubscriptSlice { expr, positions } => {
+            assert_ne!(
+                positions.len(),
+                0,
+                "subscript expression must contain at least one position"
+            );
+            if positions.len() > 1 && !ecx.qcx.scx.experimental_mode() {
+                bail!(
+                    "multi-dimensional slicing requires experimental mode; see \
+                https://materialize.io/docs/cli/#experimental-mode"
+                )
+            };
+            let expr = plan_expr(ecx, expr)?.type_as_any(ecx)?;
+            let ty = ecx.scalar_type(&expr);
+            match &ty {
+                ScalarType::List(_) => {
+                    let pos_len = positions.len();
+                    let n_dims = ty.unwrap_list_n_dims();
+                    if pos_len > n_dims {
+                        bail!(
+                            "cannot slice on {} dimensions; list only has {} dimension{}",
+                            pos_len,
+                            n_dims,
+                            if n_dims == 1 { "" } else { "s" }
+                        )
+                    }
+                }
+                ty => bail!("cannot subscript type {}", ty),
+            };
+
+            let mut exprs = vec![expr];
+            let op_str = "subscript (slicing)";
+
+            for p in positions {
+                let start = if let Some(start) = &p.start {
+                    plan_expr(ecx, start)?.explicit_cast_to(op_str, ecx, ScalarType::Int64)?
+                } else {
+                    ScalarExpr::literal(Datum::Int64(1), ColumnType::new(ScalarType::Int64, true))
+                };
+
+                let end = if let Some(end) = &p.end {
+                    plan_expr(ecx, end)?.explicit_cast_to(op_str, ecx, ScalarType::Int64)?
+                } else {
+                    ScalarExpr::literal(
+                        Datum::Int64(i64::MAX - 1),
+                        ColumnType::new(ScalarType::Int64, true),
+                    )
+                };
+
+                exprs.push(start);
+                exprs.push(end);
+            }
+
+            ScalarExpr::CallVariadic {
+                func: VariadicFunc::ListSlice,
+                exprs,
+            }
+            .into()
+        }
 
         // Subqueries.
         Expr::Exists(query) => {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -82,3 +82,575 @@ query T
 SELECT LIST[LIST[]::text list, LIST['a', 'b'], LIST['z']]
 ----
 {{},{a,b},{z}}
+
+# 🔬 list subscripts
+# 🔬🔬 list indexes
+query R
+SELECT LIST [1, 2, 3][2];
+----
+2
+
+# exceeds maximum index
+query R
+SELECT LIST [1, 2, 3][100];
+----
+NULL
+
+# exceeds maximum dimension
+query error cannot subscript type i32
+SELECT LIST [1, 2, 3][1][1];
+
+# 🔬🔬 list slices
+query T
+SELECT LIST [1, 2, 3][2:3];
+----
+{2,3}
+
+query T
+SELECT LIST [1, 2, 3][2:];
+----
+{2,3}
+
+query T
+SELECT LIST [1, 2, 3][:2];
+----
+{1,2}
+
+query T
+SELECT LIST [1, 2, 3][:];
+----
+{1,2,3}
+
+# start exceeds maximum index
+query R
+SELECT LIST [1, 2, 3][100:];
+----
+NULL
+
+# end exceeds maximum index
+query T
+SELECT LIST [1, 2, 3][:100];
+----
+{1,2,3}
+
+# exceeds maximum dimension
+query error cannot slice on 2 dimensions; list only has 1 dimension
+SELECT LIST [1, 2, 3][:, :]
+
+# successive slices
+query T
+SELECT LIST [1, 2, 3][2:3][1:1];
+----
+{2}
+
+# 🔬🔬 list slices + index
+query T
+SELECT LIST [1, 2, 3][2:3][2];
+----
+3
+
+# 🔬 list list subscripts
+# 🔬🔬 list list indexes
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][1]
+----
+{1,2,3}
+
+query R
+SELECT LIST [[1, 2, 3], [4, 5]][1][3]
+----
+3
+
+# exceeds maximum index
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][100]
+----
+NULL
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][1][100]
+----
+NULL
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][100][1]
+----
+NULL
+
+# exceeds maximum dimension
+query error cannot subscript type i32
+SELECT LIST [[1, 2, 3], [4, 5]][1][1][1]
+
+# 🔬🔬 list list slices
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][2:2]
+----
+{{4,5}}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][1:2, 2:3];
+----
+{{2,3},{5}}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][2:]
+----
+{{4,5}}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][:2, 2:]
+----
+{{2,3},{5}}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][:, 2:]
+----
+{{2,3},{5}}
+
+# start exceeds maximum index
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][100:, :]
+----
+NULL
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][:, 100:]
+----
+NULL
+
+# propagating NULL lists
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][:, 3:3]
+----
+{{3},NULL}
+
+# end exceeds maximum index
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][:100, :];
+----
+{{1,2,3},{4,5}}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][:, :100]
+----
+{{1,2,3},{4,5}}
+
+# exceeds maximum dimension
+query error cannot slice on 3 dimensions; list only has 2 dimensions
+SELECT LIST [[1, 2, 3], [4, 5]][:, :, :]
+
+# successive slice operations
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][2:2][1:1]
+----
+{{4,5}}
+
+# 🔬🔬 list list slices + index
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][1:2][2]
+----
+{4,5}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][1:2][2][2:2]
+----
+{5}
+
+query T
+SELECT LIST [[1, 2, 3], [4, 5]][1:2][2][2:2][1]
+----
+5
+
+# 🔬 list list list
+# 🔬🔬 list list list indexes
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1]
+----
+{{1,2},{3,4,5}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2]
+----
+{3,4,5}
+
+query R
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2][3]
+----
+5
+
+# exceeds maximum index
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100]
+----
+NULL
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][100]
+----
+NULL
+
+query R
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2][100]
+----
+NULL
+
+query R
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100][2][3]
+----
+NULL
+
+# exceeds maximum dimension
+query error cannot subscript type i32
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2][3][1]
+
+# 🔬🔬 list list list slices
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2]
+----
+{{{1,2},{3,4,5}},{{6}}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 1:1];
+----
+{{{1,2}},{{6}},{{7,8}}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, 1:1];
+----
+{{{1},{3}},{{6}},{{7},{9}}}
+
+# start exceeds maximum index
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100:100];
+----
+NULL
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 100:100];
+----
+NULL
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, 100:100];
+----
+NULL
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 100:100, :];
+----
+NULL
+
+# propagating NULL lists
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 2:2];
+----
+{{{3,4,5}},NULL,{{9}}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, 2:2, 2:2];
+----
+{{{4}},NULL,NULL}
+
+# end exceeds maximum index
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:100];
+----
+{{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :100];
+----
+{{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, :100];
+----
+{{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :100, :100];
+----
+{{{1,2},{3,4,5}},{{6}},{{7,8},{9}}}
+
+# exceeds maximum dimension
+query error cannot slice on 4 dimensions; list only has 3 dimensions
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][:, :, :, :];
+
+# 🔬🔬 list list list slices + index
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2][1];
+----
+{{1,2},{3,4,5}}
+
+query T
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2][1][2:2][1];
+----
+{3,4,5}
+
+query R
+SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2][1][2:3][1][2:3][2];
+----
+5
+
+# 🔬 NULL expressions
+query R
+SELECT (LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2][1]
+----
+NULL
+
+query T
+SELECT (LIST[[1, 2, 3], NULL, [4]]::INT LIST LIST)[2:3, 2:2]
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][NULL]
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][NULL:NULL]
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][1:NULL]
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][NULL:1]
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][NULL:]
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][:NULL]
+----
+NULL
+
+query T
+SELECT LIST[NULL][:]
+----
+{NULL}
+
+query T
+SELECT LIST[1, NULL, 3][:NULL]
+----
+NULL
+
+query T
+SELECT (LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:];
+----
+{NULL,{4,NULL,6}}
+
+query T
+SELECT (LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3][1];
+----
+NULL
+
+# 🔬🔬 Slices and NULLs
+
+# NULL literals are not touched by slice operations
+query T
+SELECT (LIST[NULL]::INT LIST)[1:1];
+----
+{NULL}
+
+# Slicing into a NULL list produces an empty result expressed as NULL; if all
+# results are empty, reduce them all to a single NULL
+query T
+SELECT (LIST[NULL, NULL]::INT LIST LIST)[:, 1:1];
+----
+NULL
+
+# Literal NULLs are NOT empty results and don't get reduced
+query T
+SELECT (LIST[NULL, [NULL]]::INT LIST LIST)[:, 1:1];
+----
+{NULL,{NULL}}
+
+# Results can intermix values and empty-results-as-NULLs
+query T
+SELECT (LIST [[1, NULL, 3], NULL, [4, 5, 6]]::INT LIST LIST)[2:3, 2:2];
+----
+{NULL,{5}}
+
+# Results can intermix NULL values and empty-results-as-NULLs
+query T
+SELECT (LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 2:2];
+----
+{NULL,{NULL}}
+
+# Empty results across dimensions are still reduced
+query T
+SELECT (LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 4:4];
+----
+NULL
+
+# Outer list's second position produces empty results, but third position
+# produces value, so cannot be totally reduced
+query T
+SELECT (LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:, :, :];
+----
+{NULL,NULL,{{NULL}}}
+
+# Third position returns empty results, along with the first and second
+# position, so all can be reduced to NULL
+query T
+SELECT (LIST [NULL, [NULL], [[NULL]]]::INT LIST LIST LIST)[:, :, 2:2];
+----
+NULL
+
+# 🔬 Empty lists expressions
+query T
+SELECT (LIST[]::INT LIST)[1]
+----
+NULL
+
+query T
+SELECT (LIST[]::INT LIST)[:]
+----
+NULL
+
+query T
+SELECT (LIST[]::INT LIST)[1:1]
+----
+NULL
+
+query T
+SELECT (LIST[]::INT LIST LIST)[1:1, 1:1]
+----
+NULL
+
+# 🔬 Other subcript values
+
+# 🔬🔬 end > start
+query T
+SELECT LIST[1, 2, 3][2:1];
+----
+NULL
+
+# 🔬🔬 Negative values
+query T
+SELECT LIST[1, 2, 3][-100];
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][-100:];
+----
+{1,2,3}
+
+query T
+SELECT LIST[1, 2, 3][-100:99];
+----
+{1,2,3}
+
+query T
+SELECT LIST[1, 2, 3][-100:-99];
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][-100:-101];
+----
+NULL
+
+query T
+SELECT LIST[1, 2, 3][:-100];
+----
+NULL
+
+# 🔬🔬 min/max
+query R
+SELECT LIST[1][9223372036854775807::bigint]
+----
+NULL
+
+query R
+SELECT LIST[1][-9223372036854775807::bigint]
+----
+NULL
+
+query R
+SELECT LIST[1][9223372036854775807::bigint:9223372036854775807::bigint]
+----
+NULL
+
+query R
+SELECT LIST[1][9223372036854775807::bigint:-9223372036854775807::bigint]
+----
+NULL
+
+query T
+SELECT LIST[1][-9223372036854775807::bigint:9223372036854775807::bigint]
+----
+{1}
+
+query R
+SELECT LIST[1][-9223372036854775807::bigint:-9223372036854775807::bigint]
+----
+NULL
+
+# 🔬 Non-int subscript values
+# 🔬🔬 Ok
+query R
+select LIST[1,2,3][1.4];
+----
+1
+
+query R
+select LIST[1,2,3][1.5];
+----
+2
+
+query R
+select LIST[1,2,3][1.5::real];
+----
+2
+
+query R
+select LIST[1,2,3][1.5::float];
+----
+2
+
+query R
+select LIST[1,2,3][1.5 + 1.6];
+----
+3
+
+query T
+select LIST[1,2,3][0.1 * 2 : 0.5 + 1.6];
+----
+{1,2}
+
+query T
+select LIST[1,2,3][LIST[1][2.0 / 2]];
+----
+1
+
+# 🔬🔬 Err
+query error invalid input syntax for int8: invalid digit found in string: "dog"
+SELECT LIST[1,2,3]['dog']
+
+query error subscript \(indexing\) does not support casting from date to i64
+SELECT LIST [[1, 2, 3], [4, 5]][DATE '2001-01-01']
+
+query error subscript \(indexing\) does not support casting from timestamp to i64
+SELECT LIST [[1, 2, 3], [4, 5]][TIMESTAMP '2001-01-01']
+
+query error invalid input syntax for int8: invalid digit found in string: "dog"
+SELECT LIST[1,2,3][1:'dog']
+
+query error subscript \(slicing\) does not support casting from date to i64
+SELECT LIST [[1, 2, 3], [4, 5]][1:DATE '2001-01-01']
+
+query error subscript \(slicing\) does not support casting from timestamp to i64
+SELECT LIST [[1, 2, 3], [4, 5]][1:TIMESTAMP '2001-01-01']


### PR DESCRIPTION
Not sure the best way to share a "design doc", so just put `list-syntax-semantics.md` for review in the root. Will pull that out and convert it to documentation after I get an OK.

The only "contentious" topic here, I believe, is the behavior of multi-dimensional slices w/r/t jagged lists; the meat of which you can find [here](https://github.com/MaterializeInc/materialize/compare/main...sploiselle:list-funcs?expand=1#diff-25040f7114a80f00050e2d5cc53db67bR2991-R2993). Welcome to feedback on anything, though.

Note that this is a draft, so the code is in more of a POC state. I haven't thoroughly tested things like _NULL_-handling, etc., because I wanted to make sure that the top-level idea was sound before delving into all of the corners. That being said, fixes for glaring errors are very welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3683)
<!-- Reviewable:end -->
