### PR TITLE
sql: unblock many remaining postgres lateral join tests

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -37,6 +37,7 @@ sqllogictest \
 sqllogictest \
     -v \
     test/sqllogictest/*.slt \
-    test/sqllogictest/transform/*.slt \
+    test/sqllogictest/postgres/*.slt \
     test/sqllogictest/sqlite/test \
+    test/sqllogictest/transform/*.slt \
     | tee -a target/slt.log

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -155,6 +155,7 @@ tests=(
     test/sqllogictest/cockroach/window.slt
     test/sqllogictest/cockroach/with.slt
     # test/sqllogictest/cockroach/zero.slt
+    test/sqllogictest/postgres/join-lateral.slt
 )
 
 if [[ "${BUILDKITE-}" ]]; then

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -317,7 +317,10 @@ pub enum TableFactor {
     /// `(foo <JOIN> bar [ <JOIN> baz ... ])`.
     /// The inner `TableWithJoins` can have no joins only if its
     /// `relation` is itself a `TableFactor::NestedJoin`.
-    NestedJoin(Box<TableWithJoins>),
+    NestedJoin {
+        join: Box<TableWithJoins>,
+        alias: Option<TableAlias>,
+    },
 }
 
 impl AstDisplay for TableFactor {
@@ -356,10 +359,14 @@ impl AstDisplay for TableFactor {
                     f.write_node(alias);
                 }
             }
-            TableFactor::NestedJoin(table_reference) => {
+            TableFactor::NestedJoin { join, alias } => {
                 f.write_str("(");
-                f.write_node(table_reference);
+                f.write_node(join);
                 f.write_str(")");
+                if let Some(alias) = alias {
+                    f.write_str(" AS ");
+                    f.write_node(alias);
+                }
             }
         }
     }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -38,8 +38,8 @@ pub enum Statement {
         table_name: ObjectName,
         /// COLUMNS
         columns: Vec<Ident>,
-        /// A SQL query that specifies what to insert
-        source: Box<Query>,
+        /// A SQL query that specifies what to insert.
+        source: InsertSource,
     },
     Copy {
         /// TABLE
@@ -274,7 +274,7 @@ impl AstDisplay for Statement {
                     f.write_str(")");
                 }
                 f.write_str(" ");
-                f.write_node(&source);
+                f.write_node(source);
             }
             Statement::Copy {
                 table_name,
@@ -740,6 +740,22 @@ impl AstDisplay for Statement {
     }
 }
 impl_display!(Statement);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum InsertSource {
+    Query(Box<Query>),
+    DefaultValues,
+}
+
+impl AstDisplay for InsertSource {
+    fn fmt(&self, f: &mut AstFormatter) {
+        match self {
+            InsertSource::Query(query) => f.write_node(query),
+            InsertSource::DefaultValues => f.write_str("DEFAULT VALUES"),
+        }
+    }
+}
+impl_display!(InsertSource);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub enum ObjectType {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2793,7 +2793,10 @@ impl Parser {
                 }
             }
             self.expect_token(&Token::RParen)?;
-            Ok(TableFactor::NestedJoin(Box::new(table_and_joins)))
+            Ok(TableFactor::NestedJoin {
+                join: Box::new(table_and_joins),
+                alias: self.parse_optional_table_alias(keywords::RESERVED_FOR_TABLE_ALIAS)?,
+            })
         } else {
             let name = self.parse_object_name()?;
             if self.consume_token(&Token::LParen) {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2854,7 +2854,11 @@ impl Parser {
         self.expect_keyword("INTO")?;
         let table_name = self.parse_object_name()?;
         let columns = self.parse_parenthesized_column_list(Optional)?;
-        let source = Box::new(self.parse_query()?);
+        let source = if self.parse_keywords(vec!["DEFAULT", "VALUES"]) {
+            InsertSource::DefaultValues
+        } else {
+            InsertSource::Query(Box::new(self.parse_query()?))
+        };
         Ok(Statement::Insert {
             table_name,
             columns,

--- a/src/sql-parser/tests/testdata/insert
+++ b/src/sql-parser/tests/testdata/insert
@@ -23,39 +23,55 @@ INSERT INTO customer VALUES (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None } }
+Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
 
 parse-statement
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None } }
+Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
 
 parse-statement
 INSERT INTO public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [], source: Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None } }
+Insert { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
 
 parse-statement
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("db"), Ident("public"), Ident("customer")]), columns: [], source: Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None } }
+Insert { table_name: ObjectName([Ident("db"), Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
 
 parse-statement
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None } }
+Insert { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
 
 parse-statement
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 ----
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query { ctes: [Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: SetOperation { op: Union, all: false, left: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None, fetch: None } }
+Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: SetOperation { op: Union, all: false, left: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None, fetch: None }) }
+
+parse-statement
+INSERT INTO customer DEFAULT VALUES
+----
+INSERT INTO customer DEFAULT VALUES
+=>
+Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: DefaultValues }
+
+parse-statement
+INSERT INTO customer DEFAULT VALUES, DEFAULT VALUES
+----
+error:
+Parse error:
+INSERT INTO customer DEFAULT VALUES, DEFAULT VALUES
+                                   ^
+Expected end of statement, found: ,

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -511,28 +511,35 @@ SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) 
 ----
 SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) NATURAL JOIN (f NATURAL JOIN (g NATURAL JOIN h))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("c")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }, Join { relation: Table { name: ObjectName([Ident("e")]), alias: None }, join_operator: Inner(Natural) }] }), join_operator: Inner(Natural) }] }), join_operator: Inner(Natural) }, Join { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("f")]), alias: None }, joins: [Join { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("g")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("h")]), alias: None }, join_operator: Inner(Natural) }] }), join_operator: Inner(Natural) }] }), join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("c")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }, Join { relation: Table { name: ObjectName([Ident("e")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }, Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("f")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("g")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("h")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN c
 ----
 SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN c
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }), joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+
+parse-statement
+SELECT * FROM (a NATURAL JOIN b) c NATURAL JOIN d
+----
+SELECT * FROM (a NATURAL JOIN b) AS c NATURAL JOIN d
+=>
+Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: Some(TableAlias { name: Ident("c"), columns: [], strict: false }) }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
 
 parse-statement
 SELECT * FROM (((a NATURAL JOIN b)))
 ----
 SELECT * FROM (((a NATURAL JOIN b)))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin(TableWithJoins { relation: NestedJoin(TableWithJoins { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }), joins: [] }), joins: [] }), joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
 
 parse-statement
 SELECT * FROM a NATURAL JOIN (((b NATURAL JOIN c)))
 ----
 SELECT * FROM a NATURAL JOIN (((b NATURAL JOIN c)))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin(TableWithJoins { relation: NestedJoin(TableWithJoins { relation: NestedJoin(TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }), joins: [] }), joins: [] }), join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN (b))

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1784,24 +1784,22 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<ScalarExpr, Pla
     // ask what table it came from. Stupid, but it works.
     let (exprs, field_names): (Vec<_>, Vec<_>) = ecx
         .scope
-        .items
+        .all_items()
         .iter()
-        .enumerate()
-        .filter(|(_i, item)| {
+        .filter(|(_level, _column, item)| {
             item.is_from_table(&PartialName {
                 database: None,
                 schema: None,
                 item: col_name.as_str().to_owned(),
             })
         })
-        .enumerate()
-        .map(|(i, (column, item))| {
-            let expr = ScalarExpr::Column(ColumnRef { level: 0, column });
+        .map(|(level, column, item)| {
+            let expr = ScalarExpr::Column(ColumnRef { level: *level, column: *column });
             let name = item
                 .names
                 .first()
                 .and_then(|n| n.column_name.clone())
-                .unwrap_or_else(|| ColumnName::from(format!("f{}", i + 1)));
+                .unwrap_or_else(|| ColumnName::from(format!("f{}", column + 1)));
             (expr, name)
         })
         .unzip();

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -169,7 +169,7 @@ impl Scope {
         self.items.len()
     }
 
-    fn all_items(&self) -> Vec<(usize, usize, &ScopeItem)> {
+    pub fn all_items(&self) -> Vec<(usize, usize, &ScopeItem)> {
         // These are in order of preference eg
         // given scopes A(B(C))
         // items from C should be preferred to items from B to items from A

--- a/test/sqllogictest/postgres/join-lateral.slt
+++ b/test/sqllogictest/postgres/join-lateral.slt
@@ -636,5 +636,13 @@ select f1,g from int4_tbl a full join lateral generate_series(0, a.f1) g on true
 #    int8_tbl x cross join (int4_tbl x cross join lateral (select x.f1) ss);
 
 # LATERAL can be used to put an aggregate into the FROM clause of its query
-# query error aggregate functions are not allowed in FROM clause of their own query level
-# select 1 from tenk1 a, lateral (select max(a.unique1) from int4_tbl b) ss;
+#
+# TODO(benesch): when we support aggregates that refer exclusively to outer
+# columns, this case should still be disallowed, but with the following error
+# message instead:
+#
+#     aggregate functions are not allowed in FROM clause of their own query level
+#
+# See: https://www.postgresql.org/message-id/1375925710.17807.13.camel%40vanquo.pezone.net
+query error aggregate functions that refer exclusively to outer columns not yet supported
+select 1 from tenk1 a, lateral (select max(a.unique1) from int4_tbl b) ss;

--- a/test/sqllogictest/postgres/join-lateral.slt
+++ b/test/sqllogictest/postgres/join-lateral.slt
@@ -489,18 +489,16 @@ f1  f1
 2147483647  NULL
 -2147483647  NULL
 
-# TODO(benesch): correlated table reference.
-#
-# query II colnames,rowsort
-# select * from int4_tbl i left join
-#   lateral (select coalesce(i) from int2_tbl j where i.f1 = j.f1) k on true;
-# ----
-# f1  coalesce
-# 0  (0)
-# 123456  NULL
-# -123456  NULL
-# 2147483647  NULL
-# -2147483647  NULL
+query IT colnames,rowsort
+select * from int4_tbl left join
+  lateral (select coalesce(int4_tbl) from int2_tbl j where int4_tbl.f1 = j.f1) k on true;
+----
+f1  coalesce
+0  (0)
+123456  NULL
+-123456  NULL
+2147483647  NULL
+-2147483647  NULL
 
 query IIII colnames,rowsort
 select * from int4_tbl a,

--- a/test/sqllogictest/postgres/join-lateral.slt
+++ b/test/sqllogictest/postgres/join-lateral.slt
@@ -239,14 +239,12 @@ x f1 y
  2147483647  2147483647  2147483647
 -2147483647 -2147483647 -2147483647
 
-# TODO(benesch): parse failure.
-#
-# query III colnames
-# select * from ((select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1) j,
-#   lateral (select x) ss2(y);
-# ----
-# x f1 y
-# 0 0 0
+query III colnames
+select * from ((select f1/2 as x from int4_tbl) ss1 join int4_tbl i4 on x = f1) j,
+  lateral (select x) ss2(y);
+----
+x f1 y
+0 0 0
 
 # lateral references requiring pullup
 query II rowsort

--- a/test/sqllogictest/postgres/join-lateral.slt
+++ b/test/sqllogictest/postgres/join-lateral.slt
@@ -68,11 +68,11 @@ INSERT INTO tenk1 VALUES
 # absolutely fall over since the plans for a lot of these lateral joins are
 # absolutely horrible.
 
-# statement ok
-# CREATE TABLE onerow ()
+statement ok
+CREATE TABLE onerow ()
 
-# statement ok
-# INSERT INTO onerow DEFAULT VALUES
+statement ok
+INSERT INTO onerow DEFAULT VALUES
 
 query II colnames
 select unique2, x.*
@@ -411,35 +411,33 @@ vx  vy
 4567890123456789  4567890123456789
 4567890123456789  -4567890123456789
 
-# TODO(benesch): cannot construct onerow table.
-#
-# query II
-# select v.* from
-#   (int8_tbl x left join (select q1,(select coalesce(q2,0)) q2 from int8_tbl) y on x.q2 = y.q1)
-#   left join int4_tbl z on z.f1 = x.q2,
-#   lateral (select x.q1,y.q1 from onerow union all select x.q2,y.q2 from onerow) v(vx,vy);
-# ----
-# vx  vy
-# 4567890123456789  123
-# 123  456
-# 4567890123456789  123
-# 123  4567890123456789
-# 4567890123456789  4567890123456789
-# 4567890123456789  123
-# 123  4567890123456789
-# 4567890123456789  123
-# 4567890123456789  4567890123456789
-# 4567890123456789  4567890123456789
-# 123  4567890123456789
-# 4567890123456789  4567890123456789
-# 4567890123456789  4567890123456789
-# 4567890123456789  -4567890123456789
-# 123  4567890123456789
-# 4567890123456789  -4567890123456789
-# 123  NULL
-# 456  NULL
-# 4567890123456789  NULL
-# -4567890123456789  NULL
+query II colnames,rowsort
+select v.* from
+  (int8_tbl x left join (select q1,(select coalesce(q2,0)) q2 from int8_tbl) y on x.q2 = y.q1)
+  left join int4_tbl z on z.f1 = x.q2,
+  lateral (select x.q1,y.q1 from onerow union all select x.q2,y.q2 from onerow) v(vx,vy);
+----
+vx  vy
+4567890123456789  123
+123  456
+4567890123456789  123
+123  4567890123456789
+4567890123456789  4567890123456789
+4567890123456789  123
+123  4567890123456789
+4567890123456789  123
+4567890123456789  4567890123456789
+4567890123456789  4567890123456789
+123  4567890123456789
+4567890123456789  4567890123456789
+4567890123456789  4567890123456789
+4567890123456789  -4567890123456789
+123  4567890123456789
+4567890123456789  -4567890123456789
+123  NULL
+456  NULL
+4567890123456789  NULL
+-4567890123456789  NULL
 
 query IIIII rowsort
 select * from

--- a/test/sqllogictest/postgres/join-lateral.slt
+++ b/test/sqllogictest/postgres/join-lateral.slt
@@ -101,22 +101,20 @@ NULL 2147483647
 
 # check scoping of lateral versus parent references
 # the first of these should return int8_tbl.q2, the second int8_tbl.q1
-# TODO(benesch): col name should be "r", not "?column?"
 query III colnames,rowsort
 select *, (select r from (select q1 as q2) x, (select q2 as r) y) from int8_tbl
 ----
-q1  q2  ?column?
+q1  q2  r
 123  456  456
 123  4567890123456789  4567890123456789
 4567890123456789  123  123
 4567890123456789  4567890123456789  4567890123456789
 4567890123456789  -4567890123456789  -4567890123456789
 
-# TODO(benesch): col name should be "r", not "?column?"
 query III colnames,rowsort
 select *, (select r from (select q1 as q2) x, lateral (select q2 as r) y) from int8_tbl;
 ----
-q1  q2  ?column?
+q1  q2  r
 123  456  123
 123  4567890123456789  123
 4567890123456789  123  4567890123456789

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -93,3 +93,17 @@ CREATE TABLE nullary ()
 query
 SELECT * FROM nullary
 ----
+
+# Check that column names propagate through several layers of subqueries.
+query T colnames
+SELECT (SELECT * FROM (SELECT 1 AS a) _)
+----
+a
+1
+
+# Check that the EXISTS operator names its output column as such.
+query T colnames
+SELECT EXISTS (SELECT 1)
+----
+exists
+true

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -651,8 +651,6 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 
 EOF
 
-
-
 statement ok
 CREATE TABLE xs (x int not null)
 
@@ -687,3 +685,6 @@ from ys
 0  -1
 1  -1
 2  1
+
+query error aggregate functions that refer exclusively to outer columns not yet supported
+SELECT (SELECT count(likes.likee)) FROM likes

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -93,15 +93,13 @@ EXPLAIN PLAN FOR SELECT generate_series FROM generate_series(-2, 2)
 
 EOF
 
-# TODO(justin): currently incorrect. Should return element directly, not
-# 1-tuple.
-query T colnames
+query I colnames
 SELECT x FROM generate_series(1, 3) x
 ----
 x
-(1)
-(2)
-(3)
+1
+2
+3
 
 # TODO(justin): Don't currently support the 3-argument version.
 statement error


### PR DESCRIPTION
The PostgreSQL lateral join tests that we imported uncovered a bunch of Postgres incompatibilities in our SQL parser. This patch series fixes those; see individual commits for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3785)
<!-- Reviewable:end -->
