### PR TITLE
sql: don't elide identity joins when LATERAL

### DIFF
--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -81,7 +81,13 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT generate_series FROM generate_series(-2, 2)
 ----
 %0 =
+| Constant ()
+
+%1 =
 | CallTable generate_series(-(2), 2)
+
+%2 =
+| InnerLateralJoin %0 %1 on true
 
 EOF
 
@@ -158,6 +164,18 @@ SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 1  2  1  2  1
 2  3  2  3  2
 3  4  3  4  3
+
+# Regression test for #3877: a table function as the first FROM item inside of
+# a LATERAL subquery should not miscount outer scope depth.
+query II
+SELECT x.a, generate_series FROM x, LATERAL (SELECT * FROM generate_series(1, x.a))
+----
+1  1
+2  1
+2  2
+3  1
+3  2
+3  3
 
 query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(1, a)


### PR DESCRIPTION
A query of the form

    SELECT ... FROM t1, LATERAL (SELECT * FROM table_func(t1.col))

would previously cause a panic in decorrelation. This query plans as,
roughly:

    %1 = Get t1
    %2 = Constant ()
    %3 = CallTable table_func(#^^0)
    %4 = InnerLateralJoin %2 %3
    %5 = InnerLateralJoin %1 %4

The planner was previously being too clever and, noticing that %2 was
the join identity, attempting to simplify to:

    %1 = Get t1
    %3 = CallTable table_func(#^^0)
    %5 = InnerLateralJoin %1 %3

And, indeed, this is almost valid... except that the column reference in
%3 is still doubly outer, when it needs to be only singly outer.

We *could* fix up the column references, but this is a lot of work for a
normalization rule that exists only to try to tame the output of
`EXPLAIN RAW PLAN`. (The optimized plan is the same regardless of
whether we apply this rule during SQL planner). So, instead, just don't
perform such elision on lateral joins.

Fix #3877.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3883)
<!-- Reviewable:end -->
