### PR TITLE
Use monoids for monotonic min/max

### DIFF
--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -315,7 +315,7 @@ where
                         .map(|((key, value), time, _)| (key, time, monoids::MaxMonoid { value }))
                         .as_collection()
                         .count()
-                        .map(|(key, min)| (key, min.value));
+                        .map(|(key, max)| (key, max.value));
                 }
             } else {
                 partial = build_hierarchical(partial, &func)

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -285,27 +285,25 @@ where
                 // in a min/max monoid wrapper. This would permit in-place
                 // compaction, and a substantially smaller memory footprint.
 
-                use timely::dataflow::operators::map::Map;
                 use differential_dataflow::operators::reduce::Count;
+                use timely::dataflow::operators::map::Map;
 
                 // We need two different code paths for min and max, as the
                 // monoid wrapper type encodes the logic.
                 if is_min(&func) {
-                    partial =
-                    partial
+                    partial = partial
                         .inner
                         .map(|((key, value), time, _)| (key, time, monoids::MinMonoid { value }))
                         .as_collection()
                         .count()
-                        .map(|(key, min)|  (key, min.value));
+                        .map(|(key, min)| (key, min.value));
                 } else if is_max(&func) {
-                    partial =
-                    partial
+                    partial = partial
                         .inner
                         .map(|((key, value), time, _)| (key, time, monoids::MaxMonoid { value }))
                         .as_collection()
                         .count()
-                        .map(|(key, min)|  (key, min.value));
+                        .map(|(key, min)| (key, min.value));
                 }
             } else {
                 partial = build_hierarchical(partial, &func)
@@ -635,21 +633,20 @@ fn is_max(func: &AggregateFunc) -> bool {
         | AggregateFunc::MaxTimestampTz => true,
         _ => false,
     }
-
 }
 
 /// Monoids for in-place compaction of monotonic streams.
 pub mod monoids {
-    use serde::{Deserialize, Serialize};
     use repr::{Datum, Row};
+    use serde::{Deserialize, Serialize};
 
     #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
     pub struct MinMonoid {
         pub value: Row,
     }
 
-    use std::ops::AddAssign;
     use differential_dataflow::difference::Semigroup;
+    use std::ops::AddAssign;
 
     impl<'a> AddAssign<&'a Self> for MinMonoid {
         fn add_assign(&mut self, rhs: &'a Self) {
@@ -670,7 +667,9 @@ pub mod monoids {
     }
 
     impl Semigroup for MinMonoid {
-        fn is_zero(&self) -> bool { false }
+        fn is_zero(&self) -> bool {
+            false
+        }
     }
 
     #[derive(Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
@@ -697,6 +696,8 @@ pub mod monoids {
     }
 
     impl Semigroup for MaxMonoid {
-        fn is_zero(&self) -> bool { false }
+        fn is_zero(&self) -> bool {
+            false
+        }
     }
 }

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test monotonicity analyses which derive from ENVELOPE NONE sources.
+# Note that these only test the implementation for monotonic sources,
+# they do not test that the analysis doesn't have false positives on
+# non-monotonic sources.
+
+$ set non-dbz-schema={
+    "type": "record",
+    "name": "cpx",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=non-dbz-data
+
+$ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp=1
+{"a": 1, "b": 2}
+{"a": 2, "b": 3}
+{"a": 2, "b": 4}
+
+> CREATE MATERIALIZED SOURCE non_dbz_data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT a, min(b) FROM non_dbz_data group by a
+a min
+---
+1 2
+2 3
+
+> SELECT a, max(b) FROM non_dbz_data group by a
+a max
+---
+1 2
+2 4


### PR DESCRIPTION
This PR uses differential dataflow's support for monoids (in place of integer counts) to accumulate min and max operators with monotonic (non-removing) inputs. This is appropriate for mins and maxes in a way that doesn't easily generalize to top k (at least, for non-trivial k), so trying it out here first.

There may be some iteration as errors are surfaced. In particular, this implementation will perform less type-based error checking than the prior implementation, which would panic on type errors (this implementation just goes with the smallest non-Datum::Null value, which could in principle be of different types if we have errors elsewhere in the system).

cc @ruchirK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4122)
<!-- Reviewable:end -->
