### PR TITLE
chbench: single service workflows

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -404,26 +404,55 @@ mzconduct:
         container: peeker
         seconds: 10
 
-    # Helper workflows
-    bring-up-source-data-postgres:
+    # Brings up materialized for isolated tests, i.e. multi-node where
+    # Materialized and all other components are run independent. Should be used
+    # with cloud-benchmark-infra
+    cloud-benchmark-mz:
+      env:
+        MZ_PORT: 6875
+        KAFKA_HOST: ${INFRA_HOST:-kafka}
+        KAFKA_PORT: 9092
+        SR_HOST: ${INFRA_HOST:-schema-registry}
+        PEEKER_PORT: "16875:16875"
+        MZ_SQL_EXPORTER_PORT: "9400:9399"
       steps:
       - step: start-services
-        services: [materialized,postgres]
+        services: [materialized]
       - step: wait-for-tcp
         host: materialized
         port: 6875
-      - step: wait-for-postgres
-        dbname: postgres
-        timeout_secs: 30
       - step: start-services
-        services: [connector-postgres]
+        services: [prometheus_sql_exporter_mz]
       - step: wait-for-tcp
-        host: connect
-        port: 8083
-        timeout_secs: 120
+        host: ${INFRA_HOST:-kafka}
+        port: 9092
       - step: wait-for-tcp
-        host: schema-registry
+        host: ${INFRA_HOST:-schema-registry}
         port: 8081
+      - step: run
+        service: peeker
+        daemon: true
+        command: --queries ${PEEKER_QUERIES:-loadtest}
+      - step: ensure-stays-up
+        container: peeker
+        seconds: 10
+
+    # Brings up all non-materialized components for isolated load-tests, i.e.
+    # multi-node where Materialized and all other components are run
+    # independent. Should be used with cloud-benchmark-mz
+    cloud-benchmark-infra:
+      env:
+        MZ_HOST: ${MZ_HOST:-materialized}
+        MZ_PORT: 6875
+        MYSQL_PORT: 3306
+        KAFKA_PORT: 9092
+        CC_PORT: 9021
+        MYSQL_EXPORTER_PORT: "9399:9399"
+      steps:
+      - step: workflow
+        workflow: bring-up-mysql-kafka
+      - step: start-services
+        services: [prometheus_sql_exporter_mysql_tpcch]
       - step: drop-kafka-topics
         kafka-container: chbench_kafka_1
         topic_pattern: debezium.tpcch.*
@@ -432,15 +461,19 @@ mzconduct:
         command: >-
           gen
           --warehouses=1
-          --config-file-path=/etc/chbenchmark/mz-default-postgres.cfg
+          --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
+      - step: wait-for-tcp
+        host: ${MZ_HOST:-materialized}
+        port: 6875
+      - step: workflow
+        workflow: heavy-load
 
-    bring-up-source-data-mysql:
+    # Helper workflows
+
+    bring-up-mysql-kafka:
       steps:
       - step: start-services
-        services: [materialized, mysql]
-      - step: wait-for-tcp
-        host: materialized
-        port: 6875
+        services: [mysql]
       - step: wait-for-mysql
         user: root
         password: debezium
@@ -454,6 +487,26 @@ mzconduct:
       - step: wait-for-tcp
         host: schema-registry
         port: 8081
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+
+    # Brings up everything to run chbench unisolated, i.e. local tests.
+    bring-up-source-data-mysql:
+      steps:
+      - step: start-services
+        services: [materialized]
+      - step: wait-for-tcp
+        host: materialized
+        port: 6875
+      - step: workflow
+        workflow: bring-up-mysql-kafka
+      - step: wait-for-tcp
+        host: materialized
+        port: 6875
+      - step: wait-for-tcp
+        host: mysql
+        port: 3306
       - step: drop-kafka-topics
         kafka-container: chbench_kafka_1
         topic_pattern: debezium.tpcch.*
@@ -463,6 +516,52 @@ mzconduct:
           gen
           --warehouses=1
           --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
+
+    bring-up-postgres-kafka:
+      steps:
+      - step: start-services
+        services: [postgres]
+      - step: wait-for-postgres
+        dbname: postgres
+        timeout_secs: 30
+      - step: start-services
+        services: [connector-postgres]
+      - step: wait-for-tcp
+        host: connect
+        port: 8083
+        timeout_secs: 120
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+
+    # Brings up everything to run chbench unisolated, i.e. local tests.
+    bring-up-source-data-postgres:
+      steps:
+      - step: start-services
+        services: [materialized]
+      - step: wait-for-tcp
+        host: materialized
+        port: 6875
+      - step: workflow
+        workflow: bring-up-postgres-kafka
+      - step: wait-for-tcp
+        host: materialized
+        port: 6875
+      - step: wait-for-tcp
+        host: postgres
+        port: 5432
+      - step: drop-kafka-topics
+        kafka-container: chbench_kafka_1
+        topic_pattern: debezium.tpcch.*
+      - step: run
+        service: chbench
+        command: >-
+          gen
+          --warehouses=1
+          --config-file-path=/etc/chbenchmark/mz-default-postgres.cfg
 
     heavy-load:
       steps:
@@ -477,7 +576,7 @@ mzconduct:
          --run-seconds=864000
          -l /dev/stdout
          --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
-         --mz-url=postgresql://materialized:6875/materialize?sslmode=disable
+         --mz-url=postgresql://${MZ_HOST:-materialized}:6875/materialize?sslmode=disable
 
     heavy-load-postgres:
       steps:

--- a/src/peeker/config.toml
+++ b/src/peeker/config.toml
@@ -7,9 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# This config supports bash-like environment variables, e.g.
+# `${ENV_VAR:-default}`. The `default` value is optional, but `peeker`
+# panics if the `ENV_VAR` is not present and no default value is provided.
+
 [[sources]]
-kafka_broker = "kafka:9092"
-schema_registry = "http://schema-registry:8081"
+kafka_broker = "${KAFA_HOST:-kafka}:9092"
+schema_registry = "http://${SR_HOST:-schema-registry}:8081"
 topic_namespace = "debezium.tpcch."
 materialized = false
 names = [

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -411,9 +411,14 @@ lazy_static! {
 fn substitute_config_env_vars(contents: &str) -> String {
     let mut parsed_contents = contents.to_string();
     for cap in BASHLIKE_ENV_VAR_PATTERN.captures_iter(contents) {
-        let val = match env::var(cap.name("var").unwrap().as_str()) {
+        let var = cap.name("var").unwrap().as_str();
+        let val = match env::var(var) {
             Ok(val) => val,
-            Err(_) => cap.name("default").unwrap().as_str().to_string(),
+            Err(_) => cap
+                .name("default")
+                .unwrap_or_else(|| panic!("Env Var is not set and has no default: {}", var))
+                .as_str()
+                .to_string(),
         };
         parsed_contents = parsed_contents.replace(cap.name("declaration").unwrap().as_str(), &val);
     }

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -11,10 +11,13 @@
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
+use std::env;
 use std::result::Result as StdResult;
 use std::time::Duration;
 
+use lazy_static::lazy_static;
 use log::debug;
+use regex::Regex;
 use serde::{Deserialize, Deserializer};
 
 use crate::{Error, Result};
@@ -104,13 +107,16 @@ fn load_config(config_path: Option<String>, cli_queries: Option<String>) -> Resu
         .map(std::fs::read_to_string)
         .unwrap_or_else(|| Ok(DEFAULT_CONFIG.to_string()));
     let conf = match &config_file {
-        Ok(contents) => toml::from_str::<RawConfig>(&contents).map_err(|e| {
-            format!(
-                "Unable to parse config file {}: {}",
-                config_path.as_deref().unwrap_or("DEFAULT"),
-                e
-            )
-        })?,
+        Ok(contents) => {
+            let contents = substitute_config_env_vars(contents);
+            toml::from_str::<RawConfig>(&contents).map_err(|e| {
+                format!(
+                    "Unable to parse config file {}: {}",
+                    config_path.as_deref().unwrap_or("DEFAULT"),
+                    e
+                )
+            })?
+        }
         Err(e) => {
             eprintln!(
                 "unable to read config file {:?}: {}",
@@ -390,4 +396,50 @@ where
 {
     let d = Duration::from_millis(Deserialize::deserialize(deser)?);
     Ok(Some(d))
+}
+
+lazy_static! {
+    static ref BASHLIKE_ENV_VAR_PATTERN: Regex =
+        Regex::new(r"(?P<declaration>\$\{(?P<var>[^:}]+)(:-(?P<default>[^}]+))?\})").unwrap();
+}
+
+/// replace instances of `${VAR:-default}` with a local environment variable if
+/// present or the default value.
+///
+/// # Panics
+/// - If environment variable does not exist and no default value is provided.
+fn substitute_config_env_vars(contents: &str) -> String {
+    let mut parsed_contents = contents.to_string();
+    for cap in BASHLIKE_ENV_VAR_PATTERN.captures_iter(contents) {
+        let val = match env::var(cap.name("var").unwrap().as_str()) {
+            Ok(val) => val,
+            Err(_) => cap.name("default").unwrap().as_str().to_string(),
+        };
+        parsed_contents = parsed_contents.replace(cap.name("declaration").unwrap().as_str(), &val);
+    }
+    parsed_contents
+}
+
+#[test]
+fn test_substitute_config_env_vars() {
+    fn remove_test_vars() {
+        env::remove_var("MZ_TEST_ENV_VAR_NAME");
+        env::remove_var("MZ_TEST_ENV_VAR_DAY");
+    }
+
+    remove_test_vars();
+    let contents =
+        "Hello, ${MZ_TEST_ENV_VAR_NAME:-Sean}; how is your ${MZ_TEST_ENV_VAR_DAY:-Friday}?";
+    let parsed_contents = substitute_config_env_vars(contents);
+    assert_eq!(parsed_contents, "Hello, Sean; how is your Friday?");
+
+    env::set_var("MZ_TEST_ENV_VAR_NAME", "friend");
+    env::set_var("MZ_TEST_ENV_VAR_DAY", "weekend");
+    let parsed_contents = substitute_config_env_vars(contents);
+    let valid_env_var_sub = "Hello, friend; how is your weekend?";
+    if parsed_contents != valid_env_var_sub {
+        remove_test_vars();
+        assert_eq!(parsed_contents, valid_env_var_sub);
+    }
+    remove_test_vars();
 }


### PR DESCRIPTION
@quodlibetor Shuffled things around a little bit to allow code re-use with some new workflows to support spinning up just MZ and just the non-MZ chbench components. I might have gone a little too far in terms of abstracting things, so definitely glad to re-shuffle them if you have a clearer vision.

Included in this change is support for bash-like env vars in Peeker's `toml` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3957)
<!-- Reviewable:end -->
