### PR TITLE
Do not panic if Datum::Dummy is observed

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -213,12 +213,15 @@ impl RelationExpr {
             RelationExpr::Constant { rows, typ } => {
                 for (row, _diff) in rows {
                     for (datum, column_typ) in row.iter().zip(typ.column_types.iter()) {
-                        assert!(
-                            datum.is_instance_of(column_typ),
-                            "Expected datum of type {:?}, got value {:?}",
-                            column_typ,
-                            datum
-                        );
+                        // If the record will be observed, we should validate its type.
+                        if datum != Datum::Dummy {
+                            assert!(
+                                datum.is_instance_of(column_typ),
+                                "Expected datum of type {:?}, got value {:?}",
+                                column_typ,
+                                datum
+                            );
+                        }
                     }
                 }
                 let result = typ.clone();


### PR DESCRIPTION
The `Datum::Dummy` variant is used for values that are not observed. It is not unexpected for it to exist in the AST, even in constant expressions. For example, a `Map` with an unused expression will have it replaced by `Datum::Dummy`, and it may eventually be reduced to a constant.

The `RelationExpr::typ()` method would panic if it saw a `Datum::Dummy` in a `RelationExpr::Constant`, as part of validating that each datum has its stated type. Instead, it just does not validate the type of data of this variant.

cc: @justinj

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3913)
<!-- Reviewable:end -->
