### PR TITLE
Use Rust equality for join equivalences

### DIFF
--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -266,3 +266,14 @@ where
 2  l2  2  2  2  3
 2  l2  2  2  2  3
 3  l3  2  2  2  3
+
+# Test that joins with an `(= #x null)` constraint pass records, rather than drop them.
+query III rowsort
+SELECT * FROM
+    (((SELECT 1 FROM l2) LEFT JOIN
+    (SELECT 1 FROM r2) ON false) LEFT JOIN (SELECT 1 FROM r2) ON false);
+----
+1  NULL  NULL
+1  NULL  NULL
+1  NULL  NULL
+1  NULL  NULL


### PR DESCRIPTION
When converting `equivalences` equivalences to post-join filters, we relied on `BinaryFunc::Eq` which treats `Datum::Null` as not equal to itself. That is not correct once we have it in `equivalences` which looks for actual matches.

cc: @justinj

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3908)
<!-- Reviewable:end -->
