### PR TITLE
dataflow: drop capabilities for static file sources when finished

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -26,6 +26,11 @@ Rochester      NY        14618   2
 "New York"     NY        10004   3
 "bad,place\""  CA        92679   4
 
+# The timestamp chosen when reading from a static CSV should be the end of time,
+# since the definition of "static" means "will never change again".
+> SELECT count(*), mz_logical_timestamp() FROM static_csv
+4  18446744073709551615
+
 # Static CSV with automatic headers.
 > CREATE MATERIALIZED SOURCE static_csv_header
   FROM FILE '${testdrive.temp-dir}/static.csv'


### PR DESCRIPTION
This regressed in #3532, and static file sources were having their
capabilities downgrade only every few seconds. Restore the original
behavior of dropping the capability entirely after the file is read so
that there is no need to periodically downgrade the capability at all.

This makes joining a table against a static file source much lower
latency. Fix #3975.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4240)
<!-- Reviewable:end -->
