### PR TITLE
Get rid of some dubious transmutes

### DIFF
--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -6,7 +6,6 @@ use std::cmp;
 use std::fmt::{self, Display};
 use std::fs::File;
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
-use std::mem::transmute;
 
 use anyhow::{bail, Error};
 use chrono::{NaiveDate, NaiveDateTime};

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -68,14 +68,14 @@ fn decode_len<R: Read>(reader: &mut R) -> Result<usize, Error> {
 fn decode_float<R: Read>(reader: &mut R) -> Result<f32, Error> {
     let mut buf = [0u8; 4];
     reader.read_exact(&mut buf[..])?;
-    Ok(unsafe { transmute::<[u8; 4], f32>(buf) })
+    Ok(f32::from_le_bytes(buf))
 }
 
 #[inline]
 fn decode_double<R: Read>(reader: &mut R) -> Result<f64, Error> {
     let mut buf = [0u8; 8];
     reader.read_exact(&mut buf[..])?;
-    Ok(unsafe { transmute::<[u8; 8], f64>(buf) })
+    Ok(f64::from_le_bytes(buf))
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Not only were these `unsafe`s unnecessary, but they were definitely wrong on big-endian systems, and _I think_ even technically UB on mainstream systems (since `[u8; 4]` and `f32` don't have the same alignment guarantees).

Anyway, there is no downside to just doing it the safe way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4199)
<!-- Reviewable:end -->
