### PR TITLE
Update docs site for v0.4.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -131,6 +131,12 @@ in the infrastructure repository. All of these tests can be run in parallel.
   git push origin $tag
   ```
 
+### Verify the Release Build and Deploy
+
+- [ ] Find your build in buildkite, for example
+  https://buildkite.com/materialize/tests/builds?branch=v0.4.3
+- [ ] Wait for the completion of the "Deploy" step
+
 ### Create Homebrew bottle and update tap
 
 - [ ] Follow the instructions in [MaterializeInc/homebrew-materialize's

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -7,6 +7,7 @@ pygmentsUseClasses = true
 # Keep the releases in reverse order of their release date. The first release
 # in the list is assumed to be the most recent.
 versions = [
+  { name = "v0.4.3", date = "17 September 2020" },
   { name = "v0.4.2", date = "3 September 2020" },
   { name = "v0.4.1", date = "19 August 2020" },
   { name = "v0.4.0", date = "27 July 2020" },

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -56,7 +56,7 @@ Wrap your release notes at the 80 character mark.
   cluster. This can be retrieved using a new `mz_cluster_id()` SQL function.
 
 <span id="v0.4.3"></span>
-## v0.4.3 (Unreleased)
+## v0.4.3
 
 * Permit adjusting the logical compaction window on a per-index basis via the
   [`logical_compaction_window`](/sql/alter-index/#available-parameters)


### PR DESCRIPTION
- Add a record for the version
- Remote `(unreleased)` from 0.4.3
- Add a note to the release issue template for how to find the deploy in buildkite before starting the homebrew build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4238)
<!-- Reviewable:end -->
