### PR TITLE
coord: make catalog responsible for installing builtins

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -34,6 +34,14 @@ pub enum Builtin {
 }
 
 impl Builtin {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Builtin::Log(log) => log.name,
+            Builtin::Table(table) => table.name,
+            Builtin::View(view) => view.name,
+        }
+    }
+
     pub fn id(&self) -> GlobalId {
         match self {
             Builtin::Log(log) => log.id,
@@ -452,13 +460,6 @@ impl BUILTINS {
     pub fn tables(&self) -> impl Iterator<Item = &'static BuiltinTable> + '_ {
         self.values().filter_map(|b| match b {
             Builtin::Table(table) => Some(*table),
-            _ => None,
-        })
-    }
-
-    pub fn views(&self) -> impl Iterator<Item = &'static BuiltinView> + '_ {
-        self.values().filter_map(|b| match b {
-            Builtin::View(view) => Some(*view),
             _ => None,
         })
     }

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -1,0 +1,24 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::Path;
+
+/// Configures a catalog.
+#[derive(Debug)]
+pub struct Config<'a> {
+    /// The path to the catalog on disk.
+    ///
+    /// If set to `None`, indicates that an ephemeral in-memory catalog should
+    /// be used.
+    pub path: Option<&'a Path>,
+    /// Whether to enable experimental mode.
+    pub experimental_mode: Option<bool>,
+    /// Whether to enable logging sources and the views that depend upon them.
+    pub enable_logging: bool,
+}

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -126,7 +126,7 @@ impl Action for SqlAction {
         })
         .await?;
 
-        if let Some(data_dir) = &state.data_dir {
+        if let Some(path) = &state.materialized_catalog_path {
             match self.stmt {
                 Statement::CreateDatabase { .. }
                 | Statement::CreateIndex { .. }
@@ -136,7 +136,7 @@ impl Action for SqlAction {
                 | Statement::CreateView { .. }
                 | Statement::DropDatabase { .. }
                 | Statement::DropObjects { .. } => {
-                    let disk_state = coord::dump_catalog(data_dir).map_err(|e| e.to_string())?;
+                    let disk_state = coord::dump_catalog(path).map_err(|e| e.to_string())?;
                     let mem_state = reqwest::get(&format!(
                         "http://{}/internal/catalog",
                         state.materialized_addr,

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -23,7 +23,7 @@ services:
         --aws-region=us-east-2
         --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://ignored@materialized:6875
-        --validate-catalog=/share/mzdata
+        --validate-catalog=/share/mzdata/catalog
         $$*
       - bash
     command: test/testdrive/*.td


### PR DESCRIPTION
Putting the catalog in charge of installing its own builtins is better
separation of concerns and allows for more code reuse. It also paves the
way for a more complicated commit to remove the use of
SourceConnector::Local.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3961)
<!-- Reviewable:end -->
