### PR TITLE
dataflow: remove first_export_id

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -622,12 +622,12 @@ where
                 }
                 Message::Worker(WorkerFeedbackWithMeta {
                     worker_id: _,
-                    message: WorkerFeedback::CreateSource(source_id),
+                    message: WorkerFeedback::CreateSource(src_instance_id),
                 }) => {
-                    if let Some(entry) = self.catalog.try_get_by_id(source_id.sid) {
+                    if let Some(entry) = self.catalog.try_get_by_id(src_instance_id.source_id) {
                         if let CatalogItem::Source(s) = entry.item() {
                             ts_tx
-                                .send(TimestampMessage::Add(source_id, s.connector.clone()))
+                                .send(TimestampMessage::Add(src_instance_id, s.connector.clone()))
                                 .expect("Failed to send CREATE Instance notice to timestamper");
                         } else {
                             panic!("A non-source is re-using the same source ID");

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -26,9 +26,7 @@ use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use url::Url;
 
-use expr::{
-    GlobalId, OptimizedRelationExpr, PartitionId, RelationExpr, ScalarExpr, SourceInstanceId,
-};
+use expr::{GlobalId, OptimizedRelationExpr, PartitionId, RelationExpr, ScalarExpr};
 use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use kafka_util::KafkaAddr;
@@ -78,7 +76,7 @@ pub struct BuildDesc {
 /// A description of a dataflow to construct and results to surface.
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct DataflowDesc {
-    pub source_imports: BTreeMap<SourceInstanceId, SourceDesc>,
+    pub source_imports: BTreeMap<GlobalId, SourceDesc>,
     pub index_imports: BTreeMap<GlobalId, (IndexDesc, RelationType)>,
     /// Views and indexes to be built and stored in the local context.
     /// Objects must be built in the specific order as the Vec
@@ -128,7 +126,7 @@ impl DataflowDesc {
 
     pub fn add_source_import(
         &mut self,
-        id: SourceInstanceId,
+        id: GlobalId,
         connector: SourceConnector,
         desc: RelationDesc,
     ) {
@@ -256,8 +254,8 @@ impl DataflowDesc {
 
     /// The number of columns associated with an identifier in the dataflow.
     pub fn arity_of(&self, id: &GlobalId) -> usize {
-        for (source, desc) in self.source_imports.iter() {
-            if &source.sid == id {
+        for (source_id, desc) in self.source_imports.iter() {
+            if source_id == id {
                 return desc.desc.typ().arity();
             }
         }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -278,7 +278,7 @@ where
         &mut self,
         render_state: &mut RenderState,
         scope: &mut Child<'g, G, G::Timestamp>,
-        src_id: SourceInstanceId,
+        src_id: GlobalId,
         mut src: SourceDesc,
     ) {
         if let Some(operator) = &src.operators {
@@ -296,11 +296,11 @@ where
             ts_frequency,
         } = src.connector
         {
-            let get_expr = RelationExpr::global_get(src_id.sid, src.desc.typ().clone());
+            let get_expr = RelationExpr::global_get(src_id, src.desc.typ().clone());
 
             // This uid must be unique across all different instantiations of a source
             let uid = SourceInstanceId {
-                sid: src_id.sid,
+                sid: src_id,
                 vid: self.first_export_id,
             };
 
@@ -538,13 +538,13 @@ where
 
                 // Introduce the stream by name, as an unarranged collection.
                 self.collections.insert(
-                    RelationExpr::global_get(src_id.sid, src.desc.typ().clone()),
+                    RelationExpr::global_get(src_id, src.desc.typ().clone()),
                     (collection, err_collection),
                 );
                 capability
             };
             let token = Rc::new(capability);
-            self.source_tokens.insert(src_id.sid, token.clone());
+            self.source_tokens.insert(src_id, token.clone());
 
             // We also need to keep track of this mapping globally to activate sources
             // on timestamp advancement queries

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -124,6 +124,7 @@ use dataflow_types::Timestamp;
 use dataflow_types::*;
 use expr::{GlobalId, Id, RelationExpr, ScalarExpr, SourceInstanceId};
 use ore::cast::CastFrom;
+use ore::collections::CollectionExt as _;
 use ore::iter::IteratorExt;
 use repr::{Datum, RelationType, Row, RowArena};
 
@@ -183,9 +184,10 @@ pub fn build_local_input<A: Allocate>(
             // data is being stored, identified by the index_id
             // 2) the source stream that data comes in from, which is identified
             //    by the source_id, passed into this method as index.on_id
-            let mut context = Context::<_, _, _, Timestamp>::for_dataflow(&DataflowDesc::new(
-                "local-input".into(),
-            ));
+            let mut context = Context::<_, _, _, Timestamp>::for_dataflow(
+                &DataflowDesc::new("local-input".into()),
+                scope.addr().into_element(),
+            );
             let ((handle, capability), stream) = region.new_unordered_input();
             if region.index() == 0 {
                 render_state
@@ -229,7 +231,7 @@ pub fn build_dataflow<A: Allocate>(
         // so that other similar uses (e.g. with iterative scopes) do not require weird
         // alternate type signatures.
         scope.clone().region(|region| {
-            let mut context = Context::for_dataflow(&dataflow);
+            let mut context = Context::for_dataflow(&dataflow, scope.addr().into_element());
 
             assert!(
                 !dataflow
@@ -300,8 +302,8 @@ where
 
             // This uid must be unique across all different instantiations of a source
             let uid = SourceInstanceId {
-                sid: src_id,
-                vid: self.first_export_id,
+                source_id: src_id,
+                dataflow_id: self.dataflow_id,
             };
 
             // TODO(benesch): we force all sources to have an empty
@@ -586,7 +588,7 @@ where
         } else {
             panic!(
                 "import of index {} failed while building dataflow {}",
-                idx_id, self.first_export_id
+                idx_id, self.dataflow_id
             );
         }
     }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -390,7 +390,7 @@ impl KafkaSourceInfo {
         } = kc;
         let kafka_config =
             create_kafka_config(&source_name, &addr, group_id_prefix, &config_options);
-        let source_global_id = source_id.sid;
+        let source_global_id = source_id.source_id;
         let source_id = source_id.to_string();
         let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
             .create_with_context(GlueConsumerContext(consumer_activator))

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -101,18 +101,19 @@ impl fmt::Display for GlobalId {
     }
 }
 
-/// Unique identifier used for each *instance* of a source in a dataflow
+/// Unique identifier for an instantiation of a source.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SourceInstanceId {
-    // Global Source Id
-    pub sid: GlobalId,
-    // Id of the view with which this source is instantiated
-    pub vid: GlobalId,
+    // The ID of the source.
+    pub source_id: GlobalId,
+    // The ID of the timely dataflow containing this instantiation of this
+    // source.
+    pub dataflow_id: usize,
 }
 
 impl fmt::Display for SourceInstanceId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}/{}", self.sid, self.vid)
+        write!(f, "{}/{}", self.source_id, self.dataflow_id)
     }
 }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -69,7 +69,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
 
     // Push demand information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(columns) = demand.get(&Id::Global(source_id.sid)).clone() {
+        if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
@@ -106,7 +106,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
 
     // Push predicate information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(list) = predicates.get(&Id::Global(source_id.sid)).clone() {
+        if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
             // Install no-op predicate information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {


### PR DESCRIPTION
Using the Timely dataflow ID, as suggested in #1720, makes things much
cleaner.

Fix #1720.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3864)
<!-- Reviewable:end -->
