### PR TITLE
sql: handle dependent map exprs when simplifying quantified comparisons

### DIFF
--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -161,6 +161,11 @@ pub fn try_simplify_quantified_comparisons(expr: &mut RelationExpr) {
                 outers.push(input.typ(&outers, &NO_PARAMS));
                 for scalar in scalars {
                     walk_scalar(scalar, &outers, false);
+                    let (inner, outers) = outers
+                        .split_last_mut()
+                        .expect("outers known to have at least one element");
+                    let scalar_type = scalar.typ(&outers, inner, &NO_PARAMS);
+                    inner.column_types.push(scalar_type);
                 }
             }
             RelationExpr::Filter { predicates, input } => {

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -672,5 +672,14 @@ SELECT * FROM
 ----
 1  1  1  1
 
+# Regression test for #4157, in which quantified expression simplification
+# failed to handle map expressions which depended upon a column introduced by
+# an earlier expression in the same map node.
+query I
+SELECT (SELECT 1 FROM ((SELECT col1) UNION (SELECT 1)))
+FROM (SELECT 1 col1)
+----
+1
+
 query error aggregate functions that refer exclusively to outer columns not yet supported
 SELECT (SELECT count(likes.likee)) FROM likes


### PR DESCRIPTION
The optimization that simplifies quantified comparisons was not properly
accounting for the fact that map expressions can refer to columns
introduced by earlier expressions in the same map node.

That map expressions work like this is the gift that just keeps on
giving.

Fix #4157.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4183)
<!-- Reviewable:end -->
