### PR TITLE
avro: simplify and document AvroRead/Skip traits

### DIFF
--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashMap;
-use std::io::{BufRead, Read};
+use std::io::{self, BufRead, Read};
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, TryRecvError};
 
@@ -394,12 +394,10 @@ struct ForeverTailedFile<Ev, Handle> {
 }
 
 impl<Ev, H> Skip for ForeverTailedFile<Ev, H> {
-    fn skip(&mut self, len: usize) -> Result<(), anyhow::Error> {
+    fn skip(&mut self, len: usize) -> Result<(), io::Error> {
         self.inner.skip(len)
     }
 }
-
-impl<Ev, H> AvroRead for ForeverTailedFile<Ev, H> {}
 
 impl<Ev, H> Read for ForeverTailedFile<Ev, H> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {


### PR DESCRIPTION
* `AvroRead` can be automatically implemented for traits that implement
  `Read` and `Skip`.

* `Skip::skip` should not error when seeking past the end of a buffer,
   as this is not the behavior of io::Seek, which many implementations
   use under the hood.

* Add docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3884)
<!-- Reviewable:end -->
