### PR TITLE
Add chaos test verification to release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -84,6 +84,8 @@ in the infrastructure repository. All of these tests can be run in parallel.
   - [ ] The "Time behind external source" dashboard panel in Grafana should have remained
     at 0ms or similar for the entirety of the run.
 
+- [ ] Verify the `chaos_run` container for each of the chaos tests exits successfully.
+
 - [ ] Remove all load test machines.
 
 ## Final release

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -84,7 +84,10 @@ in the infrastructure repository. All of these tests can be run in parallel.
   - [ ] The "Time behind external source" dashboard panel in Grafana should have remained
     at 0ms or similar for the entirety of the run.
 
-- [ ] Verify the `chaos_run` container for each of the chaos tests exits successfully.
+- [ ] Let the chaos tests run for 24 hours, with the following success criteria:
+
+  - [ ] Each chaos test's `chaos_run` container should complete with a `0` exit code. To check
+        this, ssh into each EC2 instance running a chaos test and run `docker ps -a`.
 
 - [ ] Remove all load test machines.
 


### PR DESCRIPTION
We currently have [two chaos tests](https://github.com/MaterializeInc/materialize/blob/main/test/chaos/mzcompose.yml#L139) that should be added to the release verification process. To verify these tests, the release manager just needs to check that the `chaos_run` container exists successfully. 

Also, I'm handling the next release! So I'll be sure to work out any issues that might come up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3936)
<!-- Reviewable:end -->
