### PR TITLE
sql: don't crash if parameters are used in a view

### DIFF
--- a/src/materialized/tests/pgwire.rs
+++ b/src/materialized/tests/pgwire.rs
@@ -87,6 +87,17 @@ fn test_bind_params() -> Result<(), Box<dyn Error>> {
         assert_eq!(val.to_string(), "2.46");
     }
 
+    // A `CREATE` statement with parameters should be rejected.
+    match client.query_one("CREATE VIEW v AS SELECT $3", &[]) {
+        Ok(_) => panic!("query with invalid parameters executed successfully"),
+        Err(err) => {
+            assert!(err.to_string().contains("there is no parameter $3"));
+            // TODO(benesch): this should be `UNDEFINED_PARAMETER`, but blocked
+            // on #3147.
+            assert_eq!(err.code(), Some(&SqlState::INTERNAL_ERROR));
+        }
+    }
+
     Ok(())
 }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1405,8 +1405,7 @@ fn handle_create_view(
     };
     let (mut relation_expr, mut desc, finishing) =
         query::plan_root_query(scx, *query.clone(), QueryLifetime::Static)?;
-    // TODO(jamii) can views even have parameters?
-    relation_expr.bind_parameters(&params);
+    relation_expr.bind_parameters(&params)?;
     //TODO: materialize#724 - persist finishing information with the view?
     relation_expr.finish(finishing);
     let relation_expr = relation_expr.decorrelate();
@@ -2263,7 +2262,7 @@ fn handle_explain(
     } else {
         Some(finishing)
     };
-    sql_expr.bind_parameters(&params);
+    sql_expr.bind_parameters(&params)?;
     let expr = sql_expr.clone().decorrelate();
     Ok(Plan::ExplainPlan {
         raw_plan: sql_expr,
@@ -2283,7 +2282,7 @@ fn handle_query(
     lifetime: QueryLifetime,
 ) -> Result<(::expr::RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
     let (mut expr, desc, finishing) = query::plan_root_query(scx, query, lifetime)?;
-    expr.bind_parameters(&params);
+    expr.bind_parameters(&params)?;
     Ok((expr.decorrelate(), desc, finishing))
 }
 


### PR DESCRIPTION
Prevent a query like

    CREATE VIEW v AS SELECT $1

from crashing Materialize. Now Materialize returns the same error
message as PostgreSQL ("there is no parameter $N").

Fix #3906.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4185)
<!-- Reviewable:end -->
