### PR TITLE
coord,dataflow: remove SequencedCommand::AppendLog

### DIFF
--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -171,6 +171,7 @@ pub fn construct<A: Allocate>(
                                 frontier_session.give((
                                     row_packer.pack(&[
                                         Datum::String(&name.to_string()),
+                                        Datum::Int64(worker as i64),
                                         Datum::Int64(logical as i64),
                                     ]),
                                     time_ms,

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -165,7 +165,6 @@ impl CommandsProcessedMetrics {
             SequencedCommand::CreateLocalInput { .. } => self.create_local_input_int += 1,
             SequencedCommand::Insert { .. } => self.insert_int += 1,
             SequencedCommand::AllowCompaction(..) => self.allow_compaction_int += 1,
-            SequencedCommand::AppendLog(..) => self.append_log_int += 1,
             SequencedCommand::AdvanceSourceTimestamp { .. } => {
                 self.advance_source_timestamp_int += 1
             }
@@ -216,10 +215,6 @@ impl CommandsProcessedMetrics {
             self.allow_compaction
                 .inc_by(self.allow_compaction_int as i64);
             self.allow_compaction_int = 0;
-        }
-        if self.append_log_int > 0 {
-            self.append_log.inc_by(self.append_log_int as i64);
-            self.append_log_int = 0;
         }
         if self.advance_source_timestamp_int > 0 {
             self.advance_source_timestamp

--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -75,16 +75,16 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
         // Test that catalog recovery correctly populates `mz_catalog_names`.
         assert_eq!(
             client
-                .query("SELECT * FROM mz_catalog_names", &[])?
+                .query("SELECT global_id FROM mz_catalog_names ORDER BY 1", &[])?
                 .into_iter()
                 .map(|row| row.get(0))
                 .collect::<Vec<String>>(),
             vec![
-                "u6", "u1", "u4", "s27", "s23", "s55", "u2", "s31", "s25", "s35", "s57", "s3",
-                "s11", "s17", "s1", "s5", "s13", "s29", "s7", "u3", "u5", "s15", "s41", "s28",
-                "s24", "s56", "s47", "s49", "s21", "s32", "s45", "s9", "s26", "s33", "s51", "s58",
-                "s37", "s43", "s4", "s12", "s18", "s19", "s2", "s6", "s14", "s30", "s39", "s53",
-                "s8", "s16", "s22", "s10", "s20"
+                "s1", "s10", "s11", "s12", "s13", "s14", "s15", "s16", "s17", "s18", "s19", "s2",
+                "s20", "s21", "s22", "s23", "s24", "s25", "s26", "s27", "s28", "s29", "s3", "s30",
+                "s31", "s32", "s33", "s35", "s37", "s39", "s4", "s41", "s43", "s47", "s49", "s5",
+                "s51", "s53", "s54", "s55", "s56", "s57", "s58", "s59", "s6", "s7", "s8", "s9",
+                "u1", "u2", "u3", "u4", "u5", "u6",
             ]
         );
     }

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -186,7 +186,6 @@ mz_dataflow_operator_addresses
 mz_dataflow_operators
 mz_kafka_sinks
 mz_materialization_dependencies
-mz_materialization_frontiers
 mz_materializations
 mz_peek_active
 mz_peek_durations
@@ -195,11 +194,13 @@ mz_scheduling_histogram
 mz_scheduling_parks
 mz_view_foreign_keys
 mz_view_keys
+mz_worker_materialization_frontiers
 
 > SHOW VIEWS FROM mz_catalog
 mz_addresses_with_unit_length
 mz_dataflow_names
 mz_dataflow_operator_dataflows
+mz_materialization_frontiers
 mz_perf_arrangement_records
 mz_perf_dependency_frontiers
 mz_perf_peek_durations_aggregates

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -199,26 +199,26 @@ VIEWS        TYPE  QUERYABLE
 names_view   USER  true
 
 > SHOW FULL SOURCES FROM mz_catalog
-SOURCES                           TYPE   MATERIALIZED
------------------------------------------------------
-mz_arrangement_sharing            SYSTEM true
-mz_arrangement_sizes              SYSTEM true
-mz_avro_ocf_sinks                 SYSTEM true
-mz_catalog_names                  SYSTEM true
-mz_dataflow_channels              SYSTEM true
-mz_dataflow_operator_addresses    SYSTEM true
-mz_dataflow_operators             SYSTEM true
-mz_kafka_sinks                    SYSTEM true
-mz_materialization_dependencies   SYSTEM true
-mz_materialization_frontiers      SYSTEM true
-mz_materializations               SYSTEM true
-mz_peek_active                    SYSTEM true
-mz_peek_durations                 SYSTEM true
-mz_scheduling_elapsed             SYSTEM true
-mz_scheduling_histogram           SYSTEM true
-mz_scheduling_parks               SYSTEM true
-mz_view_foreign_keys              SYSTEM true
-mz_view_keys                      SYSTEM true
+SOURCES                              TYPE   MATERIALIZED
+--------------------------------------------------------
+mz_arrangement_sharing               SYSTEM true
+mz_arrangement_sizes                 SYSTEM true
+mz_avro_ocf_sinks                    SYSTEM true
+mz_catalog_names                     SYSTEM true
+mz_dataflow_channels                 SYSTEM true
+mz_dataflow_operator_addresses       SYSTEM true
+mz_dataflow_operators                SYSTEM true
+mz_kafka_sinks                       SYSTEM true
+mz_materialization_dependencies      SYSTEM true
+mz_materializations                  SYSTEM true
+mz_peek_active                       SYSTEM true
+mz_peek_durations                    SYSTEM true
+mz_scheduling_elapsed                SYSTEM true
+mz_scheduling_histogram              SYSTEM true
+mz_scheduling_parks                  SYSTEM true
+mz_view_foreign_keys                 SYSTEM true
+mz_view_keys                         SYSTEM true
+mz_worker_materialization_frontiers  SYSTEM true
 
 > SHOW FULL VIEWS FROM mz_catalog
 VIEWS                             TYPE   QUERYABLE MATERIALIZED
@@ -226,6 +226,7 @@ VIEWS                             TYPE   QUERYABLE MATERIALIZED
 mz_addresses_with_unit_length     SYSTEM true      false
 mz_dataflow_names                 SYSTEM true      false
 mz_dataflow_operator_dataflows    SYSTEM true      false
+mz_materialization_frontiers      SYSTEM true      false
 mz_perf_arrangement_records       SYSTEM true      false
 mz_perf_dependency_frontiers      SYSTEM true      false
 mz_perf_peek_durations_aggregates SYSTEM true      false


### PR DESCRIPTION
@frankmcsherry this might be total bogus, but it struck me as plausible enough so figured I'd whip it up as a PR.

We can avoid the dataflow -> coord -> dataflow transfer for the
mz_materialization_frontiers logging view by having each worker record
its own frontiers and taking the min across all workers via a view.

Fix #3684.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3685)
<!-- Reviewable:end -->

