### PR TITLE
ci/deploy: try harder not to cache latest redirect

### DIFF
--- a/ci/deploy/deploy_util.py
+++ b/ci/deploy/deploy_util.py
@@ -47,6 +47,7 @@ def set_latest_redirect(platform: str, version: str) -> None:
                 "cp",
                 "--acl=public-read",
                 "--cache-control=no-cache",
+                "--metadata-directive=REPLACE",
                 f"--website-redirect={target}",
                 empty.name,
                 s3_url,


### PR DESCRIPTION
Apparently the `--cache-control=no-cache` has no effect unless you also
set `--metadata-directive=REPLACE`. See if that works.

Fix #3869.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3945)
<!-- Reviewable:end -->
