### PR TITLE
Refactor chaos tests to add to release checklist

### DIFF
--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -839,7 +839,8 @@ class RandomChaos(WorkflowStep):
         self._services = services
         self._other_service = other_service
 
-    def get_running_docker_processes(self, running: bool = False) -> str:
+    @staticmethod
+    def get_docker_processes(running: bool = False) -> str:
         """
         Use 'docker ps' to return all Docker process information.
 
@@ -866,7 +867,7 @@ class RandomChaos(WorkflowStep):
         :return: Docker container id strs
         """
         try:
-            docker_processes = self.get_running_docker_processes(running=running)
+            docker_processes = self.get_docker_processes(running=running)
 
             patterns = []
             if services:

--- a/test/chaos/README.md
+++ b/test/chaos/README.md
@@ -1,29 +1,24 @@
 ### Chaos
 
-This crate is intended to provide tools and tests to chaos test Materialize. The tests are
-implemented as `mzconduct` workflows, meaning that they can be run as follows:
+Tests in this crate chaos test Materialize. Each test is implemented as an `mzconduct`
+workflow and can be run as follows:
 
 ```shell script
-bin/mzconduct up chaos -w delay-kafka
+bin/mzconduct up chaos -w test-bytes-to-kafka
 ```
 
-In this command, `chaos` indicates the name of the target `mzcompose.yml` file and `delay-kafka`
-indicates the name of the target test. Each test has its own unique workflow.
+In this command, `chaos` indicates the name of the target `mzcompose.yml` file and `test-bytes-to-kafka`
+indicates the name of the target chaos test.
 
 These tests can be run:
-1. Locally via the above command
+1. Locally using the above command or some variation
 2. On EC2 instances via our `infra` terraform commands
 
 ### Existing Tests
 
-For the configuration:
+- `test-bytes-to-kafka`: In this test, simple records are pushed directly to Kafka and
+   subsequently read by Materialize.
 
-- Bytes -> Kafka -> Materialize:
-    - basic Docker chaos tests (pause, stop, kill)
-    - basic network chaos tests (delay, rate, limit, loss, corrupt, duplicate)
-
-- Mysql -> Debezium -> Kafka -> Materialize:
-    - basic Docker chaos tests (pause, stop, kill)
-    - basic network chaos tests (delay, rate, limit, loss, corrupt, duplicate)
-
-All other tests are yet to be created and added.
+- `test-mysql-debezium-kafka`: In this test, chbench data will be loaded into a MySQL
+   database. As the data changes, Debezium will push those changes to Kafka. Materialize
+   will read in the changes from Kafka.

--- a/test/chaos/connector-mysql/Dockerfile
+++ b/test/chaos/connector-mysql/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM confluentinc/cp-enterprise-kafka:5.3.0
+
+# https://github.com/confluentinc/cp-docker-images/issues/764
+RUN sed -i s,https://s3-us-west-2.amazonaws.com/staging-confluent-packages-5.3.0/deb/5.3,https://packages.confluent.io/deb/5.3, /etc/apt/sources.list
+
+RUN apt-get update && apt-get -qy install curl
+
+RUN curl -fsSL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /usr/local/bin/wait-for-it \
+    && chmod +x /usr/local/bin/wait-for-it
+
+COPY docker-entrypoint.sh /usr/local/bin
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/test/chaos/connector-mysql/docker-entrypoint.sh
+++ b/test/chaos/connector-mysql/docker-entrypoint.sh
@@ -11,20 +11,25 @@
 
 set -euo pipefail
 
+wait-for-it --timeout=60 zookeeper:2181
+wait-for-it --timeout=60 kafka:9092
+
 topics=(
-    mysql.tpcch.warehouse
-    mysql.tpcch.district
-    mysql.tpcch.customer
-    mysql.tpcch.history
-    mysql.tpcch.neworder
-    mysql.tpcch.order
-    mysql.tpcch.orderline
-    mysql.tpcch.item
-    mysql.tpcch.stock
-    mysql.tpcch.nation
-    mysql.tpcch.supplier
-    mysql.tpcch.region
+    debezium.tpcch.warehouse
+    debezium.tpcch.district
+    debezium.tpcch.customer
+    debezium.tpcch.history
+    debezium.tpcch.neworder
+    debezium.tpcch.order
+    debezium.tpcch.orderline
+    debezium.tpcch.item
+    debezium.tpcch.stock
+    debezium.tpcch.nation
+    debezium.tpcch.supplier
+    debezium.tpcch.region
 )
+
+wait-for-it --timeout=60 connect:8083
 
 echo "${topics[@]}" | xargs -n1 -P8 kafka-topics --bootstrap-server kafka:9092 --create --partitions 1 --replication-factor 1 --topic
 
@@ -36,10 +41,10 @@ curl -H 'Content-Type: application/json' connect:8083/connectors --data '{
     "database.port": "3306",
     "database.user": "debezium",
     "database.password": "dbz",
-    "database.server.name": "mysql",
+    "database.server.name": "debezium",
     "database.server.id": "1234",
     "database.history.kafka.bootstrap.servers": "kafka:9092",
     "database.history.kafka.topic": "mysql-history",
     "time.precision.mode": "connect"
-  }
+ }
 }'

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -18,10 +18,10 @@ x-port-mappings:
   - &kafka 9092:9092
   - &connect 8083:8083
   - &mysql 3306:3306
+  - &control-center ${CC_PORT:-9021:9021}
 
 version: '3.7'
 services:
-  # Core test services.
   chaos:
     init: true
     mzbuild: chaos
@@ -40,6 +40,9 @@ services:
     image: confluentinc/cp-zookeeper:5.3.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
+    cap_add:
+      - NET_ADMIN
+
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.3.0
     ports:
@@ -53,6 +56,7 @@ services:
       KAFKA_JMX_PORT: 9991
     cap_add:
       - NET_ADMIN
+
   schema-registry:
     image: confluentinc/cp-schema-registry:5.2.1
     ports:
@@ -62,8 +66,9 @@ services:
       - SCHEMA_REGISTRY_HOST_NAME=schema-registry
       - SCHEMA_REGISTRY_LISTENERS=http://schema-registry:8081,http://localhost:8081
     depends_on: [zookeeper, kafka]
+    cap_add:
+      - NET_ADMIN
 
-  # mysql -> debezium -> kafka test services.
   connect:
     build: connect
     ports:
@@ -80,12 +85,16 @@ services:
     depends_on: [kafka, schema-registry]
     cap_add:
       - NET_ADMIN
+
   connector:
     image: confluentinc/cp-enterprise-kafka:5.3.0
     volumes:
       - ./connector/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
     entrypoint:
       - docker-entrypoint.sh
+    cap_add:
+      - NET_ADMIN
+
   mysql:
     image: debezium/example-mysql:1.1
     ports:
@@ -99,6 +108,19 @@ services:
         source: chbench-gen
         target: /var/lib/mysql-files
         read_only: true
+    cap_add:
+      - NET_ADMIN
+
+  connector-mysql:
+    build: connector-mysql
+    depends_on: [schema-registry, control-center]
+  control-center:
+    image: confluentinc/cp-enterprise-control-center:5.3.0
+    restart: always
+    depends_on: [zookeeper, kafka, connect]
+    ports:
+      - *control-center
+
   chbench:
     init: true
     mzbuild: chbenchmark
@@ -113,215 +135,27 @@ volumes:
 
 mzconduct:
   workflows:
-    # This test is designed to delay egress network traffic of the Kafka broker.
-    delay-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-delay-docker
-          container: chaos_kafka_1
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    delay-debezium-chbench:
-      steps:
-        - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-delay-docker
-          container: chaos_connect_1
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    # This test is designed to rate limit egress network traffic of the Kafka broker.
-    rate-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-rate-docker
-          container: chaos_kafka_1
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    rate-debezium-chbench:
-      steps:
-        - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-rate-docker
-          container: chaos_connect_1
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    # This test is designed to test packet loss from the Kafka broker.
-    loss-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-loss-docker
-          container: chaos_kafka_1
-          percent: 10
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    loss-debezium-chbench:
-      steps:
-        - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-loss-docker
-          container: chaos_connect_1
-          percent: 10
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    # This test is designed to test packet loss from the Kafka broker.
-    duplicate-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-duplicate-docker
-          container: chaos_kafka_1
-          percent: 10
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    duplicate-debezium-chbench:
-      steps:
-        - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-duplicate-docker
-          container: chaos_connect_1
-          percent: 10
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    # This test is designed to test packet corruption from the Kafka broker.
-    corrupt-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-corrupt-docker
-          container: chaos_kafka_1
-          percent: 10
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    corrupt-debezium-chbench:
-      steps:
-        - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: chaos-corrupt-docker
-          container: chaos_connect_1
-          percent: 10
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: workflow
-          workflow: run-netem-and-confirm
-
-    # These tests are designed to start and stop the specified Docker container.
-    pause-kafka:
+    test-bytes-to-kafka:
       steps:
         - step: workflow
           workflow: start-everything
         - step: workflow
           workflow: chaos-bytes-to-kafka
-        - step: chaos-pause-docker
-          service: kafka
+        - step: random-chaos
           other_service: chaos_run
+        - step: workflow
+          workflow: confirm-test
 
-    pause-debezium-chbench:
+    test-mysql-debezium-kafka:
       steps:
         - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
+          workflow: chbench-load-test
         - step: workflow
           workflow: chaos-mysql-debezium-kafka
-        - step: chaos-pause-docker
-          service: chaos_connect_1
-          other_service: chbench
-
-    # These tests are designed to start and stop the specified Docker container.
-    stop-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: chaos-stop-docker
-          service: kafka
+        - step: random-chaos
           other_service: chaos_run
-
-    stop-debezium-chbench:
-      steps:
         - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: chaos-stop-docker
-          service: chaos_connect_1
-          other_service: chbench
-
-    # These tests are designed to kill the specified Docker container.
-    kill-kafka:
-      steps:
-        - step: workflow
-          workflow: start-everything
-        - step: workflow
-          workflow: chaos-bytes-to-kafka
-        - step: chaos-kill-docker
-          service: kafka
-        - step: chaos-confirm
-          service: materialized
-          running: true
-        - step: chaos-confirm
-          service: kafka
-          exit_code: 137 #SIGKILL
-
-    kill-debezium-chbench:
-      steps:
-        - step: workflow
-          workflow: chbench-chaos-test
-        - step: workflow
-          workflow: start-everything
-        - step: workflow
-          workflow: chaos-mysql-debezium-kafka
-        - step: chaos-kill-docker
-          service: chaos_connect_1
-        - step: chaos-confirm
-          service: materialized
-          running: true
-        - step: chaos-confirm
-          service: chaos_connect_1
-          exit_code: 137 #SIGKILL
+          workflow: confirm-test
 
     # Helper workflows
     start-everything:
@@ -338,7 +172,6 @@ mzconduct:
           host: materialized
           port: 6875
 
-    # Chaos test workflows
     chaos-bytes-to-kafka:
       steps:
         - step: run
@@ -350,7 +183,7 @@ mzconduct:
             --materialized-port 6875
             --kafka-url kafka:9092
             --kafka-partitions 100
-            --message-count 100000000
+            --message-count 10000
 
     chaos-mysql-debezium-kafka:
       steps:
@@ -364,14 +197,7 @@ mzconduct:
             --kafka-url kafka:9092
             --run-seconds=864000
 
-
-    # To verify a netem chaos test, we run the chaos container to completion
-    # and check the following conditions:
-    #
-    # - the materialized container did not crash
-    # - the kafka container did not crash
-    # - the chaos container completed successfully
-    run-netem-and-confirm:
+    confirm-test:
       steps:
         - step: chaos-confirm
           service: chaos_run
@@ -380,22 +206,19 @@ mzconduct:
         - step: chaos-confirm
           service: materialized
           running: true
-        - step: chaos-confirm
-          service: chaos_kafka_1
-          running: true
 
     # chbench helper workflows
-    chbench-chaos-test:
+    chbench-load-test:
       steps:
         - step: workflow
-          workflow: chbench-bring-up-source-data
+          workflow: bring-up-source-data-mysql
         - step: workflow
-          workflow: chbench-heavy-load
+          workflow: heavy-load
 
-    chbench-bring-up-source-data:
+    bring-up-source-data-mysql:
       steps:
         - step: start-services
-          services: [materialized, mysql, zookeeper, kafka, schema-registry, connect]
+          services: [materialized, mysql]
         - step: wait-for-tcp
           host: materialized
           port: 6875
@@ -403,6 +226,11 @@ mzconduct:
           user: root
           password: debezium
           timeout_secs: 30
+        - step: drop-kafka-topics
+          kafka-container: chbench_kafka_1
+          topic_pattern: debezium.tpcch.*
+        - step: start-services
+          services: [connector-mysql]
         - step: wait-for-tcp
           host: connect
           port: 8083
@@ -410,22 +238,14 @@ mzconduct:
         - step: wait-for-tcp
           host: schema-registry
           port: 8081
-        - step: wait-for-tcp
-          host: kafka
-          port: 9092
-        - step: start-services
-          services: [connector]
-        - step: drop-kafka-topics
-          kafka-container: chaos_kafka_1
-          topic_pattern: mysql.tpcch.*
         - step: run
           service: chbench
           command: >-
             gen
             --warehouses=1
-            --config-file-path=/etc/chbenchmark/mz-default.cfg
+            --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
 
-    chbench-heavy-load:
+    heavy-load:
       steps:
         - step: run
           service: chbench
@@ -437,5 +257,5 @@ mzconduct:
             --transactional-threads=1
             --run-seconds=864000
             -l /dev/stdout
-            --config-file-path=/etc/chbenchmark/mz-default.cfg
+            --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
             --mz-url=postgresql://materialized:6875/materialize?sslmode=disable

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -135,6 +135,7 @@ volumes:
 
 mzconduct:
   workflows:
+    # Test workflows
     test-bytes-to-kafka:
       steps:
         - step: workflow

--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -59,7 +59,7 @@ async fn mysql_debezium_kafka(args: Args) -> Result<(), anyhow::Error> {
 
     // Create Kafka source.
     let src_query = "CREATE SOURCE src_orderline
-                           FROM KAFKA BROKER 'kafka:9092' TOPIC 'mysql.tpcch.orderline'
+                           FROM KAFKA BROKER 'kafka:9092' TOPIC 'debezium.tpcch.orderline'
                            FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081'
                            ENVELOPE DEBEZIUM;";
     log::info!("creating source=> {}", src_query);


### PR DESCRIPTION
Before it was refactored, the chaos testing code was written so each type of chaos was its own `mzconduct` workflow step, effectively meaning that we needed individual tests for each type of chaos. This meant that running all of the chaos tests would require spinning up 18 different tests!

This PR refactors the existing code to introduce a new `mzconduct` workflow step: `RandomChaos`. `RandomChaos` will select a random type of chaos to apply to a random container for 60 seconds at a time. This reduces the number of tests that need to be run from 18 -> 2, making it reasonable to add to the release verification process.

Once this is merged, I will run the two tests myself on EC2 instances to make sure they succeed. (I've only tested these new workflows locally for shorter amounts of time). Once those pass, I will update the release checklist.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3919)
<!-- Reviewable:end -->
