### PR TITLE
Make SchemaCache cache schema parsing and resolution errors

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2255,7 +2255,7 @@ mod tests {
         );
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Unions cannot contain duplicate types"
+            "Schema parse error: Unions cannot contain duplicate types"
         );
 
         let writer_schema = Schema::parse_str(

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -951,7 +951,7 @@ fn validate_schema_2(
 
 pub fn parse_schema(schema: &str) -> anyhow::Result<Schema> {
     let schema = serde_json::from_str(schema)?;
-    Schema::parse(&schema)
+    Ok(Schema::parse(&schema)?)
 }
 
 fn is_null(schema: &SchemaPieceOrNamed) -> bool {
@@ -1459,10 +1459,7 @@ impl Decoder {
         }
 
         let resolved_schema = match &mut self.writer_schemas {
-            Some(cache) => cache
-                .get(schema_id, &self.reader_schema)
-                .await?
-                .unwrap_or(&self.reader_schema),
+            Some(cache) => cache.get(schema_id, &self.reader_schema).await?,
             // If we haven't been asked to use a schema registry, we have no way
             // to discover the writer's schema. That's ok; we'll just use the
             // reader's schema and hope it lines up.
@@ -1967,7 +1964,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
 }
 
 struct SchemaCache {
-    cache: HashMap<i32, Option<Schema>>,
+    cache: HashMap<i32, Result<Schema, AvroError>>,
     ccsr_client: ccsr::Client,
 
     reader_fingerprint: SchemaFingerprint,
@@ -1988,22 +1985,39 @@ impl SchemaCache {
     /// Looks up the writer schema for ID. If the schema is literally identical
     /// to the reader schema, as determined by the reader schema fingerprint
     /// that this schema cache was initialized with, returns None.
-    async fn get(&mut self, id: i32, reader_schema: &Schema) -> anyhow::Result<Option<&Schema>> {
+    async fn get(&mut self, id: i32, reader_schema: &Schema) -> anyhow::Result<&Schema> {
         match self.cache.entry(id) {
-            Entry::Occupied(o) => Ok(o.into_mut().as_ref()),
+            Entry::Occupied(o) => o
+                .into_mut()
+                .as_ref()
+                .map_err(|e| anyhow::Error::new(e.clone())),
             Entry::Vacant(v) => {
-                // TODO(benesch): make this asynchronous, to avoid blocking the
-                // Timely thread on this network request.
-                let res = self.ccsr_client.get_schema_by_id(id).await?;
-                let schema = parse_schema(&res.raw)?;
-                if schema.fingerprint::<Sha256>().bytes == self.reader_fingerprint.bytes {
-                    Ok(v.insert(None).as_ref())
-                } else {
-                    // the writer schema differs from the reader schema,
-                    // so we need to perform schema resolution.
-                    let resolved = resolve_schemas(&schema, reader_schema)?;
-                    Ok(v.insert(Some(resolved)).as_ref())
-                }
+                // An issue with _fetching_ the schema should be returned
+                // immediately, and not cached, since it might get better on the
+                // next retry.
+                // TODO - some sort of exponential backoff or similar logic
+                let response = self.ccsr_client.get_schema_by_id(id).await?;
+                // Now, we've gotten some json back, so we want to cache it (regardless of whether it's a valid
+                // avro schema, it won't change).
+                //
+                // However, we can't just cache it directly, since resolving schemas takes significant CPU work,
+                // which  we don't want to repeat for every record. So, parse and resolve it, and cache the
+                // result (whether schema or error).
+                let rf = &self.reader_fingerprint.bytes;
+                let result = (|| {
+                    let schema = Schema::parse_str(&response.raw)?;
+                    if &schema.fingerprint::<Sha256>().bytes == rf {
+                        Ok(schema)
+                    } else {
+                        // the writer schema differs from the reader schema,
+                        // so we need to perform schema resolution.
+                        let resolved = resolve_schemas(&schema, reader_schema)?;
+                        Ok(resolved)
+                    }
+                })();
+                v.insert(result)
+                    .as_ref()
+                    .map_err(|e| anyhow::Error::new(e.clone()))
             }
         }
     }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1984,7 +1984,9 @@ impl SchemaCache {
 
     /// Looks up the writer schema for ID. If the schema is literally identical
     /// to the reader schema, as determined by the reader schema fingerprint
-    /// that this schema cache was initialized with, returns None.
+    /// that this schema cache was initialized with, returns the schema directly.
+    /// If not, performs schema resolution on the reader and writer and
+    /// returns the result.
     async fn get(&mut self, id: i32, reader_schema: &Schema) -> anyhow::Result<&Schema> {
         match self.cache.entry(id) {
             Entry::Occupied(o) => o


### PR DESCRIPTION
(1) Make a few more places in avro return `AvroError` instead of `anyhow::Error`. This is part of an ongoing project to make Avro use typed errors; see e.g. https://github.com/MaterializeInc/materialize/pull/4198 .

I don't actually make `ParseSchemaError` typed in this diff; it's still just a string. For commit hygiene reasons I just change the API no more than necessary, and will make it actually typed in a future PR.

(2) [the meat of this PR]. In interchange, cache the AvroError when for any reason we can't decode or resolve schemas. This will enable us to serve errors on future records referencing the same schema, without going back to the schema registry every time.

Nothing will work in Materialize without being able to resolve schemas, but at least now in that case we won't also be browning out the user's CSR instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4211)
<!-- Reviewable:end -->
