### PR TITLE
expr,sql: give every aggregate function an identity

### DIFF
--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -342,10 +342,6 @@ where
             move |(key, row)| {
                 let datum = row.unpack_first();
                 let (aggs, nonnulls) = match aggr {
-                    AggregateFunc::CountAll => {
-                        // Nothing beyond the accumulated count is needed.
-                        (0i128, 0i128)
-                    }
                     AggregateFunc::Count => {
                         // Count needs to distinguish nulls from zero.
                         (1, if datum.is_null() { 0 } else { 1 })
@@ -412,7 +408,6 @@ where
                 // The finished value depends on the aggregation function in a variety of ways.
                 let value = match (&aggr, agg2) {
                     (AggregateFunc::Count, _) => Datum::Int64(agg2 as i64),
-                    (AggregateFunc::CountAll, _) => Datum::Int64(tot as i64),
                     (AggregateFunc::All, _) => {
                         // If any false, else if all true, else must be no false and some nulls.
                         if agg2 > 0 {
@@ -544,7 +539,6 @@ fn accumulable_hierarchical(func: &AggregateFunc) -> (bool, bool) {
         | AggregateFunc::SumFloat64
         | AggregateFunc::SumDecimal
         | AggregateFunc::Count
-        | AggregateFunc::CountAll
         | AggregateFunc::Any
         | AggregateFunc::All
         | AggregateFunc::Dummy => (true, false),

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -785,29 +785,17 @@ impl ScalarExpr {
         }
     }
 
-    pub fn literal(datum: Datum, column_type: ColumnType) -> ScalarExpr {
+    pub fn literal(datum: Datum, scalar_type: ScalarType) -> ScalarExpr {
         let row = Row::pack(&[datum]);
-        ScalarExpr::Literal(row, column_type)
+        ScalarExpr::Literal(row, ColumnType::new(scalar_type, datum.is_null()))
     }
 
     pub fn literal_true() -> ScalarExpr {
-        ScalarExpr::literal(
-            Datum::True,
-            ColumnType {
-                nullable: false,
-                scalar_type: ScalarType::Bool,
-            },
-        )
+        ScalarExpr::literal(Datum::True, ScalarType::Bool)
     }
 
     pub fn literal_null(scalar_type: ScalarType) -> ScalarExpr {
-        ScalarExpr::literal(
-            Datum::Null,
-            ColumnType {
-                nullable: true,
-                scalar_type,
-            },
-        )
+        ScalarExpr::literal(Datum::Null, scalar_type)
     }
 
     pub fn call_unary(self, func: UnaryFunc) -> Self {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 
 use ore::collections::CollectionExt;
-use repr::{ColumnName, ColumnType, Datum, ScalarType};
+use repr::{ColumnName, Datum, ScalarType};
 use sql_parser::ast::{BinaryOperator, Expr, UnaryOperator};
 
 use super::expr::{
@@ -799,7 +799,7 @@ lazy_static! {
                 params!(List(Box::new(String))) => unary_op(|ecx, e| {
                     ecx.require_experimental_mode("list_ndims")?;
                     let d = ecx.scalar_type(&e).unwrap_list_n_dims();
-                    Ok(ScalarExpr::literal(Datum::Int32(d as i32), ColumnType::new(ScalarType::Int32, false)))
+                    Ok(ScalarExpr::literal(Datum::Int32(d as i32), ScalarType::Int32))
                 })
             },
             "list_length" => {
@@ -895,7 +895,7 @@ fn plan_current_timestamp(ecx: &ExprContext, name: &str) -> Result<ScalarExpr, a
     match ecx.qcx.lifetime {
         QueryLifetime::OneShot => Ok(ScalarExpr::literal(
             Datum::from(ecx.qcx.scx.pcx.wall_time),
-            ColumnType::new(ScalarType::TimestampTz, false),
+            ScalarType::TimestampTz,
         )),
         QueryLifetime::Static => bail!("{} cannot be used in static queries", name),
     }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -43,8 +43,8 @@ use crate::names::PartialName;
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
-    AggregateExpr, AggregateFunc, BinaryFunc, CoercibleScalarExpr, ColumnOrder, ColumnRef,
-    JoinKind, RelationExpr, ScalarExpr, ScalarTypeable, UnaryFunc, VariadicFunc,
+    AggregateExpr, BinaryFunc, CoercibleScalarExpr, ColumnOrder, ColumnRef, JoinKind, RelationExpr,
+    ScalarExpr, ScalarTypeable, UnaryFunc, VariadicFunc,
 };
 use crate::plan::func;
 use crate::plan::scope::{Scope, ScopeItem, ScopeItemName};
@@ -1761,7 +1761,7 @@ fn plan_aggregate(ecx: &ExprContext, sql_func: &Function) -> Result<AggregateExp
         }
         FunctionArgs::Args(args) => args,
     };
-    let (mut expr, mut func) = func::select_aggregate_func(ecx, &name, args)?;
+    let (mut expr, func) = func::select_aggregate_func(ecx, &name, args)?;
     if let Some(filter) = &sql_func.filter {
         // If a filter is present, as in
         //
@@ -1769,25 +1769,15 @@ fn plan_aggregate(ecx: &ExprContext, sql_func: &Function) -> Result<AggregateExp
         //
         // we plan it by essentially rewriting the expression to
         //
-        //     <agg>(CASE WHEN <cond> THEN <expr> ELSE NULL)
+        //     <agg>(CASE WHEN <cond> THEN <expr> ELSE <identity>)
         //
-        // as aggregate functions ignore NULL. The only exception is `count(*)`,
-        // which includes NULLs in its count; we handle that specially by
-        // rewriting to:
-        //
-        //     count(CASE WHEN <cond> THEN TRUE ELSE NULL)
-        //
-        // (Note the `TRUE` in in place of `<expr>`.)
+        // where <identity> is the identity input for <agg>.
         let cond = plan_expr(&ecx.with_name("FILTER"), filter)?.type_as(ecx, ScalarType::Bool)?;
-        if func == AggregateFunc::CountAll {
-            func = AggregateFunc::Count;
-            expr = ScalarExpr::literal_true();
-        }
         let expr_typ = ecx.scalar_type(&expr);
         expr = ScalarExpr::If {
             cond: Box::new(cond),
             then: Box::new(expr),
-            els: Box::new(ScalarExpr::literal_null(expr_typ)),
+            els: Box::new(ScalarExpr::literal(func.identity_datum(), expr_typ)),
         };
     }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -37,9 +37,7 @@ use sql_parser::ast::{
 use ::expr::{Id, RowSetFinishing};
 use dataflow_types::Timestamp;
 use repr::adt::decimal::{Decimal, MAX_DECIMAL_PRECISION};
-use repr::{
-    strconv, ColumnName, ColumnType, Datum, RelationDesc, RelationType, RowArena, ScalarType,
-};
+use repr::{strconv, ColumnName, Datum, RelationDesc, RelationType, RowArena, ScalarType};
 
 use crate::names::PartialName;
 use crate::normalize;
@@ -1629,16 +1627,13 @@ pub fn plan_expr<'a>(ecx: &'a ExprContext, e: &Expr) -> Result<CoercibleScalarEx
                 let start = if let Some(start) = &p.start {
                     plan_expr(ecx, start)?.explicit_cast_to(op_str, ecx, ScalarType::Int64)?
                 } else {
-                    ScalarExpr::literal(Datum::Int64(1), ColumnType::new(ScalarType::Int64, true))
+                    ScalarExpr::literal(Datum::Int64(1), ScalarType::Int64)
                 };
 
                 let end = if let Some(end) = &p.end {
                     plan_expr(ecx, end)?.explicit_cast_to(op_str, ecx, ScalarType::Int64)?
                 } else {
-                    ScalarExpr::literal(
-                        Datum::Int64(i64::MAX - 1),
-                        ColumnType::new(ScalarType::Int64, true),
-                    )
+                    ScalarExpr::literal(Datum::Int64(i64::MAX - 1), ScalarType::Int64)
                 };
 
                 exprs.push(start);
@@ -2016,9 +2011,7 @@ fn plan_literal<'a>(l: &'a Value) -> Result<CoercibleScalarExpr, anyhow::Error> 
         Value::String(s) => return Ok(CoercibleScalarExpr::LiteralString(s.clone())),
         Value::Null => return Ok(CoercibleScalarExpr::LiteralNull),
     };
-    let nullable = datum == Datum::Null;
-    let typ = ColumnType::new(scalar_type, nullable);
-    let expr = ScalarExpr::literal(datum, typ);
+    let expr = ScalarExpr::literal(datum, scalar_type);
     Ok(expr.into())
 }
 

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -226,10 +226,6 @@ impl ColumnKnowledge {
                             // These methods propagate constant values exactly.
                             knowledge
                         }
-                        AggregateFunc::CountAll => DatumKnowledge {
-                            value: None,
-                            nullable: false,
-                        },
                         _ => {
                             // All aggregates are non-null if their inputs are non-null.
                             DatumKnowledge {

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -197,10 +197,7 @@ impl NonNullRequirements {
                     if column < group_key.len() {
                         group_key[column].non_null_requirements(&mut new_columns);
                     }
-                    if column == group_key.len()
-                        && aggregates.len() == 1
-                        && aggregates[0].func != expr::AggregateFunc::CountAll
-                    {
+                    if column == group_key.len() && aggregates.len() == 1 {
                         aggregates[0].expr.non_null_requirements(&mut new_columns);
                     }
                 }

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -120,11 +120,12 @@ fn scalar_nonnullable(expr: &mut ScalarExpr, metadata: &RelationType) {
 
 /// Transformations to aggregation functions, based on nonnullability of columns.
 fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
-    // An aggregate that is a count of non-nullable data can be replaced by a countall.
+    // An aggregate that is a count of non-nullable data can be replaced by
+    // count(true).
     if let (AggregateFunc::Count, ScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
-            expr.func = AggregateFunc::CountAll;
-            expr.expr = ScalarExpr::literal_null(ColumnType::new(ScalarType::Bool, true));
+            expr.expr =
+                ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, true));
         }
     }
 }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -65,11 +65,6 @@ impl ReduceElision {
                                 ),
                             )
                         }
-                        // CountAll is one no matter what the input.
-                        AggregateFunc::CountAll => ScalarExpr::literal_ok(
-                            Datum::Int64(1),
-                            a.typ(&input_type).nullable(false),
-                        ),
                         // All other variants should return the argument to the aggregation.
                         _ => a.expr.clone(),
                     })

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -234,7 +234,7 @@ ORDER BY ol_number
 %0 =
 | Get materialize.public.orderline (u19)
 | Filter (datetots(#6) > 2007-01-02 00:00:00)
-| Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) countall(true)
+| Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) count(true)
 | Map (i64tof64(#1) / i64tof64(if (#3 = 0) then {null} else {#3})), (((#2 * 10000000dec) / i64todec(if (#4 = 0) then {null} else {#4})) / 10dec)
 | Project (#0..#2, #6, #7, #5)
 
@@ -417,7 +417,7 @@ ORDER BY o_ol_cnt
 | Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
 | | implementation = Differential %1 %4.(#0, #1, #2, #3)
 | | demand = (#6)
-| Reduce group=(#6) countall(true)
+| Reduce group=(#6) count(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -917,7 +917,7 @@ ORDER BY custdist DESC, c_count DESC
 %7 =
 | Union %3 %6
 | Reduce group=(#0) count(#22)
-| Reduce group=(#1) countall(true)
+| Reduce group=(#1) count(true)
 
 Finish order_by=(#1 desc, #0 desc) limit=none offset=0 project=(#0, #1)
 
@@ -1447,7 +1447,7 @@ ORDER BY numwait DESC, su_name
 | Join %7 %12 (= #7 #47) (= #8 #48) (= #9 #49) (= #13 #50)
 | | implementation = Differential %12 %7.(#7, #8, #9, #13)
 | | demand = (#1)
-| Reduce group=(#1) countall(true)
+| Reduce group=(#1) count(true)
 
 Finish order_by=(#1 desc, #0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -1523,7 +1523,7 @@ ORDER BY substr(c_state, 1, 1)
 | Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
 | | implementation = Differential %8 %3.(#0, #1, #2)
 | | demand = (#9, #16)
-| Reduce group=(substr(#9, 1, 1)) countall(true) sum(#16)
+| Reduce group=(substr(#9, 1, 1)) count(true) sum(#16)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -1851,12 +1851,32 @@ SELECT to_jsonb(TIMESTAMP '1969-06-01 10:10:10.41');
 # jsonb_agg
 
 query T
+SELECT jsonb_agg(js) FROM (SELECT '1'::jsonb AS js WHERE false)
+----
+NULL
+
+query T
 SELECT jsonb_agg(1)
 ----
 [1.0]
 
 query T
 SELECT jsonb_agg(column1) FROM (VALUES (1), (2), (3))
+----
+[1.0,2.0,3.0]
+
+query T
+SELECT jsonb_agg(column1) FROM (VALUES (1), (2), (3), (NULL))
+----
+[null,1.0,2.0,3.0]
+
+query T
+SELECT jsonb_agg(column1) FROM (VALUES ('1'::jsonb), ('2'::jsonb), ('3'::jsonb), (NULL::jsonb))
+----
+[null,2.0,3.0,1.0]
+
+query T
+SELECT jsonb_agg(column1) FILTER (WHERE column1 IS NOT NULL) FROM (VALUES (1), (2), (3), (NULL))
 ----
 [1.0,2.0,3.0]
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -161,7 +161,7 @@ ORDER BY
 %0 =
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
-| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) countall(null) countall(null) sum(#6) countall(null) countall(true)
+| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) count(true) count(true) sum(#6) count(true) count(true)
 | Map (((#2 * 10000000dec) / i64todec(if (#6 = 0) then {null} else {#6})) / 10dec), (((#3 * 10000000dec) / i64todec(if (#7 = 0) then {null} else {#7})) / 10dec), (((#8 * 10000000dec) / i64todec(if (#9 = 0) then {null} else {#9})) / 10dec)
 | Project (#0..#5, #11..#13, #10)
 
@@ -377,7 +377,7 @@ ORDER BY
 | Join %1 %4 (= #0 #9)
 | | implementation = Differential %1 %4.(#0)
 | | demand = (#5)
-| Reduce group=(#5) countall(true)
+| Reduce group=(#5) count(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -971,7 +971,7 @@ ORDER BY
 %7 =
 | Union %3 %6
 | Reduce group=(#0) count(#8)
-| Reduce group=(#1) countall(true)
+| Reduce group=(#1) count(true)
 
 Finish order_by=(#1 desc, #0 desc) limit=none offset=0 project=(#0, #1)
 
@@ -1233,7 +1233,7 @@ WHERE
 | Join %4 %5 (= #0 #2)
 | | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
 | | demand = (#0, #5)
-| Reduce group=(#0) sum(#5) countall(null)
+| Reduce group=(#0) sum(#5) count(true)
 | Map (2dec * (((#1 * 10000000dec) / i64todec(if (#2 = 0) then {null} else {#2})) / 10dec))
 | ArrangeBy (#0)
 
@@ -1661,7 +1661,7 @@ ORDER BY
 | Join %11 %16 (= #0 #39) (= #7 #38)
 | | implementation = Differential %16 %11.(#0, #7)
 | | demand = (#1)
-| Reduce group=(#1) countall(true)
+| Reduce group=(#1) count(true)
 
 Finish order_by=(#1 desc, #0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -1725,7 +1725,7 @@ ORDER BY
 %1 =
 | Get materialize.public.customer (u15)
 | Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17")), (#5 > 0dec)
-| Reduce group=() sum(#5) countall(null)
+| Reduce group=() sum(#5) count(true)
 | Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
 | ArrangeBy ()
 
@@ -1765,7 +1765,7 @@ ORDER BY
 | Join %3 %8 (= #0 #11)
 | | implementation = Differential %8 %3.(#0)
 | | demand = (#4, #5)
-| Reduce group=(substr(#4, 1, 2)) countall(true) sum(#5)
+| Reduce group=(substr(#4, 1, 2)) count(true) sum(#5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 


### PR DESCRIPTION
In order to transform a SQL expression of the form

    <agg>(<expr>) FILTER (WHERE <cond>)

into

    <agg>(CASE WHEN <cond> THEN <expr> ELSE <identity>)

every aggregate function must have an identity. The transformation was
previously assuming that null was the identity for every aggregate
function, which was wrong. For example, the identity for ANY is false,
not null.

There are two big changes in this commit:

  * AggregateFunc::CountAll is removed. There was *no* identity for
    this function, because it did not look at its input. Its usage is
    replaced by Count(true).

    This has the potential to make count(*) a bit slower, but I can't
    imagine the extra null check being that expensive in practice.

  * AggregateFunc::JsonbAgg learns to treat null as the identity.
    These are not the semantics that SQL wants, but the SQL layer can
    easily recover those semantics with a coalesce shim. (Shimming
    an identity onto the old semantics, by contrast, is not possible.)

Fix #3872.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3879)
<!-- Reviewable:end -->
