### PR TITLE
sql: handle GROUP BY ordinal refs to items of arbitrary expressions

### DIFF
--- a/demo/billing/src/mz.rs
+++ b/demo/billing/src/mz.rs
@@ -211,9 +211,9 @@ pub async fn validate_sink(
 
 fn billing_agg_view(unit: &str) -> String {
     format!("CREATE MATERIALIZED VIEW billing_agg_by_{unit} AS
-SELECT date_trunc as {unit}, client_id, meter, cpu_num, memory_gb, disk_gb, sum(value)
+SELECT date_trunc('{unit}', interval_start::timestamp) AS {unit}, client_id, meter, cpu_num, memory_gb, disk_gb, sum(value)
 FROM billing_records
-GROUP BY date_trunc('{unit}', interval_start::timestamp), client_id, meter, cpu_num, memory_gb, disk_gb",
+GROUP BY {unit}, client_id, meter, cpu_num, memory_gb, disk_gb",
 unit = unit)
 }
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -66,6 +66,19 @@ Wrap your release notes at the 80 character mark.
 - Support casts from [`boolean`](/sql/types/boolean) to [`int`](/sql/types/int).
 
 - Add UI at `materialized:6875/prof` HTTP endpoint for creating heap dumps.
+- Allow ordinal references in `GROUP BY` clauses to refer to items in the
+  `SELECT` list that are formed from arbitrary expressions, as in:
+
+  ```sql
+  SELECT a + 1, sum(b) FROM ... GROUP BY 1
+  ```
+
+  Previously, Materialize only handled ordinal references to items that were
+  simple column references, as in:
+
+  ```sql
+  SELECT a, sum(b) FROM ... GROUP BY 1
+  ```
 
 <span id="v0.4.0"></span>
 ## v0.4.0

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -614,7 +614,7 @@ fn plan_view_select_intrusive(
         let mut group_scope = Scope::empty(Some(qcx.outer_scope.clone()));
         let mut select_all_mapping = BTreeMap::new();
         for group_expr in group_by {
-            let expr = plan_group_by_expr(ecx, group_expr, &projection)?;
+            let (group_expr, expr) = plan_group_by_expr(ecx, group_expr, &projection)?;
             let new_column = group_key.len();
             // Repeated expressions in GROUP BY confuse name resolution later,
             // and dropping them doesn't change the result.
@@ -635,12 +635,12 @@ fn plan_view_select_intrusive(
                     // the movement here.
                     select_all_mapping.insert(*old_column, new_column);
                     let mut scope_item = ecx.scope.items[*old_column].clone();
-                    scope_item.expr = Some(group_expr.clone());
+                    scope_item.expr = group_expr.cloned();
                     scope_item
                 } else {
                     ScopeItem {
-                        names: invent_column_name(ecx, group_expr).into_iter().collect(),
-                        expr: Some(group_expr.clone()),
+                        names: vec![],
+                        expr: group_expr.cloned(),
                         nameable: true,
                     }
                 };
@@ -812,17 +812,23 @@ fn plan_view_select_intrusive(
 /// names/expressions defined in the `SELECT` clause. These special cases are
 /// handled by this function; see comments within the implementation for
 /// details.
-fn plan_group_by_expr(
+fn plan_group_by_expr<'a>(
     ecx: &ExprContext,
-    group_expr: &Expr,
-    projection: &[(ExpandedSelectItem, Option<ColumnName>)],
-) -> Result<ScalarExpr, anyhow::Error> {
+    group_expr: &'a Expr,
+    projection: &'a [(ExpandedSelectItem, Option<ColumnName>)],
+) -> Result<(Option<&'a Expr>, ScalarExpr), anyhow::Error> {
     let plan_projection = |column: usize| match &projection[column].0 {
-        ExpandedSelectItem::InputOrdinal(column) => Ok(ScalarExpr::Column(ColumnRef {
-            level: 0,
-            column: *column,
-        })),
-        ExpandedSelectItem::Expr(expr) => Ok(plan_expr(&ecx, expr)?.type_as_any(ecx)?),
+        ExpandedSelectItem::InputOrdinal(column) => Ok((
+            None,
+            ScalarExpr::Column(ColumnRef {
+                level: 0,
+                column: *column,
+            }),
+        )),
+        ExpandedSelectItem::Expr(expr) => Ok((
+            Some(expr.as_ref()),
+            plan_expr(&ecx, expr)?.type_as_any(ecx)?,
+        )),
     };
 
     // Check if the expression is a numeric literal, as in `GROUP BY 1`. This is
@@ -853,9 +859,12 @@ fn plan_group_by_expr(
                     Err(e.into())
                 }
             }
-            res => Ok(res?),
+            res => Ok((Some(group_expr), res?)),
         },
-        _ => plan_expr(&ecx, group_expr)?.type_as_any(ecx),
+        _ => Ok((
+            Some(group_expr),
+            plan_expr(&ecx, group_expr)?.type_as_any(ecx)?,
+        )),
     }
 }
 

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -57,6 +57,15 @@ SELECT a, sum(b) AS a FROM t GROUP BY a
 2 3
 3 1
 
+# Test that an ordinal in a GROUP BY that refers to a column that is an
+# expression, rather than a simple column reference, works.
+query IT rowsort
+SELECT 2 * a, sum(b) FROM t GROUP BY 1
+----
+2  3
+4  3
+6  1
+
 query TTT colnames
 SHOW COLUMNS FROM t
 ----


### PR DESCRIPTION
Allow ordinal references in `GROUP BY` clauses to refer to items in the
`SELECT` list that are formed from arbitrary expressions, as in:

    SELECT a + 1, sum(b) FROM ... GROUP BY 1

Previously, Materialize only handled ordinal references to items that were
simple column references, as in:

    SELECT a, sum(b) FROM ... GROUP BY 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3813)
<!-- Reviewable:end -->
