### PR TITLE
Use timely logging calibration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#316a617b961b4f1c156ab4446b3a59e9b3bd27b4"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4031,12 +4031,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#316a617b961b4f1c156ab4446b3a59e9b3bd27b4"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
 
 [[package]]
 name = "timely_communication"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#316a617b961b4f1c156ab4446b3a59e9b3bd27b4"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#316a617b961b4f1c156ab4446b3a59e9b3bd27b4"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
 
 [[package]]
 name = "timely_sort"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4031,12 +4031,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
 
 [[package]]
 name = "timely_communication"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#e3bb516412180c0f94a03a4811652269a525e55f"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
 
 [[package]]
 name = "timely_sort"

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -327,7 +327,8 @@ where
         // Track time relative to the Unix epoch, rather than when the server
         // started, so that the logging sources can be joined with tables and
         // other real time sources for semi-sensible results.
-        let epoch = Instant::now() - UNIX_EPOCH.elapsed().expect("time went backwards");
+        let now = Instant::now();
+        let unix = UNIX_EPOCH.elapsed().expect("time went backwards");
 
         // Establish loggers first, so we can either log the logging or not, as we like.
         let t_linked = std::rc::Rc::new(EventLink::new());
@@ -345,21 +346,21 @@ where
         // Register each logger endpoint.
         self.timely_worker.log_register().insert_logger(
             "timely",
-            Logger::new(epoch, self.timely_worker.index(), move |time, data| {
+            Logger::new(now, unix, self.timely_worker.index(), move |time, data| {
                 t_logger.publish_batch(time, data)
             }),
         );
 
         self.timely_worker.log_register().insert_logger(
             "differential/arrange",
-            Logger::new(epoch, self.timely_worker.index(), move |time, data| {
+            Logger::new(now, unix, self.timely_worker.index(), move |time, data| {
                 d_logger.publish_batch(time, data)
             }),
         );
 
         self.timely_worker.log_register().insert_logger(
             "materialized",
-            Logger::new(epoch, self.timely_worker.index(), move |time, data| {
+            Logger::new(now, unix, self.timely_worker.index(), move |time, data| {
                 m_logger.publish_batch(time, data)
             }),
         );


### PR DESCRIPTION
This PR uses new timely `Logger::new()` arguments to add a duration offset to the supplied instant for logging. This allows us to wind the instant further back than `Instant` may allow, and in particular use the unix epoch as calibration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/3998)
<!-- Reviewable:end -->
