### PR TITLE
Deduplicate reduce aggregations

### DIFF
--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -125,7 +125,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     if let (AggregateFunc::Count, ScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
             expr.expr =
-                ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, true));
+                ScalarExpr::literal_ok(Datum::True, ColumnType::new(ScalarType::Bool, false));
         }
     }
 }

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -161,9 +161,9 @@ ORDER BY
 %0 =
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
-| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) count(true) sum(#6) count(true)
-| Map i64todec(if (#6 = 0) then {null} else {#6}), (((#2 * 10000000dec) / #9) / 10dec), (((#3 * 10000000dec) / #9) / 10dec), (((#7 * 10000000dec) / #9) / 10dec)
-| Project (#0..#5, #10..#12, #8)
+| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) count(true) sum(#6)
+| Map i64todec(if (#6 = 0) then {null} else {#6}), (((#2 * 10000000dec) / #8) / 10dec), (((#3 * 10000000dec) / #8) / 10dec), (((#7 * 10000000dec) / #8) / 10dec)
+| Project (#0..#5, #9..#11, #6)
 
 Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0..#9)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -161,9 +161,9 @@ ORDER BY
 %0 =
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
-| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) count(true) count(true) sum(#6) count(true) count(true)
-| Map (((#2 * 10000000dec) / i64todec(if (#6 = 0) then {null} else {#6})) / 10dec), (((#3 * 10000000dec) / i64todec(if (#7 = 0) then {null} else {#7})) / 10dec), (((#8 * 10000000dec) / i64todec(if (#9 = 0) then {null} else {#9})) / 10dec)
-| Project (#0..#5, #11..#13, #10)
+| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) count(true) sum(#6) count(true)
+| Map i64todec(if (#6 = 0) then {null} else {#6}), (((#2 * 10000000dec) / #9) / 10dec), (((#3 * 10000000dec) / #9) / 10dec), (((#7 * 10000000dec) / #9) / 10dec)
+| Project (#0..#5, #10..#12, #8)
 
 Finish order_by=(#0 asc, #1 asc) limit=none offset=0 project=(#0..#9)
 


### PR DESCRIPTION
The aggregations in `Reduce` may contain duplicates, notably in the case that `avg` results in multiple counts of non-nullable columns, which yields several `count(*)` aggregates. This PR removes any duplicates and uses a projection to copy the column references around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3881)
<!-- Reviewable:end -->
