### PR TITLE
comm: disable maximum frame length

### DIFF
--- a/src/comm/src/protocol.rs
+++ b/src/comm/src/protocol.rs
@@ -166,7 +166,7 @@ where
     C: Connection,
 {
     let mut codec = LengthDelimitedCodec::new();
-    codec.set_max_frame_length(1 << 30 /* 1GiB */);
+    codec.set_max_frame_length(usize::MAX);
     Framed::new(conn, codec)
 }
 


### PR DESCRIPTION
comm channels are trusted, so we don't actually want a maximum frame
length at all. (Whatever we pick is destined to be too small; someone
somewhere has a machine where shipping around N gigabytes is reasonable,
for all values of N.) Just disable the frame length check entirely. If
we can allocate it, it's ok.

This isn't to say that we shouldn't be more helpful in preventing folks
from OOMing their Materialize instance, but enforcing limits at the comm
layer is pretty unhelpful, because the limits are not tied to anything
the user understands. Better to enforce limits on e.g. the maximum
number of rows, or the maximum pgwire result set size, rather than
"result sets must not exceed 1GB when encoded using Materialize's
internal bincode representation." Fixing that in a principled way is
punted to another commit.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3768)
<!-- Reviewable:end -->


