### PR TITLE
sql-parser: split out ast::Statement variants into dedicated structs

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -37,8 +37,9 @@ use rusoto_kinesis::KinesisClient;
 use dataflow::source::read_file_task;
 use dataflow::source::FileReadStyle;
 use dataflow_types::{
-    Consistency, DataEncoding, Envelope, ExternalSourceConnector, FileSourceConnector,
-    KafkaSourceConnector, KinesisSourceConnector, MzOffset, SourceConnector, TimestampSourceUpdate,
+    AvroOcfEncoding, Consistency, DataEncoding, Envelope, ExternalSourceConnector,
+    FileSourceConnector, KafkaSourceConnector, KinesisSourceConnector, MzOffset, SourceConnector,
+    TimestampSourceUpdate,
 };
 use expr::{PartitionId, SourceInstanceId};
 use ore::collections::CollectionExt;
@@ -724,14 +725,16 @@ fn is_ts_valid(
 ///
 fn identify_consistency_format(enc: DataEncoding, env: Envelope) -> ConsistencyFormatting {
     if let Envelope::Debezium(_) = env {
-        if let DataEncoding::AvroOcf { reader_schema: _ } = enc {
+        if let DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema: _ }) = enc {
             ConsistencyFormatting::DebeziumOcf
         } else {
             ConsistencyFormatting::DebeziumAvro
         }
     } else {
         match enc {
-            DataEncoding::AvroOcf { reader_schema: _ } => ConsistencyFormatting::ByoAvroOcf,
+            DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema: _ }) => {
+                ConsistencyFormatting::ByoAvroOcf
+            }
             DataEncoding::Avro(_) => ConsistencyFormatting::ByoAvro,
             _ => ConsistencyFormatting::ByoBytes,
         }

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -24,7 +24,7 @@ use timely::dataflow::{
 
 use ::avro::{types::Value, Schema};
 use dataflow_types::LinearOperator;
-use dataflow_types::{DataEncoding, Envelope, Timestamp};
+use dataflow_types::{DataEncoding, Envelope, RegexEncoding, Timestamp};
 use expr::Diff;
 use interchange::avro::{extract_row, DebeziumDecodeState, DiffPair};
 use log::error;
@@ -470,7 +470,9 @@ where
         (_, Envelope::Debezium(_)) => unreachable!(
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
-        (DataEncoding::Regex { regex }, Envelope::None) => regex_fn(stream, regex, debug_name),
+        (DataEncoding::Regex(RegexEncoding { regex }), Envelope::None) => {
+            regex_fn(stream, regex, debug_name)
+        }
         (DataEncoding::Protobuf(enc), Envelope::None) => decode_values_inner(
             stream,
             protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -389,7 +389,7 @@ where
                             .as_collection(),
                     );
                     let reader_schema = match &encoding {
-                        DataEncoding::AvroOcf { reader_schema } => reader_schema,
+                        DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => reader_schema,
                         _ => unreachable!(
                             "Internal error: \
                                  Avro OCF schema should have already been resolved.\n\

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -20,7 +20,9 @@ use timely::scheduling::{Activator, SyncActivator};
 
 use avro::types::Value;
 use avro::{AvroRead, Schema, Skip};
-use dataflow_types::{Consistency, DataEncoding, ExternalSourceConnector, MzOffset};
+use dataflow_types::{
+    AvroOcfEncoding, Consistency, DataEncoding, ExternalSourceConnector, MzOffset,
+};
 use expr::{PartitionId, SourceInstanceId};
 
 use crate::server::{
@@ -78,7 +80,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
         let receiver = match connector {
             ExternalSourceConnector::AvroOcf(oc) => {
                 let reader_schema = match &encoding {
-                    DataEncoding::AvroOcf { reader_schema } => reader_schema,
+                    DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => reader_schema,
                     _ => unreachable!(
                         "Internal error: \
                                          Avro OCF schema should have already been resolved.\n\

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -27,719 +27,868 @@ use crate::ast::{
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Statement {
-    /// `SELECT`
-    Select {
-        query: Box<Query>,
-        as_of: Option<Expr>,
-    },
-    /// `INSERT`
-    Insert {
-        /// TABLE
-        table_name: ObjectName,
-        /// COLUMNS
-        columns: Vec<Ident>,
-        /// A SQL query that specifies what to insert.
-        source: InsertSource,
-    },
-    Copy {
-        /// TABLE
-        table_name: ObjectName,
-        /// COLUMNS
-        columns: Vec<Ident>,
-        /// VALUES a vector of values to be copied
-        values: Vec<Option<String>>,
-    },
-    /// `UPDATE`
-    Update {
-        /// TABLE
-        table_name: ObjectName,
-        /// Column assignments
-        assignments: Vec<Assignment>,
-        /// WHERE
-        selection: Option<Expr>,
-    },
-    /// `DELETE`
-    Delete {
-        /// `FROM`
-        table_name: ObjectName,
-        /// `WHERE`
-        selection: Option<Expr>,
-    },
-    /// `CREATE DATABASE`
-    CreateDatabase {
-        name: Ident,
-        if_not_exists: bool,
-    },
-    /// `CREATE SCHEMA`
-    CreateSchema {
-        name: ObjectName,
-        if_not_exists: bool,
-    },
-    /// `CREATE SOURCE`
-    CreateSource {
-        name: ObjectName,
-        col_names: Vec<Ident>,
-        connector: Connector,
-        with_options: Vec<SqlOption>,
-        format: Option<Format>,
-        envelope: Envelope,
-        if_not_exists: bool,
-        materialized: bool,
-    },
-    /// `CREATE SINK`
-    CreateSink {
-        name: ObjectName,
-        from: ObjectName,
-        connector: Connector,
-        with_options: Vec<SqlOption>,
-        format: Option<Format>,
-        with_snapshot: bool,
-        as_of: Option<Expr>,
-        if_not_exists: bool,
-    },
-    /// `CREATE VIEW`
-    CreateView {
-        /// View name
-        name: ObjectName,
-        columns: Vec<Ident>,
-        with_options: Vec<SqlOption>,
-        query: Box<Query>,
-        if_exists: IfExistsBehavior,
-        temporary: bool,
-        materialized: bool,
-    },
-    /// `CREATE TABLE`
-    CreateTable {
-        /// Table name
-        name: ObjectName,
-        /// Optional schema
-        columns: Vec<ColumnDef>,
-        constraints: Vec<TableConstraint>,
-        with_options: Vec<SqlOption>,
-        if_not_exists: bool,
-    },
-    /// `CREATE INDEX`
-    CreateIndex {
-        /// Optional index name.
-        name: Option<Ident>,
-        /// `ON` table or view name
-        on_name: ObjectName,
-        /// Expressions that form part of the index key. If not included, the
-        /// key_parts will be inferred from the named object.
-        key_parts: Option<Vec<Expr>>,
-        if_not_exists: bool,
-    },
-    /// `ALTER <OBJECT> ... RENAME TO`
-    AlterObjectRename {
-        object_type: ObjectType,
-        if_exists: bool,
-        name: ObjectName,
-        to_item_name: Ident,
-    },
-    DropDatabase {
-        name: Ident,
-        if_exists: bool,
-    },
-    /// `DROP`
-    DropObjects {
-        /// The type of the object to drop: TABLE, VIEW, etc.
-        object_type: ObjectType,
-        /// An optional `IF EXISTS` clause. (Non-standard.)
-        if_exists: bool,
-        /// One or more objects to drop. (ANSI SQL requires exactly one.)
-        names: Vec<ObjectName>,
-        /// Whether `CASCADE` was specified. This will be `false` when
-        /// `RESTRICT` or no drop behavior at all was specified.
-        cascade: bool,
-    },
-    /// `SET <variable>`
-    ///
-    /// Note: this is not a standard SQL statement, but it is supported by at
-    /// least MySQL and PostgreSQL. Not all MySQL-specific syntatic forms are
-    /// supported yet.
-    SetVariable {
-        local: bool,
-        variable: Ident,
-        value: SetVariableValue,
-    },
-    /// `SHOW <variable>`
-    ///
-    /// Note: this is a PostgreSQL-specific statement.
-    ShowVariable {
-        variable: Ident,
-    },
-    /// `SHOW DATABASES`
-    ShowDatabases {
-        filter: Option<ShowStatementFilter>,
-    },
-    /// `SHOW <object>S`
-    ///
-    /// ```sql
-    /// SHOW TABLES;
-    /// SHOW SOURCES;
-    /// SHOW VIEWS;
-    /// SHOW SINKS;
-    /// ```
-    ShowObjects {
-        object_type: ObjectType,
-        from: Option<ObjectName>,
-        extended: bool,
-        full: bool,
-        materialized: bool,
-        filter: Option<ShowStatementFilter>,
-    },
-    /// `SHOW INDEX|INDEXES|KEYS`
-    ///
-    /// Note: this is a MySQL-specific statement
-    ShowIndexes {
-        table_name: ObjectName,
-        extended: bool,
-        filter: Option<ShowStatementFilter>,
-    },
-    /// `SHOW COLUMNS`
-    ///
-    /// Note: this is a MySQL-specific statement.
-    ShowColumns {
-        extended: bool,
-        full: bool,
-        table_name: ObjectName,
-        filter: Option<ShowStatementFilter>,
-    },
-    /// `SHOW CREATE VIEW <view>`
-    ShowCreateView {
-        view_name: ObjectName,
-    },
-    /// `SHOW CREATE SOURCE <source>`
-    ShowCreateSource {
-        source_name: ObjectName,
-    },
-    /// `SHOW CREATE SINK <sink>`
-    ShowCreateSink {
-        sink_name: ObjectName,
-    },
-    /// `SHOW CREATE INDEX <index>`
-    ShowCreateIndex {
-        index_name: ObjectName,
-    },
-    /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
-    StartTransaction {
-        modes: Vec<TransactionMode>,
-    },
-    /// `SET TRANSACTION ...`
-    SetTransaction {
-        modes: Vec<TransactionMode>,
-    },
-    /// `COMMIT [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
-    Commit {
-        chain: bool,
-    },
-    /// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
-    Rollback {
-        chain: bool,
-    },
-    /// `TAIL`
-    Tail {
-        name: ObjectName,
-        with_snapshot: bool,
-        as_of: Option<Expr>,
-    },
-    /// `EXPLAIN ...`
-    Explain {
-        stage: ExplainStage,
-        explainee: Explainee,
-        options: ExplainOptions,
-    },
+    Select(SelectStatement),
+    Insert(InsertStatement),
+    Copy(CopyStatement),
+    Update(UpdateStatement),
+    Delete(DeleteStatement),
+    CreateDatabase(CreateDatabaseStatement),
+    CreateSchema(CreateSchemaStatement),
+    CreateSource(CreateSourceStatement),
+    CreateSink(CreateSinkStatement),
+    CreateView(CreateViewStatement),
+    CreateTable(CreateTableStatement),
+    CreateIndex(CreateIndexStatement),
+    AlterObjectRename(AlterObjectRenameStatement),
+    DropDatabase(DropDatabaseStatement),
+    DropObjects(DropObjectsStatement),
+    SetVariable(SetVariableStatement),
+    ShowDatabases(ShowDatabasesStatement),
+    ShowObjects(ShowObjectsStatement),
+    ShowIndexes(ShowIndexesStatement),
+    ShowColumns(ShowColumnsStatement),
+    ShowCreateView(ShowCreateViewStatement),
+    ShowCreateSource(ShowCreateSourceStatement),
+    ShowCreateSink(ShowCreateSinkStatement),
+    ShowCreateIndex(ShowCreateIndexStatement),
+    ShowVariable(ShowVariableStatement),
+    StartTransaction(StartTransactionStatement),
+    SetTransaction(SetTransactionStatement),
+    Commit(CommitStatement),
+    Rollback(RollbackStatement),
+    Tail(TailStatement),
+    Explain(ExplainStatement),
 }
 
 impl AstDisplay for Statement {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
-            Statement::Select { query, as_of } => {
-                f.write_node(&query);
-                if let Some(as_of) = as_of {
-                    f.write_str(" AS OF ");
-                    f.write_node(as_of);
-                }
-            }
-            Statement::Insert {
-                table_name,
-                columns,
-                source,
-            } => {
-                f.write_str("INSERT INTO ");
-                f.write_node(&table_name);
-                if !columns.is_empty() {
-                    f.write_str(" (");
-                    f.write_node(&display::comma_separated(columns));
-                    f.write_str(")");
-                }
-                f.write_str(" ");
-                f.write_node(source);
-            }
-            Statement::Copy {
-                table_name,
-                columns,
-                values,
-            } => {
-                f.write_str("COPY ");
-                f.write_node(&table_name);
-                if !columns.is_empty() {
-                    f.write_str("(");
-                    f.write_node(&display::comma_separated(columns));
-                    f.write_str(")");
-                }
-                f.write_str(" FROM stdin; ");
-                if !values.is_empty() {
-                    f.write_str("\n");
-                    let mut delim = "";
-                    for v in values {
-                        f.write_str(delim);
-                        delim = "\t";
-                        if let Some(v) = v {
-                            f.write_str(v);
-                        } else {
-                            f.write_str("\\N");
-                        }
-                    }
-                }
-                f.write_str("\n\\.");
-            }
-            Statement::Update {
-                table_name,
-                assignments,
-                selection,
-            } => {
-                f.write_str("UPDATE ");
-                f.write_node(&table_name);
-                if !assignments.is_empty() {
-                    f.write_str(" SET ");
-                    f.write_node(&display::comma_separated(assignments));
-                }
-                if let Some(selection) = selection {
-                    f.write_str(" WHERE ");
-                    f.write_node(selection);
-                }
-            }
-            Statement::Delete {
-                table_name,
-                selection,
-            } => {
-                f.write_str("DELETE FROM ");
-                f.write_node(&table_name);
-                if let Some(selection) = selection {
-                    f.write_str(" WHERE ");
-                    f.write_node(selection);
-                }
-            }
-            Statement::CreateDatabase {
-                name,
-                if_not_exists,
-            } => {
-                f.write_str("CREATE DATABASE ");
-                if *if_not_exists {
-                    f.write_str("IF NOT EXISTS ");
-                }
-                f.write_node(name);
-            }
-            Statement::CreateSchema {
-                name,
-                if_not_exists,
-            } => {
-                f.write_str("CREATE SCHEMA ");
-                if *if_not_exists {
-                    f.write_str("IF NOT EXISTS ");
-                }
-                f.write_node(&name);
-            }
-            Statement::CreateSource {
-                name,
-                col_names,
-                connector,
-                with_options,
-                format,
-                envelope,
-                if_not_exists,
-                materialized,
-            } => {
-                f.write_str("CREATE ");
-                if *materialized {
-                    f.write_str("MATERIALIZED ");
-                }
-                f.write_str("SOURCE ");
-                if *if_not_exists {
-                    f.write_str("IF NOT EXISTS ");
-                }
-                f.write_node(&name);
-                f.write_str(" ");
-                if !col_names.is_empty() {
-                    f.write_str("(");
-                    f.write_node(&display::comma_separated(col_names));
-                    f.write_str(") ");
-                }
-                f.write_str("FROM ");
-                f.write_node(connector);
-                if !with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(with_options));
-                    f.write_str(")");
-                }
-                if let Some(format) = format {
-                    f.write_str(" FORMAT ");
-                    f.write_node(format);
-                }
-                if *envelope != Default::default() {
-                    f.write_str(" ENVELOPE ");
-                    f.write_node(envelope);
-                }
-            }
-            Statement::CreateSink {
-                name,
-                from,
-                connector,
-                with_options,
-                format,
-                with_snapshot,
-                as_of,
-                if_not_exists,
-            } => {
-                f.write_str("CREATE SINK ");
-                if *if_not_exists {
-                    f.write_str("IF NOT EXISTS ");
-                }
-                f.write_node(&name);
-                f.write_str(" FROM ");
-                f.write_node(&from);
-                f.write_str(" INTO ");
-                f.write_node(connector);
-                if !with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(with_options));
-                    f.write_str(")");
-                }
-                if let Some(format) = format {
-                    f.write_str(" FORMAT ");
-                    f.write_node(format);
-                }
-                if *with_snapshot {
-                    f.write_str(" WITH SNAPSHOT");
-                } else {
-                    f.write_str(" WITHOUT SNAPSHOT");
-                }
-
-                if let Some(as_of) = as_of {
-                    f.write_str(" AS OF ");
-                    f.write_node(as_of);
-                }
-            }
-            Statement::CreateView {
-                name,
-                columns,
-                query,
-                temporary,
-                materialized,
-                if_exists,
-                with_options,
-            } => {
-                f.write_str("CREATE");
-                if *if_exists == IfExistsBehavior::Replace {
-                    f.write_str(" OR REPLACE");
-                }
-                if *temporary {
-                    f.write_str(" TEMPORARY");
-                }
-                if *materialized {
-                    f.write_str(" MATERIALIZED");
-                }
-
-                f.write_str(" VIEW");
-
-                if *if_exists == IfExistsBehavior::Skip {
-                    f.write_str(" IF NOT EXISTS");
-                }
-
-                f.write_str(" ");
-                f.write_node(&name);
-
-                if !with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(with_options));
-                    f.write_str(")");
-                }
-
-                if !columns.is_empty() {
-                    f.write_str(" (");
-                    f.write_node(&display::comma_separated(columns));
-                    f.write_str(")");
-                }
-
-                f.write_str(" AS ");
-                f.write_node(&query);
-            }
-            Statement::CreateTable {
-                name,
-                columns,
-                constraints,
-                with_options,
-                if_not_exists,
-            } => {
-                f.write_str("CREATE TABLE ");
-                if *if_not_exists {
-                    f.write_str("IF NOT EXISTS ");
-                }
-                f.write_node(&name);
-                f.write_str(" (");
-                f.write_node(&display::comma_separated(columns));
-                if !constraints.is_empty() {
-                    f.write_str(", ");
-                    f.write_node(&display::comma_separated(constraints));
-                }
-                f.write_str(")");
-
-                if !with_options.is_empty() {
-                    f.write_str(" WITH (");
-                    f.write_node(&display::comma_separated(with_options));
-                    f.write_str(")");
-                }
-            }
-            Statement::CreateIndex {
-                name,
-                on_name,
-                key_parts,
-                if_not_exists,
-            } => {
-                f.write_str("CREATE ");
-                if key_parts.is_none() {
-                    f.write_str("DEFAULT ");
-                }
-                f.write_str("INDEX ");
-                if *if_not_exists {
-                    f.write_str("IF NOT EXISTS ");
-                }
-                if let Some(name) = name {
-                    f.write_node(name);
-                    f.write_str(" ");
-                }
-                f.write_str("ON ");
-                f.write_node(&on_name);
-                if let Some(key_parts) = key_parts {
-                    f.write_str(" (");
-                    f.write_node(&display::comma_separated(key_parts));
-                    f.write_str(")");
-                }
-            }
-            Statement::AlterObjectRename {
-                object_type,
-                if_exists,
-                name,
-                to_item_name,
-            } => {
-                f.write_str("ALTER ");
-                f.write_node(object_type);
-                f.write_str(" ");
-                if *if_exists {
-                    f.write_str("IF EXISTS ");
-                }
-                f.write_node(&name);
-                f.write_str(" RENAME TO ");
-                f.write_node(to_item_name);
-            }
-            Statement::DropDatabase { name, if_exists } => {
-                f.write_str("DROP DATABASE ");
-                if *if_exists {
-                    f.write_str("IF EXISTS ");
-                }
-                f.write_node(name);
-            }
-            Statement::DropObjects {
-                object_type,
-                if_exists,
-                names,
-                cascade,
-            } => {
-                f.write_str("DROP ");
-                f.write_node(object_type);
-                f.write_str(" ");
-                if *if_exists {
-                    f.write_str("IF EXISTS ");
-                }
-                f.write_node(&display::comma_separated(names));
-                if *cascade {
-                    f.write_str(" CASCADE");
-                }
-            }
-            Statement::SetVariable {
-                local,
-                variable,
-                value,
-            } => {
-                f.write_str("SET ");
-                if *local {
-                    f.write_str("LOCAL ");
-                }
-                f.write_node(variable);
-                f.write_str(" = ");
-                f.write_node(value);
-            }
-            Statement::ShowVariable { variable } => {
-                f.write_str("SHOW ");
-                f.write_node(variable);
-            }
-            Statement::ShowDatabases { filter } => {
-                f.write_str("SHOW DATABASES");
-                if let Some(filter) = filter {
-                    f.write_str(" ");
-                    f.write_node(filter);
-                }
-            }
-            Statement::ShowObjects {
-                object_type,
-                filter,
-                full,
-                materialized,
-                from,
-                extended,
-            } => {
-                f.write_str("SHOW");
-                if *extended {
-                    f.write_str(" EXTENDED");
-                }
-                if *full {
-                    f.write_str(" FULL");
-                }
-                if *materialized {
-                    f.write_str(" MATERIALIZED");
-                }
-                f.write_str(" ");
-                f.write_str(match object_type {
-                    ObjectType::Schema => "SCHEMAS",
-                    ObjectType::Table => "TABLES",
-                    ObjectType::View => "VIEWS",
-                    ObjectType::Source => "SOURCES",
-                    ObjectType::Sink => "SINKS",
-                    ObjectType::Index => unreachable!(),
-                });
-                if let Some(from) = from {
-                    f.write_str(" FROM ");
-                    f.write_node(&from);
-                }
-                if let Some(filter) = filter {
-                    f.write_str(" ");
-                    f.write_node(filter);
-                }
-            }
-            Statement::ShowIndexes {
-                table_name,
-                extended,
-                filter,
-            } => {
-                f.write_str("SHOW ");
-                if *extended {
-                    f.write_str("EXTENDED ");
-                }
-                f.write_str("INDEXES FROM ");
-                f.write_node(&table_name);
-                if let Some(filter) = filter {
-                    f.write_str(" ");
-                    f.write_node(filter);
-                }
-            }
-            Statement::ShowColumns {
-                extended,
-                full,
-                table_name,
-                filter,
-            } => {
-                f.write_str("SHOW ");
-                if *extended {
-                    f.write_str("EXTENDED ");
-                }
-                if *full {
-                    f.write_str("FULL ");
-                }
-                f.write_str("COLUMNS FROM ");
-                f.write_node(&table_name);
-                if let Some(filter) = filter {
-                    f.write_str(" ");
-                    f.write_node(filter);
-                }
-            }
-            Statement::ShowCreateView { view_name } => {
-                f.write_str("SHOW CREATE VIEW ");
-                f.write_node(&view_name);
-            }
-            Statement::ShowCreateSource { source_name } => {
-                f.write_str("SHOW CREATE SOURCE ");
-                f.write_node(&source_name);
-            }
-            Statement::ShowCreateSink { sink_name } => {
-                f.write_str("SHOW CREATE SINK ");
-                f.write_node(&sink_name);
-            }
-            Statement::ShowCreateIndex { index_name } => {
-                f.write_str("SHOW CREATE INDEX ");
-                f.write_node(&index_name);
-            }
-            Statement::StartTransaction { modes } => {
-                f.write_str("START TRANSACTION");
-                if !modes.is_empty() {
-                    f.write_str(" ");
-                    f.write_node(&display::comma_separated(modes));
-                }
-            }
-            Statement::SetTransaction { modes } => {
-                f.write_str("SET TRANSACTION");
-                if !modes.is_empty() {
-                    f.write_str(" ");
-                    f.write_node(&display::comma_separated(modes));
-                }
-            }
-            Statement::Commit { chain } => {
-                f.write_str("COMMIT");
-                if *chain {
-                    f.write_str(" AND CHAIN");
-                }
-            }
-            Statement::Rollback { chain } => {
-                f.write_str("ROLLBACK");
-                if *chain {
-                    f.write_str(" AND CHAIN");
-                }
-            }
-            Statement::Tail {
-                name,
-                with_snapshot,
-                as_of,
-            } => {
-                f.write_str("TAIL ");
-                f.write_node(&name);
-
-                if *with_snapshot {
-                    f.write_str(" WITH SNAPSHOT");
-                } else {
-                    f.write_str(" WITHOUT SNAPSHOT");
-                }
-                if let Some(as_of) = as_of {
-                    f.write_str(" AS OF ");
-                    f.write_node(as_of);
-                }
-            }
-            Statement::Explain {
-                stage,
-                explainee,
-                options,
-            } => {
-                f.write_str("EXPLAIN ");
-                if options.typed {
-                    f.write_str("TYPED ");
-                }
-                f.write_node(stage);
-                f.write_str(" FOR ");
-                f.write_node(explainee);
-            }
+            Statement::Select(stmt) => f.write_node(stmt),
+            Statement::Insert(stmt) => f.write_node(stmt),
+            Statement::Copy(stmt) => f.write_node(stmt),
+            Statement::Update(stmt) => f.write_node(stmt),
+            Statement::Delete(stmt) => f.write_node(stmt),
+            Statement::CreateDatabase(stmt) => f.write_node(stmt),
+            Statement::CreateSchema(stmt) => f.write_node(stmt),
+            Statement::CreateSource(stmt) => f.write_node(stmt),
+            Statement::CreateSink(stmt) => f.write_node(stmt),
+            Statement::CreateView(stmt) => f.write_node(stmt),
+            Statement::CreateTable(stmt) => f.write_node(stmt),
+            Statement::CreateIndex(stmt) => f.write_node(stmt),
+            Statement::AlterObjectRename(stmt) => f.write_node(stmt),
+            Statement::DropDatabase(stmt) => f.write_node(stmt),
+            Statement::DropObjects(stmt) => f.write_node(stmt),
+            Statement::SetVariable(stmt) => f.write_node(stmt),
+            Statement::ShowDatabases(stmt) => f.write_node(stmt),
+            Statement::ShowObjects(stmt) => f.write_node(stmt),
+            Statement::ShowIndexes(stmt) => f.write_node(stmt),
+            Statement::ShowColumns(stmt) => f.write_node(stmt),
+            Statement::ShowCreateView(stmt) => f.write_node(stmt),
+            Statement::ShowCreateSource(stmt) => f.write_node(stmt),
+            Statement::ShowCreateSink(stmt) => f.write_node(stmt),
+            Statement::ShowCreateIndex(stmt) => f.write_node(stmt),
+            Statement::ShowVariable(stmt) => f.write_node(stmt),
+            Statement::StartTransaction(stmt) => f.write_node(stmt),
+            Statement::SetTransaction(stmt) => f.write_node(stmt),
+            Statement::Commit(stmt) => f.write_node(stmt),
+            Statement::Rollback(stmt) => f.write_node(stmt),
+            Statement::Tail(stmt) => f.write_node(stmt),
+            Statement::Explain(stmt) => f.write_node(stmt),
         }
     }
 }
 impl_display!(Statement);
+
+/// `SELECT`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SelectStatement {
+    pub query: Box<Query>,
+    pub as_of: Option<Expr>,
+}
+
+impl AstDisplay for SelectStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_node(&self.query);
+        if let Some(as_of) = &self.as_of {
+            f.write_str(" AS OF ");
+            f.write_node(as_of);
+        }
+    }
+}
+impl_display!(SelectStatement);
+
+/// `INSERT`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InsertStatement {
+    /// TABLE
+    pub table_name: ObjectName,
+    /// COLUMNS
+    pub columns: Vec<Ident>,
+    /// A SQL query that specifies what to insert.
+    pub source: InsertSource,
+}
+
+impl AstDisplay for InsertStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("INSERT INTO ");
+        f.write_node(&self.table_name);
+        if !self.columns.is_empty() {
+            f.write_str(" (");
+            f.write_node(&display::comma_separated(&self.columns));
+            f.write_str(")");
+        }
+        f.write_str(" ");
+        f.write_node(&self.source);
+    }
+}
+impl_display!(InsertStatement);
+
+/// `COPY`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CopyStatement {
+    /// TABLE
+    pub table_name: ObjectName,
+    /// COLUMNS
+    pub columns: Vec<Ident>,
+    /// VALUES a vector of values to be copied
+    pub values: Vec<Option<String>>,
+}
+
+impl AstDisplay for CopyStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("COPY ");
+        f.write_node(&self.table_name);
+        if !self.columns.is_empty() {
+            f.write_str("(");
+            f.write_node(&display::comma_separated(&self.columns));
+            f.write_str(")");
+        }
+        f.write_str(" FROM stdin; ");
+        if !self.values.is_empty() {
+            f.write_str("\n");
+            let mut delim = "";
+            for v in &self.values {
+                f.write_str(delim);
+                delim = "\t";
+                if let Some(v) = v {
+                    f.write_str(v);
+                } else {
+                    f.write_str("\\N");
+                }
+            }
+        }
+        f.write_str("\n\\.");
+    }
+}
+impl_display!(CopyStatement);
+
+/// `UPDATE`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UpdateStatement {
+    /// TABLE
+    pub table_name: ObjectName,
+    /// Column assignments
+    pub assignments: Vec<Assignment>,
+    /// WHERE
+    pub selection: Option<Expr>,
+}
+
+impl AstDisplay for UpdateStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("UPDATE ");
+        f.write_node(&self.table_name);
+        if !self.assignments.is_empty() {
+            f.write_str(" SET ");
+            f.write_node(&display::comma_separated(&self.assignments));
+        }
+        if let Some(selection) = &self.selection {
+            f.write_str(" WHERE ");
+            f.write_node(selection);
+        }
+    }
+}
+impl_display!(UpdateStatement);
+
+/// `DELETE`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DeleteStatement {
+    /// `FROM`
+    pub table_name: ObjectName,
+    /// `WHERE`
+    pub selection: Option<Expr>,
+}
+
+impl AstDisplay for DeleteStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("DELETE FROM ");
+        f.write_node(&self.table_name);
+        if let Some(selection) = &self.selection {
+            f.write_str(" WHERE ");
+            f.write_node(selection);
+        }
+    }
+}
+impl_display!(DeleteStatement);
+
+/// `CREATE DATABASE`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateDatabaseStatement {
+    pub name: Ident,
+    pub if_not_exists: bool,
+}
+
+impl AstDisplay for CreateDatabaseStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE DATABASE ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
+        f.write_node(&self.name);
+    }
+}
+impl_display!(CreateDatabaseStatement);
+
+/// `CREATE SCHEMA`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateSchemaStatement {
+    pub name: ObjectName,
+    pub if_not_exists: bool,
+}
+
+impl AstDisplay for CreateSchemaStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE SCHEMA ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
+        f.write_node(&self.name);
+    }
+}
+impl_display!(CreateSchemaStatement);
+
+/// `CREATE SOURCE`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateSourceStatement {
+    pub name: ObjectName,
+    pub col_names: Vec<Ident>,
+    pub connector: Connector,
+    pub with_options: Vec<SqlOption>,
+    pub format: Option<Format>,
+    pub envelope: Envelope,
+    pub if_not_exists: bool,
+    pub materialized: bool,
+}
+
+impl AstDisplay for CreateSourceStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE ");
+        if self.materialized {
+            f.write_str("MATERIALIZED ");
+        }
+        f.write_str("SOURCE ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
+        f.write_node(&self.name);
+        f.write_str(" ");
+        if !self.col_names.is_empty() {
+            f.write_str("(");
+            f.write_node(&display::comma_separated(&self.col_names));
+            f.write_str(") ");
+        }
+        f.write_str("FROM ");
+        f.write_node(&self.connector);
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
+        }
+        if let Some(format) = &self.format {
+            f.write_str(" FORMAT ");
+            f.write_node(format);
+        }
+        if self.envelope != Default::default() {
+            f.write_str(" ENVELOPE ");
+            f.write_node(&self.envelope);
+        }
+    }
+}
+impl_display!(CreateSourceStatement);
+
+/// `CREATE SINK`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateSinkStatement {
+    pub name: ObjectName,
+    pub from: ObjectName,
+    pub connector: Connector,
+    pub with_options: Vec<SqlOption>,
+    pub format: Option<Format>,
+    pub with_snapshot: bool,
+    pub as_of: Option<Expr>,
+    pub if_not_exists: bool,
+}
+
+impl AstDisplay for CreateSinkStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE SINK ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
+        f.write_node(&self.name);
+        f.write_str(" FROM ");
+        f.write_node(&self.from);
+        f.write_str(" INTO ");
+        f.write_node(&self.connector);
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
+        }
+        if let Some(format) = &self.format {
+            f.write_str(" FORMAT ");
+            f.write_node(format);
+        }
+        if self.with_snapshot {
+            f.write_str(" WITH SNAPSHOT");
+        } else {
+            f.write_str(" WITHOUT SNAPSHOT");
+        }
+
+        if let Some(as_of) = &self.as_of {
+            f.write_str(" AS OF ");
+            f.write_node(as_of);
+        }
+    }
+}
+impl_display!(CreateSinkStatement);
+
+/// `CREATE VIEW`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateViewStatement {
+    /// View name
+    pub name: ObjectName,
+    pub columns: Vec<Ident>,
+    pub with_options: Vec<SqlOption>,
+    pub query: Box<Query>,
+    pub if_exists: IfExistsBehavior,
+    pub temporary: bool,
+    pub materialized: bool,
+}
+
+impl AstDisplay for CreateViewStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE");
+        if self.if_exists == IfExistsBehavior::Replace {
+            f.write_str(" OR REPLACE");
+        }
+        if self.temporary {
+            f.write_str(" TEMPORARY");
+        }
+        if self.materialized {
+            f.write_str(" MATERIALIZED");
+        }
+
+        f.write_str(" VIEW");
+
+        if self.if_exists == IfExistsBehavior::Skip {
+            f.write_str(" IF NOT EXISTS");
+        }
+
+        f.write_str(" ");
+        f.write_node(&self.name);
+
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
+        }
+
+        if !self.columns.is_empty() {
+            f.write_str(" (");
+            f.write_node(&display::comma_separated(&self.columns));
+            f.write_str(")");
+        }
+
+        f.write_str(" AS ");
+        f.write_node(&self.query);
+    }
+}
+impl_display!(CreateViewStatement);
+
+/// `CREATE TABLE`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateTableStatement {
+    /// Table name
+    pub name: ObjectName,
+    /// Optional schema
+    pub columns: Vec<ColumnDef>,
+    pub constraints: Vec<TableConstraint>,
+    pub with_options: Vec<SqlOption>,
+    pub if_not_exists: bool,
+}
+
+impl AstDisplay for CreateTableStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE TABLE ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
+        f.write_node(&self.name);
+        f.write_str(" (");
+        f.write_node(&display::comma_separated(&self.columns));
+        if !self.constraints.is_empty() {
+            f.write_str(", ");
+            f.write_node(&display::comma_separated(&self.constraints));
+        }
+        f.write_str(")");
+
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
+        }
+    }
+}
+impl_display!(CreateTableStatement);
+
+/// `CREATE INDEX`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateIndexStatement {
+    /// Optional index name.
+    pub name: Option<Ident>,
+    /// `ON` table or view name
+    pub on_name: ObjectName,
+    /// Expressions that form part of the index key. If not included, the
+    /// key_parts will be inferred from the named object.
+    pub key_parts: Option<Vec<Expr>>,
+    pub if_not_exists: bool,
+}
+
+impl AstDisplay for CreateIndexStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CREATE ");
+        if self.key_parts.is_none() {
+            f.write_str("DEFAULT ");
+        }
+        f.write_str("INDEX ");
+        if self.if_not_exists {
+            f.write_str("IF NOT EXISTS ");
+        }
+        if let Some(name) = &self.name {
+            f.write_node(name);
+            f.write_str(" ");
+        }
+        f.write_str("ON ");
+        f.write_node(&self.on_name);
+        if let Some(key_parts) = &self.key_parts {
+            f.write_str(" (");
+            f.write_node(&display::comma_separated(key_parts));
+            f.write_str(")");
+        }
+    }
+}
+impl_display!(CreateIndexStatement);
+
+/// `ALTER <OBJECT> ... RENAME TO`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AlterObjectRenameStatement {
+    pub object_type: ObjectType,
+    pub if_exists: bool,
+    pub name: ObjectName,
+    pub to_item_name: Ident,
+}
+
+impl AstDisplay for AlterObjectRenameStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("ALTER ");
+        f.write_node(&self.object_type);
+        f.write_str(" ");
+        if self.if_exists {
+            f.write_str("IF EXISTS ");
+        }
+        f.write_node(&self.name);
+        f.write_str(" RENAME TO ");
+        f.write_node(&self.to_item_name);
+    }
+}
+impl_display!(AlterObjectRenameStatement);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DropDatabaseStatement {
+    pub name: Ident,
+    pub if_exists: bool,
+}
+
+impl AstDisplay for DropDatabaseStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("DROP DATABASE ");
+        if self.if_exists {
+            f.write_str("IF EXISTS ");
+        }
+        f.write_node(&self.name);
+    }
+}
+impl_display!(DropDatabaseStatement);
+
+/// `DROP`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DropObjectsStatement {
+    /// The type of the object to drop: TABLE, VIEW, etc.
+    pub object_type: ObjectType,
+    /// An optional `IF EXISTS` clause. (Non-standard.)
+    pub if_exists: bool,
+    /// One or more objects to drop. (ANSI SQL requires exactly one.)
+    pub names: Vec<ObjectName>,
+    /// Whether `CASCADE` was specified. This will be `false` when
+    /// `RESTRICT` or no drop behavior at all was specified.
+    pub cascade: bool,
+}
+
+impl AstDisplay for DropObjectsStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("DROP ");
+        f.write_node(&self.object_type);
+        f.write_str(" ");
+        if self.if_exists {
+            f.write_str("IF EXISTS ");
+        }
+        f.write_node(&display::comma_separated(&self.names));
+        if self.cascade {
+            f.write_str(" CASCADE");
+        }
+    }
+}
+impl_display!(DropObjectsStatement);
+
+/// `SET <variable>`
+///
+/// Note: this is not a standard SQL statement, but it is supported by at
+/// least MySQL and PostgreSQL. Not all MySQL-specific syntatic forms are
+/// supported yet.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SetVariableStatement {
+    pub local: bool,
+    pub variable: Ident,
+    pub value: SetVariableValue,
+}
+
+impl AstDisplay for SetVariableStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SET ");
+        if self.local {
+            f.write_str("LOCAL ");
+        }
+        f.write_node(&self.variable);
+        f.write_str(" = ");
+        f.write_node(&self.value);
+    }
+}
+impl_display!(SetVariableStatement);
+
+/// `SHOW <variable>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowVariableStatement {
+    pub variable: Ident,
+}
+
+impl AstDisplay for ShowVariableStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW ");
+        f.write_node(&self.variable);
+    }
+}
+impl_display!(ShowVariableStatement);
+
+/// `SHOW DATABASES`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowDatabasesStatement {
+    pub filter: Option<ShowStatementFilter>,
+}
+
+impl AstDisplay for ShowDatabasesStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW DATABASES");
+        if let Some(filter) = &self.filter {
+            f.write_str(" ");
+            f.write_node(filter);
+        }
+    }
+}
+impl_display!(ShowDatabasesStatement);
+
+/// `SHOW <object>S`
+///
+/// ```sql
+/// SHOW TABLES;
+/// SHOW SOURCES;
+/// SHOW VIEWS;
+/// SHOW SINKS;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowObjectsStatement {
+    pub object_type: ObjectType,
+    pub from: Option<ObjectName>,
+    pub extended: bool,
+    pub full: bool,
+    pub materialized: bool,
+    pub filter: Option<ShowStatementFilter>,
+}
+
+impl AstDisplay for ShowObjectsStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW");
+        if self.extended {
+            f.write_str(" EXTENDED");
+        }
+        if self.full {
+            f.write_str(" FULL");
+        }
+        if self.materialized {
+            f.write_str(" MATERIALIZED");
+        }
+        f.write_str(" ");
+        f.write_str(match &self.object_type {
+            ObjectType::Schema => "SCHEMAS",
+            ObjectType::Table => "TABLES",
+            ObjectType::View => "VIEWS",
+            ObjectType::Source => "SOURCES",
+            ObjectType::Sink => "SINKS",
+            ObjectType::Index => unreachable!(),
+        });
+        if let Some(from) = &self.from {
+            f.write_str(" FROM ");
+            f.write_node(&from);
+        }
+        if let Some(filter) = &self.filter {
+            f.write_str(" ");
+            f.write_node(filter);
+        }
+    }
+}
+impl_display!(ShowObjectsStatement);
+
+/// `SHOW INDEX|INDEXES|KEYS`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowIndexesStatement {
+    pub table_name: ObjectName,
+    pub extended: bool,
+    pub filter: Option<ShowStatementFilter>,
+}
+
+impl AstDisplay for ShowIndexesStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW ");
+        if self.extended {
+            f.write_str("EXTENDED ");
+        }
+        f.write_str("INDEXES FROM ");
+        f.write_node(&self.table_name);
+        if let Some(filter) = &self.filter {
+            f.write_str(" ");
+            f.write_node(filter);
+        }
+    }
+}
+impl_display!(ShowIndexesStatement);
+
+/// `SHOW COLUMNS`
+///
+/// Note: this is a MySQL-specific statement.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowColumnsStatement {
+    pub extended: bool,
+    pub full: bool,
+    pub table_name: ObjectName,
+    pub filter: Option<ShowStatementFilter>,
+}
+
+impl AstDisplay for ShowColumnsStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW ");
+        if self.extended {
+            f.write_str("EXTENDED ");
+        }
+        if self.full {
+            f.write_str("FULL ");
+        }
+        f.write_str("COLUMNS FROM ");
+        f.write_node(&self.table_name);
+        if let Some(filter) = &self.filter {
+            f.write_str(" ");
+            f.write_node(filter);
+        }
+    }
+}
+impl_display!(ShowColumnsStatement);
+
+/// `SHOW CREATE VIEW <view>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowCreateViewStatement {
+    pub view_name: ObjectName,
+}
+
+impl AstDisplay for ShowCreateViewStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW CREATE VIEW ");
+        f.write_node(&self.view_name);
+    }
+}
+impl_display!(ShowCreateViewStatement);
+
+/// `SHOW CREATE SOURCE <source>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowCreateSourceStatement {
+    pub source_name: ObjectName,
+}
+
+impl AstDisplay for ShowCreateSourceStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW CREATE SOURCE ");
+        f.write_node(&self.source_name);
+    }
+}
+impl_display!(ShowCreateSourceStatement);
+
+/// `SHOW CREATE SINK <sink>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowCreateSinkStatement {
+    pub sink_name: ObjectName,
+}
+
+impl AstDisplay for ShowCreateSinkStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW CREATE SINK ");
+        f.write_node(&self.sink_name);
+    }
+}
+impl_display!(ShowCreateSinkStatement);
+
+/// `SHOW CREATE INDEX <index>`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ShowCreateIndexStatement {
+    pub index_name: ObjectName,
+}
+
+impl AstDisplay for ShowCreateIndexStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SHOW CREATE INDEX ");
+        f.write_node(&self.index_name);
+    }
+}
+impl_display!(ShowCreateIndexStatement);
+
+/// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StartTransactionStatement {
+    pub modes: Vec<TransactionMode>,
+}
+
+impl AstDisplay for StartTransactionStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("START TRANSACTION");
+        if !self.modes.is_empty() {
+            f.write_str(" ");
+            f.write_node(&display::comma_separated(&self.modes));
+        }
+    }
+}
+impl_display!(StartTransactionStatement);
+
+/// `SET TRANSACTION ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SetTransactionStatement {
+    pub modes: Vec<TransactionMode>,
+}
+
+impl AstDisplay for SetTransactionStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("SET TRANSACTION");
+        if !self.modes.is_empty() {
+            f.write_str(" ");
+            f.write_node(&display::comma_separated(&self.modes));
+        }
+    }
+}
+impl_display!(SetTransactionStatement);
+
+/// `COMMIT [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CommitStatement {
+    pub chain: bool,
+}
+
+impl AstDisplay for CommitStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("COMMIT");
+        if self.chain {
+            f.write_str(" AND CHAIN");
+        }
+    }
+}
+impl_display!(CommitStatement);
+
+/// `ROLLBACK [ TRANSACTION | WORK ] [ AND [ NO ] CHAIN ]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RollbackStatement {
+    pub chain: bool,
+}
+
+impl AstDisplay for RollbackStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("ROLLBACK");
+        if self.chain {
+            f.write_str(" AND CHAIN");
+        }
+    }
+}
+impl_display!(RollbackStatement);
+
+/// `TAIL`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TailStatement {
+    pub name: ObjectName,
+    pub with_snapshot: bool,
+    pub as_of: Option<Expr>,
+}
+
+impl AstDisplay for TailStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("TAIL ");
+        f.write_node(&self.name);
+
+        if self.with_snapshot {
+            f.write_str(" WITH SNAPSHOT");
+        } else {
+            f.write_str(" WITHOUT SNAPSHOT");
+        }
+        if let Some(as_of) = &self.as_of {
+            f.write_str(" AS OF ");
+            f.write_node(as_of);
+        }
+    }
+}
+impl_display!(TailStatement);
+
+/// `EXPLAIN ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExplainStatement {
+    pub stage: ExplainStage,
+    pub explainee: Explainee,
+    pub options: ExplainOptions,
+}
+
+impl AstDisplay for ExplainStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("EXPLAIN ");
+        if self.options.typed {
+            f.write_str("TYPED ");
+        }
+        f.write_node(&self.stage);
+        f.write_str(" FOR ");
+        f.write_node(&self.explainee);
+    }
+}
+impl_display!(ExplainStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum InsertSource {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -194,10 +194,10 @@ impl Parser {
                 Token::Word(ref w) if w.keyword != "" => match w.keyword.as_ref() {
                     "SELECT" | "WITH" | "VALUES" => {
                         self.prev_token();
-                        Ok(Statement::Select {
+                        Ok(Statement::Select(SelectStatement {
                             query: Box::new(self.parse_query()?),
                             as_of: self.parse_optional_as_of()?,
-                        })
+                        }))
                     }
                     "CREATE" => Ok(self.parse_create()?),
                     "DROP" => Ok(self.parse_drop()?),
@@ -228,10 +228,10 @@ impl Parser {
                 },
                 Token::LParen => {
                     self.prev_token();
-                    Ok(Statement::Select {
+                    Ok(Statement::Select(SelectStatement {
                         query: Box::new(self.parse_query()?),
                         as_of: None, // Only the outermost SELECT may have an AS OF clause.
-                    })
+                    }))
                 }
                 unexpected => self.expected(
                     self.peek_prev_range(),
@@ -1345,19 +1345,19 @@ impl Parser {
     fn parse_create_database(&mut self) -> Result<Statement, ParserError> {
         let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_identifier()?;
-        Ok(Statement::CreateDatabase {
+        Ok(Statement::CreateDatabase(CreateDatabaseStatement {
             name,
             if_not_exists,
-        })
+        }))
     }
 
     fn parse_create_schema(&mut self) -> Result<Statement, ParserError> {
         let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_object_name()?;
-        Ok(Statement::CreateSchema {
+        Ok(Statement::CreateSchema(CreateSchemaStatement {
             name,
             if_not_exists,
-        })
+        }))
     }
 
     fn parse_format(&mut self) -> Result<Format, ParserError> {
@@ -1517,7 +1517,7 @@ impl Parser {
             Default::default()
         };
 
-        Ok(Statement::CreateSource {
+        Ok(Statement::CreateSource(CreateSourceStatement {
             name,
             col_names,
             connector,
@@ -1526,7 +1526,7 @@ impl Parser {
             envelope,
             if_not_exists,
             materialized,
-        })
+        }))
     }
 
     fn parse_create_sink(&mut self) -> Result<Statement, ParserError> {
@@ -1561,7 +1561,7 @@ impl Parser {
             true
         };
         let as_of = self.parse_optional_as_of()?;
-        Ok(Statement::CreateSink {
+        Ok(Statement::CreateSink(CreateSinkStatement {
             name,
             from,
             connector,
@@ -1570,7 +1570,7 @@ impl Parser {
             with_snapshot,
             as_of,
             if_not_exists,
-        })
+        }))
     }
 
     fn parse_connector(&mut self) -> Result<Connector, ParserError> {
@@ -1622,7 +1622,7 @@ impl Parser {
         self.expect_keyword("AS")?;
         let query = Box::new(self.parse_query()?);
         // Optional `WITH [ CASCADED | LOCAL ] CHECK OPTION` is widely supported here.
-        Ok(Statement::CreateView {
+        Ok(Statement::CreateView(CreateViewStatement {
             name,
             columns,
             query,
@@ -1630,7 +1630,7 @@ impl Parser {
             materialized,
             if_exists,
             with_options,
-        })
+        }))
     }
 
     fn parse_create_index(&mut self) -> Result<Statement, ParserError> {
@@ -1668,12 +1668,12 @@ impl Parser {
             }
         };
 
-        Ok(Statement::CreateIndex {
+        Ok(Statement::CreateIndex(CreateIndexStatement {
             name,
             on_name,
             key_parts,
             if_not_exists,
-        })
+        }))
     }
 
     fn parse_if_exists(&mut self) -> Result<bool, ParserError> {
@@ -1699,10 +1699,10 @@ impl Parser {
             "DATABASE", "SCHEMA", "TABLE", "VIEW", "SOURCE", "SINK", "INDEX",
         ]) {
             Some("DATABASE") => {
-                return Ok(Statement::DropDatabase {
+                return Ok(Statement::DropDatabase(DropDatabaseStatement {
                     if_exists: self.parse_if_exists()?,
                     name: self.parse_identifier()?,
-                });
+                }));
             }
             Some("SCHEMA") => ObjectType::Schema,
             Some("TABLE") => ObjectType::Table,
@@ -1732,12 +1732,12 @@ impl Parser {
                 "Cannot specify both CASCADE and RESTRICT in DROP"
             );
         }
-        Ok(Statement::DropObjects {
+        Ok(Statement::DropObjects(DropObjectsStatement {
             object_type,
             if_exists,
             names,
             cascade,
-        })
+        }))
     }
 
     fn parse_create_table(&mut self) -> Result<Statement, ParserError> {
@@ -1747,13 +1747,13 @@ impl Parser {
         let (columns, constraints) = self.parse_columns()?;
         let with_options = self.parse_with_options()?;
 
-        Ok(Statement::CreateTable {
+        Ok(Statement::CreateTable(CreateTableStatement {
             name: table_name,
             columns,
             constraints,
             with_options,
             if_not_exists,
-        })
+        }))
     }
 
     fn parse_columns(&mut self) -> Result<(Vec<ColumnDef>, Vec<TableConstraint>), ParserError> {
@@ -1933,12 +1933,12 @@ impl Parser {
         self.expect_keywords(&["RENAME", "TO"])?;
         let to_item_name = self.parse_identifier()?;
 
-        Ok(Statement::AlterObjectRename {
+        Ok(Statement::AlterObjectRename(AlterObjectRenameStatement {
             object_type,
             if_exists,
             name,
             to_item_name,
-        })
+        }))
     }
 
     /// Parse a copy statement
@@ -1948,11 +1948,11 @@ impl Parser {
         self.expect_keywords(&["FROM", "STDIN"])?;
         self.expect_token(&Token::SemiColon)?;
         let values = self.parse_tsv()?;
-        Ok(Statement::Copy {
+        Ok(Statement::Copy(CopyStatement {
             table_name,
             columns,
             values,
-        })
+        }))
     }
 
     /// Parse a tab separated values in
@@ -2297,10 +2297,10 @@ impl Parser {
             None
         };
 
-        Ok(Statement::Delete {
+        Ok(Statement::Delete(DeleteStatement {
             table_name,
             selection,
-        })
+        }))
     }
 
     /// Parse a query expression, i.e. a `SELECT` statement optionally
@@ -2514,15 +2514,15 @@ impl Parser {
                 (Err(_), Some(Token::Word(ident))) => SetVariableValue::Ident(ident.to_ident()),
                 (Err(_), other) => self.expected(self.peek_range(), "variable value", other)?,
             };
-            Ok(Statement::SetVariable {
+            Ok(Statement::SetVariable(SetVariableStatement {
                 local: modifier == Some("LOCAL"),
                 variable,
                 value,
-            })
+            }))
         } else if variable.as_str().to_uppercase() == "TRANSACTION" && modifier.is_none() {
-            Ok(Statement::SetTransaction {
+            Ok(Statement::SetTransaction(SetTransactionStatement {
                 modes: self.parse_transaction_modes()?,
-            })
+            }))
         } else {
             self.expected(self.peek_range(), "equals sign or TO", self.peek_token())
         }
@@ -2530,9 +2530,9 @@ impl Parser {
 
     fn parse_show(&mut self) -> Result<Statement, ParserError> {
         if self.parse_keyword("DATABASES") {
-            return Ok(Statement::ShowDatabases {
+            return Ok(Statement::ShowDatabases(ShowDatabasesStatement {
                 filter: self.parse_show_statement_filter()?,
-            });
+            }));
         }
 
         let extended = self.parse_keyword("EXTENDED");
@@ -2572,7 +2572,7 @@ impl Parser {
         } else if let Some(object_type) =
             self.parse_one_of_keywords(&["SCHEMAS", "SOURCES", "VIEWS", "SINKS", "TABLES"])
         {
-            Ok(Statement::ShowObjects {
+            Ok(Statement::ShowObjects(ShowObjectsStatement {
                 object_type: match object_type {
                     "SCHEMAS" => ObjectType::Schema,
                     "SOURCES" => ObjectType::Source,
@@ -2593,7 +2593,7 @@ impl Parser {
                     None
                 },
                 filter: self.parse_show_statement_filter()?,
-            })
+            }))
         } else if self
             .parse_one_of_keywords(&["INDEX", "INDEXES", "KEYS"])
             .is_some()
@@ -2606,11 +2606,11 @@ impl Parser {
                     } else {
                         None
                     };
-                    Ok(Statement::ShowIndexes {
+                    Ok(Statement::ShowIndexes(ShowIndexesStatement {
                         table_name,
                         extended,
                         filter,
-                    })
+                    }))
                 }
                 None => self.expected(
                     self.peek_range(),
@@ -2619,28 +2619,28 @@ impl Parser {
                 ),
             }
         } else if self.parse_keywords(vec!["CREATE", "VIEW"]) {
-            Ok(Statement::ShowCreateView {
+            Ok(Statement::ShowCreateView(ShowCreateViewStatement {
                 view_name: self.parse_object_name()?,
-            })
+            }))
         } else if self.parse_keywords(vec!["CREATE", "SOURCE"]) {
-            Ok(Statement::ShowCreateSource {
+            Ok(Statement::ShowCreateSource(ShowCreateSourceStatement {
                 source_name: self.parse_object_name()?,
-            })
+            }))
         } else if self.parse_keywords(vec!["CREATE", "SINK"]) {
-            Ok(Statement::ShowCreateSink {
+            Ok(Statement::ShowCreateSink(ShowCreateSinkStatement {
                 sink_name: self.parse_object_name()?,
-            })
+            }))
         } else if self.parse_keywords(vec!["CREATE", "INDEX"]) {
-            Ok(Statement::ShowCreateIndex {
+            Ok(Statement::ShowCreateIndex(ShowCreateIndexStatement {
                 index_name: self.parse_object_name()?,
-            })
+            }))
         } else {
             let variable = if self.parse_keywords(vec!["TRANSACTION", "ISOLATION", "LEVEL"]) {
                 Ident::new("transaction_isolation")
             } else {
                 self.parse_identifier()?
             };
-            Ok(Statement::ShowVariable { variable })
+            Ok(Statement::ShowVariable(ShowVariableStatement { variable }))
         }
     }
 
@@ -2651,12 +2651,12 @@ impl Parser {
         // allows both FROM <table> FROM <database> and FROM <database>.<table>,
         // while we only support the latter for now.
         let filter = self.parse_show_statement_filter()?;
-        Ok(Statement::ShowColumns {
+        Ok(Statement::ShowColumns(ShowColumnsStatement {
             extended,
             full,
             table_name,
             filter,
-        })
+        }))
     }
 
     fn parse_show_statement_filter(&mut self) -> Result<Option<ShowStatementFilter>, ParserError> {
@@ -2867,11 +2867,11 @@ impl Parser {
         } else {
             InsertSource::Query(Box::new(self.parse_query()?))
         };
-        Ok(Statement::Insert {
+        Ok(Statement::Insert(InsertStatement {
             table_name,
             columns,
             source,
-        })
+        }))
     }
 
     fn parse_update(&mut self) -> Result<Statement, ParserError> {
@@ -2883,11 +2883,11 @@ impl Parser {
         } else {
             None
         };
-        Ok(Statement::Update {
+        Ok(Statement::Update(UpdateStatement {
             table_name,
             assignments,
             selection,
-        })
+        }))
     }
 
     /// Parse a `var = expr` assignment, used in an UPDATE statement
@@ -3010,16 +3010,16 @@ impl Parser {
 
     fn parse_start_transaction(&mut self) -> Result<Statement, ParserError> {
         self.expect_keyword("TRANSACTION")?;
-        Ok(Statement::StartTransaction {
+        Ok(Statement::StartTransaction(StartTransactionStatement {
             modes: self.parse_transaction_modes()?,
-        })
+        }))
     }
 
     fn parse_begin(&mut self) -> Result<Statement, ParserError> {
         let _ = self.parse_one_of_keywords(&["TRANSACTION", "WORK"]);
-        Ok(Statement::StartTransaction {
+        Ok(Statement::StartTransaction(StartTransactionStatement {
             modes: self.parse_transaction_modes()?,
-        })
+        }))
     }
 
     fn parse_transaction_modes(&mut self) -> Result<Vec<TransactionMode>, ParserError> {
@@ -3059,15 +3059,15 @@ impl Parser {
     }
 
     fn parse_commit(&mut self) -> Result<Statement, ParserError> {
-        Ok(Statement::Commit {
+        Ok(Statement::Commit(CommitStatement {
             chain: self.parse_commit_rollback_chain()?,
-        })
+        }))
     }
 
     fn parse_rollback(&mut self) -> Result<Statement, ParserError> {
-        Ok(Statement::Rollback {
+        Ok(Statement::Rollback(RollbackStatement {
             chain: self.parse_commit_rollback_chain()?,
-        })
+        }))
     }
 
     fn parse_commit_rollback_chain(&mut self) -> Result<bool, ParserError> {
@@ -3096,11 +3096,11 @@ impl Parser {
             true
         };
         let as_of = self.parse_optional_as_of()?;
-        Ok(Statement::Tail {
+        Ok(Statement::Tail(TailStatement {
             name,
             with_snapshot,
             as_of,
-        })
+        }))
     }
 
     /// Parse an `EXPLAIN` statement, assuming that the `EXPLAIN` token
@@ -3141,11 +3141,11 @@ impl Parser {
             Explainee::Query(self.parse_query()?)
         };
 
-        Ok(Statement::Explain {
+        Ok(Statement::Explain(ExplainStatement {
             stage,
             explainee,
             options,
-        })
+        }))
     }
 
     /// Checks whether it is safe to descend another layer of nesting in the

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -29,7 +29,7 @@ CREATE TABLE uk_cities (
 ----
 CREATE TABLE uk_cities (name character varying(100) NOT NULL, lat double precision NULL, lng double precision, constrained int NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), ref int REFERENCES othertable (a, b))
 =>
-CreateTable { name: ObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Varchar(Some(100)), collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Double, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Double, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(BinaryOp { left: Identifier([Ident("constrained")]), op: Gt, right: Value(Number("0")) }) }] }, ColumnDef { name: Ident("ref"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: ObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Varchar(Some(100)), collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Double, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Double, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(BinaryOp { left: Identifier([Ident("constrained")]), op: Gt, right: Value(Number("0")) }) }] }, ColumnDef { name: Ident("ref"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: ObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
@@ -45,35 +45,35 @@ CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
 CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 =>
-CreateTable { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Int, collation: None, options: [] }], constraints: [], with_options: [SqlOption { name: Ident("foo"), value: String("bar") }, SqlOption { name: Ident("a"), value: Number("123") }], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Int, collation: None, options: [] }], constraints: [], with_options: [SqlOption { name: Ident("foo"), value: String("bar") }, SqlOption { name: Ident("a"), value: Number("123") }], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (bar int,)
 ----
 CREATE TABLE foo (bar int)
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: Int, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: Int, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (bar int list)
 ----
 CREATE TABLE foo (bar int list)
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Int), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Int), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (bar int list list)
 ----
 CREATE TABLE foo (bar int list list)
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Int)), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Int)), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE t ()
 ----
 CREATE TABLE t ()
 =>
-CreateTable { name: ObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE tab (foo int,
@@ -89,70 +89,70 @@ CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 ----
 CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 ----
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 ----
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: ObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: ObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 ----
 CREATE TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: BinaryOp { left: Function(Function { name: ObjectName([Ident("rtrim")]), args: Args([Function(Function { name: ObjectName([Ident("ltrim")]), args: Args([Identifier([Ident("ref_code")])]), filter: None, over: None, distinct: false })]), filter: None, over: None, distinct: false }), op: NotEq, right: Value(String("")) } }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: BinaryOp { left: Function(Function { name: ObjectName([Ident("rtrim")]), args: Args([Function(Function { name: ObjectName([Ident("ltrim")]), args: Args([Identifier([Ident("ref_code")])]), filter: None, over: None, distinct: false })]), filter: None, over: None, distinct: false }), op: NotEq, right: Value(String("")) } }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 ----
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, UNIQUE (id))
 ----
 CREATE TABLE foo (id int, UNIQUE (id))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 ----
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: ObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: ObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
 ----
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
 =>
-CreateTable { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Check { name: None, expr: BinaryOp { left: BinaryOp { left: Identifier([Ident("end_date")]), op: Gt, right: Identifier([Ident("start_date")]) }, op: Or, right: IsNull { expr: Identifier([Ident("end_date")]), negated: false } } }], with_options: [], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Int, collation: None, options: [] }], constraints: [Check { name: None, expr: BinaryOp { left: BinaryOp { left: Identifier([Ident("end_date")]), op: Gt, right: Identifier([Ident("start_date")]) }, op: Or, right: IsNull { expr: Identifier([Ident("end_date")]), negated: false } } }], with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE DATABASE foo
 ----
 CREATE DATABASE foo
 =>
-CreateDatabase { name: Ident("foo"), if_not_exists: false }
+CreateDatabase(CreateDatabaseStatement { name: Ident("foo"), if_not_exists: false })
 
 parse-statement
 CREATE DATABASE IF NOT EXISTS foo
 ----
 CREATE DATABASE IF NOT EXISTS foo
 =>
-CreateDatabase { name: Ident("foo"), if_not_exists: true }
+CreateDatabase(CreateDatabaseStatement { name: Ident("foo"), if_not_exists: true })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo
@@ -177,14 +177,14 @@ CREATE SCHEMA foo.bar
 ----
 CREATE SCHEMA foo.bar
 =>
-CreateSchema { name: ObjectName([Ident("foo"), Ident("bar")]), if_not_exists: false }
+CreateSchema(CreateSchemaStatement { name: ObjectName([Ident("foo"), Ident("bar")]), if_not_exists: false })
 
 parse-statement
 CREATE SCHEMA IF NOT EXISTS foo
 ----
 CREATE SCHEMA IF NOT EXISTS foo
 =>
-CreateSchema { name: ObjectName([Ident("foo")]), if_not_exists: true }
+CreateSchema(CreateSchemaStatement { name: ObjectName([Ident("foo")]), if_not_exists: true })
 
 parse-statement
 CREATE SCHEMA IF EXISTS foo
@@ -200,35 +200,35 @@ CREATE VIEW myschema.myview AS SELECT foo FROM bar
 ----
 CREATE VIEW myschema.myview AS SELECT foo FROM bar
 =>
-CreateView { name: ObjectName([Ident("myschema"), Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("myschema"), Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false })
 
 parse-statement
 CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar
 ----
 CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar
 =>
-CreateView { name: ObjectName([Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: true, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: true, materialized: false })
 
 parse-statement
 CREATE TEMP VIEW myview AS SELECT foo FROM bar
 ----
 CREATE TEMPORARY VIEW myview AS SELECT foo FROM bar
 =>
-CreateView { name: ObjectName([Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: true, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: true, materialized: false })
 
 parse-statement
 CREATE OR REPLACE VIEW v AS SELECT 1
 ----
 CREATE OR REPLACE VIEW v AS SELECT 1
 =>
-CreateView { name: ObjectName([Ident("v")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Replace, temporary: false, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("v")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Replace, temporary: false, materialized: false })
 
 parse-statement
 CREATE VIEW IF NOT EXISTS v AS SELECT 1
 ----
 CREATE VIEW IF NOT EXISTS v AS SELECT 1
 =>
-CreateView { name: ObjectName([Ident("v")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Skip, temporary: false, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("v")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Skip, temporary: false, materialized: false })
 
 parse-statement
 CREATE OR REPLACE VIEW IF NOT EXISTS v AS SELECT 1
@@ -244,35 +244,35 @@ CREATE VIEW v WITH (foo = 'bar', a = 123) AS SELECT 1
 ----
 CREATE VIEW v WITH (foo = 'bar', a = 123) AS SELECT 1
 =>
-CreateView { name: ObjectName([Ident("v")]), columns: [], with_options: [SqlOption { name: Ident("foo"), value: String("bar") }, SqlOption { name: Ident("a"), value: Number("123") }], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("v")]), columns: [], with_options: [SqlOption { name: Ident("foo"), value: String("bar") }, SqlOption { name: Ident("a"), value: Number("123") }], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false })
 
 parse-statement
 CREATE VIEW v (has, cols) AS SELECT 1, 2
 ----
 CREATE VIEW v (has, cols) AS SELECT 1, 2
 =>
-CreateView { name: ObjectName([Ident("v")]), columns: [Ident("has"), Ident("cols")], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("v")]), columns: [Ident("has"), Ident("cols")], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }, Expr { expr: Value(Number("2")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false })
 
 parse-statement
 CREATE MATERIALIZED VIEW myschema.myview AS SELECT foo FROM bar
 ----
 CREATE MATERIALIZED VIEW myschema.myview AS SELECT foo FROM bar
 =>
-CreateView { name: ObjectName([Ident("myschema"), Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: true }
+CreateView(CreateViewStatement { name: ObjectName([Ident("myschema"), Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: true })
 
 parse-statement
 CREATE MATERIALIZED VIEW IF NOT EXISTS myschema.myview AS SELECT foo FROM bar
 ----
 CREATE MATERIALIZED VIEW IF NOT EXISTS myschema.myview AS SELECT foo FROM bar
 =>
-CreateView { name: ObjectName([Ident("myschema"), Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Skip, temporary: false, materialized: true }
+CreateView(CreateViewStatement { name: ObjectName([Ident("myschema"), Ident("myview")]), columns: [], with_options: [], query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Skip, temporary: false, materialized: true })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(Schema(Inline("baz")))), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(Schema(Inline("baz")))), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo
@@ -281,7 +281,7 @@ FORMAT BYTES
 ----
 CREATE SOURCE foo FROM KAFKA BROKER 'bar' TOPIC 'baz' WITH (consistency = 'lug', ssl_certificate_file = '/Path/to/file') FORMAT BYTES
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz" }, with_options: [SqlOption { name: Ident("consistency"), value: String("lug") }, SqlOption { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Some(Bytes), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: Kafka { broker: "bar", topic: "baz" }, with_options: [SqlOption { name: Ident("consistency"), value: String("lug") }, SqlOption { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], format: Some(Bytes), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
@@ -289,49 +289,49 @@ CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
 ----
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE 'somemessage' USING SCHEMA FILE 'path'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Protobuf { message_name: "somemessage", schema: File("path") }), envelope: None, if_not_exists: false, materialized: true }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Protobuf { message_name: "somemessage", schema: File("path") }), envelope: None, if_not_exists: false, materialized: true })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(true) }], format: Some(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(true) }], format: Some(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(true) }], format: Some(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(true) }], format: Some(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(false) }], format: Some(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(false) }], format: Some(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(false) }], format: Some(Csv { header_row: false, n_cols: Some(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(false) }], format: Some(Csv { header_row: false, n_cols: Some(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar" }, with_options: [], format: Some(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar" }, with_options: [], format: Some(Csv { header_row: true, n_cols: None, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 ----
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(true) }], format: Some(Csv { header_row: false, n_cols: Some(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [SqlOption { name: Ident("tail"), value: Boolean(true) }], format: Some(Csv { header_row: false, n_cols: Some(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE MATERIALIZED OR VIEW foo as SELECT * from bar
@@ -347,70 +347,70 @@ CREATE SOURCE foo FROM AVRO OCF '/tmp/bar'
 ----
 CREATE SOURCE foo FROM AVRO OCF '/tmp/bar'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: AvroOcf { path: "/tmp/bar" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: AvroOcf { path: "/tmp/bar" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: None, value_schema: "blah" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED KEY SCHEMA 'a' VALUE SCHEMA 'b'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: Some(CsrSeed { key_schema: Some("a"), value_schema: "b" }), with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [SqlOption { name: Ident("a"), value: String("b") }] })), envelope: Debezium, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [SqlOption { name: Ident("a"), value: String("b") }] })), envelope: Debezium, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 =>
-CreateSource { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert(None), if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Upsert(None), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
 =>
-CreateSource { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(Schema(Inline("string")))), envelope: Upsert(Some(Avro(Schema(Inline("long"))))), if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(Schema(Inline("string")))), envelope: Upsert(Some(Avro(Schema(Inline("long"))))), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 =>
-CreateSource { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(Schema(File("path")))), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot" }, with_options: [], format: Some(Avro(Schema(File("path")))), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 =>
-CreateSource { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Bytes), envelope: None, if_not_exists: true, materialized: false }
+CreateSource(CreateSourceStatement { name: ObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar" }, with_options: [], format: Some(Bytes), envelope: None, if_not_exists: true, materialized: false })
 
 parse-statement
 CREATE SOURCE IF EXISTS foo FROM FILE 'bar' USING SCHEMA ''
@@ -426,70 +426,70 @@ CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' WITH SNAPSHOT FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic" }, with_options: [SqlOption { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic" }, with_options: [SqlOption { name: Ident("replication_factor"), value: Number("7") }], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO AVRO OCF 'baz'
 ----
 CREATE SINK foo FROM bar INTO AVRO OCF 'baz' WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: AvroOcf { path: "baz" }, with_options: [], format: None, with_snapshot: true, as_of: None, if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: AvroOcf { path: "baz" }, with_options: [], format: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES
 ----
 CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: true }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: None, if_not_exists: true })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF 123
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT AS OF 123
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: Some(Value(Number("123"))), if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: Some(Value(Number("123"))), if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITHOUT SNAPSHOT AS OF 123
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITHOUT SNAPSHOT AS OF 123
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: false, as_of: Some(Value(Number("123"))), if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: false, as_of: Some(Value(Number("123"))), if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF now()
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITH SNAPSHOT AS OF now()
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Bytes), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), with_snapshot: true, as_of: None, if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
 ----
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
 =>
-CreateSink { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [SqlOption { name: Ident("a"), value: String("b") }] })), with_snapshot: true, as_of: None, if_not_exists: false }
+CreateSink(CreateSinkStatement { name: ObjectName([Ident("foo")]), from: ObjectName([Ident("bar")]), connector: File { path: "baz" }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [SqlOption { name: Ident("a"), value: String("b") }] })), with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK IF EXISTS foo FROM bar INTO 'baz'
@@ -505,42 +505,42 @@ CREATE INDEX foo ON myschema.bar (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex { name: Some(Ident("foo")), on_name: ObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false }
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), on_name: ObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 ----
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 =>
-CreateIndex { name: Some(Ident("fizz")), on_name: ObjectName([Ident("baz")]), key_parts: Some([Function(Function { name: ObjectName([Ident("ascii")]), args: Args([Identifier([Ident("x")])]), filter: None, over: None, distinct: false }), IsNull { expr: Identifier([Ident("a")]), negated: true }, Nested(Exists(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("boop")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("boop"), Ident("z")]), op: Eq, right: Identifier([Ident("z")]) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })), Identifier([Ident("delta")])]), if_not_exists: false }
+CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), on_name: ObjectName([Ident("baz")]), key_parts: Some([Function(Function { name: ObjectName([Ident("ascii")]), args: Args([Identifier([Ident("x")])]), filter: None, over: None, distinct: false }), IsNull { expr: Identifier([Ident("a")]), negated: true }, Nested(Exists(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("boop")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("boop"), Ident("z")]), op: Eq, right: Identifier([Ident("z")]) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None })), Identifier([Ident("delta")])]), if_not_exists: false })
 
 parse-statement
 CREATE INDEX ind ON tab ((col + 1))
 ----
 CREATE INDEX ind ON tab ((col + 1))
 =>
-CreateIndex { name: Some(Ident("ind")), on_name: ObjectName([Ident("tab")]), key_parts: Some([Nested(BinaryOp { left: Identifier([Ident("col")]), op: Plus, right: Value(Number("1")) })]), if_not_exists: false }
+CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), on_name: ObjectName([Ident("tab")]), key_parts: Some([Nested(BinaryOp { left: Identifier([Ident("col")]), op: Plus, right: Value(Number("1")) })]), if_not_exists: false })
 
 parse-statement
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 ----
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 =>
-CreateIndex { name: Some(Ident("qualifiers")), on_name: ObjectName([Ident("no_parentheses")]), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), if_not_exists: false }
+CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), on_name: ObjectName([Ident("no_parentheses")]), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), if_not_exists: false })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab
 ----
 CREATE DEFAULT INDEX ON tab
 =>
-CreateIndex { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: false }
+CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: false })
 
 parse-statement
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 ----
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 =>
-CreateIndex { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: true }
+CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: true })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab (a, b)
@@ -565,7 +565,7 @@ CREATE INDEX ON tab (a, b)
 ----
 CREATE INDEX ON tab (a, b)
 =>
-CreateIndex { name: None, on_name: ObjectName([Ident("tab")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false }
+CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false })
 
 parse-statement
 CREATE INDEX IF NOT EXISTS ON tab (a, b)
@@ -599,14 +599,14 @@ DROP DATABASE mydb
 ----
 DROP DATABASE mydb
 =>
-DropDatabase { name: Ident("mydb"), if_exists: false }
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: false })
 
 parse-statement
 DROP DATABASE IF EXISTS mydb
 ----
 DROP DATABASE IF EXISTS mydb
 =>
-DropDatabase { name: Ident("mydb"), if_exists: true }
+DropDatabase(DropDatabaseStatement { name: Ident("mydb"), if_exists: true })
 
 parse-statement
 DROP DATABASE mydb.nope
@@ -622,21 +622,21 @@ DROP SCHEMA mydb.myschema
 ----
 DROP SCHEMA mydb.myschema
 =>
-DropObjects { object_type: Schema, if_exists: false, names: [ObjectName([Ident("mydb"), Ident("myschema")])], cascade: false }
+DropObjects(DropObjectsStatement { object_type: Schema, if_exists: false, names: [ObjectName([Ident("mydb"), Ident("myschema")])], cascade: false })
 
 parse-statement
 DROP TABLE foo
 ----
 DROP TABLE foo
 =>
-DropObjects { object_type: Table, if_exists: false, names: [ObjectName([Ident("foo")])], cascade: false }
+DropObjects(DropObjectsStatement { object_type: Table, if_exists: false, names: [ObjectName([Ident("foo")])], cascade: false })
 
 parse-statement
 DROP TABLE IF EXISTS foo, bar CASCADE
 ----
 DROP TABLE IF EXISTS foo, bar CASCADE
 =>
-DropObjects { object_type: Table, if_exists: true, names: [ObjectName([Ident("foo")]), ObjectName([Ident("bar")])], cascade: true }
+DropObjects(DropObjectsStatement { object_type: Table, if_exists: true, names: [ObjectName([Ident("foo")]), ObjectName([Ident("bar")])], cascade: true })
 
 parse-statement
 DROP TABLE
@@ -661,49 +661,49 @@ DROP VIEW myschema.myview
 ----
 DROP VIEW myschema.myview
 =>
-DropObjects { object_type: View, if_exists: false, names: [ObjectName([Ident("myschema"), Ident("myview")])], cascade: false }
+DropObjects(DropObjectsStatement { object_type: View, if_exists: false, names: [ObjectName([Ident("myschema"), Ident("myview")])], cascade: false })
 
 parse-statement
 DROP SOURCE myschema.mydatasource
 ----
 DROP SOURCE myschema.mydatasource
 =>
-DropObjects { object_type: Source, if_exists: false, names: [ObjectName([Ident("myschema"), Ident("mydatasource")])], cascade: false }
+DropObjects(DropObjectsStatement { object_type: Source, if_exists: false, names: [ObjectName([Ident("myschema"), Ident("mydatasource")])], cascade: false })
 
 parse-statement
 DROP INDEX IF EXISTS myschema.myindex
 ----
 DROP INDEX IF EXISTS myschema.myindex
 =>
-DropObjects { object_type: Index, if_exists: true, names: [ObjectName([Ident("myschema"), Ident("myindex")])], cascade: false }
+DropObjects(DropObjectsStatement { object_type: Index, if_exists: true, names: [ObjectName([Ident("myschema"), Ident("myindex")])], cascade: false })
 
 parse-statement
 TAIL foo.bar
 ----
 TAIL foo.bar WITH SNAPSHOT
 =>
-Tail { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: None }
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: None })
 
 parse-statement
 TAIL foo.bar AS OF 123
 ----
 TAIL foo.bar WITH SNAPSHOT AS OF 123
 =>
-Tail { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Value(Number("123"))) }
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Value(Number("123"))) })
 
 parse-statement
 TAIL foo.bar AS OF now()
 ----
 TAIL foo.bar WITH SNAPSHOT AS OF now()
 =>
-Tail { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITHOUT SNAPSHOT AS OF now()
 ----
 TAIL foo.bar WITHOUT SNAPSHOT AS OF now()
 =>
-Tail { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: false, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: false, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
 
 parse-statement
 CREATE TABLE public.customer (
@@ -722,7 +722,7 @@ CREATE TABLE public.customer (
 ----
 CREATE TABLE public.customer (customer_id int DEFAULT nextval(public.customer_customer_id_seq), store_id smallint NOT NULL, first_name character varying(45) NOT NULL, last_name character varying(45) NOT NULL, email character varying(50), address_id smallint NOT NULL, activebool boolean DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamp with time zone, active int NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 =>
-CreateTable { name: ObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("nextval")]), args: Args([Identifier([Ident("public"), Ident("customer_customer_id_seq")])]), filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: SmallInt, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Varchar(Some(45)), collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Varchar(Some(45)), collation: Some(ObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Varchar(Some(50)), collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: SmallInt, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Boolean, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Date, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false }), data_type: Text }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Timestamp, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: TimestampTz, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [SqlOption { name: Ident("fillfactor"), value: Number("20") }, SqlOption { name: Ident("user_catalog_table"), value: Boolean(true) }, SqlOption { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false }
+CreateTable(CreateTableStatement { name: ObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("nextval")]), args: Args([Identifier([Ident("public"), Ident("customer_customer_id_seq")])]), filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: SmallInt, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Varchar(Some(45)), collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Varchar(Some(45)), collation: Some(ObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Varchar(Some(50)), collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: SmallInt, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Boolean, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Date, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false }), data_type: Text }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Timestamp, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: TimestampTz, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Int, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [SqlOption { name: Ident("fillfactor"), value: Number("20") }, SqlOption { name: Ident("user_catalog_table"), value: Boolean(true) }, SqlOption { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false })
 
 parse-statement roundtrip
 CREATE TABLE public.customer (

--- a/src/sql-parser/tests/testdata/delete
+++ b/src/sql-parser/tests/testdata/delete
@@ -28,7 +28,7 @@ DELETE FROM table
 ----
 DELETE FROM table
 =>
-Delete { table_name: ObjectName([Ident("table")]), selection: None }
+Delete(DeleteStatement { table_name: ObjectName([Ident("table")]), selection: None })
 
 parse-statement roundtrip
 DELETE FROM foo WHERE name = 5
@@ -40,4 +40,4 @@ DELETE FROM foo WHERE name = 5
 ----
 DELETE FROM foo WHERE name = 5
 =>
-Delete { table_name: ObjectName([Ident("foo")]), selection: Some(BinaryOp { left: Identifier([Ident("name")]), op: Eq, right: Value(Number("5")) }) }
+Delete(DeleteStatement { table_name: ObjectName([Ident("foo")]), selection: Some(BinaryOp { left: Identifier([Ident("name")]), op: Eq, right: Value(Number("5")) }) })

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -23,46 +23,46 @@ EXPLAIN SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } })
 
 parse-statement
 EXPLAIN RAW PLAN FOR SELECT 665
 ----
 EXPLAIN RAW PLAN FOR SELECT 665
 =>
-Explain { stage: RawPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
+Explain(ExplainStatement { stage: RawPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } })
 
 parse-statement
 EXPLAIN DECORRELATED PLAN FOR SELECT 665
 ----
 EXPLAIN DECORRELATED PLAN FOR SELECT 665
 =>
-Explain { stage: DecorrelatedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
+Explain(ExplainStatement { stage: DecorrelatedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } })
 
 parse-statement
 EXPLAIN PLAN FOR SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } }
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), options: ExplainOptions { typed: false } })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain { stage: OptimizedPlan, explainee: View(ObjectName([Ident("foo")])), options: ExplainOptions { typed: false } }
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(ObjectName([Ident("foo")])), options: ExplainOptions { typed: false } })
 
 parse-statement
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain { stage: OptimizedPlan, explainee: View(ObjectName([Ident("foo")])), options: ExplainOptions { typed: true } }
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(ObjectName([Ident("foo")])), options: ExplainOptions { typed: true } })

--- a/src/sql-parser/tests/testdata/insert
+++ b/src/sql-parser/tests/testdata/insert
@@ -23,49 +23,49 @@ INSERT INTO customer VALUES (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
+Insert(InsertStatement { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) })
 
 parse-statement
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
+Insert(InsertStatement { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) })
 
 parse-statement
 INSERT INTO public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
+Insert(InsertStatement { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) })
 
 parse-statement
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("db"), Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
+Insert(InsertStatement { table_name: ObjectName([Ident("db"), Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) })
 
 parse-statement
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 =>
-Insert { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) }
+Insert(InsertStatement { table_name: ObjectName([Ident("public"), Ident("customer")]), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None, fetch: None }) })
 
 parse-statement
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 ----
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: SetOperation { op: Union, all: false, left: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None, fetch: None }) }
+Insert(InsertStatement { table_name: ObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: SetOperation { op: Union, all: false, left: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None, fetch: None }) })
 
 parse-statement
 INSERT INTO customer DEFAULT VALUES
 ----
 INSERT INTO customer DEFAULT VALUES
 =>
-Insert { table_name: ObjectName([Ident("customer")]), columns: [], source: DefaultValues }
+Insert(InsertStatement { table_name: ObjectName([Ident("customer")]), columns: [], source: DefaultValues })
 
 parse-statement
 INSERT INTO customer DEFAULT VALUES, DEFAULT VALUES

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -73,7 +73,7 @@ SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5
 ----
 SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT 5
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("id")]), op: Eq, right: Value(Number("1")) }), group_by: [], having: None }), order_by: [], limit: Some(Value(Number("5"))), offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("id")]), op: Eq, right: Value(Number("1")) }), group_by: [], having: None }), order_by: [], limit: Some(Value(Number("5"))), offset: None, fetch: None }, as_of: None })
 
 # LIMIT should not be parsed as an alias.
 
@@ -82,21 +82,21 @@ SELECT id FROM customer LIMIT 1
 ----
 SELECT id FROM customer LIMIT 1
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: Some(Value(Number("1"))), offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: Some(Value(Number("1"))), offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT 1 LIMIT 5
 ----
 SELECT 1 LIMIT 5
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: Some(Value(Number("5"))), offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: Some(Value(Number("5"))), offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT DISTINCT name FROM customer
 ----
 SELECT DISTINCT name FROM customer
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: true, projection: [Expr { expr: Identifier([Ident("name")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: true, projection: [Expr { expr: Identifier([Ident("name")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT ALL name FROM customer
@@ -108,21 +108,21 @@ SELECT * FROM foo
 ----
 SELECT * FROM foo
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo.* FROM foo
 ----
 SELECT foo.* FROM foo
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: QualifiedWildcard([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: QualifiedWildcard([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT (x).a, (x).a.b.c
 ----
 SELECT (x).a, (x).a.b.c
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, alias: None }, Expr { expr: FieldAccess { expr: FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }, field: Ident("c") }, alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, alias: None }, Expr { expr: FieldAccess { expr: FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }, field: Ident("c") }, alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT (1.a)
@@ -152,7 +152,7 @@ SELECT a.col + 1 AS newname FROM foo AS a
 ----
 SELECT a.col + 1 AS newname FROM foo AS a
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: BinaryOp { left: Identifier([Ident("a"), Ident("col")]), op: Plus, right: Value(Number("1")) }, alias: Some(Ident("newname")) }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: Some(TableAlias { name: Ident("a"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: BinaryOp { left: Identifier([Ident("a"), Ident("col")]), op: Plus, right: Value(Number("1")) }, alias: Some(Ident("newname")) }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("foo")]), alias: Some(TableAlias { name: Ident("a"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT a.col + 1 AS newname FROM foo AS a
@@ -194,14 +194,14 @@ SELECT count(*) FILTER (WHERE foo) FROM customer
 ----
 SELECT count(*) FILTER (WHERE foo) FROM customer
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Function(Function { name: ObjectName([Ident("count")]), args: Star, filter: Some(Identifier([Ident("foo")])), over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Function(Function { name: ObjectName([Ident("count")]), args: Star, filter: Some(Identifier([Ident("foo")])), over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT count(DISTINCT + x) FROM customer
 ----
 SELECT count(DISTINCT + x) FROM customer
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Function(Function { name: ObjectName([Ident("count")]), args: Args([UnaryOp { op: Plus, expr: Identifier([Ident("x")]) }]), filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Function(Function { name: ObjectName([Ident("count")]), args: Args([UnaryOp { op: Plus, expr: Identifier([Ident("x")]) }]), filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT count(ALL + x) FROM customer
@@ -275,70 +275,70 @@ SELECT * FROM customers WHERE segment IN (SELECT segm FROM bar)
 ----
 SELECT * FROM customers WHERE segment IN (SELECT segm FROM bar)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customers")]), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("segment")]), subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("segm")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, negated: false }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customers")]), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("segment")]), subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("segm")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, negated: false }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE x IN (VALUES (1))
 ----
 SELECT * FROM t WHERE x IN (VALUES (1))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: [], body: Values(Values([[Value(Number("1"))]])), order_by: [], limit: None, offset: None, fetch: None }, negated: false }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(InSubquery { expr: Identifier([Ident("x")]), subquery: Query { ctes: [], body: Values(Values([[Value(Number("1"))]])), order_by: [], limit: None, offset: None, fetch: None }, negated: false }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customers WHERE age BETWEEN 25 AND 32
 ----
 SELECT * FROM customers WHERE age BETWEEN 25 AND 32
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customers")]), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: false, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customers")]), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: false, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customers WHERE age NOT BETWEEN 25 AND 32
 ----
 SELECT * FROM customers WHERE age NOT BETWEEN 25 AND 32
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customers")]), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: true, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customers")]), alias: None }, joins: [] }], selection: Some(Between { expr: Identifier([Ident("age")]), negated: true, low: Value(Number("25")), high: Value(Number("32")) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE 1 BETWEEN 1 + 2 AND 3 + 4 IS NULL
 ----
 SELECT * FROM t WHERE 1 BETWEEN 1 + 2 AND 3 + 4 IS NULL
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(IsNull { expr: Between { expr: Value(Number("1")), negated: false, low: BinaryOp { left: Value(Number("1")), op: Plus, right: Value(Number("2")) }, high: BinaryOp { left: Value(Number("3")), op: Plus, right: Value(Number("4")) } }, negated: false }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(IsNull { expr: Between { expr: Value(Number("1")), negated: false, low: BinaryOp { left: Value(Number("1")), op: Plus, right: Value(Number("2")) }, high: BinaryOp { left: Value(Number("3")), op: Plus, right: Value(Number("4")) } }, negated: false }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 ----
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("1")) }, op: And, right: Between { expr: BinaryOp { left: Value(Number("1")), op: Plus, right: Identifier([Ident("x")]) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("1")) }, op: And, right: Between { expr: BinaryOp { left: Value(Number("1")), op: Plus, right: Identifier([Ident("x")]) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 ----
 SELECT * FROM t WHERE 1 = 1 AND 1 + x BETWEEN 1 AND 2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("1")) }, op: And, right: Between { expr: BinaryOp { left: Value(Number("1")), op: Plus, right: Identifier([Ident("x")]) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("1")) }, op: And, right: Between { expr: BinaryOp { left: Value(Number("1")), op: Plus, right: Identifier([Ident("x")]) }, negated: false, low: Value(Number("1")), high: Value(Number("2")) } }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC, id
 ----
 SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC, id
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("id")]), op: Lt, right: Value(Number("5")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None }], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("id")]), op: Lt, right: Value(Number("5")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None }], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id
 ----
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None }], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None }], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id
 ----
 SELECT id, fname, lname FROM customer ORDER BY lname ASC, fname DESC, id
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None }], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }, OrderByExpr { expr: Identifier([Ident("id")]), asc: None }], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer WHERE id < 5
@@ -346,35 +346,35 @@ ORDER BY lname ASC, fname DESC LIMIT 2
 ----
 SELECT id, fname, lname FROM customer WHERE id < 5 ORDER BY lname ASC, fname DESC LIMIT 2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("id")]), op: Lt, right: Value(Number("5")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }], limit: Some(Value(Number("2"))), offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("id")]), op: Lt, right: Value(Number("5")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("lname")]), asc: Some(true) }, OrderByExpr { expr: Identifier([Ident("fname")]), asc: Some(false) }], limit: Some(Value(Number("2"))), offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT id, fname, lname FROM customer GROUP BY lname, fname
 ----
 SELECT id, fname, lname FROM customer GROUP BY lname, fname
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("lname")]), Identifier([Ident("fname")])], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("id")]), alias: None }, Expr { expr: Identifier([Ident("fname")]), alias: None }, Expr { expr: Identifier([Ident("lname")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("lname")]), Identifier([Ident("fname")])], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(BinaryOp { left: Function(Function { name: ObjectName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), op: Gt, right: Value(Number("1")) }) }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(BinaryOp { left: Function(Function { name: ObjectName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), op: Gt, right: Value(Number("1")) }) }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING count(*) > 1
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(BinaryOp { left: Function(Function { name: ObjectName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), op: Gt, right: Value(Number("1")) }) }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(BinaryOp { left: Function(Function { name: ObjectName([Ident("count")]), args: Star, filter: None, over: None, distinct: false }), op: Gt, right: Value(Number("1")) }) }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar GROUP BY foo HAVING 1 = 1
 ----
 SELECT foo FROM bar GROUP BY foo HAVING 1 = 1
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("1")) }) }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("foo")])], having: Some(BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("1")) }) }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT id, fname, lname FROM customer WHERE id = 1 LIMIT ALL
@@ -432,63 +432,63 @@ SELECT * FROM t1, t2
 ----
 SELECT * FROM t1, t2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1a NATURAL JOIN t1b, t2a NATURAL JOIN t2b
 ----
 SELECT * FROM t1a NATURAL JOIN t1b, t2a NATURAL JOIN t2b
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t1b")]), alias: None }, join_operator: Inner(Natural) }] }, TableWithJoins { relation: Table { name: ObjectName([Ident("t2a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2b")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t1b")]), alias: None }, join_operator: Inner(Natural) }] }, TableWithJoins { relation: Table { name: ObjectName([Ident("t2a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2b")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 CROSS JOIN t2
 ----
 SELECT * FROM t1 CROSS JOIN t2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: CrossJoin }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: CrossJoin }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 JOIN t2 AS foo USING(c1)
 ----
 SELECT * FROM t1 JOIN t2 AS foo USING(c1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 JOIN t2 foo USING(c1)
 ----
 SELECT * FROM t1 JOIN t2 AS foo USING(c1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: Some(TableAlias { name: Ident("foo"), columns: [], strict: false }) }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL JOIN t2
 ----
 SELECT * FROM t1 NATURAL JOIN t2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL LEFT JOIN t2
 ----
 SELECT * FROM t1 NATURAL LEFT JOIN t2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: LeftOuter(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: LeftOuter(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL RIGHT JOIN t2
 ----
 SELECT * FROM t1 NATURAL RIGHT JOIN t2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: RightOuter(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: RightOuter(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 NATURAL FULL JOIN t2
 ----
 SELECT * FROM t1 NATURAL FULL JOIN t2
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: FullOuter(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: FullOuter(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM t1 natural
@@ -504,42 +504,42 @@ SELECT c1, c2 FROM t1, t4 JOIN t2 ON t2.c = t1.c LEFT JOIN t3 USING(q, c) WHERE 
 ----
 SELECT c1, c2 FROM t1, t4 JOIN t2 ON t2.c = t1.c LEFT JOIN t3 USING(q, c) WHERE t4.c = t1.c
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }, Expr { expr: Identifier([Ident("c2")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("t4")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: Inner(On(BinaryOp { left: Identifier([Ident("t2"), Ident("c")]), op: Eq, right: Identifier([Ident("t1"), Ident("c")]) })) }, Join { relation: Table { name: ObjectName([Ident("t3")]), alias: None }, join_operator: LeftOuter(Using([Ident("q"), Ident("c")])) }] }], selection: Some(BinaryOp { left: Identifier([Ident("t4"), Ident("c")]), op: Eq, right: Identifier([Ident("t1"), Ident("c")]) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }, Expr { expr: Identifier([Ident("c2")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("t4")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: Inner(On(BinaryOp { left: Identifier([Ident("t2"), Ident("c")]), op: Eq, right: Identifier([Ident("t1"), Ident("c")]) })) }, Join { relation: Table { name: ObjectName([Ident("t3")]), alias: None }, join_operator: LeftOuter(Using([Ident("q"), Ident("c")])) }] }], selection: Some(BinaryOp { left: Identifier([Ident("t4"), Ident("c")]), op: Eq, right: Identifier([Ident("t1"), Ident("c")]) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) NATURAL JOIN (f NATURAL JOIN (g NATURAL JOIN h))
 ----
 SELECT * FROM a NATURAL JOIN (b NATURAL JOIN (c NATURAL JOIN d NATURAL JOIN e)) NATURAL JOIN (f NATURAL JOIN (g NATURAL JOIN h))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("c")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }, Join { relation: Table { name: ObjectName([Ident("e")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }, Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("f")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("g")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("h")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("c")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }, Join { relation: Table { name: ObjectName([Ident("e")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }, Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("f")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("g")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("h")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN c
 ----
 SELECT * FROM (a NATURAL JOIN b) NATURAL JOIN c
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN b) c NATURAL JOIN d
 ----
 SELECT * FROM (a NATURAL JOIN b) AS c NATURAL JOIN d
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: Some(TableAlias { name: Ident("c"), columns: [], strict: false }) }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: Some(TableAlias { name: Ident("c"), columns: [], strict: false }) }, joins: [Join { relation: Table { name: ObjectName([Ident("d")]), alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (((a NATURAL JOIN b)))
 ----
 SELECT * FROM (((a NATURAL JOIN b)))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("b")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a NATURAL JOIN (((b NATURAL JOIN c)))
 ----
 SELECT * FROM a NATURAL JOIN (((b NATURAL JOIN c)))
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [Join { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: NestedJoin { join: TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("c")]), alias: None }, join_operator: Inner(Natural) }] }, alias: None }, joins: [] }, alias: None }, joins: [] }, alias: None }, join_operator: Inner(Natural) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM (a NATURAL JOIN (b))
@@ -555,28 +555,28 @@ SELECT c1 FROM t1 INNER JOIN t2 USING(c1)
 ----
 SELECT c1 FROM t1 JOIN t2 USING(c1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: Inner(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 LEFT OUTER JOIN t2 USING(c1)
 ----
 SELECT c1 FROM t1 LEFT JOIN t2 USING(c1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: LeftOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: LeftOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 RIGHT OUTER JOIN t2 USING(c1)
 ----
 SELECT c1 FROM t1 RIGHT JOIN t2 USING(c1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: RightOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: RightOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT c1 FROM t1 FULL OUTER JOIN t2 USING(c1)
 ----
 SELECT c1 FROM t1 FULL JOIN t2 USING(c1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: FullOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("c1")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t1")]), alias: None }, joins: [Join { relation: Table { name: ObjectName([Ident("t2")]), alias: None }, join_operator: FullOuter(Using([Ident("c1")])) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a OUTER JOIN b ON 1
@@ -595,7 +595,7 @@ SELECT foo + bar FROM a, b
 ----
 WITH a AS (SELECT 1 AS foo), b AS (SELECT 2 AS bar) SELECT foo + bar FROM a, b
 =>
-Select { query: Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: Select(Select { distinct: false, projection: [Expr { expr: BinaryOp { left: Identifier([Ident("foo")]), op: Plus, right: Identifier([Ident("bar")]) }, alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: Select(Select { distinct: false, projection: [Expr { expr: BinaryOp { left: Identifier([Ident("foo")]), op: Plus, right: Identifier([Ident("bar")]) }, alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 CREATE VIEW v AS
@@ -606,7 +606,7 @@ CREATE VIEW v AS
 ----
 CREATE VIEW v AS WITH a AS (SELECT 1 AS foo), b AS (SELECT 2 AS bar) SELECT foo + bar FROM a, b
 =>
-CreateView { name: ObjectName([Ident("v")]), columns: [], with_options: [], query: Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: Select(Select { distinct: false, projection: [Expr { expr: BinaryOp { left: Identifier([Ident("foo")]), op: Plus, right: Identifier([Ident("bar")]) }, alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false }
+CreateView(CreateViewStatement { name: ObjectName([Ident("v")]), columns: [], with_options: [], query: Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: Some(Ident("foo")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }, Cte { alias: TableAlias { name: Ident("b"), columns: [], strict: false }, query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("2")), alias: Some(Ident("bar")) }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None } }], body: Select(Select { distinct: false, projection: [Expr { expr: BinaryOp { left: Identifier([Ident("foo")]), op: Plus, right: Identifier([Ident("bar")]) }, alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("a")]), alias: None }, joins: [] }, TableWithJoins { relation: Table { name: ObjectName([Ident("b")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, if_exists: Error, temporary: false, materialized: false })
 
 parse-statement roundtrip
 WITH cte (col1, col2) AS (SELECT foo, bar FROM baz) SELECT * FROM cte
@@ -687,42 +687,42 @@ SELECT foo FROM bar OFFSET 2 ROWS
 ----
 SELECT foo FROM bar OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2 ROWS
 ----
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar ORDER BY baz OFFSET 2 ROWS
 ----
 SELECT foo FROM bar ORDER BY baz OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar(1)
 ----
 SELECT foo FROM bar(1)
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { name: ObjectName([Ident("bar")]), args: Args([Value(Number("1"))]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Function { name: ObjectName([Ident("bar")]), args: Args([Value(Number("1"))]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM LATERAL bar
@@ -738,63 +738,63 @@ SELECT 'foo' OFFSET 0 ROWS
 ----
 SELECT 'foo' OFFSET 0 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(String("foo")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("0"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(String("foo")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("0"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar OFFSET 2
 ----
 SELECT foo FROM bar OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2
 ----
 SELECT foo FROM bar WHERE foo = 4 OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar ORDER BY baz OFFSET 2
 ----
 SELECT foo FROM bar ORDER BY baz OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2) OFFSET 2 ROWS
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS) OFFSET 2 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: None }, as_of: None })
 
 parse-statement
 SELECT 'foo' OFFSET 0
 ----
 SELECT 'foo' OFFSET 0 ROWS
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(String("foo")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("0"))), fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(String("foo")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("0"))), fetch: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT foo FROM bar OFFSET 1 ROW
@@ -806,126 +806,126 @@ SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT 'foo' FETCH FIRST 2 ROWS ONLY
 ----
 SELECT 'foo' FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(String("foo")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(String("foo")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST ROWS ONLY
 ----
 SELECT foo FROM bar FETCH FIRST ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: None }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: None }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar WHERE foo = 4 FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar ORDER BY baz FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz FETCH FIRST 2 ROWS WITH TIES
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz FETCH FIRST 2 ROWS WITH TIES
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: None, fetch: Some(Fetch { with_ties: true, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: None, fetch: Some(Fetch { with_ties: true, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
 ----
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: true, quantity: Some(Value(Number("50"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: true, quantity: Some(Value(Number("50"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM bar WHERE foo = 4 ORDER BY baz OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("foo")]), op: Eq, right: Value(Number("4")) }), group_by: [], having: None }), order_by: [OrderByExpr { expr: Identifier([Ident("baz")]), asc: None }], limit: None, offset: Some(Value(Number("2"))), fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar FETCH FIRST 2 ROWS ONLY) FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM (SELECT * FROM bar FETCH FIRST 2 ROWS ONLY) FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY
 ----
 SELECT foo FROM (SELECT * FROM bar OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY) OFFSET 2 ROWS FETCH FIRST 2 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: Some(Value(Number("2"))), fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("2"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST 10 ROW ONLY
 ----
 SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("10"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("10"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH NEXT 10 ROW ONLY
 ----
 SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("10"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: Some(Value(Number("10"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH NEXT 10 ROWS WITH TIES
 ----
 SELECT foo FROM bar FETCH FIRST 10 ROWS WITH TIES
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: true, percent: false, quantity: Some(Value(Number("10"))) }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: true, percent: false, quantity: Some(Value(Number("10"))) }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH NEXT ROWS WITH TIES
 ----
 SELECT foo FROM bar FETCH FIRST ROWS WITH TIES
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: true, percent: false, quantity: None }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: true, percent: false, quantity: None }) }, as_of: None })
 
 parse-statement
 SELECT foo FROM bar FETCH FIRST ROWS ONLY
 ----
 SELECT foo FROM bar FETCH FIRST ROWS ONLY
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: None }) }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Identifier([Ident("foo")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("bar")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: Some(Fetch { with_ties: false, percent: false, quantity: None }) }, as_of: None })
 
 parse-statement
 SELECT * FROM customer LEFT JOIN (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 ----
 SELECT * FROM customer LEFT JOIN (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [Join { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("order")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("order"), Ident("customer")]), op: Eq, right: Identifier([Ident("customer"), Ident("id")]) }), group_by: [], having: None }), order_by: [], limit: Some(Value(Number("3"))), offset: None, fetch: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [Join { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("order")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("order"), Ident("customer")]), op: Eq, right: Identifier([Ident("customer"), Ident("id")]) }), group_by: [], having: None }), order_by: [], limit: Some(Value(Number("3"))), offset: None, fetch: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customer LEFT JOIN LATERAL (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 ----
 SELECT * FROM customer LEFT JOIN LATERAL (SELECT * FROM "order" WHERE "order".customer = customer.id LIMIT 3) AS "order" ON true
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [Join { relation: Derived { lateral: true, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("order")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("order"), Ident("customer")]), op: Eq, right: Identifier([Ident("customer"), Ident("id")]) }), group_by: [], having: None }), order_by: [], limit: Some(Value(Number("3"))), offset: None, fetch: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [Join { relation: Derived { lateral: true, subquery: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("order")]), alias: None }, joins: [] }], selection: Some(BinaryOp { left: Identifier([Ident("order"), Ident("customer")]), op: Eq, right: Identifier([Ident("customer"), Ident("id")]) }), group_by: [], having: None }), order_by: [], limit: Some(Value(Number("3"))), offset: None, fetch: None }, alias: Some(TableAlias { name: Ident("order"), columns: [], strict: false }) }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM customer LEFT JOIN LATERAL generate_series(1, customer.id) ON true
 ----
 SELECT * FROM customer LEFT JOIN generate_series(1, customer.id) ON true
 =>
-Select { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [Join { relation: Function { name: ObjectName([Ident("generate_series")]), args: Args([Value(Number("1")), Identifier([Ident("customer"), Ident("id")])]), alias: None }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("customer")]), alias: None }, joins: [Join { relation: Function { name: ObjectName([Ident("generate_series")]), args: Args([Value(Number("1")), Identifier([Ident("customer"), Ident("id")])]), alias: None }, join_operator: LeftOuter(On(Value(Boolean(true)))) }] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None })
 
 parse-statement
 SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -23,245 +23,245 @@ SHOW DATABASES
 ----
 SHOW DATABASES
 =>
-ShowDatabases { filter: None }
+ShowDatabases(ShowDatabasesStatement { filter: None })
 
 parse-statement
 SHOW DATABASES LIKE 'blah'
 ----
 SHOW DATABASES LIKE 'blah'
 =>
-ShowDatabases { filter: Some(Like("blah")) }
+ShowDatabases(ShowDatabasesStatement { filter: Some(Like("blah")) })
 
 parse-statement
 SHOW SCHEMAS
 ----
 SHOW SCHEMAS
 =>
-ShowObjects { object_type: Schema, from: None, extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Schema, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SCHEMAS FROM foo.bar
 ----
 SHOW SCHEMAS FROM foo.bar
 =>
-ShowObjects { object_type: Schema, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Schema, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-ShowObjects { object_type: Source, from: None, extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Source, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SOURCES FROM foo.bar
 ----
 SHOW SOURCES FROM foo.bar
 =>
-ShowObjects { object_type: Source, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW VIEWS
 ----
 SHOW VIEWS
 =>
-ShowObjects { object_type: View, from: None, extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: View, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW VIEWS FROM foo.bar
 ----
 SHOW VIEWS FROM foo.bar
 =>
-ShowObjects { object_type: View, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: View, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW TABLES
 ----
 SHOW TABLES
 =>
-ShowObjects { object_type: Table, from: None, extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Table, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW TABLES FROM foo.bar
 ----
 SHOW TABLES FROM foo.bar
 =>
-ShowObjects { object_type: Table, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SINKS
 ----
 SHOW SINKS
 =>
-ShowObjects { object_type: Sink, from: None, extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SINKS FROM foo.bar
 ----
 SHOW SINKS FROM foo.bar
 =>
-ShowObjects { object_type: Sink, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(ObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW TABLES LIKE '%foo%'
 ----
 SHOW TABLES LIKE '%foo%'
 =>
-ShowObjects { object_type: Table, from: None, extended: false, full: false, materialized: false, filter: Some(Like("%foo%")) }
+ShowObjects(ShowObjectsStatement { object_type: Table, from: None, extended: false, full: false, materialized: false, filter: Some(Like("%foo%")) })
 
 parse-statement
 SHOW FULL VIEWS
 ----
 SHOW FULL VIEWS
 =>
-ShowObjects { object_type: View, from: None, extended: false, full: true, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: View, from: None, extended: false, full: true, materialized: false, filter: None })
 
 parse-statement
 SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-ShowObjects { object_type: Source, from: None, extended: false, full: false, materialized: false, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Source, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW MATERIALIZED SOURCES FROM foo
 ----
 SHOW MATERIALIZED SOURCES FROM foo
 =>
-ShowObjects { object_type: Source, from: Some(ObjectName([Ident("foo")])), extended: false, full: false, materialized: true, filter: None }
+ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(ObjectName([Ident("foo")])), extended: false, full: false, materialized: true, filter: None })
 
 parse-statement
 SHOW MATERIALIZED VIEWS FROM foo LIKE '%foo%'
 ----
 SHOW MATERIALIZED VIEWS FROM foo LIKE '%foo%'
 =>
-ShowObjects { object_type: View, from: Some(ObjectName([Ident("foo")])), extended: false, full: false, materialized: true, filter: Some(Like("%foo%")) }
+ShowObjects(ShowObjectsStatement { object_type: View, from: Some(ObjectName([Ident("foo")])), extended: false, full: false, materialized: true, filter: Some(Like("%foo%")) })
 
 parse-statement
 SHOW INDEXES FROM foo
 ----
 SHOW INDEXES FROM foo
 =>
-ShowIndexes { table_name: ObjectName([Ident("foo")]), extended: false, filter: None }
+ShowIndexes(ShowIndexesStatement { table_name: ObjectName([Ident("foo")]), extended: false, filter: None })
 
 parse-statement
 SHOW INDEXES IN foo
 ----
 SHOW INDEXES FROM foo
 =>
-ShowIndexes { table_name: ObjectName([Ident("foo")]), extended: false, filter: None }
+ShowIndexes(ShowIndexesStatement { table_name: ObjectName([Ident("foo")]), extended: false, filter: None })
 
 parse-statement
 SHOW EXTENDED INDEXES FROM foo
 ----
 SHOW EXTENDED INDEXES FROM foo
 =>
-ShowIndexes { table_name: ObjectName([Ident("foo")]), extended: true, filter: None }
+ShowIndexes(ShowIndexesStatement { table_name: ObjectName([Ident("foo")]), extended: true, filter: None })
 
 parse-statement
 SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 ----
 SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 =>
-ShowIndexes { table_name: ObjectName([Ident("foo")]), extended: true, filter: Some(Where(BinaryOp { left: Identifier([Ident("index_name")]), op: Eq, right: Value(String("bar")) })) }
+ShowIndexes(ShowIndexesStatement { table_name: ObjectName([Ident("foo")]), extended: true, filter: Some(Where(BinaryOp { left: Identifier([Ident("index_name")]), op: Eq, right: Value(String("bar")) })) })
 
 parse-statement
 SHOW CREATE VIEW foo
 ----
 SHOW CREATE VIEW foo
 =>
-ShowCreateView { view_name: ObjectName([Ident("foo")]) }
+ShowCreateView(ShowCreateViewStatement { view_name: ObjectName([Ident("foo")]) })
 
 parse-statement
 SHOW CREATE SINK foo
 ----
 SHOW CREATE SINK foo
 =>
-ShowCreateSink { sink_name: ObjectName([Ident("foo")]) }
+ShowCreateSink(ShowCreateSinkStatement { sink_name: ObjectName([Ident("foo")]) })
 
 parse-statement
 SHOW CREATE INDEX foo
 ----
 SHOW CREATE INDEX foo
 =>
-ShowCreateIndex { index_name: ObjectName([Ident("foo")]) }
+ShowCreateIndex(ShowCreateIndexStatement { index_name: ObjectName([Ident("foo")]) })
 
 parse-statement
 SHOW COLUMNS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW COLUMNS FROM mydb.mytable
 ----
 SHOW COLUMNS FROM mydb.mytable
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mydb"), Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mydb"), Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW EXTENDED COLUMNS FROM mytable
 ----
 SHOW EXTENDED COLUMNS FROM mytable
 =>
-ShowColumns { extended: true, full: false, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: true, full: false, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW FULL COLUMNS FROM mytable
 ----
 SHOW FULL COLUMNS FROM mytable
 =>
-ShowColumns { extended: false, full: true, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: false, full: true, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW EXTENDED FULL COLUMNS FROM mytable
 ----
 SHOW EXTENDED FULL COLUMNS FROM mytable
 =>
-ShowColumns { extended: true, full: true, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: true, full: true, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 ----
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: Some(Like("pattern")) }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: Some(Like("pattern")) })
 
 parse-statement
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 ----
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: Some(Where(BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("2")) })) }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: Some(Where(BinaryOp { left: Value(Number("1")), op: Eq, right: Value(Number("2")) })) })
 
 parse-statement
 SHOW FIELDS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW COLUMNS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW FIELDS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None }
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: ObjectName([Ident("mytable")]), filter: None })
 
 parse-statement
 SHOW a
 ----
 SHOW a
 =>
-ShowVariable { variable: Ident("a") }
+ShowVariable(ShowVariableStatement { variable: Ident("a") })
 
 # TODO(justin): "all" here should be its own token so that it doesn't get
 # downcased.
@@ -270,77 +270,77 @@ SHOW ALL
 ----
 SHOW all
 =>
-ShowVariable { variable: Ident("all") }
+ShowVariable(ShowVariableStatement { variable: Ident("all") })
 
 parse-statement
 SET a = b
 ----
 SET a = b
 =>
-SetVariable { local: false, variable: Ident("a"), value: Ident(Ident("b")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("b")) })
 
 parse-statement
 SET a = 'b'
 ----
 SET a = 'b'
 =>
-SetVariable { local: false, variable: Ident("a"), value: Literal(String("b")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Literal(String("b")) })
 
 parse-statement
 SET a = 0
 ----
 SET a = 0
 =>
-SetVariable { local: false, variable: Ident("a"), value: Literal(Number("0")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Literal(Number("0")) })
 
 parse-statement
 SET a = default
 ----
 SET a = default
 =>
-SetVariable { local: false, variable: Ident("a"), value: Ident(Ident("default")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("default")) })
 
 parse-statement
 SET LOCAL a = b
 ----
 SET LOCAL a = b
 =>
-SetVariable { local: true, variable: Ident("a"), value: Ident(Ident("b")) }
+SetVariable(SetVariableStatement { local: true, variable: Ident("a"), value: Ident(Ident("b")) })
 
 parse-statement
 SET TIME ZONE utc
 ----
 SET timezone = utc
 =>
-SetVariable { local: false, variable: Ident("timezone"), value: Ident(Ident("utc")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("timezone"), value: Ident(Ident("utc")) })
 
 parse-statement
 SET a TO b
 ----
 SET a = b
 =>
-SetVariable { local: false, variable: Ident("a"), value: Ident(Ident("b")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("b")) })
 
 parse-statement
 SET SESSION a = b
 ----
 SET a = b
 =>
-SetVariable { local: false, variable: Ident("a"), value: Ident(Ident("b")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("b")) })
 
 parse-statement
 SET tiMe ZoNE 7
 ----
 SET timezone = 7
 =>
-SetVariable { local: false, variable: Ident("timezone"), value: Literal(Number("7")) }
+SetVariable(SetVariableStatement { local: false, variable: Ident("timezone"), value: Literal(Number("7")) })
 
 parse-statement
 SET LOCAL tiMe ZoNE 7
 ----
 SET LOCAL timezone = 7
 =>
-SetVariable { local: true, variable: Ident("timezone"), value: Literal(Number("7")) }
+SetVariable(SetVariableStatement { local: true, variable: Ident("timezone"), value: Literal(Number("7")) })
 
 parse-statement
 SET

--- a/src/sql-parser/tests/testdata/txn
+++ b/src/sql-parser/tests/testdata/txn
@@ -23,70 +23,70 @@ START TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE
 ----
 START TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE
 =>
-StartTransaction { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] }
+StartTransaction(StartTransactionStatement { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] })
 
 parse-statement
 START TRANSACTION READ ONLY READ WRITE ISOLATION LEVEL SERIALIZABLE
 ----
 START TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE
 =>
-StartTransaction { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] }
+StartTransaction(StartTransactionStatement { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] })
 
 parse-statement
 START TRANSACTION
 ----
 START TRANSACTION
 =>
-StartTransaction { modes: [] }
+StartTransaction(StartTransactionStatement { modes: [] })
 
 parse-statement
 BEGIN
 ----
 START TRANSACTION
 =>
-StartTransaction { modes: [] }
+StartTransaction(StartTransactionStatement { modes: [] })
 
 parse-statement
 BEGIN WORK
 ----
 START TRANSACTION
 =>
-StartTransaction { modes: [] }
+StartTransaction(StartTransactionStatement { modes: [] })
 
 parse-statement
 BEGIN TRANSACTION
 ----
 START TRANSACTION
 =>
-StartTransaction { modes: [] }
+StartTransaction(StartTransactionStatement { modes: [] })
 
 parse-statement
 START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 ----
 START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 =>
-StartTransaction { modes: [IsolationLevel(ReadUncommitted)] }
+StartTransaction(StartTransactionStatement { modes: [IsolationLevel(ReadUncommitted)] })
 
 parse-statement
 START TRANSACTION ISOLATION LEVEL READ COMMITTED
 ----
 START TRANSACTION ISOLATION LEVEL READ COMMITTED
 =>
-StartTransaction { modes: [IsolationLevel(ReadCommitted)] }
+StartTransaction(StartTransactionStatement { modes: [IsolationLevel(ReadCommitted)] })
 
 parse-statement
 START TRANSACTION ISOLATION LEVEL REPEATABLE READ
 ----
 START TRANSACTION ISOLATION LEVEL REPEATABLE READ
 =>
-StartTransaction { modes: [IsolationLevel(RepeatableRead)] }
+StartTransaction(StartTransactionStatement { modes: [IsolationLevel(RepeatableRead)] })
 
 parse-statement
 START TRANSACTION ISOLATION LEVEL SERIALIZABLE
 ----
 START TRANSACTION ISOLATION LEVEL SERIALIZABLE
 =>
-StartTransaction { modes: [IsolationLevel(Serializable)] }
+StartTransaction(StartTransactionStatement { modes: [IsolationLevel(Serializable)] })
 
 parse-statement
 START TRANSACTION ISOLATION LEVEL BAD
@@ -120,130 +120,130 @@ SET TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE
 ----
 SET TRANSACTION READ ONLY, READ WRITE, ISOLATION LEVEL SERIALIZABLE
 =>
-SetTransaction { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] }
+SetTransaction(SetTransactionStatement { modes: [AccessMode(ReadOnly), AccessMode(ReadWrite), IsolationLevel(Serializable)] })
 
 parse-statement
 COMMIT
 ----
 COMMIT
 =>
-Commit { chain: false }
+Commit(CommitStatement { chain: false })
 
 parse-statement
 COMMIT AND CHAIN
 ----
 COMMIT AND CHAIN
 =>
-Commit { chain: true }
+Commit(CommitStatement { chain: true })
 
 parse-statement
 COMMIT AND NO CHAIN
 ----
 COMMIT
 =>
-Commit { chain: false }
+Commit(CommitStatement { chain: false })
 
 parse-statement
 COMMIT WORK AND NO CHAIN
 ----
 COMMIT
 =>
-Commit { chain: false }
+Commit(CommitStatement { chain: false })
 
 parse-statement
 COMMIT TRANSACTION AND NO CHAIN
 ----
 COMMIT
 =>
-Commit { chain: false }
+Commit(CommitStatement { chain: false })
 
 parse-statement
 COMMIT WORK AND CHAIN
 ----
 COMMIT AND CHAIN
 =>
-Commit { chain: true }
+Commit(CommitStatement { chain: true })
 
 parse-statement
 COMMIT TRANSACTION AND CHAIN
 ----
 COMMIT AND CHAIN
 =>
-Commit { chain: true }
+Commit(CommitStatement { chain: true })
 
 parse-statement
 COMMIT WORK
 ----
 COMMIT
 =>
-Commit { chain: false }
+Commit(CommitStatement { chain: false })
 
 parse-statement
 COMMIT TRANSACTION
 ----
 COMMIT
 =>
-Commit { chain: false }
+Commit(CommitStatement { chain: false })
 
 parse-statement
 ROLLBACK
 ----
 ROLLBACK
 =>
-Rollback { chain: false }
+Rollback(RollbackStatement { chain: false })
 
 parse-statement
 ROLLBACK AND CHAIN
 ----
 ROLLBACK AND CHAIN
 =>
-Rollback { chain: true }
+Rollback(RollbackStatement { chain: true })
 
 parse-statement
 ROLLBACK AND NO CHAIN
 ----
 ROLLBACK
 =>
-Rollback { chain: false }
+Rollback(RollbackStatement { chain: false })
 
 parse-statement
 ROLLBACK WORK AND NO CHAIN
 ----
 ROLLBACK
 =>
-Rollback { chain: false }
+Rollback(RollbackStatement { chain: false })
 
 parse-statement
 ROLLBACK TRANSACTION AND NO CHAIN
 ----
 ROLLBACK
 =>
-Rollback { chain: false }
+Rollback(RollbackStatement { chain: false })
 
 parse-statement
 ROLLBACK WORK AND CHAIN
 ----
 ROLLBACK AND CHAIN
 =>
-Rollback { chain: true }
+Rollback(RollbackStatement { chain: true })
 
 parse-statement
 ROLLBACK TRANSACTION AND CHAIN
 ----
 ROLLBACK AND CHAIN
 =>
-Rollback { chain: true }
+Rollback(RollbackStatement { chain: true })
 
 parse-statement
 ROLLBACK WORK
 ----
 ROLLBACK
 =>
-Rollback { chain: false }
+Rollback(RollbackStatement { chain: false })
 
 parse-statement
 ROLLBACK TRANSACTION
 ----
 ROLLBACK
 =>
-Rollback { chain: false }
+Rollback(RollbackStatement { chain: false })

--- a/src/sql-parser/tests/testdata/update
+++ b/src/sql-parser/tests/testdata/update
@@ -28,4 +28,4 @@ UPDATE t SET a = 1, b = 2, c = 3 WHERE d
 ----
 UPDATE t SET a = 1, b = 2, c = 3 WHERE d
 =>
-Update { table_name: ObjectName([Ident("t")]), assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) }
+Update(UpdateStatement { table_name: ObjectName([Ident("t")]), assignments: [Assignment { id: Ident("a"), value: Value(Number("1")) }, Assignment { id: Ident("b"), value: Value(Number("2")) }, Assignment { id: Ident("c"), value: Value(Number("3")) }], selection: Some(Identifier([Ident("d")])) })

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -108,7 +108,7 @@ pub fn plan_root_query(
 /// treated as a WHERE applied to the first column in the result set.
 pub fn plan_show_where(
     scx: &StatementContext,
-    filter: Option<&ShowStatementFilter>,
+    filter: Option<ShowStatementFilter>,
     rows: Vec<Vec<Datum>>,
     desc: &RelationDesc,
 ) -> Result<(RelationExpr, RowSetFinishing), anyhow::Error> {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -23,9 +23,10 @@ use rusoto_core::Region;
 use url::Url;
 
 use dataflow_types::{
-    AvroEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding, DataEncoding, Envelope,
-    ExternalSourceConnector, FileSourceConnector, KafkaSinkConnectorBuilder, KafkaSourceConnector,
-    KinesisSourceConnector, ProtobufEncoding, SinkConnectorBuilder, SourceConnector,
+    AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding,
+    DataEncoding, Envelope, ExternalSourceConnector, FileSourceConnector,
+    KafkaSinkConnectorBuilder, KafkaSourceConnector, KinesisSourceConnector, ProtobufEncoding,
+    RegexEncoding, SinkConnectorBuilder, SourceConnector,
 };
 use expr::{like_pattern, GlobalId, RowSetFinishing};
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
@@ -1191,7 +1192,7 @@ fn handle_create_source(
             }
             Format::Regex(regex) => {
                 let regex = Regex::new(regex)?;
-                DataEncoding::Regex { regex }
+                DataEncoding::Regex(RegexEncoding { regex })
             }
             Format::Csv {
                 header_row,
@@ -1398,7 +1399,7 @@ fn handle_create_source(
                 Value::String(s) => s,
                 _ => bail!("reader_schema option must be a string"),
             };
-            let encoding = DataEncoding::AvroOcf { reader_schema };
+            let encoding = DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema });
             (connector, encoding)
         }
     };

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -15,7 +15,9 @@ use anyhow::{bail, Context};
 use tokio::io::AsyncBufReadExt;
 
 use repr::strconv;
-use sql_parser::ast::{AvroSchema, Connector, CsrSeed, Format, Ident, Statement};
+use sql_parser::ast::{
+    AvroSchema, Connector, CreateSourceStatement, CsrSeed, Format, Ident, Statement,
+};
 
 use crate::kafka_util;
 use crate::normalize;
@@ -27,14 +29,14 @@ use crate::normalize;
 /// Note that purification is asynchronous, and may take an unboundedly long
 /// time to complete.
 pub async fn purify(mut stmt: Statement) -> Result<Statement, anyhow::Error> {
-    if let Statement::CreateSource {
+    if let Statement::CreateSource(CreateSourceStatement {
         col_names,
         connector,
         format,
         with_options,
         envelope,
         ..
-    } = &mut stmt
+    }) = &mut stmt
     {
         let with_options_map = normalize::with_options(with_options);
         let mut config_options = HashMap::new();

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -22,7 +22,10 @@ use tokio_postgres::types::Type;
 use ore::collections::CollectionExt;
 use ore::retry;
 use pgrepr::{Interval, Jsonb, Numeric};
-use sql_parser::ast::Statement;
+use sql_parser::ast::{
+    CreateDatabaseStatement, CreateSchemaStatement, CreateSourceStatement, CreateTableStatement,
+    CreateViewStatement, Statement,
+};
 
 use crate::action::{Action, State};
 use crate::parser::{FailSqlCommand, SqlCommand, SqlOutput};
@@ -54,35 +57,35 @@ pub fn build_sql(mut cmd: SqlCommand, timeout: Duration) -> Result<SqlAction, St
 impl Action for SqlAction {
     async fn undo(&self, state: &mut State) -> Result<(), String> {
         match &self.stmt {
-            Statement::CreateDatabase { name, .. } => {
+            Statement::CreateDatabase(CreateDatabaseStatement { name, .. }) => {
                 self.try_drop(
                     &mut state.pgclient,
                     &format!("DROP DATABASE IF EXISTS {}", name.to_string()),
                 )
                 .await
             }
-            Statement::CreateSchema { name, .. } => {
+            Statement::CreateSchema(CreateSchemaStatement { name, .. }) => {
                 self.try_drop(
                     &mut state.pgclient,
                     &format!("DROP SCHEMA IF EXISTS {} CASCADE", name),
                 )
                 .await
             }
-            Statement::CreateSource { name, .. } => {
+            Statement::CreateSource(CreateSourceStatement { name, .. }) => {
                 self.try_drop(
                     &mut state.pgclient,
                     &format!("DROP SOURCE IF EXISTS {} CASCADE", name),
                 )
                 .await
             }
-            Statement::CreateView { name, .. } => {
+            Statement::CreateView(CreateViewStatement { name, .. }) => {
                 self.try_drop(
                     &mut state.pgclient,
                     &format!("DROP VIEW IF EXISTS {} CASCADE", name),
                 )
                 .await
             }
-            Statement::CreateTable { name, .. } => {
+            Statement::CreateTable(CreateTableStatement { name, .. }) => {
                 self.try_drop(
                     &mut state.pgclient,
                     &format!("DROP TABLE IF EXISTS {} CASCADE", name),


### PR DESCRIPTION
This splits out the large ast::Statement enum variants into dedicated
structs. For example,

    enum Statement {
        CreateTable {
            name: ObjectName,
            columns: Vec<ColumnDef>,
            // ...
        },
        // ...
    }

becomes:

    enum Statement {
        CreateTable(CreateTableStatement),
        // ...
    }

    struct CreateTableStatement {
        name: ObjectName,
        columns: Vec<ColumnDef>,
    }

This makes it possible to use types to indicate that a function expects
precisely one Statement variant, for example:

    fn handle_create_table(stmt: CreateTableStatement)

Previously, such a function had several bad options. It could take each
parameter of the struct as an argument...

    fn handle_create_table(name: ObjectName, columns: Vec<ColumnDef>, ...)

...or it could take a Statement and assert that the statement was of the
correct variant:

    fn handle_create_table(stmt: Statement) {
        let (name, columns) = match stmt {
            CreateTableStatement { name, columns } => (name, columns),
            _ => unreachable!("handle_create_table called with wrong type!"),
        };
    }

The new approach is particularly useful in the SQL planner, where both
of these bad options were in heavy use. The cost is net additional
verbosity, though some places get quite a bit more concise.

This commit is pure code movement and has no behavioral changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3857)
<!-- Reviewable:end -->
