### PR TITLE
Move AS OF parsing test to sql-parser

### DIFF
--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -935,3 +935,18 @@ Parse error:
 SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
                                    ^
 Expected SELECT, VALUES, or a subquery in the query body, found: b
+
+# Ensure parsing AS OF is case-insensitive
+parse-statement
+SELECT * FROM data as of now()
+----
+SELECT * FROM data AS OF now()
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("data")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+
+parse-statement
+SELECT * FROM data AS OF now()
+----
+SELECT * FROM data AS OF now()
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("data")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -31,12 +31,3 @@ SELECT * FROM data AS OF now()
 1 2
 2 1
 3 1
-
-# Ensure keyword matching is not case-sensitive for AS OF
-query II
-SELECT * FROM data as of now()
-----
-1 1
-1 2
-2 1
-3 1


### PR DESCRIPTION
Follow-up from: https://github.com/MaterializeInc/materialize/pull/3899

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3902)
<!-- Reviewable:end -->
