### PR TITLE
EXPLAIN: Have each delta of a DeltaQuery and aggregation of a Reduce be on a separate line.

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -122,7 +122,8 @@ operator use the outputs of chains `%0`, `%1` and `%2` as its inputs.
 %3 =
 | Join %0 %1 %2 (= #8 #17) (= #0 #9)
 | Filter (#6 = "BUILDING"), (#12 < 1995-03-15), (#27 > 1995-03-15)
-| Reduce group=(#8, #12, #15) sum((#22 * (100dec - #23)))
+| Reduce group=(#8, #12, #15)
+| | agg sum((#22 * (100dec - #23)))
 | Project (#0, #3, #1, #2)
 ```
 
@@ -153,7 +154,10 @@ example is the choice of implementation in the `Join` operator.
 ```
 %3 =
 | Join %0 %1 %2 (= #8 #17) (= #0 #9)
-| | implementation = DeltaQuery %0 %1.(#1) %2.(#0) | %1 %0.(#0) %2.(#0) | %2 %1.(#0) %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#1) %2.(#0)
+| |   delta %1 %0.(#0) %2.(#0)
+| |   delta %2 %1.(#0) %0.(#0)
 | | demand = (#6, #8, #12, #15, #22, #23, #27)
 | Filter (#6 = "BUILDING"), (#12 < 1995-03-15), (#27 > 1995-03-15)
 | Reduce group=(#8, #12, #15) sum((#22 * (100dec - #23)))
@@ -212,7 +216,7 @@ Operator | Meaning | Example
 **FlatMapUnary** | Appends the result of some table function to each row in the input | `FlatMapUnary jsonb_foreach(#3)`
 **Filter** | Remove rows of the input for which some scalar predicates return false | `Filter (#20 < #21)`
 **Join** | Perform one of INNER / LEFT / RIGHT / FULL OUTER on the two inputs, using the given predicate | `InnerJoin %0 %1 on (#1 = #2)`
-**Reduce** | Groups the input rows by some scalar expressions, reduces each group using some aggregate functions and produce rows containing the group key and aggregate outputs. In the case where the group key is empty and the input is empty, returns a single row with the aggregate functions applied to empty rows. | `Reduce group=(#5) countall(null)`
+**Reduce** | Groups the input rows by some scalar expressions, reduces each group using some aggregate functions and produce rows containing the group key and aggregate outputs. In the case where the group key is empty and the input is empty, returns a single row with the aggregate functions applied to empty rows. | `Reduce group=(#5) agg countall(null)`
 **Distinct** | Remove duplicate copies of input rows | `Distinct`
 **TopK** | Groups the inputs rows by some scalar expressions, sorts each group using the group key, removes the top `offset` rows in each group and returns the next `limit` rows | `TopK group=() order=(#1 asc, #0 desc) limit=5 offset=0`
 **Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -234,7 +234,12 @@ ORDER BY ol_number
 %0 =
 | Get materialize.public.orderline (u19)
 | Filter (datetots(#6) > 2007-01-02 00:00:00)
-| Reduce group=(#3) sum(#7) sum(#8) count(#7) count(#8) count(true)
+| Reduce group=(#3)
+| | agg sum(#7)
+| | agg sum(#8)
+| | agg count(#7)
+| | agg count(#8)
+| | agg count(true)
 | Map (i64tof64(#1) / i64tof64(if (#3 = 0) then {null} else {#3})), (((#2 * 10000000dec) / i64todec(if (#4 = 0) then {null} else {#4})) / 10dec)
 | Project (#0..#2, #6, #7, #5)
 
@@ -307,10 +312,15 @@ ORDER BY n_name, su_name, i_id
 
 %9 =
 | Join %5 %6 %7 %8 (= #27 #29) (= #21 #25) (= #17 #18)
-| | implementation = DeltaQuery %5 %6.(#0) %7.(#0) %8.(#0) | %6 %7.(#0) %8.(#0) %5.(#17) | %7 %8.(#0) %6.(#3) %5.(#17) | %8 %7.(#2) %6.(#3) %5.(#17)
+| | implementation = DeltaQuery
+| |   delta %5 %6.(#0) %7.(#0) %8.(#0)
+| |   delta %6 %7.(#0) %8.(#0) %5.(#17)
+| |   delta %7 %8.(#0) %6.(#3) %5.(#17)
+| |   delta %8 %7.(#2) %6.(#3) %5.(#17)
 | | demand = (#0, #2, #30)
 | Filter "^EUROP.*$" ~(#30)
-| Reduce group=(#0) min(#2)
+| Reduce group=(#0)
+| | agg min(#2)
 | Filter !(isnull(#1))
 | ArrangeBy (#0, #1)
 
@@ -362,10 +372,15 @@ ORDER BY revenue DESC, o_entry_d
 
 %4 =
 | Join %0 %1 %2 %3 (= #2 #24 #27 #35) (= #1 #23 #26 #34) (= #22 #25 #33) (= #0 #28)
-| | implementation = DeltaQuery %0 %2.(#2, #1, #3) %1.(#0, #1, #2) %3.(#2, #1, #0) | %1 %2.(#0, #1, #2) %0.(#0, #1, #2) %3.(#2, #1, #0) | %2 %0.(#0, #1, #2) %1.(#0, #1, #2) %3.(#2, #1, #0) | %3 %1.(#0, #1, #2) %2.(#0, #1, #2) %0.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %0 %2.(#2, #1, #3) %1.(#0, #1, #2) %3.(#2, #1, #0)
+| |   delta %1 %2.(#0, #1, #2) %0.(#0, #1, #2) %3.(#2, #1, #0)
+| |   delta %2 %0.(#0, #1, #2) %1.(#0, #1, #2) %3.(#2, #1, #0)
+| |   delta %3 %1.(#0, #1, #2) %2.(#0, #1, #2) %0.(#0, #1, #2)
 | | demand = (#1, #2, #9, #22, #29, #41)
 | Filter "^A.*$" ~(#9), (datetots(#29) > 2007-01-02 00:00:00)
-| Reduce group=(#22, #2, #1, #29) sum(#41)
+| Reduce group=(#22, #2, #1, #29)
+| | agg sum(#41)
 | Project (#0..#2, #4, #3)
 
 Finish order_by=(#3 desc, #4 asc) limit=none offset=0 project=(#0..#4)
@@ -407,7 +422,9 @@ ORDER BY o_ol_cnt
 
 %4 =
 | Join %2 %3 (= #0 #8) (= #1 #9) (= #2 #10)
-| | implementation = DeltaQuery %2 %3.(#2, #1, #0) | %3 %2.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %2 %3.(#2, #1, #0)
+| |   delta %3 %2.(#0, #1, #2)
 | | demand = (#0..#2, #4, #14)
 | Filter (#14 >= #4)
 | Distinct group=(#0, #1, #2, #4)
@@ -417,7 +434,8 @@ ORDER BY o_ol_cnt
 | Join %1 %4 (= #0 #8) (= #1 #9) (= #2 #10) (= #4 #11)
 | | implementation = Differential %1 %4.(#0, #1, #2, #3)
 | | demand = (#6)
-| Reduce group=(#6) count(true)
+| Reduce group=(#6)
+| | agg count(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -479,7 +497,8 @@ ORDER BY revenue DESC
 | | implementation = Differential %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0, #1) %4.(#0, #3) %5.(#0) %6.(#0)
 | | demand = (#26, #38, #66, #70)
 | Filter (#70 = "EUROPE"), (datetots(#26) >= 2007-01-02 00:00:00)
-| Reduce group=(#66) sum(#38)
+| Reduce group=(#66)
+| | agg sum(#38)
 
 Finish order_by=(#1 desc) limit=none offset=0 project=(#0, #1)
 
@@ -497,7 +516,8 @@ AND ol_quantity BETWEEN 1 AND 100000
 %0 =
 | Get materialize.public.orderline (u19)
 | Filter (datetots(#6) < 2020-01-01 00:00:00), (#7 <= 100000), (#7 >= 1), (datetots(#6) >= 1999-01-01 00:00:00)
-| Reduce group=() sum(#8)
+| Reduce group=()
+| | agg sum(#8)
 
 %1 =
 | Get %0
@@ -578,10 +598,18 @@ ORDER BY su_nationkey, cust_nation, l_year
 
 %7 =
 | Join %0 %1 %2 %3 %4 %5 %6 (= #64 #69) (= #38 #43) (= #27 #37 #45) (= #26 #36 #44) (= #25 #35) (= #8 #30) (= #7 #29) (= #3 #65) (= #0 #24)
-| | implementation = DeltaQuery %0 %5.(#0) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0) | %1 %0.(#0) %5.(#0) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0) | %2 %3.(#0, #1, #2) %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %5.(#0) %6.(#0) | %3 %4.(#0, #1, #2) %6.(#0) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0) | %4 %6.(#0) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0) | %5 %0.(#3) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0) | %6 %4.(#21) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %5.(#0) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0)
+| |   delta %1 %0.(#0) %5.(#0) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0)
+| |   delta %2 %3.(#0, #1, #2) %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %5.(#0) %6.(#0)
+| |   delta %3 %4.(#0, #1, #2) %6.(#0) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
+| |   delta %4 %6.(#0) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
+| |   delta %5 %0.(#3) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0)
+| |   delta %6 %4.(#21) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
 | | demand = (#3, #31, #33, #39, #52, #66, #70)
 | Filter (((#66 = "GERMANY") && (#70 = "CAMBODIA")) || ((#66 = "CAMBODIA") && (#70 = "GERMANY"))), (datetots(#31) <= 2012-01-02 00:00:00), (datetots(#31) >= 2007-01-02 00:00:00)
-| Reduce group=(#3, substr(#52, 1, 1), date_part_year_tstz(datetotstz(#39))) sum(#33)
+| Reduce group=(#3, substr(#52, 1, 1), date_part_year_tstz(datetotstz(#39)))
+| | agg sum(#33)
 
 Finish order_by=(#0 asc, #1 asc, #2 asc) limit=none offset=0 project=(#0..#3)
 
@@ -653,10 +681,21 @@ ORDER BY l_year
 
 %9 =
 | Join %0 %1 %2 %3 %4 %5 %6 %7 %8 (= #72 #78) (= #69 #70) (= #43 #48) (= #32 #42 #50) (= #31 #41 #49) (= #30 #40) (= #13 #35) (= #0 #12 #34) (= #8 #74) (= #5 #29)
-| | implementation = DeltaQuery %0 %2.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %1 %7.(#0) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %2 %0.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %0.(#0) %1.(#0) %6.(#0) %7.(#0) %8.(#0) | %4 %5.(#0, #1, #2) %6.(#0) %8.(#0) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0) | %5 %6.(#0) %8.(#0) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0) | %6 %8.(#0) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0) | %7 %1.(#3) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0) | %8 %6.(#2) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %2.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
+| |   delta %1 %7.(#0) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
+| |   delta %2 %0.(#0) %1.(#0) %7.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
+| |   delta %3 %4.(#0, #1, #2) %5.(#0, #1, #2) %2.(#0, #1) %0.(#0) %1.(#0) %6.(#0) %7.(#0) %8.(#0)
+| |   delta %4 %5.(#0, #1, #2) %6.(#0) %8.(#0) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
+| |   delta %5 %6.(#0) %8.(#0) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
+| |   delta %6 %8.(#0) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
+| |   delta %7 %1.(#3) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
+| |   delta %8 %6.(#2) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
 | | demand = (#0, #4, #38, #44, #75, #79)
 | Filter !(isnull(#0)), "^.*b$" ~(#4), (#79 = "EUROPE"), (#0 < 1000), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
-| Reduce group=(date_part_year_tstz(datetotstz(#44))) sum(if (#75 = "GERMANY") then {#38} else {0dec}) sum(#38)
+| Reduce group=(date_part_year_tstz(datetotstz(#44)))
+| | agg sum(if (#75 = "GERMANY") then {#38} else {0dec})
+| | agg sum(#38)
 | Map (((#1 * 10000000dec) / if (#2 = 0dec) then {100dec} else {#2}) * 10dec)
 | Project (#0, #3)
 
@@ -709,10 +748,17 @@ ORDER BY n_name, l_year DESC
 
 %6 =
 | Join %0 %1 %2 %3 %4 %5 (= #32 #42) (= #31 #41) (= #30 #40) (= #26 #48) (= #22 #23) (= #6 #35) (= #0 #5 #34)
-| | implementation = DeltaQuery %0 %1.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2) | %1 %0.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2) | %2 %5.(#0) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) | %3 %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0) | %4 %3.(#2, #1, #0) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0) | %5 %2.(#3) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2)
+| |   delta %1 %0.(#0) %2.(#0) %5.(#0) %3.(#5, #4) %4.(#0, #1, #2)
+| |   delta %2 %5.(#0) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
+| |   delta %3 %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
+| |   delta %4 %3.(#2, #1, #0) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
+| |   delta %5 %2.(#3) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
 | | demand = (#4, #38, #44, #49)
 | Filter "^.*BB$" ~(#4)
-| Reduce group=(#49, date_part_year_tstz(datetotstz(#44))) sum(#38)
+| Reduce group=(#49, date_part_year_tstz(datetotstz(#44)))
+| | agg sum(#38)
 
 Finish order_by=(#0 asc, #1 desc) limit=none offset=0 project=(#0..#2)
 
@@ -754,10 +800,15 @@ ORDER BY revenue DESC
 
 %4 =
 | Join %0 %1 %2 %3 (= #2 #24 #32) (= #1 #23 #31) (= #22 #30) (= #21 #40) (= #0 #25)
-| | implementation = DeltaQuery %0 %3.(#0) %1.(#2, #1, #3) %2.(#2, #1, #0) | %1 %0.(#0, #1, #2) %3.(#0) %2.(#2, #1, #0) | %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0) | %3 %0.(#21) %1.(#2, #1, #3) %2.(#2, #1, #0)
+| | implementation = DeltaQuery
+| |   delta %0 %3.(#0) %1.(#2, #1, #3) %2.(#2, #1, #0)
+| |   delta %1 %0.(#0, #1, #2) %3.(#0) %2.(#2, #1, #0)
+| |   delta %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0)
+| |   delta %3 %0.(#21) %1.(#2, #1, #3) %2.(#2, #1, #0)
 | | demand = (#0, #5, #8, #11, #26, #36, #38, #41)
 | Filter (#26 <= #36), (datetots(#26) >= 2007-01-02 00:00:00)
-| Reduce group=(#0, #5, #8, #11, #41) sum(#38)
+| Reduce group=(#0, #5, #8, #11, #41)
+| | agg sum(#38)
 | Project (#0, #1, #5, #2..#4)
 
 Finish order_by=(#2 desc) limit=none offset=0 project=(#0..#5)
@@ -796,10 +847,14 @@ ORDER BY ordercount DESC
 
 %3 =
 | Join %0 %1 %2 (= #21 #25) (= #17 #18)
-| | implementation = DeltaQuery %0 %1.(#0) %2.(#0) | %1 %2.(#0) %0.(#17) | %2 %1.(#3) %0.(#17)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0) %2.(#0)
+| |   delta %1 %2.(#0) %0.(#17)
+| |   delta %2 %1.(#3) %0.(#17)
 | | demand = (#0, #14, #26)
 | Filter (#26 = "GERMANY")
-| Reduce group=(#0) sum(#14)
+| Reduce group=(#0)
+| | agg sum(#14)
 
 %4 =
 | Get materialize.public.stock (u26)
@@ -815,10 +870,14 @@ ORDER BY ordercount DESC
 
 %7 =
 | Join %4 %5 %6 (= #21 #25) (= #17 #18)
-| | implementation = DeltaQuery %4 %5.(#0) %6.(#0) | %5 %6.(#0) %4.(#17) | %6 %5.(#3) %4.(#17)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#0) %6.(#0)
+| |   delta %5 %6.(#0) %4.(#17)
+| |   delta %6 %5.(#3) %4.(#17)
 | | demand = (#14, #26)
 | Filter (#26 = "GERMANY")
-| Reduce group=() sum(#14)
+| Reduce group=()
+| | agg sum(#14)
 | Map (i64todec(#0) * 5dec)
 | ArrangeBy ()
 
@@ -860,10 +919,14 @@ ORDER BY o_ol_cnt
 
 %2 =
 | Join %0 %1 (= #2 #10) (= #1 #9) (= #0 #8)
-| | implementation = DeltaQuery %0 %1.(#2, #1, #0) | %1 %0.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#2, #1, #0)
+| |   delta %1 %0.(#0, #1, #2)
 | | demand = (#4..#6, #14)
 | Filter (datetots(#14) < 2020-01-01 00:00:00), (#4 <= #14)
-| Reduce group=(#6) sum(if ((#5 = 1) || (#5 = 2)) then {1} else {0}) sum(if ((#5 != 1) && (#5 != 2)) then {1} else {0})
+| Reduce group=(#6)
+| | agg sum(if ((#5 = 1) || (#5 = 2)) then {1} else {0})
+| | agg sum(if ((#5 != 1) && (#5 != 2)) then {1} else {0})
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 
@@ -895,7 +958,9 @@ ORDER BY custdist DESC, c_count DESC
 
 %2 =
 | Join %0 %1 (= #2 #24) (= #1 #23) (= #0 #25)
-| | implementation = DeltaQuery %0 %1.(#2, #1, #3) | %1 %0.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#2, #1, #3)
+| |   delta %1 %0.(#0, #1, #2)
 | | demand = (#0..#22, #27)
 | Filter (#27 > 8)
 
@@ -916,8 +981,10 @@ ORDER BY custdist DESC, c_count DESC
 
 %7 =
 | Union %3 %6
-| Reduce group=(#0) count(#22)
-| Reduce group=(#1) count(true)
+| Reduce group=(#0)
+| | agg count(#22)
+| Reduce group=(#1)
+| | agg count(true)
 
 Finish order_by=(#1 desc, #0 desc) limit=none offset=0 project=(#0, #1)
 
@@ -943,10 +1010,14 @@ AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 
 %2 =
 | Join %0 %1 (= #4 #10)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#4)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#4)
 | | demand = (#6, #8, #14)
 | Filter (datetots(#6) < 2020-01-02 00:00:00), (datetots(#6) >= 2007-01-02 00:00:00)
-| Reduce group=() sum(if "^PR.*$" ~(#14) then {#8} else {0dec}) sum(#8)
+| Reduce group=()
+| | agg sum(if "^PR.*$" ~(#14) then {#8} else {0dec})
+| | agg sum(#8)
 
 %3 =
 | Get %2
@@ -1016,10 +1087,13 @@ ORDER BY su_suppkey
 
 %3 =
 | Join %1 %2 (= #5 #11) (= #4 #10)
-| | implementation = DeltaQuery %1 %2.(#0, #1) | %2 %1.(#5, #4)
+| | implementation = DeltaQuery
+| |   delta %1 %2.(#0, #1)
+| |   delta %2 %1.(#5, #4)
 | | demand = (#6, #8, #27)
 | Filter (datetots(#6) >= 2007-01-02 00:00:00)
-| Reduce group=(#27) sum(#8)
+| Reduce group=(#27)
+| | agg sum(#8)
 | ArrangeBy (#0)
 
 %4 =
@@ -1032,11 +1106,15 @@ ORDER BY su_suppkey
 
 %6 =
 | Join %4 %5 (= #5 #11) (= #4 #10)
-| | implementation = DeltaQuery %4 %5.(#0, #1) | %5 %4.(#5, #4)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#0, #1)
+| |   delta %5 %4.(#5, #4)
 | | demand = (#6, #8, #27)
 | Filter (datetots(#6) >= 2007-01-02 00:00:00)
-| Reduce group=(#27) sum(#8)
-| Reduce group=() max(#1)
+| Reduce group=(#27)
+| | agg sum(#8)
+| Reduce group=()
+| | agg max(#1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
@@ -1078,7 +1156,9 @@ ORDER BY supplier_cnt DESC
 
 %2 =
 | Join %0 %1 (= #0 #18)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#0)
 | | demand = (#17, #20..#22)
 | Filter !("^zz.*$" ~(#22))
 
@@ -1100,7 +1180,9 @@ ORDER BY supplier_cnt DESC
 
 %7 =
 | Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
+| | implementation = DeltaQuery
+| |   delta %5 %6.(#0)
+| |   delta %6 %5.(#0)
 | | demand = (#0, #7)
 | Filter "^.*bad.*$" ~(#7)
 | Negate
@@ -1116,7 +1198,8 @@ ORDER BY supplier_cnt DESC
 | Join %4 %9 (= #17 #23)
 | | implementation = Differential %9 %4.(#17)
 | | demand = (#17, #20..#22)
-| Reduce group=(#20, substr(#22, 1, 3), #21) count(distinct #17)
+| Reduce group=(#20, substr(#22, 1, 3), #21)
+| | agg count(distinct #17)
 
 Finish order_by=(#3 desc) limit=none offset=0 project=(#0..#3)
 
@@ -1152,19 +1235,26 @@ AND ol_quantity < t.a
 
 %3 =
 | Join %1 %2 (= #0 #9)
-| | implementation = DeltaQuery %1 %2.(#4) | %2 %1.(#0)
+| | implementation = DeltaQuery
+| |   delta %1 %2.(#4)
+| |   delta %2 %1.(#0)
 | | demand = (#0, #4, #12)
 | Filter "^.*b$" ~(#4)
-| Reduce group=(#0) sum(#12) count(#12)
+| Reduce group=(#0)
+| | agg sum(#12)
+| | agg count(#12)
 | Map (i64tof64(#1) / i64tof64(if (#2 = 0) then {null} else {#2}))
 | ArrangeBy (#0)
 
 %4 =
 | Join %0 %3 (= #4 #10)
-| | implementation = DeltaQuery %0 %3.(#0) | %3 %0.(#4)
+| | implementation = DeltaQuery
+| |   delta %0 %3.(#0)
+| |   delta %3 %0.(#4)
 | | demand = (#7, #8, #13)
 | Filter (i32tof64(#7) < #13)
-| Reduce group=() sum(#8)
+| Reduce group=()
+| | agg sum(#8)
 
 %5 =
 | Get %4
@@ -1217,9 +1307,13 @@ ORDER BY sum(ol_amount) DESC, o_entry_d
 
 %3 =
 | Join %0 %1 %2 (= #2 #24 #32) (= #1 #23 #31) (= #22 #30) (= #0 #25)
-| | implementation = DeltaQuery %0 %1.(#2, #1, #3) %2.(#2, #1, #0) | %1 %0.(#0, #1, #2) %2.(#2, #1, #0) | %2 %1.(#0, #1, #2) %0.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#2, #1, #3) %2.(#2, #1, #0)
+| |   delta %1 %0.(#0, #1, #2) %2.(#2, #1, #0)
+| |   delta %2 %1.(#0, #1, #2) %0.(#0, #1, #2)
 | | demand = (#0..#2, #5, #22, #26, #28, #38)
-| Reduce group=(#22, #2, #1, #0, #5, #26, #28) sum(#38)
+| Reduce group=(#22, #2, #1, #0, #5, #26, #28)
+| | agg sum(#38)
 | Filter (#7 > 20000dec)
 | Project (#4, #3, #0, #5..#7)
 
@@ -1265,10 +1359,13 @@ WHERE (
 
 %2 =
 | Join %0 %1 (= #4 #10)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#4)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#4)
 | | demand = (#2, #7, #8, #13, #14)
 | Filter ((("^.*a$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 3))) || ("^.*b$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 4)))) || ("^.*c$" ~(#14) && (((#2 = 1) || (#2 = 5)) || (#2 = 3)))), (#7 <= 10), (#13 <= 40000000dec), (#7 >= 1), (#13 >= 100dec)
-| Reduce group=() sum(#8)
+| Reduce group=()
+| | agg sum(#8)
 
 %3 =
 | Get %2
@@ -1319,7 +1416,9 @@ ORDER BY su_name
 
 %2 =
 | Join %0 %1 (= #3 #7)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#3)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#3)
 | | demand = (#0..#2, #8)
 | Filter (#8 = "GERMANY")
 
@@ -1347,7 +1446,8 @@ ORDER BY su_name
 | | implementation = Differential %5.(#0) %7.(#0) %6.(#4) %4.()
 | | demand = (#0, #11..#13, #35, #36, #43)
 | Filter "^co.*$" ~(#43), (datetots(#35) > 2010-05-23 12:00:00)
-| Reduce group=(#0, #11, #12, #13) sum(#36)
+| Reduce group=(#0, #11, #12, #13)
+| | agg sum(#36)
 | Filter (i32toi64((2 * #3)) > #4)
 | Map ((#1 * #2) % 10000)
 | Filter (#0 = #5)
@@ -1449,7 +1549,8 @@ ORDER BY numwait DESC, su_name
 | Join %7 %12 (= #7 #47) (= #8 #48) (= #9 #49) (= #13 #50)
 | | implementation = Differential %12 %7.(#7, #8, #9, #13)
 | | demand = (#1)
-| Reduce group=(#1) count(true)
+| Reduce group=(#1)
+| | agg count(true)
 
 Finish order_by=(#1 desc, #0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -1485,7 +1586,9 @@ ORDER BY substr(c_state, 1, 1)
 %1 =
 | Get materialize.public.customer (u6)
 | Filter (((((((substr(#11, 1, 1) = "1") || (substr(#11, 1, 1) = "2")) || (substr(#11, 1, 1) = "3")) || (substr(#11, 1, 1) = "4")) || (substr(#11, 1, 1) = "5")) || (substr(#11, 1, 1) = "6")) || (substr(#11, 1, 1) = "7")), (#16 > 0dec)
-| Reduce group=() sum(#16) count(#16)
+| Reduce group=()
+| | agg sum(#16)
+| | agg count(#16)
 | Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
 | ArrangeBy ()
 
@@ -1509,7 +1612,9 @@ ORDER BY substr(c_state, 1, 1)
 
 %6 =
 | Join %4 %5 (= #0 #28) (= #1 #26) (= #2 #27)
-| | implementation = DeltaQuery %4 %5.(#2, #1, #3) | %5 %4.(#0, #1, #2)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#2, #1, #3)
+| |   delta %5 %4.(#0, #1, #2)
 | | demand = (#0..#2)
 | Distinct group=(#0, #1, #2)
 | Negate
@@ -1525,7 +1630,9 @@ ORDER BY substr(c_state, 1, 1)
 | Join %3 %8 (= #0 #25) (= #1 #26) (= #2 #27)
 | | implementation = Differential %8 %3.(#0, #1, #2)
 | | demand = (#9, #16)
-| Reduce group=(substr(#9, 1, 1)) count(true) sum(#16)
+| Reduce group=(substr(#9, 1, 1))
+| | agg count(true)
+| | agg sum(#16)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -318,7 +318,9 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 
 %6 =
 | Join %4 %5 (= #0 #1)
-| | implementation = DeltaQuery %4 %5.(#0) | %5 %4.(#0)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#0)
+| |   delta %5 %4.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 | ArrangeBy (#0)
@@ -482,7 +484,9 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 
 %3 =
 | Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery %1 %2.(#0) | %2 %1.(#0)
+| | implementation = DeltaQuery
+| |   delta %1 %2.(#0)
+| |   delta %2 %1.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 
@@ -533,7 +537,9 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 
 %3 =
 | Join %1 %2 (= #0 #1)
-| | implementation = DeltaQuery %1 %2.(#0) | %2 %1.(#0)
+| | implementation = DeltaQuery
+| |   delta %1 %2.(#0)
+| |   delta %2 %1.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -161,7 +161,13 @@ ORDER BY
 %0 =
 | Get materialize.public.lineitem (u21)
 | Filter (#10 <= 1998-12-01)
-| Reduce group=(#8, #9) sum(#4) sum(#5) sum((#5 * (100dec - #6))) sum(((#5 * (100dec - #6)) * (100dec + #7))) count(true) sum(#6)
+| Reduce group=(#8, #9)
+| | agg sum(#4)
+| | agg sum(#5)
+| | agg sum((#5 * (100dec - #6)))
+| | agg sum(((#5 * (100dec - #6)) * (100dec + #7)))
+| | agg count(true)
+| | agg sum(#6)
 | Map i64todec(if (#6 = 0) then {null} else {#6}), (((#2 * 10000000dec) / #8) / 10dec), (((#3 * 10000000dec) / #8) / 10dec), (((#7 * 10000000dec) / #8) / 10dec)
 | Project (#0..#5, #9..#11, #6)
 
@@ -229,7 +235,12 @@ ORDER BY
 
 %5 =
 | Join %0 %1 %2 %3 %4 (= #23 #25) (= #12 #21) (= #9 #17) (= #0 #16)
-| | implementation = DeltaQuery %0 %2.(#0) %1.(#0) %3.(#0) %4.(#0) | %1 %3.(#0) %4.(#0) %2.(#1) %0.(#0) | %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) | %3 %4.(#0) %1.(#3) %2.(#1) %0.(#0) | %4 %3.(#2) %1.(#3) %2.(#1) %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %2.(#0) %1.(#0) %3.(#0) %4.(#0)
+| |   delta %1 %3.(#0) %4.(#0) %2.(#1) %0.(#0)
+| |   delta %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0)
+| |   delta %3 %4.(#0) %1.(#3) %2.(#1) %0.(#0)
+| |   delta %4 %3.(#2) %1.(#3) %2.(#1) %0.(#0)
 | | demand = (#0, #2, #4, #5, #10, #11, #13..#15, #19, #22, #26)
 | Filter "^.*BRASS$" ~(#4), (#5 = 15), (#26 = "EUROPE")
 
@@ -259,10 +270,16 @@ ORDER BY
 
 %12 =
 | Join %7 %8 %9 %10 %11 (= #0 #1) (= #2 #6) (= #9 #13) (= #15 #17)
-| | implementation = DeltaQuery %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0) | %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0) | %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0) | %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0) | %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
+| | implementation = DeltaQuery
+| |   delta %7 %8.(#0) %9.(#0) %10.(#0) %11.(#0)
+| |   delta %8 %7.(#0) %9.(#0) %10.(#0) %11.(#0)
+| |   delta %9 %10.(#0) %11.(#0) %8.(#1) %7.(#0)
+| |   delta %10 %11.(#0) %9.(#3) %8.(#1) %7.(#0)
+| |   delta %11 %10.(#2) %9.(#3) %8.(#1) %7.(#0)
 | | demand = (#0, #4, #18)
 | Filter (#18 = "EUROPE")
-| Reduce group=(#0) min(#4)
+| Reduce group=(#0)
+| | agg min(#4)
 | ArrangeBy (#0, #1)
 
 %13 =
@@ -315,10 +332,14 @@ ORDER BY
 
 %3 =
 | Join %0 %1 %2 (= #8 #17) (= #0 #9)
-| | implementation = DeltaQuery %0 %1.(#1) %2.(#0) | %1 %0.(#0) %2.(#0) | %2 %1.(#0) %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#1) %2.(#0)
+| |   delta %1 %0.(#0) %2.(#0)
+| |   delta %2 %1.(#0) %0.(#0)
 | | demand = (#6, #8, #12, #15, #22, #23, #27)
 | Filter (#6 = "BUILDING"), (#12 < 1995-03-15), (#27 > 1995-03-15)
-| Reduce group=(#8, #12, #15) sum((#22 * (100dec - #23)))
+| Reduce group=(#8, #12, #15)
+| | agg sum((#22 * (100dec - #23)))
 | Project (#0, #3, #1, #2)
 
 Finish order_by=(#1 desc, #2 asc) limit=none offset=0 project=(#0..#3)
@@ -367,7 +388,9 @@ ORDER BY
 
 %4 =
 | Join %2 %3 (= #0 #9)
-| | implementation = DeltaQuery %2 %3.(#0) | %3 %2.(#0)
+| | implementation = DeltaQuery
+| |   delta %2 %3.(#0)
+| |   delta %3 %2.(#0)
 | | demand = (#0, #20, #21)
 | Filter (#20 < #21)
 | Distinct group=(#0)
@@ -377,7 +400,8 @@ ORDER BY
 | Join %1 %4 (= #0 #9)
 | | implementation = Differential %1 %4.(#0)
 | | demand = (#5)
-| Reduce group=(#5) count(true)
+| Reduce group=(#5)
+| | agg count(true)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -440,7 +464,8 @@ ORDER BY
 | | implementation = Differential %2.(#0) %1.(#0) %0.(#0) %3.(#0, #3) %4.(#0) %5.(#0)
 | | demand = (#12, #22, #23, #41, #45)
 | Filter (#45 = "ASIA"), (#12 < 1995-01-01), (#12 >= 1994-01-01)
-| Reduce group=(#41) sum((#22 * (100dec - #23)))
+| Reduce group=(#41)
+| | agg sum((#22 * (100dec - #23)))
 
 Finish order_by=(#1 desc) limit=none offset=0 project=(#0, #1)
 
@@ -462,7 +487,8 @@ WHERE
 %0 =
 | Get materialize.public.lineitem (u21)
 | Filter (#4 < 2400dec), (datetots(#10) < 1995-01-01 00:00:00), (#6 <= 7dec), (#6 >= 5dec), (#10 >= 1994-01-01)
-| Reduce group=() sum((#5 * #6))
+| Reduce group=()
+| | agg sum((#5 * #6))
 
 %1 =
 | Get %0
@@ -553,10 +579,17 @@ ORDER BY
 
 %6 =
 | Join %0 %1 %2 %3 %4 %5 (= #35 #44) (= #24 #32) (= #7 #23) (= #3 #40) (= #0 #9)
-| | implementation = DeltaQuery %0 %4.(#0) %1.(#2) %2.(#0) %3.(#0) %5.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) %4.(#0) %5.(#0) | %2 %3.(#0) %5.(#0) %1.(#0) %0.(#0) %4.(#0) | %3 %5.(#0) %2.(#1) %1.(#0) %0.(#0) %4.(#0) | %4 %0.(#3) %1.(#2) %2.(#0) %3.(#0) %5.(#0) | %5 %3.(#3) %2.(#1) %1.(#0) %0.(#0) %4.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %4.(#0) %1.(#2) %2.(#0) %3.(#0) %5.(#0)
+| |   delta %1 %0.(#0) %2.(#0) %3.(#0) %4.(#0) %5.(#0)
+| |   delta %2 %3.(#0) %5.(#0) %1.(#0) %0.(#0) %4.(#0)
+| |   delta %3 %5.(#0) %2.(#1) %1.(#0) %0.(#0) %4.(#0)
+| |   delta %4 %0.(#3) %1.(#2) %2.(#0) %3.(#0) %5.(#0)
+| |   delta %5 %3.(#3) %2.(#1) %1.(#0) %0.(#0) %4.(#0)
 | | demand = (#12, #13, #17, #41, #45)
 | Filter (((#41 = "FRANCE") && (#45 = "GERMANY")) || ((#41 = "GERMANY") && (#45 = "FRANCE"))), (#17 <= 1996-12-31), (#17 >= 1995-01-01)
-| Reduce group=(#41, #45, date_part_year_tstz(datetotstz(#17))) sum((#12 * (100dec - #13)))
+| Reduce group=(#41, #45, date_part_year_tstz(datetotstz(#17)))
+| | agg sum((#12 * (100dec - #13)))
 
 Finish order_by=(#0 asc, #1 asc, #2 asc) limit=none offset=0 project=(#0..#3)
 
@@ -637,10 +670,20 @@ ORDER BY
 
 %8 =
 | Join %0 %1 %2 %3 %4 %5 %6 %7 (= #51 #57) (= #44 #49) (= #33 #41) (= #16 #32) (= #12 #53) (= #9 #18) (= #0 #17)
-| | implementation = DeltaQuery %0 %2.(#1) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0) | %1 %6.(#0) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0) | %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0) | %3 %4.(#0) %5.(#0) %7.(#0) %2.(#0) %0.(#0) %1.(#0) %6.(#0) | %4 %5.(#0) %7.(#0) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0) | %5 %7.(#0) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0) | %6 %1.(#3) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0) | %7 %5.(#2) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %2.(#1) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0)
+| |   delta %1 %6.(#0) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0)
+| |   delta %2 %0.(#0) %1.(#0) %3.(#0) %4.(#0) %5.(#0) %6.(#0) %7.(#0)
+| |   delta %3 %4.(#0) %5.(#0) %7.(#0) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
+| |   delta %4 %5.(#0) %7.(#0) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
+| |   delta %5 %7.(#0) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
+| |   delta %6 %1.(#3) %2.(#2) %0.(#0) %3.(#0) %4.(#0) %5.(#0) %7.(#0)
+| |   delta %7 %5.(#2) %4.(#3) %3.(#1) %2.(#0) %0.(#0) %1.(#0) %6.(#0)
 | | demand = (#4, #21, #22, #36, #54, #58)
 | Filter (#4 = "ECONOMY ANODIZED STEEL"), (#58 = "AMERICA"), (#36 <= 1996-12-31), (#36 >= 1995-01-01)
-| Reduce group=(date_part_year_tstz(datetotstz(#36))) sum(if (#54 = "BRAZIL") then {(#21 * (100dec - #22))} else {0dec}) sum((#21 * (100dec - #22)))
+| Reduce group=(date_part_year_tstz(datetotstz(#36)))
+| | agg sum(if (#54 = "BRAZIL") then {(#21 * (100dec - #22))} else {0dec})
+| | agg sum((#21 * (100dec - #22)))
 | Map (((#1 * 10000000dec) / #2) * 1000dec)
 | Project (#0, #3)
 
@@ -710,10 +753,17 @@ ORDER BY
 
 %6 =
 | Join %0 %1 %2 %3 %4 %5 (= #9 #18 #33) (= #0 #17 #32) (= #16 #37) (= #12 #46)
-| | implementation = DeltaQuery %0 %2.(#1) %3.(#0, #1) %1.(#0) %4.(#0) %5.(#0) | %1 %5.(#0) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0) | %2 %3.(#0, #1) %0.(#0) %1.(#0) %4.(#0) %5.(#0) | %3 %0.(#0) %1.(#0) %5.(#0) %2.(#1, #2) %4.(#0) | %4 %2.(#0) %3.(#0, #1) %0.(#0) %1.(#0) %5.(#0) | %5 %1.(#3) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %2.(#1) %3.(#0, #1) %1.(#0) %4.(#0) %5.(#0)
+| |   delta %1 %5.(#0) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0)
+| |   delta %2 %3.(#0, #1) %0.(#0) %1.(#0) %4.(#0) %5.(#0)
+| |   delta %3 %0.(#0) %1.(#0) %5.(#0) %2.(#1, #2) %4.(#0)
+| |   delta %4 %2.(#0) %3.(#0, #1) %0.(#0) %1.(#0) %5.(#0)
+| |   delta %5 %1.(#3) %2.(#2) %3.(#0, #1) %0.(#0) %4.(#0)
 | | demand = (#1, #20..#22, #35, #41, #47)
 | Filter "^.*green.*$" ~(#1)
-| Reduce group=(#47, date_part_year_tstz(datetotstz(#41))) sum(((#21 * (100dec - #22)) - (#35 * #20)))
+| Reduce group=(#47, date_part_year_tstz(datetotstz(#41)))
+| | agg sum(((#21 * (100dec - #22)) - (#35 * #20)))
 
 Finish order_by=(#0 asc, #1 desc) limit=none offset=0 project=(#0..#2)
 
@@ -773,10 +823,15 @@ ORDER BY
 
 %4 =
 | Join %0 %1 %2 %3 (= #8 #17) (= #3 #33) (= #0 #9)
-| | implementation = DeltaQuery %0 %3.(#0) %1.(#1) %2.(#0) | %1 %0.(#0) %3.(#0) %2.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#1) %2.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %3.(#0) %1.(#1) %2.(#0)
+| |   delta %1 %0.(#0) %3.(#0) %2.(#0)
+| |   delta %2 %1.(#0) %0.(#0) %3.(#0)
+| |   delta %3 %0.(#3) %1.(#1) %2.(#0)
 | | demand = (#0..#2, #4, #5, #7, #12, #22, #23, #25, #34)
 | Filter (#25 = "R"), (#12 < 1994-01-01), (datetots(#12) < 1994-01-01 00:00:00), (#12 >= 1993-10-01)
-| Reduce group=(#0, #1, #5, #4, #34, #2, #7) sum((#22 * (100dec - #23)))
+| Reduce group=(#0, #1, #5, #4, #34, #2, #7)
+| | agg sum((#22 * (100dec - #23)))
 | Project (#0, #1, #7, #2, #4, #5, #3, #6)
 
 Finish order_by=(#2 desc) limit=none offset=0 project=(#0..#7)
@@ -828,10 +883,14 @@ ORDER BY
 
 %3 =
 | Join %0 %1 %2 (= #8 #12) (= #1 #5)
-| | implementation = DeltaQuery %0 %1.(#0) %2.(#0) | %1 %2.(#0) %0.(#1) | %2 %1.(#3) %0.(#1)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0) %2.(#0)
+| |   delta %1 %2.(#0) %0.(#1)
+| |   delta %2 %1.(#3) %0.(#1)
 | | demand = (#0, #2, #3, #13)
 | Filter (#13 = "GERMANY")
-| Reduce group=(#0) sum((#3 * i32todec(#2)))
+| Reduce group=(#0)
+| | agg sum((#3 * i32todec(#2)))
 
 %4 =
 | Get materialize.public.partsupp (u11)
@@ -847,10 +906,14 @@ ORDER BY
 
 %7 =
 | Join %4 %5 %6 (= #8 #12) (= #1 #5)
-| | implementation = DeltaQuery %4 %5.(#0) %6.(#0) | %5 %6.(#0) %4.(#1) | %6 %5.(#3) %4.(#1)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#0) %6.(#0)
+| |   delta %5 %6.(#0) %4.(#1)
+| |   delta %6 %5.(#3) %4.(#1)
 | | demand = (#2, #3, #13)
 | Filter (#13 = "GERMANY")
-| Reduce group=() sum((#3 * i32todec(#2)))
+| Reduce group=()
+| | agg sum((#3 * i32todec(#2)))
 | Map (#0 * 1dec)
 | ArrangeBy ()
 
@@ -907,10 +970,14 @@ ORDER BY
 
 %2 =
 | Join %0 %1 (= #0 #9)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#0)
 | | demand = (#5, #19..#21, #23)
 | Filter ((#23 = "MAIL") || (#23 = "SHIP")), (#19 < #20), (#20 < #21), (datetots(#21) < 1995-01-01 00:00:00), (#21 >= 1994-01-01)
-| Reduce group=(#23) sum(if ((#5 = "1-URGENT") || (#5 = "2-HIGH")) then {1} else {0}) sum(if ((#5 != "1-URGENT") && (#5 != "2-HIGH")) then {1} else {0})
+| Reduce group=(#23)
+| | agg sum(if ((#5 = "1-URGENT") || (#5 = "2-HIGH")) then {1} else {0})
+| | agg sum(if ((#5 != "1-URGENT") && (#5 != "2-HIGH")) then {1} else {0})
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 
@@ -950,7 +1017,9 @@ ORDER BY
 
 %2 =
 | Join %0 %1 (= #0 #9)
-| | implementation = DeltaQuery %0 %1.(#1) | %1 %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#1)
+| |   delta %1 %0.(#0)
 | | demand = (#0..#8, #16)
 | Filter !("^.*special.*requests.*$" ~(#16))
 
@@ -971,8 +1040,10 @@ ORDER BY
 
 %7 =
 | Union %3 %6
-| Reduce group=(#0) count(#8)
-| Reduce group=(#1) count(true)
+| Reduce group=(#0)
+| | agg count(#8)
+| Reduce group=(#1)
+| | agg count(true)
 
 Finish order_by=(#1 desc, #0 desc) limit=none offset=0 project=(#0, #1)
 
@@ -1005,10 +1076,14 @@ WHERE
 
 %2 =
 | Join %0 %1 (= #1 #16)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#1)
 | | demand = (#5, #6, #10, #20)
 | Filter (datetots(#10) < 1995-10-01 00:00:00), (#10 >= 1995-09-01)
-| Reduce group=() sum(if "^PROMO.*$" ~(#20) then {(#5 * (100dec - #6))} else {0dec}) sum((#5 * (100dec - #6)))
+| Reduce group=()
+| | agg sum(if "^PROMO.*$" ~(#20) then {(#5 * (100dec - #6))} else {0dec})
+| | agg sum((#5 * (100dec - #6)))
 
 %3 =
 | Get %2
@@ -1079,7 +1154,8 @@ ORDER BY
 
 %2 =
 | Get materialize.public.revenue (u27)
-| Reduce group=() max(#1)
+| Reduce group=()
+| | agg max(#1)
 | Filter !(isnull(#0))
 | ArrangeBy (#0)
 
@@ -1140,7 +1216,9 @@ ORDER BY
 
 %2 =
 | Join %0 %1 (= #0 #5)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#0)
 | | demand = (#1, #8..#10)
 | Filter !("^MEDIUM POLISHED.*$" ~(#9)), ((((((((#10 = 49) || (#10 = 14)) || (#10 = 23)) || (#10 = 45)) || (#10 = 19)) || (#10 = 3)) || (#10 = 36)) || (#10 = 9)), (#8 != "Brand#45")
 
@@ -1162,7 +1240,9 @@ ORDER BY
 
 %7 =
 | Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
+| | implementation = DeltaQuery
+| |   delta %5 %6.(#0)
+| |   delta %6 %5.(#0)
 | | demand = (#0, #7)
 | Filter "^.*Customer.*Complaints.*$" ~(#7)
 | Negate
@@ -1178,7 +1258,8 @@ ORDER BY
 | Join %4 %9 (= #1 #14)
 | | implementation = Differential %9 %4.(#1)
 | | demand = (#1, #8..#10)
-| Reduce group=(#8, #9, #10) count(distinct #1)
+| Reduce group=(#8, #9, #10)
+| | agg count(distinct #1)
 
 Finish order_by=(#3 desc, #0 asc, #1 asc, #2 asc) limit=none offset=0 project=(#0..#3)
 
@@ -1215,7 +1296,9 @@ WHERE
 
 %2 =
 | Join %0 %1 (= #1 #16)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#1)
 | | demand = (#1, #4, #5, #19, #22)
 | Filter (#19 = "Brand#23"), (#22 = "MED BOX")
 
@@ -1233,9 +1316,13 @@ WHERE
 
 %6 =
 | Join %4 %5 (= #0 #2)
-| | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#1)
+| |   delta %5 %4.(#0)
 | | demand = (#0, #5)
-| Reduce group=(#0) sum(#5) count(true)
+| Reduce group=(#0)
+| | agg sum(#5)
+| | agg count(true)
 | Map (2dec * (((#1 * 10000000dec) / i64todec(if (#2 = 0) then {null} else {#2})) / 10dec))
 | ArrangeBy (#0)
 
@@ -1244,7 +1331,8 @@ WHERE
 | | implementation = Differential %3 %6.(#0)
 | | demand = (#4, #5, #28)
 | Filter ((#4 * 10000000dec) < #28)
-| Reduce group=() sum(#5)
+| Reduce group=()
+| | agg sum(#5)
 
 %8 =
 | Get %7
@@ -1318,7 +1406,10 @@ ORDER BY
 
 %3 =
 | Join %0 %1 %2 (= #8 #17) (= #0 #9)
-| | implementation = DeltaQuery %0 %1.(#1) %2.(#0) | %1 %0.(#0) %2.(#0) | %2 %1.(#0) %0.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#1) %2.(#0)
+| |   delta %1 %0.(#0) %2.(#0)
+| |   delta %2 %1.(#0) %0.(#0)
 | | demand = (#0, #1, #8, #11, #12, #21)
 
 %4 =
@@ -1335,9 +1426,12 @@ ORDER BY
 
 %7 =
 | Join %5 %6 (= #0 #1)
-| | implementation = DeltaQuery %5 %6.(#0) | %6 %5.(#0)
+| | implementation = DeltaQuery
+| |   delta %5 %6.(#0)
+| |   delta %6 %5.(#0)
 | | demand = (#0, #5)
-| Reduce group=(#0, #0) sum(#5)
+| Reduce group=(#0, #0)
+| | agg sum(#5)
 | Filter (#2 > 30000dec)
 | Distinct group=(#0)
 | ArrangeBy (#0)
@@ -1346,7 +1440,8 @@ ORDER BY
 | Join %4 %7 (= #8 #33)
 | | implementation = Differential %4 %7.(#0)
 | | demand = (#0, #1, #8, #11, #12, #21)
-| Reduce group=(#1, #0, #8, #12, #11) sum(#21)
+| Reduce group=(#1, #0, #8, #12, #11)
+| | agg sum(#21)
 
 Finish order_by=(#4 desc, #3 asc) limit=none offset=0 project=(#0..#5)
 
@@ -1401,10 +1496,13 @@ WHERE
 
 %2 =
 | Join %0 %1 (= #1 #16)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#1)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#1)
 | | demand = (#4..#6, #13, #14, #19, #21, #22)
 | Filter (((((((#19 = "Brand#12") && ((((#22 = "SM CASE") || (#22 = "SM BOX")) || (#22 = "SM PACK")) || (#22 = "SM PKG"))) && (#4 >= 100dec)) && (#4 <= 1100dec)) && (#21 <= 5)) || (((((#19 = "Brand#23") && ((((#22 = "MED BAG") || (#22 = "MED BOX")) || (#22 = "MED PKG")) || (#22 = "MED PACK"))) && (#4 >= 1000dec)) && (#4 <= 2000dec)) && (#21 <= 10))) || (((((#19 = "Brand#34") && ((((#22 = "LG CASE") || (#22 = "LG BOX")) || (#22 = "LG PACK")) || (#22 = "LG PKG"))) && (#4 >= 2000dec)) && (#4 <= 3000dec)) && (#21 <= 15))), ((#14 = "AIR") || (#14 = "AIR REG")), (#13 = "DELIVER IN PERSON"), (#21 >= 1)
-| Reduce group=() sum((#5 * (100dec - #6)))
+| Reduce group=()
+| | agg sum((#5 * (100dec - #6)))
 
 %3 =
 | Get %2
@@ -1477,7 +1575,9 @@ ORDER BY
 
 %2 =
 | Join %0 %1 (= #3 #7)
-| | implementation = DeltaQuery %0 %1.(#0) | %1 %0.(#3)
+| | implementation = DeltaQuery
+| |   delta %0 %1.(#0)
+| |   delta %1 %0.(#3)
 | | demand = (#0..#2, #8)
 | Filter (#8 = "CANADA")
 
@@ -1517,10 +1617,13 @@ ORDER BY
 
 %11 =
 | Join %9 %10 (= #1 #4) (= #0 #3)
-| | implementation = DeltaQuery %9 %10.(#1, #2) | %10 %9.(#0, #1)
+| | implementation = DeltaQuery
+| |   delta %9 %10.(#1, #2)
+| |   delta %10 %9.(#0, #1)
 | | demand = (#0, #1, #6, #12)
 | Filter (datetots(#12) < 1996-01-01 00:00:00), (#12 >= 1995-01-01)
-| Reduce group=(#0, #1) sum(#6)
+| Reduce group=(#0, #1)
+| | agg sum(#6)
 | Map (5dec * #2)
 | ArrangeBy (#0, #1)
 
@@ -1603,7 +1706,11 @@ ORDER BY
 
 %4 =
 | Join %0 %1 %2 %3 (= #7 #23) (= #3 #32) (= #0 #9)
-| | implementation = DeltaQuery %0 %3.(#0) %1.(#2) %2.(#0) | %1 %0.(#0) %2.(#0) %3.(#0) | %2 %1.(#0) %0.(#0) %3.(#0) | %3 %0.(#3) %1.(#2) %2.(#0)
+| | implementation = DeltaQuery
+| |   delta %0 %3.(#0) %1.(#2) %2.(#0)
+| |   delta %1 %0.(#0) %2.(#0) %3.(#0)
+| |   delta %2 %1.(#0) %0.(#0) %3.(#0)
+| |   delta %3 %0.(#3) %1.(#2) %2.(#0)
 | | demand = (#0, #1, #7, #18, #19, #25, #33)
 | Filter (#25 = "F"), (#33 = "SAUDI ARABIA"), (#19 > #18)
 
@@ -1664,7 +1771,8 @@ ORDER BY
 | Join %11 %16 (= #0 #39) (= #7 #38)
 | | implementation = Differential %16 %11.(#0, #7)
 | | demand = (#1)
-| Reduce group=(#1) count(true)
+| Reduce group=(#1)
+| | agg count(true)
 
 Finish order_by=(#1 desc, #0 asc) limit=none offset=0 project=(#0, #1)
 
@@ -1728,7 +1836,9 @@ ORDER BY
 %1 =
 | Get materialize.public.customer (u15)
 | Filter (((((((substr(#4, 1, 2) = "13") || (substr(#4, 1, 2) = "31")) || (substr(#4, 1, 2) = "23")) || (substr(#4, 1, 2) = "29")) || (substr(#4, 1, 2) = "30")) || (substr(#4, 1, 2) = "18")) || (substr(#4, 1, 2) = "17")), (#5 > 0dec)
-| Reduce group=() sum(#5) count(true)
+| Reduce group=()
+| | agg sum(#5)
+| | agg count(true)
 | Map (((#0 * 10000000dec) / i64todec(if (#1 = 0) then {null} else {#1})) / 10dec)
 | ArrangeBy ()
 
@@ -1752,7 +1862,9 @@ ORDER BY
 
 %6 =
 | Join %4 %5 (= #0 #12)
-| | implementation = DeltaQuery %4 %5.(#1) | %5 %4.(#0)
+| | implementation = DeltaQuery
+| |   delta %4 %5.(#1)
+| |   delta %5 %4.(#0)
 | | demand = (#0)
 | Distinct group=(#0)
 | Negate
@@ -1768,7 +1880,9 @@ ORDER BY
 | Join %3 %8 (= #0 #11)
 | | implementation = Differential %8 %3.(#0)
 | | demand = (#4, #5)
-| Reduce group=(substr(#4, 1, 2)) count(true) sum(#5)
+| Reduce group=(substr(#4, 1, 2))
+| | agg count(true)
+| | agg sum(#5)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#2)
 

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -29,7 +29,9 @@ GROUP BY sumc, sumd
 | Get materialize.public.test1 (u1)
 | Map (#0 + #1), (#4 + #2), (#4 + #3)
 | TopK group=() order=(#3 asc) limit=4 offset=0
-| Reduce group=(#5, #6) sum(#3) count(#3)
+| Reduce group=(#5, #6)
+| | agg sum(#3)
+| | agg count(#3)
 | Map (i64tof64(#2) / i64tof64(if (#3 = 0) then {null} else {#3}))
 | Project (#4, #0, #1)
 
@@ -51,7 +53,9 @@ EXPLAIN PLAN FOR VIEW plan_test1
 ----
 %0 =
 | Get materialize.public.test1 (u1)
-| Reduce group=(((#0 + #1) + #2), ((#0 + #1) + #3)) sum(#3) count(#3)
+| Reduce group=(((#0 + #1) + #2), ((#0 + #1) + #3))
+| | agg sum(#3)
+| | agg count(#3)
 | Map (i64tof64(#2) / i64tof64(if (#3 = 0) then {null} else {#3}))
 | Project (#4, #0, #1)
 


### PR DESCRIPTION
Making the change to the way DeltaQueries are formatted in EXPLAIN according to @frankmcsherry's stated preference.

The reduce change is motivated by recently having viewed a bunch of plans where a reduce has like half a dozen aggregations of the complexity `sum(if ((#5 = "1-URGENT") || (#5 = "2-HIGH")) then {1} else {0})` ([See here](https://github.com/MaterializeInc/materialize/blob/main/test/sqllogictest/tpch.slt#L913)) but even more complicated looking because the columns are nested. The group key for the same reduce is even more complicated, containing, say, a column with multiple cases. Putting the group key and aggregations on separate lines would help the legibility of such complicated reductions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4178)
<!-- Reviewable:end -->
