### PR TITLE
expr: make API of RelationExpr::global_uses nicer

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -188,11 +188,7 @@ impl CatalogItem {
         match self {
             CatalogItem::Source(_) => vec![],
             CatalogItem::Sink(sink) => vec![sink.from],
-            CatalogItem::View(view) => {
-                let mut out = Vec::new();
-                view.optimized_expr.as_ref().global_uses(&mut out);
-                out
-            }
+            CatalogItem::View(view) => view.optimized_expr.as_ref().global_uses(),
             CatalogItem::Index(idx) => vec![idx.on],
         }
     }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2238,14 +2238,8 @@ where
         // the compacted arrangements we have at hand. It remains unresolved
         // what to do if it cannot be satisfied (perhaps the query should use
         // a larger timestamp and block, perhaps the user should intervene).
-        let mut uses_ids = Vec::new();
-        source.global_uses(&mut uses_ids);
-
-        let need_to_determine = when == PeekWhen::Immediately;
-
-        uses_ids.sort();
-        uses_ids.dedup();
-        if need_to_determine
+        let mut uses_ids = source.global_uses();
+        if when == PeekWhen::Immediately
             && uses_ids.iter().any(|id| {
                 if let Some(view_state) = self.views.get(id) {
                     !view_state.queryable
@@ -2419,10 +2413,7 @@ where
     /// Initializes managed state and logs the insertion (and removal of any existing view).
     fn insert_view(&mut self, view_id: GlobalId, view: &catalog::View) {
         self.views.remove(&view_id);
-        let mut uses = Vec::new();
-        view.optimized_expr.as_ref().global_uses(&mut uses);
-        uses.sort();
-        uses.dedup();
+        let uses = view.optimized_expr.as_ref().global_uses();
         self.views.insert(
             view_id,
             ViewState::new(

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -708,15 +708,30 @@ impl RelationExpr {
         }
     }
 
+    /// Returns the distinct global identifiers on which this expression
+    /// depends.
+    ///
+    /// See [`Relationexpr::global_uses_into`] to reuse an existing vector.
+    pub fn global_uses(&self) -> Vec<GlobalId> {
+        let mut out = vec![];
+        self.global_uses_into(&mut out);
+        out.sort();
+        out.dedup();
+        out
+    }
+
     /// Appends global identifiers on which this expression depends to `out`.
-    pub fn global_uses(&self, out: &mut Vec<GlobalId>) {
+    ///
+    /// Unlike [`RelationExpr::global_uses`], this method does not deduplicate
+    /// the global identifiers.
+    pub fn global_uses_into(&self, out: &mut Vec<GlobalId>) {
         if let RelationExpr::Get {
             id: Id::Global(id), ..
         } = self
         {
             out.push(*id);
         }
-        self.visit1(|e| e.global_uses(out))
+        self.visit1(|expr| expr.global_uses_into(out))
     }
 
     /// Applies a fallible `f` to each child `RelationExpr`.


### PR DESCRIPTION
No caller wants to supply their own vector, so just teach the
global_uses method to return a vector by handling the recursive
parameter passing internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3980)
<!-- Reviewable:end -->
