### PR TITLE
Remove purgatory tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -104,18 +104,6 @@ steps:
           config: test/kafka-sasl-plain/mzcompose.yml
           run: testdrive
 
-  - id: testdrive-purgatory
-    label: ":racing_car: testdrive purgatory"
-    depends_on: build
-    command: test/testdrive/ci-only/*.td
-    timeout_in_minutes: 30
-    inputs: [test/testdrive/ci-only]
-    soft_fail: true
-    plugins:
-      - ./ci/plugins/mzcompose:
-          config: test/testdrive/mzcompose.yml
-          run: testdrive
-
   - id: short-sqllogictest
     label: ":bulb: Short SQL logic tests"
     depends_on: build


### PR DESCRIPTION
I'd been meaning to fix these tests for a while, but haven't gotten to it! It doesn't make much sense to keep paying for tests we aren't verifying. 

This configuration should come back when the following issues are addressed: https://github.com/MaterializeInc/materialize/issues/2895, https://github.com/MaterializeInc/materialize/issues/2694

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3912)
<!-- Reviewable:end -->
