### PR TITLE
dataflow, sql: store starting offsets in a HashMap

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -566,9 +566,8 @@ pub struct KafkaSourceConnector {
     // Represents options specified by user when creating the source, e.g.
     // security settings.
     pub config_options: HashMap<String, String>,
-    // FIXME (brennan) - in the very near future, this should be made into a hashmap of partition |-> offset.
-    // #2736
-    pub start_offset: i64,
+    // Map from partition -> starting offset
+    pub start_offsets: HashMap<i32, i64>,
     pub group_id_prefix: Option<String>,
 }
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -308,9 +308,9 @@ where
             // can produce errors.
             let mut err_collection = Collection::empty(scope);
 
-            let fast_forwarded = match connector {
-                ExternalSourceConnector::Kafka(KafkaSourceConnector { start_offset, .. }) => {
-                    start_offset > 0
+            let fast_forwarded = match &connector {
+                ExternalSourceConnector::Kafka(KafkaSourceConnector { start_offsets, .. }) => {
+                    start_offsets.values().any(|&val| val > 0)
                 }
                 _ => false,
             };

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1307,11 +1307,14 @@ fn handle_create_source(scx: &StatementContext, stmt: Statement) -> Result<Plan,
                         bail!("`start_offset` is not yet implemented for BYO consistency sources.")
                     }
 
+                    let mut start_offsets = HashMap::new();
+                    start_offsets.insert(0, start_offset);
+
                     let connector = ExternalSourceConnector::Kafka(KafkaSourceConnector {
                         addr: broker.parse()?,
                         topic: topic.clone(),
                         config_options,
-                        start_offset,
+                        start_offsets,
                         group_id_prefix,
                     });
                     let encoding = get_encoding(format)?;


### PR DESCRIPTION
Touches #2736

Previously, we had a single start_offset per source, and we used that start_offset
across all of the partitions. This commit adds the ability to specify offsets
on a per-partition basis but does not allow for a user to actually specify multiple
offsets from the SQL interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3856)
<!-- Reviewable:end -->
