### PR TITLE
repr: improve readability of ColumnType construction

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -223,20 +223,20 @@ impl CatalogView {
         match self {
             // Paths for Avro OCF sinks.
             CatalogView::MzAvroOcfSinks => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("path", ScalarType::Bytes)
+                .with_column("global_id", ScalarType::String.nullable(false))
+                .with_column("path", ScalarType::Bytes.nullable(false))
                 .with_key(vec![0]),
 
             // Name -> global ID mapping.
             CatalogView::MzCatalogNames => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("name", ScalarType::String)
+                .with_column("global_id", ScalarType::String.nullable(false))
+                .with_column("name", ScalarType::String.nullable(false))
                 .with_key(vec![0]),
 
             // Topics for Kafka sinks.
             CatalogView::MzKafkaSinks => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("topic", ScalarType::String)
+                .with_column("global_id", ScalarType::String.nullable(false))
+                .with_column("topic", ScalarType::String.nullable(false))
                 .with_key(vec![0]),
 
             // Foreign key relationship: child, parent, then pairs of child and
@@ -245,18 +245,18 @@ impl CatalogView {
             // relationships from one child relation to the same parent
             // relation.
             CatalogView::MzViewForeignKeys => RelationDesc::empty()
-                .with_nonnull_column("child_id", ScalarType::String)
-                .with_nonnull_column("child_column", ScalarType::Int64)
-                .with_nonnull_column("parent_id", ScalarType::String)
-                .with_nonnull_column("parent_column", ScalarType::Int64)
-                .with_nonnull_column("key_group", ScalarType::Int64)
+                .with_column("child_id", ScalarType::String.nullable(false))
+                .with_column("child_column", ScalarType::Int64.nullable(false))
+                .with_column("parent_id", ScalarType::String.nullable(false))
+                .with_column("parent_column", ScalarType::Int64.nullable(false))
+                .with_column("key_group", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 4]),
 
             // Primary key relations.
             CatalogView::MzViewKeys => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("column", ScalarType::Int64)
-                .with_nonnull_column("key_group", ScalarType::Int64),
+                .with_column("global_id", ScalarType::String.nullable(false))
+                .with_column("column", ScalarType::Int64.nullable(false))
+                .with_column("key_group", ScalarType::Int64.nullable(false)),
         }
     }
 }

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -184,86 +184,86 @@ impl LogVariant {
     pub fn schema(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("name", ScalarType::String)
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("name", ScalarType::String.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Channels) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("source_node", ScalarType::Int64)
-                .with_nonnull_column("source_port", ScalarType::Int64)
-                .with_nonnull_column("target_node", ScalarType::Int64)
-                .with_nonnull_column("target_port", ScalarType::Int64)
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("source_node", ScalarType::Int64.nullable(false))
+                .with_column("source_port", ScalarType::Int64.nullable(false))
+                .with_column("target_node", ScalarType::Int64.nullable(false))
+                .with_column("target_port", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Elapsed) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("elapsed_ns", ScalarType::Int64)
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("elapsed_ns", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Histogram) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("duration_ns", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("duration_ns", ScalarType::Int64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
-                .with_nonnull_column("id", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("slot", ScalarType::Int64)
-                .with_nonnull_column("value", ScalarType::Int64)
+                .with_column("id", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("slot", ScalarType::Int64.nullable(false))
+                .with_column("value", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("slept_for", ScalarType::Int64)
-                .with_nonnull_column("requested", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("slept_for", ScalarType::Int64.nullable(false))
+                .with_column("requested", ScalarType::Int64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1, 2]),
 
             LogVariant::Differential(DifferentialLog::Arrangement) => RelationDesc::empty()
-                .with_nonnull_column("operator", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("records", ScalarType::Int64)
-                .with_nonnull_column("batches", ScalarType::Int64)
+                .with_column("operator", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("records", ScalarType::Int64.nullable(false))
+                .with_column("batches", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Differential(DifferentialLog::Sharing) => RelationDesc::empty()
-                .with_nonnull_column("operator", ScalarType::Int64)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_column("operator", ScalarType::Int64.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => RelationDesc::empty()
-                .with_nonnull_column("name", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64)
+                .with_column("name", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
-                .with_nonnull_column("dataflow", ScalarType::String)
-                .with_nonnull_column("source", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64),
+                .with_column("dataflow", ScalarType::String.nullable(false))
+                .with_column("source", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => RelationDesc::empty()
-                .with_nonnull_column("global_id", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("time", ScalarType::Int64),
+                .with_column("global_id", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("time", ScalarType::Int64.nullable(false)),
 
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => RelationDesc::empty()
-                .with_nonnull_column("uuid", ScalarType::String)
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("id", ScalarType::String)
-                .with_nonnull_column("time", ScalarType::Int64)
+                .with_column("uuid", ScalarType::String.nullable(false))
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("id", ScalarType::String.nullable(false))
+                .with_column("time", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
             LogVariant::Materialized(MaterializedLog::PeekDuration) => RelationDesc::empty()
-                .with_nonnull_column("worker", ScalarType::Int64)
-                .with_nonnull_column("duration_ns", ScalarType::Int64)
-                .with_nonnull_column("count", ScalarType::Int64)
+                .with_column("worker", ScalarType::Int64.nullable(false))
+                .with_column("duration_ns", ScalarType::Int64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
         }
     }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -318,7 +318,7 @@ impl DataEncoding {
 
         // Add columns for the data, based on the encoding format.
         Ok(match self {
-            DataEncoding::Bytes => key_desc.with_nonnull_column("data", ScalarType::Bytes),
+            DataEncoding::Bytes => key_desc.with_column("data", ScalarType::Bytes.nullable(false)),
             DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => {
                 avro::validate_value_schema(&*reader_schema, envelope.get_avro_envelope_type())
                     .context("validating avro ocf reader schema")?
@@ -367,14 +367,15 @@ impl DataEncoding {
                         None => format!("column{}", i),
                         Some(name) => name.to_owned(),
                     };
-                    let ty = ColumnType::new(ScalarType::String, true);
+                    let ty = ScalarType::String.nullable(true);
                     desc.with_column(name, ty)
                 }),
-            DataEncoding::Csv(CsvEncoding { n_cols, .. }) => (1..=*n_cols)
-                .fold(key_desc, |desc, i| {
-                    desc.with_nonnull_column(format!("column{}", i), ScalarType::String)
-                }),
-            DataEncoding::Text => key_desc.with_nonnull_column("text", ScalarType::String),
+            DataEncoding::Csv(CsvEncoding { n_cols, .. }) => {
+                (1..=*n_cols).fold(key_desc, |desc, i| {
+                    desc.with_column(format!("column{}", i), ScalarType::String.nullable(false))
+                })
+            }
+            DataEncoding::Text => key_desc.with_column("text", ScalarType::String.nullable(false)),
         })
     }
 
@@ -494,22 +495,10 @@ pub enum ExternalSourceConnector {
 impl ExternalSourceConnector {
     pub fn metadata_columns(&self) -> Vec<(ColumnName, ColumnType)> {
         match self {
-            Self::Kafka(_) => vec![(
-                "mz_offset".into(),
-                ColumnType::new(ScalarType::Int64, false),
-            )],
-            Self::File(_) => vec![(
-                "mz_line_no".into(),
-                ColumnType::new(ScalarType::Int64, false),
-            )],
-            Self::Kinesis(_) => vec![(
-                "mz_offset".into(),
-                ColumnType::new(ScalarType::Int64, false),
-            )],
-            Self::AvroOcf(_) => vec![(
-                "mz_obj_no".into(),
-                ColumnType::new(ScalarType::Int64, false),
-            )],
+            Self::Kafka(_) => vec![("mz_offset".into(), ScalarType::Int64.nullable(false))],
+            Self::File(_) => vec![("mz_line_no".into(), ScalarType::Int64.nullable(false))],
+            Self::Kinesis(_) => vec![("mz_offset".into(), ScalarType::Int64.nullable(false))],
+            Self::AvroOcf(_) => vec![("mz_obj_no".into(), ScalarType::Int64.nullable(false))],
         }
     }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -505,7 +505,7 @@ impl AggregateFunc {
             // max/min/sum return null on empty sets
             _ => true,
         };
-        ColumnType::new(scalar_type, nullable)
+        scalar_type.nullable(nullable)
     }
 }
 
@@ -727,31 +727,29 @@ impl TableFunc {
     pub fn output_type(&self) -> RelationType {
         RelationType::new(match self {
             TableFunc::JsonbEach { stringify: true } => vec![
-                ColumnType::new(ScalarType::String, false),
-                ColumnType::new(ScalarType::String, true),
+                ScalarType::String.nullable(false),
+                ScalarType::String.nullable(true),
             ],
             TableFunc::JsonbEach { stringify: false } => vec![
-                ColumnType::new(ScalarType::String, false),
-                ColumnType::new(ScalarType::Jsonb, false),
+                ScalarType::String.nullable(false),
+                ScalarType::Jsonb.nullable(false),
             ],
-            TableFunc::JsonbObjectKeys => vec![ColumnType::new(ScalarType::String, false)],
+            TableFunc::JsonbObjectKeys => vec![ScalarType::String.nullable(false)],
             TableFunc::JsonbArrayElements { stringify: true } => {
-                vec![ColumnType::new(ScalarType::String, true)]
+                vec![ScalarType::String.nullable(true)]
             }
             TableFunc::JsonbArrayElements { stringify: false } => {
-                vec![ColumnType::new(ScalarType::Jsonb, false)]
+                vec![ScalarType::Jsonb.nullable(false)]
             }
             TableFunc::RegexpExtract(a) => a
                 .capture_groups_iter()
-                .map(|cg| ColumnType::new(ScalarType::String, cg.nullable))
+                .map(|cg| ScalarType::String.nullable(cg.nullable))
                 .collect(),
-            TableFunc::CsvExtract(n_cols) => {
-                iter::repeat(ColumnType::new(ScalarType::String, false))
-                    .take(*n_cols)
-                    .collect()
-            }
-            TableFunc::GenerateSeriesInt32 => vec![ColumnType::new(ScalarType::Int32, false)],
-            TableFunc::GenerateSeriesInt64 => vec![ColumnType::new(ScalarType::Int64, false)],
+            TableFunc::CsvExtract(n_cols) => iter::repeat(ScalarType::String.nullable(false))
+                .take(*n_cols)
+                .collect(),
+            TableFunc::GenerateSeriesInt32 => vec![ScalarType::Int32.nullable(false)],
+            TableFunc::GenerateSeriesInt64 => vec![ScalarType::Int64.nullable(false)],
             TableFunc::Repeat => vec![],
         })
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -556,8 +556,8 @@ impl RelationExpr {
     ///
     /// // A common schema for each input.
     /// let schema = RelationType::new(vec![
-    ///     ColumnType::new(ScalarType::Int32, false),
-    ///     ColumnType::new(ScalarType::Int32, false),
+    ///     ScalarType::Int32.nullable(false),
+    ///     ScalarType::Int32.nullable(false),
     /// ]);
     ///
     /// // the specific data are not important here.

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -735,8 +735,7 @@ fn get_named_columns<'a>(
                 // the column's output type is nullable, as this
                 // column will be null whenever it is uninhabited.
                 let ty = validate_schema_2(seen_avro_nodes, node)?;
-                let nullable = vs.len() > 1;
-                columns.push((name.into(), ColumnType::new(ty, nullable)));
+                columns.push((name.into(), ty.nullable(vs.len() > 1)));
                 if let Some(named_idx) = named_idx {
                     seen_avro_nodes.remove(&named_idx);
                 }
@@ -745,10 +744,7 @@ fn get_named_columns<'a>(
         Ok(columns)
     } else {
         let scalar_type = validate_schema_2(seen_avro_nodes, schema)?;
-        Ok(vec![(
-            base_name.into(),
-            ColumnType::new(scalar_type, false),
-        )])
+        Ok(vec![(base_name.into(), scalar_type.nullable(false))])
     }
 }
 
@@ -1956,7 +1952,7 @@ mod tests {
             ),
         ];
         for (typ, datum, expected) in valid_pairings {
-            let desc = RelationDesc::empty().with_nonnull_column("column1", typ);
+            let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
             let avro_value = Encoder::new(desc, false).row_to_avro(vec![datum]);
             assert_eq!(
                 Value::Record(vec![("column1".into(), expected)]),

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -19,7 +19,10 @@ use crate::ScalarType;
 /// The type of a [`Datum`](crate::Datum).
 ///
 /// [`ColumnType`] bundles information about the scalar type of a datum (e.g.,
-/// Int32 or String) with additional attributes, like its nullability.
+/// Int32 or String) with its nullability.
+///
+/// To construct a column type, either initialize the struct directly, or
+/// use the [`ScalarType::nullable`] method.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct ColumnType {
     /// Whether this datum can be null.
@@ -29,16 +32,6 @@ pub struct ColumnType {
 }
 
 impl ColumnType {
-    /// Constructs a new `ColumnType` with the specified [`ScalarType`] as its
-    /// underlying type. If desired, the `nullable` property can be modified
-    /// with the `nullable(bool)` method.
-    pub fn new(scalar_type: ScalarType, nullable: bool) -> Self {
-        ColumnType {
-            nullable,
-            scalar_type,
-        }
-    }
-
     pub fn union(&self, other: &Self) -> Result<Self, anyhow::Error> {
         if self.scalar_type != other.scalar_type {
             bail!(
@@ -183,8 +176,8 @@ impl From<&ColumnName> for ColumnName {
 /// use repr::{ColumnType, RelationDesc, ScalarType};
 ///
 /// let desc = RelationDesc::empty()
-///     .with_nonnull_column("id", ScalarType::Int64)
-///     .with_column("price", ColumnType::new(ScalarType::Float64, true));
+///     .with_column("id", ScalarType::Int64.nullable(false))
+///     .with_column("price", ScalarType::Float64.nullable(true));
 /// ```
 ///
 /// In more complicated cases, like when constructing a `RelationDesc` in
@@ -247,14 +240,6 @@ impl RelationDesc {
             self = self.with_key(k);
         }
         self
-    }
-
-    /// Appends a named, nonnullable column with the specified scalar type.
-    pub fn with_nonnull_column<N>(self, name: N, scalar_type: ScalarType) -> Self
-    where
-        N: Into<ColumnName>,
-    {
-        self.with_column(name, ColumnType::new(scalar_type, false))
     }
 
     /// Appends a named column with the specified column type.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -667,6 +667,15 @@ impl<'a> ScalarType {
             _ => self.clone(),
         }
     }
+
+    /// Derives a column type from this scalar type with the specified
+    /// nullability.
+    pub fn nullable(self, nullable: bool) -> ColumnType {
+        ColumnType {
+            nullable,
+            scalar_type: self,
+        }
+    }
 }
 
 // TODO(benesch): the implementations of PartialEq and Hash for ScalarType can

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -561,7 +561,7 @@ impl ScalarExpr {
                                 expr1: Box::new(cond_expr.clone()),
                                 expr2: Box::new(SS::literal_ok(
                                     Datum::False,
-                                    ColumnType::new(ScalarType::Bool, false),
+                                    ScalarType::Bool.nullable(false),
                                 )),
                             }),
                             expr2: Box::new(SS::CallUnary {
@@ -613,11 +613,10 @@ impl ScalarExpr {
                             // optimizer.
                             .product(expr::RelationExpr::constant(
                                 vec![vec![Datum::True]],
-                                RelationType::new(vec![ColumnType::new(ScalarType::Bool, false)]),
+                                RelationType::new(vec![ScalarType::Bool.nullable(false)]),
                             ));
                         // append False to anything that didn't return any rows
-                        let default =
-                            vec![(Datum::False, ColumnType::new(ScalarType::Bool, false))];
+                        let default = vec![(Datum::False, ScalarType::Bool.nullable(false))];
                         get_inner.lookup(id_gen, exists, default)
                     },
                 );

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -59,31 +59,18 @@ use crate::pure::Schema;
 
 lazy_static! {
     static ref SHOW_DATABASES_DESC: RelationDesc =
-        RelationDesc::empty().with_nonnull_column("Database", ScalarType::String);
-    static ref SHOW_INDEXES_DESC: RelationDesc = RelationDesc::new(
-        RelationType::new(vec![
-            ColumnType::new(ScalarType::String, false),
-            ColumnType::new(ScalarType::String, false),
-            ColumnType::new(ScalarType::String, true),
-            ColumnType::new(ScalarType::String, true),
-            ColumnType::new(ScalarType::Bool, false),
-            ColumnType::new(ScalarType::Int64, false),
-        ]),
-        vec![
-            "Source_or_view",
-            "Key_name",
-            "Column_name",
-            "Expression",
-            "Null",
-            "Seq_in_index",
-        ]
-        .into_iter()
-        .map(Some),
-    );
+        RelationDesc::empty().with_column("Database", ScalarType::String.nullable(false));
+    static ref SHOW_INDEXES_DESC: RelationDesc = RelationDesc::empty()
+        .with_column("Source_or_view", ScalarType::String.nullable(false))
+        .with_column("Key_name", ScalarType::String.nullable(false))
+        .with_column("Column_name", ScalarType::String.nullable(true))
+        .with_column("Expression", ScalarType::String.nullable(true))
+        .with_column("Null", ScalarType::Bool.nullable(false))
+        .with_column("Seq_in_index", ScalarType::Int64.nullable(false));
     static ref SHOW_COLUMNS_DESC: RelationDesc = RelationDesc::empty()
-        .with_nonnull_column("Field", ScalarType::String)
-        .with_nonnull_column("Nullable", ScalarType::String)
-        .with_nonnull_column("Type", ScalarType::String);
+        .with_column("Field", ScalarType::String.nullable(false))
+        .with_column("Nullable", ScalarType::String.nullable(false))
+        .with_column("Type", ScalarType::String.nullable(false));
 }
 
 pub fn make_show_objects_desc(
@@ -94,17 +81,19 @@ pub fn make_show_objects_desc(
     let col_name = object_type_as_plural_str(object_type);
     if full {
         let mut relation_desc = RelationDesc::empty()
-            .with_nonnull_column(col_name, ScalarType::String)
-            .with_nonnull_column("TYPE", ScalarType::String);
+            .with_column(col_name, ScalarType::String.nullable(false))
+            .with_column("TYPE", ScalarType::String.nullable(false));
         if ObjectType::View == object_type {
-            relation_desc = relation_desc.with_nonnull_column("QUERYABLE", ScalarType::Bool);
+            relation_desc =
+                relation_desc.with_column("QUERYABLE", ScalarType::Bool.nullable(false));
         }
         if !materialized && (ObjectType::View == object_type || ObjectType::Source == object_type) {
-            relation_desc = relation_desc.with_nonnull_column("MATERIALIZED", ScalarType::Bool);
+            relation_desc =
+                relation_desc.with_column("MATERIALIZED", ScalarType::Bool.nullable(false));
         }
         relation_desc
     } else {
-        RelationDesc::empty().with_nonnull_column(col_name, ScalarType::String)
+        RelationDesc::empty().with_column(col_name, ScalarType::String.nullable(false))
     }
 }
 
@@ -144,13 +133,13 @@ pub fn describe_statement(
         Statement::Explain(ExplainStatement {
             stage, explainee, ..
         }) => (
-            Some(RelationDesc::empty().with_nonnull_column(
+            Some(RelationDesc::empty().with_column(
                 match stage {
                     ExplainStage::RawPlan => "Raw Plan",
                     ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
                     ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
                 },
-                ScalarType::String,
+                ScalarType::String.nullable(false),
             )),
             match explainee {
                 Explainee::Query(q) => {
@@ -171,8 +160,8 @@ pub fn describe_statement(
         Statement::ShowCreateView(_) => (
             Some(
                 RelationDesc::empty()
-                    .with_nonnull_column("View", ScalarType::String)
-                    .with_nonnull_column("Create View", ScalarType::String),
+                    .with_column("View", ScalarType::String.nullable(false))
+                    .with_column("Create View", ScalarType::String.nullable(false)),
             ),
             vec![],
         ),
@@ -180,8 +169,8 @@ pub fn describe_statement(
         Statement::ShowCreateSource(_) => (
             Some(
                 RelationDesc::empty()
-                    .with_nonnull_column("Source", ScalarType::String)
-                    .with_nonnull_column("Create Source", ScalarType::String),
+                    .with_column("Source", ScalarType::String.nullable(false))
+                    .with_column("Create Source", ScalarType::String.nullable(false)),
             ),
             vec![],
         ),
@@ -189,8 +178,8 @@ pub fn describe_statement(
         Statement::ShowCreateTable(_) => (
             Some(
                 RelationDesc::empty()
-                    .with_nonnull_column("Table", ScalarType::String)
-                    .with_nonnull_column("Create Table", ScalarType::String),
+                    .with_column("Table", ScalarType::String.nullable(false))
+                    .with_column("Create Table", ScalarType::String.nullable(false)),
             ),
             vec![],
         ),
@@ -198,8 +187,8 @@ pub fn describe_statement(
         Statement::ShowCreateSink(_) => (
             Some(
                 RelationDesc::empty()
-                    .with_nonnull_column("Sink", ScalarType::String)
-                    .with_nonnull_column("Create Sink", ScalarType::String),
+                    .with_column("Sink", ScalarType::String.nullable(false))
+                    .with_column("Create Sink", ScalarType::String.nullable(false)),
             ),
             vec![],
         ),
@@ -207,8 +196,8 @@ pub fn describe_statement(
         Statement::ShowCreateIndex(_) => (
             Some(
                 RelationDesc::empty()
-                    .with_nonnull_column("Index", ScalarType::String)
-                    .with_nonnull_column("Create Index", ScalarType::String),
+                    .with_column("Index", ScalarType::String.nullable(false))
+                    .with_column("Create Index", ScalarType::String.nullable(false)),
             ),
             vec![],
         ),
@@ -234,9 +223,9 @@ pub fn describe_statement(
                 (
                     Some(
                         RelationDesc::empty()
-                            .with_nonnull_column("name", ScalarType::String)
-                            .with_nonnull_column("setting", ScalarType::String)
-                            .with_nonnull_column("description", ScalarType::String),
+                            .with_column("name", ScalarType::String.nullable(false))
+                            .with_column("setting", ScalarType::String.nullable(false))
+                            .with_column("description", ScalarType::String.nullable(false)),
                     ),
                     vec![],
                 )
@@ -244,7 +233,7 @@ pub fn describe_statement(
                 (
                     Some(
                         RelationDesc::empty()
-                            .with_nonnull_column(variable.as_str(), ScalarType::String),
+                            .with_column(variable.as_str(), ScalarType::String.nullable(false)),
                     ),
                     vec![],
                 )
@@ -1597,7 +1586,7 @@ fn handle_create_table(
                         }
                     }
                 }
-                Ok(ColumnType::new(ty, nullable))
+                Ok(ty.nullable(nullable))
             })
             .collect::<Result<Vec<_>, anyhow::Error>>()?,
     );

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -37,7 +37,7 @@ use tokio_postgres::types::FromSql;
 use dataflow_types::SourceConnector;
 use pgrepr::Jsonb;
 use repr::adt::decimal::Significand;
-use repr::{ColumnType, Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use repr::{Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
 use sql::ast::{
     ColumnOption, CreateTableStatement, DataType, DeleteStatement, DropObjectsStatement,
     InsertStatement, ObjectType, Statement, TableConstraint, UpdateStatement,
@@ -163,7 +163,7 @@ END $$;
                             let ty = scalar_type_from_sql(&c.data_type)?;
                             let nullable =
                                 !c.options.iter().any(|o| o.option == ColumnOption::NotNull);
-                            Ok(ColumnType::new(ty, nullable))
+                            Ok(ty.nullable(nullable))
                         })
                         .collect::<Result<Vec<_>, anyhow::Error>>()?,
                 );

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -346,8 +346,7 @@ pub fn optimize(
                 expr.reduce(input_type);
                 optimize(expr, input_type, column_knowledge)?
             } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
-                *expr =
-                    ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool, false));
+                *expr = ScalarExpr::literal_ok(Datum::False, ScalarType::Bool.nullable(false));
                 optimize(expr, input_type, column_knowledge)?
             } else {
                 DatumKnowledge::default()

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -16,7 +16,7 @@
 //! use transform::fusion::filter::Filter;
 //!
 //! let input = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool, false),
+//!     ScalarType::Bool.nullable(false),
 //! ]));
 //!
 //! let predicate0 = ScalarExpr::Column(0);

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -16,7 +16,7 @@
 
 use crate::TransformArgs;
 use expr::{AggregateExpr, AggregateFunc, RelationExpr, ScalarExpr, UnaryFunc};
-use repr::{ColumnType, Datum, RelationType, ScalarType};
+use repr::{Datum, RelationType, ScalarType};
 
 /// Harvests information about non-nullability of columns from sources.
 #[derive(Debug)]
@@ -108,10 +108,7 @@ fn scalar_nonnullable(expr: &mut ScalarExpr, metadata: &RelationType) {
         {
             if let ScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = ScalarExpr::literal_ok(
-                        Datum::False,
-                        ColumnType::new(ScalarType::Bool, false),
-                    );
+                    *e = ScalarExpr::literal_ok(Datum::False, ScalarType::Bool.nullable(false));
                 }
             }
         }
@@ -124,8 +121,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     // count(true).
     if let (AggregateFunc::Count, ScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
-            expr.expr =
-                ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, false));
+            expr.expr = ScalarExpr::literal_ok(Datum::True, ScalarType::Bool.nullable(false));
         }
     }
 }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -19,13 +19,13 @@
 //! use transform::predicate_pushdown::PredicatePushdown;
 //!
 //! let input1 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool, false),
+//!     ScalarType::Bool.nullable(false),
 //! ]));
 //! let input2 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool, false),
+//!     ScalarType::Bool.nullable(false),
 //! ]));
 //! let input3 = RelationExpr::constant(vec![], RelationType::new(vec![
-//!     ColumnType::new(ScalarType::Bool, false),
+//!     ScalarType::Bool.nullable(false),
 //! ]));
 //! let join = RelationExpr::join(
 //!     vec![input1.clone(), input2.clone(), input3.clone()],
@@ -35,7 +35,7 @@
 //! let predicate0 = ScalarExpr::column(0);
 //! let predicate1 = ScalarExpr::column(1);
 //! let predicate01 = ScalarExpr::column(0).call_binary(ScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ColumnType::new(ScalarType::Bool, false));
+//! let predicate012 = ScalarExpr::literal_ok(Datum::False, ScalarType::Bool.nullable(false));
 //!
 //! let mut expr = join.filter(
 //!    vec![
@@ -56,7 +56,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::TransformArgs;
 use expr::{AggregateFunc, Id, RelationExpr, ScalarExpr};
-use repr::{ColumnType, Datum, ScalarType};
+use repr::{Datum, ScalarType};
 
 /// Pushes predicates down through other operators.
 #[derive(Debug)]
@@ -330,7 +330,7 @@ impl PredicatePushdown {
                                 push_down.push(aggregates[0].expr.clone());
                                 aggregates[0].expr = ScalarExpr::literal_ok(
                                     Datum::True,
-                                    ColumnType::new(ScalarType::Bool, false),
+                                    ScalarType::Bool.nullable(false),
                                 );
                             } else {
                                 retain.push(predicate);

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -57,11 +57,11 @@ impl ReduceElision {
                             a.expr.clone().call_unary(UnaryFunc::IsNull).if_then_else(
                                 ScalarExpr::literal_ok(
                                     Datum::Int64(0),
-                                    column_type.clone().nullable(false),
+                                    column_type.scalar_type.clone().nullable(false),
                                 ),
                                 ScalarExpr::literal_ok(
                                     Datum::Int64(1),
-                                    column_type.nullable(false),
+                                    column_type.scalar_type.nullable(false),
                                 ),
                             )
                         }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -492,7 +492,7 @@ pub mod demorgans {
 pub mod undistribute_and {
 
     use expr::{BinaryFunc, RelationExpr, ScalarExpr};
-    use repr::{ColumnType, Datum, ScalarType};
+    use repr::{Datum, ScalarType};
 
     use crate::{TransformArgs, TransformError};
 
@@ -556,7 +556,7 @@ pub mod undistribute_and {
             suppress_ands(expr2, ands);
 
             // If either argument is in our list, replace it by `true`.
-            let tru = ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, false));
+            let tru = ScalarExpr::literal_ok(Datum::True, ScalarType::Bool.nullable(false));
             if ands.contains(expr1) {
                 *expr = std::mem::replace(expr2, tru);
             } else if ands.contains(expr2) {


### PR DESCRIPTION
Adjust the ColumnType construction pattern from

    ColumnType::new(ScalarType::Bool, true)

to:

    ScalarType::Bool.nullable(true)

The most important difference is that the purpose of a literal `true` or
`false` is immediately clear to the reader. With the old API, I was
continually forgetting both what the bool parameter meant at all
("nullability"), and then it would take me another moment to remember if
"true" meant "null" or "not null". In the new API, it is much more
obvious.

An alternative to this design would be to introduce an enum like

    enum Nullable {
        Nullable,
        NotNullable
    }

but there are two big downsides with this. The first is the verbosity:
even if you shorten to e.g. `Nullable::Yes`, it's still a mouthful.
The second is that enums don't compose as well as booleans. It's nice to
be able to write

    if ty.nullable { /* ... */ }

or:

    let nullable = ty1.nullable || ty2.nullable;

Using an enum instead of a raw boolean makes such patterns more
difficult.

One downside of the proposed approach is that it's not immediately clear
from the call site that you're creating a `ColumnType`. I think this is
offset by how fundamental the method is; after all, nullability is *the*
difference between a scalar type and a column type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3871)
<!-- Reviewable:end -->
