### PR TITLE
ALTER RENAME statements update the mz_catalog_names system table

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -897,7 +897,8 @@ impl Catalog {
             DropItem(GlobalId),
             UpdateItem {
                 id: GlobalId,
-                name: FullName,
+                from_name: Option<FullName>,
+                to_name: FullName,
                 item: CatalogItem,
             },
         }
@@ -1047,14 +1048,16 @@ impl Catalog {
                         tx.update_item(id.clone(), &dependent_item.name.item, &serialized_item)?;
                         actions.push(Action::UpdateItem {
                             id: id.clone(),
-                            name: dependent_item.name.clone(),
+                            from_name: None,
+                            to_name: dependent_item.name.clone(),
                             item: updated_item,
                         });
                     }
                     tx.update_item(id.clone(), &to_full_name.item, &serialized_item)?;
                     actions.push(Action::UpdateItem {
                         id,
-                        name: to_full_name,
+                        from_name: Some(entry.name.clone()),
+                        to_name: to_full_name,
                         item,
                     });
                     actions
@@ -1163,7 +1166,12 @@ impl Catalog {
                     OpStatus::DroppedItem(metadata)
                 }
 
-                Action::UpdateItem { id, name, item } => {
+                Action::UpdateItem {
+                    id,
+                    from_name,
+                    to_name,
+                    item,
+                } => {
                     let mut entry = self.by_id.remove(&id).unwrap();
                     info!(
                         "update {} {} ({})",
@@ -1178,12 +1186,15 @@ impl Catalog {
                         .expect("catalog out of sync")
                         .items;
                     schema_items.remove(&entry.name.item);
-                    entry.name = name;
+                    entry.name = to_name;
                     entry.item = item;
                     schema_items.insert(entry.name.item.clone(), id);
                     self.by_id.insert(id, entry);
 
-                    OpStatus::UpdatedItem
+                    match from_name {
+                        Some(from_name) => OpStatus::UpdatedItem { id, from_name },
+                        None => OpStatus::NoOp, // If name didn't change, don't update system tables.
+                    }
                 }
             })
             .collect())
@@ -1443,7 +1454,10 @@ pub enum OpStatus {
         schema_name: String,
     },
     DroppedItem(CatalogEntry),
-    UpdatedItem,
+    UpdatedItem {
+        id: GlobalId,
+        from_name: FullName,
+    },
     NoOp,
 }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2091,6 +2091,17 @@ where
                         self.update_mz_columns_catalog_view(desc, *id, 1);
                     }
                 }
+                catalog::OpStatus::UpdatedItem { id, from_name } => {
+                    // Remove old name from mz_catalog_names.
+                    self.report_catalog_update(*id, from_name.to_string(), -1);
+
+                    // Add new name to mz_catalog_names.
+                    self.report_catalog_update(
+                        *id,
+                        self.catalog.humanize_id(expr::Id::Global(*id)).unwrap(),
+                        1,
+                    );
+                }
                 catalog::OpStatus::DroppedDatabase { name, id } => {
                     self.update_mz_databases_catalog_view(*id, name, -1);
                 }

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -49,13 +49,73 @@ materialize.public.mz_view  materialize.public.mz_view_primary_idx  mz_obj_no   
     "materialize"."public"."mz_data"
     ';
 
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_data%';
+name
+-----
+materialize.public.mz_data
+materialize.public.mz_data_primary_idx
+
 > ALTER SOURCE mz_data RENAME TO renamed_mz_data;
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_data%';
+name
+-----
+materialize.public.mz_data_primary_idx
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.renamed_mz_data%';
+name
+-----
+materialize.public.renamed_mz_data
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_view%';
+name
+-----
+materialize.public.mz_view
+materialize.public.mz_view_primary_idx
 
 > ALTER VIEW mz_view RENAME TO renamed_mz_view;
 
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_view%';
+name
+-----
+materialize.public.mz_view_primary_idx
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.renamed_mz_view%';
+name
+-----
+materialize.public.renamed_mz_view
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_view_primary_idx%';
+name
+-----
+materialize.public.mz_view_primary_idx
+
 > ALTER INDEX mz_view_primary_idx RENAME TO renamed_index;
 
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_view_primary_idx%';
+name
+-----
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.renamed_index%';
+name
+-----
+materialize.public.renamed_index
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.sink1%';
+name
+-----
+materialize.public.sink1
+
 > ALTER SINK sink1 RENAME TO renamed_sink
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.sink1%';
+name
+-----
+
+> SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.renamed_sink%';
+name
+-----
+materialize.public.renamed_sink
 
 # Source was successfully renamed
 > SHOW SOURCES;


### PR DESCRIPTION
When an object is updated via an ALTER RENAME statement, issue a retraction
for the old name and an addition of the new name to the `mz_catalog.mz_catalog_names`
system table.

This change is necessary to keep the `mz_catalog_names` table correct and up-to-date,
as well as the information returned by joins with this table (e.g., the results of `SHOW COLUMNS`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4140)
<!-- Reviewable:end -->
