### PR TITLE
catalog: load stored catalog items in gid order

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -251,13 +251,14 @@ impl Connection {
     }
 
     pub fn load_items(&self) -> Result<Vec<(GlobalId, FullName, Vec<u8>)>, Error> {
+        // Order user views by their GlobalId
         self.inner
             .prepare(
                 "SELECT items.gid, databases.name, schemas.name, items.name, items.definition
                 FROM items
                 JOIN schemas ON items.schema_id = schemas.id
                 JOIN databases ON schemas.database_id = databases.id
-                ORDER BY items.rowid",
+                ORDER BY json_extract(items.gid, '$.User')",
             )?
             .query_and_then(params![], |row| -> Result<_, Error> {
                 let id: SqlVal<GlobalId> = row.get(0)?;


### PR DESCRIPTION
Previously, on restart we loaded catalog items in rowid order. This was fine, as
for most catalog items the rowid order corresponds exactly to the gid order
(between user items). However, some items need to be modified after they have
been created, which we currently do by deleting the old item, and then inserting
a new, modified version of the item. This breaks the rowid ordering.

Note that we will have to revisit this change if we ever persist user items and system
items in the catalog, as the gid order likely does not do what we want between user and
system ids.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3861)
<!-- Reviewable:end -->
