### PR TITLE
deps: bump to latest rdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.24.0"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#0c02524ee95c509b8ec0de6c801016c2457ddf17"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#770ac7419f9c2d0b8607a5614efc978dd1c6182b"
 dependencies = [
  "futures",
  "libc",
@@ -2702,8 +2702,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "2.0.0+1.4.2"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#0c02524ee95c509b8ec0de6c801016c2457ddf17"
+version = "2.1.0+1.5.0"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#770ac7419f9c2d0b8607a5614efc978dd1c6182b"
 dependencies = [
  "cmake",
  "libc",

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -408,30 +408,6 @@ impl KafkaSourceInfo {
             .assign(&partition_list)
             .expect("assignment known to be valid");
 
-        // Trick librdkafka into updating its metadata for the topic so that we
-        // start seeing data for the partition immediately. Otherwise we might
-        // need to wait the full `topic.metadata.refresh.interval.ms` interval.
-        //
-        // We don't actually care about the results of the metadata refresh, and
-        // would prefer not to wait for it to complete, so we execute this
-        // request with a timeout of 0s and ignore the result. This relies on an
-        // implementation detail, which is that librdkafka does not proactively
-        // cancel metadata fetch operations when they reach their timeout.
-        // Unfortunately there is no asynchronous metadata fetch API.
-        //
-        // It is not a problem if the metadata request fails, because the
-        // background metadata refresh will retry indefinitely. As long as a
-        // background request succeeds eventually, we'll start receiving data
-        // for the new partitions.
-        //
-        // TODO(benesch): remove this if upstream makes this metadata refresh
-        // happen automatically [0].
-        //
-        // [0]: https://github.com/edenhill/librdkafka/issues/2917
-        let _ = self
-            .consumer
-            .fetch_metadata(Some(&self.topic_name), Duration::from_secs(0));
-
         let partition_queue = self
             .consumer
             .split_partition_queue(&self.topic_name, partition_id)


### PR DESCRIPTION
The latest rdkafka includes two particularly relevant fixes:

  * The consumer group join logic is much faster, and noticeably cuts
    down on testdrive's running time.

  * Partition metadata is automatically fetched when interest in a new
    partition is registered.

Supersedes #2868.
Fix #2753.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3804)
<!-- Reviewable:end -->
