### PR TITLE
Use crate name "mz-avro" instead of "avro" internally

### DIFF
--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-avro = { path = "../avro", package = "mz-avro", features = ["snappy"] }
 aws-util = { path = "../aws-util" }
 backtrace = "0.3.50"
 bincode = { version = "1.3", optional = true }
@@ -25,6 +24,7 @@ interchange = { path = "../interchange" }
 itertools = "0.9"
 lazy_static = "1.4"
 log = "0.4"
+mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -22,8 +22,8 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::bail;
-use avro::schema::Schema;
-use avro::types::Value;
+use mz_avro::schema::Schema;
+use mz_avro::types::Value;
 use futures::executor::block_on;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -906,7 +906,7 @@ impl Timestamper {
                         };
                         // The first 5 bytes are reserved for the schema id/schema registry information
                         let mut bytes = &msg[5..];
-                        let res = avro::from_avro_datum(&DEBEZIUM_TRX_SCHEMA_VALUE, &mut bytes);
+                        let res = mz_avro::from_avro_datum(&DEBEZIUM_TRX_SCHEMA_VALUE, &mut bytes);
                         match res {
                             Err(_) => {
                                 // This was a key message, can safely ignore it
@@ -942,7 +942,7 @@ impl Timestamper {
                         };
                         // The first 5 bytes are reserved for the schema id/schema registry information
                         let mut bytes = &msg[5..];
-                        let res = avro::from_avro_datum(&BYO_CONSISTENCY_SCHEMA, &mut bytes);
+                        let res = mz_avro::from_avro_datum(&BYO_CONSISTENCY_SCHEMA, &mut bytes);
                         let (topic, partition_count, partition, timestamp, offset) = match res {
                             Ok(record) => {
                                 if let Value::Record(record) = record {
@@ -1197,8 +1197,8 @@ impl Timestamper {
         _id: SourceInstanceId,
         fc: &FileSourceConnector,
         timestamp_topic: String,
-    ) -> Option<ByoFileConnector<avro::types::Value, anyhow::Error>> {
-        let ctor = move |file| avro::Reader::new(file);
+    ) -> Option<ByoFileConnector<mz_avro::types::Value, anyhow::Error>> {
+        let ctor = move |file| mz_avro::Reader::new(file);
         let tail = if fc.tail {
             FileReadStyle::TailFollowFd
         } else {

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.32"
 async-trait = "0.1.40"
-avro = { path = "../avro", package = "mz-avro", features = ["snappy"] }
 aws-util = { path = "../aws-util" }
 bincode = "1.3.1"
 byteorder = "1.3"
@@ -25,6 +24,7 @@ itertools = "0.9"
 kafka-util = { path = "../kafka-util" }
 lazy_static = "1.4"
 log = "0.4"
+mz-avro = { path = "../avro", features = ["snappy"] }
 notify = "4.0"
 ore = { path = "../ore" }
 pdqselect = "0.1.0"

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -22,7 +22,7 @@ use timely::dataflow::{
     Scope, Stream,
 };
 
-use ::avro::{types::Value, Schema};
+use ::mz_avro::{types::Value, Schema};
 use dataflow_types::LinearOperator;
 use dataflow_types::{DataEncoding, Envelope, RegexEncoding};
 use interchange::avro::{extract_row, DebeziumDecodeState, DiffPair};

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -119,8 +119,8 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::worker::Worker as TimelyWorker;
 
-use avro::types::Value;
-use avro::Schema;
+use mz_avro::types::Value;
+use mz_avro::Schema;
 use dataflow_types::*;
 use expr::{GlobalId, Id, RelationExpr, ScalarExpr, SourceInstanceId};
 use ore::cast::CastFrom;

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -34,7 +34,7 @@ pub fn avro_ocf<G>(
 
     let res = OpenOptions::new().append(true).open(&connector.path);
     let mut avro_writer = match res {
-        Ok(f) => Some(avro::Writer::new(schema.clone(), f)),
+        Ok(f) => Some(mz_avro::Writer::new(schema.clone(), f)),
         Err(e) => {
             error!("creating avro ocf file writer for sink failed: {}", e);
             None

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -18,8 +18,8 @@ use log::error;
 use notify::{RecursiveMode, Watcher};
 use timely::scheduling::{Activator, SyncActivator};
 
-use avro::types::Value;
-use avro::{AvroRead, Schema, Skip};
+use mz_avro::types::Value;
+use mz_avro::{AvroRead, Schema, Skip};
 use dataflow_types::{
     AvroOcfEncoding, Consistency, DataEncoding, ExternalSourceConnector, MzOffset,
 };
@@ -89,7 +89,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
                     ),
                 };
                 let reader_schema = Schema::parse_str(reader_schema).unwrap();
-                let ctor = { move |file| avro::Reader::with_schema(&reader_schema, file) };
+                let ctor = { move |file| mz_avro::Reader::with_schema(&reader_schema, file) };
                 let tail = if oc.tail {
                     FileReadStyle::TailFollowFd
                 } else {

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -9,7 +9,7 @@
 
 //! Types related to the creation of dataflow sources.
 
-use avro::types::Value;
+use mz_avro::types::Value;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -12,7 +12,6 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.32"
-avro = { path = "../avro", package = "mz-avro", features = ["snappy"] }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"
@@ -22,6 +21,7 @@ lazy_static = "1.4.0"
 log = "0.4.11"
 num-traits = "0.2.12" # don't want to upgrade to autocfg 1.0 until more things use it
 itertools = "0.9.0"
+mz-avro = { path = "../avro", features = ["snappy"] }
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }
 protobuf = "2.17"

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -6,11 +6,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use avro::types::Value as AvroValue;
 use byteorder::{NetworkEndian, WriteBytesExt};
 use chrono::{Duration, NaiveDate};
 use criterion::{black_box, Criterion, Throughput};
 use futures::executor::block_on;
+use mz_avro::types::Value as AvroValue;
 
 use interchange::avro::{parse_schema, DebeziumDeduplicationStrategy, Decoder, EnvelopeType};
 use std::ops::Add;
@@ -386,7 +386,7 @@ pub fn bench_avro(c: &mut Criterion) {
     let mut buf = Vec::new();
     buf.write_u8(0).unwrap();
     buf.write_i32::<NetworkEndian>(0).unwrap();
-    buf.extend(avro::to_avro_datum(&schema, record).unwrap());
+    buf.extend(mz_avro::to_avro_datum(&schema, record).unwrap());
     let len = buf.len() as u64;
 
     let mut decoder = Decoder::new(

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -24,11 +24,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::Sha256;
 
-use avro::schema::{
+use mz_avro::schema::{
     resolve_schemas, RecordField, Schema, SchemaFingerprint, SchemaNode, SchemaPiece,
     SchemaPieceOrNamed,
 };
-use avro::{
+use mz_avro::{
     give_value,
     types::{DecimalValue, Scalar, Value},
     AvroArrayAccess, AvroDecode, AvroDeserializer, AvroRead, AvroRecordAccess, GeneralDeserializer,
@@ -466,22 +466,22 @@ impl<'a> AvroDecode for AvroFlatDecoder<'a> {
         Ok(())
     }
     #[inline]
-    fn scalar(self, scalar: avro::types::Scalar) -> Result<Self::Out> {
+    fn scalar(self, scalar: mz_avro::types::Scalar) -> Result<Self::Out> {
         match scalar {
-            avro::types::Scalar::Null => self.packer.push(Datum::Null),
-            avro::types::Scalar::Boolean(val) => {
+            mz_avro::types::Scalar::Null => self.packer.push(Datum::Null),
+            mz_avro::types::Scalar::Boolean(val) => {
                 if val {
                     self.packer.push(Datum::True)
                 } else {
                     self.packer.push(Datum::False)
                 }
             }
-            avro::types::Scalar::Int(val) => self.packer.push(Datum::Int32(val)),
-            avro::types::Scalar::Long(val) => self.packer.push(Datum::Int64(val)),
-            avro::types::Scalar::Float(val) => self.packer.push(Datum::Float32(OrderedFloat(val))),
-            avro::types::Scalar::Double(val) => self.packer.push(Datum::Float64(OrderedFloat(val))),
-            avro::types::Scalar::Date(val) => self.packer.push(Datum::Date(val)),
-            avro::types::Scalar::Timestamp(val) => self.packer.push(Datum::Timestamp(val)),
+            mz_avro::types::Scalar::Int(val) => self.packer.push(Datum::Int32(val)),
+            mz_avro::types::Scalar::Long(val) => self.packer.push(Datum::Int64(val)),
+            mz_avro::types::Scalar::Float(val) => self.packer.push(Datum::Float32(OrderedFloat(val))),
+            mz_avro::types::Scalar::Double(val) => self.packer.push(Datum::Float64(OrderedFloat(val))),
+            mz_avro::types::Scalar::Date(val) => self.packer.push(Datum::Date(val)),
+            mz_avro::types::Scalar::Timestamp(val) => self.packer.push(Datum::Timestamp(val)),
         }
         Ok(())
     }
@@ -1559,7 +1559,7 @@ pub fn encode_debezium_transaction_unchecked(
         ("event_count".into(), event_count),
     ]);
     debug_assert!(avro.validate(DEBEZIUM_TRANSACTION_SCHEMA.top_node()));
-    avro::encode_unchecked(&avro, &DEBEZIUM_TRANSACTION_SCHEMA, &mut buf);
+    mz_avro::encode_unchecked(&avro, &DEBEZIUM_TRANSACTION_SCHEMA, &mut buf);
     buf
 }
 
@@ -1626,7 +1626,7 @@ impl Encoder {
         encode_avro_header(&mut buf, schema_id);
         let avro = self.diff_pair_to_avro(diff_pair, transaction_id);
         debug_assert!(avro.validate(self.writer_schema.top_node()));
-        avro::encode_unchecked(&avro, &self.writer_schema, &mut buf);
+        mz_avro::encode_unchecked(&avro, &self.writer_schema, &mut buf);
         buf
     }
 
@@ -1642,7 +1642,7 @@ impl Encoder {
         encode_avro_header(&mut buf, schema_id);
         buf.write_i32::<NetworkEndian>(schema_id)
             .expect("writing to vec cannot fail");
-        avro::write_avro_datum(
+        mz_avro::write_avro_datum(
             &self.writer_schema,
             self.diff_pair_to_avro(diff_pair, transaction_id),
             &mut buf,
@@ -1757,7 +1757,7 @@ where
         .zip_eq(datums)
         .map(|((name, typ), datum)| {
             let name = name.as_str().to_owned();
-            use avro::types::ToAvro;
+            use mz_avro::types::ToAvro;
             (name, TypedDatum::new(datum, typ.clone()).avro())
         })
         .collect();
@@ -1778,7 +1778,7 @@ impl<'a> TypedDatum<'a> {
     }
 }
 
-impl<'a> avro::types::ToAvro for TypedDatum<'a> {
+impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
     fn avro(self) -> Value {
         let TypedDatum { datum, typ } = self;
         if typ.nullable && datum.is_null() {
@@ -2395,7 +2395,7 @@ mod tests {
     use serde::Deserialize;
     use std::fs::File;
 
-    use avro::types::{DecimalValue, Value};
+    use mz_avro::types::{DecimalValue, Value};
     use repr::adt::decimal::Significand;
     use repr::{Datum, RelationDesc};
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.32"
-avro = { path = "../avro", package = "mz-avro", features = ["snappy"] }
 aws-arn = "0.1.1"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"
@@ -18,6 +17,7 @@ interchange = { path = "../interchange" }
 itertools = "0.9"
 lazy_static = "1.4.0"
 log = "0.4.11"
+mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -55,7 +55,7 @@ pub async fn purify(mut stmt: Statement) -> Result<Statement, anyhow::Error> {
             Connector::AvroOcf { path, .. } => {
                 let path = path.clone();
                 let f = std::fs::File::open(path)?;
-                let r = avro::Reader::new(f)?;
+                let r = mz_avro::Reader::new(f)?;
                 if !with_options_map.contains_key("reader_schema") {
                     let schema = serde_json::to_string(r.writer_schema()).unwrap();
                     with_options.push(sql_parser::ast::SqlOption {

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 async-trait = "0.1.40"
 atty = "0.2"
-avro = { path = "../avro", package = "mz-avro", features = ["snappy"] }
 aws-util = { path = "../aws-util" }
 byteorder = "1.3"
 bytes = "0.5.6"
@@ -23,6 +22,7 @@ kafka-util = { path = "../kafka-util" }
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 md-5 = "0.9"
+mz-avro = { path = "../avro", features = ["snappy"] }
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -165,7 +165,7 @@ impl Action for VerifyAction {
 
         println!("Verifying results in file {}", path.display());
 
-        // Get the rows from this file. There is no async `avro::Reader`, so
+        // Get the rows from this file. There is no async `mz_avro::Reader`, so
         // we drop into synchronous code here.
         tokio::task::block_in_place(|| {
             let file = File::open(&path)

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -25,10 +25,10 @@ use serde_json::Value as JsonValue;
 // Re-export components from the various other Avro libraries, so that other
 // testdrive modules can import just this one.
 
-pub use avro::schema::{Schema, SchemaNode, SchemaPiece, SchemaPieceOrNamed};
-pub use avro::types::{DecimalValue, ToAvro, Value};
-pub use avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
 pub use interchange::avro::parse_schema;
+pub use mz_avro::schema::{Schema, SchemaNode, SchemaPiece, SchemaPieceOrNamed};
+pub use mz_avro::types::{DecimalValue, ToAvro, Value};
+pub use mz_avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
 
 // This function is derived from code in the avro_rs project. Update the license
 // header on this file accordingly if you move it to a new home.
@@ -122,7 +122,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
             }
         }
         (JsonValue::Object(items), SchemaPiece::Record { .. }) => {
-            let mut builder = avro::types::Record::new(schema)
+            let mut builder = mz_avro::types::Record::new(schema)
                 .expect("`Record::new` should never fail if schema piece is a record!");
             for (key, val) in items {
                 let field = builder


### PR DESCRIPTION
This will make it easier to write derive macros that need to be able to construct a path to things in the crate