### PR TITLE
Enable (but do not active) memory profiling by default

### DIFF
--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -12,6 +12,7 @@
 //! (1) Turn jemalloc profiling on and off, and dump heap profiles (`PROF_CTL`)
 //! (2) Parse jemalloc heap files and make them into a hierarchical format (`parse_jeheap` and `collate_stacks`)
 
+use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
 use std::{ffi::CString, io::BufRead, time::Instant};
@@ -23,6 +24,20 @@ use tempfile::NamedTempFile;
 
 use super::{ProfStartTime, StackProfile, WeightedStack};
 use anyhow::bail;
+
+union U {
+    x: &'static u8,
+    y: &'static c_char,
+}
+
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+pub static malloc_conf: Option<&'static c_char> = Some(unsafe {
+    U {
+        x: &b"prof:true,prof_active:false\0"[0],
+    }
+    .y
+});
 
 lazy_static! {
     pub static ref PROF_CTL: Option<Arc<Mutex<JemallocProfCtl>>> = {


### PR DESCRIPTION
This should be okay, but I'll wait for an answer to https://gitter.im/jemalloc/jemalloc?at=5f3fe93749a1df0a129993e6 before landing just in case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4007)
<!-- Reviewable:end -->
