### PR TITLE
Move mz_catalog system table docs

### DIFF
--- a/doc/user/content/sql/system-tables.md
+++ b/doc/user/content/sql/system-tables.md
@@ -8,10 +8,14 @@ menu:
 ---
 
 Like PostgreSQL's `pg_catalog`, Materialize provides a handful of system tables
-containing up-to-date metadata for a given Materialize instance. These tables are
-maintained as [views](../create-view), and can be [queried](../select) as such.
+containing up-to-date metadata for a given Materialize instance.
 
 ## Details
+
+Materialize stores system tables in the `mz_catalog` schema. This schema does not belong
+to a particular database, but is available from all databases in a Materialize instance.
+
+## Tables
 
 ### mz_databases
 
@@ -20,7 +24,7 @@ instance.
 
 Field     | Meaning
 ----------|----------
-global_id | The unique id of the database.
+global_id | The unique ID of the database.
 database  | The name of the database.
 
 ### mz_schemas
@@ -29,21 +33,21 @@ database  | The name of the database.
 
 Field     | Meaning
 ----------|----------
-schema_id | The unique id of the schema.
+schema_id | The unique ID of the schema.
 database_id  | The `global_id` of the database containing the schema.
 name      | The name of the schema.
 type      | Either `"SYSTEM"` or `"USER"`. `"SYSTEM"` schemas are created and maintained by the Materialize system, and cannot be updated or deleted. `"USER"` schemas were created by a user of the system, and can be updated or deleted.
 
 ### mz_columns
 
-`mz_catalog.mz_columns` contains a unique row for each column in every Table, Source, and View
+`mz_catalog.mz_columns` contains a unique row for each column in every table, source, and view
 in a Materialized instance.
 
 Field     | Meaning
 ----------|----------
-qualified_name | The fully qualified name of the Table, Source, or View containing the column. E.g., `materialize.public.table`.
-global_id | The unique id of the Table, Source, or View containing the column.
-field_number | The index of the column in the Table, Source, or View.
+qualified_name | The fully qualified name of the table, source, and view containing the column. E.g., `materialize.public.table`.
+global_id | The unique id of the table, source, and view containing the column.
+field_number | The index of the column in the table, source, and view.
 field | The name of the column, or `?column?` if unknown.
 nullable | Boolean value indicating whether or not the given column can contain a null value.
 type | The data type of the column.

--- a/doc/user/content/sql/system-tables.md
+++ b/doc/user/content/sql/system-tables.md
@@ -1,0 +1,49 @@
+---
+title: "System Tables"
+description: "System tables store metadata about your Materialize instance."
+weight: 14
+menu:
+  main:
+    parent: 'sql'
+---
+
+Like PostgreSQL's `pg_catalog`, Materialize provides a handful of system tables
+containing up-to-date metadata for a given Materialize instance. These tables are
+maintained as [views](../create-view), and can be [queried](../select) as such.
+
+## Details
+
+### mz_databases
+
+`mz_catalog.mz_databases` contains a unique row for each database in a Materialize
+instance.
+
+Field     | Meaning
+----------|----------
+global_id | The unique id of the database.
+database  | The name of the database.
+
+### mz_schemas
+
+`mz_catalog.mz_schemas` contains a unique row for each schema.
+
+Field     | Meaning
+----------|----------
+schema_id | The unique id of the schema.
+database_id  | The `global_id` of the database containing the schema.
+name      | The name of the schema.
+type      | Either `"SYSTEM"` or `"USER"`. `"SYSTEM"` schemas are created and maintained by the Materialize system, and cannot be updated or deleted. `"USER"` schemas were created by a user of the system, and can be updated or deleted.
+
+### mz_columns
+
+`mz_catalog.mz_columns` contains a unique row for each column in every Table, Source, and View
+in a Materialized instance.
+
+Field     | Meaning
+----------|----------
+qualified_name | The fully qualified name of the Table, Source, or View containing the column. E.g., `materialize.public.table`.
+global_id | The unique id of the Table, Source, or View containing the column.
+field_number | The index of the column in the Table, Source, or View.
+field | The name of the column, or `?column?` if unknown.
+nullable | Boolean value indicating whether or not the given column can contain a null value.
+type | The data type of the column.

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -18,6 +18,9 @@
 //! Builtin's names, columns, and types are part of the stable API of
 //! Materialize. Be careful to maintain backwards compatibility when changing
 //! definitions of existing builtins!
+//!
+//! More information about builtin system tables and types can be found in
+//! https://materialize.io/docs/sql/system-tables/.
 
 use std::collections::BTreeMap;
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -944,14 +944,7 @@ where
         );
     }
 
-    /// Inserts a single row into the MZ_DATABASES catalog view, with diff `diff`.
-    ///
-    /// # Arguments
-    ///
-    /// * `global_id`:   Global id of the database.
-    /// * `name`:        Name of the database.
-    /// * `diff`:        The number of updates to perform. A positive number indicates an addition
-    ///                  of the row, a negative number indicates a subtraction.
+    /// Inserts or removes a row from [`builtin::MZ_DATABASES`] based on the supplied `diff`.
     fn update_mz_databases_catalog_view(&mut self, global_id: i64, name: &str, diff: isize) {
         self.update_catalog_view(
             MZ_DATABASES.id,
@@ -962,18 +955,7 @@ where
         )
     }
 
-    /// Inserts a single row into the MZ_SCHEMAS catalog view, with diff `diff`.
-    ///
-    /// # Arguments
-    ///
-    /// * `database_id`: String representation of the database in which the schema is present.
-    ///                  Possible values are an actual database's global id, or "AMBIENT".
-    /// * `schema_id`:   Id of the schema.
-    /// * `schema_name`: Name of the schema.
-    /// * `typ`:         There are two types of schemas: "SYSTEM" and "USER". This classification
-    ///                  impacts which schemas can be updated or deleted.
-    /// * `diff`:        The number of updates to perform. A positive number indicates an addition
-    ///                  of the row, a negative number indicates a subtraction.
+    /// Inserts or removes a row from [`builtin::MZ_SCHEMAS`] based on the supplied `diff`.
     fn update_mz_schemas_catalog_view(
         &mut self,
         database_id: &str,
@@ -996,16 +978,7 @@ where
         )
     }
 
-    /// Inserts a single row into the MZ_COLUMNS catalog view, with diff `diff`.
-    /// The MZ_COLUMNS catalog view contains a row for each column in every Table, Source, and View.
-    ///
-    /// # Arguments
-    ///
-    /// * `desc`:        RelationDesc of the Table, Source, or View.
-    /// * `full_name`:   Full, qualified name of the Table, Source, or View (e.g., "materialize.public.table").
-    /// * `global_id`:   GlobalId of the Table, Source, or View.
-    /// * `diff`:        The number of updates to perform. A positive number indicates an addition
-    ///                  of the row, a negative number indicates a subtraction.
+    /// Inserts or removes a row from [`builtin::MZ_COLUMNS`] based on the supplied `diff`.
     fn update_mz_columns_catalog_view(
         &mut self,
         desc: &RelationDesc,


### PR DESCRIPTION
Moves documentation for new mz_catalog system tables (e.g., mz_catalog.mz_databases)
to a new system-tables.md document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4116)
<!-- Reviewable:end -->
