### PR TITLE
pgwire,sql: respect client-provided parameter types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "predicates",
  "prometheus",
  "rdkafka-sys",
+ "repr",
  "rlimit",
  "serde_json",
  "stream-cancel",

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -191,6 +191,16 @@ steps:
           config: test/lang/js/mzcompose.yml
           run: js
 
+  - id: lang-java
+    label: ":java: tests"
+    depends_on: build
+    timeout_in_minutes: 10
+    inputs: [test/lang/java]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          config: test/lang/java/mzcompose.yml
+          run: java-smoketest
+
   - id: deploy
     label: ":rocket: Deploy"
     depends_on:

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -33,6 +33,7 @@ pub enum Command {
     Describe {
         name: String,
         stmt: Option<Statement>,
+        param_types: Vec<Option<pgrepr::Type>>,
         session: Session,
         tx: futures::channel::oneshot::Sender<Response<()>>,
     },

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -52,6 +52,7 @@ itertools = "0.9"
 pgrepr = { path = "../pgrepr" }
 postgres = { version = "0.17", features = ["with-chrono-0_4"] }
 predicates = "1.0.5"
+repr = { path = "../repr" }
 serde_json = "1"
 tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4"] }
 

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -61,6 +61,28 @@ lazy_static! {
 }
 
 impl Type {
+    /// Returns the type corresponding to the provided OID, if the OID is known.
+    pub fn from_oid(oid: u32) -> Option<Type> {
+        let ty = postgres_types::Type::from_oid(oid)?;
+        match ty {
+            postgres_types::Type::BOOL => Some(Type::Bool),
+            postgres_types::Type::BYTEA => Some(Type::Bytea),
+            postgres_types::Type::DATE => Some(Type::Date),
+            postgres_types::Type::FLOAT4 => Some(Type::Float4),
+            postgres_types::Type::FLOAT8 => Some(Type::Float8),
+            postgres_types::Type::INT4 => Some(Type::Int4),
+            postgres_types::Type::INT8 => Some(Type::Int8),
+            postgres_types::Type::INTERVAL => Some(Type::Interval),
+            postgres_types::Type::JSONB => Some(Type::Jsonb),
+            postgres_types::Type::NUMERIC => Some(Type::Numeric),
+            postgres_types::Type::TEXT | postgres_types::Type::VARCHAR => Some(Type::Text),
+            postgres_types::Type::TIME => Some(Type::Time),
+            postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
+            postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
+            _ => None,
+        }
+    }
+
     pub(crate) fn inner(&self) -> &'static postgres_types::Type {
         match self {
             Type::Bool => &postgres_types::Type::BOOL,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -128,14 +128,13 @@ pub enum FrontendMessage {
         name: String,
         /// The SQL to parse.
         sql: String,
-        /// The number of parameter data types specified. It can be zero.
-        /// Note that this is not an indication of the number of parameters that
-        /// might appear in the query string, but only the number that the
-        /// frontend wants to prespecify types for.
-        parameter_data_type_count: i16,
-        /// The OID of each parameter data type. Placing a zero here is
-        /// equivalent to leaving the type unspecified.
-        parameter_data_types: Vec<i32>,
+        /// The OID of each parameter data type for which the client wants to
+        /// prespecify types. A zero OID is equivalent to leaving the type
+        /// unspecified.
+        ///
+        /// The number of specified parameter data types can be less than the
+        /// number of parameters specified in the query.
+        param_types: Vec<u32>,
     },
 
     /// Describe an existing prepared statement.

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -259,7 +259,10 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
     use std::error::Error;
+    use std::rc::Rc;
 
     use super::*;
     use crate::catalog::DummyCatalog;
@@ -270,6 +273,7 @@ mod tests {
         let scx = &StatementContext {
             pcx: &PlanContext::default(),
             catalog: &DummyCatalog,
+            param_types: Rc::new(RefCell::new(BTreeMap::new())),
         };
 
         let parsed = sql_parser::parser::parse_statements(

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -237,8 +237,9 @@ pub fn plan(
 pub fn describe(
     catalog: &dyn Catalog,
     stmt: Statement,
+    param_types: &[Option<pgrepr::Type>],
 ) -> Result<(Option<RelationDesc>, Vec<pgrepr::Type>), anyhow::Error> {
-    let (desc, types) = statement::describe_statement(catalog, stmt)?;
+    let (desc, types) = statement::describe_statement(catalog, stmt, param_types)?;
     let types = types.into_iter().map(|t| pgrepr::Type::from(&t)).collect();
     Ok((desc, types))
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -25,7 +25,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::iter;
 use std::mem;
-use std::rc::Rc;
 
 use anyhow::{anyhow, bail, ensure, Context};
 use sql_parser::ast::visit::{self, Visit};
@@ -67,7 +66,7 @@ pub fn plan_root_query(
     scx: &StatementContext,
     mut query: Query,
     lifetime: QueryLifetime,
-) -> Result<(RelationExpr, RelationDesc, RowSetFinishing, Vec<ScalarType>), anyhow::Error> {
+) -> Result<(RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
     transform_ast::transform_query(&mut query)?;
     let qcx = QueryContext::root(scx, lifetime);
     let (mut expr, scope, mut finishing) = plan_query(&qcx, &query)?;
@@ -102,16 +101,9 @@ pub fn plan_root_query(
             .map(|i| typ.column_types[*i].clone())
             .collect(),
     );
-
     let desc = RelationDesc::new(typ, scope.column_names());
-    let mut param_types = vec![];
-    for (i, (n, typ)) in qcx.unwrap_param_types().into_iter().enumerate() {
-        if n != i + 1 {
-            bail!("unable to infer type for parameter ${}", i + 1);
-        }
-        param_types.push(typ);
-    }
-    Ok((expr, desc, finishing, param_types))
+
+    Ok((expr, desc, finishing))
 }
 
 /// Plans a SHOW statement that might have a WHERE or LIKE clause attached to it. A LIKE clause is
@@ -1493,7 +1485,7 @@ pub fn plan_expr<'a>(ecx: &'a ExprContext, e: &Expr) -> Result<CoercibleScalarEx
             if *n == 0 || *n > 65536 {
                 bail!("there is no parameter ${}", n);
             }
-            if ecx.qcx.param_types.borrow().contains_key(n) {
+            if ecx.param_types().borrow().contains_key(n) {
                 ScalarExpr::Parameter(*n).into()
             } else {
                 CoercibleScalarExpr::Parameter(*n)
@@ -2084,6 +2076,29 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, anyhow::
     })
 }
 
+pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Error> {
+    match ty {
+        pgrepr::Type::Bool => Ok(ScalarType::Bool),
+        pgrepr::Type::Int4 => Ok(ScalarType::Int32),
+        pgrepr::Type::Int8 => Ok(ScalarType::Int64),
+        pgrepr::Type::Float4 => Ok(ScalarType::Float32),
+        pgrepr::Type::Float8 => Ok(ScalarType::Float64),
+        pgrepr::Type::Numeric => Ok(ScalarType::Decimal(0, 0)),
+        pgrepr::Type::Date => Ok(ScalarType::Date),
+        pgrepr::Type::Time => Ok(ScalarType::Time),
+        pgrepr::Type::Timestamp => Ok(ScalarType::Timestamp),
+        pgrepr::Type::TimestampTz => Ok(ScalarType::TimestampTz),
+        pgrepr::Type::Interval => Ok(ScalarType::Interval),
+        pgrepr::Type::Bytea => Ok(ScalarType::Bytes),
+        pgrepr::Type::Text => Ok(ScalarType::String),
+        pgrepr::Type::Jsonb => Ok(ScalarType::Jsonb),
+        pgrepr::Type::List(l) => Ok(ScalarType::List(Box::new(scalar_type_from_pg(l)?))),
+        pgrepr::Type::Record(_) => {
+            bail!("internal error: can't convert from pg record to materialize record")
+        }
+    }
+}
+
 /// This is used to collect aggregates from within an `Expr`.
 /// See the explanation of aggregate handling at the top of the file for more details.
 struct AggregateFuncVisitor<'ast> {
@@ -2174,9 +2189,6 @@ pub struct QueryContext<'a> {
     pub outer_scope: Scope,
     /// The type of the outer relation expressions.
     pub outer_relation_types: Vec<RelationType>,
-    /// The types of the parameters in the query. This is filled in as planning
-    /// occurs.
-    pub param_types: Rc<RefCell<BTreeMap<usize, ScalarType>>>,
 }
 
 impl<'a> QueryContext<'a> {
@@ -2186,16 +2198,11 @@ impl<'a> QueryContext<'a> {
             lifetime,
             outer_scope: Scope::empty(None),
             outer_relation_types: vec![],
-            param_types: Rc::new(RefCell::new(BTreeMap::new())),
         }
     }
 
-    fn unwrap_param_types(self) -> BTreeMap<usize, ScalarType> {
-        Rc::try_unwrap(self.param_types).unwrap().into_inner()
-    }
-
     fn relation_type(&self, expr: &RelationExpr) -> RelationType {
-        expr.typ(&self.outer_relation_types, &self.param_types.borrow())
+        expr.typ(&self.outer_relation_types, &self.scx.param_types.borrow())
     }
 
     fn derived_context(&self, scope: Scope, relation_type: &RelationType) -> QueryContext<'a> {
@@ -2209,7 +2216,6 @@ impl<'a> QueryContext<'a> {
                 .chain(std::iter::once(relation_type))
                 .cloned()
                 .collect(),
-            param_types: self.param_types.clone(),
         }
     }
 }
@@ -2246,7 +2252,7 @@ impl<'a> ExprContext<'a> {
         expr.typ(
             &self.qcx.outer_relation_types,
             &self.relation_type,
-            &self.qcx.param_types.borrow(),
+            &self.qcx.scx.param_types.borrow(),
         )
     }
 
@@ -2277,5 +2283,9 @@ impl<'a> ExprContext<'a> {
         } else {
             Ok(())
         }
+    }
+
+    pub fn param_types(&self) -> &RefCell<BTreeMap<usize, ScalarType>> {
+        &self.qcx.scx.param_types
     }
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -7,9 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::path::PathBuf;
+use std::rc::Rc;
 use std::time::{Duration, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail};
@@ -101,9 +103,19 @@ pub fn make_show_objects_desc(
 pub fn describe_statement(
     catalog: &dyn Catalog,
     stmt: Statement,
+    param_types_in: &[Option<pgrepr::Type>],
 ) -> Result<(Option<RelationDesc>, Vec<ScalarType>), anyhow::Error> {
-    let pcx = &PlanContext::default();
-    let scx = &StatementContext { catalog, pcx };
+    let mut param_types = BTreeMap::new();
+    for (i, ty) in param_types_in.iter().enumerate() {
+        if let Some(ty) = ty {
+            param_types.insert(i + 1, query::scalar_type_from_pg(ty)?);
+        }
+    }
+    let scx = StatementContext {
+        catalog,
+        pcx: &PlanContext::default(),
+        param_types: Rc::new(RefCell::new(param_types)),
+    };
     Ok(match stmt {
         Statement::CreateDatabase { .. }
         | Statement::CreateSchema { .. }
@@ -139,6 +151,7 @@ pub fn describe_statement(
                             query: Box::new(q),
                             as_of: None,
                         },
+                        param_types_in,
                     )?
                     .1
                 }
@@ -230,8 +243,15 @@ pub fn describe_statement(
             // somewhere, so we don't have to reanalyze the whole query when
             // `handle_statement` is called. This will require a complicated
             // dance when bind parameters are implemented, so punting for now.
-            let (_relation_expr, desc, _finishing, param_types) =
-                query::plan_root_query(scx, *query, QueryLifetime::OneShot)?;
+            let (_relation_expr, desc, _finishing) =
+                query::plan_root_query(&scx, *query, QueryLifetime::OneShot)?;
+            let mut param_types = vec![];
+            for (i, (n, typ)) in scx.unwrap_param_types().into_iter().enumerate() {
+                if n != i + 1 {
+                    bail!("unable to infer type for parameter ${}", i + 1);
+                }
+                param_types.push(typ);
+            }
             (Some(desc), param_types)
         }
 
@@ -249,7 +269,17 @@ pub fn handle_statement(
     stmt: Statement,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
-    let scx = &StatementContext { pcx, catalog };
+    let param_types = params
+        .types
+        .iter()
+        .enumerate()
+        .map(|(i, ty)| (i + 1, ty.clone()))
+        .collect();
+    let scx = &StatementContext {
+        pcx,
+        catalog,
+        param_types: Rc::new(RefCell::new(param_types)),
+    };
     match stmt {
         Statement::Tail {
             name,
@@ -1058,7 +1088,7 @@ fn handle_create_view(
     } else {
         None
     };
-    let (mut relation_expr, mut desc, finishing, _) =
+    let (mut relation_expr, mut desc, finishing) =
         query::plan_root_query(scx, *query.clone(), QueryLifetime::Static)?;
     // TODO(jamii) can views even have parameters?
     relation_expr.bind_parameters(&params);
@@ -1823,6 +1853,7 @@ fn handle_explain(
             let scx = StatementContext {
                 pcx: entry.plan_cx(),
                 catalog: scx.catalog,
+                param_types: scx.param_types.clone(),
             };
             (scx, *query)
         }
@@ -1830,7 +1861,7 @@ fn handle_explain(
     };
     // Previouly we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
     // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
-    let (mut sql_expr, desc, finishing, _param_types) =
+    let (mut sql_expr, desc, finishing) =
         query::plan_root_query(&scx, query, QueryLifetime::OneShot)?;
     let finishing = if is_view {
         // views don't use a separate finishing
@@ -1860,7 +1891,7 @@ fn handle_query(
     params: &Params,
     lifetime: QueryLifetime,
 ) -> Result<(::expr::RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
-    let (mut expr, desc, finishing, _param_types) = query::plan_root_query(scx, query, lifetime)?;
+    let (mut expr, desc, finishing) = query::plan_root_query(scx, query, lifetime)?;
     expr.bind_parameters(&params);
     Ok((expr.decorrelate(), desc, finishing))
 }
@@ -1906,6 +1937,9 @@ fn object_type_as_plural_str(object_type: ObjectType) -> &'static str {
 pub struct StatementContext<'a> {
     pub pcx: &'a PlanContext,
     pub catalog: &'a dyn Catalog,
+    /// The types of the parameters in the query. This is filled in as planning
+    /// occurs.
+    pub param_types: Rc<RefCell<BTreeMap<usize, ScalarType>>>,
 }
 
 impl<'a> StatementContext<'a> {
@@ -1967,5 +2001,9 @@ impl<'a> StatementContext<'a> {
 
     pub fn experimental_mode(&self) -> bool {
         self.catalog.experimental_mode()
+    }
+
+    pub fn unwrap_param_types(self) -> BTreeMap<usize, ScalarType> {
+        Rc::try_unwrap(self.param_types).unwrap().into_inner()
     }
 }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -583,7 +583,7 @@ pub fn plan_coerce<'a>(
                 CoerceTo::Plain(typ) => typ,
                 CoerceTo::JsonbAny => ScalarType::Jsonb,
             };
-            let prev = ecx.qcx.param_types.borrow_mut().insert(n, typ);
+            let prev = ecx.param_types().borrow_mut().insert(n, typ);
             assert!(prev.is_none());
             ScalarExpr::Parameter(n)
         }

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -78,7 +78,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     for (sql, types) in test_cases {
         println!("> {}", sql);
         let stmt = sql::parse::parse(sql.into())?.into_element();
-        let (_desc, param_types) = sql::plan::describe(&DummyCatalog, stmt)?;
+        let (_desc, param_types) = sql::plan::describe(&DummyCatalog, stmt, &[])?;
         assert_eq!(param_types, types);
     }
     Ok(())

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -746,6 +746,7 @@ impl State {
                 .unbounded_send(coord::Command::Describe {
                     name: statement_name.clone(),
                     stmt: Some(stmt),
+                    param_types: vec![],
                     session: mem::replace(&mut self.session, Session::dummy()),
                     tx,
                 })

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -24,9 +24,11 @@
 //! Symbiosis mode is only suitable for development. It is likely to be
 //! extremely slow and inefficient on large data sets.
 
-use std::collections::HashMap;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
 use std::convert::TryInto;
 use std::env;
+use std::rc::Rc;
 
 use anyhow::{anyhow, bail};
 use chrono::Utc;
@@ -126,7 +128,11 @@ END $$;
         catalog: &dyn Catalog,
         stmt: &Statement,
     ) -> Result<Plan, anyhow::Error> {
-        let scx = StatementContext { pcx, catalog };
+        let scx = StatementContext {
+            pcx,
+            catalog,
+            param_types: Rc::new(RefCell::new(BTreeMap::new())),
+        };
         Ok(match stmt {
             Statement::CreateTable {
                 name,

--- a/test/lang/java/mzcompose
+++ b/test/lang/java/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/test/lang/java/mzcompose.yml
+++ b/test/lang/java/mzcompose.yml
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: "3"
+services:
+  materialized:
+    mzbuild: materialized
+    command: -w1
+  java-smoketest:
+    mzbuild: ci-java-smoketest
+    command: mvn test
+    working_dir: /workdir
+    volumes:
+      - ./smoketest:/workdir
+    environment:
+      - PGHOST=materialized
+      - PGPORT=6875
+    depends_on: [materialized]

--- a/test/lang/java/smoketest/Dockerfile
+++ b/test/lang/java/smoketest/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM ubuntu:bionic-20200403
+
+RUN apt-get update && apt-get install -qy maven xmlstarlet
+
+COPY pom.xml /scratch/
+
+# Convince Maven to download all necessary plugins to a local repository, so
+# that they get baked into the image. The `dependency:go-offline` plugin is a
+# bit buggy, so we have to make sure to actually execute a test to get the
+# maven-surefire plugin installed.
+RUN xmlstarlet ed --inplace \
+      --subnode /_:settings --type elem --name localRepository --value /var/lib/maven/repository \
+      /usr/share/maven/conf/settings.xml \
+   && (cd /scratch \
+      && echo "public class NoopTest { @org.junit.jupiter.api.Test void testNoop() {} }" > NoopTest.java \
+      && mvn -Dtest=NoopTest dependency:go-offline package) \
+   && xmlstarlet ed --inplace \
+      --subnode /_:settings --type elem --name offline --value true \
+      /usr/share/maven/conf/settings.xml

--- a/test/lang/java/smoketest/SmokeTest.java
+++ b/test/lang/java/smoketest/SmokeTest.java
@@ -1,0 +1,57 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+class SmokeTest {
+    private Connection conn;
+
+    @BeforeEach
+    void setUp() throws SQLException, java.lang.ClassNotFoundException {
+        String host = System.getenv("PGHOST");
+        if (host == null)
+            host = "localhost";
+        String port = System.getenv("PGPORT");
+        if (port == null)
+            port = "6875";
+        String url = String.format("jdbc:postgresql://%s:%s/", host, port);
+        conn = DriverManager.getConnection(url);
+    }
+
+    @Test
+    void testParamString() throws SQLException {
+        PreparedStatement stmt = conn.prepareStatement("SELECT ?");
+        stmt.setString(1, "foo");
+        ResultSet rs = stmt.executeQuery();
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals("foo", rs.getString(1));
+        rs.close();
+        stmt.close();
+    }
+
+    @Test
+    void testParamInt() throws SQLException {
+        PreparedStatement stmt = conn.prepareStatement("SELECT ?");
+        stmt.setInt(1, 42);
+        ResultSet rs = stmt.executeQuery();
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals("42", rs.getString(1));
+        Assertions.assertEquals(42, rs.getInt(1));
+        rs.close();
+        stmt.close();
+    }
+}

--- a/test/lang/java/smoketest/mzbuild.yml
+++ b/test/lang/java/smoketest/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: ci-java-smoketest

--- a/test/lang/java/smoketest/pom.xml
+++ b/test/lang/java/smoketest/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright Materialize, Inc. All rights reserved.
+
+Use of this software is governed by the Business Source License
+included in the LICENSE file.
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.materialize.materialized.test</groupId>
+  <artifactId>test-pgjdbc</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>test-pgjdbc</name>
+  <url>https://materialize.io/</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.6.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>
+      .
+    </testSourceDirectory>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
While most PostgreSQL clients leave parameter types unspecified and rely
on the server to perform parameter type inference, the protocol allows
for clients to explicitly specify parameter types. PgJDBC, notably,
always specifies parameter types in its default configuration.

We were previously dropping this information on the floor, which led to
some weird error messages with PgJDBC if the types didn't line up. This
commit fixes that.

Fix #3625.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3810)
<!-- Reviewable:end -->
