### PR TITLE
persistence: handle materialized sources properly

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -774,6 +774,15 @@ impl Catalog {
         self.by_id.insert(entry.id, entry);
     }
 
+    pub fn set_source_connector(&mut self, id: GlobalId, source_connector: SourceConnector) {
+        match &mut self.by_id.get_mut(&id).unwrap().item {
+            CatalogItem::Source(source) => {
+                source.connector = source_connector;
+            }
+            _ => unreachable!(),
+        }
+    }
+
     pub fn drop_database_ops(&mut self, name: String) -> Vec<Op> {
         let mut ops = vec![];
         let mut seen = HashSet::new();


### PR DESCRIPTION
Before, when we did the drop-recreate workflow, this would result in us
dropping references to any indexes for the source. This commit changes
the flow to just mutate the source connector in the catalog (which is
safe, since it doesn't get persisted in the catalog).

I'm a little uncertain about the safety of mutative operations like this (and is this the right way to mutate an enum like this)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4038)
<!-- Reviewable:end -->
