### PR TITLE
Support mz_database

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -629,8 +629,16 @@ impl Catalog {
     }
 
     /// Returns an iterator over the name of each database in the catalog.
-    pub fn databases(&self) -> impl Iterator<Item = &str> {
+    pub fn list_databases(&self) -> impl Iterator<Item = &str> {
         self.by_name.keys().map(String::as_str)
+    }
+
+    /// Returns a (name, id) pair for each database in the catalog.
+    pub fn databases(&self) -> Vec<(String, i64)> {
+        self.by_name
+            .iter()
+            .map(|(name, db)| (name.clone(), db.id))
+            .collect()
     }
 
     /// Creates a new schema in the `Catalog` for temporary items
@@ -1043,13 +1051,13 @@ impl Catalog {
                 Action::CreateDatabase { id, name } => {
                     info!("create database {}", name);
                     self.by_name.insert(
-                        name,
+                        name.clone(),
                         Database {
                             id,
                             schemas: BTreeMap::new(),
                         },
                     );
-                    OpStatus::CreatedDatabase
+                    OpStatus::CreatedDatabase(name, id)
                 }
 
                 Action::CreateSchema {
@@ -1078,8 +1086,11 @@ impl Catalog {
                 }
 
                 Action::DropDatabase { name } => {
-                    self.by_name.remove(&name);
-                    OpStatus::DroppedDatabase
+                    let id = match self.by_name.remove(&name) {
+                        Some(db) => Some(db.id),
+                        None => None,
+                    };
+                    OpStatus::DroppedDatabase(name, id)
                 }
 
                 Action::DropSchema {
@@ -1378,10 +1389,10 @@ pub enum Op {
 
 #[derive(Debug, Clone)]
 pub enum OpStatus {
-    CreatedDatabase,
+    CreatedDatabase(String, i64),
     CreatedSchema,
     CreatedItem(GlobalId),
-    DroppedDatabase,
+    DroppedDatabase(String, Option<i64>),
     DroppedSchema,
     DroppedItem(CatalogEntry),
     UpdatedItem,
@@ -1473,7 +1484,7 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
     }
 
     fn list_databases<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a> {
-        Box::new(self.catalog.databases())
+        Box::new(self.catalog.list_databases())
     }
 
     fn list_schemas<'a>(

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -16,7 +16,7 @@
 //! versions of Materialize.
 //!
 //! Builtin's names, columns, and types are part of the stable API of
-//! Materialize. Be careful to maintain backwards compatibile when changing
+//! Materialize. Be careful to maintain backwards compatibility when changing
 //! definitions of existing builtins!
 
 use std::collections::BTreeMap;
@@ -235,6 +235,14 @@ lazy_static! {
         id: GlobalId::System(2009),
         index_id: GlobalId::System(2010),
     };
+    pub static ref MZ_DATABASE: BuiltinTable = BuiltinTable {
+        name: "mz_database",
+        desc: RelationDesc::empty()
+            .with_column("global_id", ScalarType::String.nullable(false))
+            .with_column("database", ScalarType::String.nullable(false)),
+        id: GlobalId::System(2011),
+        index_id: GlobalId::System(2012),
+    };
 }
 
 pub const MZ_ADDRESSES_WITH_UNIT_LENGTHS: BuiltinView = BuiltinView {
@@ -432,6 +440,7 @@ lazy_static! {
             Builtin::Table(&MZ_CATALOG_NAMES),
             Builtin::Table(&MZ_KAFKA_SINKS),
             Builtin::Table(&MZ_AVRO_OCF_SINKS),
+            Builtin::Table(&MZ_DATABASE),
             Builtin::View(&MZ_ADDRESSES_WITH_UNIT_LENGTHS),
             Builtin::View(&MZ_DATAFLOW_NAMES),
             Builtin::View(&MZ_DATAFLOW_OPERATOR_DATAFLOWS),

--- a/test/testdrive/mz-catalog.td
+++ b/test/testdrive/mz-catalog.td
@@ -1,0 +1,53 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SHOW DATABASES
+Database
+-------------
+materialize
+
+> SELECT * FROM mz_catalog.mz_database
+global_id   database
+-----------------------
+1           materialize
+
+> CREATE DATABASE dummy
+
+> SHOW DATABASES
+Database
+------------
+materialize
+dummy
+
+> SELECT * FROM mz_catalog.mz_database
+global_id   database
+-----------------------
+1           materialize
+2           dummy
+
+! DROP DATABASE wrong_dummy
+unknown database
+
+> SELECT * FROM mz_catalog.mz_database
+global_id   database
+-----------------------
+1           materialize
+2           dummy
+
+> DROP DATABASE dummy
+
+> SHOW DATABASES
+Database
+-------------
+materialize
+
+> SELECT * FROM mz_catalog.mz_database
+global_id   database
+-----------------------
+1           materialize


### PR DESCRIPTION
One step in https://github.com/MaterializeInc/materialize/issues/2157.

This PR introduces a new `mz_database` system table. `mz_catalog.mz_database` will store the name and id of all databases in a Materialize instance, and will later be used to support `pg_catalog.pg_database`.

Next step: replace `SHOW DATABASE` implementation with `SELECT * FROM mz_catalog.mz_database`.
