### PR TITLE
Incrementally improve avro decoding API, by deriving simple cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
+name = "avro-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "aws-arn"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1516,7 @@ name = "interchange"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "avro-derive",
  "base64",
  "byteorder",
  "ccsr",
@@ -2005,6 +2015,7 @@ name = "mz-avro"
 version = "0.6.5"
 dependencies = [
  "anyhow",
+ "avro-derive",
  "byteorder",
  "chrono",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "demo/billing",
     "fuzz",
     "src/avro",
+    "src/avro-derive",
     "src/aws-util",
     "src/ccsr",
     "src/comm",

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -279,7 +279,7 @@ class CargoTest(CargoPreImage):
                 target_kind = "".join(message["target"]["kind"])
                 # TODO - ask Nikhil if this is long-term correct,
                 # but it unblocks us for now.
-                if target_kind == "proc_macro":
+                if target_kind == "proc-macro":
                     continue
                 slug = crate_name + "." + target_kind
                 if target_kind != "lib":

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -277,6 +277,10 @@ class CargoTest(CargoPreImage):
             if message.get("profile", {}).get("test", False):
                 crate_name = message["package_id"].split()[0]
                 target_kind = "".join(message["target"]["kind"])
+                # TODO - ask Nikhil if this is long-term correct,
+                # but it unblocks us for now.
+                if target_kind == "proc_macro":
+                    continue
                 slug = crate_name + "." + target_kind
                 if target_kind != "lib":
                     slug += "." + message["target"]["name"]

--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "1.0", features = ["full"] }
+syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "avro-derive"
 version = "0.1.0"
 authors = ["Brennan Vincent <brennan@umanwizard.com>"]
+license = "Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "avro-derive"
+version = "0.1.0"
+authors = ["Brennan Vincent <brennan@umanwizard.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[lib]
+proc-macro = true

--- a/src/avro-derive/src/lib.rs
+++ b/src/avro-derive/src/lib.rs
@@ -45,6 +45,9 @@ pub fn derive_decodeable(item: TokenStream) -> TokenStream {
         .fields
         .iter()
         .map(|f| {
+            // The type of the field,
+            // which must itself be AvroDecodeable so that we can recursively
+            // decode it.
             let ty = &f.ty;
             let id = f.ident.as_ref().unwrap();
             quote! {

--- a/src/avro-derive/src/lib.rs
+++ b/src/avro-derive/src/lib.rs
@@ -11,7 +11,7 @@
 ///
 /// Example:
 ///
-/// ```
+/// ```ignore
 /// fn make_complicated_decoder() -> impl AvroDecode<Out = SomeComplicatedType> {
 ///     unimplemented!()
 /// }

--- a/src/avro-derive/src/lib.rs
+++ b/src/avro-derive/src/lib.rs
@@ -1,0 +1,113 @@
+// Copyright Materialize, Inc., and other contributors (if applicable)
+//
+// Use of this software is governed by the Apache License, Version 2.0
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::parse_macro_input;
+use syn::ItemStruct;
+
+#[proc_macro_derive(AvroDecodeable, attributes(decoder_factory))]
+pub fn derive_decodeable(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as ItemStruct);
+    let name = input.ident;
+    let fields: Vec<_> = input
+        .fields
+        .iter()
+        .map(|f| {
+            let ty = &f.ty;
+            let id = f.ident.as_ref().unwrap();
+            quote! {
+                #id: Option<#ty>
+            }
+        })
+        .collect();
+
+    let decode_blocks: Vec<_> = input
+        .fields
+        .iter()
+        .map(|f| {
+            let ty = &f.ty;
+            let id = f.ident.as_ref().unwrap();
+            let id_str = id.to_string();
+            let found_twice = format!("field `{}` found twice", id);
+            let make_decoder =
+                if let Some(decoder_factory) = f.attrs.iter().find(|a| {
+                    &a.path.get_ident().as_ref().unwrap().to_string() == "decoder_factory"
+                }) {
+                    let toks = &decoder_factory.tokens;
+                    quote! {
+                        #toks()
+                    }
+                } else {
+                    quote! {
+                        <#ty as ::mz_avro::AvroDecodeable>::new_decoder()
+                    }
+                };
+            quote! {
+                #id_str => {
+                    if self.#id.is_some() {
+                        ::anyhow::bail!(#found_twice);
+                    }
+                    let decoder = #make_decoder;
+                    self.#id = Some(field.decode_field(decoder)?);
+                }
+            }
+        })
+        .collect();
+    let check_blocks: Vec<_> = input
+        .fields
+        .iter()
+        .map(|f| {
+            let id = f.ident.as_ref().unwrap();
+            let not_found = format!("field `{}` not found", id);
+            quote! {
+                let #id = if let Some(#id) = self.#id.take() {
+                    #id
+                } else {
+                    ::anyhow::bail!(#not_found);
+                };
+            }
+        })
+        .collect();
+    let return_fields: Vec<_> = input
+        .fields
+        .iter()
+        .map(|f| f.ident.as_ref().unwrap())
+        .collect();
+    let decoder_name = format_ident!("{}_DECODER", name);
+    let out = quote! {
+        #[derive(Default)]
+        #[allow(non_camel_case_types)]
+        struct #decoder_name {
+            #(#fields),*
+        }
+        impl ::mz_avro::AvroDecode for #decoder_name {
+            type Out = #name;
+            fn record<R: ::mz_avro::AvroRead, A: ::mz_avro::AvroRecordAccess<R>>(
+                mut self,
+                a: &mut A,
+            ) -> ::anyhow::Result<#name> {
+                while let Some((name, _idx, field)) = a.next_field()? {
+                    match name {
+                        #(#decode_blocks)*
+                        _ => {
+                            field.decode_field(::mz_avro::TrivialDecoder)?;
+                        }
+                    }
+                }
+                #(#check_blocks)*
+                Ok(#name {
+                    #(#return_fields),*
+                })
+            }
+        }
+        impl ::mz_avro::AvroDecodeable for #name {
+            type Decoder = #decoder_name;
+            fn new_decoder() -> #decoder_name {
+                Default::default()
+            }
+        }
+    };
+    TokenStream::from(out)
+}

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -14,6 +14,7 @@ snappy = ["byteorder", "crc", "snap"]
 
 [dependencies]
 anyhow = "1.0.32"
+avro-derive = { path = "../avro-derive" }
 byteorder = { version = "1.0.0", optional = true }
 crc = { version = "1.3.0", optional = true }
 chrono = { version = "0.4" }

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -321,8 +321,8 @@ pub mod types;
 pub use crate::codec::Codec;
 pub use crate::decode::public_decoders::*;
 pub use crate::decode::{
-    give_value, AvroArrayAccess, AvroDecode, AvroDeserializer, AvroFieldAccess, AvroRead,
-    AvroRecordAccess, GeneralDeserializer, Skip, ValueOrReader,
+    give_value, AvroArrayAccess, AvroDecode, AvroDecodeable, AvroDeserializer, AvroFieldAccess,
+    AvroRead, AvroRecordAccess, GeneralDeserializer, Skip, ValueOrReader,
 };
 pub use crate::encode::encode as encode_unchecked;
 pub use crate::reader::{from_avro_datum, Reader};

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.32"
+avro-derive = { path = "../avro-derive" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"


### PR DESCRIPTION
The basic structure of decoding an Avro record into a struct was so often the same that it made sense to stick it in a macro. The basic algorithm is:

* For each field in the record, match on the name of the field. If it matches one of the expected record fields, recurse into the appropriate sub-decoder. Save the result in an `Option<T>`.
* Otherwise, use `TrivialDecoder` to skip the field.
* After the record is fully consumed, check all the `Option<T>` stashes - if any is `None`, a required field was missing, and we should error.

Recommended sequence for doing this code review:

(1) Look at the old code in interchange/avro.rs and observe how repetitive it is
(2) Look at the macro in avro-derive/src/lib.rs to see how it accomplishes the same thing.
(3) [Optional!] I am probably the only one who cares about this, but if you want, you can look at some of the new internal support code in the avro crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4145)
<!-- Reviewable:end -->
