### PR TITLE
sql: fix bug in reduce elision

### DIFF
--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+query I
+select (select sum(1) from (select c) group by c) from (select 1 as c)
+----
+1
+
+query T
+select (select jsonb_agg(1) from (select c) group by c) from (select 1 as c)
+----
+[1.0]


### PR DESCRIPTION
Previously, reduce elision assumed that aggregates besides Count, when
fed a single row, evaluated to their input, but this was wrong for
SumInt32, which must evaluate to an Int64 rather than an Int32.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4250)
<!-- Reviewable:end -->
