### PR TITLE
Cleanup use_indexes.rs

### DIFF
--- a/src/transform/src/use_indexes.rs
+++ b/src/transform/src/use_indexes.rs
@@ -20,13 +20,13 @@ use std::collections::HashMap;
 
 use repr::RelationType;
 
-use crate::{GlobalId, Id, RelationExpr, ScalarExpr, TransformArgs, TransformError};
-use expr::BinaryFunc;
+use crate::TransformArgs;
+use expr::{BinaryFunc, GlobalId, Id, RelationExpr, ScalarExpr};
 
 /// Replaces filters of the form ScalarExpr::Column(i) == ScalarExpr::Literal, where i is a column for
 /// which an index exists, with a
 /// Join{
-///   variables: [(0, i), (1,0)],
+///   equivalences: [(0, i), (1,0)],
 ///   ArrangeBy{input, keys: [ScalarExpr::Column(i)]},
 ///   <constant>
 /// }
@@ -41,19 +41,24 @@ impl crate::Transform for FilterEqualLiteral {
         relation: &mut RelationExpr,
         args: TransformArgs,
     ) -> Result<(), crate::TransformError> {
-        self.transform(relation, args);
+        let mut indexes = HashMap::new();
+        for (on_id, idxs) in args.indexes {
+            let keys = idxs.iter().map(|(_id, keys)| keys.clone()).collect();
+            indexes.insert(*on_id, keys);
+        }
+        self.transform(relation, &indexes);
         Ok(())
     }
 }
 
 impl FilterEqualLiteral {
-    pub fn transform(&self, relation: &mut RelationExpr, args: TransformArgs) {
+    pub fn transform(&self, relation: &mut RelationExpr, indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,) {
         relation.visit_mut(&mut |e| {
-            self.action(e, args.indexes);
+            self.action(e, indexes);
         });
     }
 
-    pub fn action(
+    fn action(
         &self,
         relation: &mut RelationExpr,
         indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
@@ -135,211 +140,6 @@ impl FilterEqualLiteral {
                     }
                 }
             }
-        }
-    }
-}
-
-/// Reorders join equivalence classes in order to make use of indexes and replaces Get statements with
-/// ArrangeBy statements so we can see that the index is being used. Pushes filter statements up
-/// if it allows usage of indexes.
-/// TODO (wangandi): fuse this with JoinOrder so that index information can be used
-#[derive(Debug)]
-pub struct FilterLifting;
-
-impl crate::Transform for FilterLifting {
-    fn transform(
-        &self,
-        relation: &mut RelationExpr,
-        args: TransformArgs,
-    ) -> Result<(), TransformError> {
-        self.transform(relation, args);
-        Ok(())
-    }
-}
-
-impl FilterLifting {
-    pub fn transform(&self, relation: &mut RelationExpr, args: TransformArgs) {
-        relation.visit_mut(&mut |e| {
-            self.action(e, args);
-        });
-    }
-
-    pub fn action(&self, relation: &mut RelationExpr, args: TransformArgs) {
-        if let RelationExpr::Join {
-            inputs, variables, ..
-        } = relation
-        {
-            // find the keys being joined on for each input
-            let mut join_keys_by_input = vec![Vec::new(); inputs.len()];
-            for equivalence in variables.iter_mut() {
-                equivalence.sort();
-                assert_ne!(equivalence[0].0, equivalence[1].0);
-                // We assume the equivalence classes are sorted, and that each relation is included
-                // only once in an equivalence class
-                for (input_num, column) in equivalence.iter().skip(1) {
-                    join_keys_by_input[*input_num].push(*column)
-                }
-            }
-            // for each input, find if there is an index corresponding to keys being joined on
-            let mut matching_index_by_input = Vec::new();
-            for (input_num, (join_keys, join_input)) in join_keys_by_input
-                .into_iter()
-                .zip(inputs.iter())
-                .enumerate()
-            {
-                if let RelationExpr::Filter { input, predicates } = join_input {
-                    // if none of the predicates refer to join keys, it can be lifted
-                    if predicates.iter().all(|p| {
-                        let support = p.support();
-                        !join_keys.iter().any(|k| support.contains(k))
-                    }) {
-                        add_matching_index_by_input(
-                            &**input,
-                            args.indexes,
-                            input_num,
-                            join_keys,
-                            &mut matching_index_by_input,
-                        );
-                    }
-                } else {
-                    add_matching_index_by_input(
-                        join_input,
-                        args.indexes,
-                        input_num,
-                        join_keys,
-                        &mut matching_index_by_input,
-                    );
-                }
-            }
-            if !matching_index_by_input.is_empty() {
-                // do a topological sort of the variables. There exists a directed edge from
-                // equivalence class x to class y if there exist a variable z in x and
-                // a variable b in y such that there exists an index where z and b are keys,
-                // and z comes right before b.
-                let mut incoming_edges = std::iter::repeat(vec![])
-                    .take(variables.len())
-                    .collect::<Vec<_>>();
-                for (input_num, index) in matching_index_by_input.iter() {
-                    for k in 1..index.len() {
-                        if let ScalarExpr::Column(c_from) = index[k - 1] {
-                            if let ScalarExpr::Column(c_to) = index[k] {
-                                let from_class = variables
-                                    .iter()
-                                    .position(|eq| eq.contains(&(*input_num, c_from)));
-                                let to_class = variables
-                                    .iter()
-                                    .position(|eq| eq.contains(&(*input_num, c_to)));
-                                if let Some(from_position) = from_class {
-                                    if let Some(to_position) = to_class {
-                                        if !incoming_edges[to_position].contains(&from_position) {
-                                            incoming_edges[to_position].push(from_position)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                let mut new_variables = Vec::new();
-                while let Some(position) = incoming_edges.iter().position(|edges| edges.is_empty())
-                {
-                    new_variables.push(variables.remove(position));
-                    incoming_edges.remove(position);
-                    for edges in incoming_edges.iter_mut() {
-                        *edges = edges
-                            .iter()
-                            .filter_map(|e| match e {
-                                e if *e == position => None,
-                                e if *e > position => Some(e - 1),
-                                _ => Some(*e),
-                            })
-                            .collect();
-                    }
-                }
-                // if there is a cycle in the topological sort, don't bother sorting
-                //the rest of the variables
-                new_variables.append(variables);
-                *variables = new_variables;
-                // TODO(wangandi): considering turning the filters into wrappers instead of lifting them
-                // reorder the variables to match the key + convert input to arrangement if the variable
-                // rearrangement is a success
-                let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-                let input_arities = input_types
-                    .iter()
-                    .map(|i| i.column_types.len())
-                    .collect::<Vec<_>>();
-                let mut offset = 0;
-                let mut prior_arities = Vec::new();
-                for input in 0..inputs.len() {
-                    prior_arities.push(offset);
-                    offset += input_arities[input];
-                }
-                let mut lifted_predicates = Vec::new();
-                for (input_num, index) in matching_index_by_input {
-                    // if there was a cycle in the topological sort, test that the index can be used
-                    // in this variable ordering.
-                    if !incoming_edges.is_empty() {
-                        let mut index_iter = index.iter();
-                        let mut current_key = index_iter.next();
-                        for variable in variables.iter() {
-                            if let Some(key) = current_key {
-                                if let ScalarExpr::Column(c) = key {
-                                    if variable.contains(&(input_num, *c)) {
-                                        current_key = index_iter.next();
-                                    }
-                                }
-                            } else {
-                                break;
-                            }
-                        }
-                        if current_key.is_some() {
-                            continue;
-                        }
-                    }
-                    if let RelationExpr::Filter { input, predicates } = &mut inputs[input_num] {
-                        for predicate in predicates {
-                            let mut predicate = predicate.clone();
-                            predicate.permute(
-                                &(prior_arities[input_num]
-                                    ..(prior_arities[input_num] + input_arities[input_num]))
-                                    .collect::<Vec<_>>(),
-                            );
-                            lifted_predicates.push(predicate);
-                        }
-                        inputs[input_num] = input.take_dangerous();
-                    }
-                    inputs[input_num] = inputs[input_num].clone().arrange_by(&[index]);
-                }
-                // put an outer filter around the join if any filters were lifted.
-                if !lifted_predicates.is_empty() {
-                    *relation = relation.take_dangerous().filter(lifted_predicates);
-                }
-            }
-        }
-    }
-}
-
-fn add_matching_index_by_input(
-    join_input: &RelationExpr,
-    indexes: &HashMap<GlobalId, Vec<Vec<ScalarExpr>>>,
-    input_num: usize,
-    join_keys: Vec<usize>,
-    matching_index_by_input: &mut Vec<(usize, Vec<ScalarExpr>)>,
-) {
-    if let RelationExpr::Get {
-        id: Id::Global(id), ..
-    } = join_input
-    {
-        let index_keys = indexes.get(id).and_then(|indexes| {
-            indexes.iter().find(|ik| {
-                ik.len() == join_keys.len()
-                    && join_keys
-                        .iter()
-                        .all(|k| ik.contains(&ScalarExpr::Column(*k)))
-            })
-        });
-        if let Some(index_keys) = index_keys {
-            matching_index_by_input.push((input_num, index_keys.clone()));
         }
     }
 }


### PR DESCRIPTION
Split off from #2164 to make reviewing easier.

Because the FilterEqualLiteral transform was not used, after a bunch of months, it's gotten to the state where it no longer compiles if it's added back in. This fixes FilterEqualLiteral so that it does compile. Also, I remove the transform `FilterLifting` since `JoinImplementation` is several months old.

In commit 1:
* `FilterLifting` is removed.
* The `TransformArgs.indexes` is transformed into the form that `FilterEqualLiteral` accepts.

In commit 2:
* In light of join equivalences taking scalar expressions instead of column numbers, there is a lot of simplification to the join-to-filter code. Constructing a second constant input is no longer necessary. Extracting the column numbers from the ScalarExpr is no longer necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4131)
<!-- Reviewable:end -->
