### PR TITLE
Column type constructor must take all arguments

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -361,7 +361,7 @@ impl DataEncoding {
                         None => format!("column{}", i),
                         Some(name) => name.to_owned(),
                     };
-                    let ty = ColumnType::new(ScalarType::String).nullable(true);
+                    let ty = ColumnType::new(ScalarType::String, true);
                     desc.with_column(name, ty)
                 }),
             DataEncoding::Csv(CsvEncoding { n_cols, .. }) => (1..=*n_cols)
@@ -469,10 +469,19 @@ pub enum ExternalSourceConnector {
 impl ExternalSourceConnector {
     pub fn metadata_columns(&self) -> Vec<(ColumnName, ColumnType)> {
         match self {
-            Self::Kafka(_) => vec![("mz_offset".into(), ColumnType::new(ScalarType::Int64))],
-            Self::File(_) => vec![("mz_line_no".into(), ColumnType::new(ScalarType::Int64))],
+            Self::Kafka(_) => vec![(
+                "mz_offset".into(),
+                ColumnType::new(ScalarType::Int64, false),
+            )],
+            Self::File(_) => vec![(
+                "mz_line_no".into(),
+                ColumnType::new(ScalarType::Int64, false),
+            )],
             Self::Kinesis(_) => vec![],
-            Self::AvroOcf(_) => vec![("mz_obj_no".into(), ColumnType::new(ScalarType::Int64))],
+            Self::AvroOcf(_) => vec![(
+                "mz_obj_no".into(),
+                ColumnType::new(ScalarType::Int64, false),
+            )],
         }
     }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -497,7 +497,7 @@ impl AggregateFunc {
             // max/min/sum return null on empty sets
             _ => true,
         };
-        ColumnType::new(scalar_type).nullable(nullable)
+        ColumnType::new(scalar_type, nullable)
     }
 }
 
@@ -723,28 +723,30 @@ impl TableFunc {
     pub fn output_type(&self) -> RelationType {
         RelationType::new(match self {
             TableFunc::JsonbEach { stringify: true } => vec![
-                ColumnType::new(ScalarType::String),
-                ColumnType::new(ScalarType::String).nullable(true),
+                ColumnType::new(ScalarType::String, false),
+                ColumnType::new(ScalarType::String, true),
             ],
             TableFunc::JsonbEach { stringify: false } => vec![
-                ColumnType::new(ScalarType::String),
-                ColumnType::new(ScalarType::Jsonb),
+                ColumnType::new(ScalarType::String, false),
+                ColumnType::new(ScalarType::Jsonb, false),
             ],
-            TableFunc::JsonbObjectKeys => vec![ColumnType::new(ScalarType::String)],
+            TableFunc::JsonbObjectKeys => vec![ColumnType::new(ScalarType::String, false)],
             TableFunc::JsonbArrayElements { stringify: true } => {
-                vec![ColumnType::new(ScalarType::String).nullable(true)]
+                vec![ColumnType::new(ScalarType::String, true)]
             }
             TableFunc::JsonbArrayElements { stringify: false } => {
-                vec![ColumnType::new(ScalarType::Jsonb)]
+                vec![ColumnType::new(ScalarType::Jsonb, false)]
             }
             TableFunc::RegexpExtract(a) => a
                 .capture_groups_iter()
-                .map(|cg| ColumnType::new(ScalarType::String).nullable(cg.nullable))
+                .map(|cg| ColumnType::new(ScalarType::String, cg.nullable))
                 .collect(),
-            TableFunc::CsvExtract(n_cols) => iter::repeat(ColumnType::new(ScalarType::String))
-                .take(*n_cols)
-                .collect(),
-            TableFunc::GenerateSeries(typ) => vec![ColumnType::new(typ.clone())],
+            TableFunc::CsvExtract(n_cols) => {
+                iter::repeat(ColumnType::new(ScalarType::String, false))
+                    .take(*n_cols)
+                    .collect()
+            }
+            TableFunc::GenerateSeries(typ) => vec![ColumnType::new(typ.clone(), false)],
             TableFunc::Repeat => vec![],
         })
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -549,8 +549,8 @@ impl RelationExpr {
     ///
     /// // A common schema for each input.
     /// let schema = RelationType::new(vec![
-    ///     ColumnType::new(ScalarType::Int32),
-    ///     ColumnType::new(ScalarType::Int32),
+    ///     ColumnType::new(ScalarType::Int32, false),
+    ///     ColumnType::new(ScalarType::Int32, false),
     /// ]);
     ///
     /// // the specific data are not important here.

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -40,7 +40,7 @@ pub enum NullaryFunc {
 impl NullaryFunc {
     pub fn output_type(&self) -> ColumnType {
         match self {
-            NullaryFunc::MzLogicalTimestamp => ColumnType::new(ScalarType::Decimal(38, 0)),
+            NullaryFunc::MzLogicalTimestamp => ColumnType::new(ScalarType::Decimal(38, 0), false),
         }
     }
 }
@@ -1868,35 +1868,35 @@ impl BinaryFunc {
         };
         match self {
             And | Or | Eq | NotEq | Lt | Lte | Gt | Gte => {
-                ColumnType::new(ScalarType::Bool).nullable(in_nullable)
+                ColumnType::new(ScalarType::Bool, in_nullable)
             }
 
             MatchLikePattern => {
                 // The output can be null if the pattern is invalid.
-                ColumnType::new(ScalarType::Bool).nullable(true)
+                ColumnType::new(ScalarType::Bool, true)
             }
 
             ToCharTimestamp | ToCharTimestampTz | ConvertFrom | Trim | TrimLeading
-            | TrimTrailing => ColumnType::new(ScalarType::String).nullable(in_nullable),
+            | TrimTrailing => ColumnType::new(ScalarType::String, in_nullable),
 
             AddInt32 | SubInt32 | MulInt32 | DivInt32 | ModInt32 | EncodedBytesCharLength => {
-                ColumnType::new(ScalarType::Int32).nullable(in_nullable || is_div_mod)
+                ColumnType::new(ScalarType::Int32, in_nullable || is_div_mod)
             }
 
             AddInt64 | SubInt64 | MulInt64 | DivInt64 | ModInt64 => {
-                ColumnType::new(ScalarType::Int64).nullable(in_nullable || is_div_mod)
+                ColumnType::new(ScalarType::Int64, in_nullable || is_div_mod)
             }
 
             AddFloat32 | SubFloat32 | MulFloat32 | DivFloat32 | ModFloat32 => {
-                ColumnType::new(ScalarType::Float32).nullable(in_nullable || is_div_mod)
+                ColumnType::new(ScalarType::Float32, in_nullable || is_div_mod)
             }
 
             AddFloat64 | SubFloat64 | MulFloat64 | DivFloat64 | ModFloat64 => {
-                ColumnType::new(ScalarType::Float64).nullable(in_nullable || is_div_mod)
+                ColumnType::new(ScalarType::Float64, in_nullable || is_div_mod)
             }
 
             AddInterval | SubInterval | SubTimestamp | SubTimestampTz | SubDate => {
-                ColumnType::new(ScalarType::Interval).nullable(in_nullable)
+                ColumnType::new(ScalarType::Interval, in_nullable)
             }
 
             // TODO(benesch): we correctly compute types for decimal scale, but
@@ -1908,8 +1908,10 @@ impl BinaryFunc {
                     _ => unreachable!(),
                 };
                 assert_eq!(s1, s2);
-                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, *s1))
-                    .nullable(in_nullable || is_div_mod)
+                ColumnType::new(
+                    ScalarType::Decimal(MAX_DECIMAL_PRECISION, *s1),
+                    in_nullable || is_div_mod,
+                )
             }
             MulDecimal => {
                 let (s1, s2) = match (&input1_type.scalar_type, &input2_type.scalar_type) {
@@ -1917,7 +1919,7 @@ impl BinaryFunc {
                     _ => unreachable!(),
                 };
                 let s = s1 + s2;
-                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s)).nullable(in_nullable)
+                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s), in_nullable)
             }
             DivDecimal => {
                 let (s1, s2) = match (&input1_type.scalar_type, &input2_type.scalar_type) {
@@ -1925,12 +1927,12 @@ impl BinaryFunc {
                     _ => unreachable!(),
                 };
                 let s = s1 - s2;
-                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s)).nullable(true)
+                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s), true)
             }
 
             CastFloat32ToDecimal | CastFloat64ToDecimal => match input2_type.scalar_type {
                 ScalarType::Decimal(_, s) => {
-                    ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s)).nullable(true)
+                    ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, s), true)
                 }
                 _ => unreachable!(),
             },
@@ -1940,7 +1942,7 @@ impl BinaryFunc {
                     ScalarType::Decimal(_, s) => assert_eq!(*scale, s),
                     _ => unreachable!(),
                 }
-                ColumnType::new(input1_type.scalar_type).nullable(in_nullable)
+                ColumnType::new(input1_type.scalar_type, in_nullable)
             }
 
             AddTimestampInterval
@@ -1951,31 +1953,31 @@ impl BinaryFunc {
             | SubTimeInterval => input1_type,
 
             AddDateInterval | SubDateInterval | AddDateTime | DateTruncTimestamp => {
-                ColumnType::new(ScalarType::Timestamp).nullable(true)
+                ColumnType::new(ScalarType::Timestamp, true)
             }
 
             DatePartInterval | DatePartTimestamp | DatePartTimestampTz => {
-                ColumnType::new(ScalarType::Float64).nullable(true)
+                ColumnType::new(ScalarType::Float64, true)
             }
 
-            DateTruncTimestampTz => ColumnType::new(ScalarType::TimestampTz).nullable(true),
+            DateTruncTimestampTz => ColumnType::new(ScalarType::TimestampTz, true),
 
-            SubTime => ColumnType::new(ScalarType::Interval).nullable(true),
+            SubTime => ColumnType::new(ScalarType::Interval, true),
 
-            TextConcat => ColumnType::new(ScalarType::String).nullable(in_nullable),
+            TextConcat => ColumnType::new(ScalarType::String, in_nullable),
 
             JsonbGetInt64 { stringify: true } | JsonbGetString { stringify: true } => {
-                ColumnType::new(ScalarType::String).nullable(true)
+                ColumnType::new(ScalarType::String, true)
             }
 
             JsonbGetInt64 { stringify: false }
             | JsonbGetString { stringify: false }
             | JsonbConcat
             | JsonbDeleteInt64
-            | JsonbDeleteString => ColumnType::new(ScalarType::Jsonb).nullable(true),
+            | JsonbDeleteString => ColumnType::new(ScalarType::Jsonb, true),
 
             JsonbContainsString | JsonbContainsJsonb => {
-                ColumnType::new(ScalarType::Bool).nullable(in_nullable)
+                ColumnType::new(ScalarType::Bool, in_nullable)
             }
         }
     }
@@ -2450,28 +2452,28 @@ impl UnaryFunc {
         use UnaryFunc::*;
         let in_nullable = input_type.nullable;
         match self {
-            IsNull | CastInt32ToBool | CastInt64ToBool => ColumnType::new(ScalarType::Bool),
+            IsNull | CastInt32ToBool | CastInt64ToBool => ColumnType::new(ScalarType::Bool, false),
 
             Ascii | CharLength | BitLengthBytes | BitLengthString | ByteLengthBytes
-            | ByteLengthString => ColumnType::new(ScalarType::Int32).nullable(in_nullable),
+            | ByteLengthString => ColumnType::new(ScalarType::Int32, in_nullable),
 
-            MatchRegex(_) => ColumnType::new(ScalarType::Bool).nullable(in_nullable),
+            MatchRegex(_) => ColumnType::new(ScalarType::Bool, in_nullable),
 
-            CastStringToBool => ColumnType::new(ScalarType::Bool).nullable(true),
-            CastStringToBytes => ColumnType::new(ScalarType::Bytes).nullable(true),
-            CastStringToInt32 => ColumnType::new(ScalarType::Int32).nullable(true),
-            CastStringToInt64 => ColumnType::new(ScalarType::Int64).nullable(true),
-            CastStringToFloat32 => ColumnType::new(ScalarType::Float32).nullable(true),
-            CastStringToFloat64 => ColumnType::new(ScalarType::Float64).nullable(true),
+            CastStringToBool => ColumnType::new(ScalarType::Bool, true),
+            CastStringToBytes => ColumnType::new(ScalarType::Bytes, true),
+            CastStringToInt32 => ColumnType::new(ScalarType::Int32, true),
+            CastStringToInt64 => ColumnType::new(ScalarType::Int64, true),
+            CastStringToFloat32 => ColumnType::new(ScalarType::Float32, true),
+            CastStringToFloat64 => ColumnType::new(ScalarType::Float64, true),
             CastStringToDecimal(scale) => {
-                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale)).nullable(true)
+                ColumnType::new(ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale), true)
             }
-            CastStringToDate => ColumnType::new(ScalarType::Date).nullable(true),
-            CastStringToTime => ColumnType::new(ScalarType::Time).nullable(true),
-            CastStringToTimestamp => ColumnType::new(ScalarType::Timestamp).nullable(true),
-            CastStringToTimestampTz => ColumnType::new(ScalarType::TimestampTz).nullable(true),
+            CastStringToDate => ColumnType::new(ScalarType::Date, true),
+            CastStringToTime => ColumnType::new(ScalarType::Time, true),
+            CastStringToTimestamp => ColumnType::new(ScalarType::Timestamp, true),
+            CastStringToTimestampTz => ColumnType::new(ScalarType::TimestampTz, true),
             CastStringToInterval | CastTimeToInterval => {
-                ColumnType::new(ScalarType::Interval).nullable(true)
+                ColumnType::new(ScalarType::Interval, true)
             }
 
             CastBoolToStringExplicit
@@ -2490,94 +2492,92 @@ impl UnaryFunc {
             | CastRecordToString { .. }
             | TrimWhitespace
             | TrimLeadingWhitespace
-            | TrimTrailingWhitespace => ColumnType::new(ScalarType::String).nullable(in_nullable),
+            | TrimTrailingWhitespace => ColumnType::new(ScalarType::String, in_nullable),
 
             CastInt32ToFloat32 | CastInt64ToFloat32 | CastSignificandToFloat32 => {
-                ColumnType::new(ScalarType::Float32).nullable(in_nullable)
+                ColumnType::new(ScalarType::Float32, in_nullable)
             }
 
             CastInt32ToFloat64
             | CastInt64ToFloat64
             | CastFloat32ToFloat64
-            | CastSignificandToFloat64 => {
-                ColumnType::new(ScalarType::Float64).nullable(in_nullable)
-            }
+            | CastSignificandToFloat64 => ColumnType::new(ScalarType::Float64, in_nullable),
 
             CastInt64ToInt32 | CastDecimalToInt32(_) => {
-                ColumnType::new(ScalarType::Int32).nullable(in_nullable)
+                ColumnType::new(ScalarType::Int32, in_nullable)
             }
 
-            CastFloat64ToInt32 => ColumnType::new(ScalarType::Int32).nullable(true),
+            CastFloat64ToInt32 => ColumnType::new(ScalarType::Int32, true),
 
             CastInt32ToInt64 | CastDecimalToInt64(_) | CastFloat32ToInt64 | CastFloat64ToInt64 => {
-                ColumnType::new(ScalarType::Int64).nullable(in_nullable)
+                ColumnType::new(ScalarType::Int64, in_nullable)
             }
 
-            CastInt32ToDecimal => ColumnType::new(ScalarType::Decimal(10, 0)).nullable(in_nullable),
-            CastInt64ToDecimal => ColumnType::new(ScalarType::Decimal(20, 0)).nullable(in_nullable),
+            CastInt32ToDecimal => ColumnType::new(ScalarType::Decimal(10, 0), in_nullable),
+            CastInt64ToDecimal => ColumnType::new(ScalarType::Decimal(20, 0), in_nullable),
 
             CastTimestampToDate | CastTimestampTzToDate => {
-                ColumnType::new(ScalarType::Date).nullable(in_nullable)
+                ColumnType::new(ScalarType::Date, in_nullable)
             }
 
-            CastIntervalToTime => ColumnType::new(ScalarType::Time).nullable(in_nullable),
+            CastIntervalToTime => ColumnType::new(ScalarType::Time, in_nullable),
 
             CastDateToTimestamp | CastTimestampTzToTimestamp => {
-                ColumnType::new(ScalarType::Timestamp).nullable(in_nullable)
+                ColumnType::new(ScalarType::Timestamp, in_nullable)
             }
 
             CastDateToTimestampTz | CastTimestampToTimestampTz => {
-                ColumnType::new(ScalarType::TimestampTz).nullable(in_nullable)
+                ColumnType::new(ScalarType::TimestampTz, in_nullable)
             }
 
             // can return null for invalid json
-            CastStringToJsonb => ColumnType::new(ScalarType::Jsonb).nullable(true),
+            CastStringToJsonb => ColumnType::new(ScalarType::Jsonb, true),
 
             // converts null to jsonnull
-            CastJsonbOrNullToJsonb => ColumnType::new(ScalarType::Jsonb).nullable(false),
+            CastJsonbOrNullToJsonb => ColumnType::new(ScalarType::Jsonb, false),
 
             // can return null for other jsonb types
-            CastJsonbToString => ColumnType::new(ScalarType::String).nullable(true),
-            CastJsonbToFloat64 => ColumnType::new(ScalarType::Float64).nullable(true),
-            CastJsonbToBool => ColumnType::new(ScalarType::Bool).nullable(true),
+            CastJsonbToString => ColumnType::new(ScalarType::String, true),
+            CastJsonbToFloat64 => ColumnType::new(ScalarType::Float64, true),
+            CastJsonbToBool => ColumnType::new(ScalarType::Bool, true),
 
             CeilFloat32 | FloorFloat32 | RoundFloat32 => {
-                ColumnType::new(ScalarType::Float32).nullable(in_nullable)
+                ColumnType::new(ScalarType::Float32, in_nullable)
             }
             CeilFloat64 | FloorFloat64 | RoundFloat64 => {
-                ColumnType::new(ScalarType::Float64).nullable(in_nullable)
+                ColumnType::new(ScalarType::Float64, in_nullable)
             }
             CeilDecimal(scale) | FloorDecimal(scale) | RoundDecimal(scale) | SqrtDec(scale) => {
                 match input_type.scalar_type {
                     ScalarType::Decimal(_, s) => assert_eq!(*scale, s),
                     _ => unreachable!(),
                 }
-                ColumnType::new(input_type.scalar_type).nullable(in_nullable)
+                ColumnType::new(input_type.scalar_type, in_nullable)
             }
 
-            SqrtFloat32 => ColumnType::new(ScalarType::Float32).nullable(true),
-            SqrtFloat64 => ColumnType::new(ScalarType::Float64).nullable(true),
+            SqrtFloat32 => ColumnType::new(ScalarType::Float32, true),
+            SqrtFloat64 => ColumnType::new(ScalarType::Float64, true),
 
             Not | NegInt32 | NegInt64 | NegFloat32 | NegFloat64 | NegDecimal | NegInterval
             | AbsInt32 | AbsInt64 | AbsFloat32 | AbsFloat64 | AbsDecimal => input_type,
 
             DatePartInterval(_) | DatePartTimestamp(_) | DatePartTimestampTz(_) => {
-                ColumnType::new(ScalarType::Float64).nullable(in_nullable)
+                ColumnType::new(ScalarType::Float64, in_nullable)
             }
 
-            DateTruncTimestamp(_) => ColumnType::new(ScalarType::Timestamp).nullable(true),
-            DateTruncTimestampTz(_) => ColumnType::new(ScalarType::TimestampTz).nullable(true),
+            DateTruncTimestamp(_) => ColumnType::new(ScalarType::Timestamp, true),
+            DateTruncTimestampTz(_) => ColumnType::new(ScalarType::TimestampTz, true),
 
-            ToTimestamp => ColumnType::new(ScalarType::TimestampTz).nullable(true),
+            ToTimestamp => ColumnType::new(ScalarType::TimestampTz, true),
 
-            JsonbArrayLength => ColumnType::new(ScalarType::Int64).nullable(true),
-            JsonbTypeof => ColumnType::new(ScalarType::String).nullable(in_nullable),
-            JsonbStripNulls => ColumnType::new(ScalarType::Jsonb).nullable(true),
-            JsonbPretty => ColumnType::new(ScalarType::String).nullable(in_nullable),
+            JsonbArrayLength => ColumnType::new(ScalarType::Int64, true),
+            JsonbTypeof => ColumnType::new(ScalarType::String, in_nullable),
+            JsonbStripNulls => ColumnType::new(ScalarType::Jsonb, true),
+            JsonbPretty => ColumnType::new(ScalarType::String, in_nullable),
 
             RecordGet(i) => match input_type.scalar_type {
                 ScalarType::Record { mut fields } => {
-                    ColumnType::new(fields.swap_remove(*i).1).nullable(true)
+                    ColumnType::new(fields.swap_remove(*i).1, true)
                 }
                 _ => unreachable!("RecordGet specified nonexistent field"),
             },
@@ -3012,26 +3012,28 @@ impl VariadicFunc {
                 );
                 input_types.into_first().nullable(true)
             }
-            Concat => ColumnType::new(ScalarType::String).nullable(true),
-            MakeTimestamp => ColumnType::new(ScalarType::Timestamp).nullable(true),
-            Substr => ColumnType::new(ScalarType::String).nullable(true),
-            Replace => ColumnType::new(ScalarType::String).nullable(true),
-            JsonbBuildArray | JsonbBuildObject => ColumnType::new(ScalarType::Jsonb).nullable(true),
+            Concat => ColumnType::new(ScalarType::String, true),
+            MakeTimestamp => ColumnType::new(ScalarType::Timestamp, true),
+            Substr => ColumnType::new(ScalarType::String, true),
+            Replace => ColumnType::new(ScalarType::String, true),
+            JsonbBuildArray | JsonbBuildObject => ColumnType::new(ScalarType::Jsonb, true),
             ListCreate { elem_type } => {
                 debug_assert!(
                     input_types.iter().all(|t| t.scalar_type == *elem_type),
                     "Args to ListCreate should have types that are compatible with the elem_type"
                 );
-                ColumnType::new(ScalarType::List(Box::new(elem_type.clone())))
+                ColumnType::new(ScalarType::List(Box::new(elem_type.clone())), false)
             }
-            RecordCreate { field_names } => ColumnType::new(ScalarType::Record {
-                fields: field_names
-                    .clone()
-                    .into_iter()
-                    .zip(input_types.into_iter().map(|ty| ty.scalar_type))
-                    .collect(),
-            })
-            .nullable(true),
+            RecordCreate { field_names } => ColumnType::new(
+                ScalarType::Record {
+                    fields: field_names
+                        .clone()
+                        .into_iter()
+                        .zip(input_types.into_iter().map(|ty| ty.scalar_type))
+                        .collect(),
+                },
+                true,
+            ),
         }
     }
 

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -611,9 +611,10 @@ mod tests {
             ColumnType::new(ScalarType::Int64, false),
         ]);
         let col = |i| ScalarExpr::Column(i);
-        let err = |e| ScalarExpr::literal(Err(e), ColumnType::new(ScalarType::Int64));
-        let lit = |i| ScalarExpr::literal_ok(Datum::Int64(i), ColumnType::new(ScalarType::Int64));
-        let null = || ScalarExpr::literal_null(ColumnType::new(ScalarType::Int64));
+        let err = |e| ScalarExpr::literal(Err(e), ColumnType::new(ScalarType::Int64, false));
+        let lit =
+            |i| ScalarExpr::literal_ok(Datum::Int64(i), ColumnType::new(ScalarType::Int64, false));
+        let null = || ScalarExpr::literal_null(ColumnType::new(ScalarType::Int64, true));
 
         struct TestCase {
             input: ScalarExpr,

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -203,7 +203,7 @@ impl ScalarExpr {
     pub fn take(&mut self) -> Self {
         mem::replace(
             self,
-            ScalarExpr::literal_null(ColumnType::new(ScalarType::String)),
+            ScalarExpr::literal_null(ColumnType::new(ScalarType::String, true)),
         )
     }
 
@@ -267,8 +267,8 @@ impl ScalarExpr {
     /// use repr::{ColumnType, Datum, RelationType, ScalarType};
     ///
     /// let expr_0 = ScalarExpr::Column(0);
-    /// let expr_t = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool));
-    /// let expr_f = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
+    /// let expr_t = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, false));
+    /// let expr_f = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool, false));
     ///
     /// let mut test =
     /// expr_t
@@ -276,7 +276,7 @@ impl ScalarExpr {
     ///     .call_binary(expr_f.clone(), BinaryFunc::And)
     ///     .if_then_else(expr_0, expr_t.clone());
     ///
-    /// let input_type = RelationType::new(vec![ColumnType::new(ScalarType::Int32)]);
+    /// let input_type = RelationType::new(vec![ColumnType::new(ScalarType::Int32, false)]);
     /// test.reduce(&input_type);
     /// assert_eq!(test, expr_t);
     /// ```
@@ -606,9 +606,9 @@ mod tests {
     #[test]
     fn test_reduce() {
         let relation_type = RelationType::new(vec![
-            ColumnType::new(ScalarType::Int64).nullable(true),
-            ColumnType::new(ScalarType::Int64).nullable(true),
-            ColumnType::new(ScalarType::Int64).nullable(false),
+            ColumnType::new(ScalarType::Int64, true),
+            ColumnType::new(ScalarType::Int64, true),
+            ColumnType::new(ScalarType::Int64, false),
         ]);
         let col = |i| ScalarExpr::Column(i);
         let err = |e| ScalarExpr::literal(Err(e), ColumnType::new(ScalarType::Int64));

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -705,7 +705,7 @@ fn get_named_columns<'a>(
                 // column will be null whenever it is uninhabited.
                 let ty = validate_schema_2(seen_avro_nodes, node)?;
                 let nullable = vs.len() > 1;
-                columns.push((name.into(), ColumnType::new(ty).nullable(nullable)));
+                columns.push((name.into(), ColumnType::new(ty, nullable)));
                 if let Some(named_idx) = named_idx {
                     seen_avro_nodes.remove(&named_idx);
                 }
@@ -716,7 +716,7 @@ fn get_named_columns<'a>(
         let scalar_type = validate_schema_2(seen_avro_nodes, schema)?;
         Ok(vec![(
             base_name.into(),
-            ColumnType::new(scalar_type).nullable(false),
+            ColumnType::new(scalar_type, false),
         )])
     }
 }

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -30,11 +30,11 @@ pub struct ColumnType {
 
 impl ColumnType {
     /// Constructs a new `ColumnType` with the specified [`ScalarType`] as its
-    /// underlying type. If desired, the `nullable` property can be set with the
-    /// methods of the same name.
-    pub fn new(scalar_type: ScalarType) -> Self {
+    /// underlying type. If desired, the `nullable` property can be modified
+    /// with the `nullable(bool)` method.
+    pub fn new(scalar_type: ScalarType, nullable: bool) -> Self {
         ColumnType {
-            nullable: false,
+            nullable,
             scalar_type,
         }
     }
@@ -184,7 +184,7 @@ impl From<&ColumnName> for ColumnName {
 ///
 /// let desc = RelationDesc::empty()
 ///     .with_nonnull_column("id", ScalarType::Int64)
-///     .with_column("price", ColumnType::new(ScalarType::Float64).nullable(true));
+///     .with_column("price", ColumnType::new(ScalarType::Float64, true));
 /// ```
 ///
 /// In more complicated cases, like when constructing a `RelationDesc` in
@@ -254,7 +254,7 @@ impl RelationDesc {
     where
         N: Into<ColumnName>,
     {
-        self.with_column(name, ColumnType::new(scalar_type))
+        self.with_column(name, ColumnType::new(scalar_type, false))
     }
 
     /// Appends a named column with the specified column type.

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -458,10 +458,11 @@ impl ScalarExpr {
                             // optimizer.
                             .product(expr::RelationExpr::constant(
                                 vec![vec![Datum::True]],
-                                RelationType::new(vec![ColumnType::new(ScalarType::Bool)]),
+                                RelationType::new(vec![ColumnType::new(ScalarType::Bool, false)]),
                             ));
                         // append False to anything that didn't return any rows
-                        let default = vec![(Datum::False, ColumnType::new(ScalarType::Bool))];
+                        let default =
+                            vec![(Datum::False, ColumnType::new(ScalarType::Bool, false))];
                         get_inner.lookup(id_gen, exists, default)
                     },
                 );

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -733,7 +733,7 @@ impl ScalarExpr {
                 let datum = parameters.datums.iter().nth(*n - 1).unwrap();
                 let scalar_type = &parameters.types[*n - 1];
                 let row = Row::pack(&[datum]);
-                let column_type = ColumnType::new(scalar_type.clone()).nullable(datum.is_null());
+                let column_type = ColumnType::new(scalar_type.clone(), datum.is_null());
                 *self = ScalarExpr::Literal(row, column_type);
             }
             ScalarExpr::CallUnary { expr, .. } => expr.bind_parameters(parameters),
@@ -975,7 +975,7 @@ impl ScalarTypeable for ScalarExpr {
                     outers[outers.len() - *level].column_types[*column].clone()
                 }
             }
-            ScalarExpr::Parameter(n) => ColumnType::new(params[&n].clone()).nullable(true),
+            ScalarExpr::Parameter(n) => ColumnType::new(params[&n].clone(), true),
             ScalarExpr::Literal(_, typ) => typ.clone(),
             ScalarExpr::CallNullary(func) => func.output_type(),
             ScalarExpr::CallUnary { expr, func } => {
@@ -993,7 +993,7 @@ impl ScalarTypeable for ScalarExpr {
                 let else_type = els.typ(outers, inner, params);
                 then_type.union(&else_type).unwrap()
             }
-            ScalarExpr::Exists(_) => ColumnType::new(ScalarType::Bool).nullable(true),
+            ScalarExpr::Exists(_) => ColumnType::new(ScalarType::Bool, true),
             ScalarExpr::Select(expr) => {
                 let mut outers = outers.to_vec();
                 outers.push(inner.clone());

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -877,7 +877,7 @@ fn plan_current_timestamp(ecx: &ExprContext, name: &str) -> Result<ScalarExpr, a
     match ecx.qcx.lifetime {
         QueryLifetime::OneShot => Ok(ScalarExpr::literal(
             Datum::from(ecx.qcx.scx.pcx.wall_time),
-            ColumnType::new(ScalarType::TimestampTz),
+            ColumnType::new(ScalarType::TimestampTz, false),
         )),
         QueryLifetime::Static => bail!("{} cannot be used in static queries", name),
     }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1777,7 +1777,7 @@ fn plan_literal<'a>(l: &'a Value) -> Result<CoercibleScalarExpr, anyhow::Error> 
         Value::Null => return Ok(CoercibleScalarExpr::LiteralNull),
     };
     let nullable = datum == Datum::Null;
-    let typ = ColumnType::new(scalar_type).nullable(nullable);
+    let typ = ColumnType::new(scalar_type, nullable);
     let expr = ScalarExpr::literal(datum, typ);
     Ok(expr.into())
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -50,12 +50,12 @@ lazy_static! {
         RelationDesc::empty().with_nonnull_column("Database", ScalarType::String);
     static ref SHOW_INDEXES_DESC: RelationDesc = RelationDesc::new(
         RelationType::new(vec![
-            ColumnType::new(ScalarType::String),
-            ColumnType::new(ScalarType::String),
-            ColumnType::new(ScalarType::String).nullable(true),
-            ColumnType::new(ScalarType::String).nullable(true),
-            ColumnType::new(ScalarType::Bool),
-            ColumnType::new(ScalarType::Int64),
+            ColumnType::new(ScalarType::String, false),
+            ColumnType::new(ScalarType::String, false),
+            ColumnType::new(ScalarType::String, true),
+            ColumnType::new(ScalarType::String, true),
+            ColumnType::new(ScalarType::Bool, false),
+            ColumnType::new(ScalarType::Int64, false),
         ]),
         vec![
             "Source_or_view",

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -112,7 +112,7 @@ fn to_jsonb_any_record_cast(
     for (i, (name, _ty)) in fields.iter().enumerate() {
         exprs.push(ScalarExpr::literal(
             Datum::String(name.as_str()),
-            ColumnType::new(ScalarType::String),
+            ColumnType::new(ScalarType::String, false),
         ));
         exprs.push(plan_cast(
             "to_jsonb_any_record",
@@ -225,7 +225,7 @@ lazy_static! {
             (Float32, Explicit(Decimal(0, 0))) => CastOp::F(|_ecx, e, to_type| {
                 let (_, s) = to_type.scalar_type().unwrap_decimal_parts();
                 let s = ScalarExpr::literal(
-                    Datum::from(i32::from(s)), ColumnType::new(to_type.scalar_type())
+                    Datum::from(i32::from(s)), ColumnType::new(to_type.scalar_type(), false)
                 );
                 Ok(e.call_binary(s, BinaryFunc::CastFloat32ToDecimal))
             }),
@@ -238,7 +238,7 @@ lazy_static! {
             (Float64, Explicit(Decimal(0, 0))) => CastOp::F(|_ecx, e, to_type| {
                 let (_, s) = to_type.scalar_type().unwrap_decimal_parts();
                 let s = ScalarExpr::literal(Datum::from(
-                    i32::from(s)), ColumnType::new(to_type.scalar_type()));
+                    i32::from(s)), ColumnType::new(to_type.scalar_type(), false));
                 Ok(e.call_binary(s, BinaryFunc::CastFloat64ToDecimal))
             }),
             (Float64, Explicit(String)) => CastFloat64ToString,
@@ -257,7 +257,7 @@ lazy_static! {
                 let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
                 let factor = 10_f32.powi(i32::from(s));
                 let factor =
-                    ScalarExpr::literal(Datum::from(factor), ColumnType::new(Float32));
+                    ScalarExpr::literal(Datum::from(factor), ColumnType::new(Float32, false));
                 Ok(e.call_unary(CastSignificandToFloat32)
                     .call_binary(factor, BinaryFunc::DivFloat32))
             }),
@@ -265,7 +265,7 @@ lazy_static! {
                 let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
                 let factor = 10_f64.powi(i32::from(s));
                 let factor =
-                    ScalarExpr::literal(Datum::from(factor), ColumnType::new(Float32));
+                    ScalarExpr::literal(Datum::from(factor), ColumnType::new(Float32, false));
                 Ok(e.call_unary(CastSignificandToFloat64)
                     .call_binary(factor, BinaryFunc::DivFloat64))
             }),
@@ -380,14 +380,14 @@ pub fn get_cast<'a>(from: &ScalarType, cast_to: &CastTo) -> Option<&'a CastOp> {
 pub fn rescale_decimal(expr: ScalarExpr, s1: u8, s2: u8) -> ScalarExpr {
     match s1.cmp(&s2) {
         Ordering::Less => {
-            let typ = ColumnType::new(ScalarType::Decimal(38, s2 - s1));
+            let typ = ColumnType::new(ScalarType::Decimal(38, s2 - s1), false);
             let factor = 10_i128.pow(u32::from(s2 - s1));
             let factor = ScalarExpr::literal(Datum::from(factor), typ);
             expr.call_binary(factor, BinaryFunc::MulDecimal)
         }
         Ordering::Equal => expr,
         Ordering::Greater => {
-            let typ = ColumnType::new(ScalarType::Decimal(38, s1 - s2));
+            let typ = ColumnType::new(ScalarType::Decimal(38, s1 - s2), false);
             let factor = 10_i128.pow(u32::from(s1 - s2));
             let factor = ScalarExpr::literal(Datum::from(factor), typ);
             expr.call_binary(factor, BinaryFunc::DivDecimal)
@@ -501,15 +501,18 @@ pub fn plan_coerce<'a>(
 
         (LiteralNull, Plain(typ)) => ScalarExpr::literal_null(typ),
         (LiteralNull, JsonbAny) => {
-            ScalarExpr::literal(Datum::JsonNull, ColumnType::new(ScalarType::Jsonb))
+            ScalarExpr::literal(Datum::JsonNull, ColumnType::new(ScalarType::Jsonb, false))
         }
 
         (LiteralString(s), Plain(typ)) => {
-            let lit = ScalarExpr::literal(Datum::String(&s), ColumnType::new(ScalarType::String));
+            let lit = ScalarExpr::literal(
+                Datum::String(&s),
+                ColumnType::new(ScalarType::String, false),
+            );
             plan_cast("string literal", ecx, lit, CastTo::Explicit(typ))?
         }
         (LiteralString(s), JsonbAny) => {
-            ScalarExpr::literal(Datum::String(&s), ColumnType::new(ScalarType::Jsonb))
+            ScalarExpr::literal(Datum::String(&s), ColumnType::new(ScalarType::Jsonb, false))
         }
 
         (LiteralList(exprs), coerce_to) => {

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -153,7 +153,7 @@ END $$;
                             let ty = scalar_type_from_sql(&c.data_type)?;
                             let nullable =
                                 !c.options.iter().any(|o| o.option == ColumnOption::NotNull);
-                            Ok(ColumnType::new(ty).nullable(nullable))
+                            Ok(ColumnType::new(ty, nullable))
                         })
                         .collect::<Result<Vec<_>, anyhow::Error>>()?,
                 );

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -350,10 +350,8 @@ pub fn optimize(
                 expr.reduce(input_type);
                 optimize(expr, input_type, column_knowledge)?
             } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
-                *expr = ScalarExpr::literal_ok(
-                    Datum::False,
-                    ColumnType::new(ScalarType::Bool).nullable(false),
-                );
+                *expr =
+                    ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool, false));
                 optimize(expr, input_type, column_knowledge)?
             } else {
                 DatumKnowledge::default()

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -16,7 +16,7 @@
 //! use transform::fusion::filter::Filter;
 //!
 //! let input = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(ScalarType::Bool, false),
 //! ]));
 //!
 //! let predicate0 = ScalarExpr::Column(0);

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -379,7 +379,10 @@ impl LiteralLifting {
                         .eval(Some(aggr.expr.eval(&[], &temp).unwrap()), &temp);
                     result.push(ScalarExpr::literal_ok(
                         eval,
-                        aggr.func.output_type(aggr.expr.typ(&input.typ())),
+                        // This type information should be available in the `a.expr` literal,
+                        // but extracting it with pattern matching seems awkward.
+                        aggr.func
+                            .output_type(aggr.expr.typ(&repr::RelationType::empty())),
                     ));
                 }
                 result.reverse();

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -108,7 +108,10 @@ fn scalar_nonnullable(expr: &mut ScalarExpr, metadata: &RelationType) {
         {
             if let ScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
+                    *e = ScalarExpr::literal_ok(
+                        Datum::False,
+                        ColumnType::new(ScalarType::Bool, false),
+                    );
                 }
             }
         }
@@ -121,7 +124,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     if let (AggregateFunc::Count, ScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
             expr.func = AggregateFunc::CountAll;
-            expr.expr = ScalarExpr::literal_null(ColumnType::new(ScalarType::Bool).nullable(true));
+            expr.expr = ScalarExpr::literal_null(ColumnType::new(ScalarType::Bool, true));
         }
     }
 }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -19,13 +19,13 @@
 //! use transform::predicate_pushdown::PredicatePushdown;
 //!
 //! let input1 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(ScalarType::Bool, false),
 //! ]));
 //! let input2 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(ScalarType::Bool, false),
 //! ]));
 //! let input3 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool),
+//!     ColumnType::new(ScalarType::Bool, false),
 //! ]));
 //! let join = RelationExpr::join(
 //!     vec![input1.clone(), input2.clone(), input3.clone()],
@@ -35,7 +35,7 @@
 //! let predicate0 = ScalarExpr::column(0);
 //! let predicate1 = ScalarExpr::column(1);
 //! let predicate01 = ScalarExpr::column(0).call_binary(ScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool));
+//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool, false));
 //!
 //! let mut expr = join.filter(
 //!    vec![

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -330,7 +330,7 @@ impl PredicatePushdown {
                                 push_down.push(aggregates[0].expr.clone());
                                 aggregates[0].expr = ScalarExpr::literal_ok(
                                     Datum::True,
-                                    ColumnType::new(ScalarType::Bool),
+                                    ColumnType::new(ScalarType::Bool, false),
                                 );
                             } else {
                                 retain.push(predicate);

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -556,7 +556,7 @@ pub mod undistribute_and {
             suppress_ands(expr2, ands);
 
             // If either argument is in our list, replace it by `true`.
-            let tru = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool));
+            let tru = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, false));
             if ands.contains(expr1) {
                 *expr = std::mem::replace(expr2, tru);
             } else if ands.contains(expr2) {


### PR DESCRIPTION
The `ColumnType::new()` method previously took a scalar type and defaulted to promising non-nullability. This seems error prone. The method was altered to take nullability as an argument, to avoid any confusion about default values. There are no intended semantic changes, except that `ScalarExpr::take`, which replaces `self` with a literal null, now presents as nullable rather than nonnullable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3703)
<!-- Reviewable:end -->
