### PR TITLE
coord,dataflow: un-special-case local inputs

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -39,12 +39,11 @@ use timely::worker::Worker as TimelyWorker;
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
-    DataflowDesc, DataflowError, IndexDesc, MzOffset, PeekResponse, Timestamp,
-    TimestampSourceUpdate, Update,
+    DataflowDesc, DataflowError, MzOffset, PeekResponse, Timestamp, TimestampSourceUpdate, Update,
 };
 use expr::{Diff, GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
 use ore::future::channel::mpsc::ReceiverExt;
-use repr::{Datum, RelationType, Row, RowArena};
+use repr::{Datum, Row, RowArena};
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
@@ -110,18 +109,6 @@ pub enum SequencedCommand {
     CancelPeek {
         /// The identifier of the peek request to cancel.
         conn_id: u32,
-    },
-    /// Create a local input named `index.on_id`
-    CreateLocalInput {
-        /// A name to use for the input.
-        name: String,
-        /// A globally unique identifier to use for the local input's index.
-        index_id: GlobalId,
-        /// Contains the global id of the local input
-        /// and the keys that its index is arranged on
-        index: IndexDesc,
-        /// The relation type of the input.
-        on_type: RelationType,
     },
     /// Insert `updates` into the local input named `id`.
     Insert {
@@ -670,29 +657,12 @@ where
                 }
             }
 
-            SequencedCommand::CreateLocalInput {
-                name,
-                index_id,
-                index,
-                on_type,
-            } => {
-                render::build_local_input(
-                    self.timely_worker,
-                    &mut self.render_state,
-                    index_id,
-                    &name,
-                    index,
-                    on_type,
-                );
-                self.reported_frontiers
-                    .insert(index_id, Antichain::from_elem(0));
-                if let Some(logger) = self.materialized_logger.as_mut() {
-                    logger.log(MaterializedEvent::Frontier(index_id, 0, 1));
-                }
-            }
-
             SequencedCommand::Insert { id, updates } => {
-                if let Some(input) = self.render_state.local_inputs.get_mut(&id) {
+                if self.timely_worker.index() == 0 {
+                    let input = match self.render_state.local_inputs.get_mut(&id) {
+                        Some(input) => input,
+                        None => panic!("local input {} missing for insert", id),
+                    };
                     let mut session = input.handle.session(input.capability.clone());
                     for update in updates {
                         assert!(update.timestamp >= *input.capability.time());

--- a/src/dataflow/src/server/metrics.rs
+++ b/src/dataflow/src/server/metrics.rs
@@ -171,7 +171,6 @@ impl CommandsProcessedMetrics {
             SequencedCommand::DropIndexes(..) => self.drop_indexes_int += 1,
             SequencedCommand::Peek { .. } => self.peek_int += 1,
             SequencedCommand::CancelPeek { .. } => self.cancel_peek_int += 1,
-            SequencedCommand::CreateLocalInput { .. } => self.create_local_input_int += 1,
             SequencedCommand::Insert { .. } => self.insert_int += 1,
             SequencedCommand::AllowCompaction(..) => self.allow_compaction_int += 1,
             SequencedCommand::AdvanceSourceTimestamp { .. } => {
@@ -212,11 +211,6 @@ impl CommandsProcessedMetrics {
         if self.cancel_peek_int > 0 {
             self.cancel_peek.inc_by(self.cancel_peek_int as i64);
             self.cancel_peek_int = 0;
-        }
-        if self.create_local_input_int > 0 {
-            self.create_local_input
-                .inc_by(self.create_local_input_int as i64);
-            self.create_local_input_int = 0;
         }
         if self.insert_int > 0 {
             self.insert.inc_by(self.insert_int as i64);


### PR DESCRIPTION
The only difference between a local source and an external source is
that data comes from a local Timely unordered input rather than Kafka or
a file. Yet the coordinator and dataflow layers had a separate API for
describing how to build a local input. This complicated the code
unnecessarily, so remove it. Local sources are now built and exported as
an index via DataflowDescs, just like for external sources.

Supersedes #3888.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3963)
<!-- Reviewable:end -->
