### PR TITLE
Don't allow simultaneous memory and CPU profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,6 +2751,7 @@ dependencies = [
  "lazy_static",
  "prof-common",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -42,7 +42,7 @@ rlimit = "0.3.0"
 stream-cancel = "0.6.1"
 sysctl = "0.4.0"
 tempfile = "3.1"
-tokio = "0.2"
+tokio = { version = "0.2", features = ["sync"] }
 tokio-openssl = "0.4.0"
 tracing = "0.1.18"
 tracing-subscriber = "0.2.7"

--- a/src/materialized/src/http/templates/prof.html
+++ b/src/materialized/src/http/templates/prof.html
@@ -45,6 +45,17 @@
     <input type="checkbox" id="mergeThreads" name="threads" value="merge" />
     <label for="mergeThreads">Merge threads</label>
   </div>
-  <button name="action" value="time_fg">Visualize time profile (flamegraph)</button>
+  <div>
+    <button name="action" value="time_fg">Visualize time profile (flamegraph)</button>
+{% match mem_prof %}
+{% when crate::http::prof::MemProfilingStatus::Enabled with (start_time) %}
+  {% match start_time %}
+  {% when Some with (_) %}
+    <strong>Note.</strong> Will deactivate memory profiling.
+  {% when None %}
+  {% endmatch %}
+{% when crate::http::prof::MemProfilingStatus::Disabled %}
+{% endmatch %}
+  </div>
 </form>
 {% endblock %}

--- a/src/prof_common/src/time.rs
+++ b/src/prof_common/src/time.rs
@@ -13,8 +13,10 @@ use pprof::ProfilerGuard;
 use std::{os::raw::c_int, time::Duration};
 use tokio::time::delay_for;
 
-// SAFETY - nothing else must be attempting to unwind backtraces while this is called.
-// In particular, jemalloc memory profiling must be off.
+/// # Safety
+///
+/// Nothing else must be attempting to unwind backtraces while this is called.
+/// In particular, jemalloc memory profiling must be off.
 pub async unsafe fn prof_time(
     total_time: Duration,
     sample_freq: u32,

--- a/src/prof_common/src/time.rs
+++ b/src/prof_common/src/time.rs
@@ -13,7 +13,9 @@ use pprof::ProfilerGuard;
 use std::{os::raw::c_int, time::Duration};
 use tokio::time::delay_for;
 
-pub async fn prof_time(
+// SAFETY - nothing else must be attempting to unwind backtraces while this is called.
+// In particular, jemalloc memory profiling must be off.
+pub async unsafe fn prof_time(
     total_time: Duration,
     sample_freq: u32,
     merge_threads: bool,

--- a/src/prof_jemalloc/Cargo.toml
+++ b/src/prof_jemalloc/Cargo.toml
@@ -10,4 +10,5 @@ backtrace = "0.3"
 jemalloc-ctl = { version = "0.3", features = ["use_std"] }
 lazy_static = "1.4.0"
 tempfile = "3.1"
+tokio = { version = "0.2", features = ["sync"] }
 prof-common = { path = "../prof_common" }

--- a/src/prof_jemalloc/src/lib.rs
+++ b/src/prof_jemalloc/src/lib.rs
@@ -15,8 +15,8 @@
 
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::{ffi::CString, io::BufRead, time::Instant};
+use tokio::sync::Mutex;
 
 use jemalloc_ctl::raw;
 use lazy_static::lazy_static;


### PR DESCRIPTION
See https://github.com/tikv/pprof-rs/issues/36. Running the pprof CPU profiler at the same time as the jemalloc profiler is apparently UB. It reliably causes deadlocks in Materialize if the jemalloc sampling rate is aggressive enough (e.g. 2^14). 

If another user accesses `/prof` while a CPU profile is running, this will have the unfortunate side effect of hanging their page load until the profile is done. We can improve that UX as a follow-up, but it requires a bit of refactoring (it's not as simple as just calling `try_lock`) and since it's a purely cosmetic issue, I didn't want it to block this UB safety issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3922)
<!-- Reviewable:end -->
