### PR TITLE
sql: don't distinct while decorrelating

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -220,7 +220,7 @@ impl Default for Optimizer {
                     Box::new(crate::projection_extraction::ProjectionExtraction),
                     Box::new(crate::projection_lifting::ProjectionLifting),
                     Box::new(crate::map_lifting::LiteralLifting),
-                    Box::new(crate::nonnull_requirements::NonNullRequirements),
+                    // Box::new(crate::nonnull_requirements::NonNullRequirements),
                     Box::new(crate::column_knowledge::ColumnKnowledge),
                     Box::new(crate::reduction_pushdown::ReductionPushdown),
                     Box::new(crate::redundant_join::RedundantJoin),

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -392,31 +392,18 @@ ORDER BY o_ol_cnt
 ----
 %0 =
 | Get materialize.public.order (u16)
-| Filter (datetots(#4) < 2012-01-02 00:00:00), (datetots(#4) >= 2007-01-02 00:00:00)
-
-%1 =
-| Get %0
-
-%2 =
-| Get %0
 | ArrangeBy (#0, #1, #2)
 
-%3 =
+%1 =
 | Get materialize.public.orderline (u19)
 | ArrangeBy (#2, #1, #0)
 
-%4 =
-| Join %2 %3 (= #0 #8) (= #1 #9) (= #2 #10)
-| | implementation = DeltaQuery %2 %3.(#2, #1, #0) | %3 %2.(#0, #1, #2)
-| | demand = (#0..#2, #4, #14)
-| Filter (#14 >= #4)
-| Distinct group=(#0, #1, #2, #4)
-| ArrangeBy (#0, #1, #2, #3)
-
-%5 =
-| Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
-| | implementation = Differential %1 %4.(#0, #1, #2, #3)
-| | demand = (#6)
+%2 =
+| Join %0 %1 (= #2 #10) (= #1 #9) (= #0 #8)
+| | implementation = DeltaQuery %0 %1.(#2, #1, #0) | %1 %0.(#0, #1, #2)
+| | demand = (#0..#7, #14)
+| Filter (datetots(#4) < 2012-01-02 00:00:00), (#14 >= #4), (datetots(#4) >= 2007-01-02 00:00:00)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7)
 | Reduce group=(#6) countall(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
@@ -802,30 +789,55 @@ ORDER BY ordercount DESC
 | Reduce group=(#0) sum(#14)
 
 %4 =
-| Get materialize.public.stock (u26)
-| ArrangeBy (#17)
+| Get %3
+| ArrangeBy ()
 
 %5 =
-| Get materialize.public.supplier (u34)
-| ArrangeBy (#0) (#3)
+| Get materialize.public.stock (u26)
 
 %6 =
-| Get materialize.public.nation (u31)
+| Get materialize.public.supplier (u34)
 | ArrangeBy (#0)
 
 %7 =
-| Join %4 %5 %6 (= #21 #25) (= #17 #18)
-| | implementation = DeltaQuery %4 %5.(#0) %6.(#0) | %5 %6.(#0) %4.(#17) | %6 %5.(#3) %4.(#17)
-| | demand = (#14, #26)
-| Filter (#26 = "GERMANY")
-| Reduce group=() sum(#14)
-| Map (i32todec(#0) * 5dec)
-| ArrangeBy ()
+| Get materialize.public.nation (u31)
+| ArrangeBy (#0)
 
 %8 =
-| Join %3 %7
-| | implementation = Differential %3 %7.()
-| | demand = (#0, #1, #3)
+| Join %4 %5 %6 %7 (= #19 #20) (= #23 #27)
+| | implementation = Differential %5 %6.(#0) %7.(#0) %4.()
+| | demand = (#0, #1, #16, #28)
+| Filter (#28 = "GERMANY")
+| Reduce group=(#0, #1) sum(#16)
+
+%9 =
+| Get %8
+
+%10 =
+| Get %8
+| Negate
+| Project (#0, #1)
+
+%11 =
+| Get %3
+
+%12 =
+| Union %10 %11
+
+%13 =
+| Get %3
+| ArrangeBy (#0, #1)
+
+%14 =
+| Join %12 %13 (= #0 #2) (= #1 #3)
+| | implementation = Differential %12 %13.(#0, #1)
+| | demand = (#0, #1)
+| Map null
+| Project (#0, #1, #4)
+
+%15 =
+| Union %9 %14
+| Map (i32todec(#2) * 5dec)
 | Filter ((i32todec(#1) * 1000dec) > #3)
 | Project (#0, #1)
 
@@ -1014,6 +1026,7 @@ ORDER BY su_suppkey
 ----
 %0 =
 | Get materialize.public.supplier (u34)
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.orderline (u19)
@@ -1033,27 +1046,19 @@ ORDER BY su_suppkey
 
 %4 =
 | Get materialize.public.orderline (u19)
-| ArrangeBy (#5, #4)
+| Filter (datetots(#6) >= 2007-01-02 00:00:00)
 
 %5 =
 | Get materialize.public.stock (u26)
 | ArrangeBy (#0, #1)
 
 %6 =
-| Join %4 %5 (= #5 #11) (= #4 #10)
-| | implementation = DeltaQuery %4 %5.(#0, #1) | %5 %4.(#5, #4)
-| | demand = (#6, #8, #27)
-| Filter (datetots(#6) >= 2007-01-02 00:00:00)
-| Reduce group=(#27) sum(#8)
-| Reduce group=() max(#1)
-| Filter !(isnull(#0))
-| ArrangeBy (#0)
-
-%7 =
-| Join %0 %3 %6 (= #0 #7) (= #8 #9)
-| | implementation = Differential %0 %3.(#0) %6.(#0)
-| | demand = (#0..#2, #4, #8)
-| Filter !(isnull(#8))
+| Join %0 %3 %4 %5 (= #0 #7) (= #13 #19) (= #14 #20)
+| | implementation = Differential %4 %5.(#0, #1) %0.() %3.(#0)
+| | demand = (#0..#6, #8, #17, #36)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #0, #8, #36) sum(#17)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7, #8) max(#10)
+| Filter (#8 = #9)
 | Project (#0..#2, #4, #8)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#4)
@@ -1088,46 +1093,38 @@ ORDER BY supplier_cnt DESC
 %2 =
 | Join %0 %1 (= #0 #18)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
-| | demand = (#17, #20..#22)
+| | demand = (#0..#17, #19..#22)
 | Filter !("^zz.*$" ~(#22))
 
 %3 =
 | Get %2
-| Distinct group=(#17)
 
 %4 =
-| Get %2
-| ArrangeBy (#17)
-
-%5 =
-| Get %3
-| ArrangeBy (#0)
-
-%6 =
 | Get materialize.public.supplier (u34)
 | ArrangeBy (#0)
 
-%7 =
-| Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
-| | demand = (#0, #7)
-| Filter "^.*bad.*$" ~(#7)
+%5 =
+| Join %3 %4 (= #17 #23)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0..#17, #19..#22, #29)
+| Filter "^.*bad.*$" ~(#29)
 | Negate
-| Project (#0)
+| Project (#0..#17, #0, #19..#22)
+
+%6 =
+| Get %2
+| Project (#0..#17, #0, #19..#22)
+
+%7 =
+| Union %5 %6
 
 %8 =
-| Get %3
+| Get %2
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #19, #20, #21, #22)
 
 %9 =
-| Union %7 %8
-
-%10 =
-| Get %3
-| ArrangeBy (#0)
-
-%11 =
-| Join %4 %9 %10 (= #17 #23 #24)
-| | implementation = Differential %9 %10.(#0) %4.(#17)
+| Join %7 %8 (= #0 #18 #23) (= #1 #24) (= #2 #25) (= #3 #26) (= #4 #27) (= #5 #28) (= #6 #29) (= #7 #30) (= #8 #31) (= #9 #32) (= #10 #33) (= #11 #34) (= #12 #35) (= #13 #36) (= #14 #37) (= #15 #38) (= #16 #39) (= #17 #40) (= #19 #42) (= #20 #43) (= #21 #44) (= #22 #45)
+| | implementation = Differential %7 %8.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #19, #20, #21, #22)
 | | demand = (#17, #20..#22)
 | Reduce group=(#20, substr(#22, 1, 3), #21) count(distinct #17)
 
@@ -1324,66 +1321,34 @@ ORDER BY su_name
 ----
 %0 =
 | Get materialize.public.supplier (u34)
-| ArrangeBy (#3)
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.nation (u31)
 | ArrangeBy (#0)
 
 %2 =
-| Join %0 %1 (= #3 #7)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#3)
-| | demand = (#0..#2, #8)
-| Filter (#8 = "GERMANY")
-
-%3 =
-| Get %2
-| ArrangeBy ()
-
-%4 =
 | Get materialize.public.stock (u26)
 
-%5 =
+%3 =
 | Get materialize.public.orderline (u19)
 | ArrangeBy (#4)
 
-%6 =
-| Join %3 %4 %5 (= #11 #33)
-| | implementation = Differential %4 %5.(#4) %3.()
-| | demand = (#0, #11..#13, #35, #36)
-| Filter (datetots(#35) > 2010-05-23 12:00:00)
-
-%7 =
-| Get %2
-
-%8 =
-| Get %6
-
-%9 =
-| Get %6
-| Distinct group=(#11)
-| ArrangeBy (#0)
-
-%10 =
+%4 =
 | Get materialize.public.item (u24)
 | ArrangeBy (#0)
 
-%11 =
-| Join %8 %9 %10 (= #11 #39 #40)
-| | implementation = Differential %8 %9.(#0) %10.(#0)
-| | demand = (#0, #11..#13, #36, #44)
-| Filter "^co.*$" ~(#44)
-| Reduce group=(#0, #11, #12, #13) sum(#36)
-| Filter ((2 * #3) > #4)
-| Map ((#1 * #2) % 10000)
-| Filter (#0 = #5)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%12 =
-| Join %7 %11 (= #0 #11)
-| | implementation = Differential %7 %11.(#0)
-| | demand = (#1, #2)
+%5 =
+| Join %0 %1 %2 %3 %4 (= #3 #7) (= #11 #33 #39)
+| | implementation = Differential %2 %4.(#0) %3.(#4) %0.() %1.(#0)
+| | demand = (#0..#6, #8..#32, #34..#38, #43)
+| Filter "^co.*$" ~(#43), (#8 = "GERMANY"), (datetots(#35) > 2010-05-23 12:00:00)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #3, "GERMANY", #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #11, #34, #35, #36, #37, #38)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7, "GERMANY", #9, #10, #11, #12, #13) sum(#36)
+| Filter ((2 * #13) > #14)
+| Map ((#11 * #12) % 10000)
+| Filter (#0 = #15)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, "GERMANY", #9, #10)
 | Project (#1, #2)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
@@ -1439,45 +1404,38 @@ ORDER BY numwait DESC, su_name
 %5 =
 | Join %0 %1 %2 %3 %4 (= #0 #42) (= #3 #43) (= #7 #17) (= #8 #18) (= #9 #19 #26) (= #11 #25)
 | | implementation = Differential %1 %2.(#0, #1, #2) %3.(#0, #1) %0.(#0) %4.(#0)
-| | demand = (#1, #7..#9, #13, #21, #44)
+| | demand = (#0..#16, #20..#24, #27..#41, #44..#46)
 | Filter (#44 = "GERMANY"), (#13 > #21)
 
 %6 =
 | Get %5
-| Distinct group=(#7, #8, #9, #13)
 
 %7 =
-| Get %5
-| ArrangeBy (#7, #8, #9, #13)
-
-%8 =
-| Get %6
-
-%9 =
 | Get materialize.public.orderline (u19)
 | ArrangeBy (#2, #1, #0)
 
-%10 =
-| Join %8 %9 (= #0 #4) (= #1 #5) (= #2 #6)
-| | implementation = Differential %8 %9.(#2, #1, #0)
-| | demand = (#0..#3, #10)
-| Filter (#10 > #3)
-| Distinct group=(#0, #1, #2, #3)
+%8 =
+| Join %6 %7 (= #7 #47) (= #8 #48) (= #9 #49)
+| | implementation = Differential %6 %7.(#2, #1, #0)
+| | demand = (#0..#16, #20..#24, #27..#41, #45, #46, #53)
+| Filter (#53 > #13)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #7, #8, #9, #20, #21, #22, #23, #24, #11, #9, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #0, #3, "GERMANY", #45, #46)
 | Negate
 
+%9 =
+| Get %5
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #7, #8, #9, #20, #21, #22, #23, #24, #11, #9, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #0, #3, "GERMANY", #45, #46)
+
+%10 =
+| Union %8 %9
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46)
+
 %11 =
-| Get %6
+| Get %5
 
 %12 =
-| Union %10 %11
-
-%13 =
-| Get %6
-| ArrangeBy (#0, #1, #2, #3)
-
-%14 =
-| Join %7 %12 %13 (= #7 #47 #51) (= #8 #48 #52) (= #9 #49 #53) (= #13 #50 #54)
-| | implementation = Differential %12 %13.(#0, #1, #2, #3) %7.(#7, #8, #9, #13)
+| Join %10 %11 (= #0 #42 #47) (= #1 #48) (= #2 #49) (= #3 #43 #50) (= #4 #51) (= #5 #52) (= #6 #53) (= #7 #17 #54) (= #8 #18 #55) (= #9 #19 #26 #56) (= #10 #57) (= #11 #25 #58) (= #12 #59) (= #13 #60) (= #14 #61) (= #15 #62) (= #16 #63) (= #20 #67) (= #21 #68) (= #22 #69) (= #23 #70) (= #24 #71) (= #27 #74) (= #28 #75) (= #29 #76) (= #30 #77) (= #31 #78) (= #32 #79) (= #33 #80) (= #34 #81) (= #35 #82) (= #36 #83) (= #37 #84) (= #38 #85) (= #39 #86) (= #40 #87) (= #41 #88) (= #44 #91) (= #45 #92) (= #46 #93)
+| | implementation = Differential %11 %10.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46)
 | | demand = (#1)
 | Reduce group=(#1) countall(true)
 
@@ -1513,47 +1471,77 @@ ORDER BY substr(c_state, 1, 1)
 | Filter (((((((substr(#11, 1, 1) = "1") || (substr(#11, 1, 1) = "2")) || (substr(#11, 1, 1) = "3")) || (substr(#11, 1, 1) = "4")) || (substr(#11, 1, 1) = "5")) || (substr(#11, 1, 1) = "6")) || (substr(#11, 1, 1) = "7"))
 
 %1 =
-| Get materialize.public.customer (u6)
-| Filter (((((((substr(#11, 1, 1) = "1") || (substr(#11, 1, 1) = "2")) || (substr(#11, 1, 1) = "3")) || (substr(#11, 1, 1) = "4")) || (substr(#11, 1, 1) = "5")) || (substr(#11, 1, 1) = "6")) || (substr(#11, 1, 1) = "7")), (#16 > 0dec)
-| Reduce group=() sum(#16) count(#16)
-| Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
+| Get %0
 | ArrangeBy ()
 
 %2 =
-| Join %0 %1
-| | implementation = Differential %0 %1.()
-| | demand = (#0..#2, #9, #16, #24)
-| Filter ((#16 * 1000000dec) > #24)
+| Get materialize.public.customer (u6)
+| Filter (((((((substr(#11, 1, 1) = "1") || (substr(#11, 1, 1) = "2")) || (substr(#11, 1, 1) = "3")) || (substr(#11, 1, 1) = "4")) || (substr(#11, 1, 1) = "5")) || (substr(#11, 1, 1) = "6")) || (substr(#11, 1, 1) = "7")), (#16 > 0dec)
 
 %3 =
-| Get %2
-| ArrangeBy (#0, #1, #2)
+| Join %1 %2
+| | implementation = Differential %2 %1.()
+| | demand = (#0..#21, #38)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21) sum(#38) count(#38)
 
 %4 =
-| Get %2
-| ArrangeBy (#0, #1, #2)
+| Get %3
 
 %5 =
+| Get %3
+| Negate
+| Project (#0..#21)
+
+%6 =
+| Get %0
+
+%7 =
+| Union %5 %6
+
+%8 =
+| Get %0
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
+
+%9 =
+| Join %7 %8 (= #0 #22) (= #1 #23) (= #2 #24) (= #3 #25) (= #4 #26) (= #5 #27) (= #6 #28) (= #7 #29) (= #8 #30) (= #9 #31) (= #10 #32) (= #11 #33) (= #12 #34) (= #13 #35) (= #14 #36) (= #15 #37) (= #16 #38) (= #17 #39) (= #18 #40) (= #19 #41) (= #20 #42) (= #21 #43)
+| | implementation = Differential %7 %8.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
+| | demand = (#0..#21)
+| Map null, 0
+| Project (#0..#21, #44, #45)
+
+%10 =
+| Union %4 %9
+| Map (((#22 * 10000000dec) / i64todec(if (#23 = 0) then {null} else {#23})) / 10dec)
+| Filter ((#16 * 1000000dec) > #24)
+
+%11 =
+| Get %10
+
+%12 =
 | Get materialize.public.order (u16)
 | ArrangeBy (#2, #1, #3)
 
-%6 =
-| Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
-| | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
-| | demand = (#0..#2)
-| Distinct group=(#0, #1, #2)
+%13 =
+| Join %11 %12 (= #0 #28) (= #1 #26) (= #2 #27)
+| | implementation = Differential %11 %12.(#2, #1, #3)
+| | demand = (#0..#21)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 | Negate
 
-%7 =
-| Get %2
-| Project (#0..#2)
+%14 =
+| Get %10
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 
-%8 =
-| Union %6 %7
+%15 =
+| Union %13 %14
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 
-%9 =
-| Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
-| | implementation = Differential %8 %3.(#0, #1, #2)
+%16 =
+| Get %10
+
+%17 =
+| Join %15 %16 (= #0 #22) (= #1 #23) (= #2 #24) (= #3 #25) (= #4 #26) (= #5 #27) (= #6 #28) (= #7 #29) (= #8 #30) (= #9 #31) (= #10 #32) (= #11 #33) (= #12 #34) (= #13 #35) (= #14 #36) (= #15 #37) (= #16 #38) (= #17 #39) (= #18 #40) (= #19 #41) (= #20 #42) (= #21 #43)
+| | implementation = Differential %16 %15.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 | | demand = (#9, #16)
 | Reduce group=(substr(#9, 1, 1)) countall(true) sum(#16)
 

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -142,53 +142,24 @@ WHERE l1.la IN (
 ----
 %0 =
 | Get materialize.public.l (u1)
-| Distinct group=(#0)
-| ArrangeBy ()
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.l (u1)
-
-%2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
-| | demand = (#0, #1)
-
-%3 =
-| Get materialize.public.l (u1)
-
-%4 =
-| Get %2
-| Filter (#0 = (#1 + 1))
-
-%5 =
-| Get %2
-| Filter !(isnull(#1))
-| Distinct group=(#1)
+| Filter !(isnull(#0))
 | ArrangeBy (#0)
 
-%6 =
+%2 =
 | Get materialize.public.l (u1)
 | Filter !(isnull(#0))
 
-%7 =
-| Join %5 %6 (= #0 (#1 + 1))
-| | implementation = Differential %6 %5.(#0)
-| | demand = (#0)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%8 =
-| Join %4 %7 (= #1 #3)
-| | implementation = Differential %4 %7.(#0)
-| | demand = (#0)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%9 =
-| Join %3 %8 (= #0 #2)
-| | implementation = Differential %3 %8.(#0)
-| | demand = (#0, #1)
-| Project (#0, #1)
+%3 =
+| Join %0 %1 %2 (= #0 (#2 + 1)) (= #2 (#4 + 1))
+| | implementation = Differential %2 %1.(#0) %0.(#0)
+| | demand = (#0..#3)
+| Distinct group=(#0, #1, #2, #3)
+| Distinct group=(#0, #1)
 
 EOF
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -253,16 +253,16 @@ EXPLAIN PLAN FOR SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 ----
 %0 =
 | Get materialize.public.t1 (u39)
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.t2 (u41)
-| Distinct group=()
-| ArrangeBy ()
 
 %2 =
 | Join %0 %1
-| | implementation = Differential %0 %1.()
+| | implementation = Differential %1 %0.()
 | | demand = (#0)
+| Distinct group=(#0)
 
 EOF
 
@@ -271,21 +271,20 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 ----
 %0 =
 | Get materialize.public.t1 (u39)
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.t3 (u43)
+| ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.t2 (u41)
-| Distinct group=()
-| ArrangeBy ()
 
 %3 =
 | Join %0 %1 %2 (= #0 #1)
-| | implementation = Differential %1 %2.() %0.(#0)
+| | implementation = Differential %2 %0.() %1.(#0)
 | | demand = (#0, #2)
-| Project (#0, #0, #2)
+| Distinct group=(#0, #0, #2)
 
 EOF
 
@@ -300,34 +299,14 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | Get materialize.public.t3 (u43)
 
 %2 =
-| Join %0 %1 (= #0 #1)
-| | implementation = Differential %1 %0.(#0)
-| | demand = (#0, #2)
-
-%3 =
-| Get %2
-
-%4 =
-| Get %2
-| Distinct group=(#2)
-| ArrangeBy (#0)
-
-%5 =
 | Get materialize.public.t2 (u41)
 | ArrangeBy (#0)
 
-%6 =
-| Join %4 %5 (= #0 #1)
-| | implementation = DeltaQuery %4 %5.(#0) | %5 %4.(#0)
-| | demand = (#0)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%7 =
-| Join %3 %6 (= #2 #3)
-| | implementation = Differential %3 %6.(#0)
+%3 =
+| Join %0 %1 %2 (= #0 #1) (= #2 #3)
+| | implementation = Differential %1 %0.(#0) %2.(#0)
 | | demand = (#0, #2)
-| Project (#0, #0, #2)
+| Distinct group=(#0, #0, #2)
 
 EOF
 
@@ -470,59 +449,47 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 ----
 %0 =
 | Get materialize.public.y (u59)
-| Distinct group=(#0)
-
-%1 =
-| Get %0
 | ArrangeBy (#0)
 
-%2 =
+%1 =
 | Get materialize.public.x (u57)
 | ArrangeBy (#0)
 
-%3 =
-| Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery %1 %2.(#0) | %2 %1.(#0)
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 
+%3 =
+| Get %2
+| Map true
+
 %4 =
+| Get %2
+| Negate
+
+%5 =
+| Get materialize.public.y (u59)
+| Distinct group=(#0)
+
+%6 =
+| Union %4 %5
+
+%7 =
 | Get materialize.public.y (u59)
 | ArrangeBy (#0)
 
-%5 =
-| Get %3
-| Map true
-
-%6 =
-| Get %3
-| Negate
-
-%7 =
-| Get %0
-
 %8 =
-| Union %6 %7
-
-%9 =
-| Get %0
-| ArrangeBy (#0)
-
-%10 =
-| Join %8 %9 (= #0 #1)
-| | implementation = Differential %8 %9.(#0)
-| | demand = (#0)
+| Join %6 %7 (= #0 #1)
+| | implementation = Differential %6 %7.(#0)
+| | demand = ()
 | Map false
 | Project (#0, #2)
 
-%11 =
-| Union %5 %10
-
-%12 =
-| Join %4 %11 (= #0 #1)
-| | implementation = Differential %11 %4.(#0)
-| | demand = (#2)
-| Project (#2)
+%9 =
+| Union %3 %8
+| Project (#1)
 
 EOF
 
@@ -531,60 +498,48 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 ----
 %0 =
 | Get materialize.public.y (u59)
-| Distinct group=(#0)
-
-%1 =
-| Get %0
 | ArrangeBy (#0)
 
-%2 =
+%1 =
 | Get materialize.public.x (u57)
 | ArrangeBy (#0)
 
-%3 =
-| Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery %1 %2.(#0) | %2 %1.(#0)
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 
+%3 =
+| Get %2
+| Map true
+
 %4 =
+| Get %2
+| Negate
+
+%5 =
+| Get materialize.public.y (u59)
+| Distinct group=(#0)
+
+%6 =
+| Union %4 %5
+
+%7 =
 | Get materialize.public.y (u59)
 | ArrangeBy (#0)
 
-%5 =
-| Get %3
-| Map true
-
-%6 =
-| Get %3
-| Negate
-
-%7 =
-| Get %0
-
 %8 =
-| Union %6 %7
-
-%9 =
-| Get %0
-| ArrangeBy (#0)
-
-%10 =
-| Join %8 %9 (= #0 #1)
-| | implementation = Differential %8 %9.(#0)
-| | demand = (#0)
+| Join %6 %7 (= #0 #1)
+| | implementation = Differential %6 %7.(#0)
+| | demand = ()
 | Map false
 | Project (#0, #2)
 
-%11 =
-| Union %5 %10
-
-%12 =
-| Join %4 %11 (= #0 #1)
-| | implementation = Differential %11 %4.(#0)
-| | demand = (#2)
-| Map !(#2)
-| Project (#3)
+%9 =
+| Union %3 %8
+| Map !(#1)
+| Project (#2)
 
 EOF
 
@@ -594,60 +549,48 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 ----
 %0 =
 | Get materialize.public.y (u59)
-| Distinct group=(#0)
-
-%1 =
-| Get %0
 | ArrangeBy ()
 
-%2 =
+%1 =
 | Get materialize.public.x (u57)
 
-%3 =
-| Join %1 %2
-| | implementation = Differential %2 %1.()
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 | | demand = (#0, #1)
 | Filter (#0 <= #1)
 | Distinct group=(#0)
 
+%3 =
+| Get %2
+| Map true
+
 %4 =
+| Get %2
+| Negate
+
+%5 =
+| Get materialize.public.y (u59)
+| Distinct group=(#0)
+
+%6 =
+| Union %4 %5
+
+%7 =
 | Get materialize.public.y (u59)
 | ArrangeBy (#0)
 
-%5 =
-| Get %3
-| Map true
-
-%6 =
-| Get %3
-| Negate
-
-%7 =
-| Get %0
-
 %8 =
-| Union %6 %7
-
-%9 =
-| Get %0
-| ArrangeBy (#0)
-
-%10 =
-| Join %8 %9 (= #0 #1)
-| | implementation = Differential %8 %9.(#0)
-| | demand = (#0)
+| Join %6 %7 (= #0 #1)
+| | implementation = Differential %6 %7.(#0)
+| | demand = ()
 | Map false
 | Project (#0, #2)
 
-%11 =
-| Union %5 %10
-
-%12 =
-| Join %4 %11 (= #0 #1)
-| | implementation = Differential %11 %4.(#0)
-| | demand = (#2)
-| Map !(#2)
-| Project (#3)
+%9 =
+| Union %3 %8
+| Map !(#1)
+| Project (#2)
 
 EOF
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -230,45 +230,47 @@ ORDER BY
 %5 =
 | Join %0 %1 %2 %3 %4 (= #23 #25) (= #12 #21) (= #9 #17) (= #0 #16)
 | | implementation = DeltaQuery %0 %2.(#0) %1.(#0) %3.(#0) %4.(#0) | %1 %3.(#0) %4.(#0) %2.(#1) %0.(#0) | %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) | %3 %4.(#0) %1.(#3) %2.(#1) %0.(#0) | %4 %3.(#2) %1.(#3) %2.(#1) %0.(#0)
-| | demand = (#0, #2, #4, #5, #10, #11, #13..#15, #19, #22, #26)
+| | demand = (#0..#15, #18..#20, #22..#24, #26, #27)
 | Filter "^.*BRASS$" ~(#4), (#5 = 15), (#26 = "EUROPE")
 
 %6 =
 | Get %5
 
 %7 =
-| Get %5
-| Distinct group=(#0)
+| Get materialize.public.partsupp (u11)
 | ArrangeBy (#0)
 
 %8 =
-| Get materialize.public.partsupp (u11)
-| ArrangeBy (#0) (#1)
+| Get %5
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #18, #19, #20, #22, #23, #24, #26, #27)
 
 %9 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| ArrangeBy (#0)
 
 %10 =
-| Get materialize.public.nation (u1)
-| ArrangeBy (#0) (#2)
+| Get %5
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #18, #19, #20, #22, #23, #24, #26, #27)
 
 %11 =
-| Get materialize.public.region (u4)
+| Get materialize.public.nation (u1)
 | ArrangeBy (#0)
 
 %12 =
-| Join %7 %8 %9 %10 %11 (= #0 #1) (= #2 #6) (= #9 #13) (= #15 #17)
-| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0) | %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0) | %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0) | %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
-| | demand = (#0, #4, #18)
-| Filter (#18 = "EUROPE")
-| Reduce group=(#0) min(#4)
-| ArrangeBy (#0, #1)
+| Get %5
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #18, #19, #20, #22, #23, #24, #26, #27)
 
 %13 =
-| Join %6 %12 (= #0 #28) (= #19 #29)
-| | implementation = Differential %6 %12.(#0, #1)
-| | demand = (#0, #2, #10, #11, #13..#15, #22)
+| Get materialize.public.region (u4)
+| ArrangeBy (#0)
+
+%14 =
+| Join %6 %7 %8 %9 %10 %11 %12 %13 (= #0 #28 #33 #68 #100) (= #1 #34 #69 #101) (= #2 #35 #70 #102) (= #3 #36 #71 #103) (= #4 #37 #72 #104) (= #5 #38 #73 #105) (= #6 #39 #74 #106) (= #7 #40 #75 #107) (= #8 #41 #76 #108) (= #9 #42 #77 #109) (= #10 #43 #78 #110) (= #11 #44 #79 #111) (= #12 #45 #80 #112) (= #13 #46 #81 #113) (= #14 #47 #82 #114) (= #15 #48 #83 #115) (= #18 #51 #86 #118) (= #19 #52 #87 #119) (= #20 #53 #88 #120) (= #22 #55 #90 #122) (= #23 #56 #91 #123) (= #24 #57 #92 #124) (= #26 #59 #94 #126) (= #27 #60 #95 #127) (= #29 #61) (= #64 #96) (= #98 #128)
+| | implementation = Differential %6 %8.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #18, #19, #20, #22, #23, #24, #26, #27) %10.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #18, #19, #20, #22, #23, #24, #26, #27) %12.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #18, #19, #20, #22, #23, #24, #26, #27) %7.(#0) %9.(#0) %11.(#0) %13.(#0)
+| | demand = (#0..#4, #6..#15, #18..#20, #22..#24, #27, #31, #129)
+| Filter (#129 = "EUROPE")
+| Reduce group=(#0, #1, #2, #3, #4, 15, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #0, #9, #18, #19, #20, #12, #22, #23, #24, #23, "EUROPE", #27) min(#31)
+| Filter (#19 = #28)
 | Project (#14, #10, #22, #0, #2, #11, #13, #15)
 
 Finish order_by=(#0 desc, #2 asc, #1 asc, #3 asc) limit=none offset=0 project=(#0..#7)
@@ -352,31 +354,18 @@ ORDER BY
 ----
 %0 =
 | Get materialize.public.orders (u18)
-| Filter (datetots(#4) < 1993-10-01 00:00:00), (#4 >= 1993-07-01)
-
-%1 =
-| Get %0
-
-%2 =
-| Get %0
 | ArrangeBy (#0)
 
-%3 =
+%1 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#0)
 
-%4 =
-| Join %2 %3 (= #0 #9)
-| | implementation = DeltaQuery %2 %3.(#0) | %3 %2.(#0)
-| | demand = (#0, #20, #21)
-| Filter (#20 < #21)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%5 =
-| Join %1 %4 (= #0 #9)
-| | implementation = Differential %1 %4.(#0)
-| | demand = (#5)
+%2 =
+| Join %0 %1 (= #0 #9)
+| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
+| | demand = (#0..#8, #20, #21)
+| Filter (#20 < #21), (datetots(#4) < 1993-10-01 00:00:00), (#4 >= 1993-07-01)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8)
 | Reduce group=(#5) countall(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
@@ -831,33 +820,26 @@ ORDER BY
 | | demand = (#0, #2, #3, #13)
 | Filter (#13 = "GERMANY")
 | Reduce group=(#0) sum((#3 * i32todec(#2)))
+| ArrangeBy ()
 
 %4 =
 | Get materialize.public.partsupp (u11)
-| ArrangeBy (#1)
 
 %5 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
+| ArrangeBy (#0)
 
 %6 =
 | Get materialize.public.nation (u1)
 | ArrangeBy (#0)
 
 %7 =
-| Join %4 %5 %6 (= #8 #12) (= #1 #5)
-| | implementation = DeltaQuery %4 %5.(#0) %6.(#0) | %5 %6.(#0) %4.(#1) | %6 %5.(#3) %4.(#1)
-| | demand = (#2, #3, #13)
-| Filter (#13 = "GERMANY")
-| Reduce group=() sum((#3 * i32todec(#2)))
-| Map (#0 * 1dec)
-| ArrangeBy ()
-
-%8 =
-| Join %3 %7
-| | implementation = Differential %3 %7.()
-| | demand = (#0, #1, #3)
-| Filter ((#1 * 10000dec) > #3)
+| Join %3 %4 %5 %6 (= #3 #7) (= #10 #14)
+| | implementation = Differential %4 %5.(#0) %6.(#0) %3.()
+| | demand = (#0, #1, #4, #5, #15)
+| Filter (#15 = "GERMANY")
+| Reduce group=(#0, #1) sum((#5 * i32todec(#4)))
+| Filter ((#1 * 10000dec) > (#2 * 1dec))
 | Project (#0, #1)
 
 Finish order_by=(#1 desc) limit=none offset=0 project=(#0, #1)
@@ -1079,22 +1061,21 @@ ORDER BY
 ----
 %0 =
 | Get materialize.public.supplier (u8)
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.revenue (u27)
-| Filter !(isnull(#1))
 | ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.revenue (u27)
-| Reduce group=() max(#1)
-| Filter !(isnull(#0))
-| ArrangeBy (#0)
 
 %3 =
-| Join %0 %1 %2 (= #0 #7) (= #8 #9)
-| | implementation = Differential %0 %1.(#0) %2.(#0)
-| | demand = (#0..#2, #4, #8)
+| Join %0 %1 %2 (= #0 #7)
+| | implementation = Differential %2 %0.() %1.(#0)
+| | demand = (#0..#6, #8, #10)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #0, #8) max(#10)
+| Filter (#8 = #9)
 | Project (#0..#2, #4, #8)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#4)
@@ -1149,46 +1130,38 @@ ORDER BY
 %2 =
 | Join %0 %1 (= #0 #5)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
-| | demand = (#1, #8..#10)
+| | demand = (#0..#4, #6..#13)
 | Filter !("^MEDIUM POLISHED.*$" ~(#9)), ((((((((#10 = 49) || (#10 = 14)) || (#10 = 23)) || (#10 = 45)) || (#10 = 19)) || (#10 = 3)) || (#10 = 36)) || (#10 = 9)), (#8 != "Brand#45")
 
 %3 =
 | Get %2
-| Distinct group=(#1)
 
 %4 =
-| Get %2
-| ArrangeBy (#1)
-
-%5 =
-| Get %3
-| ArrangeBy (#0)
-
-%6 =
 | Get materialize.public.supplier (u8)
 | ArrangeBy (#0)
 
-%7 =
-| Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
-| | demand = (#0, #7)
-| Filter "^.*Customer.*Complaints.*$" ~(#7)
+%5 =
+| Join %3 %4 (= #1 #14)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0..#4, #6..#13, #20)
+| Filter "^.*Customer.*Complaints.*$" ~(#20)
 | Negate
-| Project (#0)
+| Project (#0..#4, #0, #6..#13)
+
+%6 =
+| Get %2
+| Project (#0..#4, #0, #6..#13)
+
+%7 =
+| Union %5 %6
 
 %8 =
-| Get %3
+| Get %2
+| ArrangeBy (#0, #1, #2, #3, #4, #6, #7, #8, #9, #10, #11, #12, #13)
 
 %9 =
-| Union %7 %8
-
-%10 =
-| Get %3
-| ArrangeBy (#0)
-
-%11 =
-| Join %4 %9 %10 (= #1 #14 #15)
-| | implementation = Differential %9 %10.(#0) %4.(#1)
+| Join %7 %8 (= #0 #5 #14) (= #1 #15) (= #2 #16) (= #3 #17) (= #4 #18) (= #6 #20) (= #7 #21) (= #8 #22) (= #9 #23) (= #10 #24) (= #11 #25) (= #12 #26) (= #13 #27)
+| | implementation = Differential %7 %8.(#0, #1, #2, #3, #4, #6, #7, #8, #9, #10, #11, #12, #13)
 | | demand = (#1, #8..#10)
 | Reduce group=(#8, #9, #10) count(distinct #1)
 
@@ -1228,53 +1201,72 @@ WHERE
 %2 =
 | Join %0 %1 (= #1 #16)
 | | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
-| | demand = (#1, #4, #5, #19, #22)
+| | demand = (#0..#15, #17..#24)
 | Filter (#19 = "Brand#23"), (#22 = "MED BOX")
 
 %3 =
 | Get %2
 
 %4 =
-| Get %2
-| Distinct group=(#1)
-| ArrangeBy (#0)
-
-%5 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#1)
 
+%5 =
+| Join %3 %4 (= #1 #26)
+| | implementation = Differential %3 %4.(#1)
+| | demand = (#0..#15, #17, #18, #20, #21, #23, #24, #29)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #1, #17, #18, "Brand#23", #20, #21, "MED BOX", #23, #24) sum(#29) countall(null)
+
 %6 =
-| Join %4 %5 (= #0 #2)
-| | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
-| | demand = (#0, #5)
-| Reduce group=(#0) sum(#5) countall(null)
-| Map (2dec * (((#1 * 10000000dec) / i64todec(if (#2 = 0) then {null} else {#2})) / 10dec))
-| ArrangeBy (#0)
+| Get %5
 
 %7 =
-| Join %3 %6 (= #1 #25)
-| | implementation = Differential %3 %6.(#0)
-| | demand = (#4, #5, #28)
-| Filter ((#4 * 10000000dec) < #28)
-| Reduce group=() sum(#5)
+| Get %5
+| Negate
+| Project (#0..#24)
 
 %8 =
-| Get %7
+| Get %2
+| Map "Brand#23", "MED BOX"
+| Project (#0..#15, #1, #17, #18, #25, #20, #21, #26, #23, #24)
 
 %9 =
-| Get %7
+| Union %7 %8
+
+%10 =
+| Get %2
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #17, #18, #19, #20, #21, #22, #23, #24)
+
+%11 =
+| Join %9 %10 (= #0 #25) (= #1 #16 #26) (= #2 #27) (= #3 #28) (= #4 #29) (= #5 #30) (= #6 #31) (= #7 #32) (= #8 #33) (= #9 #34) (= #10 #35) (= #11 #36) (= #12 #37) (= #13 #38) (= #14 #39) (= #15 #40) (= #17 #42) (= #18 #43) (= #19 #44) (= #20 #45) (= #21 #46) (= #22 #47) (= #23 #48) (= #24 #49)
+| | implementation = Differential %9 %10.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #17, #18, #19, #20, #21, #22, #23, #24)
+| | demand = (#4, #5)
+| Map null, 0
+| Project (#0..#24, #50, #51)
+
+%12 =
+| Union %6 %11
+| Map (2dec * (((#25 * 10000000dec) / i64todec(if (#26 = 0) then {null} else {#26})) / 10dec))
+| Filter ((#4 * 10000000dec) < #27)
+| Reduce group=() sum(#5)
+
+%13 =
+| Get %12
+
+%14 =
+| Get %12
 | Negate
 | Project ()
 
-%10 =
+%15 =
 | Constant ()
 
-%11 =
-| Union %9 %10
+%16 =
+| Union %14 %15
 | Map null
 
-%12 =
-| Union %8 %11
+%17 =
+| Union %13 %16
 | Map ((#0 * 10000000dec) / 70dec)
 | Project (#1)
 
@@ -1329,35 +1321,16 @@ ORDER BY
 | ArrangeBy (#0)
 
 %3 =
-| Join %0 %1 %2 (= #8 #17) (= #0 #9)
-| | implementation = DeltaQuery %0 %1.(#1) %2.(#0) | %1 %0.(#0) %2.(#0) | %2 %1.(#0) %0.(#0)
-| | demand = (#0, #1, #8, #11, #12, #21)
-
-%4 =
-| Get %3
-
-%5 =
-| Get %3
-| Distinct group=(#8)
-| ArrangeBy (#0)
-
-%6 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#0)
 
-%7 =
-| Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
-| | demand = (#0, #5)
-| Reduce group=(#0, #0) sum(#5)
-| Filter (#2 > 30000dec)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%8 =
-| Join %4 %7 (= #8 #33)
-| | implementation = Differential %4 %7.(#0)
-| | demand = (#0, #1, #8, #11, #12, #21)
+%4 =
+| Join %0 %1 %2 %3 (= #8 #17 #33) (= #0 #9)
+| | implementation = DeltaQuery %0 %1.(#1) %2.(#0) %3.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %1.(#0) %0.(#0) %2.(#0)
+| | demand = (#0..#8, #10..#16, #18..#32, #37)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #0, #10, #11, #12, #13, #14, #15, #16, #8, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #8) sum(#37)
+| Filter (#34 > 30000dec)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32)
 | Reduce group=(#1, #0, #8, #12, #11) sum(#21)
 
 Finish order_by=(#4 desc, #3 asc) limit=none offset=0 project=(#0..#5)
@@ -1481,85 +1454,39 @@ ORDER BY
 ----
 %0 =
 | Get materialize.public.supplier (u8)
-| ArrangeBy (#3)
+| ArrangeBy (#0) (#3)
 
 %1 =
 | Get materialize.public.nation (u1)
 | ArrangeBy (#0)
 
 %2 =
-| Join %0 %1 (= #3 #7)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#3)
-| | demand = (#0..#2, #8)
-| Filter (#8 = "CANADA")
+| Get materialize.public.partsupp (u11)
+| ArrangeBy (#0) (#1)
 
 %3 =
-| Get %2
-| ArrangeBy ()
-
-%4 =
-| Get materialize.public.partsupp (u11)
-
-%5 =
-| Join %3 %4
-| | implementation = Differential %4 %3.()
-| | demand = (#0, #11..#13)
-
-%6 =
-| Get %5
-
-%7 =
-| Get %5
-| Distinct group=(#11)
-| ArrangeBy (#0)
-
-%8 =
 | Get materialize.public.part (u6)
 | ArrangeBy (#0)
 
-%9 =
-| Join %6 %7 %8 (= #11 #16 #17)
-| | implementation = Differential %6 %7.(#0) %8.(#0)
-| | demand = (#0, #11..#13, #18)
-| Filter "^forest.*$" ~(#18)
+%4 =
+| Join %0 %1 %2 %3 (= #3 #7) (= #11 #16) (= #0 #12)
+| | implementation = DeltaQuery %0 %1.(#0) %2.(#1) %3.(#0) | %1 %0.(#3) %2.(#1) %3.(#0) | %2 %0.(#0) %1.(#0) %3.(#0) | %3 %2.(#0) %0.(#0) %1.(#0)
+| | demand = (#0..#6, #8..#11, #13..#15, #17)
+| Filter "^forest.*$" ~(#17), (#8 = "CANADA")
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #3, "CANADA", #9, #10, #11, #0, #13, #14, #15)
 
-%10 =
-| Get %2
-
-%11 =
-| Get %9
-| Filter (#0 = #12)
-
-%12 =
-| Get %9
-| Distinct group=(#11, #12)
-| ArrangeBy (#0, #1)
-
-%13 =
+%5 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#1, #2)
 
-%14 =
-| Join %12 %13 (= #1 #4) (= #0 #3)
-| | implementation = DeltaQuery %12 %13.(#1, #2) | %13 %12.(#0, #1)
-| | demand = (#0, #1, #6, #12)
-| Filter (datetots(#12) < 1996-01-01 00:00:00), (#12 >= 1995-01-01)
-| Reduce group=(#0, #1) sum(#6)
-| Map (5dec * #2)
-| ArrangeBy (#0, #1)
-
-%15 =
-| Join %11 %14 (= #11 #26) (= #12 #27)
-| | implementation = Differential %11 %14.(#0, #1)
-| | demand = (#0, #13, #29)
-| Filter ((i32todec(#13) * 1000dec) > #29)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%16 =
-| Join %10 %15 (= #0 #11)
-| | implementation = Differential %10 %15.(#0)
-| | demand = (#1, #2)
+%6 =
+| Join %4 %5 (= #11 #17) (= #12 #18)
+| | implementation = Differential %4 %5.(#1, #2)
+| | demand = (#0..#7, #9..#15, #20, #26)
+| Filter (datetots(#26) < 1996-01-01 00:00:00), (#26 >= 1995-01-01)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7, "CANADA", #9, #10, #11, #12, #13, #14, #15) sum(#20)
+| Filter ((i32todec(#13) * 1000dec) > (5dec * #16))
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, "CANADA", #9, #10)
 | Project (#1, #2)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
@@ -1626,71 +1553,45 @@ ORDER BY
 | ArrangeBy (#0)
 
 %4 =
-| Join %0 %1 %2 %3 (= #7 #23) (= #3 #32) (= #0 #9)
-| | implementation = DeltaQuery %0 %3.(#0) %1.(#2) %2.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#2) %2.(#0)
-| | demand = (#0, #1, #7, #18, #19, #25, #33)
-| Filter (#25 = "F"), (#33 = "SAUDI ARABIA"), (#19 > #18)
+| Get materialize.public.lineitem (u21)
+| ArrangeBy (#0)
 
 %5 =
-| Get %4
+| Join %0 %1 %2 %3 %4 (= #7 #23 #36) (= #3 #32) (= #0 #9)
+| | implementation = DeltaQuery %0 %3.(#0) %1.(#2) %2.(#0) %4.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) %4.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) %4.(#0) | %3 %0.(#3) %1.(#2) %2.(#0) %4.(#0) | %4 %2.(#0) %1.(#0) %0.(#0) %3.(#0)
+| | demand = (#0..#8, #10..#22, #24..#31, #33..#35, #38)
+| Filter (#25 = "F"), (#33 = "SAUDI ARABIA"), (#38 != #0), (#19 > #18)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #0, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #7, #24, "F", #26, #27, #28, #29, #30, #31, #3, "SAUDI ARABIA", #34, #35)
 
 %6 =
-| Get %4
-| Distinct group=(#7, #0)
+| Get %5
 
 %7 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#0)
 
 %8 =
-| Join %6 %7 (= #0 #2)
+| Join %6 %7 (= #7 #36)
 | | implementation = Differential %6 %7.(#0)
-| | demand = (#0, #1, #4)
-| Filter (#4 != #1)
-| Distinct group=(#0, #1)
-| ArrangeBy (#0, #1)
-
-%9 =
-| Join %5 %8 (= #0 #37) (= #7 #36)
-| | implementation = Differential %5 %8.(#0, #1)
-| | demand = (#0, #1, #7)
-
-%10 =
-| Get %9
-| Distinct group=(#7, #0)
-
-%11 =
-| Get %9
-| ArrangeBy (#0, #7)
-
-%12 =
-| Get %10
-
-%13 =
-| Get materialize.public.lineitem (u21)
-| ArrangeBy (#0)
-
-%14 =
-| Join %12 %13 (= #0 #2)
-| | implementation = Differential %12 %13.(#0)
-| | demand = (#0, #1, #4, #13, #14)
-| Filter (#4 != #1), (#14 > #13)
-| Distinct group=(#0, #1)
+| | demand = (#0..#24, #26..#32, #34, #35, #38, #47, #48)
+| Filter (#38 != #9), (#48 > #47)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, "F", #26, #27, #28, #29, #30, #31, #32, "SAUDI ARABIA", #34, #35)
 | Negate
 
-%15 =
-| Get %10
+%9 =
+| Get %5
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, "F", #26, #27, #28, #29, #30, #31, #32, "SAUDI ARABIA", #34, #35)
 
-%16 =
-| Union %14 %15
+%10 =
+| Union %8 %9
 
-%17 =
-| Get %10
-| ArrangeBy (#0, #1)
+%11 =
+| Get %5
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35)
 
-%18 =
-| Join %11 %16 %17 (= #0 #39 #41) (= #7 #38 #40)
-| | implementation = Differential %16 %17.(#0, #1) %11.(#0, #7)
+%12 =
+| Join %10 %11 (= #0 #36) (= #1 #37) (= #2 #38) (= #3 #39) (= #4 #40) (= #5 #41) (= #6 #42) (= #7 #43) (= #8 #44) (= #9 #45) (= #10 #46) (= #11 #47) (= #12 #48) (= #13 #49) (= #14 #50) (= #15 #51) (= #16 #52) (= #17 #53) (= #18 #54) (= #19 #55) (= #20 #56) (= #21 #57) (= #22 #58) (= #23 #59) (= #24 #60) (= #25 #61) (= #26 #62) (= #27 #63) (= #28 #64) (= #29 #65) (= #30 #66) (= #31 #67) (= #32 #68) (= #33 #69) (= #34 #70) (= #35 #71)
+| | implementation = Differential %10 %11.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35)
 | | demand = (#1)
 | Reduce group=(#1) countall(true)
 
@@ -1754,47 +1655,77 @@ ORDER BY
 | Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17"))
 
 %1 =
-| Get materialize.public.customer (u15)
-| Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17")), (#5 > 0dec)
-| Reduce group=() sum(#5) countall(null)
-| Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
+| Get %0
 | ArrangeBy ()
 
 %2 =
-| Join %0 %1
-| | implementation = Differential %0 %1.()
-| | demand = (#0, #4, #5, #10)
-| Filter ((#5 * 1000000dec) > #10)
+| Get materialize.public.customer (u15)
+| Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17")), (#5 > 0dec)
 
 %3 =
-| Get %2
-| ArrangeBy (#0)
+| Join %1 %2
+| | implementation = Differential %2 %1.()
+| | demand = (#0..#7, #13)
+| Reduce group=(#0, #1, #2, #3, #4, #5, #6, #7) sum(#13) countall(null)
 
 %4 =
-| Get %2
-| ArrangeBy (#0)
+| Get %3
 
 %5 =
+| Get %3
+| Negate
+| Project (#0..#7)
+
+%6 =
+| Get %0
+
+%7 =
+| Union %5 %6
+
+%8 =
+| Get %0
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7)
+
+%9 =
+| Join %7 %8 (= #0 #8) (= #1 #9) (= #2 #10) (= #3 #11) (= #4 #12) (= #5 #13) (= #6 #14) (= #7 #15)
+| | implementation = Differential %7 %8.(#0, #1, #2, #3, #4, #5, #6, #7)
+| | demand = (#0..#7)
+| Map null, 0
+| Project (#0..#7, #16, #17)
+
+%10 =
+| Union %4 %9
+| Map (((#8 * 10000000dec) / i64todec(if (#9 = 0) then {null} else {#9})) / 10dec)
+| Filter ((#5 * 1000000dec) > #10)
+
+%11 =
+| Get %10
+
+%12 =
 | Get materialize.public.orders (u18)
 | ArrangeBy (#1)
 
-%6 =
-| Join %4 %5 (= #0 #12)
-| | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
-| | demand = (#0)
-| Distinct group=(#0)
+%13 =
+| Join %11 %12 (= #0 #12)
+| | implementation = Differential %11 %12.(#1)
+| | demand = (#0..#7)
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7)
 | Negate
 
-%7 =
-| Get %2
-| Project (#0)
+%14 =
+| Get %10
+| Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7)
 
-%8 =
-| Union %6 %7
+%15 =
+| Union %13 %14
+| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7)
 
-%9 =
-| Join %3 %8 (= #0 #11)
-| | implementation = Differential %8 %3.(#0)
+%16 =
+| Get %10
+
+%17 =
+| Join %15 %16 (= #0 #8) (= #1 #9) (= #2 #10) (= #3 #11) (= #4 #12) (= #5 #13) (= #6 #14) (= #7 #15)
+| | implementation = Differential %16 %15.(#0, #1, #2, #3, #4, #5, #6, #7)
 | | demand = (#4, #5)
 | Reduce group=(substr(#4, 1, 2)) countall(true) sum(#5)
 


### PR DESCRIPTION
Weirdly, removing it doesn't seem to cause correctness problems, and
maybe improves a lot of plans. (Plans get wider, but joins also vanish.)
This is a combination of #2944 plus some new stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3729)
<!-- Reviewable:end -->
