### PR TITLE
Factor Avro serialization, reduce allocation

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1981,7 +1981,7 @@ mod tests {
         ];
         for (typ, datum, expected) in valid_pairings {
             let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
-            let avro_value = Encoder::new(desc, false).row_to_avro(std::iter::Once(datum));
+            let avro_value = Encoder::new(desc, false).row_to_avro(std::iter::once(datum));
             assert_eq!(
                 Value::Record(vec![("column1".into(), expected)]),
                 avro_value


### PR DESCRIPTION
While learning about Avro encoding, I thought I'd pick things apart a bit for clarity and re-use. It also seemed we could avoid some allocations so I did that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4006)
<!-- Reviewable:end -->
