### PR TITLE
The nanos portion of a timestamp needs to come before the tz

### DIFF
--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -304,8 +304,9 @@ pub fn format_timestamptz<F>(buf: &mut F, ts: DateTime<Utc>) -> Nestable
 where
     F: FormatBuffer,
 {
-    write!(buf, "{}", ts.format("%Y-%m-%d %H:%M:%S+00"));
+    write!(buf, "{}", ts.format("%Y-%m-%d %H:%M:%S"));
     format_nanos(buf, ts.timestamp_subsec_nanos());
+    write!(buf, "+00");
     // NOTE(benesch): this may be overly conservative. Perhaps timestamptzs
     // never have special characters.
     Nestable::MayNeedEscaping

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -831,7 +831,7 @@ SELECT to_timestamp(946684800)
 query T
 SELECT to_timestamp(1262349296.7890123)
 ----
-2010-01-01 12:34:56+00.789012
+2010-01-01 12:34:56.789012+00
 
 # TODO(benesch): this should return an error, not NULL.
 query T

--- a/test/testdrive/dates-times.td
+++ b/test/testdrive/dates-times.td
@@ -105,3 +105,9 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
 
 > SELECT TIMESTAMPTZ '1989-06-01 9:10:10.410+700'
 "1989-06-01 02:10:10.410 UTC"
+
+> SELECT '1989-06-01 10:10:10.410+04:00'::timestamptz::text
+"1989-06-01 06:10:10.41+00"
+
+> SELECT '1989-06-01 10:10:10.413+04:00'::timestamptz::text
+"1989-06-01 06:10:10.413+00"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3798)
<!-- Reviewable:end -->
