### PR TITLE
Redundant join elimination

### DIFF
--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -13,6 +13,10 @@
 // that replace simple and common alternatives frustrate developers.
 #![allow(clippy::comparison_chain, clippy::filter_next)]
 
+use std::collections::HashMap;
+
+use expr::Id;
+
 use crate::{RelationExpr, ScalarExpr, TransformArgs};
 
 /// Remove redundant collections of distinct elements from joins.
@@ -25,95 +29,319 @@ impl crate::Transform for RedundantJoin {
         relation: &mut RelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        relation.visit_mut(&mut |e| {
-            self.action(e);
-        });
+        self.action(relation, &mut HashMap::new());
         Ok(())
     }
 }
 
 impl RedundantJoin {
     /// Remove redundant collections of distinct elements from joins.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::Join {
-            inputs,
-            equivalences,
-            demand,
-            implementation,
-        } = relation
-        {
-            let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-            let input_arities = input_types
-                .iter()
-                .map(|i| i.column_types.len())
-                .collect::<Vec<_>>();
-
-            let mut offset = 0;
-            let mut prior_arities = Vec::new();
-            for input in 0..inputs.len() {
-                prior_arities.push(offset);
-                offset += input_arities[input];
+    ///
+    /// This method recursively determines "provenance" information for the relation, that being a set of
+    /// pairs of `Id` and column correspondences, indicating that some columns in this relation correspond
+    /// to columns in the bound `Id`; specifically, that projected on to these columns, the distinct rows
+    /// of this relation would be contained in the distinct rows of the identified relation.
+    pub fn action(
+        &self,
+        relation: &mut RelationExpr,
+        lets: &mut HashMap<Id, Vec<ProvInfo>>,
+    ) -> Vec<ProvInfo> {
+        match relation {
+            RelationExpr::Let { id, value, body } => {
+                // Recursively determine provenance of the value.
+                let value_prov = self.action(value, lets);
+                let old = lets.insert(Id::Local(*id), value_prov);
+                let result = self.action(body, lets);
+                if let Some(old) = old {
+                    lets.insert(Id::Local(*id), old);
+                } else {
+                    lets.remove(&Id::Local(*id));
+                }
+                result
+            }
+            RelationExpr::Get { id, typ } => {
+                let mut val_info = lets.get(id).map(|x| x.clone()).unwrap_or(Vec::new());
+                // Add information about being exactly this let binding too.
+                val_info.push(ProvInfo {
+                    id: *id,
+                    binding: (0..typ.arity()).map(|c| (c, c)).collect::<Vec<_>>(),
+                    exact: true,
+                });
+                val_info
             }
 
-            // It is possible that two inputs are the same, and joined on columns that form a key for them.
-            // If so, we can remove one of them, and replace references to it with corresponding references
-            // to the other.
-            let mut columns = 0;
-            let mut projection = Vec::new();
-            let mut to_remove = Vec::new();
-            for (index, input) in inputs.iter().enumerate() {
-                let keys = input.typ().keys;
-                if let Some(prior) = (0..index)
-                    .filter(|prior| {
-                        &inputs[*prior] == input
-                            && keys.iter().any(|key| {
-                                key.iter().all(|k| {
-                                    equivalences.iter().any(|e| {
-                                        e.contains(&ScalarExpr::Column(prior_arities[index] + *k))
-                                            && e.contains(&ScalarExpr::Column(
-                                                prior_arities[*prior] + *k,
-                                            ))
-                                    })
-                                })
-                            })
+            RelationExpr::Join {
+                inputs,
+                equivalences,
+                demand,
+                implementation,
+            } => {
+                // Recursively apply transformation, and determine input provenance.
+                let mut input_prov = inputs
+                    .iter_mut()
+                    .map(|i| self.action(i, lets))
+                    .collect::<Vec<_>>();
+
+                // Determine useful information about the structure of the inputs.
+                let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+                let input_arities = input_types
+                    .iter()
+                    .map(|i| i.column_types.len())
+                    .collect::<Vec<_>>();
+
+                let mut offset = 0;
+                let mut prior_arities = Vec::new();
+                for input in 0..inputs.len() {
+                    prior_arities.push(offset);
+                    offset += input_arities[input];
+                }
+
+                // If we find an input that can be removed, we should do so!
+                // We only do this once per invocation to keep our sanity, but we could rewrite it to iterate.
+                if let Some((input, bindings)) = (0..input_types.len())
+                    .filter(|i| !input_types[*i].keys.is_empty())
+                    .flat_map(|i| {
+                        find_redundancy(
+                            i,
+                            &input_arities[..],
+                            &prior_arities[..],
+                            equivalences,
+                            &input_prov[..],
+                        )
+                        .map(|b| (i, b))
                     })
                     .next()
                 {
-                    projection.extend(
-                        prior_arities[prior]..(prior_arities[prior] + input_arities[prior]),
-                    );
-                    to_remove.push(index);
-                // TODO: check for relation repetition in any variable.
-                } else {
-                    projection.extend(columns..(columns + input_arities[index]));
-                    columns += input_arities[index];
-                }
-            }
+                    // println!("Found redundancy: \n\tinput {:?}\n\tbinding {:?}", input, bindings);
 
-            // Update constraints to reference `prior`. Shift subsequent references.
-            if !to_remove.is_empty() {
-                // remove in reverse order.
-                while let Some(index) = to_remove.pop() {
-                    inputs.remove(index);
-                }
-                for equivalence in equivalences.iter_mut() {
-                    for expr in equivalence.iter_mut() {
-                        expr.permute(&projection[..]);
+                    let mut columns = 0;
+                    let mut projection = Vec::new();
+                    for i in 0..input_arities.len() {
+                        if i != input {
+                            projection.extend(columns..columns + input_arities[i]);
+                            columns += input_arities[i];
+                        } else {
+                            // This should happen only once, and `.drain(..)` could work.
+                            projection.extend(bindings.clone());
+                        }
                     }
-                    equivalence.sort();
-                    equivalence.dedup();
+                    // Bindings need to be refreshed, now that we know where each target column will be.
+                    // This is important because they could have been to columns *after* the removed
+                    // relation, and our original take on where they would be is no longer correct.
+                    for c in prior_arities[input]..prior_arities[input] + input_arities[input] {
+                        projection[c] = projection[projection[c]];
+                    }
+
+                    for equivalence in equivalences.iter_mut() {
+                        for expr in equivalence.iter_mut() {
+                            expr.permute(&projection[..]);
+                        }
+                        equivalence.sort();
+                        equivalence.dedup();
+                    }
+                    equivalences.retain(|es| es.len() > 1);
+
+                    inputs.remove(input);
+                    input_prov.remove(input);
+
+                    // Unset demand and implementation, as irrevocably hosed by this transformation.
+                    *demand = None;
+                    *implementation = expr::JoinImplementation::Unimplemented;
+
+                    *relation = relation.take_dangerous().project(projection);
+                    // The projection will gum up provenance reasoning anyhow, so don't work hard.
+                    Vec::new()
+                } else {
+                    // Provenance information should be the union of input provenance information,
+                    // with columns updated. Because rows may be dropped in the join, all `exact`
+                    // bits should be un-set.
+                    let mut results = Vec::new();
+                    for (input, input_prov) in input_prov.into_iter().enumerate() {
+                        for mut prov in input_prov {
+                            prov.exact = false;
+                            for (_src, inp) in prov.binding.iter_mut() {
+                                *inp += prior_arities[input];
+                            }
+                            results.push(prov);
+                        }
+                    }
+                    results
                 }
-                equivalences.retain(|v| v.len() > 1);
-                *demand = None;
             }
 
-            // Implement a projection if the projection removed any columns.
-            let orig_arity = input_arities.iter().sum::<usize>();
-            if projection.len() != orig_arity || projection.iter().enumerate().any(|(i, p)| i != *p)
-            {
-                *implementation = expr::JoinImplementation::Unimplemented;
-                *relation = relation.take_dangerous().project(projection);
+            RelationExpr::Filter { input, .. } => {
+                // Filter drops records, and so is not set to `exact`.
+                let mut result = self.action(input, lets);
+                for prov in result.iter_mut() {
+                    prov.exact = false;
+                }
+                result
+            }
+
+            RelationExpr::Map { input, .. } => self.action(input, lets),
+
+            RelationExpr::Union { left, right } => {
+                self.action(left, lets);
+                self.action(right, lets);
+                Vec::new()
+            }
+
+            RelationExpr::Constant { .. } => Vec::new(),
+
+            RelationExpr::Reduce {
+                input, group_key, ..
+            } => {
+                // Reduce yields its first few columns as a key, and produces
+                // all key tuples that were present in its input.
+                let mut result = self.action(input, lets);
+                for prov in result.iter_mut() {
+                    // update the bindings. no need to update `exact`.
+                    let new_bindings = group_key
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, e)| {
+                            if let ScalarExpr::Column(c) = e {
+                                Some((i, c))
+                            } else {
+                                None
+                            }
+                        })
+                        .filter_map(|(i, c)| {
+                            // output column `i` corresponds to input column `c`.
+                            prov.binding
+                                .iter()
+                                .find(|(_src, inp)| inp == c)
+                                .map(|(src, _inp)| (*src, i))
+                        })
+                        .collect::<Vec<_>>();
+                    prov.binding = new_bindings;
+                }
+                // TODO: For min, max aggregates, we could preserve provenance
+                // if the expression references a column.
+                result
+            }
+
+            RelationExpr::Threshold { input } => {
+                // Threshold may drop records, and so is not set to `exact`.
+                let mut result = self.action(input, lets);
+                for prov in result.iter_mut() {
+                    prov.exact = false;
+                }
+                result
+            }
+
+            RelationExpr::TopK { input, .. } => {
+                // TopK may drop records, and so is not exact.
+                let mut result = self.action(input, lets);
+                for prov in result.iter_mut() {
+                    prov.exact = false;
+                }
+                result
+            }
+
+            RelationExpr::Project { input, .. } => {
+                self.action(input, lets);
+                // Projections generally get hoisted, and we can
+                // wait until that happens to implement this analysis.
+                Vec::new()
+            }
+
+            RelationExpr::FlatMap { input, .. } => {
+                // FlatMap may drop records, and so is not set to `exact`.
+                let mut result = self.action(input, lets);
+                for prov in result.iter_mut() {
+                    prov.exact = false;
+                }
+                result
+            }
+
+            RelationExpr::Negate { input } => {
+                // Negate changes the sign on its multiplicities,
+                // which means "distinct" counts would now be -1.
+                // We set `exact` to false to inhibit the optimization,
+                // but should probably fix `.keys` instead.
+                let mut result = self.action(input, lets);
+                for prov in result.iter_mut() {
+                    prov.exact = false;
+                }
+                result
+            }
+
+            RelationExpr::ArrangeBy { input, .. } => self.action(input, lets),
+        }
+    }
+}
+
+/// A relationship between a collections columns and some source columns.
+#[derive(Clone, Debug)]
+pub struct ProvInfo {
+    // The Id (local or global) of the source
+    id: Id,
+    // A list of source column, current column associations.
+    // There should be at most one occurrence of each number in the second position.
+    binding: Vec<(usize, usize)>,
+    // Are these the exact set of columns, with none omitted?
+    exact: bool,
+}
+
+// Attempts to discover a replacement relation for `input`, and replacement column bindings for its columns.
+fn find_redundancy(
+    input: usize,
+    input_arities: &[usize],
+    prior_arities: &[usize],
+    equivalences: &[Vec<ScalarExpr>],
+    input_prov: &[Vec<ProvInfo>],
+) -> Option<Vec<usize>> {
+    // println!();
+    // println!("Input: {}", input);
+    // println!("Arities: {:?}", input_arities);
+    // println!("Prior: {:?}", prior_arities);
+    // println!("Equiv: {:?}", equivalences);
+    // println!("Prov: {:?}", input_prov);
+
+    // A join input can be removed if
+    //   1. it contains distinct records (i.e. has a key),
+    //   2. it has some `exact` provenance for all columns,
+    //   3. all of its columns are equated to another inputs by the join and by its provenance.
+    // If the input is removed, all references to its columns should be replaced by references
+    // to the corresponding columns in the other input.
+
+    for provenance in input_prov[input].iter() {
+        // We can only elide if the input contains all records, and binds all columns.
+        if provenance.exact && provenance.binding.len() == input_arities[input] {
+            // examine all *other* inputs that have not been removed...
+            for other in 0..input_arities.len() {
+                if other != input {
+                    for other_prov in input_prov[other].iter().filter(|p| p.id == provenance.id) {
+                        // We need to find each column of `input` bound in `other` with this provenance.
+                        let mut bindings = HashMap::new();
+                        for (src, input_col) in provenance.binding.iter() {
+                            for (src2, other_col) in other_prov.binding.iter() {
+                                if src == src2 {
+                                    if equivalences.iter().any(|e| {
+                                        e.contains(&ScalarExpr::Column(
+                                            prior_arities[input] + input_col,
+                                        )) && e.contains(&ScalarExpr::Column(
+                                            prior_arities[other] + other_col,
+                                        ))
+                                    }) {
+                                        bindings
+                                            .insert(input_col, prior_arities[other] + *other_col);
+                                    }
+                                }
+                            }
+                        }
+                        if bindings.len() == input_arities[input] {
+                            let binding = (0..input_arities[input])
+                                .map(|c| bindings[&c])
+                                .collect::<Vec<_>>();
+                            return Some(binding);
+                        }
+                    }
+                }
             }
         }
     }
+
+    None
 }

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -29,7 +29,9 @@ impl crate::Transform for RedundantJoin {
         relation: &mut RelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
+        // println!("PRE: {}", relation.pretty());
         self.action(relation, &mut HashMap::new());
+        // println!("PST: {}", relation.pretty());
         Ok(())
     }
 }
@@ -292,6 +294,7 @@ fn find_redundancy(
     equivalences: &[Vec<ScalarExpr>],
     input_prov: &[Vec<ProvInfo>],
 ) -> Option<Vec<usize>> {
+
     // println!();
     // println!("Input: {}", input);
     // println!("Arities: {:?}", input_arities);
@@ -335,6 +338,9 @@ fn find_redundancy(
                             let binding = (0..input_arities[input])
                                 .map(|c| bindings[&c])
                                 .collect::<Vec<_>>();
+                            // println!("Found redundancy for {:?}", input);
+                            // println!("\tother: {:?}", other);
+                            // println!("\tbinding: {:?}", binding);
                             return Some(binding);
                         }
                     }

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -101,6 +101,7 @@ impl RedundantJoin {
                 // If we find an input that can be removed, we should do so!
                 // We only do this once per invocation to keep our sanity, but we could rewrite it to iterate.
                 if let Some((input, bindings)) = (0..input_types.len())
+                    .rev()
                     .filter(|i| !input_types[*i].keys.is_empty())
                     .flat_map(|i| {
                         find_redundancy(

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -312,10 +312,11 @@ impl RedundantJoin {
             }
 
             RelationExpr::Negate { input } => {
-                // Negate changes the sign on its multiplicities,
-                // which means "distinct" counts would now be -1.
-                // We set `exact` to false to inhibit the optimization,
-                // but should probably fix `.keys` instead.
+                // Negate does not guarantee that the multiplicity of
+                // each source record it at least one. This could have
+                // been a problem in `Union`, where we might report
+                // that the union of positive and negative records is
+                // "exact": cancelations would make this false.
                 let mut result = self.action(input, lets);
                 for prov in result.iter_mut() {
                     prov.exact = false;

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1122,12 +1122,8 @@ ORDER BY supplier_cnt DESC
 | Union %7 %8
 
 %10 =
-| Get %3
-| ArrangeBy (#0)
-
-%11 =
-| Join %4 %9 %10 (= #17 #23 #24)
-| | implementation = Differential %9 %10.(#0) %4.(#17)
+| Join %4 %9 (= #17 #23)
+| | implementation = Differential %9 %4.(#17)
 | | demand = (#17, #20..#22)
 | Reduce group=(#20, substr(#22, 1, 3), #21) count(distinct #17)
 
@@ -1338,51 +1334,37 @@ ORDER BY su_name
 
 %3 =
 | Get %2
-| ArrangeBy ()
 
 %4 =
 | Get materialize.public.stock (u26)
+| ArrangeBy ()
 
 %5 =
+| Get %2
+
+%6 =
 | Get materialize.public.orderline (u19)
 | ArrangeBy (#4)
 
-%6 =
-| Join %3 %4 %5 (= #11 #33)
-| | implementation = Differential %4 %5.(#4) %3.()
-| | demand = (#0, #11..#13, #35, #36)
-| Filter (datetots(#35) > 2010-05-23 12:00:00)
-
 %7 =
-| Get %2
-
-%8 =
-| Get %6
-
-%9 =
-| Get %6
-| Distinct group=(#11)
-| ArrangeBy (#0)
-
-%10 =
 | Get materialize.public.item (u24)
 | ArrangeBy (#0)
 
-%11 =
-| Join %8 %9 %10 (= #11 #39 #40)
-| | implementation = Differential %8 %9.(#0) %10.(#0)
-| | demand = (#0, #11..#13, #36, #44)
-| Filter "^co.*$" ~(#44)
-| Reduce group=(#0, #11, #12, #13) sum(#36)
+%8 =
+| Join %4 %5 %6 %7 (= #0 #33 #39)
+| | implementation = Differential %5 %4.() %7.(#0) %6.(#4)
+| | demand = (#0..#2, #18, #35, #36, #43)
+| Filter "^co.*$" ~(#43), (datetots(#35) > 2010-05-23 12:00:00)
+| Reduce group=(#18, #0, #1, #2) sum(#36)
 | Filter ((2 * #3) > #4)
 | Map ((#1 * #2) % 10000)
 | Filter (#0 = #5)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
-%12 =
-| Join %7 %11 (= #0 #11)
-| | implementation = Differential %7 %11.(#0)
+%9 =
+| Join %3 %8 (= #0 #11)
+| | implementation = Differential %3 %8.(#0)
 | | demand = (#1, #2)
 | Project (#1, #2)
 
@@ -1472,12 +1454,8 @@ ORDER BY numwait DESC, su_name
 | Union %10 %11
 
 %13 =
-| Get %6
-| ArrangeBy (#0, #1, #2, #3)
-
-%14 =
-| Join %7 %12 %13 (= #7 #47 #51) (= #8 #48 #52) (= #9 #49 #53) (= #13 #50 #54)
-| | implementation = Differential %12 %13.(#0, #1, #2, #3) %7.(#7, #8, #9, #13)
+| Join %7 %12 (= #7 #47) (= #8 #48) (= #9 #49) (= #13 #50)
+| | implementation = Differential %12 %7.(#7, #8, #9, #13)
 | | demand = (#1)
 | Reduce group=(#1) countall(true)
 
@@ -1552,8 +1530,12 @@ ORDER BY substr(c_state, 1, 1)
 | Union %6 %7
 
 %9 =
-| Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
-| | implementation = Differential %8 %3.(#0, #1, #2)
+| Get %2
+| ArrangeBy (#0, #1, #2)
+
+%10 =
+| Join %3 %8 %9 (= #0 #25 #28) (= #1 #26 #29) (= #2 #27 #30)
+| | implementation = Differential %8 %3.(#0, #1, #2) %9.(#0, #1, #2)
 | | demand = (#9, #16)
 | Reduce group=(substr(#9, 1, 1)) countall(true) sum(#16)
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -912,20 +912,10 @@ ORDER BY custdist DESC, c_count DESC
 
 %6 =
 | Union %4 %5
+| Map null, null, null, null, null, null, null, null
 
 %7 =
-| Get materialize.public.customer (u6)
-| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
-
-%8 =
-| Join %6 %7 (= #0 #22) (= #1 #23) (= #2 #24) (= #3 #25) (= #4 #26) (= #5 #27) (= #6 #28) (= #7 #29) (= #8 #30) (= #9 #31) (= #10 #32) (= #11 #33) (= #12 #34) (= #13 #35) (= #14 #36) (= #15 #37) (= #16 #38) (= #17 #39) (= #18 #40) (= #19 #41) (= #20 #42) (= #21 #43)
-| | implementation = Differential %6 %7.(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
-| | demand = (#0)
-| Map null, null, null, null, null, null, null, null
-| Project (#0..#21, #44..#51)
-
-%9 =
-| Union %3 %8
+| Union %3 %6
 | Reduce group=(#0) count(#22)
 | Reduce group=(#1) countall(true)
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1508,36 +1508,32 @@ ORDER BY substr(c_state, 1, 1)
 | ArrangeBy (#0, #1, #2)
 
 %4 =
-| Get %2
-| ArrangeBy (#0, #1, #2)
-
-%5 =
 | Get materialize.public.order (u16)
 | ArrangeBy (#2, #1, #3)
 
-%6 =
-| Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
-| | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
+%5 =
+| Join %3 %4 (= #0 #28) (= #1 #26) (= #2 #27)
+| | implementation = DeltaQuery %3 %4.(#2, #1, #3) | %4 %3.(#0, #1, #2)
 | | demand = (#0..#2)
 | Distinct group=(#0, #1, #2)
 | Negate
 
-%7 =
+%6 =
 | Get %2
 | Project (#0..#2)
 
-%8 =
-| Union %6 %7
+%7 =
+| Union %5 %6
 
-%9 =
+%8 =
 | Get %2
 | ArrangeBy (#0, #1, #2)
 
-%10 =
-| Join %3 %8 %9 (= #0 #25 #28) (= #1 #26 #29) (= #2 #27 #30)
-| | implementation = Differential %8 %3.(#0, #1, #2) %9.(#0, #1, #2)
-| | demand = (#9, #16)
-| Reduce group=(substr(#9, 1, 1)) countall(true) sum(#16)
+%9 =
+| Join %7 %8 (= #0 #3) (= #1 #4) (= #2 #5)
+| | implementation = Differential %7 %8.(#0, #1, #2)
+| | demand = (#12, #19)
+| Reduce group=(substr(#12, 1, 1)) countall(true) sum(#19)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1336,11 +1336,11 @@ ORDER BY su_name
 | Get %2
 
 %4 =
-| Get materialize.public.stock (u26)
+| Get %2
 | ArrangeBy ()
 
 %5 =
-| Get %2
+| Get materialize.public.stock (u26)
 
 %6 =
 | Get materialize.public.orderline (u19)
@@ -1351,11 +1351,11 @@ ORDER BY su_name
 | ArrangeBy (#0)
 
 %8 =
-| Join %4 %5 %6 %7 (= #0 #33 #39)
-| | implementation = Differential %5 %4.() %7.(#0) %6.(#4)
-| | demand = (#0..#2, #18, #35, #36, #43)
+| Join %4 %5 %6 %7 (= #11 #33 #39)
+| | implementation = Differential %5 %7.(#0) %6.(#4) %4.()
+| | demand = (#0, #11..#13, #35, #36, #43)
 | Filter "^co.*$" ~(#43), (datetots(#35) > 2010-05-23 12:00:00)
-| Reduce group=(#18, #0, #1, #2) sum(#36)
+| Reduce group=(#0, #11, #12, #13) sum(#36)
 | Filter ((2 * #3) > #4)
 | Map ((#1 * #2) % 10000)
 | Filter (#0 = #5)
@@ -1508,32 +1508,32 @@ ORDER BY substr(c_state, 1, 1)
 | ArrangeBy (#0, #1, #2)
 
 %4 =
+| Get %2
+| ArrangeBy (#0, #1, #2)
+
+%5 =
 | Get materialize.public.order (u16)
 | ArrangeBy (#2, #1, #3)
 
-%5 =
-| Join %3 %4 (= #0 #28) (= #1 #26) (= #2 #27)
-| | implementation = DeltaQuery %3 %4.(#2, #1, #3) | %4 %3.(#0, #1, #2)
+%6 =
+| Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
+| | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
 | | demand = (#0..#2)
 | Distinct group=(#0, #1, #2)
 | Negate
 
-%6 =
+%7 =
 | Get %2
 | Project (#0..#2)
 
-%7 =
-| Union %5 %6
-
 %8 =
-| Get %2
-| ArrangeBy (#0, #1, #2)
+| Union %6 %7
 
 %9 =
-| Join %7 %8 (= #0 #3) (= #1 #4) (= #2 #5)
-| | implementation = Differential %7 %8.(#0, #1, #2)
-| | demand = (#12, #19)
-| Reduce group=(substr(#12, 1, 1)) countall(true) sum(#19)
+| Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
+| | implementation = Differential %8 %3.(#0, #1, #2)
+| | demand = (#9, #16)
+| Reduce group=(substr(#9, 1, 1)) countall(true) sum(#16)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -503,24 +503,14 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 
 %8 =
 | Union %6 %7
+| Map false
 
 %9 =
-| Get %0
-| ArrangeBy (#0)
+| Union %5 %8
 
 %10 =
-| Join %8 %9 (= #0 #1)
-| | implementation = Differential %8 %9.(#0)
-| | demand = (#0)
-| Map false
-| Project (#0, #2)
-
-%11 =
-| Union %5 %10
-
-%12 =
-| Join %4 %11 (= #0 #1)
-| | implementation = Differential %11 %4.(#0)
+| Join %4 %9 (= #0 #1)
+| | implementation = Differential %9 %4.(#0)
 | | demand = (#2)
 | Project (#2)
 
@@ -564,24 +554,14 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 
 %8 =
 | Union %6 %7
+| Map false
 
 %9 =
-| Get %0
-| ArrangeBy (#0)
+| Union %5 %8
 
 %10 =
-| Join %8 %9 (= #0 #1)
-| | implementation = Differential %8 %9.(#0)
-| | demand = (#0)
-| Map false
-| Project (#0, #2)
-
-%11 =
-| Union %5 %10
-
-%12 =
-| Join %4 %11 (= #0 #1)
-| | implementation = Differential %11 %4.(#0)
+| Join %4 %9 (= #0 #1)
+| | implementation = Differential %9 %4.(#0)
 | | demand = (#2)
 | Map !(#2)
 | Project (#3)
@@ -627,24 +607,14 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 
 %8 =
 | Union %6 %7
+| Map false
 
 %9 =
-| Get %0
-| ArrangeBy (#0)
+| Union %5 %8
 
 %10 =
-| Join %8 %9 (= #0 #1)
-| | implementation = Differential %8 %9.(#0)
-| | demand = (#0)
-| Map false
-| Project (#0, #2)
-
-%11 =
-| Union %5 %10
-
-%12 =
-| Join %4 %11 (= #0 #1)
-| | implementation = Differential %11 %4.(#0)
+| Join %4 %9 (= #0 #1)
+| | implementation = Differential %9 %4.(#0)
 | | demand = (#2)
 | Map !(#2)
 | Project (#3)

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -62,7 +62,7 @@ EOF
 query T multiline
 EXPLAIN PLAN FOR SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp
-    LEFT JOIN LATERAL (SELECT name, pop FROM cities  where cities.state = grp.state ORDER BY pop DESC LIMIT 3) ON state = grp.state
+    LEFT JOIN LATERAL (SELECT name, pop FROM cities  where cities.state = grp.state ORDER BY pop DESC LIMIT 3) ON true
 ----
 %0 =
 | Get materialize.public.cities (u1)

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -54,29 +54,7 @@ EXPLAIN PLAN FOR SELECT state, name FROM
 ----
 %0 =
 | Get materialize.public.cities (u1)
-| Distinct group=(#1)
-
-%1 =
-| Get %0
-| ArrangeBy (#0)
-
-%2 =
-| Get %0
-| ArrangeBy (#0)
-
-%3 =
-| Get materialize.public.cities (u1)
-
-%4 =
-| Join %2 %3 (= #0 #2)
-| | implementation = Differential %3 %2.(#0)
-| | demand = (#0, #1, #3)
-| TopK group=(#0) order=(#3 desc) limit=3 offset=0
-
-%5 =
-| Join %1 %4 (= #0 #1)
-| | implementation = Differential %4 %1.(#0)
-| | demand = (#0, #2)
-| Project (#0, #2)
+| TopK group=(#1) order=(#2 desc) limit=3 offset=0
+| Project (#1, #0)
 
 EOF

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -58,3 +58,35 @@ EXPLAIN PLAN FOR SELECT state, name FROM
 | Project (#1, #0)
 
 EOF
+
+query T multiline
+EXPLAIN PLAN FOR SELECT state, name FROM
+    (SELECT DISTINCT state FROM cities) grp
+    LEFT JOIN LATERAL (SELECT name, pop FROM cities  where cities.state = grp.state ORDER BY pop DESC LIMIT 3) ON state = grp.state
+----
+%0 =
+| Get materialize.public.cities (u1)
+| TopK group=(#1) order=(#2 desc) limit=3 offset=0
+
+%1 =
+| Get %0
+| Project (#1, #0, #2)
+
+%2 =
+| Get %0
+| Distinct group=(#1)
+| Negate
+
+%3 =
+| Get materialize.public.cities (u1)
+| Distinct group=(#1)
+
+%4 =
+| Union %2 %3
+| Map null, null
+
+%5 =
+| Union %1 %4
+| Project (#0, #1)
+
+EOF

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -237,32 +237,32 @@ ORDER BY
 | Get %5
 
 %7 =
-| Get materialize.public.partsupp (u11)
-| ArrangeBy (#0) (#1)
-
-%8 =
-| Get materialize.public.supplier (u8)
-| ArrangeBy (#0) (#3)
-
-%9 =
-| Get materialize.public.nation (u1)
-| ArrangeBy (#0) (#2)
-
-%10 =
 | Get %5
 | Distinct group=(#0)
 | ArrangeBy (#0)
+
+%8 =
+| Get materialize.public.partsupp (u11)
+| ArrangeBy (#0) (#1)
+
+%9 =
+| Get materialize.public.supplier (u8)
+| ArrangeBy (#0) (#3)
+
+%10 =
+| Get materialize.public.nation (u1)
+| ArrangeBy (#0) (#2)
 
 %11 =
 | Get materialize.public.region (u4)
 | ArrangeBy (#0)
 
 %12 =
-| Join %7 %8 %9 %10 %11 (= #0 #16) (= #1 #5) (= #8 #12) (= #14 #17)
-| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %9.(#0) %11.(#0) %7.(#1) %10.(#0) | %9 %11.(#0) %8.(#3) %7.(#1) %10.(#0) | %10 %7.(#0) %8.(#0) %9.(#0) %11.(#0) | %11 %9.(#2) %8.(#3) %7.(#1) %10.(#0)
-| | demand = (#0, #3, #18)
+| Join %7 %8 %9 %10 %11 (= #0 #1) (= #2 #6) (= #9 #13) (= #15 #17)
+| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0) | %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0) | %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0) | %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
+| | demand = (#0, #4, #18)
 | Filter (#18 = "EUROPE")
-| Reduce group=(#0) min(#3)
+| Reduce group=(#0) min(#4)
 | ArrangeBy (#0, #1)
 
 %13 =
@@ -1750,32 +1750,32 @@ ORDER BY
 | ArrangeBy (#0)
 
 %4 =
+| Get %2
+| ArrangeBy (#0)
+
+%5 =
 | Get materialize.public.orders (u18)
 | ArrangeBy (#1)
 
-%5 =
-| Join %3 %4 (= #0 #12)
-| | implementation = DeltaQuery %3 %4.(#1) | %4 %3.(#0)
+%6 =
+| Join %4 %5 (= #0 #12)
+| | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 | Negate
 
-%6 =
+%7 =
 | Get %2
 | Project (#0)
 
-%7 =
-| Union %5 %6
-
 %8 =
-| Get %2
-| ArrangeBy (#0)
+| Union %6 %7
 
 %9 =
-| Join %7 %8 (= #0 #1)
-| | implementation = Differential %7 %8.(#0)
-| | demand = (#5, #6)
-| Reduce group=(substr(#5, 1, 2)) countall(true) sum(#6)
+| Join %3 %8 (= #0 #11)
+| | implementation = Differential %8 %3.(#0)
+| | demand = (#4, #5)
+| Reduce group=(substr(#4, 1, 2)) countall(true) sum(#5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -966,20 +966,10 @@ ORDER BY
 
 %6 =
 | Union %4 %5
+| Map null, null, null, null, null, null, null, null, null
 
 %7 =
-| Get materialize.public.customer (u15)
-| ArrangeBy (#0, #1, #2, #3, #4, #5, #6, #7)
-
-%8 =
-| Join %6 %7 (= #0 #8) (= #1 #9) (= #2 #10) (= #3 #11) (= #4 #12) (= #5 #13) (= #6 #14) (= #7 #15)
-| | implementation = Differential %6 %7.(#0, #1, #2, #3, #4, #5, #6, #7)
-| | demand = (#0)
-| Map null, null, null, null, null, null, null, null, null
-| Project (#0..#7, #16..#24)
-
-%9 =
-| Union %3 %8
+| Union %3 %6
 | Reduce group=(#0) count(#8)
 | Reduce group=(#1) countall(true)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -237,32 +237,32 @@ ORDER BY
 | Get %5
 
 %7 =
-| Get %5
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%8 =
 | Get materialize.public.partsupp (u11)
 | ArrangeBy (#0) (#1)
 
-%9 =
+%8 =
 | Get materialize.public.supplier (u8)
 | ArrangeBy (#0) (#3)
 
-%10 =
+%9 =
 | Get materialize.public.nation (u1)
 | ArrangeBy (#0) (#2)
+
+%10 =
+| Get %5
+| Distinct group=(#0)
+| ArrangeBy (#0)
 
 %11 =
 | Get materialize.public.region (u4)
 | ArrangeBy (#0)
 
 %12 =
-| Join %7 %8 %9 %10 %11 (= #0 #1) (= #2 #6) (= #9 #13) (= #15 #17)
-| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0) | %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0) | %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0) | %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
-| | demand = (#0, #4, #18)
+| Join %7 %8 %9 %10 %11 (= #0 #16) (= #1 #5) (= #8 #12) (= #14 #17)
+| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %9.(#0) %11.(#0) %7.(#1) %10.(#0) | %9 %11.(#0) %8.(#3) %7.(#1) %10.(#0) | %10 %7.(#0) %8.(#0) %9.(#0) %11.(#0) | %11 %9.(#2) %8.(#3) %7.(#1) %10.(#0)
+| | demand = (#0, #3, #18)
 | Filter (#18 = "EUROPE")
-| Reduce group=(#0) min(#4)
+| Reduce group=(#0) min(#3)
 | ArrangeBy (#0, #1)
 
 %13 =
@@ -1183,12 +1183,8 @@ ORDER BY
 | Union %7 %8
 
 %10 =
-| Get %3
-| ArrangeBy (#0)
-
-%11 =
-| Join %4 %9 %10 (= #1 #14 #15)
-| | implementation = Differential %9 %10.(#0) %4.(#1)
+| Join %4 %9 (= #1 #14)
+| | implementation = Differential %9 %4.(#1)
 | | demand = (#1, #8..#10)
 | Reduce group=(#8, #9, #10) count(distinct #1)
 
@@ -1501,64 +1497,51 @@ ORDER BY
 | Get materialize.public.partsupp (u11)
 
 %5 =
-| Join %3 %4
-| | implementation = Differential %4 %3.()
-| | demand = (#0, #11..#13)
-
-%6 =
-| Get %5
-
-%7 =
-| Get %5
-| Distinct group=(#11)
-| ArrangeBy (#0)
-
-%8 =
 | Get materialize.public.part (u6)
 | ArrangeBy (#0)
 
-%9 =
-| Join %6 %7 %8 (= #11 #16 #17)
-| | implementation = Differential %6 %7.(#0) %8.(#0)
-| | demand = (#0, #11..#13, #18)
-| Filter "^forest.*$" ~(#18)
+%6 =
+| Join %3 %4 %5 (= #11 #16)
+| | implementation = Differential %4 %5.(#0) %3.()
+| | demand = (#0, #11..#13, #17)
+| Filter "^forest.*$" ~(#17)
 
-%10 =
+%7 =
 | Get %2
 
-%11 =
-| Get %9
+%8 =
+| Get %6
 | Filter (#0 = #12)
 
-%12 =
-| Get %9
+%9 =
+| Get %6
 | Distinct group=(#11, #12)
 | ArrangeBy (#0, #1)
 
-%13 =
+%10 =
 | Get materialize.public.lineitem (u21)
 | ArrangeBy (#1, #2)
 
-%14 =
-| Join %12 %13 (= #1 #4) (= #0 #3)
-| | implementation = DeltaQuery %12 %13.(#1, #2) | %13 %12.(#0, #1)
+%11 =
+| Join %9 %10 (= #1 #4) (= #0 #3)
+| | implementation = DeltaQuery %9 %10.(#1, #2) | %10 %9.(#0, #1)
 | | demand = (#0, #1, #6, #12)
 | Filter (datetots(#12) < 1996-01-01 00:00:00), (#12 >= 1995-01-01)
 | Reduce group=(#0, #1) sum(#6)
 | Map (5dec * #2)
 | ArrangeBy (#0, #1)
 
-%15 =
-| Join %11 %14 (= #11 #26) (= #12 #27)
-| | implementation = Differential %11 %14.(#0, #1)
-| | demand = (#0, #13, #29)
-| Filter ((i32todec(#13) * 1000dec) > #29)
+%12 =
+| Join %8 %11 (= #11 #25) (= #12 #26)
+| | implementation = Differential %8 %11.(#0, #1)
+| | demand = (#0, #13, #28)
+| Filter ((i32todec(#13) * 1000dec) > #28)
 | Distinct group=(#0)
 | ArrangeBy (#0)
 
-%16 =
-| Join %10 %15 (= #0 #11)
-| | implementation = Differential %10 %15.(#0)
+%13 =
+| Join %7 %12 (= #0 #11)
+| | implementation = Differential %7 %12.(#0)
 | | demand = (#1, #2)
 | Project (#1, #2)
 
@@ -1685,12 +1668,8 @@ ORDER BY
 | Union %14 %15
 
 %17 =
-| Get %10
-| ArrangeBy (#0, #1)
-
-%18 =
-| Join %11 %16 %17 (= #0 #39 #41) (= #7 #38 #40)
-| | implementation = Differential %16 %17.(#0, #1) %11.(#0, #7)
+| Join %11 %16 (= #0 #39) (= #7 #38)
+| | implementation = Differential %16 %11.(#0, #7)
 | | demand = (#1)
 | Reduce group=(#1) countall(true)
 
@@ -1793,8 +1772,12 @@ ORDER BY
 | Union %6 %7
 
 %9 =
-| Join %3 %8 (= #0 #11)
-| | implementation = Differential %8 %3.(#0)
+| Get %2
+| ArrangeBy (#0)
+
+%10 =
+| Join %3 %8 %9 (= #0 #11 #12)
+| | implementation = Differential %8 %3.(#0) %9.(#0)
 | | demand = (#4, #5)
 | Reduce group=(substr(#4, 1, 2)) countall(true) sum(#5)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1750,36 +1750,32 @@ ORDER BY
 | ArrangeBy (#0)
 
 %4 =
-| Get %2
-| ArrangeBy (#0)
-
-%5 =
 | Get materialize.public.orders (u18)
 | ArrangeBy (#1)
 
-%6 =
-| Join %4 %5 (= #0 #12)
-| | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
+%5 =
+| Join %3 %4 (= #0 #12)
+| | implementation = DeltaQuery %3 %4.(#1) | %4 %3.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 | Negate
 
-%7 =
+%6 =
 | Get %2
 | Project (#0)
 
-%8 =
-| Union %6 %7
+%7 =
+| Union %5 %6
 
-%9 =
+%8 =
 | Get %2
 | ArrangeBy (#0)
 
-%10 =
-| Join %3 %8 %9 (= #0 #11 #12)
-| | implementation = Differential %8 %3.(#0) %9.(#0)
-| | demand = (#4, #5)
-| Reduce group=(substr(#4, 1, 2)) countall(true) sum(#5)
+%9 =
+| Join %7 %8 (= #0 #1)
+| | implementation = Differential %7 %8.(#0)
+| | demand = (#5, #6)
+| Reduce group=(substr(#5, 1, 2)) countall(true) sum(#6)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 


### PR DESCRIPTION
This PR means to generalize #3783, which digs deeper into redundant join elimination. This PR goes a bit further, and tracks provenance of each collection with respect to local and global identifiers. Each collection can have sets of columns that derive from each identifier, with the guarantee that projected on to these columns they will be contained in the corresponding projection of the identified collection. In some cases the sets of columns are identical.

If we join two relations `left` and `right`, and `left` is 1. distinct, 2. has all of its columns drawn from some identifier, and `right` contains the same columns and they are equated by the join, then we can replace the join by `right` followed by some projection nonsense.

This recovers the observed `TopK` optimization in `topk.slt`, and does a few interesting things in `tpch.slt` and `chbench.slt` that I still need to look at. One thing it does not do is optimize query 04 in either, which would be a good target. There it seems that the "branch key optimization", which reduces the columns of `left` down to those inspected in the subquery, requires the join by `left` to recover the columns. This might be "correct", in that the subquery might be better computed only on the distinct set of relevant identifiers, rather than e.g. maintain rendundant aggregates decorated with the attendant columns. In cases where this transformation would apply we know that the join is on keys that are distinct in `left` so there wouldn't be an asymptotic loss to disable the optimization, but it's all complicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3808)
<!-- Reviewable:end -->
