### PR TITLE
sql: fix LATERAL-related panic in try_simplify_quantified_comparison

### DIFF
--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -656,5 +656,12 @@ from ys
 1  -1
 2  1
 
+# Regression test for #3924, in which quantified comparision simplification was
+# not correctly handling LATERAL joins.
+query II
+SELECT * FROM (VALUES (1)), LATERAL (SELECT * FROM (SELECT column1) WHERE true)
+----
+1  1
+
 query error aggregate functions that refer exclusively to outer columns not yet supported
 SELECT (SELECT count(likes.likee)) FROM likes


### PR DESCRIPTION
The try_simplify_quantified_comparison function, which optimizes a SQL
expression pre-decorrelation, needs to walk a SQL expression while
keeping track of the outer relation type. It was not properly updated
for the addition of LATERAL joins, which are an additional expression
variant that introduce a new inner scope.

If we start writing more SQL optimizations, we'll want to figure out how
to package up this logic so it only needs to be written in one place.
But for now, hardcoding it here is the simple fix.

Fix #3924.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3932)
<!-- Reviewable:end -->
