### PR TITLE
chbench q08 rewrite

### DIFF
--- a/demo/chbench/chbench/mz-default-mysql.cfg
+++ b/demo/chbench/chbench/mz-default-mysql.cfg
@@ -138,7 +138,7 @@ all_queries: (
      query:
         "SELECT\n"
         "    extract(year FROM o_entry_d) AS l_year,\n"
-        "    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share\n"
+        "    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END AS mkt_share\n"
         "FROM debezium_tpcch_item, debezium_tpcch_supplier, debezium_tpcch_stock, debezium_tpcch_orderline, debezium_tpcch_order, debezium_tpcch_customer, debezium_tpcch_nation n1, debezium_tpcch_nation n2, debezium_tpcch_region\n"
         "WHERE i_id = s_i_id\n"
         "AND ol_i_id = s_i_id\n"

--- a/demo/chbench/chbench/mz-default-postgres.cfg
+++ b/demo/chbench/chbench/mz-default-postgres.cfg
@@ -138,7 +138,7 @@ all_queries: (
      query:
         "SELECT\n"
         "    extract(year FROM o_entry_d) AS l_year,\n"
-        "    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share\n"
+        "    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END AS mkt_share\n"
         "FROM debezium_tpcch_item, debezium_tpcch_supplier, debezium_tpcch_stock, debezium_tpcch_orderline, debezium_tpcch_order, debezium_tpcch_customer, debezium_tpcch_nation n1, debezium_tpcch_nation n2, debezium_tpcch_region\n"
         "WHERE i_id = s_i_id\n"
         "AND ol_i_id = s_i_id\n"

--- a/demo/chbench/chbench/src/dialect/HanaDialect.h
+++ b/demo/chbench/chbench/src/dialect/HanaDialect.h
@@ -427,7 +427,7 @@ class HanaDialect : public Dialect {
         // TPC-H-Query 8
         "select\n"
         "	extract(year from o_entry_d) as l_year,\n"
-        "	sum(case when n2.n_name = 'GERMANY' then ol_amount else 0 end) / sum(ol_amount) as mkt_share\n"
+        "	sum(case when n2.n_name = 'GERMANY' then ol_amount else 0 end) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END as mkt_share\n"
         "from\n"
         "	TPCCH.item, TPCCH.supplier, TPCCH.stock, TPCCH.orderline, TPCCH.\"ORDER\", TPCCH.customer, TPCCH.nation n1, TPCCH.nation n2, TPCCH.region\n"
         "where\n"

--- a/demo/chbench/chbench/src/dialect/MySqlDialect.h
+++ b/demo/chbench/chbench/src/dialect/MySqlDialect.h
@@ -394,7 +394,7 @@ class MySqlDialect : public Dialect {
         // TPC-H-Query 8
         "select\n"
         "	extract(year from o_entry_d) as l_year,\n"
-        "	sum(case when n2.n_name = 'GERMANY' then ol_amount else 0 end) / sum(ol_amount) as mkt_share\n"
+        "	sum(case when n2.n_name = 'GERMANY' then ol_amount else 0 end) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END as mkt_share\n"
         "from\n"
         "	tpcch.item, tpcch.supplier, tpcch.stock, tpcch.orderline, tpcch.order, tpcch.customer, tpcch.nation n1, tpcch.nation n2, tpcch.region\n"
         "where\n"

--- a/demo/chbench/chbench/src/dialect/PostgresDialect.h
+++ b/demo/chbench/chbench/src/dialect/PostgresDialect.h
@@ -439,7 +439,7 @@ class PostgresDialect : public Dialect {
         // TPC-H-Query 8
         "select\n"
         "	extract(year from o_entry_d) as l_year,\n"
-        "	sum(case when n2.n_name = 'GERMANY' then ol_amount else 0 end) / sum(ol_amount) as mkt_share\n"
+        "	sum(case when n2.n_name = 'GERMANY' then ol_amount else 0 end) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END as mkt_share\n"
         "from\n"
         "	tpcch.item, tpcch.supplier, tpcch.stock, tpcch.orderline, tpcch.order, tpcch.customer, tpcch.nation n1, tpcch.nation n2, tpcch.region\n"
         "where\n"

--- a/src/peeker/config.toml
+++ b/src/peeker/config.toml
@@ -222,7 +222,7 @@ name = "q08"
 query = """
 SELECT
     extract(year FROM o_entry_d) AS l_year,
-    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share
+    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END AS mkt_share
 FROM item, supplier, stock, orderline, "order", customer, nation n1, nation n2, region
 WHERE i_id = s_i_id
   AND ol_i_id = s_i_id

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -592,7 +592,7 @@ query T multiline
 EXPLAIN PLAN FOR
 SELECT
     EXTRACT(year FROM o_entry_d) AS l_year,
-    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / sum(ol_amount) AS mkt_share
+    sum(CASE WHEN n2.n_name = 'GERMANY' THEN ol_amount ELSE 0 END) / CASE WHEN sum(ol_amount) = 0 THEN 1 ELSE sum(ol_amount) END AS mkt_share
 FROM item, supplier, stock, orderline, "order", customer, nation n1, nation n2, region
 WHERE i_id = s_i_id
 AND ol_i_id = s_i_id

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -657,7 +657,7 @@ ORDER BY l_year
 | | demand = (#0, #4, #38, #44, #75, #79)
 | Filter !(isnull(#0)), "^.*b$" ~(#4), (#79 = "EUROPE"), (#0 < 1000), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
 | Reduce group=(date_part_year_tstz(datetotstz(#44))) sum(if (#75 = "GERMANY") then {#38} else {0dec}) sum(#38)
-| Map (((#1 * 10000000dec) / #2) * 10dec)
+| Map (((#1 * 10000000dec) / if (#2 = 0dec) then {100dec} else {#2}) * 10dec)
 | Project (#0, #3)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)


### PR DESCRIPTION
Query number 8 can contain a division that might be 0 at some point in our use of it; the length of time that this appears to happen seems exacerbated when using > 1 warehouse for chbench. This causes a cascading set of problems for benchmarking:

- We enter a 2-second sleep for each set of `peek`, which absolutely demolishes our QPS because we're really only able to do any work once every 2 seconds until we get some data in `orderline`
- Our logs get absolutely spammed with attempts to reinitialize the underlying data
- I was not able to drop the problematic view from the materialized instance and had a difficult time troubleshooting the issue because of the log spam
- The length of time that this occurs seems excessively drug out

To resolve this, I propose we simply rewrite the query. We could re-architect `peeker` to be more well-behaved in this failure scenario, but I also think that simply rewriting the query to avoid a divide by zero error is sane and, at the very least, expeditious in the immediate term because it provides benchmarking a simple way to include `q08`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4134)
<!-- Reviewable:end -->
