### PR TITLE
Coordinating real-time timestamps across workers

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -420,6 +420,12 @@ impl ConsistencyInfo {
             }
         }
         assert!(new_ts > self.last_closed_ts);
+        // Round new_ts to the next greatest self.downgrade_capability_frequency increment.
+        // This is to guarantee that different workers downgrade (without coordination) to the
+        // "same" next time
+        new_ts = new_ts
+            + (self.downgrade_capability_frequency
+                - (new_ts % self.downgrade_capability_frequency));
         self.last_closed_ts = new_ts;
         Some(self.last_closed_ts)
     }


### PR DESCRIPTION
This PR forces workers to pick real-time timestamps that are identical across workers. This minimises the amount of recomputation work that has to be done every time a capability is downgraded. 

This is achieved by "rounding" the chosen timestamp modulo "timestamp_frequency".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3782)
<!-- Reviewable:end -->
