### PR TITLE
Don't run materialized as root inside Docker

### DIFF
--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -13,4 +13,8 @@ RUN apt-get update && apt-get -qy install ca-certificates
 
 COPY kdestroy kinit materialized /usr/local/bin/
 
+RUN mkdir -p mzdata && chown 9000:9000 mzdata
+
+USER 9000:9000
+
 ENTRYPOINT ["materialized", "--log-file=stderr"]


### PR DESCRIPTION
Running container processes as unprivileged users whenever possible is considered a best practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4182)
<!-- Reviewable:end -->
