### PR TITLE
Reduce frequency of compaction

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -681,11 +681,17 @@ where
                     if !index_state.upper.frontier().is_empty() {
                         let mut compaction_frontier = Antichain::new();
                         for time in index_state.upper.frontier().iter() {
-                            compaction_frontier.insert(time.saturating_sub(compaction_latency_ms));
+                            compaction_frontier.insert(
+                                compaction_latency_ms
+                                    * (time.saturating_sub(compaction_latency_ms)
+                                        / compaction_latency_ms),
+                            );
                         }
-                        index_state.advance_since(&compaction_frontier);
-                        self.since_updates
-                            .push((name.clone(), index_state.since.clone()));
+                        if index_state.since != compaction_frontier {
+                            index_state.advance_since(&compaction_frontier);
+                            self.since_updates
+                                .push((name.clone(), index_state.since.clone()));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR changes the logical compaction to only occur at multiples of the `logical_compaction_window`, which reduces the number of times that it changes. It should still ensure that at least this amount is available, but it may now lag a bit before informing the worker that this is the case.

Previously, any collection that updates frequently reports the changes to its upper frontier to the coordinator. For each change, the logical compaction lower bound is updated. This results in as many compaction notifications as there are changes in the upper bound, potentially many per second even though the window could be a minute.