### PR TITLE
Incorrect use of unwrap_or causing source ingestion slowdown

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -771,7 +771,9 @@ where
                             let partition = message.partition.clone();
                             let offset = message.offset;
 
-                            // Update ingestion metrics
+                            // Update ingestion metrics. Guaranteed to exist as the appropriate
+                            // entry gets created in SourceConstructor or when a new partition
+                            // is discovered
                             consistency_info
                                 .partition_metrics
                                 .get_mut(&partition)

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -775,11 +775,7 @@ where
                             consistency_info
                                 .partition_metrics
                                 .get_mut(&partition)
-                                .unwrap_or(&mut PartitionMetrics::new(
-                                    &name,
-                                    &id.to_string(),
-                                    &partition.to_string(),
-                                ))
+                                .unwrap()
                                 .offset_received
                                 .set(offset.offset);
 


### PR DESCRIPTION
Source Ingestion code was unnecessarily using unwrap_or, causing PartitionMetrics to be created on every iteration of the ingestion loop. 

This unwrap_or is not necessary as the code guarantees that an entry for every partition is guaranteed to exist (for file sources, this is created in SourceConstructor. For Kafka, this entry is created when a new partition queue is added)

Fixes: #3705

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3714)
<!-- Reviewable:end -->
