### PR TITLE
print allocator stats in memory flamegraph

### DIFF
--- a/src/materialized/src/http/templates/flamegraph.html
+++ b/src/materialized/src/http/templates/flamegraph.html
@@ -66,6 +66,11 @@
         </form>
     </div>
     <div id="chart"></div>
+    <div id="extras">
+      {% for extra_line in extras %}
+      <p>{{ extra_line }}</p>
+      {% endfor %}
+    </div>
     <div id="details"></div>
 </div>
 


### PR DESCRIPTION
The DRY principle would demand that instead of copying the human byte formatting logic from javascript, we split it out into an npm package, rewrite materialize in Node, and depend on the same package from both the client and server.

However, I felt that approach had some significant downsides.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3931)
<!-- Reviewable:end -->
