### PR TITLE
Exclude temp views created by select queries from mz_perf_dependency_frontiers.

### DIFF
--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -439,18 +439,21 @@ GROUP BY
     id: GlobalId::System(43),
 };
 
+// Excludes materializations not in the catalog
+// Only known materializations not in the catalog are ones from temporary
+// dataflows created to serve select queries
 const VIEW_PERF_DEPENDENCY_FRONTIERS: LogView = LogView {
     name: "mz_perf_dependency_frontiers",
     sql: "CREATE VIEW mz_perf_dependency_frontiers AS SELECT DISTINCT
-        coalesce(mcn.name, index_deps.dataflow) as dataflow,
-        coalesce(mcn_source.name, frontier_source.global_id) as source,
+        mcn.name as dataflow,
+        mcn_source.name as source,
         frontier_source.time - frontier_df.time as lag_ms
 FROM
         mz_catalog.mz_materialization_dependencies index_deps
 JOIN mz_catalog.mz_materialization_frontiers frontier_source ON index_deps.source = frontier_source.global_id
 JOIN mz_catalog.mz_materialization_frontiers frontier_df ON index_deps.dataflow = frontier_df.global_id
-LEFT JOIN mz_catalog.mz_catalog_names mcn ON mcn.global_id = index_deps.dataflow
-LEFT JOIN mz_catalog.mz_catalog_names mcn_source ON mcn_source.global_id = frontier_source.global_id",
+JOIN mz_catalog.mz_catalog_names mcn ON mcn.global_id = index_deps.dataflow
+JOIN mz_catalog.mz_catalog_names mcn_source ON mcn_source.global_id = frontier_source.global_id",
     id: GlobalId::System(59),
 };
 


### PR DESCRIPTION
Closes #3918. 

Originally, I considered trying to remove temp views created by select queries from `mz_materialization_dependencies` and `mz_materialization_frontiers`, but that would be difficult because the server does not distinguish between temporary indexes created by select queries and more persistent ones. Thus, I have opted to have them filtered away by `mz_perf_dependency_frontiers` instead. Objects created by select queries are not in the catalog, but everything else is (including temp views created by CREATE TEMPORARY VIEW).

I have tested that I have not broken the `mz_perf_dependency_frontiers` view, but I haven't confirmed that temp views created by select queries are gone since the blips only occur about once a day on load tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3929)
<!-- Reviewable:end -->
