### PR TITLE
doc/user: correct requirements on SSL configuration

### DIFF
--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -13,10 +13,10 @@ cluster. For more detail, see [SSL-encrypted Kafka details](#ssl-encrypted-kafka
 
 Field | Value | Description
 ------|-------|------------
-`ssl_ca_location` | `text` | The absolute path to your SSL certificate's CA certificate. Required for SSL client and server authentication.
 `ssl_certificate_location` | `text` | The absolute path to your SSL certificate. Required for SSL client authentication.
 `ssl_key_location` | `text` | The absolute path to your SSL certificate's key. Required for SSL client authentication.
-`ssl_key_password` | `text` | Your SSL key's password.
+`ssl_key_password` | `text` | Your SSL key's password, if any.
+`ssl_ca_location` | `text` | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
 
 #### Kerberos `WITH` options
 


### PR DESCRIPTION
The ssl_ca_location is not actually required; if omitted, the system
default CA certificates are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4146)
<!-- Reviewable:end -->
