### PR TITLE
materialized: configure jemalloc to apply to c dependencies, too

### DIFF
--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = "1"
 tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4"] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-jemallocator = { version = "0.3", features = ["profiling"] }
+jemallocator = { version = "0.3", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 # NOTE: when target-specific features are stabilized [0], we will want
 # to put the jemalloc-specific bits of the prof crate behind a "jemalloc"
 # feature flag so that we can enable the non-jemalloc bits on macOS.


### PR DESCRIPTION
@umanwizard no idea if this actually works!

Notably, this will make librdkafka use jemalloc, which should improve
observability of memory usage at the very least, if not also
improving performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3938)
<!-- Reviewable:end -->
