### PR TITLE
sql: improve error messages for unsupported SQL statements

### DIFF
--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -231,11 +231,16 @@ pub fn describe_statement(
                 query::plan_root_query(scx, *query, QueryLifetime::OneShot)?;
             (Some(desc), param_types)
         }
+
+        Statement::Insert { .. } => bail!("INSERT statements are not supported"),
+        Statement::Update { .. } => bail!("UPDATE statements are not supported"),
+        Statement::Delete { .. } => bail!("DELETE statements are not supported"),
+        Statement::Copy { .. } => bail!("COPY statements are not supported"),
         Statement::CreateTable { .. } => bail!(
             "CREATE TABLE statements are not supported. \
              Try CREATE SOURCE or CREATE [MATERIALIZED] VIEW instead."
         ),
-        _ => unsupported!(format!("{:?}", stmt)),
+        Statement::SetTransaction { .. } => bail!("SET TRANSACTION statements are not supported"),
     })
 }
 
@@ -317,7 +322,15 @@ pub fn handle_statement(
             options,
         } => handle_explain(scx, stage, explainee, options, params),
 
-        _ => bail!("unsupported SQL statement: {:?}", stmt),
+        Statement::Insert { .. } => bail!("INSERT statements are not supported"),
+        Statement::Update { .. } => bail!("UPDATE statements are not supported"),
+        Statement::Delete { .. } => bail!("DELETE statements are not supported"),
+        Statement::Copy { .. } => bail!("COPY statements are not supported"),
+        Statement::CreateTable { .. } => bail!(
+            "CREATE TABLE statements are not supported. \
+             Try CREATE SOURCE or CREATE [MATERIALIZED] VIEW instead."
+        ),
+        Statement::SetTransaction { .. } => bail!("SET TRANSACTION statements are not supported"),
     }
 }
 

--- a/test/testdrive/unsupported.td
+++ b/test/testdrive/unsupported.td
@@ -1,0 +1,19 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set-sql-timeout duration=125ms
+
+! INSERT INTO foo VALUES (1)
+INSERT statements are not supported
+
+! UPDATE foo SET x = 1
+UPDATE statements are not supported
+
+! DELETE FROM foo
+DELETE statements are not supported


### PR DESCRIPTION
Printing the debug representation of the unsupported statement is gross.
Print a prettier + more succient representation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3696)
<!-- Reviewable:end -->
