### PR TITLE
Add durations to peeker

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -444,6 +444,7 @@ mzconduct:
         PEEKER_PORT: "16875:16875"
         MYSQL_EXPORTER_PORT: "9399:9399"
         NUM_WAREHOUSES: ${NUM_WAREHOUSES:-1}
+        OLTP_THREADS: ${OLTP_THREADS:-1}
       steps:
       - step: workflow
         workflow: bring-up-mysql-kafka
@@ -463,14 +464,27 @@ mzconduct:
         host: ${MZ_HOST:-materialized}
         port: 6875
         timeout_secs: 300
-      - step: workflow
-        workflow: heavy-load
+      - step: run
+        service: chbench
+        daemon: true
+        command: >-
+          run
+          --dsn=mysql --gen-dir=/var/lib/mysql-files
+          --analytic-threads=0
+          --transactional-threads=${OLTP_THREADS:-1}
+          --warmup-seconds=300
+          --run-seconds=1200
+          -l /dev/stdout
+          --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
+          --mz-url=postgresql://${MZ_HOST:-materialized}:6875/materialize?sslmode=disable
       - step: run
         service: peeker
         daemon: true
         command: >-
           --queries ${PEEKER_QUERIES:-loadtest}
           --materialized-url postgres://ignoreuser@${MZ_HOST:-materialized}:6875/materialize
+          --warmup-seconds=300
+          --run-seconds=1200
       - step: ensure-stays-up
         container: peeker
         seconds: 10


### PR DESCRIPTION
- Adds warmup and run durations for peeker, as well as uses them for benchmarking work.

  This not only makes my data little tidier and easier to grok, but also gives me a chance to terminate the `chbench` run so I can find out the `tpmC` value it registered, which gives me a sense of when I have saturated the MySQL box.
- Adds unused lever to control number of OLTP threads (i.e. writers) in benchmark; this will be another dimension we need to test to modulate the load we feed from Debezium to Kafka, but I haven't done that plumbing yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4169)
<!-- Reviewable:end -->
