### PR TITLE
dataflow-types: move PeekWhen into sql

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -36,8 +36,8 @@ use timely::progress::ChangeBatch;
 use dataflow::{SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    AvroOcfSinkConnector, DataflowDesc, IndexDesc, KafkaSinkConnector, PeekResponse, PeekWhen,
-    SinkConnector, SourceConnector, TailSinkConnector, Timestamp, TimestampSourceUpdate, Update,
+    AvroOcfSinkConnector, DataflowDesc, IndexDesc, KafkaSinkConnector, PeekResponse, SinkConnector,
+    SourceConnector, TailSinkConnector, Timestamp, TimestampSourceUpdate, Update,
 };
 use expr::{
     GlobalId, Id, IdHumanizer, NullaryFunc, RelationExpr, RowSetFinishing, ScalarExpr,
@@ -50,7 +50,7 @@ use sql::ast::display::AstDisplay;
 use sql::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use sql::catalog::Catalog as _;
 use sql::names::{DatabaseSpecifier, FullName};
-use sql::plan::{MutationKind, Params, Plan, PlanContext};
+use sql::plan::{MutationKind, Params, PeekWhen, Plan, PlanContext};
 use transform::Optimizer;
 
 use crate::catalog::{self, Catalog, CatalogItem, CatalogView, SinkConnectorState, Source};

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -37,16 +37,6 @@ use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType};
 /// System-wide timestamp type.
 pub type Timestamp = u64;
 
-/// Specifies when a `Peek` should occur.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub enum PeekWhen {
-    /// The peek should occur at the latest possible timestamp that allows the
-    /// peek to complete immediately.
-    Immediately,
-    /// The peek should occur at the specified timestamp.
-    AtTimestamp(Timestamp),
-}
-
 /// The response from a `Peek`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum PeekResponse {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -30,7 +30,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
-use dataflow_types::{PeekWhen, SinkConnectorBuilder, SourceConnector, Timestamp};
+use dataflow_types::{SinkConnectorBuilder, SourceConnector, Timestamp};
 use repr::{ColumnName, RelationDesc, Row, ScalarType};
 
 use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
@@ -189,6 +189,16 @@ pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
     pub keys: Vec<::expr::ScalarExpr>,
+}
+
+/// Specifies when a `Peek` should occur.
+#[derive(Debug, PartialEq)]
+pub enum PeekWhen {
+    /// The peek should occur at the latest possible timestamp that allows the
+    /// peek to complete immediately.
+    Immediately,
+    /// The peek should occur at the specified timestamp.
+    AtTimestamp(Timestamp),
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -25,7 +25,7 @@ use url::Url;
 use dataflow_types::{
     AvroEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding, DataEncoding, Envelope,
     ExternalSourceConnector, FileSourceConnector, KafkaSinkConnectorBuilder, KafkaSourceConnector,
-    KinesisSourceConnector, PeekWhen, ProtobufEncoding, SinkConnectorBuilder, SourceConnector,
+    KinesisSourceConnector, ProtobufEncoding, SinkConnectorBuilder, SourceConnector,
 };
 use expr::{like_pattern, GlobalId, RowSetFinishing};
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
@@ -46,7 +46,7 @@ use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
 use crate::plan::{
-    query, scalar_type_from_sql, Index, Params, Plan, PlanContext, Sink, Source, View,
+    query, scalar_type_from_sql, Index, Params, PeekWhen, Plan, PlanContext, Sink, Source, View,
 };
 use crate::pure::Schema;
 


### PR DESCRIPTION
PeekWhen is a purely SQL -> coord concept. It doesn't involve the
dataflow layer at all, as PeekWhen::Immediate has been resolved into a
specific peek timestamp by the time the command hits the dataflow layer.
So move the type into the `sql` crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3886)
<!-- Reviewable:end -->
