### PR TITLE
kafka-util: absorb responsibility for creating topics synchronously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ore",
  "rand",
  "rdkafka",
  "serde",
@@ -3596,6 +3597,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "kafka-util",
  "log",
  "ore",
  "rand",
@@ -3621,6 +3623,7 @@ dependencies = [
  "getopts",
  "interchange",
  "itertools",
+ "kafka-util",
  "krb5-src",
  "lazy_static",
  "md-5",

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "kafka-util"
 version = "0.1.0"
-authors = ["Brennan Vincent <brennan@materialize.io>"]
 edition = "2018"
 publish = false
 
 [dependencies]
 anyhow = "1.0"
 clap = "2.33"
+ore = { path = "../../src/ore" }
 rand = "0.7"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "kafka-util"
+description = "Utilities for working with Kafka."
 version = "0.1.0"
 edition = "2018"
 publish = false

--- a/src/kafka-util/src/addr.rs
+++ b/src/kafka-util/src/addr.rs
@@ -44,8 +44,10 @@ impl fmt::Display for KafkaAddr {
     }
 }
 
+/// An error while parsing a Kafka address.
 #[derive(Clone, Debug)]
 pub enum KafkaAddrParseError {
+    /// The Kafka address contained an invalid port.
     InvalidPort(ParseIntError),
 }
 

--- a/src/kafka-util/src/admin.rs
+++ b/src/kafka-util/src/admin.rs
@@ -1,0 +1,114 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use std::fmt;
+use std::iter;
+use std::time::Duration;
+
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic};
+use rdkafka::client::ClientContext;
+use rdkafka::error::{KafkaError, RDKafkaError};
+
+use ore::collections::CollectionExt;
+use ore::retry;
+
+pub async fn create_topic<'a, C>(
+    client: &'a AdminClient<C>,
+    admin_opts: &AdminOptions,
+    new_topic: &'a NewTopic<'a>,
+) -> Result<(), CreateTopicError>
+where
+    C: ClientContext,
+{
+    let res = client
+        .create_topics(iter::once(new_topic), &admin_opts)
+        .await?;
+    if res.len() != 1 {
+        return Err(CreateTopicError::TopicCountMismatch(res.len()));
+    }
+    match res.into_element() {
+        Ok(_) | Err((_, RDKafkaError::TopicAlreadyExists)) => Ok(()),
+        Err((_, e)) => Err(CreateTopicError::Kafka(KafkaError::AdminOp(e))),
+    }?;
+
+    // Topic creation is asynchronous, and if we don't wait for it to complete,
+    // we might produce a message (below) that causes it to get automatically
+    // created with the default number partitions, and not the number of
+    // partitions requested in `new_topic`.
+    retry::retry_for(Duration::from_secs(8), |_| async {
+        let metadata = client
+            .inner()
+            // N.B. It is extremely important not to ask specifically
+            // about the topic here, even though the API supports it!
+            // Asking about the topic will create it automatically...
+            // with the wrong number of partitions. Yes, this is
+            // unbelievably horrible.
+            .fetch_metadata(None, Some(Duration::from_secs(1)))?;
+        let topic = metadata
+            .topics()
+            .iter()
+            .find(|t| t.name() == new_topic.name)
+            .ok_or(CreateTopicError::MissingMetadata)?;
+        if topic.partitions().len() as i32 != new_topic.num_partitions {
+            return Err(CreateTopicError::PartitionCountMismatch {
+                expected: new_topic.num_partitions,
+                actual: topic.partitions().len() as i32,
+            });
+        }
+        Ok(())
+    })
+    .await
+}
+
+#[derive(Debug)]
+pub enum CreateTopicError {
+    Kafka(KafkaError),
+    TopicCountMismatch(usize),
+    MissingMetadata,
+    PartitionCountMismatch { expected: i32, actual: i32 },
+}
+
+impl fmt::Display for CreateTopicError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CreateTopicError::Kafka(e) => write!(f, "{}", e),
+            CreateTopicError::TopicCountMismatch(n) => write!(
+                f,
+                "kafka topic creation returned {} results, but exactly one result was expected",
+                n
+            ),
+            CreateTopicError::MissingMetadata => {
+                f.write_str("unable to fetch topic metadata after creation")
+            }
+            CreateTopicError::PartitionCountMismatch { expected, actual } => write!(
+                f,
+                "topic reports {} partitions, but expected {} partitions",
+                actual, expected
+            ),
+        }
+    }
+}
+
+impl Error for CreateTopicError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            CreateTopicError::Kafka(e) => Some(e),
+            CreateTopicError::TopicCountMismatch(_)
+            | CreateTopicError::MissingMetadata
+            | CreateTopicError::PartitionCountMismatch { .. } => None,
+        }
+    }
+}
+
+impl From<KafkaError> for CreateTopicError {
+    fn from(e: KafkaError) -> CreateTopicError {
+        CreateTopicError::Kafka(e)
+    }
+}

--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -9,4 +9,6 @@
 
 mod addr;
 
+pub mod admin;
+
 pub use addr::{KafkaAddr, KafkaAddrParseError};

--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -7,6 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![deny(missing_docs)]
+
+//! Utilities for working with Kafka.
+
 mod addr;
 
 pub mod admin;

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3"
 getopts = "0.2"
 interchange = { path = "../interchange" }
 itertools = "0.9"
+kafka-util = { path = "../kafka-util" }
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 md-5 = "0.9"

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.32"
 chrono = "0.4.13"
+kafka-util = { path = "../../src/kafka-util" }
 log = "0.4.11"
 ore = { path = "../../src/ore" }
 rand = "0.7.3"

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -7,17 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![allow(dead_code)]
-
 //! Kafka topic management
 
 use std::time::Duration;
 
-use anyhow::{bail, Context};
+use anyhow::Context;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
-use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::error::KafkaError;
+use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord};
 
 pub struct KafkaClient {
     producer: FutureProducer<DefaultClientContext>,
@@ -60,71 +59,24 @@ impl KafkaClient {
         let mut config = ClientConfig::new();
         config.set("bootstrap.servers", &self.kafka_url);
 
+        let client = config
+            .create::<AdminClient<_>>()
+            .expect("creating admin kafka client failed");
+
+        let admin_opts = AdminOptions::new().request_timeout(timeout);
+
         let mut topic = NewTopic::new(
             &self.topic,
             partitions,
             TopicReplication::Fixed(replication),
         );
-
         for (key, val) in configs {
             topic = topic.set(key, val);
         }
 
-        let res = config
-            .create::<AdminClient<_>>()
-            .expect("creating admin kafka client failed")
-            .create_topics(&[topic], &AdminOptions::new().request_timeout(timeout))
+        kafka_util::admin::create_topic(&client, &admin_opts, &topic)
             .await
             .context(format!("creating Kafka topic: {}", &self.topic))?;
-
-        if res.len() != 1 {
-            bail!(
-                "error creating topic {}: \
-             kafka topic creation returned {} results, but exactly one result was expected",
-                self.topic,
-                res.len()
-            );
-        }
-
-        if let Err((_, e)) = res[0] {
-            bail!("error creating topic {}: {}", self.topic, e);
-        }
-
-        // Topic creation is asynchronous, and if we don't wait for it to
-        // complete, we might produce a message (below) that causes it to
-        // get automatically created with multiple partitions. (Since
-        // multiple partitions have no ordering guarantees, this violates
-        // many assumptions that our tests make.)
-        ore::retry::retry_for(Duration::from_secs(8), |_| async {
-            let metadata = self
-                .producer
-                .client()
-                // N.B. It is extremely important not to ask specifically
-                // about the topic here, even though the API supports it!
-                // Asking about the topic will create it automatically...
-                // with the wrong number of partitions. Yes, this is
-                // unbelievably horrible.
-                .fetch_metadata(None, Some(Duration::from_secs(1)))?;
-            if metadata.topics().is_empty() {
-                bail!("metadata fetch returned no topics");
-            }
-            let topic = match metadata.topics().iter().find(|t| t.name() == self.topic) {
-                Some(topic) => topic,
-                None => bail!("metadata fetch did not return topic {}", self.topic,),
-            };
-            if topic.partitions().is_empty() {
-                bail!("metadata fetch returned a topic with no partitions");
-            } else if topic.partitions().len() as i32 != partitions {
-                bail!(
-                    "topic {} was created with {} partitions when exactly {} was expected",
-                    self.topic,
-                    topic.partitions().len(),
-                    partitions
-                );
-            }
-            Ok(())
-        })
-        .await?;
 
         Ok(())
     }
@@ -141,11 +93,7 @@ impl KafkaClient {
         Ok(())
     }
 
-    pub fn send_key_value(
-        &self,
-        key: &[u8],
-        message: &[u8],
-    ) -> std::result::Result<rdkafka::producer::DeliveryFuture, rdkafka::error::KafkaError> {
+    pub fn send_key_value(&self, key: &[u8], message: &[u8]) -> Result<DeliveryFuture, KafkaError> {
         let record: FutureRecord<_, _> = FutureRecord::to(&self.topic)
             .key(key)
             .payload(message)


### PR DESCRIPTION
This makes it possible to share this code between testdrive and
test-util.

Fix #3756.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3806)
<!-- Reviewable:end -->
