### PR TITLE
coord,sql: separate tables and sources

### DIFF
--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -176,6 +176,8 @@ pub trait CatalogItem {
 /// The type of a [`CatalogItem`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CatalogItemType {
+    /// A table.
+    Table,
     /// A source.
     Source,
     /// A sink.
@@ -189,6 +191,7 @@ pub enum CatalogItemType {
 impl fmt::Display for CatalogItemType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            CatalogItemType::Table => f.write_str("table"),
             CatalogItemType::Source => f.write_str("source"),
             CatalogItemType::Sink => f.write_str("sink"),
             CatalogItemType::View => f.write_str("view"),

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -82,7 +82,7 @@ pub enum Plan {
     },
     CreateTable {
         name: FullName,
-        source: Source,
+        table: Table,
         if_not_exists: bool,
     },
     CreateView {
@@ -160,6 +160,12 @@ pub enum Plan {
         to_name: String,
         object_type: ObjectType,
     },
+}
+
+#[derive(Clone, Debug)]
+pub struct Table {
+    pub create_sql: String,
+    pub desc: RelationDesc,
 }
 
 #[derive(Clone, Debug)]

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -34,7 +34,6 @@ use anyhow::{anyhow, bail};
 use chrono::Utc;
 use tokio_postgres::types::FromSql;
 
-use dataflow_types::SourceConnector;
 use pgrepr::Jsonb;
 use repr::adt::decimal::Significand;
 use repr::{Datum, RelationDesc, RelationType, Row, RowPacker, ScalarType};
@@ -45,7 +44,7 @@ use sql::ast::{
 use sql::catalog::Catalog;
 use sql::names::FullName;
 use sql::normalize;
-use sql::plan::{scalar_type_from_sql, MutationKind, Plan, PlanContext, Source, StatementContext};
+use sql::plan::{scalar_type_from_sql, MutationKind, Plan, PlanContext, StatementContext, Table};
 
 pub struct Postgres {
     client: tokio_postgres::Client,
@@ -213,14 +212,13 @@ END $$;
                 self.table_types
                     .insert(name.clone(), (sql_types, desc.clone()));
 
-                let source = Source {
+                let table = Table {
                     create_sql: stmt.to_string(),
-                    connector: SourceConnector::Local,
                     desc,
                 };
                 Plan::CreateTable {
                     name,
-                    source,
+                    table,
                     if_not_exists: *if_not_exists,
                 }
             }

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -170,10 +170,10 @@ SHOW VIEWS WHERE "VIEWS" = 'u'
 query T
 SHOW SOURCES
 ----
-xyz
 
 statement error supported
 SHOW SOURCES WHERE "SOURCES" = 'u'
+----
 
 # SHOW OBJECTS
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -174,17 +174,14 @@ materialize
  VIEWS
 -------
 
-# Check default sources and views in mz_catalog.
+# Check default sources, tables, and views in mz_catalog.
 
 > SHOW SOURCES FROM mz_catalog
 mz_arrangement_sharing
 mz_arrangement_sizes
-mz_avro_ocf_sinks
-mz_catalog_names
 mz_dataflow_channels
 mz_dataflow_operator_addresses
 mz_dataflow_operators
-mz_kafka_sinks
 mz_materialization_dependencies
 mz_materializations
 mz_peek_active
@@ -192,9 +189,14 @@ mz_peek_durations
 mz_scheduling_elapsed
 mz_scheduling_histogram
 mz_scheduling_parks
+mz_worker_materialization_frontiers
+
+> SHOW TABLES FROM mz_catalog
+mz_avro_ocf_sinks
+mz_catalog_names
+mz_kafka_sinks
 mz_view_foreign_keys
 mz_view_keys
-mz_worker_materialization_frontiers
 
 > SHOW VIEWS FROM mz_catalog
 mz_addresses_with_unit_length

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -203,12 +203,9 @@ SOURCES                              TYPE   MATERIALIZED
 --------------------------------------------------------
 mz_arrangement_sharing               SYSTEM true
 mz_arrangement_sizes                 SYSTEM true
-mz_avro_ocf_sinks                    SYSTEM true
-mz_catalog_names                     SYSTEM true
 mz_dataflow_channels                 SYSTEM true
 mz_dataflow_operator_addresses       SYSTEM true
 mz_dataflow_operators                SYSTEM true
-mz_kafka_sinks                       SYSTEM true
 mz_materialization_dependencies      SYSTEM true
 mz_materializations                  SYSTEM true
 mz_peek_active                       SYSTEM true
@@ -216,9 +213,16 @@ mz_peek_durations                    SYSTEM true
 mz_scheduling_elapsed                SYSTEM true
 mz_scheduling_histogram              SYSTEM true
 mz_scheduling_parks                  SYSTEM true
-mz_view_foreign_keys                 SYSTEM true
-mz_view_keys                         SYSTEM true
 mz_worker_materialization_frontiers  SYSTEM true
+
+> SHOW FULL TABLES FROM mz_catalog
+TABLES                TYPE
+----------------------------
+mz_avro_ocf_sinks     SYSTEM
+mz_catalog_names      SYSTEM
+mz_kafka_sinks        SYSTEM
+mz_view_foreign_keys  SYSTEM
+mz_view_keys          SYSTEM
 
 > SHOW FULL VIEWS FROM mz_catalog
 VIEWS                             TYPE   QUERYABLE MATERIALIZED

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -33,7 +33,6 @@ t
 > SHOW SOURCES;
 SOURCES
 -------
-t
 
 > SHOW INDEXES FROM t;
 Source_or_view        Key_name                          Column_name  Expression  Null   Seq_in_index
@@ -129,7 +128,6 @@ v
 > SHOW SOURCES;
 SOURCES
 -------
-v
 
 > CREATE TABLE t (a int, b text NOT NULL)
 


### PR DESCRIPTION
A table is still a local source at the level of the dataflow layer, but
tables and sources are now treated separately by the sql/coord layers.
This ensures `SHOW SOURCES`/`SHOW TABLES` show different data.

Fix #3904.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3976)
<!-- Reviewable:end -->
