### PR TITLE
Allow differential join to use an arrangement for first input.

### DIFF
--- a/src/dataflow/src/render/join.rs
+++ b/src/dataflow/src/render/join.rs
@@ -9,8 +9,12 @@
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arrange;
+use differential_dataflow::operators::arrange::arrangement::Arranged;
 use differential_dataflow::operators::join::JoinCore;
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
+use differential_dataflow::trace::BatchReader;
+use differential_dataflow::trace::Cursor;
+use differential_dataflow::trace::TraceReader;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
@@ -187,34 +191,27 @@ where
                     .chain(next_vals.iter().map(|i| prior_arities[*input] + *i))
                     .collect();
 
-                // Pre-test for the arrangement existence, so that we can populate it if the
-                // collection is present but the arrangement is not.
-                if self.arrangement(&inputs[*input], &next_keys[..]).is_none() {
-                    // The join may be faulty, and announce keys for an arrangement we have
-                    // not formed. This *shouldn't* happen, but we prefer to do something
-                    // sane rather than panic.
-                    if self.collection(&inputs[*input]).is_some() {
-                        let arrange_by = RelationExpr::ArrangeBy {
-                            input: Box::new(inputs[*input].clone()),
-                            keys: vec![next_keys[..].to_vec()],
-                        };
-                        self.render_arrangeby(&arrange_by, Some("MissingArrangement"));
-                    } else {
-                        panic!("Arrangement alarmingly absent!");
-                    }
-                }
-
                 let (j, es) = if input_index == 0 && start_arr.is_some() {
                     // if a starting arrangement has been specified, use that
                     let start_arr = start_arr.as_ref().unwrap();
                     match self.arrangement(&inputs[*start], start_arr) {
                         Some(ArrangementFlavor::Local(oks, es)) => {
-                            errs = errs.concat(&es.as_collection(|k, _v| k.clone()));
-                            self.differential_join(oks, &inputs[*input], &next_keys[..], next_vals)
+                            let (j, next_es) = self.differential_join(
+                                oks,
+                                &inputs[*input],
+                                &next_keys[..],
+                                next_vals,
+                            );
+                            (j, es.as_collection(|k, _v| k.clone()).concat(&next_es))
                         }
                         Some(ArrangementFlavor::Trace(_gid, oks, es)) => {
-                            errs = errs.concat(&es.as_collection(|k, _v| k.clone()));
-                            self.differential_join(oks, &inputs[*input], &next_keys[..], next_vals)
+                            let (j, next_es) = self.differential_join(
+                                oks,
+                                &inputs[*input],
+                                &next_keys[..],
+                                next_vals,
+                            );
+                            (j, es.as_collection(|k, _v| k.clone()).concat(&next_es))
                         }
                         None => {
                             unreachable!("Start arrangement not present");
@@ -236,11 +233,17 @@ where
                             Ok((key, row))
                         }
                     });
-                    errs = errs.concat(&es);
                     let prev_keyed = prev_keyed
                         .arrange_named::<OrdValSpine<_, _, _, _>>(&format!("JoinStage: {}", input));
-                    self.differential_join(prev_keyed, &inputs[*input], &next_keys[..], next_vals)
+                    let (j, next_es) = self.differential_join(
+                        prev_keyed,
+                        &inputs[*input],
+                        &next_keys[..],
+                        next_vals,
+                    );
+                    (j, es.concat(&next_es))
                 };
+
                 joined = j;
                 errs = errs.concat(&es);
 
@@ -282,9 +285,9 @@ where
         }
     }
 
-    /// Joins the next input to the arranged version of the join of previous inputs.
-    /// This is split into its own method to enable reuse of code with different
-    /// types of `prev_keyed`.
+    /// Looks up the arrangement for the next input and joins it to the arranged
+    /// version of the join of previous inputs. This is split into its own method
+    /// to enable reuse of code with different types of `prev_keyed`.
     fn differential_join<J>(
         &mut self,
         prev_keyed: J,
@@ -295,48 +298,68 @@ where
     where
         J: JoinCore<G, Row, Row, expr::Diff>,
     {
+        // Pre-test for the arrangement existence, so that we can populate it if the
+        // collection is present but the arrangement is not.
+        if self.arrangement(next_input, next_keys).is_none() {
+            // The join may be faulty, and announce keys for an arrangement we have
+            // not formed. This *shouldn't* happen, but we prefer to do something
+            // sane rather than panic.
+            if self.collection(next_input).is_some() {
+                let arrange_by = RelationExpr::ArrangeBy {
+                    input: Box::new(next_input.clone()),
+                    keys: vec![next_keys.to_vec()],
+                };
+                self.render_arrangeby(&arrange_by, Some("MissingArrangement"));
+            } else {
+                panic!("Arrangement alarmingly absent!");
+            }
+        }
+
         match self.arrangement(next_input, next_keys) {
-            Some(ArrangementFlavor::Local(oks, es)) => {
-                let mut row_packer = repr::RowPacker::new();
-                (
-                    prev_keyed.join_core(&oks, move |_keys, old, new| {
-                        let prev_datums = old.unpack();
-                        let next_datums = new.unpack();
-                        // TODO: We could in principle apply some predicates here, and avoid
-                        // constructing output rows that will be filtered out soon.
-                        Some(
-                            row_packer.pack(
-                                prev_datums
-                                    .iter()
-                                    .chain(next_vals.iter().map(|i| &next_datums[*i])),
-                            ),
-                        )
-                    }),
-                    es.as_collection(|k, _v| k.clone()),
-                )
-            }
-            Some(ArrangementFlavor::Trace(_gid, oks, es)) => {
-                let mut row_packer = repr::RowPacker::new();
-                (
-                    prev_keyed.join_core(&oks, move |_keys, old, new| {
-                        let prev_datums = old.unpack();
-                        let next_datums = new.unpack();
-                        // TODO: We could in principle apply some predicates here, and avoid
-                        // constructing output rows that will be filtered out soon.
-                        Some(
-                            row_packer.pack(
-                                prev_datums
-                                    .iter()
-                                    .chain(next_vals.iter().map(|i| &next_datums[*i])),
-                            ),
-                        )
-                    }),
-                    es.as_collection(|k, _v| k.clone()),
-                )
-            }
+            Some(ArrangementFlavor::Local(oks, es)) => (
+                self.differential_join_inner(prev_keyed, oks, next_vals),
+                es.as_collection(|k, _v| k.clone()),
+            ),
+            Some(ArrangementFlavor::Trace(_gid, oks, es)) => (
+                self.differential_join_inner(prev_keyed, oks, next_vals),
+                es.as_collection(|k, _v| k.clone()),
+            ),
             None => {
                 unreachable!("Arrangement absent despite explicit construction");
             }
         }
+    }
+
+    /// Joins the arrangement for `next_input` to the arranged version of the
+    /// join of previous inputs. This is split into its own method to enable
+    /// reuse of code with different types of `next_input`.
+    fn differential_join_inner<J, Tr2>(
+        &mut self,
+        prev_keyed: J,
+        next_input: Arranged<G, Tr2>,
+        next_vals: Vec<usize>,
+    ) -> Collection<G, Row>
+    where
+        J: JoinCore<G, Row, Row, expr::Diff>,
+        Tr2: TraceReader<Key = Row, Val = Row, Time = G::Timestamp, R = expr::Diff>
+            + Clone
+            + 'static,
+        Tr2::Batch: BatchReader<Row, Tr2::Val, G::Timestamp, expr::Diff> + 'static,
+        Tr2::Cursor: Cursor<Row, Tr2::Val, G::Timestamp, expr::Diff> + 'static,
+    {
+        let mut row_packer = repr::RowPacker::new();
+        prev_keyed.join_core(&next_input, move |_keys, old, new| {
+            let prev_datums = old.unpack();
+            let next_datums = new.unpack();
+            // TODO: We could in principle apply some predicates here, and avoid
+            // constructing output rows that will be filtered out soon.
+            Some(
+                row_packer.pack(
+                    prev_datums
+                        .iter()
+                        .chain(next_vals.iter().map(|i| &next_datums[*i])),
+                ),
+            )
+        })
     }
 }

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -407,9 +407,14 @@ impl JoinImplementation {
     fn fmt_with(&self, input_chains: &[usize]) -> String {
         use JoinImplementation::*;
         match self {
-            Differential(pos, inputs) => format!(
-                "Differential %{} {}",
+            Differential((pos, first_arr), inputs) => format!(
+                "Differential %{}{} {}",
                 input_chains[*pos],
+                if let Some(arr) = first_arr {
+                    format!(".({})", Separated(", ", arr.clone()))
+                } else {
+                    "".to_string()
+                },
                 Separated(
                     " ",
                     inputs

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1149,13 +1149,17 @@ impl AggregateExpr {
 pub enum JoinImplementation {
     /// Perform a sequence of binary differential dataflow joins.
     ///
-    /// The first argument indicates the index of the starting collection, and
-    /// the sequence that follows lists other relation indexes, and the key for
+    /// The first argument indicates 1) the index of the starting collection
+    /// and 2) if it should be arranged, the keys to arrange it by.
+    /// The sequence that follows lists other relation indexes, and the key for
     /// the arrangement we should use when joining it in.
     ///
     /// Each collection index should occur exactly once, either in the first
     /// position or somewhere in the list.
-    Differential(usize, Vec<(usize, Vec<ScalarExpr>)>),
+    Differential(
+        (usize, Option<Vec<ScalarExpr>>),
+        Vec<(usize, Vec<ScalarExpr>)>,
+    ),
     /// Perform independent delta query dataflows for each input.
     ///
     /// The argument is a sequence of plans, for the input collections in order.

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -215,6 +215,10 @@ mod delta_queries {
                 &input_relation[..],
                 prior_arities,
             );
+
+            // A viable delta query requires that, for every order,
+            // there is an arrangement for every input except for 
+            // the starting one.
             if !orders
                 .iter()
                 .all(|o| o.iter().skip(1).all(|(c, _, _)| c.arranged))

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -217,7 +217,7 @@ mod delta_queries {
             );
 
             // A viable delta query requires that, for every order,
-            // there is an arrangement for every input except for 
+            // there is an arrangement for every input except for
             // the starting one.
             if !orders
                 .iter()

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1004,6 +1004,7 @@ ORDER BY su_suppkey
 ----
 %0 =
 | Get materialize.public.supplier (u34)
+| ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.orderline (u19)
@@ -1041,7 +1042,7 @@ ORDER BY su_suppkey
 
 %7 =
 | Join %0 %3 %6 (= #0 #7) (= #8 #9)
-| | implementation = Differential %0 %3.(#0) %6.(#0)
+| | implementation = Differential %0.(#0) %3.(#0) %6.(#0)
 | | demand = (#0..#2, #4, #8)
 | Filter !(isnull(#8))
 | Project (#0..#2, #4, #8)
@@ -1331,6 +1332,7 @@ ORDER BY su_name
 
 %5 =
 | Get materialize.public.stock (u26)
+| ArrangeBy (#0)
 
 %6 =
 | Get materialize.public.orderline (u19)
@@ -1342,7 +1344,7 @@ ORDER BY su_name
 
 %8 =
 | Join %4 %5 %6 %7 (= #11 #33 #39)
-| | implementation = Differential %5 %7.(#0) %6.(#4) %4.()
+| | implementation = Differential %5.(#0) %7.(#0) %6.(#4) %4.()
 | | demand = (#0, #11..#13, #35, #36, #43)
 | Filter "^co.*$" ~(#43), (datetots(#35) > 2010-05-23 12:00:00)
 | Reduce group=(#0, #11, #12, #13) sum(#36)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1069,6 +1069,7 @@ ORDER BY
 ----
 %0 =
 | Get materialize.public.supplier (u8)
+| ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.revenue (u27)
@@ -1083,7 +1084,7 @@ ORDER BY
 
 %3 =
 | Join %0 %1 %2 (= #0 #7) (= #8 #9)
-| | implementation = Differential %0 %1.(#0) %2.(#0)
+| | implementation = Differential %0.(#0) %1.(#0) %2.(#0)
 | | demand = (#0..#2, #4, #8)
 | Project (#0..#2, #4, #8)
 
@@ -1485,6 +1486,7 @@ ORDER BY
 
 %4 =
 | Get materialize.public.partsupp (u11)
+| ArrangeBy (#0)
 
 %5 =
 | Get materialize.public.part (u6)
@@ -1492,7 +1494,7 @@ ORDER BY
 
 %6 =
 | Join %3 %4 %5 (= #11 #16)
-| | implementation = Differential %4 %5.(#0) %3.()
+| | implementation = Differential %4.(#0) %5.(#0) %3.()
 | | demand = (#0, #11..#13, #17)
 | Filter "^forest.*$" ~(#17)
 


### PR DESCRIPTION
Split off from #2164 because I realized this can go in first, and this has sufficient complexity to warrant another PR. 

The Differential Join implementation is now `Differential((usize, Option<Vec<ScalarExpr>>), Vec<(usize, Vec<ScalarExpr>)>)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3944)
<!-- Reviewable:end -->
