### PR TITLE
coord,sql: fix some table buglets

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1268,6 +1268,16 @@ impl Catalog {
         &self.indexes
     }
 
+    /// Returns the default index for the specified `id`.
+    ///
+    /// Panics if `id` does not exist, or if `id` is not an object on which
+    /// indexes can be built.
+    pub fn default_index_for(&self, id: GlobalId) -> Option<GlobalId> {
+        // The default index is just whatever index happens to appear first in
+        // self.indexes.
+        self.indexes[&id].first().map(|(id, _keys)| *id)
+    }
+
     /// Finds the nearest indexes that can satisfy the views or sources whose
     /// identifiers are listed in `ids`.
     ///

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -298,6 +298,11 @@ impl CatalogEntry {
         }
     }
 
+    /// Reports whether this catalog entry is a table.
+    pub fn is_table(&self) -> bool {
+        matches!(self.item(), CatalogItem::Table(_))
+    }
+
     /// Collects the identifiers of the dataflows that this dataflow depends
     /// upon.
     pub fn uses(&self) -> Vec<GlobalId> {
@@ -896,6 +901,13 @@ impl Catalog {
         }
 
         let temporary_ids = self.temporary_ids(&ops)?;
+        let drop_ids: HashSet<_> = ops
+            .iter()
+            .filter_map(|op| match op {
+                Op::DropItem(id) => Some(*id),
+                _ => None,
+            })
+            .collect();
         let mut actions = Vec::with_capacity(ops.len());
         let mut storage = self.storage();
         let mut tx = storage.transaction()?;
@@ -976,7 +988,20 @@ impl Catalog {
                     }]
                 }
                 Op::DropItem(id) => {
-                    if !self.get_by_id(&id).item().is_temporary() {
+                    let entry = self.get_by_id(&id);
+                    // Prevent dropping a table's default index unless the table
+                    // is being dropped too.
+                    if let CatalogItem::Index(Index { on, .. }) = entry.item() {
+                        if self.get_by_id(on).is_table()
+                            && self.default_index_for(*on) == Some(id)
+                            && !drop_ids.contains(on)
+                        {
+                            return Err(Error::new(ErrorKind::MandatoryTableIndex(
+                                entry.name().to_string(),
+                            )));
+                        }
+                    }
+                    if !entry.item().is_temporary() {
                         tx.remove_item(id)?;
                     }
                     vec![Action::DropItem(id)]

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -34,6 +34,7 @@ pub(crate) enum ErrorKind {
     SchemaNotEmpty(String),
     InvalidTemporaryDependency(String),
     InvalidTemporarySchema,
+    MandatoryTableIndex(String),
     UnsatisfiableLoggingDependency {
         depender_name: String,
     },
@@ -81,6 +82,7 @@ impl std::error::Error for Error {
             | ErrorKind::SchemaNotEmpty(_)
             | ErrorKind::InvalidTemporaryDependency(_)
             | ErrorKind::InvalidTemporarySchema
+            | ErrorKind::MandatoryTableIndex(_)
             | ErrorKind::UnsatisfiableLoggingDependency { .. }
             | ErrorKind::AmbiguousRename { .. }
             | ErrorKind::ExperimentalModeRequired
@@ -119,6 +121,11 @@ impl fmt::Display for Error {
             ErrorKind::InvalidTemporarySchema => {
                 write!(f, "cannot create temporary item in non-temporary schema")
             }
+            ErrorKind::MandatoryTableIndex(index_name) => write!(
+                f,
+                "cannot drop '{}' as it is the default index for a table",
+                index_name
+            ),
             ErrorKind::UnsatisfiableLoggingDependency { depender_name } => write!(
                 f,
                 "catalog item '{}' depends on system logging, but logging is disabled",

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1504,8 +1504,8 @@ where
                 typ: _,
             } = source.as_ref()
             {
-                if let Some((index_id, _)) = self.catalog.indexes()[&id].first() {
-                    (true, *index_id)
+                if let Some(index_id) = self.catalog.default_index_for(*id) {
+                    (true, index_id)
                 } else if materialize {
                     (false, self.catalog.allocate_id()?)
                 } else {
@@ -1769,10 +1769,10 @@ where
         // TODO: The logic that follows is at variance from PEEK logic which consults the
         // "queryable" state of its inputs. We might want those to line up, but it is only
         // a "might".
-        else if let Some((index_id, _)) = self.catalog.indexes()[&source_id].first() {
+        else if let Some(index_id) = self.catalog.default_index_for(source_id) {
             let upper = self
                 .indexes
-                .upper_of(index_id)
+                .upper_of(&index_id)
                 .expect("name missing at coordinator");
 
             if let Some(ts) = upper.get(0) {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1806,6 +1806,16 @@ fn handle_insert(
     match source {
         InsertSource::Query(query) => {
             let table = scx.catalog.get_item(&scx.resolve_item(table_name)?);
+            if table.id().is_system() {
+                bail!("cannot insert into system table '{}'", table.name());
+            }
+            if table.item_type() != CatalogItemType::Table {
+                bail!(
+                    "cannot insert into {} '{}'",
+                    table.item_type(),
+                    table.name()
+                );
+            }
             if let SetExpr::Values(values) = &query.body {
                 let column_info: Vec<(Option<&ColumnName>, &ColumnType)> =
                     table.desc()?.iter().collect();

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -40,6 +40,9 @@ Source_or_view        Key_name                          Column_name  Expression 
 materialize.public.t  materialize.public.t_primary_idx  a            <null>      true              1
 materialize.public.t  materialize.public.t_primary_idx  b            <null>      false             2
 
+! DROP INDEX t_primary_idx
+cannot drop 'materialize.public.t_primary_idx' as it is the default index for a table
+
 > SHOW COLUMNS in t;
 Field      Nullable  Type
 -------------------------
@@ -96,6 +99,15 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 > SELECT * FROM t CROSS JOIN mz_dataflow_operators LIMIT 0
 
 > DROP SOURCE data
+
+# Ensure that tables work after creating a custom index, and that the custom
+# index is not subject to the same no-drop restriction as the default index.
+> CREATE INDEX t_custom_idx ON t (b)
+> SELECT * FROM t;
+a    b
+---------
+1    "a"
+> DROP INDEX t_custom_idx
 
 ! INSERT INTO t (a) VALUES (1, 'a');
 INSERT statement with specified columns not yet supported

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -192,6 +192,13 @@ SOURCES
 ! CREATE TABLE s (a int primary key);
 CREATE TABLE with column constraint: PRIMARY KEY
 
+> CREATE VIEW view AS SELECT 1
+! INSERT INTO view VALUES (1)
+cannot insert into view 'materialize.public.view'
+
+! INSERT INTO mz_kafka_sinks VALUES ('bad', 'bad')
+cannot insert into system table 'mz_catalog.mz_kafka_sinks'
+
 # Test that a fairly large INSERT completes.
 > CREATE TABLE large (a int)
 > INSERT INTO large VALUES


### PR DESCRIPTION
The first commit is a follow-up from #3982 which I forgot to push before merging. The second commit ensures that a table's default index is not dropped, which came up in #3982 and is tracked in #3905. The third commit is another table bug I discovered that I didn't bother filing an issue for.

~I believe the only remaining issue before marking tables non-experimental is #3975.~ We're good to go after this, I believe!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3992)
<!-- Reviewable:end -->
