### PR TITLE
transform: fix projection provenance gathering in redundant join opt

### DIFF
--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -286,13 +286,14 @@ impl RedundantJoin {
                 // but they neither drop rows nor invent values.
                 let mut result = self.action(input, lets);
                 for provenance in result.iter_mut() {
-                    let new_binding = (0..outputs.len())
+                    let new_binding = outputs
+                        .iter()
                         .enumerate()
                         .flat_map(|(i, c)| {
                             provenance
                                 .binding
                                 .iter()
-                                .find(|(_, l)| l == &c)
+                                .find(|(_, l)| l == c)
                                 .map(|(s, _)| (*s, i))
                         })
                         .collect::<Vec<_>>();

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -277,3 +277,21 @@ SELECT * FROM
 1  NULL  NULL
 1  NULL  NULL
 1  NULL  NULL
+
+# Regression test for #3914. The gist is that we want to exercise the
+# redundant join optimization on a join whose inputs contain projections. This
+# turns out to be extremely hard to accomplish because the projection lifting
+# optimization is very good at eliminating all but the top-level projection.
+# Having this test seems better than not, but it's fragile.
+statement ok
+CREATE VIEW gh3914 AS VALUES (NULL::int)
+
+query TTI
+SELECT * FROM (
+    (SELECT 'foo')
+    RIGHT JOIN (
+        (SELECT true) CROSS JOIN (SELECT 1 FROM gh3914 EXCEPT ALL (SELECT 456 WHERE false))
+    ) ON true
+)
+----
+foo  true  1


### PR DESCRIPTION
Clearly there aren't enough tests of this transform. Working on coming up with one that's not as complex as the example in #3914.

----

This code meant to iterate over the pair (new_pos, old_pos), but instead
was iterating over the pair (new_pos, new_pos). Needless to say, this
resulted in utter chaos whenever this optimization fired on a join whose
inputs contained projections.

Fix #3914.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3917)
<!-- Reviewable:end -->
