### PR TITLE
Fix unreachable panic in INSERT code

### DIFF
--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -199,6 +199,11 @@ cannot insert into view 'materialize.public.view'
 ! INSERT INTO mz_kafka_sinks VALUES ('bad', 'bad')
 cannot insert into system table 'mz_catalog.mz_kafka_sinks'
 
+> CREATE TABLE j (time TIMESTAMP NOT NULL);
+
+# Verify that INSERT value is desugared.
+> INSERT INTO j VALUES ((TIMESTAMP '2020-08-28 15:08:00'));
+
 # Test that a fairly large INSERT completes.
 > CREATE TABLE large (a int)
 > INSERT INTO large VALUES


### PR DESCRIPTION
Adds a call to transform_query from handle_insert to fix the following
panic: "entered unreachable code: Expr::Nested not desugared".

Fixes: https://github.com/MaterializeInc/materialize/issues/4097

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4100)
<!-- Reviewable:end -->
