### PR TITLE
pgtest: add postgres wire protocol tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgtest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "datadriven",
+ "fallible-iterator",
+ "getopts",
+ "postgres",
+ "postgres-protocol",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pgwire"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "src/ore",
     "src/peeker",
     "src/pgrepr",
+    "src/pgtest",
     "src/pgwire",
     "src/prof",
     "src/protoc",

--- a/bin/lint
+++ b/bin/lint
@@ -75,6 +75,7 @@ copyright_files=$(grep -vE \
     -e '^ci/www/public/_redirects$' \
     -e 'demo/chbench/chbench' \
     -e 'test/sqllogictest/postgres/testdata/.*\.data' \
+    -e 'test/pgtest/.*\.pt' \
     -e 'gen/.*\.rs' \
     <<< "$files"
 )

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pgtest"
+description = "Postgres wire protocol test framework."
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+bytes = "0.5"
+datadriven = "0.2.0"
+fallible-iterator = "0.2"
+getopts = "0.2"
+postgres = "0.17.5"
+postgres-protocol = "0.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -1,0 +1,329 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! pgtest is a Postgres wire protocol tester using
+//! datadriven test files. It can be used to send [specific
+//! messages](https://www.postgresql.org/docs/current/protocol-message-formats.html)
+//! to any Postgres-compatible server and record received messages.
+//!
+//! The following datadriven directives are supported:
+//! - `send`: Sends input messages to the server. Arguments, if needed,
+//! are specified using JSON. Refer to the associated types to see
+//! supported arguments. Arguments can be omitted to use defaults.
+//! - `until`: Waits until input messages have been received from the
+//! server. Additional messages are accumulated and returned as well.
+//!
+//! Supported `send` types:
+//! - [`Query`](struct.Query.html)
+//! - [`Parse`](struct.Parse.html)
+//! - [`Bind`](struct.Bind.html)
+//! - [`Execute`](struct.Execute.html)
+//! - `Sync`
+//!
+//! For example, to execute a simple prepared statement:
+//! ```pgtest
+//! send
+//! Parse {"query": "SELECT $1::text, 1 + $2::int4"}
+//! Bind {"values": ["blah", "4"]}
+//! Execute
+//! Sync
+//! ----
+//!
+//! until
+//! ReadyForQuery
+//! ----
+//! ParseComplete
+//! BindComplete
+//! DataRow {"fields":["blah","5"]}
+//! CommandComplete {"tag":"SELECT 1"}
+//! ReadyForQuery {"status":"I"}
+//! ```
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::{Duration, Instant};
+
+use anyhow::bail;
+use bytes::{BufMut, BytesMut};
+use fallible_iterator::FallibleIterator;
+use postgres_protocol::message::backend::Message;
+use postgres_protocol::message::frontend;
+use postgres_protocol::IsNull;
+use serde::{Deserialize, Serialize};
+
+pub struct PgTest {
+    stream: TcpStream,
+    recv_buf: BytesMut,
+    send_buf: BytesMut,
+    timeout: Duration,
+}
+
+impl PgTest {
+    pub fn new(addr: &str, user: &str, timeout: Duration) -> anyhow::Result<Self> {
+        let mut pgtest = PgTest {
+            stream: TcpStream::connect(addr)?,
+            recv_buf: BytesMut::new(),
+            send_buf: BytesMut::new(),
+            timeout,
+        };
+        pgtest.send(|buf| frontend::startup_message(vec![("user", user)], buf).unwrap())?;
+        match pgtest.recv()?.1 {
+            Message::AuthenticationOk => {}
+            _ => bail!("expected AuthenticationOk"),
+        };
+        pgtest.until(vec!["ReadyForQuery"])?;
+        Ok(pgtest)
+    }
+    pub fn send<F: Fn(&mut BytesMut)>(&mut self, f: F) -> anyhow::Result<()> {
+        self.send_buf.clear();
+        f(&mut self.send_buf);
+        self.stream.write_all(&self.send_buf)?;
+        Ok(())
+    }
+    pub fn until(&mut self, until: Vec<&str>) -> anyhow::Result<Vec<String>> {
+        let mut msgs = Vec::with_capacity(until.len());
+        for expect in until {
+            loop {
+                let (ch, msg) = match self.recv() {
+                    Ok((ch, msg)) => (ch, msg),
+                    Err(err) => bail!("{}: waiting for {}, saw {:?}", err, expect, msgs),
+                };
+                let (typ, args) = match msg {
+                    Message::ReadyForQuery(body) => (
+                        "ReadyForQuery",
+                        serde_json::to_string(&ReadyForQuery {
+                            status: (body.status() as char).to_string(),
+                        })?,
+                    ),
+                    Message::RowDescription(body) => (
+                        "RowDescription",
+                        serde_json::to_string(&RowDescription {
+                            fields: body
+                                .fields()
+                                .map(|f| {
+                                    Ok(Field {
+                                        name: f.name().to_string(),
+                                    })
+                                })
+                                .collect()
+                                .unwrap(),
+                        })?,
+                    ),
+                    Message::DataRow(body) => {
+                        let buf = body.buffer();
+                        (
+                            "DataRow",
+                            serde_json::to_string(&DataRow {
+                                fields: body
+                                    .ranges()
+                                    .map(|range| {
+                                        let range = range.unwrap();
+                                        // TODO(mjibson): support not strings.
+                                        Ok(String::from_utf8(buf[range.start..range.end].to_vec())
+                                            .unwrap())
+                                    })
+                                    .collect()
+                                    .unwrap(),
+                            })?,
+                        )
+                    }
+                    Message::CommandComplete(body) => (
+                        "CommandComplete",
+                        serde_json::to_string(&CommandComplete {
+                            tag: body.tag().unwrap().to_string(),
+                        })?,
+                    ),
+                    Message::ParseComplete => ("ParseComplete", "".to_string()),
+                    Message::BindComplete => ("BindComplete", "".to_string()),
+                    Message::PortalSuspended => ("PortalSuspended", "".to_string()),
+                    Message::ErrorResponse(body) => (
+                        "ErrorResponse",
+                        serde_json::to_string(&ErrorResponse {
+                            fields: body
+                                .fields()
+                                .map(|f| {
+                                    Ok(ErrorField {
+                                        typ: f.type_(),
+                                        value: f.value().to_string(),
+                                    })
+                                })
+                                .collect()
+                                .unwrap(),
+                        })?,
+                    ),
+                    _ => ("UNKNOWN", format!("'{}'", ch)),
+                };
+                let mut s = typ.to_string();
+                if !args.is_empty() {
+                    s.push(' ');
+                    s.push_str(&args);
+                }
+                msgs.push(s);
+                if expect == typ {
+                    break;
+                }
+            }
+        }
+        Ok(msgs)
+    }
+    /// Returns the PostgreSQL message format and the `Message`.
+    ///
+    /// An error is returned if a new message is not received within the timeout.
+    pub fn recv(&mut self) -> anyhow::Result<(char, Message)> {
+        let mut buf = [0; 1024];
+        let until = Instant::now();
+        loop {
+            if until.elapsed() > self.timeout {
+                bail!("timeout after {:?} waiting for new message", self.timeout);
+            }
+            let mut ch: char = '0';
+            if self.recv_buf.len() > 0 {
+                ch = self.recv_buf[0] as char;
+            }
+            if let Some(msg) = Message::parse(&mut self.recv_buf)? {
+                return Ok((ch, msg));
+            };
+            // If there was no message, read more bytes.
+            let sz = self.stream.read(&mut buf)?;
+            self.recv_buf.extend_from_slice(&buf[..sz]);
+        }
+    }
+}
+
+// Backend messages
+
+#[derive(Serialize)]
+pub struct ReadyForQuery {
+    pub status: String,
+}
+
+#[derive(Serialize)]
+pub struct RowDescription {
+    pub fields: Vec<Field>,
+}
+
+#[derive(Serialize)]
+pub struct Field {
+    pub name: String,
+}
+
+#[derive(Serialize)]
+pub struct DataRow {
+    pub fields: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct CommandComplete {
+    pub tag: String,
+}
+
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    pub fields: Vec<ErrorField>,
+}
+
+#[derive(Serialize)]
+pub struct ErrorField {
+    pub typ: u8,
+    pub value: String,
+}
+
+impl Drop for PgTest {
+    fn drop(&mut self) {
+        let _ = self.send(|buf| frontend::terminate(buf));
+    }
+}
+
+pub fn walk(addr: &str, user: &str, timeout: Duration, dir: &str) {
+    datadriven::walk(dir, |tf| {
+        let mut pgt = PgTest::new(addr, user, timeout).unwrap();
+        tf.run(|tc| -> String {
+            let lines = tc.input.lines();
+            match tc.directive.as_str() {
+                "send" => {
+                    for line in lines {
+                        let mut line = line.splitn(2, ' ');
+                        let typ = line.next().unwrap_or("");
+                        let args = line.next().unwrap_or("{}");
+                        pgt.send(|buf| match typ {
+                            "Query" => {
+                                let v: Query = serde_json::from_str(args).unwrap();
+                                frontend::query(&v.query, buf).unwrap();
+                            }
+                            "ReadyForQuery" => {
+                                let v: Query = serde_json::from_str(args).unwrap();
+                                frontend::query(&v.query, buf).unwrap();
+                            }
+                            "Parse" => {
+                                let v: Parse = serde_json::from_str(args).unwrap();
+                                frontend::parse("", &v.query, vec![], buf).unwrap();
+                            }
+                            "Sync" => frontend::sync(buf),
+                            "Bind" => {
+                                let v: Bind = serde_json::from_str(args).unwrap();
+                                let values = v.values.unwrap_or_default();
+                                if frontend::bind(
+                                    "",     // portal
+                                    "",     // statement
+                                    vec![], // formats
+                                    values, // values
+                                    |t, buf| {
+                                        buf.put_slice(t.as_bytes());
+                                        Ok(IsNull::No)
+                                    }, // serializer
+                                    vec![], // result_formats
+                                    buf,
+                                )
+                                .is_err()
+                                {
+                                    panic!("bind error");
+                                }
+                            }
+                            "Execute" => {
+                                let v: Execute = serde_json::from_str(args).unwrap();
+                                frontend::execute("", v.max_rows.unwrap_or(0), buf).unwrap();
+                            }
+                            _ => panic!("unknown message type {}", typ),
+                        })
+                        .unwrap();
+                    }
+                    "".to_string()
+                }
+                "until" => format!("{}\n", pgt.until(lines.collect()).unwrap().join("\n")),
+                _ => panic!("unknown directive {}", tc.input),
+            }
+        })
+    });
+}
+
+// Frontend messages
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Query {
+    pub query: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Parse {
+    pub query: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Bind {
+    pub values: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Execute {
+    pub max_rows: Option<i32>,
+}

--- a/src/pgtest/src/main.rs
+++ b/src/pgtest/src/main.rs
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{anyhow, Result};
+use getopts::Options;
+
+use std::env;
+
+fn main() -> Result<()> {
+    let args: Vec<_> = env::args().collect();
+
+    let mut opts = Options::new();
+
+    opts.optopt(
+        "",
+        "addr",
+        "database address, default localhost:6875",
+        "HOSTNAME:PORT",
+    );
+    opts.optopt("", "user", "database user, default materialize", "USERNAME");
+
+    let usage_details = anyhow!(opts.usage("usage: pgtest [options] DIRECTORY"));
+    let opts = match opts.parse(&args[1..]) {
+        Ok(opts) => opts,
+        Err(_) => return Err(usage_details),
+    };
+    if opts.free.len() != 1 {
+        return Err(usage_details);
+    }
+    let directory = &opts.free[0];
+
+    pgtest::walk(
+        &opts
+            .opt_str("addr")
+            .unwrap_or_else(|| "localhost:6875".to_string()),
+        &opts
+            .opt_str("user")
+            .unwrap_or_else(|| "materialize".to_string()),
+        std::time::Duration::from_secs(5),
+        directory,
+    );
+
+    Ok(())
+}

--- a/test/pgtest/prepare.pt
+++ b/test/pgtest/prepare.pt
@@ -1,0 +1,46 @@
+# Test basic prepared statement parameters.
+send
+Parse {"query": "SELECT $1::text, 1 + $2::int4"}
+Bind {"values": ["blah", "4"]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["blah","5"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Test portal max rows.
+send
+Query {"query": "BEGIN"}
+Parse {"query": "VALUES (1), (2)"}
+Bind
+Execute {"max_rows": 1}
+Execute {"max_rows": 1}
+Execute {"max_rows": 1}
+Execute {"max_rows": 1}
+Query {"query": "COMMIT"}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+PortalSuspended
+DataRow {"fields":["2"]}
+PortalSuspended
+CommandComplete {"tag":"SELECT 0"}
+CommandComplete {"tag":"SELECT 0"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Add a postgres wire protocol tester. This is useful because it allows
us to test things against a real postgres server and compare the results
to mz without needing to depend on drivers and their specific behavior.

To demonstrate this, a test file is included that demonstrates a current
bug in our pgwire implementation, hence why it isn't hooked up to
builds yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4165)
<!-- Reviewable:end -->
