### PR TITLE
dataflow: compact mz_scheduling_histogram and mz_scheduling_elapsed

### DIFF
--- a/src/dataflow/src/logging/timely.rs
+++ b/src/dataflow/src/logging/timely.rs
@@ -304,12 +304,8 @@ pub fn construct<A: Allocate>(
         let delay = std::time::Duration::from_nanos(10_000_000_000);
 
         // Only keep metrics and histograms for the dataflow operators that currently exist.
-        elapsed = thin_collection(elapsed, delay, |c| {
-            c.semijoin(&operates.map(|(k, _)| k ))
-        });
-        histogram = thin_collection(histogram, delay, |c| {
-            c.semijoin(&operates.map(|(k, _)| k ))
-        });
+        elapsed = thin_collection(elapsed, delay, |c| c.semijoin(&operates.map(|(k, _)| k)));
+        histogram = thin_collection(histogram, delay, |c| c.semijoin(&operates.map(|(k, _)| k)));
 
         let elapsed = elapsed.map({
             let mut row_packer = repr::RowPacker::new();


### PR DESCRIPTION
This is in a pretty rough state rn I just want to get eyes and tests on it.

This commit:

* delays converting data from the operators stream to Rows until after
* the elapsed and histogram streams can join against it to determine which records they need to keep around

TODO:

* see if I broke these logs
* see if I actually helped with memory consumption
* make this logic less repetitive
* potentially remove the need for the tracking hashmaps for operates and addresses using something similar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4127)
<!-- Reviewable:end -->


Touches #979 