### PR TITLE
*: use conventional capitalization for "Uuid"

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -372,7 +372,7 @@ fn cast_string_to_interval<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 
 fn cast_string_to_uuid<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     strconv::parse_uuid(a.unwrap_str())
-        .map(Datum::UUID)
+        .map(Datum::Uuid)
         .err_into()
 }
 
@@ -2536,7 +2536,7 @@ impl UnaryFunc {
             CastStringToTimestamp => ScalarType::Timestamp.nullable(true),
             CastStringToTimestampTz => ScalarType::TimestampTz.nullable(true),
             CastStringToInterval | CastTimeToInterval => ScalarType::Interval.nullable(true),
-            CastStringToUuid => ScalarType::UUID.nullable(true),
+            CastStringToUuid => ScalarType::Uuid.nullable(true),
 
             CastBoolToInt32 => ScalarType::Int32.nullable(in_nullable),
 
@@ -2948,7 +2948,7 @@ where
         Bytes => strconv::format_bytes(buf, d.unwrap_bytes()),
         String => strconv::format_string(buf, d.unwrap_str()),
         Jsonb => strconv::format_jsonb(buf, JsonbRef::from_datum(d)),
-        UUID => strconv::format_uuid(buf, d.unwrap_uuid()),
+        Uuid => strconv::format_uuid(buf, d.unwrap_uuid()),
         Record { fields } => {
             let mut fields = fields.iter();
             strconv::format_record(buf, &d.unwrap_list(), |buf, d| {

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1501,7 +1501,7 @@ fn build_schema(columns: &[(ColumnName, ColumnType)], include_transaction: bool)
                 "type": "string",
                 "connect.name": "io.debezium.data.Json",
             }),
-            ScalarType::UUID => unimplemented!("uuid type"),
+            ScalarType::Uuid => unimplemented!("uuid type"),
             ScalarType::List(_t) => unimplemented!("list types"),
             ScalarType::Record { .. } => unimplemented!("record types"),
         };
@@ -1862,7 +1862,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::Bytes => Value::Bytes(Vec::from(datum.unwrap_bytes())),
                 ScalarType::String => Value::String(datum.unwrap_str().to_owned()),
                 ScalarType::Jsonb => Value::Json(JsonbRef::from_datum(datum).to_serde_json()),
-                ScalarType::UUID => unimplemented!("uuid type"),
+                ScalarType::Uuid => unimplemented!("uuid type"),
                 ScalarType::List(_t) => unimplemented!("list types"),
                 ScalarType::Record { .. } => unimplemented!("record types"),
             };
@@ -2124,7 +2124,7 @@ pub mod cdc_v2 {
                 ScalarType::Jsonb => json!({
                     "type": "string",
                 }),
-                ScalarType::UUID => json!({
+                ScalarType::Uuid => json!({
                     "type": "string",
                     "logicalType": "uuid",
                 }),

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -46,7 +46,7 @@ pub enum Type {
     /// A date and time, with a timezone.
     TimestampTz,
     /// A universally unique identifier.
-    UUID,
+    Uuid,
 }
 
 lazy_static! {
@@ -81,7 +81,7 @@ impl Type {
             postgres_types::Type::TIME => Some(Type::Time),
             postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
             postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),
-            postgres_types::Type::UUID => Some(Type::UUID),
+            postgres_types::Type::UUID => Some(Type::Uuid),
             _ => None,
         }
     }
@@ -102,7 +102,7 @@ impl Type {
             Type::Time => &postgres_types::Type::TIME,
             Type::Timestamp => &postgres_types::Type::TIMESTAMP,
             Type::TimestampTz => &postgres_types::Type::TIMESTAMPTZ,
-            Type::UUID => &postgres_types::Type::UUID,
+            Type::Uuid => &postgres_types::Type::UUID,
             Type::List(_) => &LIST,
             Type::Record(_) => &postgres_types::Type::RECORD,
         }
@@ -138,7 +138,7 @@ impl Type {
             Type::Time => 4,
             Type::Timestamp => 8,
             Type::TimestampTz => 8,
-            Type::UUID => 16,
+            Type::Uuid => 16,
             Type::List(_) => -1,
             Type::Record(_) => -1,
         }
@@ -162,7 +162,7 @@ impl From<&ScalarType> for Type {
             ScalarType::Bytes => Type::Bytea,
             ScalarType::String => Type::Text,
             ScalarType::Jsonb => Type::Jsonb,
-            ScalarType::UUID => Type::UUID,
+            ScalarType::Uuid => Type::Uuid,
             ScalarType::List(t) => Type::List(Box::new(From::from(&**t))),
             ScalarType::Record { fields } => {
                 Type::Record(fields.iter().map(|(_name, ty)| Type::from(ty)).collect())

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -67,7 +67,7 @@ pub enum Value {
     /// A variable-length string.
     Text(String),
     /// A universally unique identifier.
-    UUID(Uuid),
+    Uuid(Uuid),
 }
 
 impl Value {
@@ -97,7 +97,7 @@ impl Value {
             (_, ScalarType::Jsonb) => {
                 Some(Value::Jsonb(Jsonb(JsonbRef::from_datum(datum).to_owned())))
             }
-            (Datum::UUID(u), ScalarType::UUID) => Some(Value::UUID(u)),
+            (Datum::Uuid(u), ScalarType::Uuid) => Some(Value::Uuid(u)),
             (Datum::List(list), ScalarType::List(elem_type)) => Some(Value::List(
                 list.iter()
                     .map(|elem| Value::from_datum(elem, elem_type))
@@ -144,7 +144,7 @@ impl Value {
                 buf.push_row(js.0.into_row()).unpack_first(),
                 ScalarType::Jsonb,
             ),
-            Value::UUID(u) => (Datum::UUID(u), ScalarType::UUID),
+            Value::Uuid(u) => (Datum::Uuid(u), ScalarType::Uuid),
             Value::List(elems) => {
                 let elem_pg_type = match typ {
                     Type::List(t) => &*t,
@@ -201,7 +201,7 @@ impl Value {
             Value::Numeric(n) => strconv::format_decimal(buf, &n.0),
             Value::Text(s) => strconv::format_string(buf, s),
             Value::Jsonb(js) => strconv::format_jsonb(buf, js.0.as_ref()),
-            Value::UUID(u) => strconv::format_uuid(buf, *u),
+            Value::Uuid(u) => strconv::format_uuid(buf, *u),
             Value::List(elems) => encode_list(buf, elems),
             Value::Record(elems) => encode_record(buf, elems),
         }
@@ -225,7 +225,7 @@ impl Value {
             Value::Numeric(n) => n.to_sql(&PgType::NUMERIC, buf),
             Value::Text(s) => s.to_sql(&PgType::TEXT, buf),
             Value::Jsonb(js) => js.to_sql(&PgType::JSONB, buf),
-            Value::UUID(u) => u.to_sql(&PgType::UUID, buf),
+            Value::Uuid(u) => u.to_sql(&PgType::UUID, buf),
             Value::List(_) => {
                 // for now just use text encoding
                 self.encode_text(buf);
@@ -304,7 +304,7 @@ impl Value {
             Type::Text => Value::Text(raw.to_owned()),
             Type::Numeric => Value::Numeric(Numeric(strconv::parse_decimal(raw)?)),
             Type::Jsonb => Value::Jsonb(Jsonb(strconv::parse_jsonb(raw)?)),
-            Type::UUID => Value::UUID(Uuid::parse_str(raw)?),
+            Type::Uuid => Value::Uuid(Uuid::parse_str(raw)?),
             Type::List(elem_type) => Value::List(decode_list(&elem_type, raw)?),
             Type::Record(_) => {
                 return Err(Box::new(DecodeError::new(
@@ -332,7 +332,7 @@ impl Value {
             Type::Time => NaiveTime::from_sql(ty.inner(), raw).map(Value::Time),
             Type::Timestamp => NaiveDateTime::from_sql(ty.inner(), raw).map(Value::Timestamp),
             Type::TimestampTz => DateTime::<Utc>::from_sql(ty.inner(), raw).map(Value::TimestampTz),
-            Type::UUID => Uuid::from_sql(ty.inner(), raw).map(Value::UUID),
+            Type::Uuid => Uuid::from_sql(ty.inner(), raw).map(Value::Uuid),
             Type::List(_) => {
                 // just using the text encoding for now
                 Value::decode_text(ty, raw)
@@ -412,7 +412,7 @@ pub fn null_datum(ty: &Type) -> (Datum<'static>, ScalarType) {
         Type::Time => ScalarType::Time,
         Type::Timestamp => ScalarType::Timestamp,
         Type::TimestampTz => ScalarType::TimestampTz,
-        Type::UUID => ScalarType::UUID,
+        Type::Uuid => ScalarType::Uuid,
         Type::List(t) => {
             let (_, elem_type) = null_datum(t);
             ScalarType::List(Box::new(elem_type))

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -172,7 +172,7 @@ enum Tag {
     Interval,
     Bytes,
     String,
-    UUID,
+    Uuid,
     List,
     Dict,
     JsonNull,
@@ -292,10 +292,10 @@ unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
             let string = read_untagged_string(data, offset);
             Datum::String(string)
         }
-        Tag::UUID => {
+        Tag::Uuid => {
             let mut b: uuid::Bytes = [0; 16];
             b.copy_from_slice(read_untagged_bytes(data, offset));
-            Datum::UUID(Uuid::from_bytes(b))
+            Datum::Uuid(Uuid::from_bytes(b))
         }
         Tag::List => {
             let bytes = read_untagged_bytes(data, offset);
@@ -387,8 +387,8 @@ fn push_datum(data: &mut Vec<u8>, datum: Datum) {
             data.push(Tag::String as u8);
             push_untagged_string(data, string);
         }
-        Datum::UUID(u) => {
-            data.push(Tag::UUID as u8);
+        Datum::Uuid(u) => {
+            data.push(Tag::Uuid as u8);
             push_untagged_bytes(data, u.as_bytes());
         }
         Datum::List(list) => {
@@ -424,7 +424,7 @@ pub fn datum_size(datum: &Datum) -> usize {
         Datum::Decimal(_) => 1 + size_of::<Significand>(),
         Datum::Bytes(bytes) => 1 + size_of::<usize>() + bytes.len(),
         Datum::String(string) => 1 + size_of::<usize>() + string.as_bytes().len(),
-        Datum::UUID(_) => 1 + size_of::<Uuid>(),
+        Datum::Uuid(_) => 1 + size_of::<Uuid>(),
         Datum::List(list) => 1 + size_of::<usize>() + list.data.len(),
         Datum::Dict(dict) => 1 + size_of::<usize>() + dict.data.len(),
         Datum::JsonNull => 1,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -64,7 +64,7 @@ pub enum Datum<'a> {
     /// distinct from a non-null datum that contains the JSON value `null`.
     JsonNull,
     /// A universally unique identifier.
-    UUID(Uuid),
+    Uuid(Uuid),
     /// A placeholder value.
     ///
     /// Dummy values are never meant to be observed. Many operations on `Datum`
@@ -268,10 +268,10 @@ impl<'a> Datum<'a> {
     ///
     /// # Panics
     ///
-    /// Panics if the datum is not [`Datum::UUID`].
+    /// Panics if the datum is not [`Datum::Uuid`].
     pub fn unwrap_uuid(&self) -> Uuid {
         match self {
-            Datum::UUID(u) => *u,
+            Datum::Uuid(u) => *u,
             _ => panic!("Datum::unwrap_uuid called on {:?}", self),
         }
     }
@@ -352,8 +352,8 @@ impl<'a> Datum<'a> {
                     (Datum::Bytes(_), _) => false,
                     (Datum::String(_), ScalarType::String) => true,
                     (Datum::String(_), _) => false,
-                    (Datum::UUID(_), ScalarType::UUID) => true,
-                    (Datum::UUID(_), _) => false,
+                    (Datum::Uuid(_), ScalarType::Uuid) => true,
+                    (Datum::Uuid(_), _) => false,
                     (Datum::List(list), ScalarType::List(t)) => list
                         .iter()
                         .all(|e| e.is_null() || is_instance_of_scalar(e, t)),
@@ -550,7 +550,7 @@ impl fmt::Display for Datum<'_> {
                 }
                 f.write_str("\"")
             }
-            Datum::UUID(u) => write!(f, "{}", u),
+            Datum::Uuid(u) => write!(f, "{}", u),
             Datum::List(list) => {
                 f.write_str("[")?;
                 write_delimited(f, ", ", list, |f, e| write!(f, "{}", e))?;
@@ -619,8 +619,8 @@ pub enum ScalarType {
     ///   * [`Datum::List`]
     ///   * [`Datum::Dict`]
     Jsonb,
-    /// The type of [`Datum::UUID`].
-    UUID,
+    /// The type of [`Datum::Uuid`].
+    Uuid,
     /// The type of [`Datum::List`].
     ///
     /// Elements within the list are of the specified type. List elements may
@@ -719,7 +719,7 @@ impl PartialEq for ScalarType {
             | (Interval, Interval)
             | (Bytes, Bytes)
             | (String, String)
-            | (UUID, UUID)
+            | (Uuid, Uuid)
             | (Jsonb, Jsonb) => true,
 
             (List(a), List(b)) => a.eq(b),
@@ -739,7 +739,7 @@ impl PartialEq for ScalarType {
             | (Bytes, _)
             | (String, _)
             | (Jsonb, _)
-            | (UUID, _)
+            | (Uuid, _)
             | (List(_), _)
             | (Record { .. }, _) => false,
         }
@@ -777,7 +777,7 @@ impl Hash for ScalarType {
                 state.write_u8(15);
                 fields.hash(state);
             }
-            UUID => state.write_u8(16),
+            Uuid => state.write_u8(16),
         }
     }
 }
@@ -805,7 +805,7 @@ impl fmt::Display for ScalarType {
             Bytes => f.write_str("bytes"),
             String => f.write_str("string"),
             Jsonb => f.write_str("jsonb"),
-            UUID => f.write_str("uuid"),
+            Uuid => f.write_str("uuid"),
             List(t) => write!(f, "{} list", t),
             Record { fields } => {
                 f.write_str("record(")?;

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -62,7 +62,7 @@ impl TypeCategory {
     fn from_type(typ: &ScalarType) -> Self {
         match typ {
             ScalarType::Bool => Self::Bool,
-            ScalarType::Bytes | ScalarType::Jsonb | ScalarType::UUID | ScalarType::List(_) => {
+            ScalarType::Bytes | ScalarType::Jsonb | ScalarType::Uuid | ScalarType::List(_) => {
                 Self::UserDefined
             }
             ScalarType::Date

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2112,7 +2112,7 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, anyhow::
         DataType::Interval => ScalarType::Interval,
         DataType::Bytea => ScalarType::Bytes,
         DataType::Jsonb => ScalarType::Jsonb,
-        DataType::Uuid => ScalarType::UUID,
+        DataType::Uuid => ScalarType::Uuid,
         DataType::List(elem_type) => ScalarType::List(Box::new(scalar_type_from_sql(elem_type)?)),
         other @ DataType::Binary(..)
         | other @ DataType::Blob(_)
@@ -2139,7 +2139,7 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
         pgrepr::Type::Bytea => Ok(ScalarType::Bytes),
         pgrepr::Type::Text => Ok(ScalarType::String),
         pgrepr::Type::Jsonb => Ok(ScalarType::Jsonb),
-        pgrepr::Type::UUID => Ok(ScalarType::UUID),
+        pgrepr::Type::Uuid => Ok(ScalarType::Uuid),
         pgrepr::Type::List(l) => Ok(ScalarType::List(Box::new(scalar_type_from_pg(l)?))),
         pgrepr::Type::Record(_) => {
             bail!("internal error: can't convert from pg record to materialize record")

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -330,7 +330,7 @@ lazy_static! {
             (String, Explicit(Interval)) => CastStringToInterval,
             (String, Explicit(Bytes)) => CastStringToBytes,
             (String, Explicit(Jsonb)) => CastStringToJsonb,
-            (String, Explicit(UUID)) => CastStringToUuid,
+            (String, Explicit(Uuid)) => CastStringToUuid,
             (String, JsonbAny) => CastJsonbOrNullToJsonb,
 
             // RECORD
@@ -351,7 +351,7 @@ lazy_static! {
             (Jsonb, JsonbAny) => CastJsonbOrNullToJsonb,
 
             // UUID
-            (UUID, Explicit(String)) => CastUuidToString
+            (Uuid, Explicit(String)) => CastUuidToString
         }
     };
 }

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -447,7 +447,7 @@ fn push_column(
         }
         DataType::Uuid => {
             let u = get_column_inner::<Uuid>(postgres_row, i, nullable)?.unwrap();
-            row.push(Datum::UUID(u));
+            row.push(Datum::Uuid(u));
         }
         _ => bail!(
             "Postgres to materialize conversion not yet supported for {:?}",


### PR DESCRIPTION
Unlike in Go, the conventional capitalization of acronyms in Rust uses CamelCase. Adjust "UUID" to "Uuid" accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4177)
<!-- Reviewable:end -->
