### PR TITLE
sql: add UUID type support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
  "ore",
  "postgres-types",
  "repr",
+ "uuid",
 ]
 
 [[package]]
@@ -2609,6 +2610,7 @@ dependencies = [
  "postgres-protocol",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -3027,6 +3029,7 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "smallvec",
+ "uuid",
 ]
 
 [[package]]
@@ -3740,6 +3743,7 @@ dependencies = [
  "sql",
  "tokio",
  "tokio-postgres",
+ "uuid",
  "whoami",
 ]
 
@@ -3923,6 +3927,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1462,6 +1462,7 @@ fn build_schema(columns: &[(ColumnName, ColumnType)], include_transaction: bool)
                 "type": "string",
                 "connect.name": "io.debezium.data.Json",
             }),
+            ScalarType::UUID => unimplemented!("uuid type"),
             ScalarType::List(_t) => unimplemented!("list types"),
             ScalarType::Record { .. } => unimplemented!("record types"),
         };
@@ -1817,6 +1818,7 @@ impl<'a> avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::Bytes => Value::Bytes(Vec::from(datum.unwrap_bytes())),
                 ScalarType::String => Value::String(datum.unwrap_str().to_owned()),
                 ScalarType::Jsonb => Value::Json(JsonbRef::from_datum(datum).to_serde_json()),
+                ScalarType::UUID => unimplemented!("uuid type"),
                 ScalarType::List(_t) => unimplemented!("list types"),
                 ScalarType::Record { .. } => unimplemented!("record types"),
             };

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -10,6 +10,7 @@ byteorder = "1.3"
 bytes = "0.5"
 chrono = "0.4"
 lazy_static = "1.4.0"
-postgres-types = { version = "0.1.1", features = ["with-chrono-0_4"] }
+postgres-types = { version = "0.1.1", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 ore = { path = "../ore" }
 repr = { path = "../repr" }
+uuid = "0.8"

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -45,6 +45,8 @@ pub enum Type {
     Timestamp,
     /// A date and time, with a timezone.
     TimestampTz,
+    /// A universally unique identifier.
+    UUID,
 }
 
 lazy_static! {
@@ -79,6 +81,7 @@ impl Type {
             postgres_types::Type::TIME => Some(Type::Time),
             postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
             postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
+            postgres_types::Type::UUID => Some(Type::UUID),
             _ => None,
         }
     }
@@ -99,6 +102,7 @@ impl Type {
             Type::Time => &postgres_types::Type::TIME,
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
+            Type::UUID => &postgres_types::Type::UUID,
             Type::List(_) => &LIST,
             Type::Record(_) => &postgres_types::Type::RECORD,
         }
@@ -134,6 +138,7 @@ impl Type {
             Type::Time => 4,
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
+            Type::UUID => 16,
             Type::List(_) => -1,
             Type::Record(_) => -1,
         }
@@ -157,6 +162,7 @@ impl From<&ScalarType> for Type {
             ScalarType::Bytes => Type::Bytea,
             ScalarType::String => Type::Text,
             ScalarType::Jsonb => Type::Jsonb,
+            ScalarType::UUID => Type::UUID,
             ScalarType::List(t) => Type::List(Box::new(From::from(&**t))),
             ScalarType::Record { fields } => {
                 Type::Record(fields.iter().map(|(_name, ty)| Type::from(ty)).collect())

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_regex = "1.1.0"
 smallvec = { version = "1.4.2", features = ["serde"] }
+uuid = "0.8"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -29,6 +29,7 @@ use std::fmt;
 use chrono::offset::TimeZone;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use ore::fmt::FormatBuffer;
 
@@ -438,6 +439,20 @@ where
     F: FormatBuffer,
 {
     write!(buf, "{:#}", jsonb)
+}
+
+pub fn parse_uuid(s: &str) -> Result<Uuid, ParseError> {
+    s.trim()
+        .parse()
+        .map_err(|e| ParseError::new("uuid", s).with_details(e))
+}
+
+pub fn format_uuid<F>(buf: &mut F, uuid: Uuid) -> Nestable
+where
+    F: FormatBuffer,
+{
+    write!(buf, "{}", uuid);
+    Nestable::Yes
 }
 
 fn format_nanos_to_micros<F>(buf: &mut F, nanos: u32)

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -62,7 +62,9 @@ impl TypeCategory {
     fn from_type(typ: &ScalarType) -> Self {
         match typ {
             ScalarType::Bool => Self::Bool,
-            ScalarType::Bytes | ScalarType::Jsonb | ScalarType::List(_) => Self::UserDefined,
+            ScalarType::Bytes | ScalarType::Jsonb | ScalarType::UUID | ScalarType::List(_) => {
+                Self::UserDefined
+            }
             ScalarType::Date
             | ScalarType::Time
             | ScalarType::Timestamp

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2111,13 +2111,13 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, anyhow::
         DataType::Interval => ScalarType::Interval,
         DataType::Bytea => ScalarType::Bytes,
         DataType::Jsonb => ScalarType::Jsonb,
+        DataType::Uuid => ScalarType::UUID,
         DataType::List(elem_type) => ScalarType::List(Box::new(scalar_type_from_sql(elem_type)?)),
         other @ DataType::Binary(..)
         | other @ DataType::Blob(_)
         | other @ DataType::Clob(_)
         | other @ DataType::Regclass
         | other @ DataType::TimeTz
-        | other @ DataType::Uuid
         | other @ DataType::Varbinary(_) => bail!("Unexpected SQL type: {:?}", other),
     })
 }
@@ -2138,6 +2138,7 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
         pgrepr::Type::Bytea => Ok(ScalarType::Bytes),
         pgrepr::Type::Text => Ok(ScalarType::String),
         pgrepr::Type::Jsonb => Ok(ScalarType::Jsonb),
+        pgrepr::Type::UUID => Ok(ScalarType::UUID),
         pgrepr::Type::List(l) => Ok(ScalarType::List(Box::new(scalar_type_from_pg(l)?))),
         pgrepr::Type::Record(_) => {
             bail!("internal error: can't convert from pg record to materialize record")

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -330,6 +330,7 @@ lazy_static! {
             (String, Explicit(Interval)) => CastStringToInterval,
             (String, Explicit(Bytes)) => CastStringToBytes,
             (String, Explicit(Jsonb)) => CastStringToJsonb,
+            (String, Explicit(UUID)) => CastStringToUuid,
             (String, JsonbAny) => CastJsonbOrNullToJsonb,
 
             // RECORD
@@ -347,7 +348,10 @@ lazy_static! {
             (Jsonb, Explicit(Float64)) => CastJsonbToFloat64,
             (Jsonb, Explicit(Decimal(0, 0))) => CastOp::F(from_jsonb_f64_cast),
             (Jsonb, Explicit(String)) => CastJsonbToString,
-            (Jsonb, JsonbAny) => CastJsonbOrNullToJsonb
+            (Jsonb, JsonbAny) => CastJsonbOrNullToJsonb,
+
+            // UUID
+            (UUID, Explicit(String)) => CastUuidToString
         }
     };
 }

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -18,4 +18,5 @@ tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-serde
 repr = { path = "../repr" }
 serde_json = "1.0"
 sql = { path = "../sql" }
+uuid = "0.8"
 whoami = "0.9"

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -33,6 +33,7 @@ use std::rc::Rc;
 use anyhow::{anyhow, bail};
 use chrono::Utc;
 use tokio_postgres::types::FromSql;
+use uuid::Uuid;
 
 use pgrepr::Jsonb;
 use repr::adt::decimal::Significand;
@@ -443,6 +444,10 @@ fn push_column(
             } else {
                 row.push(Datum::Null)
             }
+        }
+        DataType::Uuid => {
+            let u = get_column_inner::<Uuid>(postgres_row, i, nullable)?.unwrap();
+            row.push(Datum::UUID(u));
         }
         _ => bail!(
             "Postgres to materialize conversion not yet supported for {:?}",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -45,6 +45,7 @@ tempfile = "3.1"
 termcolor = "1.1.0"
 tokio = "0.2"
 url = "2.1.0"
+uuid = "0.8"
 
 [build-dependencies]
 protoc = { path = "../protoc" }

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -375,6 +375,7 @@ fn decode_row(row: Row) -> Result<Vec<String>, String> {
                     .map(|x| x.to_string()),
                 Type::INTERVAL => row.get::<_, Option<Interval>>(i).map(|x| x.to_string()),
                 Type::JSONB => row.get::<_, Option<Jsonb>>(i).map(|v| v.0.to_string()),
+                Type::UUID => row.get::<_, Option<uuid::Uuid>>(i).map(|v| v.to_string()),
                 _ => return Err(format!("unable to handle SQL type: {:?}", ty)),
             }
             .unwrap_or_else(|| "<null>".into()),

--- a/test/sqllogictest/uuid.slt
+++ b/test/sqllogictest/uuid.slt
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query T
+SELECT '63616665-6630-3064-6465-616462656568'::uuid
+----
+63616665-6630-3064-6465-616462656568
+
+query T
+SELECT '63616665-6630-3064-6465-616462656568'::uuid::text
+----
+63616665-6630-3064-6465-616462656568
+
+query T
+SELECT '63616665-6630-3064-6465-616462656568'::text::uuid
+----
+63616665-6630-3064-6465-616462656568
+
+query error invalid input syntax for uuid
+SELECT 'Z3616665-6630-3064-6465-616462656568'::uuid
+
+query error does not support casting from uuid to bytes
+SELECT '63616665-6630-3064-6465-616462656568'::uuid::bytes

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test exercises UUIDs at the boundary (e.g., by sending them
+# through pgwire). Operations on UUIDs are more thoroughly tested in
+# uuid.slt.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                "name": "u",
+                "type": {
+                  "type": "string",
+                  "logicalType": "uuid"
+                }
+              }
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+{"before": null, "after": {"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}
+{"before": null, "after": {"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}
+
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
+{"before": null, "after": null}
+
+> CREATE SOURCE data FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED VIEW data_view as SELECT * from data
+
+> SELECT * FROM data_view
+"16fd95b0-65b7-4249-9b66-1547cd95923d"
+"b141698b-fb7f-492d-bc8a-0d159641c7a3"
+
+> SELECT '85907cb9-ac9b-4e35-84b8-60dc69368aca'::uuid
+"85907cb9-ac9b-4e35-84b8-60dc69368aca"
+
+> SELECT '85907cb9-ac9b-4e35-84b8-60dc69368aca'::uuid::text
+"85907cb9-ac9b-4e35-84b8-60dc69368aca"


### PR DESCRIPTION
Add simple UUID type support with casting to and from strings.

The uuid crate appears well supported and comes with postgres
serialization support.

Fixes #3687

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4143)
<!-- Reviewable:end -->
