### PR TITLE
Make "unexpected foo" defaults in Avro decoders opt-in

### DIFF
--- a/src/avro-derive/src/lib.rs
+++ b/src/avro-derive/src/lib.rs
@@ -162,6 +162,9 @@ pub fn derive_decodeable(item: TokenStream) -> TokenStream {
                     #(#return_fields),*
                 })
             }
+            ::mz_avro::define_unexpected! {
+                union_branch, array, map, enum_variant, scalar, decimal, bytes, string, json, uuid, fixed
+            }
         }
         impl ::mz_avro::StatefulAvroDecodeable for #name {
             type Decoder = #decoder_name;

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -322,7 +322,8 @@ pub use crate::codec::Codec;
 pub use crate::decode::public_decoders::*;
 pub use crate::decode::{
     give_value, AvroArrayAccess, AvroDecode, AvroDecodeable, AvroDeserializer, AvroFieldAccess,
-    AvroRead, AvroRecordAccess, GeneralDeserializer, Skip, StatefulAvroDecodeable, ValueOrReader,
+    AvroMapAccess, AvroRead, AvroRecordAccess, GeneralDeserializer, Skip, StatefulAvroDecodeable,
+    ValueOrReader,
 };
 pub use crate::encode::encode as encode_unchecked;
 pub use crate::reader::{from_avro_datum, Reader};


### PR DESCRIPTION
It's easy to forget to add the proper decoding arms in all the internal structs like TrivialDecoder, ValueDecoder, etc. when adding a new type to Avro decoding. Thus, we now force the user to explicitly state that a given type is unexpected, by specifying it in the `define_unexpected!` macro.

Now, if a new function is added in `AvroDecode`, the user will properly get a bunch of compile errors in the struct impls where it needs to be added.

(Also, this uncovered a genuine bug: `fn map` was not overridden in `TrivialDecoder`, so go ahead and do that)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4194)
<!-- Reviewable:end -->
