### PR TITLE
coord: remove max_timestamp_batch parameter

### DIFF
--- a/demo/billing/src/config.rs
+++ b/demo/billing/src/config.rs
@@ -86,11 +86,6 @@ pub struct Args {
     #[structopt(long)]
     pub check_sink: bool,
 
-    #[structopt(long)]
-    /// The maximum batch size to associate with this source. If none is supplied, Materialize,
-    /// Materialize will create a source with no upper bound on batch size
-    pub batch_size: Option<u64>,
-
     /// Whether or not the billing demo should create a new source topic.
     #[structopt(
         long,
@@ -155,7 +150,6 @@ impl Args {
             low_memory: self.low_memory,
             seed: self.seed,
             check_sink: self.check_sink,
-            batch_size: self.batch_size,
         }
     }
 
@@ -194,5 +188,4 @@ pub struct MzConfig {
     pub low_memory: bool,
     pub seed: u64,
     pub check_sink: bool,
-    pub batch_size: Option<u64>,
 }

--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -158,7 +158,6 @@ async fn create_materialized_source(config: MzConfig) -> Result<()> {
             config::CSV_SOURCE_NAME,
             randomizer::NUM_CLIENTS,
             config.seed,
-            config.batch_size,
         )
         .await?;
 
@@ -169,7 +168,6 @@ async fn create_materialized_source(config: MzConfig) -> Result<()> {
             &config.kafka_topic,
             config::KAFKA_SOURCE_NAME,
             "billing.Batch",
-            config.batch_size,
         )
         .await?;
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -57,6 +57,11 @@ Wrap your release notes at the 80 character mark.
 
   This fixes a regression introduced in v0.4.1.
 
+- Remove the `max_timestamp_batch_size`
+  [`WITH` option](https://materialize.io/docs/sql/create-source/avro-kafka/#with-options)
+  from sources. Materialize now automatically selects the optimal batch size.
+  **Backwards-incompatible change.**
+
 <span id="v0.4.1"></span>
 ## v0.4.1
 

--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -4,7 +4,6 @@
 `statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics.
 `ignore_source_keys` | `bool` | Default: `false`. If `true`, do not perform optimizations assuming uniqueness of primary keys in schemas.
 `timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently timestamps advance in the system. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
-`max_timestamp_batch_size` | `int` | Default: `0`. Bounds the maximum number of messages that can be assigned to the same batch. A value of 0 creates no upper bound.
 `topic_metadata_refresh_interval_ms` | `int` | Default: `30000`. Sets the frequency in `ms` at which the system checks for new partitions. Accepts values [0,3600000].
 
 #### SSL `WITH` options

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2404,7 +2404,6 @@ fn augment_connector_for_persistence(
             encoding,
             envelope,
             consistency,
-            max_ts_batch,
             ts_frequency,
         } => {
             if !connector.persistence_enabled() {
@@ -2417,7 +2416,6 @@ fn augment_connector_for_persistence(
                         encoding,
                         envelope,
                         consistency,
-                        max_ts_batch,
                         ts_frequency,
                     }))
                 } else {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -476,7 +476,6 @@ pub enum SourceConnector {
         encoding: DataEncoding,
         envelope: Envelope,
         consistency: Consistency,
-        max_ts_batch: i64,
         ts_frequency: Duration,
     },
     Local,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -259,7 +259,6 @@ where
                 encoding,
                 envelope,
                 consistency,
-                max_ts_batch: _,
                 ts_frequency,
             } => {
                 // TODO(benesch): this match arm is hard to follow. Refactor.

--- a/test/testdrive/timestamps-file.td
+++ b/test/testdrive/timestamps-file.td
@@ -32,7 +32,7 @@ a,b
 > CREATE MATERIALIZED VIEW view_byo AS SELECT * FROM data_byo
 
 > CREATE MATERIALIZED SOURCE data_byo2 (a,b) FROM FILE '${testdrive.temp-dir}/data2.csv'
-    WITH (consistency = '${testdrive.temp-dir}/data-consistency.csv', tail=true, max_timestamp_batch_size=2)
+    WITH (consistency = '${testdrive.temp-dir}/data-consistency.csv', tail=true)
     FORMAT CSV WITH HEADER
 
 > CREATE MATERIALIZED VIEW view_byo2 AS SELECT * FROM data_byo2

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -63,7 +63,7 @@ $ kafka-ingest partition=1 format=avro topic=data schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}', max_timestamp_batch_size=3)
+    WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED SOURCE data_empty

--- a/test/testdrive/timestamps-kafka-avro.td
+++ b/test/testdrive/timestamps-kafka-avro.td
@@ -80,7 +80,7 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data3_byo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data3-${testdrive.seed}'
-      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}', max_timestamp_batch_size=2)
+      WITH (consistency = 'testdrive-data-consistency-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED SOURCE data_rt
@@ -89,7 +89,6 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 
 > CREATE MATERIALIZED SOURCE data2_rt
     FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
-       WITH(max_timestamp_batch_size=3)
     FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED VIEW view_byo AS SELECT b, sum(a) FROM data_byo GROUP BY b

--- a/test/testdrive/timestamps-ocf.td
+++ b/test/testdrive/timestamps-ocf.td
@@ -57,7 +57,7 @@ $ avro-ocf-write path=data2.ocf schema=${schema}
 {"a": 1, "b": 1}
 {"a": 2, "b": 2}
 
-> CREATE MATERIALIZED SOURCE data_byo FROM AVRO OCF '${testdrive.temp-dir}/data.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf', tail=true , max_timestamp_batch_size=2)
+> CREATE MATERIALIZED SOURCE data_byo FROM AVRO OCF '${testdrive.temp-dir}/data.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf', tail=true )
 
 > CREATE MATERIALIZED SOURCE data_byo2 FROM AVRO OCF '${testdrive.temp-dir}/data2.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf')
 


### PR DESCRIPTION
Tuning the batch size is hard for users to understand, and provides
less-optimal throughput than just using the natural batch size. Plus the
batch size parameter was ignored for real-time sources, further
increasing confusion. Just remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4009)
<!-- Reviewable:end -->
