### PR TITLE
sql: fix GROUP BY ordinal references

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -19,6 +19,7 @@
 //! In `RelationExpr`, aggregates can only be applied immediately at the time of grouping.
 //! To deal with this, whenever we see a SQL GROUP BY we look ahead for aggregates and precompute them in the `RelationExpr::Reduce`. When we reach the same aggregates during normal planning later on, we look them up in an `ExprContext` to find the precomputed versions.
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
@@ -570,9 +571,41 @@ fn plan_view_select_intrusive(
         relation_expr = relation_expr.filter(vec![expr]);
     }
 
-    // Step 3. Handle GROUP BY clause.
+    // Step 3. Gather aggregates.
+    let aggregates = {
+        let mut aggregate_visitor = AggregateFuncVisitor::new();
+        for p in projection {
+            aggregate_visitor.visit_select_item(p);
+        }
+        for o in order_by_exprs {
+            aggregate_visitor.visit_order_by_expr(o);
+        }
+        if let Some(having) = having {
+            aggregate_visitor.visit_expr(having);
+        }
+        aggregate_visitor.into_result()?
+    };
+
+    // Step 4. Expand SELECT clause.
+    let projection = {
+        let ecx = &ExprContext {
+            qcx,
+            name: "SELECT clause",
+            scope: &from_scope,
+            relation_type: &qcx.relation_type(&relation_expr),
+            allow_aggregates: true,
+            allow_subqueries: true,
+        };
+        let mut out = vec![];
+        for si in projection {
+            out.extend(expand_select_item(&ecx, si)?);
+        }
+        out
+    };
+
+    // Step 5. Handle GROUP BY clause.
     let (group_scope, select_all_mapping) = {
-        // gather group columns
+        // Compute GROUP BY expressions.
         let ecx = &ExprContext {
             qcx,
             name: "GROUP BY clause",
@@ -586,9 +619,19 @@ fn plan_view_select_intrusive(
         let mut group_scope = Scope::empty(Some(qcx.outer_scope.clone()));
         let mut select_all_mapping = BTreeMap::new();
         for group_expr in group_by {
-            let expr = plan_expr_or_col_index(ecx, group_expr)?;
+            let expr = match check_col_index(&ecx.name, group_expr, projection.len())? {
+                None => plan_expr(&ecx, group_expr)?.type_as_any(ecx)?,
+                Some(i) => match &projection[i].0 {
+                    ExpandedSelectItem::InputOrdinal(column) => ScalarExpr::Column(ColumnRef {
+                        level: 0,
+                        column: *column,
+                    }),
+                    ExpandedSelectItem::Expr(expr) => plan_expr(&ecx, expr)?.type_as_any(ecx)?,
+                },
+            };
             let new_column = group_key.len();
-            // repeated exprs in GROUP BY confuse name resolution later, and dropping them doesn't change the result
+            // Repeated expressions in GROUP BY confuse name resolution later,
+            // and dropping them doesn't change the result.
             if group_exprs
                 .iter()
                 .find(|existing_expr| **existing_expr == expr)
@@ -599,8 +642,11 @@ fn plan_view_select_intrusive(
                     column: old_column,
                 }) = &expr
                 {
-                    // If we later have `SELECT foo.*` then we have to find all the `foo` items in `from_scope` and figure out where they ended up in `group_scope`.
-                    // This is really hard to do right using SQL name resolution, so instead we just track the movement here.
+                    // If we later have `SELECT foo.*` then we have to find all
+                    // the `foo` items in `from_scope` and figure out where they
+                    // ended up in `group_scope`. This is really hard to do
+                    // right using SQL name resolution, so instead we just track
+                    // the movement here.
                     select_all_mapping.insert(*old_column, new_column);
                     let mut scope_item = ecx.scope.items[*old_column].clone();
                     scope_item.expr = Some(group_expr.clone());
@@ -618,17 +664,8 @@ fn plan_view_select_intrusive(
                 group_scope.items.push(scope_item);
             }
         }
-        // gather aggregates
-        let mut aggregate_visitor = AggregateFuncVisitor::new();
-        for p in projection {
-            aggregate_visitor.visit_select_item(p);
-        }
-        for o in order_by_exprs {
-            aggregate_visitor.visit_order_by_expr(o);
-        }
-        if let Some(having) = having {
-            aggregate_visitor.visit_expr(having);
-        }
+
+        // Plan aggregates.
         let ecx = &ExprContext {
             qcx,
             name: "aggregate function",
@@ -637,9 +674,9 @@ fn plan_view_select_intrusive(
             allow_aggregates: false,
             allow_subqueries: true,
         };
-        let mut aggregates = vec![];
-        for sql_function in aggregate_visitor.into_result()? {
-            aggregates.push(plan_aggregate(ecx, sql_function)?);
+        let mut agg_exprs = vec![];
+        for sql_function in aggregates {
+            agg_exprs.push(plan_aggregate(ecx, sql_function)?);
             group_scope.items.push(ScopeItem {
                 names: vec![ScopeItemName {
                     table_name: None,
@@ -650,9 +687,9 @@ fn plan_view_select_intrusive(
                 nameable: true,
             });
         }
-        if !aggregates.is_empty() || !group_key.is_empty() || having.is_some() {
+        if !agg_exprs.is_empty() || !group_key.is_empty() || having.is_some() {
             // apply GROUP BY / aggregates
-            relation_expr = relation_expr.map(group_exprs).reduce(group_key, aggregates);
+            relation_expr = relation_expr.map(group_exprs).reduce(group_key, agg_exprs);
             (group_scope, select_all_mapping)
         } else {
             // if no GROUP BY, aggregates or having then all columns remain in scope
@@ -663,7 +700,7 @@ fn plan_view_select_intrusive(
         }
     };
 
-    // Step 4. Handle HAVING clause.
+    // Step 6. Handle HAVING clause.
     if let Some(having) = having {
         let ecx = &ExprContext {
             qcx,
@@ -677,40 +714,66 @@ fn plan_view_select_intrusive(
         relation_expr = relation_expr.filter(vec![expr]);
     }
 
-    // Step 5. Handle SELECT clause.
+    // Step 7. Handle SELECT clause.
     let (project_key, map_scope) = {
         let mut new_exprs = vec![];
         let mut project_key = vec![];
         let mut map_scope = group_scope.clone();
-        for p in projection {
-            let ecx = &ExprContext {
-                qcx,
-                name: "SELECT clause",
-                scope: &group_scope,
-                relation_type: &qcx.relation_type(&relation_expr),
-                allow_aggregates: true,
-                allow_subqueries: true,
-            };
-            for (expr, scope_item) in plan_select_item(ecx, p, &from_scope, &select_all_mapping)? {
-                if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
-                    project_key.push(column);
-                    // Mark the output names as prioritized, so that they shadow
-                    // any input columns of the same name.
-                    map_scope.items[column]
-                        .names
-                        .splice(..0, scope_item.prioritized().names);
-                } else {
-                    project_key.push(group_scope.len() + new_exprs.len());
-                    new_exprs.push(expr);
-                    map_scope.items.push(scope_item.prioritized());
+        let ecx = &ExprContext {
+            qcx,
+            name: "SELECT clause",
+            scope: &group_scope,
+            relation_type: &qcx.relation_type(&relation_expr),
+            allow_aggregates: true,
+            allow_subqueries: true,
+        };
+        for (select_item, column_name) in projection {
+            let expr = match select_item {
+                ExpandedSelectItem::InputOrdinal(i) => {
+                    if let Some(column) = select_all_mapping.get(&i).copied() {
+                        ScalarExpr::Column(ColumnRef { level: 0, column })
+                    } else {
+                        bail!("column \"{}\" must appear in the GROUP BY clause or be used in an aggregate function", from_scope.items[i].short_display_name());
+                    }
                 }
+                ExpandedSelectItem::Expr(expr) => plan_expr(ecx, &expr)?.type_as_any(ecx)?,
+            };
+            if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
+                project_key.push(column);
+                // Mark the output name as prioritized, so that they shadow any
+                // input columns of the same name.
+                if let Some(column_name) = column_name {
+                    map_scope.items[column].names.insert(
+                        0,
+                        ScopeItemName {
+                            table_name: None,
+                            column_name: Some(column_name),
+                            priority: true,
+                        },
+                    );
+                }
+            } else {
+                project_key.push(group_scope.len() + new_exprs.len());
+                new_exprs.push(expr);
+                map_scope.items.push(ScopeItem {
+                    names: column_name
+                        .into_iter()
+                        .map(|column_name| ScopeItemName {
+                            table_name: None,
+                            column_name: Some(column_name),
+                            priority: true,
+                        })
+                        .collect(),
+                    expr: None,
+                    nameable: true,
+                });
             }
         }
         relation_expr = relation_expr.map(new_exprs);
         (project_key, map_scope)
     };
 
-    // Step 6. Handle intrusive ORDER BY.
+    // Step 8. Handle intrusive ORDER BY.
     let order_by = {
         let mut order_by = vec![];
         let mut new_exprs = vec![];
@@ -972,108 +1035,85 @@ fn invent_column_name(expr: &Expr) -> Option<ScopeItemName> {
     })
 }
 
-fn plan_select_item<'a>(
+enum ExpandedSelectItem<'a> {
+    InputOrdinal(usize),
+    Expr(Cow<'a, Expr>),
+}
+
+fn expand_select_item<'a>(
     ecx: &ExprContext,
     s: &'a SelectItem,
-    select_all_scope: &Scope,
-    select_all_mapping: &BTreeMap<usize, usize>,
-) -> Result<Vec<(ScalarExpr, ScopeItem)>, anyhow::Error> {
+) -> Result<Vec<(ExpandedSelectItem<'a>, Option<ColumnName>)>, anyhow::Error> {
     match s {
         SelectItem::Expr {
             expr: Expr::QualifiedWildcard(table_name),
             alias: _,
         } => {
             let table_name = normalize::object_name(ObjectName(table_name.clone()))?;
-            let out = select_all_scope
+            let out: Vec<_> = ecx
+                .scope
                 .items
                 .iter()
                 .enumerate()
                 .filter(|(_i, item)| item.is_from_table(&table_name))
                 .map(|(i, item)| {
-                    let expr = ScalarExpr::Column(ColumnRef {
-                        level: 0,
-                        column: *select_all_mapping.get(&i).ok_or_else(|| {
-                            anyhow!("internal error: unable to resolve scope item {:?}", item)
-                        })?,
-                    });
-                    let mut out_item = item.clone();
-                    out_item.expr = None;
-                    Ok((expr, out_item))
+                    let name = item.names.get(0).and_then(|n| n.column_name.clone());
+                    (ExpandedSelectItem::InputOrdinal(i), name)
                 })
-                .collect::<Result<Vec<_>, anyhow::Error>>()?;
+                .collect();
             if out.is_empty() {
                 bail!("no table named '{}' in scope", table_name);
             }
             Ok(out)
         }
         SelectItem::Expr {
-            expr: Expr::WildcardAccess(expr),
+            expr: Expr::WildcardAccess(sql_expr),
             alias: _,
         } => {
-            let expr = plan_expr(ecx, expr)?.type_as_any(ecx)?;
+            // A bit silly to have to plan the expression here just to get its
+            // type, since we throw away the planned expression, but fixing this
+            // requires a separate semantic analysis phase. Luckily this is an
+            // uncommon operation and the PostgreSQL docs have a warning that
+            // this operation is slow in Postgres too.
+            let expr = plan_expr(ecx, sql_expr)?.type_as_any(ecx)?;
             let fields = match ecx.scalar_type(&expr) {
                 ScalarType::Record { fields, .. } => fields,
                 ty => bail!("type {} is not composite", ty),
             };
-            Ok(fields
+            let items = fields
                 .iter()
-                .enumerate()
-                .map(|(i, (name, _ty))| {
-                    let expr = expr.clone().call_unary(UnaryFunc::RecordGet(i));
-                    let scope_item = ScopeItem {
-                        names: vec![ScopeItemName {
-                            table_name: None,
-                            column_name: Some(name.clone()),
-                            priority: false,
-                        }],
-                        expr: None,
-                        nameable: true,
-                    };
-                    (expr, scope_item)
+                .map(|(name, _ty)| {
+                    let item = ExpandedSelectItem::Expr(Cow::Owned(Expr::FieldAccess {
+                        expr: sql_expr.clone(),
+                        field: Ident::new(name.as_str()),
+                    }));
+                    (item, Some(name.clone()))
                 })
-                .collect())
-        }
-        SelectItem::Expr {
-            expr: sql_expr,
-            alias,
-        } => {
-            let expr = plan_expr(ecx, sql_expr)?.type_as_any(ecx)?;
-            let names: Vec<_> = match alias {
-                None => invent_column_name(sql_expr).into_iter().collect(),
-                Some(alias) => vec![ScopeItemName {
-                    table_name: None,
-                    column_name: Some(normalize::column_name(alias.clone())),
-                    priority: false,
-                }],
-            };
-            let scope_item = ScopeItem {
-                names,
-                expr: Some(sql_expr.clone()),
-                nameable: true,
-            };
-            Ok(vec![(expr, scope_item)])
+                .collect();
+            Ok(items)
         }
         SelectItem::Wildcard => {
-            let out = select_all_scope
+            let items: Vec<_> = ecx
+                .scope
                 .items
                 .iter()
                 .enumerate()
                 .map(|(i, item)| {
-                    let expr = ScalarExpr::Column(ColumnRef {
-                        level: 0,
-                        column: *select_all_mapping.get(&i).ok_or_else(|| {
-                            anyhow!("internal error: unable to resolve scope item {:?}", item)
-                        })?,
-                    });
-                    let mut out_item = item.clone();
-                    out_item.expr = None;
-                    Ok((expr, out_item))
+                    let name = item.names.get(0).and_then(|n| n.column_name.clone());
+                    (ExpandedSelectItem::InputOrdinal(i), name)
                 })
-                .collect::<Result<Vec<_>, anyhow::Error>>()?;
-            if out.is_empty() {
+                .collect();
+            if items.is_empty() {
                 bail!("SELECT * with no tables specified is not valid");
             }
-            Ok(out)
+            Ok(items)
+        }
+        SelectItem::Expr { expr, alias } => {
+            let name = alias
+                .clone()
+                .map(normalize::column_name)
+                .or_else(|| invent_column_name(&expr).and_then(|n| n.column_name));
+            Ok(vec![(ExpandedSelectItem::Expr(Cow::Borrowed(expr)), name)])
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -598,6 +598,9 @@ fn plan_view_select_intrusive(
         };
         let mut out = vec![];
         for si in projection {
+            if *si == SelectItem::Wildcard && from.is_empty() {
+                bail!("SELECT * with no tables specified is not valid");
+            }
             out.extend(expand_select_item(&ecx, si)?);
         }
         out
@@ -1147,9 +1150,6 @@ fn expand_select_item<'a>(
                     (ExpandedSelectItem::InputOrdinal(i), name)
                 })
                 .collect();
-            if items.is_empty() {
-                bail!("SELECT * with no tables specified is not valid");
-            }
             Ok(items)
         }
         SelectItem::Expr { expr, alias } => {

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -105,12 +105,20 @@ impl ScopeItem {
             .any(|n| n.table_name.as_ref() == Some(&table_name))
     }
 
-    pub fn prioritized(&self) -> ScopeItem {
-        let mut out = self.clone();
-        for name in &mut out.names {
-            name.priority = true;
+    pub fn short_display_name(&self) -> String {
+        match self.names.get(0) {
+            None => "?".into(),
+            Some(name) => {
+                let column_name = match &name.column_name {
+                    None => "?column?",
+                    Some(column_name) => column_name.as_str(),
+                };
+                match &name.table_name {
+                    None => column_name.into(),
+                    Some(table_name) => format!("{}.{}", table_name.item, column_name),
+                }
+            }
         }
-        out
     }
 }
 

--- a/src/sqllogictest/src/parser.rs
+++ b/src/sqllogictest/src/parser.rs
@@ -202,11 +202,7 @@ impl<'a> Parser<'a> {
             });
         }
 
-        let types = parse_types(
-            words
-                .next()
-                .ok_or_else(|| anyhow!("missing types in: {}", first_line))?,
-        )?;
+        let types = words.next().map_or(Ok(vec![]), parse_types)?;
         let mut sort = Sort::No;
         let mut check_column_names = false;
         let mut multiline = false;

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -36,6 +36,27 @@ SELECT a + 1 FROM t GROUP BY a + 1 HAVING sum(b) = 3
 2
 3
 
+# Simple column names in GROUP BY can refer to columns from the output list...
+query TII rowsort
+SELECT 'dummy', a AS c, sum(b) FROM t GROUP BY c
+----
+dummy 1 3
+dummy 2 3
+dummy 3 1
+
+# ...unless they are ambiguous...
+query error column name "c" is ambiguous
+SELECT a AS c, sum(b) AS c FROM t GROUP BY c
+
+# ...although ambiguity between the input list and the output list is not an
+# error; the column in the input list is preferred.
+query II rowsort
+SELECT a, sum(b) AS a FROM t GROUP BY a
+----
+1 3
+2 3
+3 1
+
 query TTT colnames
 SHOW COLUMNS FROM t
 ----

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -219,24 +219,22 @@ SELECT count(*), k FROM kv GROUP BY k
 1 7
 1 8
 
-# not in spec
 # GROUP BY specified using column index works.
-# query II rowsort
-# SELECT count(*), k FROM kv GROUP BY 2
-# ----
-# 1 1
-# 1 3
-# 1 5
-# 1 6
-# 1 7
-# 1 8
+query II rowsort
+SELECT count(*), k FROM kv GROUP BY 2
+----
+1 1
+1 3
+1 5
+1 6
+1 7
+1 8
 
 query error aggregate functions are not allowed in GROUP BY
 SELECT * FROM kv GROUP BY v, count(DISTINCT w)
 
-# not in spec
-# query error aggregate functions are not allowed in GROUP BY
-# SELECT count(DISTINCT w) FROM kv GROUP BY 1
+query error aggregate functions are not allowed in GROUP BY
+SELECT count(DISTINCT w) FROM kv GROUP BY 1
 
 query error aggregate functions are not allowed in RETURNING
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v)
@@ -250,13 +248,11 @@ SELECT sum(v) FROM kv GROUP BY k LIMIT 1 OFFSET sum(v)
 query error aggregate functions are not allowed in VALUES
 INSERT INTO kv (k, v) VALUES (99, count(1))
 
-# not in spec
-# query error pgcode 42P10 GROUP BY position 5 is not in select list
-# SELECT count(*), k FROM kv GROUP BY 5
+query error pgcode 42P10 column reference 5 in GROUP BY clause is out of range \(1 - 2\)
+SELECT count(*), k FROM kv GROUP BY 5
 
-# not in spec
-# query error pgcode 42P10 GROUP BY position 0 is not in select list
-# SELECT count(*), k FROM kv GROUP BY 0
+query error pgcode 42P10 column reference 0 in GROUP BY clause is out of range \(1 - 2\)
+SELECT count(*), k FROM kv GROUP BY 0
 
 # unsure about spec, but this is consistent with our stance of always treating GROUP BY as an expr
 # query error pgcode 42601 non-integer constant in GROUP BY
@@ -305,16 +301,15 @@ SELECT v, count(*), w FROM kv GROUP BY v, w
 4    1 5
 NULL 1 5
 
-# not in spec
 # Grouping by more than one column using column numbers works.
-# query III rowsort
-# SELECT v, count(*), w FROM kv GROUP BY 1, 3
-# ----
-# 2    1 2
-# 2    2 3
-# 4    1 2
-# 4    1 5
-# NULL 1 5
+query III rowsort
+SELECT v, count(*), w FROM kv GROUP BY 1, 3
+----
+2    1 2
+2    2 3
+4    1 2
+4    1 5
+NULL 1 5
 
 # Selecting and grouping on a function expression works.
 query IT rowsort
@@ -946,24 +941,24 @@ query error aggregate functions are not allowed in FILTER
 SELECT v, count(*) FILTER (WHERE count(*) > 5) FROM filter_test GROUP BY v
 
 # Tests with * inside GROUP BY.
-# query I
-# SELECT 1 FROM kv GROUP BY kv.*
-# ----
-# 1
-# 1
-# 1
-# 1
-# 1
-# 1
-#
-# query R rowsort
-# SELECT sum(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
-# ----
-# 1.1
-# 6.1
-# 6.1
-# 6.1
-# 6.1
+query I
+SELECT 1 FROM kv GROUP BY kv.*
+----
+1
+1
+1
+1
+1
+1
+
+query R rowsort
+SELECT sum(abc.b) FROM kv JOIN abc ON kv.v > abc.b GROUP BY kv.*
+----
+1.5
+1.5
+1.5
+3.5
+3.5
 
 query BB
 SELECT max(true), min(true)

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -84,3 +84,12 @@ SELECT *
 
 query error column name "k" is ambiguous
 SELECT k FROM (SELECT 1 AS k, 2 AS k)
+
+# Wildcards on a zero-arity table are ok, though.
+
+statement ok
+CREATE TABLE nullary ()
+
+query
+SELECT * FROM nullary
+----

--- a/test/sqllogictest/select_all_group_by.slt
+++ b/test/sqllogictest/select_all_group_by.slt
@@ -36,7 +36,7 @@ SELECT a FROM foo GROUP BY a, foo.a
 ----
 37
 
-statement error internal error: unable to resolve scope item
+statement error column "bar.b" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT *, count(*) FROM bar GROUP BY a
 
 query II


### PR DESCRIPTION
GROUP BY ordinal references, like the `1` in the following example

    SELECT a, sum(b) FROM foo GROUP BY 1

are meant to refer to an output column, not an input column.

This commit fixes the bug and enables the CockroachDB SLTs that would
have exposed the issue. It also vastly improves the error message when
SELECTing a non-aggregated column.

Fix #443.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3686)
<!-- Reviewable:end -->
