### PR TITLE
Monotonic TopK and Reduce::{min, max}

### DIFF
--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -281,12 +281,11 @@ where
         if hierarchical {
             if monotonic && is_min_or_max(&func) {
                 use differential_dataflow::operators::iterate::Variable;
-                use differential_dataflow::operators::Consolidate;
                 let delay = std::time::Duration::from_nanos(10_000_000_000);
                 let retractions = Variable::new(&mut partial.scope(), delay.as_millis() as u64);
                 let thinned = partial.concat(&retractions.negate());
                 let result = build_hierarchical(thinned, &func);
-                retractions.set(&partial.concat(&result.negate()).consolidate());
+                retractions.set(&partial.concat(&result.negate()));
                 partial = result
             } else {
                 partial = build_hierarchical(partial, &func)

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -17,7 +17,6 @@ use differential_dataflow::operators::{Reduce, Threshold};
 use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
-use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::DataflowError;
 use expr::{AggregateExpr, AggregateFunc, RelationExpr};
@@ -27,12 +26,6 @@ use repr::{Datum, Row, RowArena, RowPacker};
 use super::context::Context;
 use crate::render::context::Arrangement;
 
-// impl<G, T> Context<G, RelationExpr, Row, T>
-// where
-//     G: Scope,
-//     G::Timestamp: Lattice + Refines<T>,
-//     T: Timestamp + Lattice,
-// {
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
 impl<G> Context<G, RelationExpr, Row, dataflow_types::Timestamp>
 where

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -11,18 +11,16 @@ use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
-use timely::progress::{timestamp::Refines, Timestamp};
 
 use expr::{Diff, RelationExpr};
 use repr::Row;
 
 use crate::render::context::Context;
 
-impl<G, T> Context<G, RelationExpr, Row, T>
+// The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
+impl<G> Context<G, RelationExpr, Row, dataflow_types::Timestamp>
 where
-    G: Scope,
-    G::Timestamp: Lattice + Refines<T>,
-    T: Timestamp + Lattice,
+    G: Scope<Timestamp = dataflow_types::Timestamp>,
 {
     pub fn render_topk(&mut self, relation_expr: &RelationExpr) {
         if let RelationExpr::TopK {
@@ -31,14 +29,83 @@ where
             order_key,
             limit,
             offset,
-            monotonic: _,
+            monotonic,
         } = relation_expr
         {
             let arity = input.arity();
-            use differential_dataflow::operators::reduce::Reduce;
-
-            // self.ensure_rendered(input, scope, worker_index);
             let (ok_input, err_input) = self.collection(input).unwrap();
+
+            // For monotonic inputs, we are able to retract inputs not produced as outputs.
+            if *monotonic {
+                use differential_dataflow::operators::iterate::Variable;
+                use differential_dataflow::operators::Consolidate;
+                let delay = std::time::Duration::from_nanos(10_000_000_000);
+                let retractions = Variable::new(&mut ok_input.scope(), delay.as_millis() as u64);
+                let thinned = ok_input.concat(&retractions.negate());
+                let result = build_topk(thinned, group_key, order_key, *offset, *limit, arity);
+                retractions.set(&ok_input.concat(&result.negate()).consolidate());
+                self.collections
+                    .insert(relation_expr.clone(), (result, err_input));
+            } else {
+                let result = build_topk(ok_input, group_key, order_key, *offset, *limit, arity);
+                self.collections
+                    .insert(relation_expr.clone(), (result, err_input));
+            }
+
+            /// Constructs a TopK dataflow subgraph.
+            fn build_topk<G>(
+                collection: Collection<G, Row, Diff>,
+                group_key: &[usize],
+                order_key: &[expr::ColumnOrder],
+                offset: usize,
+                limit: Option<usize>,
+                arity: usize,
+            ) -> Collection<G, Row, Diff>
+            where
+                G: Scope,
+                G::Timestamp: Lattice,
+            {
+                let group_clone = group_key.to_vec();
+                let mut collection = collection.map({
+                    let mut row_packer = repr::RowPacker::new();
+                    move |row| {
+                        let row_hash = row.hashed();
+                        let datums = row.unpack();
+                        let group_row = row_packer.pack(group_clone.iter().map(|i| datums[*i]));
+                        ((group_row, row_hash), row)
+                    }
+                });
+                // This sequence of numbers defines the shifts that happen to the 64 bit hash
+                // of the record, and has the properties that 1. there are not too many of them,
+                // and 2. each has a modest difference to the next.
+                //
+                // These two properties mean that there should be no reductions on groups that
+                // are substantially larger than `offset + limit` (the largest factor should be
+                // bounded by two raised to the difference between subsequent numbers);
+                if let Some(limit) = limit {
+                    for log_modulus in
+                        [60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4u64].iter()
+                    {
+                        // here we do not apply `offset`, but instead restrict ourself with a limit
+                        // that includes the offset. We cannot apply `offset` until we perform the
+                        // final, complete reduction.
+                        collection = build_topk_stage(
+                            collection,
+                            order_key,
+                            1u64 << log_modulus,
+                            0,
+                            Some(offset + limit),
+                            arity,
+                        );
+                    }
+                }
+
+                // We do a final step, both to make sure that we complete the reduction, and to correctly
+                // apply `offset` to the final group, as we have not yet been applying it to the partially
+                // formed groups.
+                build_topk_stage(collection, order_key, 1u64, offset, limit, arity)
+                    .map(|((_key, _hash), row)| row)
+            }
 
             // To provide a robust incremental orderby-limit experience, we want to avoid grouping
             // *all* records (or even large groups) and then applying the ordering and limit. Instead,
@@ -60,6 +127,7 @@ where
                 G: Scope,
                 G::Timestamp: Lattice,
             {
+                use differential_dataflow::operators::Reduce;
                 let order_clone = order_key.to_vec();
 
                 collection
@@ -130,49 +198,6 @@ where
                         }
                     })
             }
-
-            let group_clone = group_key.to_vec();
-            let mut collection = ok_input.map({
-                let mut row_packer = repr::RowPacker::new();
-                move |row| {
-                    let row_hash = row.hashed();
-                    let datums = row.unpack();
-                    let group_row = row_packer.pack(group_clone.iter().map(|i| datums[*i]));
-                    ((group_row, row_hash), row)
-                }
-            });
-            // This sequence of numbers defines the shifts that happen to the 64 bit hash
-            // of the record, and has the properties that 1. there are not too many of them,
-            // and 2. each has a modest difference to the next.
-            //
-            // These two properties mean that there should be no reductions on groups that
-            // are substantially larger than `offset + limit` (the largest factor should be
-            // bounded by two raised to the difference between subsequent numbers);
-            if let Some(limit) = limit {
-                for log_modulus in
-                    [60, 56, 52, 48, 44, 40, 36, 32, 28, 24, 20, 16, 12, 8, 4u64].iter()
-                {
-                    // here we do not apply `offset`, but instead restrict ourself with a limit
-                    // that includes the offset. We cannot apply `offset` until we perform the
-                    // final, complete reduction.
-                    collection = build_topk_stage(
-                        collection,
-                        order_key,
-                        1u64 << log_modulus,
-                        0,
-                        Some(*offset + *limit),
-                        arity,
-                    );
-                }
-            }
-
-            // We do a final step, both to make sure that we complete the reduction, and to correctly
-            // apply `offset` to the final group, as we have not yet been applying it to the partially
-            // formed groups.
-            let result = build_topk_stage(collection, order_key, 1u64, *offset, *limit, arity)
-                .map(|((_key, _hash), row)| row);
-            self.collections
-                .insert(relation_expr.clone(), (result, err_input));
         }
     }
 }

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -31,6 +31,7 @@ where
             order_key,
             limit,
             offset,
+            monotonic: _,
         } = relation_expr
         {
             let arity = input.arity();

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -38,12 +38,11 @@ where
             // For monotonic inputs, we are able to retract inputs not produced as outputs.
             if *monotonic {
                 use differential_dataflow::operators::iterate::Variable;
-                use differential_dataflow::operators::Consolidate;
                 let delay = std::time::Duration::from_nanos(10_000_000_000);
                 let retractions = Variable::new(&mut ok_input.scope(), delay.as_millis() as u64);
                 let thinned = ok_input.concat(&retractions.negate());
                 let result = build_topk(thinned, group_key, order_key, *offset, *limit, arity);
-                retractions.set(&ok_input.concat(&result.negate()).consolidate());
+                retractions.set(&ok_input.concat(&result.negate()));
                 self.collections
                     .insert(relation_expr.clone(), (result, err_input));
             } else {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -150,6 +150,8 @@ pub enum RelationExpr {
         group_key: Vec<ScalarExpr>,
         /// Expressions which determine values to append to each row, after the group keys.
         aggregates: Vec<AggregateExpr>,
+        /// True iff the input is known to monotonically increase (only addition of records).
+        monotonic: bool,
     },
     /// Groups and orders within each group, limiting output.
     ///
@@ -389,6 +391,7 @@ impl RelationExpr {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 let input_typ = input.typ();
                 let mut column_types = group_key
@@ -631,6 +634,7 @@ impl RelationExpr {
             input: Box::new(self),
             group_key: group_key.into_iter().map(ScalarExpr::Column).collect(),
             aggregates,
+            monotonic: false,
         }
     }
 
@@ -954,6 +958,7 @@ impl RelationExpr {
                 group_key,
                 aggregates,
                 input: _,
+                monotonic: _,
             } => {
                 for s in group_key {
                     s.visit_mut(f);

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -165,6 +165,8 @@ pub enum RelationExpr {
         limit: Option<usize>,
         /// Number of records to skip
         offset: usize,
+        /// True iff the input is known to monotonically increase (only addition of records).
+        monotonic: bool,
     },
     /// Return a dataflow where the row counts are negated
     ///
@@ -651,6 +653,7 @@ impl RelationExpr {
             order_key,
             limit,
             offset,
+            monotonic: false,
         }
     }
 
@@ -976,6 +979,7 @@ impl RelationExpr {
                 order_key: _,
                 limit: _,
                 offset: _,
+                monotonic: _,
             }
             | RelationExpr::Negate { input: _ }
             | RelationExpr::Threshold { input: _ }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -189,6 +189,7 @@ impl ColumnKnowledge {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 let input_knowledge = ColumnKnowledge::harvest(input, knowledge)?;
                 let mut output = group_key

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -148,7 +148,13 @@ pub mod monotonic {
                 input, monotonic, ..
             } => {
                 *monotonic = is_monotonic(input, sources);
-                *monotonic
+                false
+            }
+            RelationExpr::Reduce {
+                input, monotonic, ..
+            } => {
+                *monotonic = is_monotonic(input, sources);
+                false
             }
             RelationExpr::Union { left, right } => {
                 let monotonic_l = is_monotonic(left, sources);

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -126,10 +126,10 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
 /// Analysis to identify monotonic collections, especially TopK inputs.
 pub mod monotonic {
 
-    use std::collections::HashSet;
+    use dataflow_types::{DataflowDesc, Envelope, SourceConnector};
     use expr::RelationExpr;
     use expr::{GlobalId, Id};
-    use dataflow_types::{DataflowDesc, Envelope, SourceConnector};
+    use std::collections::HashSet;
 
     // Determines if a relation is monotonic, and applies any optimizations along the way.
     fn is_monotonic(expr: &mut RelationExpr, sources: &HashSet<GlobalId>) -> bool {
@@ -137,18 +137,16 @@ pub mod monotonic {
             RelationExpr::Get { id, .. } => {
                 if let Id::Global(id) = id {
                     sources.contains(id)
-                } else { false }
-            },
-            RelationExpr::Project { input, .. } => {
-                is_monotonic(input, sources)
-            },
-            RelationExpr::Filter { input, .. } => {
-                is_monotonic(input, sources)
-            },
-            RelationExpr::Map { input, .. } => {
-                is_monotonic(input, sources)
-            },
-            RelationExpr::TopK { input, monotonic, .. } => {
+                } else {
+                    false
+                }
+            }
+            RelationExpr::Project { input, .. } => is_monotonic(input, sources),
+            RelationExpr::Filter { input, .. } => is_monotonic(input, sources),
+            RelationExpr::Map { input, .. } => is_monotonic(input, sources),
+            RelationExpr::TopK {
+                input, monotonic, ..
+            } => {
                 *monotonic = is_monotonic(input, sources);
                 *monotonic
             }
@@ -156,23 +154,26 @@ pub mod monotonic {
                 let monotonic_l = is_monotonic(left, sources);
                 let monotonic_r = is_monotonic(right, sources);
                 monotonic_l && monotonic_r
-            },
-            RelationExpr::ArrangeBy { input, ..} => {
-                is_monotonic(input, sources)
             }
+            RelationExpr::ArrangeBy { input, .. } => is_monotonic(input, sources),
             _ => {
-                expr.visit1_mut(|e| { is_monotonic(e, sources); });
+                expr.visit1_mut(|e| {
+                    is_monotonic(e, sources);
+                });
                 false
-            },
+            }
         }
     }
 
     /// Propagates information about monotonic inputs through views.
     pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) {
-
         let mut monotonic = std::collections::HashSet::new();
         for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-            if let SourceConnector::External { envelope: Envelope::None, .. } = source_desc.connector {
+            if let SourceConnector::External {
+                envelope: Envelope::None,
+                ..
+            } = source_desc.connector
+            {
                 monotonic.insert(source_id.clone());
             }
         }

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -220,6 +220,7 @@ impl Demand {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 let mut new_columns = HashSet::new();
                 // Group keys determine aggregation granularity and are

--- a/src/transform/src/fusion/project.rs
+++ b/src/transform/src/fusion/project.rs
@@ -53,6 +53,7 @@ impl Project {
             input,
             group_key,
             aggregates,
+            monotonic: _,
         } = relation
         {
             if let RelationExpr::Project {

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -335,6 +335,7 @@ impl LiteralLifting {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 let literals = self.action(input, gets);
                 if !literals.is_empty() {

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -394,6 +394,7 @@ impl LiteralLifting {
                 order_key,
                 limit: _,
                 offset: _,
+                monotonic: _,
             } => {
                 let literals = self.action(input, gets);
                 if !literals.is_empty() {

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -189,6 +189,7 @@ impl NonNullRequirements {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 let mut new_columns = HashSet::new();
                 for column in columns {

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -61,6 +61,7 @@ impl NonNullable {
                 input,
                 group_key: _,
                 aggregates,
+                monotonic: _,
             } => {
                 if aggregates.iter().any(|a| {
                     scalar_contains_isnull(&(a).expr)

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -302,6 +302,7 @@ impl PredicatePushdown {
                     input: inner,
                     group_key,
                     aggregates,
+                    monotonic: _,
                 } => {
                     let mut retain = Vec::new();
                     let mut push_down = Vec::new();

--- a/src/transform/src/projection_extraction.rs
+++ b/src/transform/src/projection_extraction.rs
@@ -66,6 +66,7 @@ impl ProjectionExtraction {
             input: _,
             group_key,
             aggregates,
+            monotonic: _,
         } = relation
         {
             // If any entry of aggregates exists earlier in aggregates, we can remove it

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -219,6 +219,7 @@ impl ProjectionLifting {
                 order_key,
                 limit,
                 offset,
+                monotonic: _,
             } => {
                 self.action(input, gets);
                 if let RelationExpr::Project {

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -196,6 +196,7 @@ impl ProjectionLifting {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 // Reduce *absorbs* projections, which is amazing!
                 self.action(input, gets);

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -39,6 +39,7 @@ impl ReduceElision {
             input,
             group_key,
             aggregates,
+            monotonic: _,
         } = relation
         {
             let input_type = input.typ();

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -46,6 +46,7 @@ impl FoldConstants {
                 input,
                 group_key,
                 aggregates,
+                monotonic: _,
             } => {
                 for aggregate in aggregates.iter_mut() {
                     aggregate.expr.reduce(&input.typ());

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -37,6 +37,7 @@ impl ReductionPushdown {
             input,
             group_key,
             aggregates,
+            monotonic: _,
         } = relation
         {
             // Map expressions can be absorbed into the Reduce at no cost.

--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -38,6 +38,7 @@ impl TopKElision {
             order_key: _,
             limit,
             offset,
+            monotonic: _,
         } = relation
         {
             if limit.is_none() && *offset == 0 {


### PR DESCRIPTION
Fixes #3987

This PR introduces a "monotonic" dataflow analysis, which starts from `Envelope::None` sources, and is observed by `RelationExpr::TopK` operators. "Monotonic" collections only insert records, and never remove them. In this case, the `TopK` operator can retract any inputs that are not produced as outputs, allowing it to maintain a compact memory footprint even under unbounded inputs.

For example, loading 8.7M taxi records in and grouping on some very common key, an `order by .. limit 3` query eventually ends up with summed records and maximum batches (across the `TopK` operators) of
```
 operator | sum | max 
----------+-----+-----
      265 |   7 |   2
      267 |   7 |   2
      273 |   7 |   2
      275 |   7 |   2
      281 |   7 |   2
      283 |   7 |   2
      289 |   7 |   2
      291 |   7 |   2
      297 |   7 |   2
      299 |   7 |   2
      305 |   7 |   2
      307 |   7 |   2
      313 |   7 |   2
      315 |   7 |   2
      321 |   7 |   2
      323 |   7 |   2
      329 |   7 |   2
```
meaning it got reduced down to just the input it needed.

This optimization can also be applied to `max` and `min` reductions, but we'll need some additional logic to sort out which aggregations support this (hierarchical, but also some flavor of monotonic or something).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3994)
<!-- Reviewable:end -->
