### PR TITLE
Increasing batch size in ingest mode

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -533,7 +533,7 @@ pub struct KafkaOffset {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TimestampSourceUpdate {
     /// Update for an RT source: contains an updated partition count for this source
-    RealTime(i32),
+    RealTime(i32, HashMap<PartitionId, MzOffset>),
     ///  Timestamp update for a BYO source: contains an updated partition count for this source,
     /// combined with a PartitionID, Timestamp, MzOffset tuple. This tuple informs workers that
     /// messages with Offset on PartitionId will be timestamped with Timestamp.

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -184,7 +184,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
             } else {
                 timestamp_data_updates
                     .borrow_mut()
-                    .insert(id.clone(), TimestampDataUpdate::RealTime(1))
+                    .insert(id.clone(), TimestampDataUpdate::RealTime(1, HashMap::new()))
             };
             // Check that this is the first time this source id is registered
             assert!(prev.is_none());

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -99,7 +99,7 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
         } else {
             timestamp_data_updates
                 .borrow_mut()
-                .insert(id.clone(), TimestampDataUpdate::RealTime(1))
+                .insert(id.clone(), TimestampDataUpdate::RealTime(1, HashMap::new()))
         };
         // Check that this is the first time this source id is registered
         assert!(prev.is_none());

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -168,7 +168,7 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
         } else {
             timestamp_data_updates
                 .borrow_mut()
-                .insert(id.clone(), TimestampDataUpdate::RealTime(1));
+                .insert(id.clone(), TimestampDataUpdate::RealTime(1, HashMap::new()));
             timestamp_metadata_channel
                 .as_ref()
                 .borrow_mut()


### PR DESCRIPTION
As suggested by @frankmcsherry, this PR reduces the frequency at which we downgrade capabilities (thus creating larger batch sizes) when we detect that we are trailing behind a source (when the number of known messages in the topic is greater than the number of processed messages by X). 

I wanted to get this PR up before leaving but I have not verified that it actually improves performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3822)
<!-- Reviewable:end -->
