### PR TITLE
Case-insensitive parsing of AS OF keywords

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2170,7 +2170,7 @@ impl Parser {
         match self.next_token() {
             // Do not accept `AS OF`, which is reserved for providing timestamp information
             // to queries.
-            Some(Token::Word(ref w)) if w.value == "OF" => {
+            Some(Token::Word(ref w)) if w.value.eq_ignore_ascii_case("OF") => {
                 self.prev_token();
                 self.prev_token();
                 Ok(None)

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2170,7 +2170,7 @@ impl Parser {
         match self.next_token() {
             // Do not accept `AS OF`, which is reserved for providing timestamp information
             // to queries.
-            Some(Token::Word(ref w)) if w.value.eq_ignore_ascii_case("OF") => {
+            Some(Token::Word(ref w)) if w.keyword == "OF" => {
                 self.prev_token();
                 self.prev_token();
                 Ok(None)

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -7,27 +7,36 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> CREATE VIEW data (a, b) AS VALUES (1, 1), (2, 1), (3, 1), (1, 2)
+mode cockroach
+
+statement ok
+CREATE VIEW data (a, b) AS VALUES (1, 1), (2, 1), (3, 1), (1, 2)
 
 # Don't parse 'AS OF' as a table alias.
-! SELECT * FROM data AS OF;
-Expected a timestamp value after 'AS OF', found: EOF
+statement error Expected a timestamp value after 'AS OF', found: EOF
+SELECT * FROM data AS OF;
 
-> SELECT * FROM data
+query II
+SELECT * FROM data
+----
 1 1
+1 2
 2 1
 3 1
-1 2
 
-> SELECT * FROM data AS OF now()
+query II
+SELECT * FROM data AS OF now()
+----
 1 1
+1 2
 2 1
 3 1
-1 2
 
 # Ensure keyword matching is not case-sensitive for AS OF
-> SELECT * FROM data as of now()
+query II
+SELECT * FROM data as of now()
+----
 1 1
+1 2
 2 1
 3 1
-1 2

--- a/test/testdrive/select.td
+++ b/test/testdrive/select.td
@@ -24,3 +24,10 @@ Expected a timestamp value after 'AS OF', found: EOF
 2 1
 3 1
 1 2
+
+# Ensure keyword matching is not case-sensitive for AS OF
+> SELECT * FROM data as of now()
+1 1
+2 1
+3 1
+1 2


### PR DESCRIPTION
By matching only the literal string `OF`, `of` was being incorrectly parsed as an alias and causing the following error:
```
materialize=> select * from mz_view_keys as of now();
ERROR:  Parse error:
select * from mz_view_keys as of now();
                                 ^^^
Expected end of statement, found: now
materialize=> 
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3899)
<!-- Reviewable:end -->
