### PR TITLE
coord: add integer_datetimes server var

### DIFF
--- a/src/coord/src/session/session.rs
+++ b/src/coord/src/session/session.rs
@@ -58,6 +58,12 @@ const EXTRA_FLOAT_DIGITS: ServerVar<&i32> = ServerVar {
     description: "Adjusts the number of digits displayed for floating-point values (PostgreSQL).",
 };
 
+const INTEGER_DATETIMES: ServerVar<&bool> = ServerVar {
+    name: unicase::Ascii::new("integer_datetimes"),
+    value: &true,
+    description: "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL).",
+};
+
 const SEARCH_PATH: ServerVar<&[&str]> = ServerVar {
     name: unicase::Ascii::new("search_path"),
     value: &["mz_catalog", "pg_catalog", "public", "mz_temp"],
@@ -104,6 +110,7 @@ pub struct Session {
     database: SessionVar<str>,
     date_style: ServerVar<&'static str>,
     extra_float_digits: SessionVar<i32>,
+    integer_datetimes: ServerVar<&'static bool>,
     search_path: ServerVar<&'static [&'static str]>,
     server_version: ServerVar<&'static str>,
     sql_safe_updates: SessionVar<bool>,
@@ -131,6 +138,7 @@ impl Session {
             database: SessionVar::new(&DATABASE),
             date_style: DATE_STYLE,
             extra_float_digits: SessionVar::new(&EXTRA_FLOAT_DIGITS),
+            integer_datetimes: INTEGER_DATETIMES,
             search_path: SEARCH_PATH,
             server_version: SERVER_VERSION,
             sql_safe_updates: SessionVar::new(&SQL_SAFE_UPDATES),
@@ -152,6 +160,7 @@ impl Session {
             database: SessionVar::new(&DATABASE),
             date_style: DATE_STYLE,
             extra_float_digits: SessionVar::new(&EXTRA_FLOAT_DIGITS),
+            integer_datetimes: INTEGER_DATETIMES,
             search_path: SEARCH_PATH,
             server_version: SERVER_VERSION,
             sql_safe_updates: SessionVar::new(&SQL_SAFE_UPDATES),
@@ -178,6 +187,7 @@ impl Session {
             &self.database,
             &self.date_style,
             &self.extra_float_digits,
+            &self.integer_datetimes,
             &self.search_path,
             &self.server_version,
             &self.sql_safe_updates,
@@ -195,6 +205,7 @@ impl Session {
             &self.client_encoding,
             &self.date_style,
             &self.server_version,
+            &self.integer_datetimes,
         ]
     }
 
@@ -219,6 +230,8 @@ impl Session {
             Ok(&self.date_style)
         } else if name == EXTRA_FLOAT_DIGITS.name {
             Ok(&self.extra_float_digits)
+        } else if name == INTEGER_DATETIMES.name {
+            Ok(&self.integer_datetimes)
         } else if name == SEARCH_PATH.name {
             Ok(&self.search_path)
         } else if name == SERVER_VERSION.name {
@@ -252,6 +265,8 @@ impl Session {
             bail!("parameter {} is read only", DATE_STYLE.name);
         } else if name == EXTRA_FLOAT_DIGITS.name {
             self.extra_float_digits.set(value)
+        } else if name == INTEGER_DATETIMES.name {
+            bail!("parameter {} is read only", INTEGER_DATETIMES.name);
         } else if name == SEARCH_PATH.name {
             bail!("parameter {} is read only", SEARCH_PATH.name);
         } else if name == SERVER_VERSION.name {
@@ -298,6 +313,11 @@ impl Session {
     /// Returns the value of the `extra_float_digits` configuration parameter.
     pub fn extra_float_digits(&self) -> i32 {
         *self.extra_float_digits.value()
+    }
+
+    /// Returns the value of the `integer_datetimes` configuration parameter.
+    pub fn integer_datetimes(&self) -> bool {
+        *self.integer_datetimes.value
     }
 
     /// Returns the value of the `search_path` configuration parameter.

--- a/src/coord/src/session/var.rs
+++ b/src/coord/src/session/var.rs
@@ -57,6 +57,24 @@ impl Var for ServerVar<&'static [&'static str]> {
     }
 }
 
+impl Var for ServerVar<&'static bool> {
+    fn name(&self) -> &'static str {
+        &self.name
+    }
+
+    fn value(&self) -> String {
+        match self.value {
+            true => "on",
+            false => "off",
+        }
+        .to_string()
+    }
+
+    fn description(&self) -> &'static str {
+        self.description
+    }
+}
+
 /// A `ServerVar` is the default value for a configuration parameter.
 #[derive(Debug)]
 pub struct ServerVar<V> {

--- a/test/lang/java/smoketest/SmokeTest.java
+++ b/test/lang/java/smoketest/SmokeTest.java
@@ -16,6 +16,7 @@ import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 
 class SmokeTest {
     private Connection conn;
@@ -30,6 +31,11 @@ class SmokeTest {
             port = "6875";
         String url = String.format("jdbc:postgresql://%s:%s/", host, port);
         conn = DriverManager.getConnection(url);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException, java.lang.ClassNotFoundException {
+        conn.close();
     }
 
     @Test
@@ -51,6 +57,19 @@ class SmokeTest {
         Assertions.assertTrue(rs.next());
         Assertions.assertEquals("42", rs.getString(1));
         Assertions.assertEquals(42, rs.getInt(1));
+        rs.close();
+        stmt.close();
+    }
+
+    // Regression for #4117.
+    @Test
+    void testBinaryTimestamp() throws SQLException, ClassNotFoundException {
+        Class.forName("org.postgresql.jdbc.PgConnection");
+        conn.unwrap(org.postgresql.jdbc.PgConnection.class).setForceBinary(true);
+        PreparedStatement stmt = conn.prepareStatement("SELECT '2010-01-02'::timestamp");
+        ResultSet rs = stmt.executeQuery();
+        Assertions.assertTrue(rs.next());
+        Assertions.assertEquals("2010-01-02 00:00:00", rs.getString(1));
         rs.close();
         stmt.close();
     }

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -12,6 +12,7 @@ application_name       ""                                         "Sets the appl
 client_encoding        UTF8                                       "Sets the client's character set encoding (PostgreSQL)."
 database               materialize                                "Sets the current database (CockroachDB)."
 extra_float_digits     3                                          "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
+integer_datetimes      on                                         "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
 DateStyle              "ISO, MDY"                                 "Sets the display format for date and time values (PostgreSQL)."
 search_path            "mz_catalog, pg_catalog, public, mz_temp"  "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
 server_version         9.5.0                                      "Shows the server version (PostgreSQL)."
@@ -66,3 +67,6 @@ serializable
 
 ! SET transaction_isolation = 'read committed'
 parameter transaction_isolation is read only
+
+! SET integer_datetimes = false
+parameter integer_datetimes is read only


### PR DESCRIPTION
This variable has been hardcoded to on since postgres 10. It affects how
jdbc (and perhaps other drivers) interpret binary encoded timestamps. The
encoding we are using corresponds to the hardcoded on setting.

Fixes #4117

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4132)
<!-- Reviewable:end -->
