### PR TITLE
materialized: report and log version check status during startup

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -14,6 +14,7 @@ Flag | Default | Modifies
 [`--address-file`](#horizontally-scaled-clusters) | N/A |  Address of all coordinating Materialize nodes
 [`--data-directory`](#data-directory) | `./mzdata` | Where data is persisted
 `--help` | N/A | NOP&mdash;prints binary's list of command line flags
+[`--disable-telemetry`](#telemetry) | N/A |  Disables any telemetry reporting.
 [`--experimental`](#experimental-mode) | Disabled | Get more details [here](#experimental-mode)
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
 [`--logical-compaction-window`](#compaction-window) | 60s | The amount of historical detail to retain in arrangements
@@ -232,3 +233,9 @@ the [Deployment section][persistence] for more guidance on how to tune this
 parameter.
 
 [persistence]: /ops/deployment/#persistence
+
+### Telemetry
+
+Unless disabled with `--disable-telemetry`, upon startup `materialized`
+reports its current version and cluster id to a central server operated by
+materialize.io. If a newer version is available a warning will be logged.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -78,6 +78,10 @@ Wrap your release notes at the 80 character mark.
 - Correct a query optimization that could misplan queries that referenced the
   same relation multiple times with varying filters {{% gh 4361 %}}.
 
+- Report the current version to a central server operated by
+  materialize.io. If a new version is available a warning will be
+  logged. This can be disabled with the `--disable-telemetry` option.
+
 {{% version-header v0.4.3 %}}
 
 - Permit adjusting the logical compaction window on a per-index basis via the

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -39,6 +39,7 @@ prof = { path = "../prof", features = ["auto-jemalloc"] }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false, features = ["process"] }
 rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 repr = { path = "../repr" }
+reqwest = { version = "0.10.8", features = ["json"] }
 rlimit = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/src/materialized/src/version_check.rs
+++ b/src/materialized/src/version_check.rs
@@ -1,0 +1,71 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use anyhow::bail;
+use log::warn;
+use serde::{Deserialize, Serialize};
+
+use crate::VERSION;
+use ore::retry::RetryBuilder;
+
+// Runs fetch_latest_version in a backoff loop until it succeeds once, prints a
+// warning if there is another version, then returns.
+pub async fn check_version_loop(telemetry_url: String, cluster_id: String) {
+    let current_version = VERSION;
+
+    let latest_version = RetryBuilder::new()
+        .max_sleep(None)
+        .initial_backoff(Duration::from_secs(1))
+        .build()
+        .retry(|_state| fetch_latest_version(&telemetry_url, &cluster_id, &current_version))
+        .await
+        .unwrap();
+
+    if latest_version != current_version {
+        warn!(
+            "A new version of materialized is available: {}.",
+            latest_version
+        );
+    }
+}
+
+async fn fetch_latest_version(
+    telemetry_url: &str,
+    cluster_id: &str,
+    current_version: &str,
+) -> anyhow::Result<String> {
+    let version_url = format!("{}/api/v1/version/{}", telemetry_url, cluster_id);
+    let version_request = V1VersionRequest {
+        version: current_version.to_string(),
+    };
+
+    let resp = reqwest::Client::new()
+        .post(&version_url)
+        .timeout(Duration::from_secs(10))
+        .json(&version_request)
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        bail!("failed request: {}", resp.status());
+    }
+    let version: V1VersionResponse = resp.json().await?;
+    Ok(version.latest_release)
+}
+
+#[derive(Serialize)]
+struct V1VersionRequest {
+    version: String,
+}
+
+#[derive(Deserialize)]
+struct V1VersionResponse {
+    latest_release: String,
+}

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -85,6 +85,7 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
         listen_addr: None,
         tls: config.tls,
         experimental_mode: config.experimental_mode,
+        telemetry_url: None,
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -385,7 +385,7 @@ impl State {
         // Note that the coordinator must be initialized *after* launching the
         // dataflow workers, as booting the coordinator can involve sending enough
         // data to workers to fill up a `comm` channel buffer (#3280).
-        let coord_thread = coord::serve(coord::Config {
+        let (coord_thread, _cluster_id) = coord::serve(coord::Config {
             switchboard,
             cmd_rx,
             num_timely_workers: NUM_TIMELY_WORKERS,
@@ -399,8 +399,8 @@ impl State {
             logical_compaction_window: None,
             experimental_mode: true,
         })
-        .await?
-        .join_on_drop();
+        .await?;
+        let coord_thread = coord_thread.join_on_drop();
 
         Ok(State {
             coord_client: coord::Client::new(cmd_tx).for_session(Session::dummy()),


### PR DESCRIPTION
By default in release mode, report the current version and check for
the latest version at startup, and print a warning if there's another
version available. The information sent in the request is the current
version and a unique (and non-guessable) cluster id.

Fixes #3580

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4262)
<!-- Reviewable:end -->
