### PR TITLE
coord,testdrive: tests for source persistence

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -768,15 +768,6 @@ impl Catalog {
         self.by_id.insert(entry.id, entry);
     }
 
-    pub fn set_source_connector(&mut self, id: GlobalId, source_connector: SourceConnector) {
-        match &mut self.by_id.get_mut(&id).unwrap().item {
-            CatalogItem::Source(source) => {
-                source.connector = source_connector;
-            }
-            _ => unreachable!(),
-        }
-    }
-
     pub fn drop_database_ops(&mut self, name: String) -> Vec<Op> {
         let mut ops = vec![];
         let mut seen = HashSet::new();


### PR DESCRIPTION
This commit changes the coordinator to augment the source connector with
information about previously persisted data on demand at dataflow import time.
This means that if a user creates multiple views or sinks over a persistent
source over time, they can take advantage of what has been persisted and avoid
rereading from Kafka, even if they don't restart. Additionally, this means that
we no longer need to have a mutating set method in the catalog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4106)
<!-- Reviewable:end -->
