### PR TITLE
Clean up persistence code

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -34,10 +34,8 @@ use futures::sink::{Sink, SinkExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use timely::progress::{Antichain, ChangeBatch, Timestamp as _};
 
-use dataflow::{
-    PersistedFileMetadata, PersistenceMessage, SequencedCommand, WorkerFeedback,
-    WorkerFeedbackWithMeta,
-};
+use dataflow::source::persistence::PersistedFileMetadata;
+use dataflow::{PersistenceMessage, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
     AvroOcfSinkConnector, DataflowDesc, ExternalSourceConnector, IndexDesc, KafkaSinkConnector,

--- a/src/coord/src/persistence.rs
+++ b/src/coord/src/persistence.rs
@@ -17,7 +17,7 @@ use futures::select;
 use futures::stream::StreamExt;
 use log::{error, info, trace};
 
-use dataflow::source::persistence::Record;
+use dataflow::source::persistence::{Record, RecordFileMetadata};
 use dataflow::PersistenceMessage;
 use expr::GlobalId;
 
@@ -139,12 +139,11 @@ impl Source {
                 // The offsets we put in this filename are 1-indexed
                 // MzOffsets, so the starting number is off by 1 for something like
                 // Kafka
-                let filename = format!(
-                    "materialize-{}-{}-{}-{}",
+                let filename = RecordFileMetadata::generate_file_name(
                     self.id,
-                    partition_id,
+                    *partition_id,
                     prefix_start_offset.unwrap(),
-                    prefix_end_offset
+                    prefix_end_offset,
                 );
 
                 // We'll write down the data to a file with a `-tmp` prefix to
@@ -249,7 +248,7 @@ impl Persister {
                 }
 
                 if let Some(source) = self.sources.get_mut(&data.source_id) {
-                    source.insert_record(data.partition, data.record);
+                    source.insert_record(data.partition_id, data.record);
                 }
             }
             PersistenceMessage::AddSource(id) => {

--- a/src/coord/src/persistence.rs
+++ b/src/coord/src/persistence.rs
@@ -18,6 +18,7 @@ use futures::select;
 use futures::stream::StreamExt;
 use log::{error, info, trace};
 
+use dataflow::source::persistence::PersistedRecord;
 use dataflow::PersistenceMessage;
 use dataflow_types::Timestamp;
 use expr::GlobalId;
@@ -33,14 +34,6 @@ pub struct PersistenceConfig {
     pub flush_min_records: usize,
     /// Directory where all persistence information is stored.
     pub path: PathBuf,
-}
-
-#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
-struct PersistedRecord {
-    offset: i64,
-    timestamp: Timestamp,
-    key: Vec<u8>,
-    payload: Vec<u8>,
 }
 
 #[derive(Debug)]

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -24,5 +24,5 @@ pub mod source;
 
 pub use server::{
     serve, BroadcastToken, PersistenceMessage, SequencedCommand, WorkerFeedback,
-    WorkerFeedbackWithMeta, WorkerPersistenceData,
+    WorkerFeedbackWithMeta,
 };

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -26,5 +26,3 @@ pub use server::{
     serve, BroadcastToken, PersistenceMessage, SequencedCommand, WorkerFeedback,
     WorkerFeedbackWithMeta, WorkerPersistenceData,
 };
-
-pub use source::PersistedFileMetadata;

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -53,6 +53,7 @@ use crate::logging::materialized::MaterializedEvent;
 use crate::operator::CollectionExt;
 use crate::render::{self, RenderState};
 use crate::server::metrics::Metrics;
+use crate::source::persistence::WorkerPersistenceData;
 
 mod metrics;
 
@@ -155,24 +156,6 @@ pub struct WorkerFeedbackWithMeta {
     pub worker_id: usize,
     /// The feedback itself.
     pub message: WorkerFeedback,
-}
-
-/// Source data that gets sent to the persistence thread to place in persistent storage.
-/// TODO currently fairly Kafka input-centric.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct WorkerPersistenceData {
-    /// Global Id of the Source whose data is being persisted.
-    pub source_id: GlobalId,
-    /// Partition the record belongs to.
-    pub partition: i32,
-    /// Offset where we found the message.
-    pub offset: i64,
-    /// Timestamp assigned to the message.
-    pub timestamp: Timestamp,
-    /// The key of the message.
-    pub key: Vec<u8>,
-    /// The data of the message.
-    pub payload: Vec<u8>,
 }
 
 /// All data and metadata messages that can be sent by dataflow workers or coordinator

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -36,9 +36,10 @@ use crate::server::{
     PersistenceMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
     TimestampMetadataUpdates, WorkerPersistenceData,
 };
+use crate::source::persistence::{PersistedFileMetadata, RecordIter};
 use crate::source::{
-    ConsistencyInfo, PartitionMetrics, PersistedFileMetadata, PersistenceSender, RecordIter,
-    SourceConstructor, SourceInfo, SourceMessage,
+    ConsistencyInfo, PartitionMetrics, PersistenceSender, SourceConstructor, SourceInfo,
+    SourceMessage,
 };
 
 /// Contains all information necessary to ingest data from Kafka

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -36,10 +36,11 @@ use crate::server::{
     PersistenceMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
     TimestampMetadataUpdates,
 };
-use crate::source::persistence::{Record, RecordFileMetadata, RecordIter, WorkerPersistenceData};
+use crate::source::persistence::{
+    PersistenceSender, Record, RecordFileMetadata, RecordIter, WorkerPersistenceData,
+};
 use crate::source::{
-    ConsistencyInfo, PartitionMetrics, PersistenceSender, SourceConstructor, SourceInfo,
-    SourceMessage,
+    ConsistencyInfo, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
 };
 
 /// Contains all information necessary to ingest data from Kafka

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -34,9 +34,9 @@ use log::{error, info, log_enabled, warn};
 
 use crate::server::{
     PersistenceMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
-    TimestampMetadataUpdates, WorkerPersistenceData,
+    TimestampMetadataUpdates,
 };
-use crate::source::persistence::{PersistedFileMetadata, RecordIter};
+use crate::source::persistence::{PersistedFileMetadata, RecordIter, WorkerPersistenceData};
 use crate::source::{
     ConsistencyInfo, PartitionMetrics, PersistenceSender, SourceConstructor, SourceInfo,
     SourceMessage,

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -9,9 +9,7 @@
 
 //! Types related to the creation of dataflow sources.
 
-use anyhow::{anyhow, Error};
 use avro::types::Value;
-use byteorder::{ByteOrder, NetworkEndian};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -29,7 +27,7 @@ use timely::dataflow::{
 use dataflow_types::{
     Consistency, DataEncoding, ExternalSourceConnector, MzOffset, SourceError, Timestamp,
 };
-use expr::{GlobalId, PartitionId, SourceInstanceId};
+use expr::{PartitionId, SourceInstanceId};
 use futures::sink::Sink;
 use lazy_static::lazy_static;
 use log::error;
@@ -39,7 +37,6 @@ use prometheus::{
     register_uint_gauge_vec, DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec,
     IntGaugeVec, UIntGauge, UIntGaugeVec,
 };
-use repr::Row;
 use timely::dataflow::Scope;
 use timely::scheduling::activate::{Activator, SyncActivator};
 use timely::Data;
@@ -55,6 +52,8 @@ mod file;
 mod kafka;
 mod kinesis;
 mod util;
+
+pub mod persistence;
 
 use differential_dataflow::Hashable;
 pub use file::read_file_task;
@@ -732,94 +731,6 @@ impl PartitionMetrics {
                 |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
         }
-    }
-}
-
-/// Iterator through a persisted set of records.
-pub struct RecordIter {
-    data: Vec<u8>,
-    offset: usize,
-}
-
-/// A single record from a persisted file.
-#[derive(Debug, Clone)]
-pub struct Record {
-    offset: i64,
-    time: i64,
-    key: Vec<u8>,
-    data: Vec<u8>,
-}
-
-impl Iterator for RecordIter {
-    type Item = Record;
-
-    fn next(&mut self) -> Option<Record> {
-        if self.offset >= self.data.len() {
-            return None;
-        }
-
-        let (_, data) = self.data.split_at_mut(self.offset);
-        let len = NetworkEndian::read_u32(&data) as usize;
-        assert!(
-            len >= 16,
-            format!(
-                "expected to see at least 16 bytes in record, but saw {}",
-                len
-            )
-        );
-        let (_, rest) = data.split_at_mut(4);
-        let row = rest[..len].to_vec();
-        self.offset += 4 + len;
-
-        let rec = Row::new(row);
-        let row = rec.unpack();
-
-        let offset = row[0].unwrap_int64();
-        let time = row[1].unwrap_int64();
-        let key = row[2].unwrap_bytes();
-        let data = row[3].unwrap_bytes();
-        Some(Record {
-            offset,
-            time,
-            key: key.into(),
-            data: data.into(),
-        })
-    }
-}
-
-/// Describes what is provided from a persisted file.
-#[derive(Debug)]
-pub struct PersistedFileMetadata {
-    /// The source global ID this file represents.
-    pub id: GlobalId,
-    /// The partition ID this file represents.
-    pub partition_id: i32,
-    /// The inclusive lower bound of offsets provided by this file.
-    pub start_offset: i64,
-    /// The exclusive upper bound of offsets provided by this file.
-    pub end_offset: i64,
-    /// Whether or not this file was completely written.
-    pub is_complete: bool,
-}
-
-impl PersistedFileMetadata {
-    /// Parse a file's metadata from its filename.
-    pub fn from_fname(s: &str) -> Result<Self, Error> {
-        let parts: Vec<&str> = s.split('-').collect();
-        if parts.len() < 5 || parts.len() > 6 {
-            return Err(anyhow!(
-                "expected filename to have 5 (or 6) parts, but it was {}",
-                s
-            ));
-        }
-        let is_complete = parts.len() < 6 || parts[5] != "tmp";
-        Ok(PersistedFileMetadata {
-            id: parts[1].parse()?,
-            partition_id: parts[2].parse()?,
-            start_offset: parts[3].parse()?,
-            end_offset: parts[4].parse()?,
-            is_complete,
-        })
     }
 }
 

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::pin::Pin;
 use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use timely::dataflow::{
@@ -28,7 +27,6 @@ use dataflow_types::{
     Consistency, DataEncoding, ExternalSourceConnector, MzOffset, SourceError, Timestamp,
 };
 use expr::{PartitionId, SourceInstanceId};
-use futures::sink::Sink;
 use lazy_static::lazy_static;
 use log::error;
 use prometheus::core::{AtomicI64, AtomicU64};
@@ -44,9 +42,9 @@ use timely::Data;
 use super::source::util::source;
 use crate::operator::StreamExt;
 use crate::server::{
-    PersistenceMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
-    TimestampMetadataUpdates,
+    TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
 };
+use crate::source::persistence::PersistenceSender;
 
 mod file;
 mod kafka;
@@ -94,8 +92,6 @@ pub struct SourceConfig<'a, G> {
     /// Files to read on startup.
     pub persisted_files: Vec<PathBuf>,
 }
-
-type PersistenceSender = Pin<Box<dyn Sink<PersistenceMessage, Error = comm::Error> + Send>>;
 
 #[derive(Clone, Serialize, Deserialize)]
 /// A record produced by a source

--- a/src/dataflow/src/source/persistence.rs
+++ b/src/dataflow/src/source/persistence.rs
@@ -1,0 +1,111 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Types related to source persistence.
+
+use anyhow::{anyhow, Error};
+use byteorder::{ByteOrder, NetworkEndian};
+
+use expr::GlobalId;
+use repr::Row;
+
+/// A single record from a persisted file.
+#[derive(Debug, Clone)]
+pub struct Record {
+    /// Offset of record in a partition.
+    pub offset: i64,
+    /// Timestamp of record.
+    pub time: i64,
+
+    /// Record key.
+    pub key: Vec<u8>,
+    /// Record value
+    pub data: Vec<u8>,
+}
+
+/// Iterator through a persisted set of records.
+pub struct RecordIter {
+    /// Underlying data from which we read the records.
+    pub data: Vec<u8>,
+    /// Offset into the data.
+    pub offset: usize,
+}
+
+impl Iterator for RecordIter {
+    type Item = Record;
+
+    fn next(&mut self) -> Option<Record> {
+        if self.offset >= self.data.len() {
+            return None;
+        }
+
+        let (_, data) = self.data.split_at_mut(self.offset);
+        let len = NetworkEndian::read_u32(&data) as usize;
+        assert!(
+            len >= 16,
+            format!(
+                "expected to see at least 16 bytes in record, but saw {}",
+                len
+            )
+        );
+        let (_, rest) = data.split_at_mut(4);
+        let row = rest[..len].to_vec();
+        self.offset += 4 + len;
+
+        let rec = Row::new(row);
+        let row = rec.unpack();
+
+        let offset = row[0].unwrap_int64();
+        let time = row[1].unwrap_int64();
+        let key = row[2].unwrap_bytes();
+        let data = row[3].unwrap_bytes();
+        Some(Record {
+            offset,
+            time,
+            key: key.into(),
+            data: data.into(),
+        })
+    }
+}
+
+/// Describes what is provided from a persisted file.
+#[derive(Debug)]
+pub struct PersistedFileMetadata {
+    /// The source global ID this file represents.
+    pub id: GlobalId,
+    /// The partition ID this file represents.
+    pub partition_id: i32,
+    /// The inclusive lower bound of offsets provided by this file.
+    pub start_offset: i64,
+    /// The exclusive upper bound of offsets provided by this file.
+    pub end_offset: i64,
+    /// Whether or not this file was completely written.
+    pub is_complete: bool,
+}
+
+impl PersistedFileMetadata {
+    /// Parse a file's metadata from its filename.
+    pub fn from_fname(s: &str) -> Result<Self, Error> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() < 5 || parts.len() > 6 {
+            return Err(anyhow!(
+                "expected filename to have 5 (or 6) parts, but it was {}",
+                s
+            ));
+        }
+        let is_complete = parts.len() < 6 || parts[5] != "tmp";
+        Ok(PersistedFileMetadata {
+            id: parts[1].parse()?,
+            partition_id: parts[2].parse()?,
+            start_offset: parts[3].parse()?,
+            end_offset: parts[4].parse()?,
+            is_complete,
+        })
+    }
+}

--- a/src/dataflow/src/source/persistence.rs
+++ b/src/dataflow/src/source/persistence.rs
@@ -64,7 +64,7 @@ impl Record {
     /// Read a encoded length-prefixed Row from a buffer at an offset, and try
     /// to convert it back to a record. Returns the record and the next offset
     /// to read from, if possible.
-    pub fn read_record(buf: &[u8], offset: usize) -> Option<(Self, usize)> {
+    fn read_record(buf: &[u8], offset: usize) -> Option<(Self, usize)> {
         if offset >= buf.len() {
             return None;
         }
@@ -140,8 +140,6 @@ pub struct RecordFileMetadata {
     pub start_offset: i64,
     /// The exclusive upper bound of offsets provided by this file.
     pub end_offset: i64,
-    /// Whether or not this file was completely written.
-    pub is_complete: bool,
 }
 
 impl RecordFileMetadata {
@@ -188,7 +186,6 @@ impl RecordFileMetadata {
             partition_id: parts[2].parse()?,
             start_offset: parts[3].parse()?,
             end_offset: parts[4].parse()?,
-            is_complete: false,
         }))
     }
 

--- a/src/dataflow/src/source/persistence.rs
+++ b/src/dataflow/src/source/persistence.rs
@@ -12,8 +12,10 @@
 use anyhow::{anyhow, Error};
 use byteorder::{ByteOrder, NetworkEndian};
 
+use dataflow_types::Timestamp;
 use expr::GlobalId;
 use repr::Row;
+use serde::{Deserialize, Serialize};
 
 /// A single record from a persisted file.
 #[derive(Debug, Clone)]
@@ -108,4 +110,35 @@ impl PersistedFileMetadata {
             is_complete,
         })
     }
+}
+
+/// Source data that gets sent to the persistence thread to place in persistent storage.
+/// TODO currently fairly Kafka input-centric.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct WorkerPersistenceData {
+    /// Global Id of the Source whose data is being persisted.
+    pub source_id: GlobalId,
+    /// Partition the record belongs to.
+    pub partition: i32,
+    /// Offset where we found the message.
+    pub offset: i64,
+    /// Timestamp assigned to the message.
+    pub timestamp: Timestamp,
+    /// The key of the message.
+    pub key: Vec<u8>,
+    /// The data of the message.
+    pub payload: Vec<u8>,
+}
+
+/// TODO remove this
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PersistedRecord {
+    /// ...
+    pub offset: i64,
+    /// ...
+    pub timestamp: Timestamp,
+    /// ...
+    pub key: Vec<u8>,
+    /// ...
+    pub payload: Vec<u8>,
 }

--- a/src/dataflow/src/source/persistence.rs
+++ b/src/dataflow/src/source/persistence.rs
@@ -13,17 +13,24 @@
 // not directly usable for some other source types.
 
 use std::path::Path;
+use std::pin::Pin;
 
 use anyhow::{bail, Error};
 use byteorder::{ByteOrder, NetworkEndian, WriteBytesExt};
 
 use dataflow_types::Timestamp;
 use expr::GlobalId;
+use futures::sink::Sink;
 use log::error;
 use repr::{Datum, Row};
 use serde::{Deserialize, Serialize};
 
+use crate::server::PersistenceMessage;
+
 static RECORD_FILE_PREFIX: &str = "materialize";
+
+/// Type alias for object that sends data to the persister.
+pub type PersistenceSender = Pin<Box<dyn Sink<PersistenceMessage, Error = comm::Error> + Send>>;
 
 /// A single record from a source and partition that can be written to disk by
 /// the persister thread, and read back in and sent to the ingest pipeline later.


### PR DESCRIPTION
These commits are largely code movement with a few changes to error handling strategy. I'll squash when I merge but leaving these commits for now just to help myself review. 

basic idea here:

move all of the types around records that are persisted, encoding decoding those records, and interpreting filenames to
src/dataflow/src/source/persistence.rs as this is a responsibility shared by the coordinator and dataflow threads

and then move all of the logic around doing the actual writing of the files, checking which ones are available and things like that
to src/coord/src/persistence.rs (I toyed with changing that to persister.rs but decided against it for now)

hopefully this refactor makes 

- encode / decode invariants easier to review and unit test
- is a clear and useful separation of the logic
- relieves pressure on src/coord.rs and src/dataflow/src/source/mod.rs both of which are pretty large

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4012)
<!-- Reviewable:end -->
