### PR TITLE
Switch to always formatting text as microseconds

### DIFF
--- a/test/testdrive/dates-times.td
+++ b/test/testdrive/dates-times.td
@@ -94,6 +94,10 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
 > SELECT TIMESTAMPTZ '1989-06-01 9:10:10.410+07:00'
 "1989-06-01 02:10:10.410 UTC"
 
+# microseconds are returned with nanosecond precision in the binary format
+> SELECT TIMESTAMPTZ '1989-06-01 06:10:10.12345678+00:00'
+"1989-06-01 06:10:10.123457 UTC"
+
 > SELECT TIMESTAMP WITHOUT TIME ZONE '1989-06-01 10:10:10.410+04:00'
 "1989-06-01 10:10:10.410"
 
@@ -111,3 +115,10 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
 
 > SELECT '1989-06-01 10:10:10.413+04:00'::timestamptz::text
 "1989-06-01 06:10:10.413+00"
+
+# The text format should only ever return microseconds
+> SELECT '1989-06-01 10:10:10.12345678+04:00'::timestamptz::text
+"1989-06-01 06:10:10.123457+00"
+
+> SELECT '1989-06-01 10:10:10.1234564+04:00'::timestamptz::text
+"1989-06-01 06:10:10.123456+00"


### PR DESCRIPTION
Postgres only keeps microsecond granularity internally, so clients are not expected to be
ready for more than 6 digits of precision.

I'm not sure what the binary representation should be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3802)
<!-- Reviewable:end -->
