### PR TITLE
sql: don't mishandle scopes of nested lateral joins

### DIFF
--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -663,5 +663,14 @@ SELECT * FROM (VALUES (1)), LATERAL (SELECT * FROM (SELECT column1) WHERE true)
 ----
 1  1
 
+# Regression test for #3933, in which the query planner mishandled the outer
+# scope of a nested LATERAL join.
+query IIII
+SELECT * FROM
+    (SELECT 1, 1 AS col2),
+    LATERAL (SELECT * FROM (SELECT col2) LEFT JOIN LATERAL (SELECT col2) ON true)
+----
+1  1  1  1
+
 query error aggregate functions that refer exclusively to outer columns not yet supported
 SELECT (SELECT count(likes.likee)) FROM likes


### PR DESCRIPTION
The join planning code needs to keep track of *two* query contexts to
properly support lateral joins, because the left expression exists in an
outer context while the right expression and constraint expression exist
in an inner context.

This commit fixes the issue by just plumbing around the left and right
query contexts appropriately.

Fix #3933.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3942)
<!-- Reviewable:end -->
