### PR TITLE
ci/plugins: remove weird docker hack from mzconduct plugin

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -85,7 +85,7 @@ case "$cmd" in
         ;;
     run)
         args=(
-            --rm --interactive --tty
+            --rm --interactive
             --volume "$(pwd):$(pwd)"
             --workdir "$(pwd)"
             --env AWS_ACCESS_KEY_ID
@@ -100,6 +100,9 @@ case "$cmd" in
             --env BUILDKITE_TAG
             --env CI
         )
+        if [[ -t 1 ]]; then
+            args+=(--tty)
+        fi
         if [[ "$(uname -s)" = Linux ]]; then
             # Allow Docker-in-Docker by mounting the Docker socket in the
             # container. Host networking allows us to see ports created by

--- a/ci/plugins/mzconduct/hooks/pre-exit
+++ b/ci/plugins/mzconduct/hooks/pre-exit
@@ -14,8 +14,7 @@ set -euo pipefail
 echo "~~~ :docker: Cleaning up after mzconduct" >&2
 
 test_name="$BUILDKITE_PLUGIN_MZCONDUCT_TEST"
-# Note that there is a \r that seems to be emitted by docker that we need to strip
-compose_file="$(bin/ci-builder run stable bin/mzconduct show dir "$test_name" | tr -d $'\r')/mzcompose.yml"
+compose_file="$(bin/ci-builder run stable bin/mzconduct show dir "$test_name")/mzcompose.yml"
 
 run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet -f "$compose_file" "$@"


### PR DESCRIPTION
This seems really sketchy. Remove the hack to see what happens. If this
doesn't work, I'll track down the root cause.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3723)
<!-- Reviewable:end -->
