### PR TITLE
Provide context for mux error messages

### DIFF
--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use futures::future::TryFutureExt;
 use futures::stream::{Stream, StreamExt};
@@ -126,7 +127,9 @@ impl ConnectionHandler for pgwire::Server {
     }
 
     async fn handle_connection(&self, conn: SniffedStream<TcpStream>) -> Result<(), anyhow::Error> {
-        self.handle_connection(conn).await
+        self.handle_connection(conn)
+            .await
+            .context("in pgwire server")
     }
 }
 
@@ -137,7 +140,7 @@ impl ConnectionHandler for http::Server {
     }
 
     async fn handle_connection(&self, conn: SniffedStream<TcpStream>) -> Result<(), anyhow::Error> {
-        self.handle_connection(conn).await
+        self.handle_connection(conn).await.context("in http server")
     }
 }
 


### PR DESCRIPTION
Currently some users are seeing error logs like this:

    materialized::mux: error handling connection: connection closed before message completed

Which doesn't provide enough context for us to know where the issue is, or what it is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4074)
<!-- Reviewable:end -->
