### PR TITLE
deps: bump rusqlite to v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e704a02bcaecd4a08b93a23f6be59d0bd79cd161e0963e9499165a0a35df7bd"
+checksum = "e3a245984b1b06c291f46e27ebda9f369a94a1ab8461d0e845e23f9ced01f5db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d0fd62e1df63d254714e6cb40d0a0e82e7a1623e7a27f679d851af092ae58b"
+checksum = "4c78c3275d9d6eb684d2db4b2388546b32fdae0586c20a82f3905d21ea78b9ef"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -3189,7 +3189,6 @@ dependencies = [
  "lru-cache",
  "memchr",
  "smallvec",
- "time 0.1.43",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -12,9 +12,8 @@ skip = [
     { name = "miow", version = "0.2.1" },
     { name = "winapi", version = "0.2.8" },
 
-    # Waiting on chrono, hyper, reqwest, and rusqlite to migrate to time v0.2.
-    # time v0.2 is a total rewrite of time v0.1, so this doesn't seem likely
-    # to happen any time soon.
+    # Waiting on chrono to migrate to time v0.2, and hyper v0.13.8, which will
+    # drop hyper's dependency on time altogether.
     { name = "time", version = "0.1.42" },
 ]
 

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -33,7 +33,7 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 regex = "1.3.9"
 repr = { path = "../repr" }
 rusoto_kinesis = "0.45.0"
-rusqlite = { version = "0.23", features = ["bundled", "unlock_notify"] }
+rusqlite = { version = "0.24", features = ["bundled", "unlock_notify"] }
 serde = "1.0"
 serde_json = "1.0.57"
 sql = { path = "../sql" }


### PR DESCRIPTION
The new version of rusqlite depends on time v0.2, which leaves just two
remaining crates that still depend on time v0.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4088)
<!-- Reviewable:end -->
