### PR TITLE
transform: fix bug in literal lifting

### DIFF
--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -379,7 +379,7 @@ impl LiteralLifting {
                         .eval(Some(aggr.expr.eval(&[], &temp).unwrap()), &temp);
                     result.push(ScalarExpr::literal_ok(
                         eval,
-                        repr::ColumnType::new(repr::ScalarType::Bool),
+                        aggr.func.output_type(aggr.expr.typ(&input.typ())),
                     ));
                 }
                 result.reverse();

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -224,20 +224,19 @@ SELECT * FROM c WHERE bill = ANY(SELECT ship FROM o) OR bill IS NULL;
 4  TX
 5  NULL
 
-# TODO(justin): #3099
-# # Test NULL IN case. Use IS NOT NULL to prevent normalize ANY into EXISTS.
-# query IT rowsort
-# SELECT * FROM c WHERE (NULL::text IN (SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL;
-# ----
-# 3  MA
-# 5  NULL
-#
+# Test NULL IN case. Use IS NOT NULL to prevent normalize ANY into EXISTS.
+query IT rowsort
+SELECT * FROM c WHERE (NULL::text IN (SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL;
+----
+3  MA
+5  NULL
+
 # Test NULL NOT IN case. Use IS NOT NULL to prevent normalize ANY into EXISTS.
-# query IT rowsort
-# SELECT * FROM c WHERE (NULL::text NOT IN (SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL;
-# ----
-# 3  MA
-# 5  NULL
+query IT rowsort
+SELECT * FROM c WHERE (NULL::text NOT IN (SELECT ship FROM o WHERE o.c_id=c.c_id)) IS NOT NULL;
+----
+3  MA
+5  NULL
 
 # Customers where it is unknown whether a replaced bill state is one of the ship
 # states. This tests a more complex scalar expression as argument to IN.


### PR DESCRIPTION
The LiteralLifting transform was incorrectly hardcoding the output type
of AggregateFunc::{Any,All} as non-nullable, when in fact their output
type is nullable.

This caused incorrect output on the two correlated subquery tests
enabled in this commit.

The fix is to use `AggregateFunc::output_type` to compute the correct
output type; the optimizer should not be duplicating this information.
(There *is* a larger problem of "it is too easy to get nullability
information wrong", but even if that were solved, we still wouldn't want
to be hardcoding information about function output types in the
optimizer.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3702)
<!-- Reviewable:end -->
