### PR TITLE
Planning: Allow JoinImplementation to work with expression join keys.

### DIFF
--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -142,6 +142,10 @@ impl JoinImplementation {
                 available_arrangements[index].dedup();
                 // Currently we only support using arrangements all of whose
                 // keys can be found in some equivalence.
+                // Note: because `order_input` currently only finds arrangements
+                // with exact key matches, the code below can be removed with no
+                // change in behavior, but this is being kept for a future
+                // TODO: expand `order_input`
                 available_arrangements[index].retain(|key| {
                     key.iter().all(|k| {
                         let mut k = k.clone();
@@ -673,8 +677,9 @@ impl<'a> Orderer<'a> {
                                     } else {
                                         None
                                     }
-                                }); // ... extract the expression that came from start
-                                    // and shift the column numbers
+                                });
+                        // ... extract the expression that came from start
+                        // and shift the column numbers
                         if let Some(key_pos) = key_pos {
                             let mut result = self.equivalences[key_equivalence][*key_pos].clone();
                             result.visit_mut(&mut |e| {

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -470,3 +470,33 @@ SELECT * FROM l FULL JOIN r ON l.la = r.ra
 | Union %8 %13 %14
 
 EOF
+
+query ITIT rowsort
+SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = mod(r.ra, 2)
+----
+1 l1 1 r1
+1 l1 3 r3
+2 l2 4 r4
+3 l3 1 r1
+3 l3 3 r3
+
+# Test that when both keys are expressions, the join is not planned as a cross
+# join. Protects against regression of #4170.
+query T multiline
+EXPLAIN PLAN FOR SELECT * FROM l INNER JOIN r ON mod(l.la, 2) = mod(r.ra, 2)
+----
+%0 =
+| Get materialize.public.l (u1)
+| Filter !(isnull(#0))
+| ArrangeBy ((#0 % 2))
+
+%1 =
+| Get materialize.public.r (u3)
+| Filter !(isnull(#0))
+
+%2 =
+| Join %0 %1 (= (#0 % 2) (#2 % 2))
+| | implementation = Differential %1 %0.((#0 % 2))
+| | demand = (#0..#3)
+
+EOF

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -124,3 +124,46 @@ where foo.a = bar.a
 ----
 1
 0
+
+statement ok
+CREATE INDEX foo_idx2 on foo(nullif(a, 0));
+
+statement ok
+CREATE INDEX bar_idx2 on bar(-a);
+
+# Test that when join planning uses indexes on expressions.
+# Protects against regression of #4170.
+query T multiline
+EXPLAIN PLAN FOR
+select foo.b, bar.b
+from foo, bar
+where nullif(foo.a, 0) = -bar.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| ArrangeBy (if (#0 = 0) then {null} else {#0})
+
+%1 =
+| Get materialize.public.bar (u4)
+| ArrangeBy (-(#0))
+
+%2 =
+| Join %0 %1 (= -(#2) if (#0 = 0) then {null} else {#0})
+| | implementation = DeltaQuery
+| |   delta %0 %1.(-(#0))
+| |   delta %1 %0.(if (#0 = 0) then {null} else {#0})
+| | demand = (#0..#3)
+| Filter !(isnull(-(#2))), !(isnull(if (#0 = 0) then {null} else {#0}))
+| Project (#1, #3)
+
+EOF
+
+query II
+select foo.b, bar.b
+from foo, bar
+where nullif(foo.a, 0) = -bar.a
+----
+2
+NULL
+4
+3

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -174,6 +174,9 @@ DROP INDEX bar_idx;
 statement ok
 CREATE INDEX bar_idx3 on bar(a + 4);
 
+# In this test, there exists an index on bar(a + 4)
+# but not bar(a). Check that bar(a+4) is not inappropriately
+# substituted for bar(a) in the first equivalence.
 query T multiline
 EXPLAIN PLAN FOR
 select foo.b, bar.b, baz.b

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -167,3 +167,50 @@ where nullif(foo.a, 0) = -bar.a
 NULL
 4
 3
+
+statement ok
+DROP INDEX bar_idx;
+
+statement ok
+CREATE INDEX bar_idx3 on bar(a + 4);
+
+query T multiline
+EXPLAIN PLAN FOR
+select foo.b, bar.b, baz.b
+FROM foo, bar, baz
+where foo.a = bar.a
+  and bar.a + 4 = baz.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.bar (u4)
+| ArrangeBy ((#0 + 4))
+
+%2 =
+| Get materialize.public.baz (u11)
+| ArrangeBy (#0)
+
+%3 =
+| Join %0 %1 %2 (= #0 #2) (= #4 (#2 + 4))
+| | implementation = Differential %2.(#0) %1.((#0 + 4)) %0.(#0)
+| | demand = (#0, #1, #3..#5)
+| Filter !(isnull(#0)), !(isnull(#4))
+| Project (#1, #3, #5)
+
+EOF
+
+query III
+select foo.b, bar.b, baz.b
+FROM foo, bar, baz
+where foo.a = bar.a
+  and bar.a + 4 = baz.a
+----
+4
+NULL
+0
+2
+3
+2


### PR DESCRIPTION
Resolves #4170. 

Indexes containing expressions are no longer filtered on from being considered by `JoinImplementation`.
`Orderer::bound` is a `Vec<Vec<ScalarExpr>>` instead of `Vec<Vec<usize>>`.

Passed full SLT.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4192)
<!-- Reviewable:end -->
