### PR TITLE
Rework topk to do less work

### DIFF
--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -62,62 +62,62 @@ where
                 collection
                     .map(move |((key, hash), row)| ((key, hash % modulus), row))
                     .reduce_named("TopK", {
-                        move |_key, source, target| {
-                            target.extend(source.iter().map(|&(row, diff)| (row.clone(), diff)));
+                        move |_key, source, target: &mut Vec<(Row, isize)>| {
+                            // Determine if we must actually shrink the result set.
                             let must_shrink = offset > 0
                                 || limit
                                     .map(|l| {
-                                        target.iter().map(|(_, d)| *d).sum::<isize>() as usize > l
+                                        source.iter().map(|(_, d)| *d).sum::<isize>() as usize > l
                                     })
                                     .unwrap_or(false);
                             if must_shrink {
+                                // local copies that may count down to zero.
+                                let mut offset = offset;
+                                let mut limit = limit;
+
                                 if !order_clone.is_empty() {
+                                    // We decode the datums once, into a common buffer for efficiency.
+                                    // Each row should contain an identical number of columns; we should check that.
+                                    // The alternative is `Vec<Vec<Datum>>`, which involves substantially more allocations.
+                                    let mut buffer = Vec::new();
+                                    for row in source.iter() {
+                                        buffer.extend(row.0.iter());
+                                    }
+                                    let width = buffer.len() / source.len();
+                                    let mut indexes = (0..source.len()).collect::<Vec<_>>();
+
                                     //todo: use arrangements or otherwise make the sort more performant?
-                                    let sort_by = |left: &(Row, isize), right: &(Row, isize)| {
-                                        expr::compare_columns(
-                                            &order_clone,
-                                            &left.0.unpack(),
-                                            &right.0.unpack(),
-                                            || left.cmp(right),
-                                        )
-                                    };
-                                    target.sort_by(sort_by);
-                                }
+                                    indexes.sort_by(|left, right| {
+                                        let left = &buffer[left * width..width];
+                                        let right = &buffer[right * width..width];
+                                        expr::compare_columns(&order_clone, left, right, || {
+                                            left.cmp(right)
+                                        })
+                                    });
 
-                                let mut skipped = 0; // Number of records offset so far
-                                let mut output = 0; // Number of produced output records.
-                                let mut cursor = 0; // Position of current input record.
-
-                                //skip forward until an offset number of records is reached
-                                while cursor < target.len() {
-                                    if skipped + (target[cursor].1 as usize) > offset {
-                                        break;
-                                    }
-                                    skipped += target[cursor].1 as usize;
-                                    cursor += 1;
-                                }
-                                let skip_cursor = cursor;
-                                if cursor < target.len() {
-                                    if skipped < offset {
-                                        //if offset only skips some members of a group of identical
-                                        //records, return the rest
-                                        target[skip_cursor].1 -= (offset - skipped) as isize;
-                                    }
-                                    //apply limit
-                                    if let Some(limit) = limit {
-                                        while output < limit && cursor < target.len() {
-                                            let to_emit = std::cmp::min(
-                                                limit - output,
-                                                target[cursor].1 as usize,
-                                            );
-                                            target[cursor].1 = to_emit as isize;
-                                            output += to_emit;
-                                            cursor += 1;
+                                    // We now need to lay out the data in order of `buffer`, but respecting
+                                    // the `offset` and `limit` constraints.
+                                    for index in indexes.into_iter() {
+                                        let (row, mut diff) = source[index];
+                                        if diff > 0 {
+                                            // If we are still skipping early records ...
+                                            if offset > 0 {
+                                                let to_skip = std::cmp::min(offset, diff as usize);
+                                                offset -= to_skip;
+                                                diff -= to_skip as isize;
+                                            }
+                                            // We should produce at most `limit` records.
+                                            if let Some(limit) = &mut limit {
+                                                diff = std::cmp::min(diff, *limit as isize);
+                                                *limit -= diff as usize;
+                                            }
+                                            // Output the indicated number of rows.
+                                            if diff > 0 {
+                                                target.push((row.clone(), diff));
+                                            }
                                         }
-                                        target.truncate(cursor);
                                     }
                                 }
-                                target.drain(..skip_cursor);
                             }
                         }
                     })

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -85,7 +85,7 @@ where
                                     let mut buffer = Vec::with_capacity(arity * source.len());
                                     for (index, row) in source.iter().enumerate() {
                                         buffer.extend(row.0.iter());
-                                        assert_eq!(buffer.len(), arity * index);
+                                        assert_eq!(buffer.len(), arity * (index + 1));
                                     }
                                     let width = buffer.len() / source.len();
 

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -118,6 +118,10 @@ where
                                         }
                                     }
                                 }
+                            } else {
+                                for (row, diff) in source.iter() {
+                                    target.push(((*row).clone(), diff.clone()));
+                                }
                             }
                         }
                     })


### PR DESCRIPTION
This is a WIP PR that tries out a different approach to TopK computation that can do substantially fewer allocations, and `Row::unpack` calls.

cc: @umanwizard @benesch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3758)
<!-- Reviewable:end -->
