### PR TITLE
pgwire: correctly handle portal suspension/max rows logic

### DIFF
--- a/test/pgtest/prepare.pt
+++ b/test/pgtest/prepare.pt
@@ -15,7 +15,9 @@ DataRow {"fields":["blah","5"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 
-# Test portal max rows.
+# Test portal max rows. Note that even though there are two rows returned,
+# even after the second execute a portal suspended is returned, not
+# command complete.
 send
 Query {"query": "BEGIN"}
 Parse {"query": "VALUES (1), (2)"}
@@ -31,6 +33,7 @@ Sync
 until
 ReadyForQuery
 ReadyForQuery
+ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"T"}
@@ -43,4 +46,35 @@ PortalSuspended
 CommandComplete {"tag":"SELECT 0"}
 CommandComplete {"tag":"SELECT 0"}
 CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+ReadyForQuery {"status":"I"}
+
+# Test when max rows > number of total rows.
+send
+Query {"query": "BEGIN"}
+Parse {"query": "VALUES (1), (2)"}
+Bind
+Execute {"max_rows": 3}
+Execute {"max_rows": 3}
+Execute {"max_rows": 3}
+Query {"query": "COMMIT"}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 2"}
+CommandComplete {"tag":"SELECT 0"}
+CommandComplete {"tag":"SELECT 0"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
 ReadyForQuery {"status":"I"}


### PR DESCRIPTION
This PR fixes two bugs and now we match Postgres for the included test.

1) When max rows is specified and the number of remaining rows is
equal to max rows, we should return portal suspended instead of command
complete. Command complete should only be returned if more rows than
are remaining were returned.
2) If a portal has had all of its rows consumed, it should not be
re-executed. Instead it should return command complete with a count of 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4193)
<!-- Reviewable:end -->
