### PR TITLE
peeker env var exposure

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -426,6 +426,7 @@ mzconduct:
         port: 6875
       - step: start-services
         services: [prometheus_sql_exporter_mz]
+      - step: print-env
       - step: wait-for-tcp
         host: ${INFRA_HOST:-kafka}
         port: 9092

--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -571,6 +571,18 @@ class WorkflowStep:
         """Perform the action specified by this step"""
 
 
+@Steps.register("print-env")
+class PrintEnvStep(WorkflowStep):
+    """Prints the `env` `Dict` for this workflow.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def run(self, comp: Composition, workflow: Workflow) -> None:
+        print("Workflow has environment of", workflow.env)
+
+
 @Steps.register("start-services")
 class StartServicesStep(WorkflowStep):
     """


### PR DESCRIPTION
`peeker` doesn't seem to pick up the `SR_HOST` environment variable from the `mzconduct` workflow when deployed through our Terraform set up (though I had gotten this to work locally...although I can no longer run the workflows locally because of some MySQL change that says the images don't have sufficient disk space? Trying to troubleshoot that in parallel/independently). This change just throws `println` at the problem in a way that might be OK to leave in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4054)
<!-- Reviewable:end -->
