### PR TITLE
materialized: take responsibility for conditional selection of allocator

### DIFF
--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -22,7 +22,6 @@ dataflow-types = { path = "../dataflow-types" }
 futures = "0.3"
 getopts = "0.2"
 hyper = "0.13.7"
-jemallocator = { version = "0.3", features = ["profiling"] }
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 log = "0.4.11"
@@ -32,7 +31,6 @@ openssl-sys = { version = "0.9.58", features = ["vendored"] }
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
 postgres-openssl = "0.3.0"
-prof = { path = "../prof" }
 pgwire = { path = "../pgwire" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false, features = ["process"] }
 rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
@@ -57,6 +55,17 @@ predicates = "1.0.5"
 repr = { path = "../repr" }
 serde_json = "1"
 tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+jemallocator = { version = "0.3", features = ["profiling"] }
+# NOTE(benesch): when target-specific features are stabilized [0], we will want
+# to put the jemalloc-specific bits of the prof crate behind a "jemalloc"
+# feature flag so that we can enable the non-jemalloc bits on macOS. At the
+# moment the entire prof crate is entirely jemalloc-dependent, so the
+# distinction is moot.
+#
+# [0]: https://github.com/rust-lang/cargo/issues/1197
+prof = { path = "../prof" }
 
 [package.metadata.deb]
 depends = "$auto"

--- a/src/materialized/src/http/prof.rs
+++ b/src/materialized/src/http/prof.rs
@@ -1,0 +1,151 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Profiling endpoints.
+
+use std::io::Read;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use futures::stream::TryStreamExt;
+use hyper::header::HeaderValue;
+use hyper::{Body, Method, Request, Response};
+use url::form_urlencoded;
+
+use prof::{JemallocProfCtl, JemallocProfMetadata, ProfStartTime, PROF_CTL};
+
+pub async fn handle(req: Request<Body>) -> Result<Response<Body>, anyhow::Error> {
+    match (req.method(), &*PROF_CTL) {
+        (&Method::GET, Some(prof_ctl)) => {
+            let prof_md = prof_ctl.lock().expect("Profiler lock poisoned").get_md();
+            handle_get(prof_md).await
+        }
+        (&Method::POST, Some(prof_ctl)) => handle_post(req, prof_ctl).await,
+        _ => Ok(Response::builder().status(501).body(Body::from(
+            "Jemalloc profiling disabled (HINT: run with _RJEM_MALLOC_CONF=prof:true)",
+        ))?),
+    }
+}
+
+pub async fn handle_post(
+    body: Request<Body>,
+    prof_ctl: &Arc<Mutex<JemallocProfCtl>>,
+) -> Result<Response<Body>, anyhow::Error> {
+    let body = body
+        .into_body()
+        .try_fold(vec![], |mut v, b| async move {
+            v.extend(b);
+            Ok(v)
+        })
+        .await?;
+    let action = match form_urlencoded::parse(&body)
+        .find(|(k, _v)| &**k == "action")
+        .map(|(_k, v)| v)
+    {
+        Some(action) => action,
+        None => {
+            return Ok(Response::builder()
+                .status(400)
+                .body(Body::from("Expected `action` parameter"))?)
+        }
+    };
+    match action.as_ref() {
+        "activate" => {
+            let md = {
+                let mut borrow = prof_ctl.lock().expect("Profiler lock poisoned");
+                borrow.activate()?;
+                borrow.get_md()
+            };
+            handle_get(md).await
+        }
+        "deactivate" => {
+            let md = {
+                let mut borrow = prof_ctl.lock().expect("Profiler lock poisoned");
+                borrow.deactivate()?;
+                borrow.get_md()
+            };
+            handle_get(md).await
+        }
+        "dump_file" => {
+            let mut borrow = prof_ctl.lock().expect("Profiler lock poisoned");
+            let mut f = borrow.dump()?;
+            let mut s = String::new();
+            f.read_to_string(&mut s)?;
+            let body = Body::from(s);
+            let mut response = Response::new(body);
+            response.headers_mut().append(
+                "Content-Disposition",
+                HeaderValue::from_static("attachment; filename=\"jeprof.heap\""),
+            );
+            Ok(response)
+        }
+        x => Ok(Response::builder().status(400).body(Body::from(format!(
+            "Unrecognized `action` parameter: {}",
+            x
+        )))?),
+    }
+}
+
+pub async fn handle_get(prof_md: JemallocProfMetadata) -> Result<Response<Body>, anyhow::Error> {
+    let (prof_status, can_activate, is_active) = match prof_md.start_time {
+        Some(ProfStartTime::TimeImmemorial) => (
+            "Jemalloc profiling active since server start".to_string(),
+            false,
+            true,
+        ),
+        Some(ProfStartTime::Instant(when)) => (
+            format!(
+                "Jemalloc profiling active since {:?}",
+                Instant::now() - when,
+            ),
+            false,
+            true,
+        ),
+        None => (
+            "Jemalloc profiling enabled but inactive".to_string(),
+            true,
+            false,
+        ),
+    };
+    let activate_link = if can_activate {
+        r#"<form action="/prof" method="POST"><button type="submit" name="action" value="activate">Activate</button></form>"#
+    } else {
+        ""
+    };
+    let deactivate_link = if is_active {
+        r#"<form action="/prof" method="POST"><button type="submit" name="action" value="deactivate">Deactivate</button></form>"#
+    } else {
+        ""
+    };
+    let dump_file_link = if is_active {
+        r#"<form action="/prof" method="POST"><button type="submit" name="action" value="dump_file">Download heap profile</button></form>"#
+    } else {
+        ""
+    };
+    Ok(Response::new(Body::from(format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <title>materialized profiling functions</title>
+    </head>
+    <body>
+    <p>{prof_status}</p>
+    {activate_link}
+    {deactivate_link}
+    {dump_file_link}
+    </body>
+</html>
+"#,
+        prof_status = prof_status,
+        activate_link = activate_link,
+        deactivate_link = deactivate_link,
+        dump_file_link = dump_file_link,
+    ))))
+}

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -13,14 +13,6 @@
 //! [differential dataflow]: ../differential_dataflow/index.html
 //! [timely dataflow]: ../timely/index.html
 
-// Temporarily disable jemalloc on macOS as we have observed latency issues
-// when we run load tests with jemalloc, but not the macOS system allocator
-// todo(rkhaitan) figure out which allocator we want to use for all supported
-// platforms
-#[cfg(not(target_os = "macos"))]
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use std::any::Any;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
@@ -45,6 +37,18 @@ use crate::mux::Mux;
 
 mod http;
 mod mux;
+
+// Disable jemalloc on macOS, as it is not well supported [0][1][2].
+// The issues present as runaway latency on load test workloads that are
+// comfortably handled by the macOS system allocator. Consider re-evaluating if
+// jemalloc's macOS support improves.
+//
+// [0]: https://github.com/jemalloc/jemalloc/issues/26
+// [1]: https://github.com/jemalloc/jemalloc/issues/843
+// [2]: https://github.com/jemalloc/jemalloc/issues/1467
+#[cfg(not(target_os = "macos"))]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 /// The version of the crate.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -7,22 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use jemalloc_ctl::raw;
 use lazy_static::lazy_static;
-
-#[cfg(not(target_os = "macos"))]
-mod non_macos_imports {
-    pub use std::ffi::CString;
-    pub use std::os::unix::ffi::OsStrExt;
-
-    pub use jemalloc_ctl::raw;
-    pub use tempfile::NamedTempFile;
-}
-#[cfg(not(target_os = "macos"))]
-use non_macos_imports::*;
+use tempfile::NamedTempFile;
 
 lazy_static! {
     pub static ref PROF_CTL: Option<Arc<Mutex<JemallocProfCtl>>> = {
@@ -53,29 +45,6 @@ pub struct JemallocProfCtl {
     md: JemallocProfMetadata,
 }
 
-#[cfg(target_os = "macos")]
-impl JemallocProfCtl {
-    fn get() -> Option<Self> {
-        None
-    }
-    pub fn get_md(&self) -> JemallocProfMetadata {
-        unreachable!()
-    }
-
-    pub fn activate(&mut self) -> Result<(), jemalloc_ctl::Error> {
-        unreachable!()
-    }
-
-    pub fn deactivate(&mut self) -> Result<(), jemalloc_ctl::Error> {
-        unreachable!()
-    }
-
-    pub fn dump(&mut self) -> anyhow::Result<std::fs::File> {
-        unreachable!()
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
 impl JemallocProfCtl {
     // Creates and returns the global singleton.
     fn get() -> Option<Self> {


### PR DESCRIPTION
The materialized crate should be the one place where we choose which
allocator to use based on the target OS. This commit relieves the prof
crate of that responsibility. One day, hopefully when target-specific
features are supported, the prof crate will be able to expose both
jemalloc- and non-jemalloc-dependent features, but for the moment we
just declare that the prof crate depends on jemalloc.

As an added bonus, with this commit, neither the prof crate nor
the jemallocator crate are linked on macOS. This avoids bringing in the
jemalloc dependency at all on macOS, where it is unused.

This is an alternative to #3854.

Fix #3853.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3855)
<!-- Reviewable:end -->
