### PR TITLE
sql: ensure duplicated columns have separate names

### DIFF
--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -282,17 +282,4 @@ impl Scope {
             outer_scope: self.outer_scope.clone(),
         }
     }
-
-    /// Removes cruft from planning a single SELECT statement from the scope,
-    /// readying it for use by e.g. an outer SELECT.
-    pub fn scrub(mut self) -> Self {
-        for item in &mut self.items {
-            for name in &mut item.names {
-                name.table_name = None;
-                name.priority = false;
-            }
-            item.expr = None;
-        }
-        self
-    }
 }

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -107,3 +107,11 @@ SELECT EXISTS (SELECT 1)
 ----
 exists
 true
+
+# Check that duplicated columns with different names retain their different
+# names.
+query TT colnames
+SELECT column1, column1 as column2 FROM (VALUES (1))
+----
+column1  column2
+1  1


### PR DESCRIPTION
We were previously misnaming duplicated columns in queries. For example,
in

    SELECT column1, column1 AS column2 FROM (VALUES (1))

the correct column names are "column1" and "column2". Before this patch,
we were incorrectly computing the column names as "column2" and
"column2"--essentially, the last name for a duplicated column was being
applied to all columns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3935)
<!-- Reviewable:end -->
