### PR TITLE
kafka-util: introduce dedicated KafkaAddr type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,7 @@ dependencies = [
  "futures",
  "interchange",
  "itertools",
+ "kafka-util",
  "lazy_static",
  "log",
  "mz-avro",
@@ -682,6 +683,7 @@ dependencies = [
  "comm",
  "expr",
  "interchange",
+ "kafka-util",
  "log",
  "regex",
  "repr",
@@ -1486,6 +1488,7 @@ dependencies = [
  "clap",
  "rand",
  "rdkafka",
+ "serde",
 ]
 
 [[package]]

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -49,7 +49,8 @@ Wrap your release notes at the 80 character mark.
 <span id="v0.4.1"></span>
 ## v0.4.1 (Unreleased)
 
-No release notes yet.
+- Permit broker addresses in [Kafka sources](/sql/create-source/avro-kafka/) and
+  [Kafka sinks](/sql/create-sink/) to use IP addresses in addition to hostnames.
 
 <span id="v0.4.0"></span>
 ## v0.4.0

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -88,7 +88,7 @@ async fn build_kafka(
 
     // Create Kafka topic with single partition.
     let mut config = ClientConfig::new();
-    config.set("bootstrap.servers", &builder.broker_url.to_string());
+    config.set("bootstrap.servers", &builder.broker_addr.to_string());
     let client = config
         .create::<AdminClient<_>>()
         .expect("creating admin client failed");
@@ -127,7 +127,7 @@ async fn build_kafka(
     Ok(SinkConnector::Kafka(KafkaSinkConnector {
         schema_id,
         topic,
-        url: builder.broker_url,
+        addr: builder.broker_addr,
         consistency,
         fuel: builder.fuel,
         frontier,

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -1219,7 +1219,7 @@ impl Timestamper {
         kc: KafkaSourceConnector,
     ) -> Option<RtKafkaConnector> {
         let mut config = ClientConfig::new();
-        config.set("bootstrap.servers", &kc.url.to_string());
+        config.set("bootstrap.servers", &kc.addr.to_string());
 
         if log_enabled!(target: "librdkafka", log::Level::Debug) {
             config.set("debug", "all");
@@ -1408,7 +1408,7 @@ impl Timestamper {
             .set("max.poll.interval.ms", "300000") // 5 minutes
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
-            .set("bootstrap.servers", &kc.url.to_string());
+            .set("bootstrap.servers", &kc.addr.to_string());
 
         let group_id_prefix = kc.group_id_prefix.clone().unwrap_or_else(String::new);
         config.set(

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -11,6 +11,7 @@ interchange = { path = "../interchange" }
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
 expr = { path = "../expr" }
+kafka-util = { path = "../kafka-util" }
 log = "0.4"
 regex = "1.3.9"
 repr = { path = "../repr" }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -31,6 +31,7 @@ use expr::{
 };
 use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
+use kafka_util::KafkaAddr;
 use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType};
 
 /// System-wide timestamp type.
@@ -560,7 +561,7 @@ impl Into<KafkaOffset> for MzOffset {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSourceConnector {
-    pub url: Url,
+    pub addr: KafkaAddr,
     pub topic: String,
     // Represents options specified by user when creating the source, e.g.
     // security settings.
@@ -601,7 +602,7 @@ pub struct KafkaSinkConsistencyConnector {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSinkConnector {
-    pub url: Url,
+    pub addr: KafkaAddr,
     pub topic: String,
     pub schema_id: i32,
     pub consistency: Option<KafkaSinkConsistencyConnector>,
@@ -650,7 +651,7 @@ pub struct AvroOcfSinkConnectorBuilder {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSinkConnectorBuilder {
-    pub broker_url: Url,
+    pub broker_addr: KafkaAddr,
     pub schema_registry_url: Url,
     pub value_schema: String,
     pub topic_prefix: String,

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -22,6 +22,7 @@ failure = "0.1"
 futures = "0.3"
 interchange = { path = "../interchange" }
 itertools = "0.9"
+kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4"
 log = "0.4"
 notify = "4.0"

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -212,7 +212,7 @@ where
     let sink_hash = id.hashed();
 
     let mut config = ClientConfig::new();
-    config.set("bootstrap.servers", &connector.url.to_string());
+    config.set("bootstrap.servers", &connector.addr.to_string());
 
     // Increase limits for the Kafka producer's internal buffering of messages
     // Currently we don't have a great backpressure mechanism to tell indexes or

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -13,19 +13,19 @@ use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use dataflow_types::{
-    Consistency, DataEncoding, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset,
-};
-use expr::{PartitionId, SourceInstanceId};
-use log::{error, info, log_enabled, warn};
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::message::BorrowedMessage;
 use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientConfig, ClientContext, Message, Statistics, TopicPartitionList};
-
 use timely::scheduling::activate::{Activator, SyncActivator};
-use url::Url;
+
+use dataflow_types::{
+    Consistency, DataEncoding, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset,
+};
+use expr::{PartitionId, SourceInstanceId};
+use kafka_util::KafkaAddr;
+use log::{error, info, log_enabled, warn};
 
 use crate::server::{
     TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
@@ -340,14 +340,14 @@ impl KafkaSourceInfo {
         kc: KafkaSourceConnector,
     ) -> KafkaSourceInfo {
         let KafkaSourceConnector {
-            url,
+            addr,
             topic,
             config_options,
             group_id_prefix,
             ..
         } = kc;
         let kafka_config =
-            create_kafka_config(&source_name, &url, group_id_prefix, &config_options);
+            create_kafka_config(&source_name, &addr, group_id_prefix, &config_options);
         let source_id = source_id.to_string();
         let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
             .create_with_context(GlueConsumerContext(consumer_activator))
@@ -486,14 +486,14 @@ impl KafkaSourceInfo {
 /// Creates a Kafka config.
 fn create_kafka_config(
     name: &str,
-    url: &Url,
+    addr: &KafkaAddr,
     group_id_prefix: Option<String>,
     config_options: &HashMap<String, String>,
 ) -> ClientConfig {
     let mut kafka_config = ClientConfig::new();
 
     // Broker configuration.
-    kafka_config.set("bootstrap.servers", &url.to_string());
+    kafka_config.set("bootstrap.servers", &addr.to_string());
 
     // Opt-out of Kafka's offset management facilities. Whenever we restart,
     // we want to restart from the beginning of the topic.

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -10,3 +10,4 @@ anyhow = "1.0"
 clap = "2.33"
 rand = "0.7"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/src/kafka-util/src/addr.rs
+++ b/src/kafka-util/src/addr.rs
@@ -1,0 +1,96 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use std::fmt;
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Represents the address of a Kafka broker.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KafkaAddr {
+    host: String,
+    port: u16,
+}
+
+impl FromStr for KafkaAddr {
+    type Err = KafkaAddrParseError;
+
+    fn from_str(s: &str) -> Result<KafkaAddr, Self::Err> {
+        let mut parts = s.splitn(2, ':');
+        let host = parts.next().expect("splitn returns at least one part");
+        let port = match parts.next() {
+            None => 9092,
+            Some(port) => port.parse().map_err(KafkaAddrParseError::InvalidPort)?,
+        };
+        Ok(KafkaAddr {
+            host: host.to_owned(),
+            port,
+        })
+    }
+}
+
+impl fmt::Display for KafkaAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}:{}", self.host, self.port)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum KafkaAddrParseError {
+    InvalidPort(ParseIntError),
+}
+
+impl fmt::Display for KafkaAddrParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            KafkaAddrParseError::InvalidPort(e) => write!(
+                f,
+                "unable to parse Kafka broker address: invalid port: {}",
+                e
+            ),
+        }
+    }
+}
+
+impl Error for KafkaAddrParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ok() -> Result<(), Box<dyn Error>> {
+        let test_cases = vec![
+            ("localhost", ("localhost", 9092)),
+            ("foohost", ("foohost", 9092)),
+            ("1.2.3.4", ("1.2.3.4", 9092)),
+            ("localhost:42", ("localhost", 42)),
+            ("1.2.3.4:1234", ("1.2.3.4", 1234)),
+        ];
+
+        for (input, (host, port)) in test_cases {
+            let addr: KafkaAddr = input.parse()?;
+            assert_eq!(addr.host, host);
+            assert_eq!(addr.port, port);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_err() {
+        assert_eq!(
+            "host:badport".parse::<KafkaAddr>().unwrap_err().to_string(),
+            "unable to parse Kafka broker address: invalid port: invalid digit found in string",
+        )
+    }
+}

--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod addr;
+
+pub use addr::{KafkaAddr, KafkaAddrParseError};

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -714,7 +714,7 @@ fn handle_show_create_index(
 fn kafka_sink_builder(
     format: Option<Format>,
     with_options: Vec<SqlOption>,
-    mut broker: String,
+    broker: String,
     topic_prefix: String,
     desc: RelationDesc,
     topic_suffix: String,
@@ -736,10 +736,7 @@ fn kafka_sink_builder(
         _ => unsupported!("non-confluent schema registry avro sinks"),
     };
 
-    if !broker.contains(':') {
-        broker += ":9092";
-    }
-    let broker_url = broker.parse()?;
+    let broker_addr = broker.parse()?;
 
     let mut with_options = normalize::with_options(&with_options);
     let include_consistency = match with_options.remove("consistency") {
@@ -769,7 +766,7 @@ fn kafka_sink_builder(
     };
 
     Ok(SinkConnectorBuilder::Kafka(KafkaSinkConnectorBuilder {
-        broker_url,
+        broker_addr,
         schema_registry_url,
         value_schema,
         topic_prefix,
@@ -1281,7 +1278,7 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                     }
 
                     let connector = ExternalSourceConnector::Kafka(KafkaSourceConnector {
-                        url: broker.parse()?,
+                        addr: broker.parse()?,
                         topic: topic.clone(),
                         config_options,
                         start_offset,


### PR DESCRIPTION
We were previously using a url::Url to carry around Kafka broker's
host/port information. Unfortunately the Rust URL library refuses to
parse a URL of the form

    12.34.56.78:9092

and instead returns a confusing error about a "relative URL without a
base."

Rather than trying to wrangle this infuriatingly pedantic `url` crate
into dealing with this, introduce a new KafkaAddr type that stores a
host string/port number, and has the flexible parsing we're looking for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3797)
<!-- Reviewable:end -->
