### PR TITLE
Add `repeat` function

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -33,9 +33,6 @@ use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType};
 
-/// System-wide update type.
-pub type Diff = isize;
-
 /// System-wide timestamp type.
 pub type Timestamp = u64;
 

--- a/src/dataflow/src/arrangement/manager.rs
+++ b/src/dataflow/src/arrangement/manager.rs
@@ -19,8 +19,8 @@ use differential_dataflow::trace::implementations::spine_fueled_neu::Spine;
 use differential_dataflow::trace::TraceReader;
 use timely::progress::frontier::{Antichain, AntichainRef};
 
-use dataflow_types::{DataflowError, Diff, Timestamp};
-use expr::GlobalId;
+use dataflow_types::{DataflowError, Timestamp};
+use expr::{Diff, GlobalId};
 use repr::Row;
 
 pub type OrdKeySpine<K, T, R, O = usize> = Spine<K, (), T, R, Rc<OrdKeyBatch<K, T, R, O>>>;

--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -10,7 +10,8 @@
 use log::error;
 
 use async_trait::async_trait;
-use dataflow_types::{Diff, Timestamp};
+use dataflow_types::Timestamp;
+use expr::Diff;
 use interchange::avro::{DebeziumDeduplicationStrategy, Decoder, EnvelopeType};
 use repr::Row;
 

--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -16,7 +16,8 @@ use log::error;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 
-use dataflow_types::{Diff, Timestamp};
+use dataflow_types::Timestamp;
+use expr::Diff;
 use repr::{Datum, Row};
 
 use crate::{metrics::EVENTS_COUNTER, source::SourceOutput};

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -24,7 +24,8 @@ use timely::dataflow::{
 
 use ::avro::{types::Value, Schema};
 use dataflow_types::LinearOperator;
-use dataflow_types::{DataEncoding, Diff, Envelope, Timestamp};
+use dataflow_types::{DataEncoding, Envelope, Timestamp};
+use expr::Diff;
 use interchange::avro::{extract_row, DebeziumDecodeState, DiffPair};
 use log::error;
 use repr::Datum;

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -10,7 +10,8 @@
 use async_trait::async_trait;
 use log::error;
 
-use dataflow_types::{Diff, Timestamp};
+use dataflow_types::Timestamp;
+use expr::Diff;
 use interchange::protobuf::{self, Decoder};
 use repr::Row;
 

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use crate::source::SourceOutput;
-use dataflow_types::{Diff, Timestamp};
+use dataflow_types::Timestamp;
+use expr::Diff;
 
 use log::warn;
 use regex::Regex;

--- a/src/dataflow/src/operator.rs
+++ b/src/dataflow/src/operator.rs
@@ -7,10 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use dataflow_types::Diff;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
+use expr::Diff;
 use std::ops::Mul;
 use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
@@ -136,6 +136,12 @@ where
         E: Data,
         L: FnMut(&D1) -> Result<bool, E> + 'static;
 
+    /// Like [`Collection::flat_map`], but the first element
+    /// returned from `logic` is allowed to represent a failure. The first
+    /// returned collection will contain the successful applications of `logic`,
+    /// while the second returned collection will contain the failed
+    /// applications; in each case, with the multiplicities multiplied by the
+    /// second element returned from `logic`.
     fn explode_fallible<D2, E, R2, I, L>(
         &self,
         logic: L,

--- a/src/dataflow/src/operator.rs
+++ b/src/dataflow/src/operator.rs
@@ -11,6 +11,7 @@ use dataflow_types::Diff;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
+use std::ops::Mul;
 use timely::dataflow::channels::pact::{ParallelizationContract, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -134,6 +135,21 @@ where
     where
         E: Data,
         L: FnMut(&D1) -> Result<bool, E> + 'static;
+
+    fn explode_fallible<D2, E, R2, I, L>(
+        &self,
+        logic: L,
+    ) -> (
+        Collection<G, D2, <R2 as Mul<R>>::Output>,
+        Collection<G, E, <R2 as Mul<R>>::Output>,
+    )
+    where
+        D2: Data,
+        E: Data,
+        R2: Semigroup + Mul<R>,
+        <R2 as Mul<R>>::Output: Data + Semigroup,
+        I: IntoIterator<Item = (Result<D2, E>, R2)>,
+        L: FnMut(D1) -> I + 'static;
 }
 
 impl<G, D1> StreamExt<G, D1> for Stream<G, D1>
@@ -337,6 +353,29 @@ where
                     Ok(retain) => Ok(retain),
                     Err(e) => Err((e, t.clone(), r.clone())),
                 });
+        (ok_stream.as_collection(), err_stream.as_collection())
+    }
+    fn explode_fallible<D2, E, R2, I, L>(
+        &self,
+        mut logic: L,
+    ) -> (
+        Collection<G, D2, <R2 as Mul<R>>::Output>,
+        Collection<G, E, <R2 as Mul<R>>::Output>,
+    )
+    where
+        D2: Data,
+        E: Data,
+        R2: Semigroup + Mul<R>,
+        <R2 as Mul<R>>::Output: Data + Semigroup,
+        I: IntoIterator<Item = (Result<D2, E>, R2)>,
+        L: FnMut(D1) -> I + 'static,
+    {
+        let (ok_stream, err_stream) = self.inner.flat_map_fallible(move |(d1, t, r)| {
+            logic(d1).into_iter().map(move |res| match res {
+                (Ok(d2), r2) => Ok((d2, t.clone(), r2 * r.clone())),
+                (Err(e), r2) => Err((e, t.clone(), r2 * r.clone())),
+            })
+        });
         (ok_stream.as_collection(), err_stream.as_collection())
     }
 }

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -13,8 +13,7 @@ use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
-use dataflow_types::*;
-use expr::RelationExpr;
+use expr::{Diff, RelationExpr};
 use repr::Row;
 
 use crate::render::context::Context;

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -41,10 +41,10 @@ use timely::worker::Worker as TimelyWorker;
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    DataflowDesc, DataflowError, Diff, IndexDesc, MzOffset, PeekResponse, Timestamp,
+    DataflowDesc, DataflowError, IndexDesc, MzOffset, PeekResponse, Timestamp,
     TimestampSourceUpdate, Update,
 };
-use expr::{GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
+use expr::{Diff, GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
 use ore::future::channel::mpsc::ReceiverExt;
 use repr::{Datum, RelationType, Row, RowArena};
 

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -15,8 +15,8 @@ use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::{Scope, Stream};
 
-use dataflow_types::{AvroOcfSinkConnector, Diff, Timestamp};
-use expr::GlobalId;
+use dataflow_types::{AvroOcfSinkConnector, Timestamp};
+use expr::{Diff, GlobalId};
 use interchange::avro::{DiffPair, Encoder};
 use repr::{RelationDesc, Row};
 

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -33,8 +33,8 @@ use timely::dataflow::operators::generic::FrontieredInputHandle;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::MutableAntichain;
 
-use dataflow_types::{Diff, KafkaSinkConnector, Timestamp};
-use expr::GlobalId;
+use dataflow_types::{KafkaSinkConnector, Timestamp};
+use expr::{Diff, GlobalId};
 use interchange::avro::{self, DiffPair, Encoder};
 use repr::{RelationDesc, Row};
 

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -14,8 +14,8 @@ use timely::dataflow::{Scope, Stream};
 use futures::executor::block_on;
 use futures::sink::SinkExt;
 
-use dataflow_types::{Diff, TailSinkConnector, Timestamp, Update};
-use expr::GlobalId;
+use dataflow_types::{TailSinkConnector, Timestamp, Update};
+use expr::{Diff, GlobalId};
 use repr::Row;
 
 pub fn tail<G>(

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -34,6 +34,8 @@ pub use scalar::{like_pattern, EvalError, ScalarExpr};
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct OptimizedRelationExpr(pub RelationExpr);
 
+pub type Diff = isize;
+
 impl OptimizedRelationExpr {
     /// Declare that the input `expr` is optimized, without actually running it
     /// through an optimizer. This can be useful to mark as optimized literal

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -17,13 +17,13 @@ use ordered_float::OrderedFloat;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use ore::cast::CastFrom;
 use repr::adt::decimal::Significand;
 use repr::adt::regex::Regex as ReprRegex;
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
 use crate::scalar::func::jsonb_stringify;
-
-type Diff = isize;
+use crate::Diff;
 
 // TODO(jamii) be careful about overflow in sum/avg
 // see https://timely.zulipchat.com/#narrow/stream/186635-engineering/topic/additional.20work/near/163507435
@@ -684,12 +684,7 @@ pub fn csv_extract(a: Datum, n_cols: usize) -> Vec<(Row, Diff)> {
 }
 
 pub fn repeat(a: Datum) -> Vec<(Row, Diff)> {
-    let n = match a {
-        Datum::Int64(n) => n as Diff,
-        Datum::Int32(n) => n as Diff,
-        Datum::Null => 0,
-        _ => panic!("Expected integer"),
-    };
+    let n = Diff::cast_from(a.unwrap_int64());
     vec![(repr::RowPacker::new().finish(), n)]
 }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -687,7 +687,8 @@ pub fn repeat(a: Datum) -> Vec<(Row, Diff)> {
     let n = match a {
         Datum::Int64(n) => n as Diff,
         Datum::Int32(n) => n as Diff,
-        _ => panic!(),
+        Null => 0,
+        _ => panic!("Expected integer"),
     };
     vec![(repr::RowPacker::new().finish(), n)]
 }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -23,6 +23,8 @@ use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
 use crate::scalar::func::jsonb_stringify;
 
+type Diff = isize;
+
 // TODO(jamii) be careful about overflow in sum/avg
 // see https://timely.zulipchat.com/#narrow/stream/186635-engineering/topic/additional.20work/near/163507435
 
@@ -499,7 +501,7 @@ impl AggregateFunc {
     }
 }
 
-fn jsonb_each<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> Vec<Row> {
+fn jsonb_each<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> Vec<(Row, Diff)> {
     let mut row_packer = repr::RowPacker::new();
     match a {
         Datum::Dict(dict) => dict
@@ -508,25 +510,29 @@ fn jsonb_each<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> 
                 if stringify {
                     v = jsonb_stringify(v, temp_storage);
                 }
-                row_packer.pack(&[Datum::String(k), v])
+                (row_packer.pack(&[Datum::String(k), v]), 1)
             })
             .collect(),
         _ => vec![],
     }
 }
 
-fn jsonb_object_keys<'a>(a: Datum<'a>) -> Vec<Row> {
+fn jsonb_object_keys<'a>(a: Datum<'a>) -> Vec<(Row, Diff)> {
     let mut row_packer = repr::RowPacker::new();
     match a {
         Datum::Dict(dict) => dict
             .iter()
-            .map(move |(k, _)| row_packer.pack(&[Datum::String(k)]))
+            .map(move |(k, _)| (row_packer.pack(&[Datum::String(k)]), 1))
             .collect(),
         _ => vec![],
     }
 }
 
-fn jsonb_array_elements<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> Vec<Row> {
+fn jsonb_array_elements<'a>(
+    a: Datum<'a>,
+    temp_storage: &'a RowArena,
+    stringify: bool,
+) -> Vec<(Row, Diff)> {
     let mut row_packer = repr::RowPacker::new();
     match a {
         Datum::List(list) => list
@@ -535,14 +541,14 @@ fn jsonb_array_elements<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify:
                 if stringify {
                     e = jsonb_stringify(e, temp_storage);
                 }
-                row_packer.pack(&[e])
+                (row_packer.pack(&[e]), 1)
             })
             .collect(),
         _ => vec![],
     }
 }
 
-fn regexp_extract(a: Datum, r: &AnalyzedRegex) -> Option<Row> {
+fn regexp_extract(a: Datum, r: &AnalyzedRegex) -> Option<(Row, Diff)> {
     let mut row_packer = repr::RowPacker::new();
     match a {
         Datum::String(s) => {
@@ -552,20 +558,20 @@ fn regexp_extract(a: Datum, r: &AnalyzedRegex) -> Option<Row> {
                 .iter()
                 .skip(1)
                 .map(|m| Datum::from(m.map(|m| m.as_str())));
-            Some(row_packer.pack(datums_iter))
+            Some((row_packer.pack(datums_iter), 1))
         }
         _ => None,
     }
 }
 
-fn generate_series<'a>(typ: &ScalarType, start: Datum<'a>, stop: Datum<'a>) -> Vec<Row> {
+fn generate_series<'a>(typ: &ScalarType, start: Datum<'a>, stop: Datum<'a>) -> Vec<(Row, Diff)> {
     let mut row_packer = repr::RowPacker::new();
     match (typ, start, stop) {
         (ScalarType::Int64, Datum::Int64(start), Datum::Int64(stop)) => (start..stop + 1)
-            .map(move |i| row_packer.pack(&[Datum::Int64(i)]))
+            .map(move |i| (row_packer.pack(&[Datum::Int64(i)]), 1))
             .collect(),
         (ScalarType::Int32, Datum::Int32(start), Datum::Int32(stop)) => (start..stop + 1)
-            .map(|i| row_packer.pack(&[Datum::Int32(i)]))
+            .map(|i| (row_packer.pack(&[Datum::Int32(i)]), 1))
             .collect(),
         (_, Datum::Null, _) | (_, _, Datum::Null) => vec![],
         _ => panic!("expected int64"),
@@ -651,7 +657,7 @@ impl AnalyzedRegex {
         &(self.0).0
     }
 }
-pub fn csv_extract(a: Datum, n_cols: usize) -> Vec<Row> {
+pub fn csv_extract(a: Datum, n_cols: usize) -> Vec<(Row, Diff)> {
     let bytes = match a {
         Datum::Bytes(bytes) => bytes,
         Datum::String(str) => str.as_bytes(),
@@ -667,7 +673,7 @@ pub fn csv_extract(a: Datum, n_cols: usize) -> Vec<Row> {
             move |res| {
                 res.ok().and_then(|sr| {
                     if sr.len() == n_cols {
-                        Some(row_packer.pack(sr.iter().map(|s| Datum::String(s))))
+                        Some((row_packer.pack(sr.iter().map(|s| Datum::String(s))), 1))
                     } else {
                         None
                     }
@@ -675,6 +681,15 @@ pub fn csv_extract(a: Datum, n_cols: usize) -> Vec<Row> {
             }
         })
         .collect()
+}
+
+pub fn repeat(a: Datum) -> Vec<(Row, Diff)> {
+    let n = match a {
+        Datum::Int64(n) => n as Diff,
+        Datum::Int32(n) => n as Diff,
+        _ => panic!(),
+    };
+    vec![(repr::RowPacker::new().finish(), n)]
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
@@ -687,10 +702,15 @@ pub enum TableFunc {
     // ScalarType is either Int32 or Int64.
     // TODO(justin): should also possibly be Timestamp{,Tz}.
     GenerateSeries(ScalarType),
+    Repeat,
 }
 
 impl TableFunc {
-    pub fn eval<'a>(&'a self, datums: Vec<Datum<'a>>, temp_storage: &'a RowArena) -> Vec<Row> {
+    pub fn eval<'a>(
+        &'a self,
+        datums: Vec<Datum<'a>>,
+        temp_storage: &'a RowArena,
+    ) -> Vec<(Row, Diff)> {
         match self {
             TableFunc::JsonbEach { stringify } => jsonb_each(datums[0], temp_storage, *stringify),
             TableFunc::JsonbObjectKeys => jsonb_object_keys(datums[0]),
@@ -700,6 +720,7 @@ impl TableFunc {
             TableFunc::RegexpExtract(a) => regexp_extract(datums[0], a).into_iter().collect(),
             TableFunc::CsvExtract(n_cols) => csv_extract(datums[0], *n_cols).into_iter().collect(),
             TableFunc::GenerateSeries(typ) => generate_series(typ, datums[0], datums[1]),
+            TableFunc::Repeat => repeat(datums[0]),
         }
     }
 
@@ -728,6 +749,7 @@ impl TableFunc {
                 .take(*n_cols)
                 .collect(),
             TableFunc::GenerateSeries(typ) => vec![ColumnType::new(typ.clone())],
+            TableFunc::Repeat => vec![],
         })
     }
 
@@ -739,6 +761,7 @@ impl TableFunc {
             TableFunc::RegexpExtract(a) => a.capture_groups_len(),
             TableFunc::CsvExtract(n_cols) => *n_cols,
             TableFunc::GenerateSeries(_) => 1,
+            TableFunc::Repeat => 0,
         }
     }
 }
@@ -756,6 +779,7 @@ impl fmt::Display for TableFunc {
                 f.write_fmt(format_args!("csv_extract({}, _)", n_cols))
             }
             TableFunc::GenerateSeries(_) => f.write_str("generate_series"),
+            TableFunc::Repeat => f.write_str("repeat"),
         }
     }
 }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -687,7 +687,7 @@ pub fn repeat(a: Datum) -> Vec<(Row, Diff)> {
     let n = match a {
         Datum::Int64(n) => n as Diff,
         Datum::Int32(n) => n as Diff,
-        Null => 0,
+        Datum::Null => 0,
         _ => panic!("Expected integer"),
     };
     vec![(repr::RowPacker::new().finish(), n)]

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -28,29 +28,28 @@ pub trait CastFrom<T> {
     fn cast_from(from: T) -> Self;
 }
 
+macro_rules! cast_from {
+    ($from:ty, $to:ty) => {
+        impl CastFrom<$from> for $to {
+            fn cast_from(from: $from) -> $to {
+                from as $to
+            }
+        }
+    };
+}
+
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
-impl CastFrom<u32> for usize {
-    fn cast_from(from: u32) -> usize {
-        from as usize
-    }
-}
+cast_from!(u32, usize);
 
 #[cfg(target_pointer_width = "64")]
-impl CastFrom<i32> for usize {
-    fn cast_from(from: i32) -> usize {
-        from as usize
-    }
-}
+cast_from!(i32, usize);
 
 #[cfg(target_pointer_width = "64")]
-impl CastFrom<u64> for usize {
-    fn cast_from(from: u64) -> usize {
-        from as usize
-    }
-}
+cast_from!(u64, usize);
 
-impl CastFrom<usize> for u64 {
-    fn cast_from(from: usize) -> u64 {
-        from as u64
-    }
-}
+cast_from!(usize, u64);
+
+#[cfg(target_pointer_width = "64")]
+cast_from!(i64, isize);
+
+cast_from!(isize, i64);

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1399,6 +1399,13 @@ lazy_static! {
                         exprs: vec![n],
                         column_names: vec![]
                     })
+                }),
+                params!(Int32) => unary_op(move |_ecx, n| {
+                    Ok(TableFuncPlan {
+                        func: TableFunc::Repeat,
+                        exprs: vec![n],
+                        column_names: vec![]
+                    })
                 })
             }
         }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1391,6 +1391,15 @@ lazy_static! {
                         column_names,
                     })
                 })
+            },
+            "repeat" => {
+                params!(Int64) => unary_op(move |_ecx, n| {
+                    Ok(TableFuncPlan {
+                        func: TableFunc::Repeat,
+                        exprs: vec![n],
+                        column_names: vec![]
+                    })
+                })
             }
         }
     };

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1399,13 +1399,6 @@ lazy_static! {
                         exprs: vec![n],
                         column_names: vec![]
                     })
-                }),
-                params!(Int32) => unary_op(move |_ecx, n| {
-                    Ok(TableFuncPlan {
-                        func: TableFunc::Repeat,
-                        exprs: vec![n],
-                        column_names: vec![]
-                    })
                 })
             }
         }

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -117,7 +117,8 @@ impl NonNullRequirements {
                     | TableFunc::JsonbArrayElements { .. }
                     | TableFunc::GenerateSeries(_)
                     | TableFunc::RegexpExtract(_)
-                    | TableFunc::CsvExtract(_) => {
+                    | TableFunc::CsvExtract(_)
+                    | TableFunc::Repeat => {
                         for expr in exprs {
                             expr.non_null_requirements(&mut columns);
                         }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -203,10 +203,10 @@ impl FoldConstants {
                                 .collect::<Result<Vec<_>, _>>()?,
                             &temp_storage,
                         );
-                        for output_row in output_rows {
+                        for (output_row, diff2) in output_rows {
                             let row = row_packer
                                 .pack(input_row.clone().into_iter().chain(output_row.into_iter()));
-                            new_rows.push((row, *diff))
+                            new_rows.push((row, diff2 * *diff))
                         }
                     }
                     *relation = RelationExpr::Constant {

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -229,3 +229,19 @@ EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.
 | Filter (#1 = #3)
 
 EOF
+
+query I
+SELECT * FROM generate_series(0,3), repeat(generate_series);
+----
+1
+2
+2
+3
+3
+3
+
+query I
+SELECT abs(generate_series) FROM generate_series(-1, 2), repeat(generate_series);
+----
+2
+2


### PR DESCRIPTION
The intended semantics of this function: generate a relation of `n` rows and zero columns.

We can't (yet?) output relations with zero columns, but the intended use is joining with other relations, for example:

```
query I
SELECT * FROM generate_series(0,3), repeat(generate_series);
----
1
2
2
3
3
3
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3691)
<!-- Reviewable:end -->
