### PR TITLE
Tidy handle_show functions

### DIFF
--- a/doc/user/content/sql/show-index.md
+++ b/doc/user/content/sql/show-index.md
@@ -17,7 +17,7 @@ aliases:
 
 Field | Use
 ------|-----
-_view&lowbar;name_ | The name of the view whose indexes you want to show.
+_on&lowbar;name_ | The name of the object whose indexes you want to show. This can be the name of a table, source, or view.
 
 ## Details
 
@@ -26,14 +26,14 @@ _view&lowbar;name_ | The name of the view whose indexes you want to show.
 `SHOW INDEX`'s output is a table, with this structure:
 
 ```nofmt
- View | Key_name | Column_name | Expression | Null | Seq_in_index
-------+----------+-------------+------------+------+--------------
- ...  | ...      | ...         | ...        | ...  | ...
+ On_name | Key_name | Column_name | Expression | Null | Seq_in_index
+---------+----------+-------------+------------+------+--------------
+ ...     | ...      | ...         | ...        | ...  | ...
 ```
 
 Field | Meaning
 ------|--------
-**View** | The name of the view the index belongs to.
+**On_name** | The name of the table, source, or view the index belongs to.
 **Key_name** | The name of the index.
 **Column_name** | The indexed column.
 **Expression** | An expression used to generate the column in the index.
@@ -59,9 +59,9 @@ SHOW FULL VIEWS;
 SHOW INDEXES FROM my_materialized_view;
 ```
 ```nofmt
- View | Key_name | Column_name | Expression | Null | Seq_in_index
-------+----------+-------------+------------+------+--------------
- ...  | ...      | ...         | ...        | ...  | ...
+ On_name | Key_name | Column_name | Expression | Null | Seq_in_index
+---------+----------+-------------+------------+------+--------------
+ ...     | ...      | ...         | ...        | ...  | ...
 ```
 
 ## Related pages

--- a/doc/user/layouts/partials/sql-grammar/show-index.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-index.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="483" height="235">
+<svg xmlns="http://www.w3.org/2000/svg" width="471" height="235">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="62" height="32" rx="10"/>
@@ -49,38 +49,38 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="281" y="65">IN</text>
-   <rect x="373" y="3" width="88" height="32"/>
-   <rect x="371" y="1" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="381" y="21">view_name</text>
-   <rect x="299" y="157" width="50" height="32" rx="10"/>
-   <rect x="297"
+   <rect x="373" y="3" width="76" height="32"/>
+   <rect x="371" y="1" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="381" y="21">on_name</text>
+   <rect x="287" y="157" width="50" height="32" rx="10"/>
+   <rect x="285"
          y="155"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="307" y="175">LIKE</text>
-   <rect x="369" y="157" width="66" height="32" rx="10"/>
-   <rect x="367"
+   <text class="terminal" x="295" y="175">LIKE</text>
+   <rect x="357" y="157" width="66" height="32" rx="10"/>
+   <rect x="355"
          y="155"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="377" y="175">pattern</text>
-   <rect x="299" y="201" width="70" height="32" rx="10"/>
-   <rect x="297"
+   <text class="terminal" x="365" y="175">pattern</text>
+   <rect x="287" y="201" width="70" height="32" rx="10"/>
+   <rect x="285"
          y="199"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="307" y="219">WHERE</text>
-   <rect x="389" y="201" width="46" height="32"/>
-   <rect x="387" y="199" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="397" y="219">expr</text>
+   <text class="terminal" x="295" y="219">WHERE</text>
+   <rect x="377" y="201" width="46" height="32"/>
+   <rect x="375" y="199" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="385" y="219">expr</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m62 0 h10 m0 0 h18 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m56 0 h10 m0 0 h24 m40 -88 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m34 0 h10 m0 0 h26 m20 -44 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-226 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m50 0 h10 m0 0 h10 m66 0 h10 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m70 0 h10 m0 0 h10 m46 0 h10 m23 -44 h-3"/>
-   <polygon points="473 171 481 167 481 175"/>
-   <polygon points="473 171 465 167 465 175"/>
+         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m62 0 h10 m0 0 h18 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m56 0 h10 m0 0 h24 m40 -88 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m34 0 h10 m0 0 h26 m20 -44 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-226 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m50 0 h10 m0 0 h10 m66 0 h10 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v24 m176 0 v-24 m-176 24 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m70 0 h10 m0 0 h10 m46 0 h10 m23 -44 h-3"/>
+   <polygon points="461 171 469 167 469 175"/>
+   <polygon points="461 171 453 167 453 175"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -221,7 +221,7 @@ show_create_view ::=
 show_databases ::=
     'SHOW' 'DATABASES' ('LIKE' 'pattern' | 'WHERE' expr)
 show_index ::=
-    'SHOW' ('INDEX' | 'INDEXES' | 'KEYS') ('FROM' | 'IN') view_name
+    'SHOW' ('INDEX' | 'INDEXES' | 'KEYS') ('FROM' | 'IN') on_name
     ('LIKE' 'pattern' | 'WHERE' expr)
 show_schemas ::=
     'SHOW' 'SCHEMAS' ('FROM' database_name)?

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -334,6 +334,7 @@ where
         }
 
         // Insert initial named objects into system tables.
+        coord.report_database_update(AMBIENT_DATABASE_ID, "AMBIENT", 1);
         let dbs: Vec<(String, i64, Vec<(String, i64, Vec<(String, GlobalId)>)>)> = coord
             .catalog
             .databases()

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -645,7 +645,9 @@ fn plan_view_select_intrusive(
             allow_aggregates: false,
             allow_subqueries: true,
         };
-        let expr = plan_expr(ecx, &selection)?.type_as(ecx, ScalarType::Bool)?;
+        let expr = plan_expr(ecx, &selection)
+            .map_err(|e| anyhow::anyhow!("WHERE clause error: {}", e))?
+            .type_as(ecx, ScalarType::Bool)?;
         relation_expr = relation_expr.filter(vec![expr]);
     }
 

--- a/test/sqllogictest/index.slt
+++ b/test/sqllogictest/index.slt
@@ -37,14 +37,14 @@ CREATE INDEX bar_idx ON bar (substr(z, 3))
 query TTTTBI colnames
 SHOW INDEX IN bar
 ----
-Source_or_view           Key_name                            Column_name  Expression     Null  Seq_in_index
+On_name                 Key_name                            Column_name  Expression     Null  Seq_in_index
 materialize.public.bar  materialize.public.bar_idx  NULL  substr(z,␠3)  true  1
 materialize.public.bar  materialize.public.bar_primary_idx  z  NULL  false  1
 
 query TTTTBI colnames
 SHOW INDEX FROM foo
 ----
-Source_or_view          Key_name                            Column_name  Expression  Null   Seq_in_index
+On_name                 Key_name                            Column_name  Expression  Null   Seq_in_index
 materialize.public.foo  materialize.public.edge_columns     a            NULL        false  1
 materialize.public.foo  materialize.public.edge_columns     NULL         floor(c)    true   2
 materialize.public.foo  materialize.public.foo_idx          NULL         a␠+␠c       true   1
@@ -58,7 +58,7 @@ DROP INDEX foo_idx
 query TTTTBI colnames,rowsort
 SHOW INDEX in foo
 ----
-Source_or_view                    Key_name                            Column_name  Expression  Null   Seq_in_index
+On_name                 Key_name                            Column_name  Expression  Null   Seq_in_index
 materialize.public.foo  materialize.public.foo_primary_idx  a            NULL        false  1
 materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3
@@ -71,7 +71,7 @@ DROP INDEX edge_columns
 query TTTTBI colnames,rowsort
 SHOW INDEX in foo
 ----
-Source_or_view                    Key_name                            Column_name  Expression  Null   Seq_in_index
+On_name                 Key_name                            Column_name  Expression  Null   Seq_in_index
 materialize.public.foo  materialize.public.foo_primary_idx  a            NULL        false  1
 materialize.public.foo  materialize.public.foo_primary_idx  b            NULL        true   2
 materialize.public.foo  materialize.public.foo_primary_idx  c            NULL        true   3

--- a/test/sqllogictest/show.slt
+++ b/test/sqllogictest/show.slt
@@ -33,7 +33,7 @@ SHOW DATABASES WHERE (SELECT true)
 ----
 materialize
 
-statement error WHERE clause must have type bool, not type i32
+statement error WHERE clause error: no overload for bool AND i32
 SHOW DATABASES WHERE 7
 ----
 
@@ -74,32 +74,32 @@ CREATE INDEX idx1 ON v (b)
 query TTTTTT colnames
 SHOW INDEXES FROM v
 ----
-Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+On_name               Key_name                 Column_name Expression Null  Seq_in_index
 materialize.public.v  materialize.public.idx1  b           NULL       false 1
 
 query TTTTTT colnames
 SHOW INDEXES FROM v WHERE Column_name = 'b'
 ----
-Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+On_name               Key_name                 Column_name Expression Null  Seq_in_index
 materialize.public.v  materialize.public.idx1  b           NULL       false 1
 
 query TTTTTT colnames
 SHOW INDEXES FROM v WHERE Column_name = 'c'
 ----
-Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+On_name               Key_name                 Column_name Expression Null  Seq_in_index
 
 # Reference a different column
 
 query TTTTTT colnames
 SHOW INDEXES FROM v WHERE Key_name = 'materialize.public.idx1'
 ----
-Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+On_name               Key_name                 Column_name Expression Null  Seq_in_index
 materialize.public.v  materialize.public.idx1  b           NULL       false 1
 
 query TTTTTT colnames
 SHOW INDEXES FROM v WHERE key_name LIKE '%v'
 ----
-Source_or_view        Key_name                 Column_name Expression Null  Seq_in_index
+On_name               Key_name                 Column_name Expression Null  Seq_in_index
 
 # TODO(justin): not handled in parser yet:
 #   SHOW INDEXES FROM v LIKE '%v'

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -48,10 +48,10 @@ database
 ----
 materialize
 
-# This SELECT should always return the same result as SHOW DATABASES.
 > SELECT * FROM mz_catalog.mz_databases
 id          database
 -----------------------
+-1          AMBIENT
 1           materialize
 
 # Creating a database should be reflected in the output of SHOW DATABASES.
@@ -62,7 +62,7 @@ database
 d
 materialize
 
-> SELECT * FROM mz_catalog.mz_databases
+> SELECT * FROM mz_catalog.mz_databases WHERE id != -1
 id          database
 -----------------------
 1           materialize
@@ -124,6 +124,7 @@ materialize
 > SELECT * FROM mz_catalog.mz_databases
 id          database
 -----------------------
+-1          AMBIENT
 1           materialize
 
 # The session database should remain set to the dropped database, but future
@@ -189,6 +190,7 @@ materialize
 > SELECT * FROM mz_catalog.mz_databases
 id          database
 -----------------------
+-1          AMBIENT
 1           materialize
 2           d
 4           d2

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -148,13 +148,13 @@ catalog item 'materialize.public.i1' is an index and so cannot be depended upon
 > CREATE INDEX i2 ON v2a(x*2);
 
 > SHOW INDEX in v2a;
-Source_or_view           Key_name                             Column_name Expression     Null   Seq_in_index
+On_name                  Key_name                             Column_name Expression     Null   Seq_in_index
 ------------------------------------------------------------------------------------------------------------
 materialize.public.v2a   materialize.public.i2                <null>      "x * 2"    false  1
 materialize.public.v2a   materialize.public.v2a_primary_idx   x           <null>         false  1
 
 > SHOW INDEX in v2;
-Source_or_view         Key_name                              Column_name Expression Null   Seq_in_index
+On_name                Key_name                              Column_name Expression Null   Seq_in_index
 -------------------------------------------------------------------------------------------------------
 materialize.public.v2  materialize.public.i1                 x           <null>     false  1
 materialize.public.v2  materialize.public.v2_primary_idx     x           <null>     false  1
@@ -167,7 +167,7 @@ materialize.public.v2  materialize.public.v2_primary_idx     x           <null> 
 unknown catalog item 'v2a'
 
 > SHOW INDEX in v2;
-Source_or_view           Key_name                              Column_name Expression Null  Seq_in_index
+On_name                  Key_name                              Column_name Expression Null  Seq_in_index
 ------------------------------------------------------------------------------------------------------
 materialize.public.v2    materialize.public.i1                 x           <null>     false 1
 materialize.public.v2    materialize.public.v2_primary_idx     x           <null>     false 1
@@ -182,7 +182,7 @@ unknown catalog item 'i2'
 > CREATE INDEX i3 ON v4a(y);
 
 > SHOW INDEX in v4a;
-Source_or_view           Key_name                               Column_name Expression Null  Seq_in_index
+On_name                  Key_name                               Column_name Expression Null  Seq_in_index
 -------------------------------------------------------------------------------------------------------
 materialize.public.v4a   materialize.public.i3                  y           <null>     false 1
 materialize.public.v4a   materialize.public.v4a_primary_idx     y           <null>     false 1
@@ -190,7 +190,7 @@ materialize.public.v4a   materialize.public.v4a_primary_idx     y           <nul
 > CREATE INDEX i4 ON v4(x);
 
 > SHOW INDEX in v4;
-Source_or_view          Key_name                           Column_name Expression Null  Seq_in_index
+On_name                 Key_name                           Column_name Expression Null  Seq_in_index
 ------------------------------------------------------------------------------------------------
 materialize.public.v4   materialize.public.i4              x           <null>     false 1
 materialize.public.v4   materialize.public.v4_primary_idx  x           <null>     false 1
@@ -206,7 +206,7 @@ unknown catalog item 'v4a'
 unknown catalog item 'i3'
 
 > SHOW INDEX in v4;
-Source_or_view          Key_name                              Column_name Expression Null  Seq_in_index
+On_name                 Key_name                              Column_name Expression Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------
 materialize.public.v4   materialize.public.i4                  x           <null>     false 1
 materialize.public.v4   materialize.public.v4_primary_idx      x           <null>     false 1
@@ -217,7 +217,7 @@ materialize.public.v4   materialize.public.v4_primary_idx      y           <null
 > CREATE INDEX i5 ON v5(substr);
 
 > SHOW INDEX in v5;
-Source_or_view               Key_name                            Column_name Expression Null  Seq_in_index
+On_name                 Key_name                            Column_name Expression Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------
 materialize.public.v5   materialize.public.i5               substr      <null>     true  1
 materialize.public.v5   materialize.public.v5_primary_idx   substr      <null>     true  1
@@ -225,11 +225,16 @@ materialize.public.v5   materialize.public.v5_primary_idx   substr      <null>  
 > CREATE VIEW multicol AS SELECT 'a' AS a, 'b', 'c', 'd' AS d
 > CREATE INDEX i6 ON multicol (2, a, 4)
 > SHOW INDEX IN multicol
-Source_or_view               Key_name               Column_name  Expression   Null    Seq_in_index
+On_name                      Key_name               Column_name  Expression   Null    Seq_in_index
 -----------------------------------------------------------------------------------------------------
 materialize.public.multicol  materialize.public.i6  ?column?     <null>       false   1
 materialize.public.multicol  materialize.public.i6  a            <null>       false   2
 materialize.public.multicol  materialize.public.i6  d            <null>       false   3
+
+> SHOW INDEX IN multicol WHERE Column_name = 'a'
+On_name                      Key_name               Column_name  Expression   Null    Seq_in_index
+-----------------------------------------------------------------------------------------------------
+materialize.public.multicol  materialize.public.i6  a            <null>       false   2
 
 # Test cascade deletes all indexes associated with cascaded views
 > DROP VIEW v4 CASCADE;
@@ -263,7 +268,7 @@ unknown catalog item 'i4'
 > CREATE INDEX j1 on s3(ascii(y))
 
 > SHOW INDEX in s3;
-Source_or_view          Key_name                              Column_name Expression     Null  Seq_in_index
+On_name                 Key_name                              Column_name Expression     Null  Seq_in_index
 ----------------------------------------------------------------------------------------------------
 materialize.public.s3   materialize.public.j1                 <null>      "ascii(y)" false 1
 materialize.public.s3   materialize.public.s3_primary_idx     x           <null>         false 1
@@ -291,14 +296,14 @@ unknown catalog item 'j1'
 > CREATE INDEX j3 on w(z);
 
 > SHOW INDEX in s4;
-Source_or_view          Key_name                              Column_name Expression  Null  Seq_in_index
+On_name                 Key_name                              Column_name Expression  Null  Seq_in_index
 ----------------------------------------------------------------------------------------------------
 materialize.public.s4   materialize.public.j2                 <null>      "x + 2" false 1
 materialize.public.s4   materialize.public.s4_primary_idx     x           <null>      false 1
 materialize.public.s4   materialize.public.s4_primary_idx     y           <null>      false 2
 
 > SHOW INDEX in w;
-Source_or_view         Key_name                            Column_name Expression Null  Seq_in_index
+On_name                Key_name                            Column_name Expression Null  Seq_in_index
 ----------------------------------------------------------------------------------------------------
 materialize.public.w   materialize.public.j3               z           <null>     false 1
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -38,7 +38,7 @@ field_number     field
 2                mz_obj_no
 
 > SHOW INDEXES FROM mz_data
-Source_or_view                Key_name                              Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                              Column_name  Expression  Null   Seq_in_index
 ----------------------------------------------------------------------------------------------------------------
 materialize.public.mz_data  materialize.public.mz_data_primary_idx  a            <null>      false             1
 materialize.public.mz_data  materialize.public.mz_data_primary_idx  b            <null>      false             2
@@ -49,14 +49,14 @@ materialize.public.mz_data  materialize.public.mz_data_primary_idx  mz_obj_no   
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
 
 > SHOW INDEXES FROM data
-Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+On_name                   Key_name                              Column_name  Expression  Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
 > SHOW INDEXES FROM data
-Source_or_view           Key_name                             Column_name  Expression  Null   Seq_in_index
+On_name                  Key_name                             Column_name  Expression  Null   Seq_in_index
 ----------------------------------------------------------------------------------------------------------
 materialize.public.data  materialize.public.data_primary_idx  a            <null>      false             1
 materialize.public.data  materialize.public.data_primary_idx  b            <null>      false             2
@@ -65,7 +65,7 @@ materialize.public.data  materialize.public.data_primary_idx  mz_obj_no    <null
 > CREATE DEFAULT INDEX ON mz_data
 
 > SHOW INDEXES FROM mz_data
-Source_or_view                Key_name                               Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                               Column_name  Expression  Null   Seq_in_index
 ------------------------------------------------------------------------------------------------------------------
 materialize.public.mz_data  materialize.public.mz_data_primary_idx   a            <null>      false             1
 materialize.public.mz_data  materialize.public.mz_data_primary_idx   b            <null>      false             2
@@ -79,7 +79,7 @@ materialize.public.mz_data  materialize.public.mz_data_primary_idx1  mz_obj_no  
   SELECT b, sum(a) FROM data GROUP BY b
 
 > SHOW INDEXES FROM matv
-Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+On_name                   Key_name                              Column_name  Expression  Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------------
 materialize.public.matv  materialize.public.matv_primary_idx  b            <null>      false             1
 
@@ -87,14 +87,14 @@ materialize.public.matv  materialize.public.matv_primary_idx  b            <null
 > CREATE VIEW data_view as SELECT * from data
 
 > SHOW INDEXES FROM data_view
-Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+On_name                   Key_name                              Column_name  Expression  Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                                  Column_name  Expression  Null   Seq_in_index
 --------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.data_view_primary_idx  a            <null>      false             1
 materialize.public.data_view  materialize.public.data_view_primary_idx  b            <null>      false             2
@@ -104,7 +104,7 @@ materialize.public.data_view  materialize.public.data_view_primary_idx  mz_obj_n
 > CREATE MATERIALIZED VIEW mz_data_view as SELECT * from data
 
 > SHOW INDEXES FROM mz_data_view
-Source_or_view                   Key_name                                     Column_name  Expression  Null   Seq_in_index
+On_name                          Key_name                                     Column_name  Expression  Null   Seq_in_index
 --------------------------------------------------------------------------------------------------------------------------
 materialize.public.mz_data_view  materialize.public.mz_data_view_primary_idx  a            <null>      false             1
 materialize.public.mz_data_view  materialize.public.mz_data_view_primary_idx  b            <null>      false             2
@@ -114,7 +114,7 @@ materialize.public.mz_data_view  materialize.public.mz_data_view_primary_idx  mz
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                                  Column_name  Expression  Null   Seq_in_index
 --------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.data_view_primary_idx  a            <null>      false             1
 materialize.public.data_view  materialize.public.data_view_primary_idx  b            <null>      false             2
@@ -124,7 +124,7 @@ materialize.public.data_view  materialize.public.data_view_primary_idx  mz_obj_n
 > CREATE DEFAULT INDEX IF NOT EXISTS ON matv
 
 > SHOW INDEXES FROM matv
-Source_or_view            Key_name                              Column_name  Expression  Null  Seq_in_index
+On_name                   Key_name                              Column_name  Expression  Null  Seq_in_index
 -----------------------------------------------------------------------------------------------------------
 materialize.public.matv  materialize.public.matv_primary_idx  b            <null>      false             1
 
@@ -132,7 +132,7 @@ materialize.public.matv  materialize.public.matv_primary_idx  b            <null
 > CREATE DEFAULT INDEX ON matv
 
 > SHOW INDEXES FROM matv
-Source_or_view            Key_name                               Column_name  Expression  Null   Seq_in_index
+On_name                   Key_name                               Column_name  Expression  Null   Seq_in_index
 -------------------------------------------------------------------------------------------------------------
 materialize.public.matv  materialize.public.matv_primary_idx   b            <null>      false             1
 materialize.public.matv  materialize.public.matv_primary_idx1  b            <null>      false             1
@@ -141,7 +141,7 @@ materialize.public.matv  materialize.public.matv_primary_idx1  b            <nul
 > CREATE DEFAULT INDEX named_idx ON data_view
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                                  Column_name  Expression  Null   Seq_in_index
 --------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.data_view_primary_idx  a            <null>      false             1
 materialize.public.data_view  materialize.public.data_view_primary_idx  b            <null>      false             2
@@ -157,7 +157,7 @@ materialize.public.data_view  materialize.public.named_idx              mz_obj_n
 > CREATE INDEX ON data_view(a)
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                                  Column_name  Expression  Null   Seq_in_index
 --------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.data_view_a_idx        a            <null>      false             1
 
@@ -168,7 +168,7 @@ materialize.public.data_view  materialize.public.data_view_a_idx        a       
 > CREATE INDEX ON data_view(b - a, a)
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                                  Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                                  Column_name  Expression  Null   Seq_in_index
 --------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.data_view_b_a_idx      a            <null>      false             2
 materialize.public.data_view  materialize.public.data_view_b_a_idx      b            <null>      false             1
@@ -182,7 +182,7 @@ materialize.public.data_view  materialize.public.data_view_expr_a_idx   a       
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                       Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                       Column_name  Expression  Null   Seq_in_index
 ---------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.named_idx   <null>       "b - a"     false             1
 materialize.public.data_view  materialize.public.named_idx   a            <null>      false             2
@@ -194,7 +194,7 @@ materialize.public.data_view  materialize.public.named_idx   a            <null>
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-Source_or_view                Key_name                                   Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                                   Column_name  Expression  Null   Seq_in_index
 ---------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view  materialize.public.data_view_primary_idx   <null>       "b - a"     false             1
 materialize.public.data_view  materialize.public.data_view_primary_idx   a            <null>      false             2

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -31,7 +31,7 @@ $ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
     SELECT * FROM mz_data
 
 > SHOW INDEXES FROM mz_view
-Source_or_view                Key_name                              Column_name  Expression  Null   Seq_in_index
+On_name                       Key_name                              Column_name  Expression  Null   Seq_in_index
 ----------------------------------------------------------------------------------------------------------------
 materialize.public.mz_view  materialize.public.mz_view_primary_idx  a            <null>      false             1
 materialize.public.mz_view  materialize.public.mz_view_primary_idx  b            <null>      false             2
@@ -146,7 +146,7 @@ materialize.public.renamed_mz_view  "CREATE VIEW \"materialize\".\"public\".\"re
 
 # Item's indexes are properly re-attributed
 > SHOW INDEXES FROM renamed_mz_view
-Source_or_view                      Key_name                          Column_name Expression Null  Seq_in_index
+On_name                             Key_name                          Column_name Expression Null  Seq_in_index
 ---------------------------------------------------------------------------------------------------------------
  materialize.public.renamed_mz_view materialize.public.renamed_index  a           <null>     false            1
  materialize.public.renamed_mz_view materialize.public.renamed_index  b           <null>     false            2

--- a/test/testdrive/show.td
+++ b/test/testdrive/show.td
@@ -372,3 +372,13 @@ Field    Nullable   Type
 ------------------------
 b        YES        date
 a        YES        text
+
+> SHOW COLUMNS in t WHERE Field = 'a'
+Field    Nullable   Type
+------------------------
+a        YES        text
+
+> SHOW COLUMNS in t LIKE '%b%'
+Field    Nullable   Type
+------------------------
+b        YES        date

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -35,7 +35,7 @@ SOURCES
 -------
 
 > SHOW INDEXES FROM t;
-Source_or_view        Key_name                          Column_name  Expression  Null   Seq_in_index
+On_name               Key_name                          Column_name  Expression  Null   Seq_in_index
 ----------------------------------------------------------------------------------------------------------------
 materialize.public.t  materialize.public.t_primary_idx  a            <null>      true              1
 materialize.public.t  materialize.public.t_primary_idx  b            <null>      false             2


### PR DESCRIPTION
This change:
- Updates `handle_show_databases`, `handle_show_schemas`, and `handle_show_indexes`
  to generate query strings instead of building a Select statement programmatically.
- Cleans up unnecessary helper functions.
- Renames the `SHOW INDEXES` `Source_or_view` output column to `On_name`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4243)
<!-- Reviewable:end -->
