### PR TITLE
sql: add basic list built-in functions

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -167,10 +167,10 @@ If you want to use experimental mode, you should **really** read the section bel
 
 {{< /warning >}}
 
-Materialize offers access to experimental features through the
-`--experimental` flag. However, as experimental features shift, there is no
-guarantee that future versions of Materialize will be interoperable with the
-experimental features.
+Materialize offers access to experimental features through the `--experimental`
+flag. Unlike most features in Materialize, experimental features' syntax and/or
+semantics can shift at any time, and **there is no guarantee that future
+versions of Materialize will be interoperable with the experimental features**.
 
 Using experimental mode means that **you are likely to lose access to all of
 your sources and views within Materialize** and will have to recreate them and

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -549,6 +549,10 @@ pub enum EvalError {
     IntegerOutOfRange,
     IntervalOutOfRange,
     TimestampOutOfRange,
+    InvalidDimension {
+        max_dim: usize,
+        val: i64,
+    },
     InvalidEncodingName(String),
     InvalidByteSequence {
         byte_sequence: String,
@@ -569,6 +573,11 @@ impl std::fmt::Display for EvalError {
             EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
             EvalError::IntervalOutOfRange => f.write_str("interval out of range"),
             EvalError::TimestampOutOfRange => f.write_str("timestamp out of range"),
+            EvalError::InvalidDimension { max_dim, val } => write!(
+                f,
+                "invalid dimension: {}; must use value within [1, {}]",
+                val, max_dim
+            ),
             EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
             EvalError::InvalidByteSequence {
                 byte_sequence,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -661,8 +661,9 @@ impl<'a> ScalarType {
     /// equality.
     pub fn desaturate(&self) -> ScalarType {
         match self {
-            ScalarType::Record { .. } => ScalarType::Record { fields: vec![] },
             ScalarType::Decimal(..) => ScalarType::Decimal(0, 0),
+            ScalarType::List(..) => ScalarType::List(Box::new(ScalarType::String)),
+            ScalarType::Record { .. } => ScalarType::Record { fields: vec![] },
             _ => self.clone(),
         }
     }

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -476,13 +476,13 @@ SELECT (LIST[NULL, [NULL]]::INT LIST LIST)[:, 1:1];
 ----
 {NULL,{NULL}}
 
-# Results can intermix values and empty-results-as-NULLs
+# Results can mix values and empty-results-as-NULLs
 query T
 SELECT (LIST [[1, NULL, 3], NULL, [4, 5, 6]]::INT LIST LIST)[2:3, 2:2];
 ----
 {NULL,{5}}
 
-# Results can intermix NULL values and empty-results-as-NULLs
+# Results can mix NULL values and empty-results-as-NULLs
 query T
 SELECT (LIST [[1, NULL, 3], NULL, [4, NULL, 6]]::INT LIST LIST)[2:3, 2:2];
 ----
@@ -529,7 +529,7 @@ SELECT (LIST[]::INT LIST LIST)[1:1, 1:1]
 ----
 NULL
 
-# 🔬 Other subcript values
+# 🔬 Other subscript values
 
 # 🔬🔬 end > start
 query T
@@ -654,3 +654,273 @@ SELECT LIST [[1, 2, 3], [4, 5]][1:DATE '2001-01-01']
 
 query error subscript \(slicing\) does not support casting from timestamp to i64
 SELECT LIST [[1, 2, 3], [4, 5]][1:TIMESTAMP '2001-01-01']
+
+# 🔬 Built-in functions
+
+# 🔬🔬 list_ndims
+query R
+SELECT list_ndims(LIST [1, 2, 3])
+----
+1
+
+query R
+SELECT list_ndims(LIST []::INT LIST)
+----
+1
+
+query R
+SELECT list_ndims(LIST[[1],[1]])
+----
+2
+
+query R
+SELECT list_ndims(LIST [[[1], [1]], [[1]]])
+----
+3
+
+# 🔬🔬🔬 slices
+
+query R
+SELECT list_ndims(LIST[[1],[1]][1:1])
+----
+2
+
+query R
+SELECT list_ndims(LIST [[[1], [1]], [[1]]][1:2])
+----
+3
+
+# 🔬🔬🔬 interior lists
+query R
+SELECT list_ndims(LIST[[1],[1]][1])
+----
+1
+
+query R
+SELECT list_ndims(LIST [[[1], [1]], [[1]]][1])
+----
+2
+
+query R
+SELECT list_ndims(LIST [[[1], [1]], [[1]]][1][1])
+----
+1
+
+# 🔬🔬🔬 NULL elements
+
+query R
+SELECT list_ndims(LIST[NULL]::INT LIST)
+----
+1
+
+query R
+SELECT list_ndims(LIST[NULL]::INT LIST LIST)
+----
+2
+
+query R
+SELECT list_ndims(LIST[[1], NULL]::INT LIST LIST)
+----
+2
+
+query R
+SELECT list_ndims((LIST[[1],NULL]::INT LIST LIST)[2])
+----
+1
+
+# 🔬🔬 list_length
+
+query R
+SELECT list_length(LIST [1])
+----
+1
+
+query R
+SELECT list_length(LIST [1, 1])
+----
+2
+
+query R
+SELECT list_length(LIST[[1],[1]])
+----
+2
+
+query R
+SELECT list_length(LIST [[[1], [1]], [[1]]])
+----
+2
+
+query R
+SELECT list_length(LIST []::INT LIST)
+----
+0
+
+# 🔬🔬🔬 slices
+
+query R
+SELECT list_length(LIST[[1],[1]][1:1])
+----
+1
+
+query R
+SELECT list_length(LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1:2])
+----
+2
+
+# 🔬🔬🔬 indexing operations
+query R
+SELECT list_length(LIST [[[1], [1]], [[1]]][1])
+----
+2
+
+query R
+SELECT list_length(LIST [[[1], [1]], [[1]]][1][1])
+----
+1
+
+# 🔬🔬🔬 NULL elements
+
+query R
+SELECT list_length(LIST[1, NULL]::INT LIST)
+----
+2
+
+query R
+SELECT list_length(LIST[[1],NULL]::INT LIST LIST)
+----
+2
+
+query R
+SELECT list_length((LIST[[1],NULL]::INT LIST LIST)[2])
+----
+NULL
+
+# 🔬🔬 list_length_max
+query R
+SELECT list_length_max(LIST [1, 2, 3], 1)
+----
+3
+
+query R
+SELECT list_length_max(LIST [1, 2, 3, 4], 1)
+----
+4
+
+query R
+SELECT list_length_max(LIST[[1],[2,3]], 2)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]], 2)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]], 3)
+----
+3
+
+query R
+SELECT list_length_max(LIST []::INT LIST, 1)
+----
+0
+
+query R
+SELECT list_length_max(LIST [[]]::INT LIST LIST, 2)
+----
+0
+
+# 🔬🔬🔬 slices
+
+query R
+SELECT list_length_max(LIST[[1], [2]][1:1], 1)
+----
+1
+
+query R
+SELECT list_length_max(LIST[[1], [2, 3]][2:2], 2)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]][1:2], 1)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]][1:1], 2)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]][1:1], 3)
+----
+3
+
+# 🔬🔬🔬 indexing operations
+query R
+SELECT list_length_max(LIST[[1], [2, 3]][2], 1)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]][1], 1)
+----
+2
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]][1], 2)
+----
+3
+
+query R
+SELECT list_length_max(LIST [[[1, 2, 3], [4]], [[5]]][1][2], 1)
+----
+1
+
+# 🔬🔬🔬 NULL elements
+
+query R
+SELECT list_length_max(NULL::INT LIST, 1);
+----
+NULL
+
+query R
+SELECT list_length_max(LIST[1, NULL, 3]::INT LIST, 1)
+----
+3
+
+query R
+SELECT list_length_max(LIST[[1],NULL]::INT LIST LIST, 1)
+----
+2
+
+query R
+SELECT list_length_max((LIST[[1],NULL]::INT LIST LIST), 2)
+----
+1
+
+query T
+SELECT list_length_max((LIST[NULL]::INT LIST LIST), 2)
+----
+NULL
+
+# 🔬🔬🔬 errors
+query error invalid dimension: 2; must use value within \[1, 1\]
+SELECT list_length_max((LIST[1]::INT LIST), 2)
+
+query error invalid dimension: 2; must use value within \[1, 1\]
+SELECT list_length_max((LIST[NULL]::INT LIST), 2)
+
+query error invalid dimension: 3; must use value within \[1, 2\]
+SELECT list_length_max((LIST[NULL]::INT LIST LIST), 3)
+
+query error invalid dimension: 0; must use value within \[1, 1\]
+SELECT list_length_max((LIST[1]::INT LIST), 0)
+
+query error invalid dimension: -1; must use value within \[1, 1\]
+SELECT list_length_max((LIST[1]::INT LIST), -1)
+
+query error invalid dimension: -1; must use value within \[1, 1\]
+SELECT list_length_max((LIST[1]::INT LIST), LIST[-1][1])


### PR DESCRIPTION
Adds:

* `list_ndims(list)` to get the number of dimensions in a list
* `list_length(list)` to get the length of a list, without the ability to descend into its inner lists
* `list_length_max(list, dim)` to mirror PG's `array_length(array, dim)`, but instead of "getting the length" on a given dimension (which can differ between interior lists), it gets the maximum length among all lists in that dimension. This is less meaningful function that it is in Postgres, but I figure it provides a maybe-useful analogue and a sense of familiarity with the API.

Once I get this merged, I'll add docs for the `list` type.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3757)
<!-- Reviewable:end -->

