### PR TITLE
materialized/bin: remove unused persist-ts option

### DIFF
--- a/src/materialized/src/bin/materialized.rs
+++ b/src/materialized/src/bin/materialized.rs
@@ -113,12 +113,6 @@ fn run() -> Result<(), anyhow::Error> {
         "timestamp advancement frequency (default 10ms)",
         "DURATION",
     );
-    opts.optopt(
-        "",
-        "persist-ts",
-        "persists consistency information locally and recovers from local store",
-        "true/false",
-    );
 
     // Logging options.
     opts.optopt(


### PR DESCRIPTION
This option does not look like its used within the codebase at all. Might be missing something - in which case please yell at me!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3887)
<!-- Reviewable:end -->
