### PR TITLE
coord,dataflow: rework log id assignment

### DIFF
--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -23,6 +23,7 @@
 mod catalog;
 mod command;
 mod coord;
+mod logging;
 mod persistence;
 mod sink_connector;
 mod timestamp;

--- a/src/coord/src/logging.rs
+++ b/src/coord/src/logging.rs
@@ -1,0 +1,309 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use dataflow_types::logging::{DifferentialLog, LogVariant, MaterializedLog, TimelyLog};
+use expr::GlobalId;
+
+pub struct LogSource {
+    pub variant: LogVariant,
+    pub name: &'static str,
+    pub id: GlobalId,
+    pub index_id: GlobalId,
+}
+
+pub const LOG_SOURCES: &[LogSource] = &[
+    LogSource {
+        name: "mz_dataflow_operators",
+        variant: LogVariant::Timely(TimelyLog::Operates),
+        id: GlobalId::System(1),
+        index_id: GlobalId::System(2),
+    },
+    LogSource {
+        name: "mz_dataflow_operator_addresses",
+        variant: LogVariant::Timely(TimelyLog::Addresses),
+        id: GlobalId::System(3),
+        index_id: GlobalId::System(4),
+    },
+    LogSource {
+        name: "mz_dataflow_channels",
+        variant: LogVariant::Timely(TimelyLog::Channels),
+        id: GlobalId::System(5),
+        index_id: GlobalId::System(6),
+    },
+    LogSource {
+        name: "mz_scheduling_elapsed",
+        variant: LogVariant::Timely(TimelyLog::Elapsed),
+        id: GlobalId::System(7),
+        index_id: GlobalId::System(8),
+    },
+    LogSource {
+        name: "mz_scheduling_histogram",
+        variant: LogVariant::Timely(TimelyLog::Histogram),
+        id: GlobalId::System(9),
+        index_id: GlobalId::System(10),
+    },
+    LogSource {
+        name: "mz_scheduling_parks",
+        variant: LogVariant::Timely(TimelyLog::Parks),
+        id: GlobalId::System(11),
+        index_id: GlobalId::System(12),
+    },
+    LogSource {
+        name: "mz_arrangement_sizes",
+        variant: LogVariant::Differential(DifferentialLog::Arrangement),
+        id: GlobalId::System(13),
+        index_id: GlobalId::System(14),
+    },
+    LogSource {
+        name: "mz_arrangement_sharing",
+        variant: LogVariant::Differential(DifferentialLog::Sharing),
+        id: GlobalId::System(15),
+        index_id: GlobalId::System(16),
+    },
+    LogSource {
+        name: "mz_materializations",
+        variant: LogVariant::Materialized(MaterializedLog::DataflowCurrent),
+        id: GlobalId::System(17),
+        index_id: GlobalId::System(18),
+    },
+    LogSource {
+        name: "mz_materialization_dependencies",
+        variant: LogVariant::Materialized(MaterializedLog::DataflowDependency),
+        id: GlobalId::System(19),
+        index_id: GlobalId::System(20),
+    },
+    LogSource {
+        name: "mz_worker_materialization_frontiers",
+        variant: LogVariant::Materialized(MaterializedLog::FrontierCurrent),
+        id: GlobalId::System(21),
+        index_id: GlobalId::System(22),
+    },
+    LogSource {
+        name: "mz_peek_active",
+        variant: LogVariant::Materialized(MaterializedLog::PeekCurrent),
+        id: GlobalId::System(23),
+        index_id: GlobalId::System(24),
+    },
+    LogSource {
+        name: "mz_peek_durations",
+        variant: LogVariant::Materialized(MaterializedLog::PeekDuration),
+        id: GlobalId::System(25),
+        index_id: GlobalId::System(26),
+    },
+];
+
+pub struct LogView {
+    pub name: &'static str,
+    pub sql: &'static str,
+    pub id: GlobalId,
+}
+
+// Stores all addresses that only have one slot (0) in
+// mz_dataflow_operator_addresses. The resulting addresses are either channels
+// or dataflows.
+const VIEW_ADDRESSES_WITH_UNIT_LENGTH: LogView = LogView {
+    name: "mz_addresses_with_unit_length",
+    sql: "CREATE VIEW mz_addresses_with_unit_length AS SELECT
+    mz_dataflow_operator_addresses.id,
+    mz_dataflow_operator_addresses.worker
+FROM
+    mz_catalog.mz_dataflow_operator_addresses
+GROUP BY
+    mz_dataflow_operator_addresses.id,
+    mz_dataflow_operator_addresses.worker
+HAVING count(*) = 1",
+    id: GlobalId::System(33),
+};
+
+/// Maintains a list of the current dataflow operator ids, and their
+/// corresponding operator names and local ids (per worker).
+const VIEW_DATAFLOW_NAMES: LogView = LogView {
+    name: "mz_dataflow_names",
+    sql: "CREATE VIEW mz_dataflow_names AS SELECT
+    mz_dataflow_operator_addresses.id,
+    mz_dataflow_operator_addresses.worker,
+    mz_dataflow_operator_addresses.value as local_id,
+    mz_dataflow_operators.name
+FROM
+    mz_catalog.mz_dataflow_operator_addresses,
+    mz_catalog.mz_dataflow_operators,
+    mz_catalog.mz_addresses_with_unit_length
+WHERE
+    mz_dataflow_operator_addresses.id = mz_dataflow_operators.id AND
+    mz_dataflow_operator_addresses.worker = mz_dataflow_operators.worker AND
+    mz_dataflow_operator_addresses.id = mz_addresses_with_unit_length.id AND
+    mz_dataflow_operator_addresses.worker = mz_addresses_with_unit_length.worker AND
+    mz_dataflow_operator_addresses.slot = 0",
+    id: GlobalId::System(35),
+};
+
+/// Maintains a list of all operators bound to a dataflow and their
+/// corresponding names and dataflow names and ids (per worker).
+const VIEW_DATAFLOW_OPERATOR_DATAFLOWS: LogView = LogView {
+    name: "mz_dataflow_operator_dataflows",
+    sql: "CREATE VIEW mz_dataflow_operator_dataflows AS SELECT
+    mz_dataflow_operators.id,
+    mz_dataflow_operators.name,
+    mz_dataflow_operators.worker,
+    mz_dataflow_names.id as dataflow_id,
+    mz_dataflow_names.name as dataflow_name
+FROM
+    mz_catalog.mz_dataflow_operators,
+    mz_catalog.mz_dataflow_operator_addresses,
+    mz_catalog.mz_dataflow_names
+WHERE
+    mz_dataflow_operators.id = mz_dataflow_operator_addresses.id AND
+    mz_dataflow_operators.worker = mz_dataflow_operator_addresses.worker AND
+    mz_dataflow_operator_addresses.slot = 0 AND
+    mz_dataflow_names.local_id = mz_dataflow_operator_addresses.value AND
+    mz_dataflow_names.worker = mz_dataflow_operator_addresses.worker",
+    id: GlobalId::System(37),
+};
+
+/// Computes the minimum materialization frontiers across all workers.
+const VIEW_MATERIALIZATION_FRONTIERS: LogView = LogView {
+    name: "mz_materialization_frontiers",
+    sql: "CREATE VIEW mz_materialization_frontiers AS SELECT
+    global_id, min(time) AS time
+FROM mz_catalog.mz_worker_materialization_frontiers
+GROUP BY global_id",
+    id: GlobalId::System(54),
+};
+
+/// Maintains the number of records used by each operator in a dataflow (per
+/// worker). Operators not using any records are not shown.
+const VIEW_RECORDS_PER_DATAFLOW_OPERATOR: LogView = LogView {
+    name: "mz_records_per_dataflow_operator",
+    sql: "CREATE VIEW mz_records_per_dataflow_operator AS SELECT
+    mz_dataflow_operator_dataflows.id,
+    mz_dataflow_operator_dataflows.name,
+    mz_dataflow_operator_dataflows.worker,
+    mz_dataflow_operator_dataflows.dataflow_id,
+    mz_arrangement_sizes.records
+FROM
+    mz_catalog.mz_arrangement_sizes,
+    mz_catalog.mz_dataflow_operator_dataflows
+WHERE
+    mz_dataflow_operator_dataflows.id = mz_arrangement_sizes.operator AND
+    mz_dataflow_operator_dataflows.worker = mz_arrangement_sizes.worker",
+    id: GlobalId::System(39),
+};
+
+/// Maintains the number of records used by each dataflow (per worker).
+const VIEW_RECORDS_PER_DATAFLOW: LogView = LogView {
+    name: "mz_records_per_dataflow",
+    sql: "CREATE VIEW mz_records_per_dataflow AS SELECT
+    mz_records_per_dataflow_operator.dataflow_id as id,
+    mz_dataflow_names.name,
+    mz_records_per_dataflow_operator.worker,
+    SUM(mz_records_per_dataflow_operator.records) as records
+FROM
+    mz_catalog.mz_records_per_dataflow_operator,
+    mz_catalog.mz_dataflow_names
+WHERE
+    mz_records_per_dataflow_operator.dataflow_id = mz_dataflow_names.id AND
+    mz_records_per_dataflow_operator.worker = mz_dataflow_names.worker
+GROUP BY
+    mz_records_per_dataflow_operator.dataflow_id,
+    mz_dataflow_names.name,
+    mz_records_per_dataflow_operator.worker",
+    id: GlobalId::System(41),
+};
+
+/// Maintains the number of records used by each dataflow (across all workers).
+const VIEW_RECORDS_PER_DATAFLOW_GLOBAL: LogView = LogView {
+    name: "mz_records_per_dataflow_global",
+    sql: "CREATE VIEW mz_records_per_dataflow_global AS SELECT
+    mz_records_per_dataflow.id,
+    mz_records_per_dataflow.name,
+    SUM(mz_records_per_dataflow.records) as records
+FROM
+    mz_catalog.mz_records_per_dataflow
+GROUP BY
+    mz_records_per_dataflow.id,
+    mz_records_per_dataflow.name",
+    id: GlobalId::System(43),
+};
+
+// Excludes materializations not in the catalog
+// Only known materializations not in the catalog are ones from temporary
+// dataflows created to serve select queries
+const VIEW_PERF_DEPENDENCY_FRONTIERS: LogView = LogView {
+    name: "mz_perf_dependency_frontiers",
+    sql: "CREATE VIEW mz_perf_dependency_frontiers AS SELECT DISTINCT
+    mcn.name AS dataflow,
+    mcn_source.name AS source,
+    frontier_source.time - frontier_df.time as lag_ms
+FROM mz_catalog.mz_materialization_dependencies index_deps
+JOIN mz_catalog.mz_materialization_frontiers frontier_source ON index_deps.source = frontier_source.global_id
+JOIN mz_catalog.mz_materialization_frontiers frontier_df ON index_deps.dataflow = frontier_df.global_id
+JOIN mz_catalog.mz_catalog_names mcn ON mcn.global_id = index_deps.dataflow
+JOIN mz_catalog.mz_catalog_names mcn_source ON mcn_source.global_id = frontier_source.global_id",
+    id: GlobalId::System(59),
+};
+
+const VIEW_PERF_ARRANGEMENT_RECORDS: LogView = LogView {
+    name: "mz_perf_arrangement_records",
+    sql:
+        "CREATE VIEW mz_perf_arrangement_records AS SELECT mas.worker, name, records, operator
+FROM mz_catalog.mz_arrangement_sizes mas
+LEFT JOIN mz_catalog.mz_dataflow_operators mdo ON mdo.id = mas.operator AND mdo.worker = mas.worker",
+    id: GlobalId::System(47),
+};
+
+const VIEW_PERF_PEEK_DURATIONS_CORE: LogView = LogView {
+    name: "mz_perf_peek_durations_core",
+    sql: "CREATE VIEW mz_perf_peek_durations_core AS SELECT
+    d_upper.worker,
+    CAST(d_upper.duration_ns AS TEXT) AS le,
+    sum(d_summed.count) AS count
+FROM
+    mz_catalog.mz_peek_durations AS d_upper,
+    mz_catalog.mz_peek_durations AS d_summed
+WHERE
+    d_upper.worker = d_summed.worker AND
+    d_upper.duration_ns >= d_summed.duration_ns
+GROUP BY d_upper.worker, d_upper.duration_ns",
+    id: GlobalId::System(49),
+};
+
+const VIEW_PERF_PEEK_DURATIONS_BUCKET: LogView = LogView {
+    name: "mz_perf_peek_durations_bucket",
+    sql: "CREATE VIEW mz_perf_peek_durations_bucket AS
+(
+    SELECT * FROM mz_catalog.mz_perf_peek_durations_core
+) UNION (
+    SELECT worker, '+Inf', max(count) AS count FROM mz_catalog.mz_perf_peek_durations_core
+    GROUP BY worker
+)",
+    id: GlobalId::System(51),
+};
+
+const VIEW_PERF_PEEK_DURATIONS_AGGREGATES: LogView = LogView {
+    name: "mz_perf_peek_durations_aggregates",
+    sql: "CREATE VIEW mz_perf_peek_durations_aggregates AS SELECT worker, sum(duration_ns * count) AS sum, sum(count) AS count
+FROM mz_catalog.mz_peek_durations lpd
+GROUP BY worker",
+    id: GlobalId::System(53),
+};
+
+pub const LOG_VIEWS: &[LogView] = &[
+    VIEW_ADDRESSES_WITH_UNIT_LENGTH,
+    VIEW_DATAFLOW_NAMES,
+    VIEW_DATAFLOW_OPERATOR_DATAFLOWS,
+    VIEW_MATERIALIZATION_FRONTIERS,
+    VIEW_RECORDS_PER_DATAFLOW_OPERATOR,
+    VIEW_RECORDS_PER_DATAFLOW,
+    VIEW_RECORDS_PER_DATAFLOW_GLOBAL,
+    VIEW_PERF_DEPENDENCY_FRONTIERS,
+    VIEW_PERF_ARRANGEMENT_RECORDS,
+    VIEW_PERF_PEEK_DURATIONS_CORE,
+    VIEW_PERF_PEEK_DURATIONS_BUCKET,
+    VIEW_PERF_PEEK_DURATIONS_AGGREGATES,
+];

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -7,79 +7,44 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
-use std::time::Duration;
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 
 use expr::GlobalId;
 use repr::{RelationDesc, ScalarType};
 
 /// Logging configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoggingConfig {
-    granularity_ns: u128,
-    active_logs: HashSet<LogVariant>,
+    pub granularity_ns: u128,
+    pub active_logs: HashMap<LogVariant, GlobalId>,
 }
 
-impl LoggingConfig {
-    pub fn new(granularity: Duration) -> LoggingConfig {
-        Self {
-            granularity_ns: granularity.as_nanos(),
-            active_logs: LogVariant::default_logs().into_iter().collect(),
-        }
-    }
-
-    pub fn granularity_ns(&self) -> u128 {
-        self.granularity_ns
-    }
-
-    pub fn active_logs(&self) -> &HashSet<LogVariant> {
-        &self.active_logs
-    }
-
-    pub fn active_views(&self) -> Vec<LogView> {
-        vec![
-            VIEW_ADDRESSES_WITH_UNIT_LENGTH,
-            VIEW_DATAFLOW_NAMES,
-            VIEW_DATAFLOW_OPERATOR_DATAFLOWS,
-            VIEW_MATERIALIZATION_FRONTIERS,
-            VIEW_RECORDS_PER_DATAFLOW_OPERATOR,
-            VIEW_RECORDS_PER_DATAFLOW,
-            VIEW_RECORDS_PER_DATAFLOW_GLOBAL,
-            VIEW_PERF_DEPENDENCY_FRONTIERS,
-            VIEW_PERF_ARRANGEMENT_RECORDS,
-            VIEW_PERF_PEEK_DURATIONS_CORE,
-            VIEW_PERF_PEEK_DURATIONS_BUCKET,
-            VIEW_PERF_PEEK_DURATIONS_AGGREGATES,
-        ]
-    }
-}
-
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum LogVariant {
     Timely(TimelyLog),
     Differential(DifferentialLog),
     Materialized(MaterializedLog),
 }
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum TimelyLog {
-    /// The operators and their names
     Operates,
     Channels,
     Elapsed,
-    /// Histogram of operator execution durations
     Histogram,
     Addresses,
     Parks,
 }
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum DifferentialLog {
     Arrangement,
     Sharing,
 }
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum MaterializedLog {
     DataflowCurrent,
     DataflowDependency,
@@ -89,99 +54,22 @@ pub enum MaterializedLog {
 }
 
 impl LogVariant {
-    pub fn default_logs() -> Vec<LogVariant> {
-        vec![
-            LogVariant::Timely(TimelyLog::Operates),
-            LogVariant::Timely(TimelyLog::Channels),
-            LogVariant::Timely(TimelyLog::Elapsed),
-            LogVariant::Timely(TimelyLog::Histogram),
-            LogVariant::Timely(TimelyLog::Addresses),
-            LogVariant::Timely(TimelyLog::Parks),
-            LogVariant::Differential(DifferentialLog::Arrangement),
-            LogVariant::Differential(DifferentialLog::Sharing),
-            LogVariant::Materialized(MaterializedLog::DataflowCurrent),
-            LogVariant::Materialized(MaterializedLog::DataflowDependency),
-            LogVariant::Materialized(MaterializedLog::FrontierCurrent),
-            LogVariant::Materialized(MaterializedLog::PeekCurrent),
-            LogVariant::Materialized(MaterializedLog::PeekDuration),
-        ]
-    }
-
-    pub fn name(&self) -> &'static str {
-        // Bind all names in one place to avoid accidental clashes.
-        match self {
-            LogVariant::Timely(TimelyLog::Operates) => "mz_dataflow_operators",
-            LogVariant::Timely(TimelyLog::Addresses) => "mz_dataflow_operator_addresses",
-            LogVariant::Timely(TimelyLog::Channels) => "mz_dataflow_channels",
-            LogVariant::Timely(TimelyLog::Elapsed) => "mz_scheduling_elapsed",
-            LogVariant::Timely(TimelyLog::Histogram) => "mz_scheduling_histogram",
-            LogVariant::Timely(TimelyLog::Parks) => "mz_scheduling_parks",
-            LogVariant::Differential(DifferentialLog::Arrangement) => "mz_arrangement_sizes",
-            LogVariant::Differential(DifferentialLog::Sharing) => "mz_arrangement_sharing",
-            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => "mz_materializations",
-            LogVariant::Materialized(MaterializedLog::DataflowDependency) => {
-                "mz_materialization_dependencies"
-            }
-            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => {
-                "mz_worker_materialization_frontiers"
-            }
-            LogVariant::Materialized(MaterializedLog::PeekCurrent) => "mz_peek_active",
-            LogVariant::Materialized(MaterializedLog::PeekDuration) => "mz_peek_durations",
-        }
-    }
-
-    pub fn id(&self) -> GlobalId {
-        // Bind all identifiers in one place to avoid accidental clashes.
-        match self {
-            LogVariant::Timely(TimelyLog::Operates) => GlobalId::system(1),
-            LogVariant::Timely(TimelyLog::Channels) => GlobalId::system(3),
-            LogVariant::Timely(TimelyLog::Elapsed) => GlobalId::system(5),
-            LogVariant::Timely(TimelyLog::Histogram) => GlobalId::system(7),
-            LogVariant::Timely(TimelyLog::Addresses) => GlobalId::system(9),
-            LogVariant::Timely(TimelyLog::Parks) => GlobalId::system(11),
-            LogVariant::Differential(DifferentialLog::Arrangement) => GlobalId::system(13),
-            LogVariant::Differential(DifferentialLog::Sharing) => GlobalId::system(15),
-            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => GlobalId::system(17),
-            LogVariant::Materialized(MaterializedLog::DataflowDependency) => GlobalId::system(19),
-            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => GlobalId::system(21),
-            LogVariant::Materialized(MaterializedLog::PeekCurrent) => GlobalId::system(23),
-            LogVariant::Materialized(MaterializedLog::PeekDuration) => GlobalId::system(25),
-        }
-    }
-
-    pub fn index_id(&self) -> GlobalId {
-        // Bind all identifiers in one place to avoid accidental clashes.
-        match self {
-            LogVariant::Timely(TimelyLog::Operates) => GlobalId::system(2),
-            LogVariant::Timely(TimelyLog::Channels) => GlobalId::system(4),
-            LogVariant::Timely(TimelyLog::Elapsed) => GlobalId::system(6),
-            LogVariant::Timely(TimelyLog::Histogram) => GlobalId::system(8),
-            LogVariant::Timely(TimelyLog::Addresses) => GlobalId::system(10),
-            LogVariant::Timely(TimelyLog::Parks) => GlobalId::system(12),
-            LogVariant::Differential(DifferentialLog::Arrangement) => GlobalId::system(14),
-            LogVariant::Differential(DifferentialLog::Sharing) => GlobalId::system(16),
-            LogVariant::Materialized(MaterializedLog::DataflowCurrent) => GlobalId::system(18),
-            LogVariant::Materialized(MaterializedLog::DataflowDependency) => GlobalId::system(20),
-            LogVariant::Materialized(MaterializedLog::FrontierCurrent) => GlobalId::system(22),
-            LogVariant::Materialized(MaterializedLog::PeekCurrent) => GlobalId::system(24),
-            LogVariant::Materialized(MaterializedLog::PeekDuration) => GlobalId::system(26),
-        }
-    }
-
     /// By which columns should the logs be indexed.
     ///
     /// This is distinct from the `keys` property of the type, which indicates uniqueness.
     /// When keys exist these are good choices for indexing, but when they do not we still
     /// require index guidance.
     pub fn index_by(&self) -> Vec<usize> {
-        let typ = self.schema().typ().clone();
-        typ.keys
+        let desc = self.desc();
+        let arity = desc.arity();
+        desc.typ()
+            .keys
             .get(0)
             .cloned()
-            .unwrap_or_else(|| (0..typ.column_types.len()).collect::<Vec<_>>())
+            .unwrap_or_else(|| (0..arity).collect())
     }
 
-    pub fn schema(&self) -> RelationDesc {
+    pub fn desc(&self) -> RelationDesc {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => RelationDesc::empty()
                 .with_column("id", ScalarType::Int64.nullable(false))
@@ -272,29 +160,29 @@ impl LogVariant {
     ///
     /// The result is a list of other variants, and for each a list of local
     /// and other column identifiers that can be equated.
-    pub fn foreign_keys(&self) -> Vec<(GlobalId, Vec<(usize, usize)>)> {
+    pub fn foreign_keys(&self) -> Vec<(LogVariant, Vec<(usize, usize)>)> {
         match self {
             LogVariant::Timely(TimelyLog::Operates) => vec![],
             LogVariant::Timely(TimelyLog::Channels) => vec![],
             LogVariant::Timely(TimelyLog::Elapsed) => vec![(
-                LogVariant::Timely(TimelyLog::Operates).id(),
+                LogVariant::Timely(TimelyLog::Operates),
                 vec![(0, 0), (1, 1)],
             )],
             LogVariant::Timely(TimelyLog::Histogram) => vec![(
-                LogVariant::Timely(TimelyLog::Operates).id(),
+                LogVariant::Timely(TimelyLog::Operates),
                 vec![(0, 0), (1, 1)],
             )],
             LogVariant::Timely(TimelyLog::Addresses) => vec![(
-                LogVariant::Timely(TimelyLog::Operates).id(),
+                LogVariant::Timely(TimelyLog::Operates),
                 vec![(0, 0), (1, 1)],
             )],
             LogVariant::Timely(TimelyLog::Parks) => vec![],
             LogVariant::Differential(DifferentialLog::Arrangement) => vec![(
-                LogVariant::Timely(TimelyLog::Operates).id(),
+                LogVariant::Timely(TimelyLog::Operates),
                 vec![(0, 0), (1, 1)],
             )],
             LogVariant::Differential(DifferentialLog::Sharing) => vec![(
-                LogVariant::Timely(TimelyLog::Operates).id(),
+                LogVariant::Timely(TimelyLog::Operates),
                 vec![(0, 0), (1, 1)],
             )],
             LogVariant::Materialized(MaterializedLog::DataflowCurrent) => vec![],
@@ -305,199 +193,3 @@ impl LogVariant {
         }
     }
 }
-
-pub struct LogView {
-    pub name: &'static str,
-    pub sql: &'static str,
-    pub id: GlobalId,
-}
-
-// Stores all addresses that only have one slot (0) in
-// mz_dataflow_operator_addresses. The resulting addresses are either channels
-// or dataflows.
-const VIEW_ADDRESSES_WITH_UNIT_LENGTH: LogView = LogView {
-    name: "mz_addresses_with_unit_length",
-    sql: "CREATE VIEW mz_addresses_with_unit_length AS SELECT
-    mz_dataflow_operator_addresses.id,
-    mz_dataflow_operator_addresses.worker
-FROM
-    mz_catalog.mz_dataflow_operator_addresses
-GROUP BY
-    mz_dataflow_operator_addresses.id,
-    mz_dataflow_operator_addresses.worker
-HAVING count(*) = 1",
-    id: GlobalId::System(33),
-};
-
-/// Maintains a list of the current dataflow operator ids, and their
-/// corresponding operator names and local ids (per worker).
-const VIEW_DATAFLOW_NAMES: LogView = LogView {
-    name: "mz_dataflow_names",
-    sql: "CREATE VIEW mz_dataflow_names AS SELECT
-    mz_dataflow_operator_addresses.id,
-    mz_dataflow_operator_addresses.worker,
-    mz_dataflow_operator_addresses.value as local_id,
-    mz_dataflow_operators.name
-FROM
-    mz_catalog.mz_dataflow_operator_addresses,
-    mz_catalog.mz_dataflow_operators,
-    mz_catalog.mz_addresses_with_unit_length
-WHERE
-    mz_dataflow_operator_addresses.id = mz_dataflow_operators.id AND
-    mz_dataflow_operator_addresses.worker = mz_dataflow_operators.worker AND
-    mz_dataflow_operator_addresses.id = mz_addresses_with_unit_length.id AND
-    mz_dataflow_operator_addresses.worker = mz_addresses_with_unit_length.worker AND
-    mz_dataflow_operator_addresses.slot = 0",
-    id: GlobalId::System(35),
-};
-
-/// Maintains a list of all operators bound to a dataflow and their
-/// corresponding names and dataflow names and ids (per worker).
-const VIEW_DATAFLOW_OPERATOR_DATAFLOWS: LogView = LogView {
-    name: "mz_dataflow_operator_dataflows",
-    sql: "CREATE VIEW mz_dataflow_operator_dataflows AS SELECT
-    mz_dataflow_operators.id,
-    mz_dataflow_operators.name,
-    mz_dataflow_operators.worker,
-    mz_dataflow_names.id as dataflow_id,
-    mz_dataflow_names.name as dataflow_name
-FROM
-    mz_catalog.mz_dataflow_operators,
-    mz_catalog.mz_dataflow_operator_addresses,
-    mz_catalog.mz_dataflow_names
-WHERE
-    mz_dataflow_operators.id = mz_dataflow_operator_addresses.id AND
-    mz_dataflow_operators.worker = mz_dataflow_operator_addresses.worker AND
-    mz_dataflow_operator_addresses.slot = 0 AND
-    mz_dataflow_names.local_id = mz_dataflow_operator_addresses.value AND
-    mz_dataflow_names.worker = mz_dataflow_operator_addresses.worker",
-    id: GlobalId::System(37),
-};
-
-/// Computes the minimum materialization frontiers across all workers.
-const VIEW_MATERIALIZATION_FRONTIERS: LogView = LogView {
-    name: "mz_materialization_frontiers",
-    sql: "CREATE VIEW mz_materialization_frontiers AS SELECT
-    global_id, min(time) AS time
-FROM mz_catalog.mz_worker_materialization_frontiers
-GROUP BY global_id",
-    id: GlobalId::System(54),
-};
-
-/// Maintains the number of records used by each operator in a dataflow (per
-/// worker). Operators not using any records are not shown.
-const VIEW_RECORDS_PER_DATAFLOW_OPERATOR: LogView = LogView {
-    name: "mz_records_per_dataflow_operator",
-    sql: "CREATE VIEW mz_records_per_dataflow_operator AS SELECT
-    mz_dataflow_operator_dataflows.id,
-    mz_dataflow_operator_dataflows.name,
-    mz_dataflow_operator_dataflows.worker,
-    mz_dataflow_operator_dataflows.dataflow_id,
-    mz_arrangement_sizes.records
-FROM
-    mz_catalog.mz_arrangement_sizes,
-    mz_catalog.mz_dataflow_operator_dataflows
-WHERE
-    mz_dataflow_operator_dataflows.id = mz_arrangement_sizes.operator AND
-    mz_dataflow_operator_dataflows.worker = mz_arrangement_sizes.worker",
-    id: GlobalId::System(39),
-};
-
-/// Maintains the number of records used by each dataflow (per worker).
-const VIEW_RECORDS_PER_DATAFLOW: LogView = LogView {
-    name: "mz_records_per_dataflow",
-    sql: "CREATE VIEW mz_records_per_dataflow AS SELECT
-    mz_records_per_dataflow_operator.dataflow_id as id,
-    mz_dataflow_names.name,
-    mz_records_per_dataflow_operator.worker,
-    SUM(mz_records_per_dataflow_operator.records) as records
-FROM
-    mz_catalog.mz_records_per_dataflow_operator,
-    mz_catalog.mz_dataflow_names
-WHERE
-    mz_records_per_dataflow_operator.dataflow_id = mz_dataflow_names.id AND
-    mz_records_per_dataflow_operator.worker = mz_dataflow_names.worker
-GROUP BY
-    mz_records_per_dataflow_operator.dataflow_id,
-    mz_dataflow_names.name,
-    mz_records_per_dataflow_operator.worker",
-    id: GlobalId::System(41),
-};
-
-/// Maintains the number of records used by each dataflow (across all workers).
-const VIEW_RECORDS_PER_DATAFLOW_GLOBAL: LogView = LogView {
-    name: "mz_records_per_dataflow_global",
-    sql: "CREATE VIEW mz_records_per_dataflow_global AS SELECT
-    mz_records_per_dataflow.id,
-    mz_records_per_dataflow.name,
-    SUM(mz_records_per_dataflow.records) as records
-FROM
-    mz_catalog.mz_records_per_dataflow
-GROUP BY
-    mz_records_per_dataflow.id,
-    mz_records_per_dataflow.name",
-    id: GlobalId::System(43),
-};
-
-// Excludes materializations not in the catalog
-// Only known materializations not in the catalog are ones from temporary
-// dataflows created to serve select queries
-const VIEW_PERF_DEPENDENCY_FRONTIERS: LogView = LogView {
-    name: "mz_perf_dependency_frontiers",
-    sql: "CREATE VIEW mz_perf_dependency_frontiers AS SELECT DISTINCT
-        mcn.name as dataflow,
-        mcn_source.name as source,
-        frontier_source.time - frontier_df.time as lag_ms
-FROM
-        mz_catalog.mz_materialization_dependencies index_deps
-JOIN mz_catalog.mz_materialization_frontiers frontier_source ON index_deps.source = frontier_source.global_id
-JOIN mz_catalog.mz_materialization_frontiers frontier_df ON index_deps.dataflow = frontier_df.global_id
-JOIN mz_catalog.mz_catalog_names mcn ON mcn.global_id = index_deps.dataflow
-JOIN mz_catalog.mz_catalog_names mcn_source ON mcn_source.global_id = frontier_source.global_id",
-    id: GlobalId::System(59),
-};
-
-const VIEW_PERF_ARRANGEMENT_RECORDS: LogView = LogView {
-    name: "mz_perf_arrangement_records",
-    sql:
-        "CREATE VIEW mz_perf_arrangement_records AS SELECT mas.worker, name, records, operator
-FROM mz_catalog.mz_arrangement_sizes mas
-LEFT JOIN mz_catalog.mz_dataflow_operators mdo ON mdo.id = mas.operator AND mdo.worker = mas.worker",
-    id: GlobalId::System(47),
-};
-
-const VIEW_PERF_PEEK_DURATIONS_CORE: LogView = LogView {
-    name: "mz_perf_peek_durations_core",
-    sql: "CREATE VIEW mz_perf_peek_durations_core AS SELECT
-    d_upper.worker,
-    CAST(d_upper.duration_ns AS TEXT) AS le,
-    sum(d_summed.count) AS count
-FROM
-    mz_catalog.mz_peek_durations AS d_upper,
-    mz_catalog.mz_peek_durations AS d_summed
-WHERE
-    d_upper.worker = d_summed.worker AND
-    d_upper.duration_ns >= d_summed.duration_ns
-GROUP BY d_upper.worker, d_upper.duration_ns",
-    id: GlobalId::System(49),
-};
-
-const VIEW_PERF_PEEK_DURATIONS_BUCKET: LogView = LogView {
-    name: "mz_perf_peek_durations_bucket",
-    sql: "CREATE VIEW mz_perf_peek_durations_bucket AS
-(
-    SELECT * FROM mz_catalog.mz_perf_peek_durations_core
-) UNION (
-    SELECT worker, '+Inf', max(count) AS count FROM mz_catalog.mz_perf_peek_durations_core
-    GROUP BY worker
-)",
-    id: GlobalId::System(51),
-};
-
-const VIEW_PERF_PEEK_DURATIONS_AGGREGATES: LogView = LogView {
-    name: "mz_perf_peek_durations_aggregates",
-    sql: "CREATE VIEW mz_perf_peek_durations_aggregates AS SELECT worker, sum(duration_ns * count) AS sum, sum(count) AS count
-FROM mz_catalog.mz_peek_durations lpd
-GROUP BY worker",
-    id: GlobalId::System(53),
-};

--- a/src/dataflow/src/logging/differential.rs
+++ b/src/dataflow/src/logging/differential.rs
@@ -28,7 +28,7 @@ pub fn construct<A: Allocate>(
     config: &dataflow_types::logging::LoggingConfig,
     linked: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, DifferentialEvent)>>,
 ) -> std::collections::HashMap<LogVariant, (Vec<usize>, KeysValsHandle)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns() / 1_000_000) as Timestamp;
+    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
 
     let traces = worker.dataflow(move |scope| {
         use differential_dataflow::collection::AsCollection;
@@ -38,7 +38,7 @@ pub fn construct<A: Allocate>(
         // TODO: Rewrite as one operator with multiple outputs.
         let logs = Some(linked).replay_core(
             scope,
-            Some(Duration::from_nanos(config.granularity_ns() as u64)),
+            Some(Duration::from_nanos(config.granularity_ns as u64)),
         );
 
         // Duration statistics derive from the non-rounded event times.
@@ -126,7 +126,7 @@ pub fn construct<A: Allocate>(
         use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
-            if config.active_logs().contains(&variant) {
+            if config.active_logs.contains_key(&variant) {
                 let key = variant.index_by();
                 let key_clone = key.clone();
                 let trace = collection

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -73,7 +73,7 @@ pub fn construct<A: Allocate>(
     config: &dataflow_types::logging::LoggingConfig,
     linked: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, MaterializedEvent)>>,
 ) -> std::collections::HashMap<LogVariant, (Vec<usize>, KeysValsHandle)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns() / 1_000_000) as Timestamp;
+    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
 
     let traces = worker.dataflow(move |scope| {
         use differential_dataflow::collection::AsCollection;
@@ -83,7 +83,7 @@ pub fn construct<A: Allocate>(
         // TODO: Rewrite as one operator with multiple outputs.
         let logs = Some(linked).replay_core(
             scope,
-            Some(Duration::from_nanos(config.granularity_ns() as u64)),
+            Some(Duration::from_nanos(config.granularity_ns as u64)),
         );
 
         use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -332,7 +332,7 @@ pub fn construct<A: Allocate>(
         use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
-            if config.active_logs().contains(&variant) {
+            if config.active_logs.contains_key(&variant) {
                 let key = variant.index_by();
                 let key_clone = key.clone();
                 let trace = collection

--- a/src/dataflow/src/logging/timely.rs
+++ b/src/dataflow/src/logging/timely.rs
@@ -29,7 +29,7 @@ pub fn construct<A: Allocate>(
     config: &LoggingConfig,
     linked: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, TimelyEvent)>>,
 ) -> std::collections::HashMap<LogVariant, (Vec<usize>, KeysValsHandle)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns() / 1_000_000) as Timestamp;
+    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
 
     // A dataflow for multiple log-derived arrangements.
     let traces = worker.dataflow(move |scope| {
@@ -39,7 +39,7 @@ pub fn construct<A: Allocate>(
 
         let logs = Some(linked).replay_core(
             scope,
-            Some(Duration::from_nanos(config.granularity_ns() as u64)),
+            Some(Duration::from_nanos(config.granularity_ns as u64)),
         );
 
         use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -365,7 +365,7 @@ pub fn construct<A: Allocate>(
 
         let mut result = std::collections::HashMap::new();
         for (variant, collection) in logs {
-            if config.active_logs().contains(&variant) {
+            if config.active_logs.contains_key(&variant) {
                 let key = variant.index_by();
                 let key_clone = key.clone();
                 let trace = collection

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -109,6 +109,8 @@ struct CommandsProcessedMetrics {
     advance_source_timestamp: IntCounter,
     enable_feedback_int: i32,
     enable_feedback: IntCounter,
+    enable_logging_int: i32,
+    enable_logging: IntCounter,
     enable_persistence_int: i32,
     enable_persistence: IntCounter,
     shutdown_int: i32,
@@ -148,6 +150,8 @@ impl CommandsProcessedMetrics {
                 .with_label_values(&[worker, "advance_source_timestamp"]),
             enable_feedback_int: 0,
             enable_feedback: COMMANDS_PROCESSED_RAW.with_label_values(&[worker, "enable_feedback"]),
+            enable_logging_int: 0,
+            enable_logging: COMMANDS_PROCESSED_RAW.with_label_values(&[worker, "enable_logging"]),
             enable_persistence_int: 0,
             enable_persistence: COMMANDS_PROCESSED_RAW
                 .with_label_values(&[worker, "enable_persistence"]),
@@ -175,6 +179,7 @@ impl CommandsProcessedMetrics {
             }
             SequencedCommand::EnableFeedback(..) => self.enable_feedback_int += 1,
             SequencedCommand::EnablePersistence(..) => self.enable_persistence_int += 1,
+            SequencedCommand::EnableLogging(_) => self.enable_logging_int += 1,
             SequencedCommand::Shutdown { .. } => self.shutdown_int += 1,
             SequencedCommand::AdvanceAllLocalInputs { .. } => {
                 self.advance_all_local_inputs_int += 1

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -30,7 +30,6 @@ use tokio::runtime::Runtime;
 
 use comm::Switchboard;
 use coord::PersistenceConfig;
-use dataflow_types::logging::LoggingConfig;
 use ore::thread::{JoinHandleExt, JoinOnDropHandle};
 use ore::tokio::net::TcpStreamExt;
 
@@ -260,8 +259,6 @@ pub fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
         })
         .collect::<Result<_, io::Error>>()?;
 
-    let logging_config = config.logging_granularity.map(LoggingConfig::new);
-
     // Launch dataflow workers.
     let dataflow_guard = dataflow::serve(
         dataflow_conns,
@@ -269,7 +266,6 @@ pub fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
         config.process,
         switchboard.clone(),
         executor.clone(),
-        logging_config.clone(),
     )
     .map_err(|s| anyhow!("{}", s))?;
 
@@ -283,7 +279,6 @@ pub fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
             switchboard,
             num_timely_workers,
             symbiosis_url: config.symbiosis_url.as_deref(),
-            logging: logging_config.as_ref(),
             logging_granularity: config.logging_granularity,
             data_directory: config.data_directory.as_deref(),
             timestamp: coord::TimestampConfig {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -372,7 +372,6 @@ fn format_row(
 
 impl State {
     pub fn start() -> Result<Self, anyhow::Error> {
-        let logging_config = None;
         let process_id = 0;
 
         let (switchboard, runtime) = comm::Switchboard::local()?;
@@ -384,7 +383,6 @@ impl State {
             switchboard: switchboard.clone(),
             num_timely_workers: NUM_TIMELY_WORKERS,
             symbiosis_url: Some("postgres://"),
-            logging: logging_config.as_ref(),
             data_directory: None,
             executor: &executor,
             logging_granularity: None,
@@ -404,7 +402,6 @@ impl State {
             process_id,
             switchboard,
             runtime.handle().clone(),
-            logging_config,
         )
         .unwrap();
 


### PR DESCRIPTION
The dataflow layer hardcodes several built-in logging sources that are
accessible via SQL. This is somewhat awkward for the coordinator, which
would very much like to be the sole authority on what sources exist in
the system.

The big danger is that both the coord and dataflow crates assign system
IDs, which must never overlap. The current design makes it very hard to
tell what system IDs are in use, and it's easy to accidentally cause
clashes when allocating a new ID.

This commit reworks the dataflow layer to have no opinion on what IDs to
assign to its logging views. The new API looks like so:

    SequencedCommand::EnableLogging(LoggingConfig {
        granularity_ns: u128,
        active_logs: HashMap<LogVariant, GlobalId>,
    })

Essentially, the dataflow layer exposes the log variants it knows how to
maintain, along with an API for installing any subset of the known log
variants with specific IDs. The coordinator is now the sole place where
system IDs are assigned.

A future commit will unify `LogSource`, `LogView`, and `CatalogView`,
which all fall under the umbrella of "built-in system object" and will
be able to share quite a bit of code. The goal here is #913, exposing
`SHOW` data as views, and #2157, supporting pg_catalog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3930)
<!-- Reviewable:end -->
