### PR TITLE
Optimize outer equijoin planning

### DIFF
--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -979,7 +979,7 @@ fn attempt_outer_join(
                             .column_types
                             .into_iter()
                             .skip(oa)
-                            .map(expr::ScalarExpr::literal_null)
+                            .map(|typ| expr::ScalarExpr::literal_null(typ.nullable(true)))
                             .collect();
 
                         // Add to `result` absent elements, filled with typed nulls.
@@ -1007,7 +1007,7 @@ fn attempt_outer_join(
                             .column_types
                             .into_iter()
                             .skip(oa)
-                            .map(expr::ScalarExpr::literal_null)
+                            .map(|typ| expr::ScalarExpr::literal_null(typ.nullable(true)))
                             .collect();
 
                         // Add to `result` absent elemetns, prepended with typed nulls.

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -915,7 +915,7 @@ fn attempt_outer_join(
                 }
                 if (oa <= *c1 && *c1 < oa + la) && (oa + la <= *c2 && *c2 < oa + la + ra) {
                     l_keys.push(*c1);
-                    r_keys.push(*c2);
+                    r_keys.push(*c2 - la);
                 }
             }
         }

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -295,3 +295,178 @@ SELECT * FROM (
 )
 ----
 foo  true  1
+
+
+# Test for outer join planning.
+query T multiline
+EXPLAIN PLAN FOR
+SELECT * FROM l LEFT JOIN r ON l.la = r.ra
+----
+%0 =
+| Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.r (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1, #3)
+
+%3 =
+| Get materialize.public.l (u1)
+
+%4 =
+| Get %2
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.l (u1)
+
+%7 =
+| Union %5 %6
+| Map null, null
+
+%8 =
+| Get %2
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+
+EOF
+
+query T multiline
+EXPLAIN PLAN FOR
+SELECT * FROM l RIGHT JOIN r ON l.la = r.ra
+----
+%0 =
+| Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.r (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1, #3)
+
+%3 =
+| Get materialize.public.r (u3)
+
+%4 =
+| Get %2
+| Distinct group=(#0)
+| ArrangeBy (#0)
+
+%5 =
+| Join %3 %4 (= #0 #2)
+| | implementation = Differential %3 %4.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%6 =
+| Get materialize.public.r (u3)
+
+%7 =
+| Union %5 %6
+| Map null, null
+| Project (#2, #3, #0, #1)
+
+%8 =
+| Get %2
+| Project (#0, #1, #0, #3)
+
+%9 =
+| Union %7 %8
+
+EOF
+
+query T multiline
+EXPLAIN PLAN FOR
+SELECT * FROM l FULL JOIN r ON l.la = r.ra
+----
+%0 =
+| Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.r (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1, #3)
+
+%3 =
+| Get %2
+| Distinct group=(#0)
+
+%4 =
+| Get materialize.public.r (u3)
+
+%5 =
+| Get %3
+| ArrangeBy (#0)
+
+%6 =
+| Join %4 %5 (= #0 #2)
+| | implementation = Differential %4 %5.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%7 =
+| Get materialize.public.r (u3)
+
+%8 =
+| Union %6 %7
+| Map null, null
+| Project (#2, #3, #0, #1)
+
+%9 =
+| Get materialize.public.l (u1)
+
+%10 =
+| Get %3
+| ArrangeBy (#0)
+
+%11 =
+| Join %9 %10 (= #0 #2)
+| | implementation = Differential %9 %10.(#0)
+| | demand = (#0, #1)
+| Negate
+| Project (#0, #1)
+
+%12 =
+| Get materialize.public.l (u1)
+
+%13 =
+| Union %11 %12
+| Map null, null
+
+%14 =
+| Get %2
+| Project (#0, #1, #0, #3)
+
+%15 =
+| Union %8 %13 %14
+
+EOF


### PR DESCRIPTION
This PR introduces a new plan for outer equijoins that can use substantially less memory than our general plan. For a detailed discussion of the differences, consult #2732. This PR plans outer joins using the second technique there, which I'll sketch here (the code should be improved and commented well enough to make this entirely clear).

In addition to computing the inner join of `left` and `right`, we determine those key columns in `left` that are not present in `right`, and vice versa. For each, we perform another join that picks out of `left` those rows whose key columns are not present in `right` (by matching an element in the above set) and vice versa, and then extend each with null values as appropriate.

This is still very preliminary, and is mostly me bringing some old code up to date. We will want to stitch this in to the join planning, optionally if conditions are met, and also double and triple check its correctness, and that it produces not-insane plans.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4047)
<!-- Reviewable:end -->
