### PR TITLE
dataflow: enforce that only external sources can be imported with types

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -582,12 +582,12 @@ where
                 }
                 Message::Worker(WorkerFeedbackWithMeta {
                     worker_id: _,
-                    message: WorkerFeedback::CreateSource(source_id),
+                    message: WorkerFeedback::CreateSource(src_instance_id),
                 }) => {
-                    if let Some(entry) = self.catalog.try_get_by_id(source_id.sid) {
+                    if let Some(entry) = self.catalog.try_get_by_id(src_instance_id.source_id) {
                         if let CatalogItem::Source(s) = entry.item() {
                             ts_tx
-                                .send(TimestampMessage::Add(source_id, s.connector.clone()))
+                                .send(TimestampMessage::Add(src_instance_id, s.connector.clone()))
                                 .expect("Failed to send CREATE Instance notice to timestamper");
                         } else {
                             panic!("A non-source is re-using the same source ID");

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1018,7 +1018,7 @@ where
                 self.views.insert(source_id, ViewState::new(false, vec![]));
                 if materialized {
                     let mut dataflow = DataflowDesc::new(name.to_string());
-                    self.import_source_or_view(&source_id, &source_id, &mut dataflow);
+                    self.import_source_or_view(&source_id, &mut dataflow);
                     self.build_arrangement(
                         &index_id.unwrap(),
                         index.unwrap(),
@@ -1747,14 +1747,9 @@ where
         Ok(())
     }
 
-    fn import_source_or_view(
-        &self,
-        orig_id: &GlobalId,
-        id: &GlobalId,
-        dataflow: &mut DataflowDesc,
-    ) {
+    fn import_source_or_view(&self, id: &GlobalId, dataflow: &mut DataflowDesc) {
         if dataflow.objects_to_build.iter().any(|bd| &bd.id == id)
-            || dataflow.source_imports.iter().any(|(i, _)| &i.sid == id)
+            || dataflow.source_imports.iter().any(|(i, _)| i == id)
         {
             return;
         }
@@ -1780,17 +1775,7 @@ where
         } else {
             match self.catalog.get_by_id(id).item() {
                 CatalogItem::Source(source) => {
-                    // A source is being imported as part of a new view. We have to notify the timestamping
-                    // thread that a source instance is being created for this view
-                    let instance_id = SourceInstanceId {
-                        sid: *id,
-                        vid: *orig_id,
-                    };
-                    dataflow.add_source_import(
-                        instance_id,
-                        source.connector.clone(),
-                        source.desc.clone(),
-                    );
+                    dataflow.add_source_import(*id, source.connector.clone(), source.desc.clone());
                 }
                 CatalogItem::View(view) => {
                     self.build_view_collection(id, &view, dataflow);
@@ -1813,7 +1798,7 @@ where
                 typ: _,
             } = e
             {
-                self.import_source_or_view(view_id, &id, dataflow);
+                self.import_source_or_view(&id, dataflow);
                 dataflow.add_dependency(*view_id, *id)
             }
         });
@@ -1861,7 +1846,7 @@ where
         on_type: RelationType,
         mut dataflow: DataflowDesc,
     ) {
-        self.import_source_or_view(id, &index.on, &mut dataflow);
+        self.import_source_or_view(&index.on, &mut dataflow);
         dataflow.add_index_to_build(*id, index.on.clone(), on_type.clone(), index.keys.clone());
         dataflow.add_index_export(*id, index.on, on_type, index.keys.clone());
         self.insert_index(*id, &index, self.logical_compaction_window_ms);
@@ -2019,7 +2004,7 @@ where
         }
         let mut dataflow = DataflowDesc::new(name);
         dataflow.set_as_of(connector.get_frontier());
-        self.import_source_or_view(&id, &from, &mut dataflow);
+        self.import_source_or_view(&from, &mut dataflow);
         let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
         dataflow.add_sink_export(id, from, from_type, connector);
         self.validate_dataflow(&mut dataflow);

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -26,9 +26,7 @@ use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use url::Url;
 
-use expr::{
-    GlobalId, OptimizedRelationExpr, PartitionId, RelationExpr, ScalarExpr, SourceInstanceId,
-};
+use expr::{GlobalId, OptimizedRelationExpr, PartitionId, RelationExpr, ScalarExpr};
 use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use kafka_util::KafkaAddr;
@@ -78,7 +76,7 @@ pub struct BuildDesc {
 /// A description of a dataflow to construct and results to surface.
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct DataflowDesc {
-    pub source_imports: BTreeMap<SourceInstanceId, SourceDesc>,
+    pub source_imports: BTreeMap<GlobalId, SourceDesc>,
     pub index_imports: BTreeMap<GlobalId, (IndexDesc, RelationType)>,
     /// Views and indexes to be built and stored in the local context.
     /// Objects must be built in the specific order as the Vec
@@ -128,7 +126,7 @@ impl DataflowDesc {
 
     pub fn add_source_import(
         &mut self,
-        id: SourceInstanceId,
+        id: GlobalId,
         connector: SourceConnector,
         desc: RelationDesc,
     ) {
@@ -256,8 +254,8 @@ impl DataflowDesc {
 
     /// The number of columns associated with an identifier in the dataflow.
     pub fn arity_of(&self, id: &GlobalId) -> usize {
-        for (source, desc) in self.source_imports.iter() {
-            if &source.sid == id {
+        for (source_id, desc) in self.source_imports.iter() {
+            if source_id == id {
                 return desc.desc.typ().arity();
             }
         }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -127,11 +127,11 @@ impl DataflowDesc {
     pub fn add_source_import(
         &mut self,
         id: GlobalId,
-        connector: SourceConnector,
+        external_desc: ExternalSourceDesc,
         desc: RelationDesc,
     ) {
         let source_description = SourceDesc {
-            connector,
+            external_desc,
             operators: None,
             desc,
         };
@@ -430,7 +430,7 @@ pub struct RegexEncoding {
 /// of the collection.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SourceDesc {
-    pub connector: SourceConnector,
+    pub external_desc: ExternalSourceDesc,
     /// Optionally, filtering and projection that may optimistically be applied
     /// to the output of the source.
     pub operators: Option<LinearOperator>,
@@ -470,15 +470,18 @@ impl Envelope {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SourceConnector {
-    External {
-        connector: ExternalSourceConnector,
-        encoding: DataEncoding,
-        envelope: Envelope,
-        consistency: Consistency,
-        max_ts_batch: i64,
-        ts_frequency: Duration,
-    },
+    External(ExternalSourceDesc),
     Local,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExternalSourceDesc {
+    pub connector: ExternalSourceConnector,
+    pub encoding: DataEncoding,
+    pub envelope: Envelope,
+    pub consistency: Consistency,
+    pub max_ts_batch: i64,
+    pub ts_frequency: Duration,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -273,7 +273,7 @@ where
         &mut self,
         render_state: &mut RenderState,
         scope: &mut Child<'g, G, G::Timestamp>,
-        src_id: SourceInstanceId,
+        src_id: GlobalId,
         mut src: SourceDesc,
     ) {
         if let Some(operator) = &src.operators {
@@ -291,11 +291,11 @@ where
             ts_frequency,
         } = src.connector
         {
-            let get_expr = RelationExpr::global_get(src_id.sid, src.desc.typ().clone());
+            let get_expr = RelationExpr::global_get(src_id, src.desc.typ().clone());
 
             // This uid must be unique across all different instantiations of a source
             let uid = SourceInstanceId {
-                sid: src_id.sid,
+                sid: src_id,
                 vid: self.first_export_id,
             };
 
@@ -523,13 +523,13 @@ where
 
                 // Introduce the stream by name, as an unarranged collection.
                 self.collections.insert(
-                    RelationExpr::global_get(src_id.sid, src.desc.typ().clone()),
+                    RelationExpr::global_get(src_id, src.desc.typ().clone()),
                     (collection, err_collection),
                 );
                 capability
             };
             let token = Rc::new(capability);
-            self.source_tokens.insert(src_id.sid, token.clone());
+            self.source_tokens.insert(src_id, token.clone());
 
             // We also need to keep track of this mapping globally to activate sources
             // on timestamp advancement queries

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -284,262 +284,255 @@ where
             }
         }
 
-        if let SourceConnector::External {
+        let ExternalSourceDesc {
             connector,
             encoding,
             envelope,
             consistency,
             max_ts_batch: _,
             ts_frequency,
-        } = src.connector
-        {
-            let get_expr = RelationExpr::global_get(src_id, src.desc.typ().clone());
+        } = src.external_desc;
 
-            // This uid must be unique across all different instantiations of a source
-            let uid = SourceInstanceId {
-                source_id: src_id,
-                dataflow_id: self.dataflow_id,
-            };
+        let get_expr = RelationExpr::global_get(src_id, src.desc.typ().clone());
 
-            // TODO(benesch): we force all sources to have an empty
-            // error stream. Likely we will want to plumb this
-            // collection into the source connector so that sources
-            // can produce errors.
-            let mut err_collection = Collection::empty(scope);
+        // This uid must be unique across all different instantiations of a source
+        let uid = SourceInstanceId {
+            source_id: src_id,
+            dataflow_id: self.dataflow_id,
+        };
 
-            let fast_forwarded = match &connector {
-                ExternalSourceConnector::Kafka(KafkaSourceConnector { start_offsets, .. }) => {
-                    start_offsets.values().any(|&val| val > 0)
-                }
-                _ => false,
-            };
+        // TODO(benesch): we force all sources to have an empty
+        // error stream. Likely we will want to plumb this
+        // collection into the source connector so that sources
+        // can produce errors.
+        let mut err_collection = Collection::empty(scope);
 
-            // All workers are responsible for reading in Kafka sources. Other sources
-            // support single-threaded ingestion only
-            let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
-                true
-            } else {
-                (usize::cast_from(uid.hashed()) % scope.peers()) == scope.index()
-            };
+        let fast_forwarded = match &connector {
+            ExternalSourceConnector::Kafka(KafkaSourceConnector { start_offsets, .. }) => {
+                start_offsets.values().any(|&val| val > 0)
+            }
+            _ => false,
+        };
 
-            let source_config = SourceConfig {
-                name: format!("{}-{}", connector.name(), uid),
-                id: uid,
-                scope,
-                // Distribute read responsibility among workers.
-                active: active_read_worker,
-                timestamp_histories: render_state.ts_histories.clone(),
-                timestamp_tx: render_state.ts_source_updates.clone(),
-                consistency,
-                timestamp_frequency: ts_frequency,
-                worker_id: scope.index(),
-                worker_count: scope.peers(),
-                encoding: encoding.clone(),
-            };
+        // All workers are responsible for reading in Kafka sources. Other sources
+        // support single-threaded ingestion only
+        let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
+            true
+        } else {
+            (usize::cast_from(uid.hashed()) % scope.peers()) == scope.index()
+        };
 
-            let capability = if let Envelope::Upsert(key_encoding) = envelope {
-                match connector {
-                    ExternalSourceConnector::Kafka(_) => {
-                        let (source, capability) = source::create_source::<_, KafkaSourceInfo, _>(
-                            source_config,
-                            connector,
+        let source_config = SourceConfig {
+            name: format!("{}-{}", connector.name(), uid),
+            id: uid,
+            scope,
+            // Distribute read responsibility among workers.
+            active: active_read_worker,
+            timestamp_histories: render_state.ts_histories.clone(),
+            timestamp_tx: render_state.ts_source_updates.clone(),
+            consistency,
+            timestamp_frequency: ts_frequency,
+            worker_id: scope.index(),
+            worker_count: scope.peers(),
+            encoding: encoding.clone(),
+        };
+
+        let capability = if let Envelope::Upsert(key_encoding) = envelope {
+            match connector {
+                ExternalSourceConnector::Kafka(_) => {
+                    let (source, capability) =
+                        source::create_source::<_, KafkaSourceInfo, _>(source_config, connector);
+
+                    let (transformed, new_err_collection) =
+                        upsert::pre_arrange_from_upsert_transforms(
+                            &source.0,
+                            encoding,
+                            key_encoding,
+                            &self.debug_name,
+                            scope.index(),
+                            self.as_of_frontier.clone(),
+                            &mut src.operators,
+                            src.desc.typ(),
                         );
 
-                        let (transformed, new_err_collection) =
-                            upsert::pre_arrange_from_upsert_transforms(
-                                &source.0,
-                                encoding,
-                                key_encoding,
-                                &self.debug_name,
-                                scope.index(),
-                                self.as_of_frontier.clone(),
-                                &mut src.operators,
-                                src.desc.typ(),
-                            );
+                    let arranged = arrange_from_upsert(
+                        &transformed,
+                        &format!("UpsertArrange: {}", src_id.to_string()),
+                    );
 
-                        let arranged = arrange_from_upsert(
-                            &transformed,
-                            &format!("UpsertArrange: {}", src_id.to_string()),
-                        );
-
-                        err_collection.concat(
-                            &new_err_collection
-                                .pass_through("upsert-linear-errors")
-                                .as_collection(),
-                        );
-
-                        let keys = src.desc.typ().keys[0]
-                            .iter()
-                            .map(|k| ScalarExpr::Column(*k))
-                            .collect::<Vec<_>>();
-                        self.set_local(&get_expr, &keys, (arranged, err_collection.arrange()));
-                        capability
-                    }
-                    _ => unreachable!("Upsert envelope unsupported for non-Kafka sources"),
-                }
-            } else {
-                let (stream, capability) = if let ExternalSourceConnector::AvroOcf(_) = connector {
-                    let ((source, err_source), capability) =
-                        source::create_source::<_, FileSourceInfo<Value>, Value>(
-                            source_config,
-                            connector,
-                        );
-                    err_collection = err_collection.concat(
-                        &err_source
-                            .map(DataflowError::SourceError)
-                            .pass_through("AvroOCF-errors")
+                    err_collection.concat(
+                        &new_err_collection
+                            .pass_through("upsert-linear-errors")
                             .as_collection(),
                     );
-                    let reader_schema = match &encoding {
-                        DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => reader_schema,
-                        _ => unreachable!(
-                            "Internal error: \
+
+                    let keys = src.desc.typ().keys[0]
+                        .iter()
+                        .map(|k| ScalarExpr::Column(*k))
+                        .collect::<Vec<_>>();
+                    self.set_local(&get_expr, &keys, (arranged, err_collection.arrange()));
+                    capability
+                }
+                _ => unreachable!("Upsert envelope unsupported for non-Kafka sources"),
+            }
+        } else {
+            let (stream, capability) = if let ExternalSourceConnector::AvroOcf(_) = connector {
+                let ((source, err_source), capability) = source::create_source::<
+                    _,
+                    FileSourceInfo<Value>,
+                    Value,
+                >(source_config, connector);
+                err_collection = err_collection.concat(
+                    &err_source
+                        .map(DataflowError::SourceError)
+                        .pass_through("AvroOCF-errors")
+                        .as_collection(),
+                );
+                let reader_schema = match &encoding {
+                    DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => reader_schema,
+                    _ => unreachable!(
+                        "Internal error: \
                                  Avro OCF schema should have already been resolved.\n\
                                 Encoding is: {:?}",
-                            encoding
-                        ),
-                    };
-
-                    let reader_schema = Schema::parse_str(reader_schema).unwrap();
-                    (
-                        decode_avro_values(&source, &envelope, reader_schema, &self.debug_name),
-                        capability,
-                    )
-                } else {
-                    let ((ok_source, err_source), capability) = match connector {
-                        ExternalSourceConnector::Kafka(_) => {
-                            source::create_source::<_, KafkaSourceInfo, _>(source_config, connector)
-                        }
-                        ExternalSourceConnector::Kinesis(_) => {
-                            source::create_source::<_, KinesisSourceInfo, _>(
-                                source_config,
-                                connector,
-                            )
-                        }
-                        ExternalSourceConnector::File(_) => {
-                            source::create_source::<_, FileSourceInfo<Vec<u8>>, Vec<u8>>(
-                                source_config,
-                                connector,
-                            )
-                        }
-                        ExternalSourceConnector::AvroOcf(_) => unreachable!(),
-                    };
-                    err_collection = err_collection.concat(
-                        &err_source
-                            .map(DataflowError::SourceError)
-                            .pass_through("source-errors")
-                            .as_collection(),
-                    );
-
-                    // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
-                    // a hypothetical future avro_extract, protobuf_extract, etc.
-                    let stream = decode_values(
-                        &ok_source,
-                        encoding,
-                        &self.debug_name,
-                        &envelope,
-                        &mut src.operators,
-                        fast_forwarded,
-                    );
-
-                    (stream, capability)
+                        encoding
+                    ),
                 };
 
-                let mut collection = match envelope {
-                    Envelope::None => stream.as_collection(),
-                    Envelope::Debezium(_) => {
-                        // TODO(btv) -- this should just be a RelationExpr::Explode (name TBD)
-                        stream.as_collection().explode({
-                            let mut row_packer = repr::RowPacker::new();
-                            move |row| {
-                                let mut datums = row.unpack();
-                                let diff = datums.pop().unwrap().unwrap_int64() as isize;
-                                Some((row_packer.pack(datums.into_iter()), diff))
-                            }
-                        })
+                let reader_schema = Schema::parse_str(reader_schema).unwrap();
+                (
+                    decode_avro_values(&source, &envelope, reader_schema, &self.debug_name),
+                    capability,
+                )
+            } else {
+                let ((ok_source, err_source), capability) = match connector {
+                    ExternalSourceConnector::Kafka(_) => {
+                        source::create_source::<_, KafkaSourceInfo, _>(source_config, connector)
                     }
-                    Envelope::Upsert(_) => unreachable!(),
+                    ExternalSourceConnector::Kinesis(_) => {
+                        source::create_source::<_, KinesisSourceInfo, _>(source_config, connector)
+                    }
+                    ExternalSourceConnector::File(_) => {
+                        source::create_source::<_, FileSourceInfo<Vec<u8>>, Vec<u8>>(
+                            source_config,
+                            connector,
+                        )
+                    }
+                    ExternalSourceConnector::AvroOcf(_) => unreachable!(),
                 };
-
-                // Implement source filtering and projection.
-                // At the moment this is strictly optional, but we perform it anyhow
-                // to demonstrate the intended use.
-                if let Some(operators) = src.operators.clone() {
-                    // Determine replacement values for unused columns.
-                    let source_type = src.desc.typ();
-                    let position_or = (0..source_type.arity())
-                        .map(|col| {
-                            if operators.projection.contains(&col) {
-                                Some(col)
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>();
-
-                    // Evaluate the predicate on each record, noting potential errors that might result.
-                    let (collection2, errors) =
-                        collection.flat_map_fallible({
-                            let mut row_packer = repr::RowPacker::new();
-                            move |input_row| {
-                                let temp_storage = RowArena::new();
-                                let datums = input_row.unpack();
-                                let pred_eval = operators
-                                    .predicates
-                                    .iter()
-                                    .map(|predicate| predicate.eval(&datums, &temp_storage))
-                                    .find(|result| result != &Ok(Datum::True));
-                                match pred_eval {
-                                    None => Some(Ok(row_packer.pack(position_or.iter().map(
-                                        |pos_or| match pos_or {
-                                            Some(index) => datums[*index],
-                                            None => Datum::Dummy,
-                                        },
-                                    )))),
-                                    Some(Ok(Datum::False)) => None,
-                                    Some(Ok(Datum::Null)) => None,
-                                    Some(Ok(x)) => {
-                                        panic!("Predicate evaluated to invalid value: {:?}", x)
-                                    }
-                                    Some(Err(x)) => Some(Err(x.into())),
-                                }
-                            }
-                        });
-
-                    collection = collection2;
-                    err_collection = err_collection.concat(&errors);
-                }
-
-                // Apply `as_of` to each timestamp.
-                let as_of_frontier1 = self.as_of_frontier.clone();
-                collection = collection
-                    .inner
-                    .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
-                    .as_collection();
-
-                let as_of_frontier2 = self.as_of_frontier.clone();
-                err_collection = err_collection
-                    .inner
-                    .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
-                    .as_collection();
-
-                // Introduce the stream by name, as an unarranged collection.
-                self.collections.insert(
-                    RelationExpr::global_get(src_id, src.desc.typ().clone()),
-                    (collection, err_collection),
+                err_collection = err_collection.concat(
+                    &err_source
+                        .map(DataflowError::SourceError)
+                        .pass_through("source-errors")
+                        .as_collection(),
                 );
-                capability
-            };
-            let token = Rc::new(capability);
-            self.source_tokens.insert(src_id, token.clone());
 
-            // We also need to keep track of this mapping globally to activate sources
-            // on timestamp advancement queries
-            let prev = render_state
-                .ts_source_mapping
-                .insert(uid, Rc::downgrade(&token));
-            assert!(prev.is_none());
-        }
+                // TODO(brennan) -- this should just be a RelationExpr::FlatMap using regexp_extract, csv_extract,
+                // a hypothetical future avro_extract, protobuf_extract, etc.
+                let stream = decode_values(
+                    &ok_source,
+                    encoding,
+                    &self.debug_name,
+                    &envelope,
+                    &mut src.operators,
+                    fast_forwarded,
+                );
+
+                (stream, capability)
+            };
+
+            let mut collection = match envelope {
+                Envelope::None => stream.as_collection(),
+                Envelope::Debezium(_) => {
+                    // TODO(btv) -- this should just be a RelationExpr::Explode (name TBD)
+                    stream.as_collection().explode({
+                        let mut row_packer = repr::RowPacker::new();
+                        move |row| {
+                            let mut datums = row.unpack();
+                            let diff = datums.pop().unwrap().unwrap_int64() as isize;
+                            Some((row_packer.pack(datums.into_iter()), diff))
+                        }
+                    })
+                }
+                Envelope::Upsert(_) => unreachable!(),
+            };
+
+            // Implement source filtering and projection.
+            // At the moment this is strictly optional, but we perform it anyhow
+            // to demonstrate the intended use.
+            if let Some(operators) = src.operators.clone() {
+                // Determine replacement values for unused columns.
+                let source_type = src.desc.typ();
+                let position_or = (0..source_type.arity())
+                    .map(|col| {
+                        if operators.projection.contains(&col) {
+                            Some(col)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                // Evaluate the predicate on each record, noting potential errors that might result.
+                let (collection2, errors) = collection.flat_map_fallible({
+                    let mut row_packer = repr::RowPacker::new();
+                    move |input_row| {
+                        let temp_storage = RowArena::new();
+                        let datums = input_row.unpack();
+                        let pred_eval = operators
+                            .predicates
+                            .iter()
+                            .map(|predicate| predicate.eval(&datums, &temp_storage))
+                            .find(|result| result != &Ok(Datum::True));
+                        match pred_eval {
+                            None => {
+                                Some(Ok(row_packer.pack(position_or.iter().map(
+                                    |pos_or| match pos_or {
+                                        Some(index) => datums[*index],
+                                        None => Datum::Dummy,
+                                    },
+                                ))))
+                            }
+                            Some(Ok(Datum::False)) => None,
+                            Some(Ok(Datum::Null)) => None,
+                            Some(Ok(x)) => panic!("Predicate evaluated to invalid value: {:?}", x),
+                            Some(Err(x)) => Some(Err(x.into())),
+                        }
+                    }
+                });
+
+                collection = collection2;
+                err_collection = err_collection.concat(&errors);
+            }
+
+            // Apply `as_of` to each timestamp.
+            let as_of_frontier1 = self.as_of_frontier.clone();
+            collection = collection
+                .inner
+                .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
+                .as_collection();
+
+            let as_of_frontier2 = self.as_of_frontier.clone();
+            err_collection = err_collection
+                .inner
+                .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
+                .as_collection();
+
+            // Introduce the stream by name, as an unarranged collection.
+            self.collections.insert(
+                RelationExpr::global_get(src_id, src.desc.typ().clone()),
+                (collection, err_collection),
+            );
+            capability
+        };
+        let token = Rc::new(capability);
+        self.source_tokens.insert(src_id, token.clone());
+
+        // We also need to keep track of this mapping globally to activate sources
+        // on timestamp advancement queries
+        let prev = render_state
+            .ts_source_mapping
+            .insert(uid, Rc::downgrade(&token));
+        assert!(prev.is_none());
     }
 
     fn import_index(

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -101,18 +101,19 @@ impl fmt::Display for GlobalId {
     }
 }
 
-/// Unique identifier used for each *instance* of a source in a dataflow
+/// Unique identifier for an instantiation of a source.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct SourceInstanceId {
-    // Global Source Id
-    pub sid: GlobalId,
-    // Id of the view with which this source is instantiated
-    pub vid: GlobalId,
+    // The ID of the source.
+    pub source_id: GlobalId,
+    // The ID of the timely dataflow containing this instantiation of this
+    // source.
+    pub dataflow_id: usize,
 }
 
 impl fmt::Display for SourceInstanceId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}/{}", self.sid, self.vid)
+        write!(f, "{}/{}", self.source_id, self.dataflow_id)
     }
 }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -24,7 +24,7 @@ use url::Url;
 
 use dataflow_types::{
     AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding,
-    DataEncoding, Envelope, ExternalSourceConnector, FileSourceConnector,
+    DataEncoding, Envelope, ExternalSourceConnector, ExternalSourceDesc, FileSourceConnector,
     KafkaSinkConnectorBuilder, KafkaSourceConnector, KinesisSourceConnector, ProtobufEncoding,
     RegexEncoding, SinkConnectorBuilder, SourceConnector,
 };
@@ -1509,14 +1509,14 @@ fn handle_create_source(
 
     let source = Source {
         create_sql,
-        connector: SourceConnector::External {
+        connector: SourceConnector::External(ExternalSourceDesc {
             connector: external_connector,
             encoding,
             envelope,
             consistency,
             max_ts_batch,
             ts_frequency,
-        },
+        }),
         desc,
     };
     Ok(Plan::CreateSource {

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -69,7 +69,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
 
     // Push demand information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(columns) = demand.get(&Id::Global(source_id.sid)).clone() {
+        if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
@@ -106,7 +106,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
 
     // Push predicate information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(list) = predicates.get(&Id::Global(source_id.sid)).clone() {
+        if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
             // Install no-op predicate information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {


### PR DESCRIPTION
It is not legal for a DataflowDesc to import a local source, as local
sources have an arrangement that should be imported directly.

Enforce this constraint via types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3888)
<!-- Reviewable:end -->
