### PR TITLE
coord: generate and persist a permanent cluster id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "transform",
  "unicase",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -52,6 +52,9 @@ Wrap your release notes at the 80 character mark.
 - Support [`CREATE TABLE`](/sql/create-table), [`DROP TABLE`](/sql/drop-table),
   [`INSERT`](/sql/insert) and [`SHOW CREATE TABLE`](/sql/show-create-table).
 
+- Generate a persistent, unique identifier associated with each
+  cluster. This can be retrieved using a new `mz_cluster_id()` SQL function.
+
 <span id="v0.4.2"></span>
 ## v0.4.2
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -244,6 +244,11 @@
     description: Converts Unix epoch (seconds since 00:00:00 UTC on January 1, 1970)
       to timestamp
 
+- type: UUID
+  functions:
+  - signature: mz_cluster_id() -> uuid
+    description: The `uuid` uniquely identifying this Materialize cluster.
+
 - type: JSON
   functions:
   - signature: 'jsonb_array_elements(j: jsonb) -> Col<jsonb>'

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -43,3 +43,4 @@ tokio = "0.2"
 transform = { path = "../transform" }
 unicase = "2.6.0"
 url = "2"
+uuid = { version = "0.8", features = ["v4"] }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -483,6 +483,12 @@ impl<'a> From<DateTime<Utc>> for Datum<'a> {
     }
 }
 
+impl From<Uuid> for Datum<'static> {
+    fn from(uuid: Uuid) -> Datum<'static> {
+        Datum::Uuid(uuid)
+    }
+}
+
 impl<'a, T> From<Option<T>> for Datum<'a>
 where
     Datum<'a>: From<T>,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -17,6 +17,7 @@ use std::time::SystemTime;
 
 use expr::{GlobalId, ScalarExpr};
 use repr::RelationDesc;
+use uuid::Uuid;
 
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
 use crate::plan::PlanContext;
@@ -57,6 +58,9 @@ pub trait Catalog: fmt::Debug {
     /// NOTE(benesch): this is only necessary for producing unique Kafka sink
     /// topics. Perhaps we can remove this when #2915 is complete.
     fn nonce(&self) -> u64;
+
+    /// Returns a persistent UUID for the the catalog.
+    fn cluster_id(&self) -> Uuid;
 
     /// Returns the database to use if one is not explicitly specified.
     fn default_database(&self) -> &str;
@@ -256,6 +260,10 @@ impl Catalog for DummyCatalog {
 
     fn nonce(&self) -> u64 {
         0
+    }
+
+    fn cluster_id(&self) -> Uuid {
+        Uuid::from_u128(0)
     }
 
     fn default_database(&self) -> &str {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -831,6 +831,9 @@ lazy_static! {
                     }
                 })
             },
+            "mz_cluster_id" => {
+                params!() => nullary_op(mz_cluster_id)
+            },
             "now" => {
                 params!() => nullary_op(|ecx| plan_current_timestamp(ecx, "now"))
             },
@@ -904,6 +907,13 @@ fn plan_current_timestamp(ecx: &ExprContext, name: &str) -> Result<ScalarExpr, a
         )),
         QueryLifetime::Static => bail!("{} cannot be used in static queries", name),
     }
+}
+
+fn mz_cluster_id(ecx: &ExprContext) -> Result<ScalarExpr, anyhow::Error> {
+    Ok(ScalarExpr::literal(
+        Datum::from(ecx.qcx.scx.catalog.cluster_id()),
+        ScalarType::Uuid,
+    ))
 }
 
 fn stringify_opt_scalartype(t: &Option<ScalarType>) -> String {


### PR DESCRIPTION
This id can be used to uniquely identify a materialize cluster across
restarts or being moved among VMs or containers.

Expose a `mz_cluster_id()` SQL function to retrieve it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4230)
<!-- Reviewable:end -->
