### PR TITLE
sql: fix literal lifting through unions

### DIFF
--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 
 use crate::TransformArgs;
 use expr::{Id, RelationExpr, ScalarExpr};
+use itertools::Itertools;
 
 /// Hoist literal values from maps wherever possible.
 #[derive(Debug)]
@@ -418,28 +419,41 @@ impl LiteralLifting {
             }
             RelationExpr::Union { base, inputs } => {
                 let mut base_literals = self.action(base, gets);
-                for input in inputs {
-                    let mut input_literals = self.action(input, gets);
+                let mut input_literals = inputs
+                    .iter_mut()
+                    .map(|input| self.action(input, gets))
+                    .collect::<Vec<Vec<ScalarExpr>>>();
 
-                    let mut results = Vec::new();
-                    while !base_literals.is_empty() && base_literals.last() == input_literals.last()
-                    {
-                        base_literals.pop();
-                        results.push(input_literals.pop().unwrap());
+                // We need to find the longest common suffix between all the arms of the union.
+                let mut suffix = Vec::new();
+                while !base_literals.is_empty()
+                    && input_literals
+                        .iter()
+                        .all(|lits| lits.last() == base_literals.last())
+                {
+                    // Every arm agrees on the last value, so push it onto the shared suffix and
+                    // remove it from each arm.
+                    suffix.push(base_literals.last().unwrap().clone());
+                    base_literals.pop();
+                    for lits in input_literals.iter_mut() {
+                        lits.pop();
                     }
-                    results.reverse();
-
-                    if !base_literals.is_empty() {
-                        **base = base.take_dangerous().map(base_literals);
-                    }
-                    if !input_literals.is_empty() {
-                        *input = input.take_dangerous().map(input_literals);
-                    }
-
-                    // TODO(frank): extract non-terminal literals.
-                    base_literals = results;
                 }
-                base_literals
+
+                // Because we pushed stuff onto the vector like a stack, we need to reverse it now.
+                suffix.reverse();
+
+                // Any remaining literals for each expression must be appended to that expression,
+                // while the shared suffix is returned to continue traveling upwards.
+                if !base_literals.is_empty() {
+                    **base = base.take_dangerous().map(base_literals);
+                }
+                for (input, literals) in inputs.iter_mut().zip_eq(input_literals) {
+                    if !literals.is_empty() {
+                        *input = input.take_dangerous().map(literals);
+                    }
+                }
+                suffix
             }
             RelationExpr::ArrangeBy { input, keys } => {
                 // TODO(frank): Not sure if this is the right behavior,

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+create table t (
+  a int,
+  b int
+)
+
+query T multiline
+explain
+(select null::int, 1, 2)
+union all
+(select a, b, 2 from t)
+union all
+(select a, b, 2 from t)
+----
+%0 =
+| Get materialize.public.t (u1)
+
+%1 =
+| Get materialize.public.t (u1)
+
+%2 =
+| Constant (null, 1)
+
+%3 =
+| Union %0 %1 %2
+| Map 2
+
+EOF
+
+query T multiline
+explain
+(select null::int, 1, 2, 3)
+union all
+(select a, b, 2, 3 from t)
+union all
+(select a, b, 2, 3 from t)
+----
+%0 =
+| Get materialize.public.t (u1)
+
+%1 =
+| Get materialize.public.t (u1)
+
+%2 =
+| Constant (null, 1)
+
+%3 =
+| Union %0 %1 %2
+| Map 2, 3
+
+EOF
+
+query T multiline
+explain
+(select null::int, 1, 2)
+union all
+(select a, b, 2 from t)
+union all
+(select a, b, 3 from t)
+----
+%0 =
+| Get materialize.public.t (u1)
+| Map 2
+
+%1 =
+| Get materialize.public.t (u1)
+| Map 3
+
+%2 =
+| Constant (null, 1, 2)
+
+%3 =
+| Union %0 %1 %2
+
+EOF


### PR DESCRIPTION
Previously the logic for determining the literals to lift through a
union was wrong, because it special-cased the `base` input, and could
result in changing the shape of some of the inputs in an invalid way.

This change changes this behaviour to extract the longest common suffix
between all arms, which makes sure that the shape of the inputs is
always correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4195)
<!-- Reviewable:end -->
