### PR TITLE
Decorrelate conditional subqueries carefully

### DIFF
--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -472,7 +472,7 @@ impl ScalarExpr {
                             .project((0..inner_arity).chain(Some(then_arity)).collect());
 
                         // Restrict to records not satisfying `cond_expr` and apply `els` as a map.
-                        let mut else_inner = get_inner.clone().filter(vec![SS::CallBinary {
+                        let mut else_inner = get_inner.filter(vec![SS::CallBinary {
                             func: expr::BinaryFunc::Or,
                             expr1: Box::new(SS::CallBinary {
                                 func: expr::BinaryFunc::Eq,

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -417,14 +417,87 @@ impl ScalarExpr {
                     .collect::<Vec<_>>(),
             },
             If { cond, then, els } => {
-                // TODO(jamii) would be nice to only run subqueries in `then` when `cond` is true
-                // (if subqueries later gain the ability to throw errors, this impacts correctness too)
-                // NOTE: This also affects performance *now* if either branch is expensive to produce
-                // and/or maintain but is not the returned result.
-                SS::If {
-                    cond: Box::new(cond.applied_to(id_gen, col_map, inner)),
-                    then: Box::new(then.applied_to(id_gen, col_map, inner)),
-                    els: Box::new(els.applied_to(id_gen, col_map, inner)),
+                // If is complicated by the fact that we do not want to determine
+                // the `then` or `else` branch for tuples that do not do not pass
+                // the `cond` test. Our strategy is to first determine cond, and
+                // then
+                let inner_arity = inner.arity();
+                let cond_expr = cond.applied_to(id_gen, col_map, inner);
+
+                // At this point, we may want to let-bind `inner` and filter each
+                // way before applying further decorrelation. Informally, we turn
+                // the `if` statement in to
+                //
+                //   let then_case = inner.filter(cond).map(then);
+                //   let else_case = inner.filter(!cond).map(else);
+                //   return then_case.concat(else_case);
+                //
+                // We only require this if either expression would result in any
+                // computation beyond the expr itself, which we will interpret as
+                // "introduces additional columns". In the absence of correlation,
+                // we should just retain a `ScalarExpr::If` expression; the inverse
+                // transformation as above is complicated to recover, and we would
+                // benefit from not introducing the complexity.
+
+                // Defensive copies, in case we mangle these in decorrelation.
+                let inner_clone = inner.clone();
+                let then_clone = then.clone();
+                let else_clone = els.clone();
+
+                let cond_arity = inner.arity();
+                let then_expr = then.applied_to(id_gen, col_map, inner);
+                let else_expr = els.applied_to(id_gen, col_map, inner);
+
+                if cond_arity == inner.arity() {
+                    // If no additional columns were added, we simply return the
+                    // `If` variant with the updated expressions.
+                    SS::If {
+                        cond: Box::new(cond_expr),
+                        then: Box::new(then_expr),
+                        els: Box::new(else_expr),
+                    }
+                } else {
+                    // If columns were added, we need a more careful approch, as
+                    // described above. First, we need to de-correlate each of
+                    // the two expressions independently, and apply their cases
+                    // as `RelationExpr::Map` operations.
+
+                    *inner = inner_clone.let_in(id_gen, |id_gen, get_inner| {
+                        // Restrict to records satisfying `cond_expr` and apply `then` as a map.
+                        let mut then_inner = get_inner.clone().filter(vec![cond_expr.clone()]);
+                        let then_expr = then_clone.applied_to(id_gen, col_map, &mut then_inner);
+                        let then_arity = then_inner.arity();
+                        then_inner = then_inner
+                            .map(vec![then_expr])
+                            .project((0..inner_arity).chain(Some(then_arity)).collect());
+
+                        // Restrict to records not satisfying `cond_expr` and apply `els` as a map.
+                        let mut else_inner = get_inner.clone().filter(vec![SS::CallBinary {
+                            func: expr::BinaryFunc::Or,
+                            expr1: Box::new(SS::CallBinary {
+                                func: expr::BinaryFunc::Eq,
+                                expr1: Box::new(cond_expr.clone()),
+                                expr2: Box::new(SS::literal_ok(
+                                    Datum::False,
+                                    ColumnType::new(ScalarType::Bool, false),
+                                )),
+                            }),
+                            expr2: Box::new(SS::CallUnary {
+                                func: expr::UnaryFunc::IsNull,
+                                expr: Box::new(cond_expr.clone()),
+                            }),
+                        }]);
+                        let else_expr = else_clone.applied_to(id_gen, col_map, &mut else_inner);
+                        let else_arity = else_inner.arity();
+                        else_inner = else_inner
+                            .map(vec![else_expr])
+                            .project((0..inner_arity).chain(Some(else_arity)).collect());
+
+                        // concatenate the two results.
+                        then_inner.union(else_inner)
+                    });
+
+                    SS::Column(inner_arity)
                 }
             }
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -673,3 +673,17 @@ select x, (select count(*) from ys where y < x) from xs
 1  1
 1  1
 2  2
+
+# Tests that conditional subqueries should not error.
+query II rowsort
+select y, (
+    case when (select count(*) from xs where x < y) != 0
+         then (select 1.0 / count(*) from xs where x < y)
+         else (select 1.0 / (count(*) - 1) from xs where x < y)
+         end
+  )
+from ys
+----
+0  -1
+1  -1
+2  1


### PR DESCRIPTION
This PR makes decorrelation more robust for subqueries in conditional logic (the `then` and `else` cases for `ScalarExpr::If`). The idea is that if no subqueries exist in either case, we use the standard approach (decorrelate each expression, return the `If`), but if subqueries exist in either `then` or `else`, we independently decorrelate each case having first filtered by `cond` appropriately. For each filtered and decorrelated relation, we apply the logic as a `map` and change the expression to look at the last column.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3736)
<!-- Reviewable:end -->

