### PR TITLE
Add release version heads-up 

### DIFF
--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -8,6 +8,8 @@ menu:
 
 `CREATE TABLE` creates a non-streaming, in-memory data source.
 
+**Note that CREATE TABLE is currently only available in the developer (unstable) builds**
+
 ## Conceptual framework
 
 Tables store non-streaming data that is inserted via [INSERT](../insert) statements.

--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -9,7 +9,7 @@ menu:
 `CREATE TABLE` creates a non-streaming, in-memory data source.
 
 {{< warning >}}
-**Note that CREATE TABLE is currently only available in the [developer](https://mtrlz.dev/) (unstable) builds**
+**CREATE TABLE is currently only available in the [developer](https://mtrlz.dev/) (unstable) builds.**
 {{< /warning >}}
 
 {{< warning >}}

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -8,6 +8,8 @@ menu:
 
 `INSERT` inserts values into a table.
 
+**Note that INSERT is currently only available in the developer (unstable) builds**
+
 ## Conceptual framework
 
 `INSERT` statements insert data into [tables](../create-table). You may want to `INSERT` data

--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -9,7 +9,7 @@ menu:
 `INSERT` inserts values into a table.
 
 {{< warning >}}
-**Note that INSERT is currently only available in the [developer](https://mtrlz.dev/) (unstable) builds**
+**INSERT is currently only available in the [developer](https://mtrlz.dev/) (unstable) builds.**
 {{< warning >}}
 
 {{< warning >}}


### PR DESCRIPTION
Note that http://downloads.mtrlz.dev/materialized-latest-x86_64-apple-darwin.tar.gz is currently on 447913e4b, which is older than the INSERT commit (8d48988)

We should also remember to drop this warning once we release 0.4.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3867)
<!-- Reviewable:end -->
