### PR TITLE
sqllogictest: round when casting floats to ints

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -312,7 +312,7 @@ fn format_row(
                 let d = d.unwrap_decimal().with_scale(*s);
                 format!("{:.0}", d)
             }
-            (Type::Integer, ScalarType::Float64) => format!("{:.0}", d.unwrap_float64().trunc()),
+            (Type::Integer, ScalarType::Float64) => (d.unwrap_float64().round() as i64).to_string(),
             (Type::Integer, ScalarType::String) => "0".to_owned(),
             (Type::Integer, ScalarType::Bool) => i8::from(d.unwrap_bool()).to_string(),
 

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -259,7 +259,7 @@ SELECT 1 + CAST ('5' AS double precision)
 ----
 6
 
-query II
+query RR
 SELECT CAST ('+Inf' AS double precision), CAST ('inf' AS double precision)
 ----
 inf inf


### PR DESCRIPTION
This fixes several tests in the full SLT suite which expect rounding
rather than truncation. We seem to have stumbled into this edge case
because of the recent change to widen the output type of SumInt32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3952)
<!-- Reviewable:end -->
