### PR TITLE
ci/deploy: don't bother setting cache-control headers on redirect

### DIFF
--- a/ci/deploy/deploy_util.py
+++ b/ci/deploy/deploy_util.py
@@ -46,8 +46,6 @@ def set_latest_redirect(platform: str, version: str) -> None:
                 "s3",
                 "cp",
                 "--acl=public-read",
-                "--cache-control=no-cache",
-                "--metadata-directive=REPLACE",
                 f"--website-redirect={target}",
                 empty.name,
                 s3_url,


### PR DESCRIPTION
S3 doesn't respect them at all, it turns out. Don't bother setting them;
instead we'll configure CloudFront not to cache the redirects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3946)
<!-- Reviewable:end -->
