### PR TITLE
dataflow: don't wrap SyncActivator in mutex when possible

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -64,7 +64,7 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
         _active: bool,
         worker_id: usize,
         worker_count: usize,
-        consumer_activator: Arc<Mutex<SyncActivator>>,
+        consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         _: &mut ConsistencyInfo,
         _: DataEncoding,
@@ -336,7 +336,7 @@ impl KafkaSourceInfo {
         source_id: SourceInstanceId,
         worker_id: usize,
         worker_count: usize,
-        consumer_activator: Arc<Mutex<SyncActivator>>,
+        consumer_activator: SyncActivator,
         kc: KafkaSourceConnector,
     ) -> KafkaSourceInfo {
         let KafkaSourceConnector {
@@ -350,7 +350,9 @@ impl KafkaSourceInfo {
             create_kafka_config(&source_name, &addr, group_id_prefix, &config_options);
         let source_id = source_id.to_string();
         let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
-            .create_with_context(GlueConsumerContext(consumer_activator))
+            .create_with_context(GlueConsumerContext(Arc::new(Mutex::new(
+                consumer_activator,
+            ))))
             .expect("Failed to create Kafka Consumer");
         KafkaSourceInfo {
             buffered_metadata: HashSet::new(),

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -9,7 +9,6 @@
 
 use std::collections::{HashSet, VecDeque};
 use std::convert::TryInto;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::time::Instant;
 
@@ -83,7 +82,7 @@ impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
         active: bool,
         _worker_id: usize,
         _worker_count: usize,
-        _consumer_activator: Arc<Mutex<SyncActivator>>,
+        _consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
         _encoding: DataEncoding,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -15,7 +15,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use timely::dataflow::{
     channels::pact::{Exchange, ParallelizationContract},
@@ -203,7 +202,7 @@ pub trait SourceConstructor<Out> {
         active: bool,
         worker_id: usize,
         worker_count: usize,
-        consumer_activator: Arc<Mutex<SyncActivator>>,
+        consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
         encoding: DataEncoding,
@@ -765,7 +764,7 @@ where
             active,
             worker_id,
             worker_count,
-            Arc::new(Mutex::new(scope.sync_activator_for(&info.address[..]))),
+            scope.sync_activator_for(&info.address[..]),
             source_connector.clone(),
             &mut consistency_info,
             encoding,


### PR DESCRIPTION
Only Kafka really needs to wrap the SyncActivator in a mutex, and if
SyncActivator learns to `impl Sync`, we'll be able to get rid of that
too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3866)
<!-- Reviewable:end -->
