### PR TITLE
sql: mark repeat function as experimental

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1423,7 +1423,8 @@ lazy_static! {
                 })
             },
             "repeat" => {
-                params!(Int64) => unary_op(move |_ecx, n| {
+                params!(Int64) => unary_op(move |ecx, n| {
+                    ecx.require_experimental_mode("repeat")?;
                     Ok(TableFuncPlan {
                         func: TableFunc::Repeat,
                         exprs: vec![n],


### PR DESCRIPTION
If repeat yields negative output, various pieces of Materialize can
panic, so it's a bit dangerous to have lying around at the moment.
Mark it as experimental, so folks don't start using it yet without
agreeing to the experimental mode contract.

Touches #3820.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3821)
<!-- Reviewable:end -->
