### PR TITLE
materialized: print warnings/errors to stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,6 @@ dependencies = [
  "lazy_static",
  "log",
  "materialized-not-macos",
- "once_cell",
  "openssl",
  "openssl-sys",
  "ore",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -15,7 +15,6 @@ askama = "0.10.3"
 async-trait = "0.1.38"
 backtrace = { version = "0.3.50" }
 cfg-if = "0.1.10"
-chrono = "0.4.15"
 comm = { path = "../comm" }
 compile-time-run = "0.2.11"
 coord = { path = "../coord" }
@@ -28,7 +27,6 @@ include_dir = "0.6.0"
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 log = "0.4.11"
-once_cell = "1.4.0"
 openssl = { version = "0.10.30", features = ["vendored"] }
 openssl-sys = { version = "0.9.58", features = ["vendored"] }
 ore = { path = "../ore" }


### PR DESCRIPTION
Rework how we configure logging so that warnings/errors go to stderr in
addition to the log file. This simplifies the panic handling code, too.
Also remove the use of a global log file variable, which was gross; I
found a way around that using `File::try_clone`.

Closes #4015.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4032)
<!-- Reviewable:end -->
