### PR TITLE
Fix td avro parsing

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -342,7 +342,6 @@ impl Schema {
 }
 
 /// This type is used to simplify enum variant comparison between `Schema` and `types::Value`.
-/// It may have utility as part of the public API, but defining as `pub(crate)` for now.
 ///
 /// **NOTE** This type was introduced due to a limitation of `mem::discriminant` requiring a _value_
 /// be constructed in order to get the discriminant, which makes it difficult to implement a
@@ -350,7 +349,7 @@ impl Schema {
 /// intermediate type should be especially fast, as the number of enum variants is small, which
 /// _should_ compile into a jump-table for the conversion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum SchemaKind {
+pub enum SchemaKind {
     // Fixed-length types
     Null,
     Boolean,
@@ -370,6 +369,28 @@ pub(crate) enum SchemaKind {
     // This can arise in resolved schemas, particularly when a union resolves to a non-union.
     // We would need to do a lookup to find the actual type.
     Unknown,
+}
+
+impl SchemaKind {
+    pub fn name(self) -> &'static str {
+        match self {
+            SchemaKind::Null => "null",
+            SchemaKind::Boolean => "boolean",
+            SchemaKind::Int => "int",
+            SchemaKind::Long => "long",
+            SchemaKind::Float => "float",
+            SchemaKind::Double => "double",
+            SchemaKind::Bytes => "bytes",
+            SchemaKind::String => "string",
+            SchemaKind::Array => "array",
+            SchemaKind::Map => "map",
+            SchemaKind::Union => "union",
+            SchemaKind::Record => "record",
+            SchemaKind::Enum => "enum",
+            SchemaKind::Fixed => "fixed",
+            SchemaKind::Unknown => "unknown",
+        }
+    }
 }
 
 impl<'a> From<&'a SchemaPiece> for SchemaKind {
@@ -474,6 +495,9 @@ impl FullName {
                 namespace: namespace.into(),
             }
         }
+    }
+    pub fn base_name(&self) -> &str {
+        &self.name
     }
 }
 
@@ -1271,7 +1295,7 @@ impl Schema {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct NamedSchemaPiece {
-    pub(crate) name: FullName,
+    pub name: FullName,
     pub piece: SchemaPiece,
 }
 

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -138,7 +138,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
             }
             Ok(builder.avro())
         }
-        (val, /*JsonValue::Object(items),*/ SchemaPiece::Union(us)) => {
+        (val, SchemaPiece::Union(us)) => {
             let variants = us.variants();
             let null_variant = variants
                 .iter()
@@ -157,7 +157,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
             }
             let items = match val {
                 JsonValue::Object(items) => items,
-                _ => return Err(format!("Union scheme element must be `null` or a map from type name to value; found {:?}", val))
+                _ => return Err(format!("Union schema element must be `null` or a map from type name to value; found {:?}", val))
             };
             let (name, val) = if items.len() == 1 {
                 (items.keys().next().unwrap(), items.values().next().unwrap())

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -26,6 +26,7 @@ use serde_json::Value as JsonValue;
 // testdrive modules can import just this one.
 
 pub use interchange::avro::parse_schema;
+use mz_avro::schema::SchemaKind;
 pub use mz_avro::schema::{Schema, SchemaNode, SchemaPiece, SchemaPieceOrNamed};
 pub use mz_avro::types::{DecimalValue, ToAvro, Value};
 pub use mz_avro::{from_avro_datum, to_avro_datum, Codec, Reader, Writer};
@@ -137,27 +138,62 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
             }
             Ok(builder.avro())
         }
-        (val, SchemaPiece::Union(us)) => {
+        (val, /*JsonValue::Object(items),*/ SchemaPiece::Union(us)) => {
             let variants = us.variants();
-            let mut last_err = format!("Union schema {:?} did not match {:?}", variants, val);
             let null_variant = variants
                 .iter()
                 .position(|v| v == &SchemaPieceOrNamed::Piece(SchemaPiece::Null));
+            if let JsonValue::Null = val {
+                return if let Some(nv) = null_variant {
+                    Ok(Value::Union {
+                        index: nv,
+                        inner: Box::new(Value::Null),
+                        n_variants: variants.len(),
+                        null_variant,
+                    })
+                } else {
+                    Err("No `null` value in union schema.".to_string())
+                };
+            }
+            let items = match val {
+                JsonValue::Object(items) => items,
+                _ => return Err(format!("Union scheme element must be `null` or a map from type name to value; found {:?}", val))
+            };
+            let (name, val) = if items.len() == 1 {
+                (items.keys().next().unwrap(), items.values().next().unwrap())
+            } else {
+                return Err(format!(
+                    "Expected one-element object to match union schema: {:?} vs {:?}",
+                    json, schema
+                ));
+            };
             for (i, variant) in variants.iter().enumerate() {
-                match from_json(val, schema.step(variant)) {
-                    Ok(avro) => {
-                        return Ok(Value::Union {
-                            index: i,
-
-                            inner: Box::new(avro),
-                            n_variants: variants.len(),
-                            null_variant,
-                        })
+                let name_matches = match variant {
+                    SchemaPieceOrNamed::Piece(piece) => SchemaKind::from(piece).name() == name,
+                    SchemaPieceOrNamed::Named(idx) => {
+                        let schema_name = &schema.root.lookup(*idx).name;
+                        if name.chars().any(|ch| ch == '.') {
+                            name == &schema_name.to_string()
+                        } else {
+                            name == schema_name.base_name()
+                        }
                     }
-                    Err(msg) => last_err = msg,
+                };
+                if name_matches {
+                    match from_json(val, schema.step(variant)) {
+                        Ok(avro) => {
+                            return Ok(Value::Union {
+                                index: i,
+                                inner: Box::new(avro),
+                                n_variants: variants.len(),
+                                null_variant,
+                            })
+                        }
+                        Err(msg) => return Err(msg),
+                    }
                 }
             }
-            Err(last_err)
+            Err(format!("Type not found in union: {}", name))
         }
         _ => Err(format!(
             "unable to match JSON value to schema: {:?} vs {:?}",

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -79,10 +79,10 @@ $ set schema={
 $ kafka-create-topic topic=real-time
 
 $ kafka-ingest format=avro topic=real-time schema=${schema} timestamp=1
-{"before": null, "after": {"a": 1, "b": 1}}
-{"before": null, "after": {"a": 2, "b": 1}}
-{"before": null, "after": {"a": 3, "b": 1}}
-{"before": null, "after": {"a": 1, "b": 2}}
+{"before": null, "after": {"row": {"a": 1, "b": 1}}}
+{"before": null, "after": {"row": {"a": 2, "b": 1}}}
+{"before": null, "after": {"row": {"a": 3, "b": 1}}}
+{"before": null, "after": {"row": {"a": 1, "b": 2}}}
 
 > CREATE SOURCE real_time_src
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-real-time-${testdrive.seed}'

--- a/test/kafka-krb5/smoketest.td
+++ b/test/kafka-krb5/smoketest.td
@@ -32,8 +32,8 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"a": 102}}
-{"before": null, "after": {"a": 201}}
+{"before": null, "after": {"row": {"a": 102}}}
+{"before": null, "after": {"row": {"a": 201}}}
 
 > CREATE SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -31,7 +31,7 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
-{"before": null, "after": {"a": 1}}
+{"before": null, "after": {"row": {"a": 1}}}
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -51,7 +51,7 @@ a
 1
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
-{"before": null, "after": {"a": 2}}
+{"before": null, "after": {"row": {"a": 2}}}
 
 > SELECT * FROM data
 a

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -31,7 +31,7 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
-{"before": null, "after": {"a": 1}}
+{"before": null, "after": {"row": {"a": 1}}}
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER 'kafka1:9092,kafka2:9092' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -51,7 +51,7 @@ a
 1
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
-{"before": null, "after": {"a": 2}}
+{"before": null, "after": {"row": {"a": 2}}}
 
 > SELECT * FROM data
 a

--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -141,10 +141,10 @@ $ set reader-schema={
 $ kafka-create-topic topic=avro-data
 
 $ kafka-ingest format=avro topic=avro-data schema=${writer-schema} publish=true timestamp=1
-{ "f5": 1234, "f4": [0], "f3": 2345, "f2": "Diamonds", "f1": [0, 1, 2, 3] }
+{ "f5": 1234, "f4": {"variant1": [0]}, "f3": 2345, "f2": "Diamonds", "f1": {"variant4": [0, 1, 2, 3]} }
 
 $ kafka-ingest format=avro topic=avro-data schema=${reader-schema} publish=true timestamp=1
-{ "f0": {"f0_0": 9999, "f0_1": null}, "f1": 3456, "f2": "Jokers", "f5": [0,1,2,3,4,5,6,7,8,9] }
+{ "f0": {"f0_0": 9999, "f0_1": null}, "f1": {"long": 3456}, "f2": "Jokers", "f5": {"extra_variant": [0,1,2,3,4,5,6,7,8,9]} }
 
 > CREATE MATERIALIZED SOURCE avro_data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'

--- a/test/testdrive/avro-ocf.td
+++ b/test/testdrive/avro-ocf.td
@@ -189,8 +189,8 @@ mz_obj_no     NO      int8
   INTO AVRO OCF '${testdrive.temp-dir}/basic-sink.ocf'
 
 $ avro-ocf-verify sink=materialize.public.basic_sink_${testdrive.seed}
-{"before": null, "after": {"a": 1, "b": 2, "mz_obj_no": 1}}
-{"before": null, "after": {"a": 3, "b": 4, "mz_obj_no": 2}}
+{"before": null, "after": {"row": {"a": 1, "b": 2, "mz_obj_no": 1}}}
+{"before": null, "after": {"row": {"a": 3, "b": 4, "mz_obj_no": 2}}}
 
 > CREATE VIEW dateish AS
   SELECT d FROM timestamp_source
@@ -199,5 +199,5 @@ $ avro-ocf-verify sink=materialize.public.basic_sink_${testdrive.seed}
   INTO AVRO OCF '${testdrive.temp-dir}/date-sink.ocf'
 
 $ avro-ocf-verify sink=materialize.public.date_sink_${testdrive.seed}
-{"before": null, "after": {"d": 10988}}
-{"before": null, "after": {"d": 10957}}
+{"before": null, "after": {"row": {"d": 10988}}}
+{"before": null, "after": {"row": {"d": 10957}}}

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -64,7 +64,7 @@ $ set schema-v2={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema-v1} publish=true timestamp=1
-{"before": null, "after": {"a": 1}}
+{"before": null, "after": {"row": {"a": 1}}}
 
 > CREATE MATERIALIZED SOURCE data_v1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -77,7 +77,7 @@ a
 1
 
 $ kafka-ingest format=avro topic=data schema=${schema-v2} publish=true timestamp=3
-{"before": null, "after": {"a": 2, "b": -1}}
+{"before": null, "after": {"row": {"a": 2, "b": -1}}}
 
 > CREATE MATERIALIZED SOURCE data_v2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -106,7 +106,7 @@ $ set valid-key-schema={
 
 $ kafka-ingest topic=data publish=true timestamp=5
   format=avro schema=${schema-v1} key-format=avro key-schema=${valid-key-schema}
-{"a": 1} {"before": null, "after": {"a": 1}}
+{"a": 1} {"before": null, "after": {"row": {"a": 1}}}
 
 > CREATE MATERIALIZED SOURCE data_v3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'

--- a/test/testdrive/avro-sinks.td
+++ b/test/testdrive/avro-sinks.td
@@ -18,7 +18,7 @@
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.unnamed_cols_sink
-{"before": null, "after": {"column1": 1, "b": 2, "column3": 3}}
+{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}}
 
 # Test that invented field names do not clash with named columns.
 
@@ -29,7 +29,7 @@ $ kafka-verify format=avro sink=materialize.public.unnamed_cols_sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.clashing_cols_sink
-{"before": null, "after": {"column1": 1, "column1_1": 2, "b": 3, "b1": 4, "b2": 5}}
+{"before": null, "after": {"row": {"column1": 1, "column1_1": 2, "b": 3, "b1": 4, "b2": 5}}}
 
 # Test a basic sink with multiple rows.
 
@@ -40,10 +40,10 @@ $ kafka-verify format=avro sink=materialize.public.clashing_cols_sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.data_sink
-{"before": null, "after": {"a": 1, "b": 1}}
-{"before": null, "after": {"a": 1, "b": 2}}
-{"before": null, "after": {"a": 2, "b": 1}}
-{"before": null, "after": {"a": 3, "b": 1}}
+{"before": null, "after": {"row": {"a": 1, "b": 1}}}
+{"before": null, "after": {"row": {"a": 1, "b": 2}}}
+{"before": null, "after": {"row": {"a": 2, "b": 1}}}
+{"before": null, "after": {"row": {"a": 3, "b": 1}}}
 
 # Test date/time types.
 
@@ -56,8 +56,8 @@ $ kafka-verify format=avro sink=materialize.public.data_sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.datetime_data_sink
-{"before": null, "after": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}
-{"before": null, "after": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}
+{"before": null, "after": {"row": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}}
+{"before": null, "after": {"row": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}}
 
 > CREATE VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04')
 
@@ -66,8 +66,8 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.time_data_sink
-{"before": null, "after": {"time": 3723000000}}
-{"before": null, "after": {"time": 3724000000}}
+{"before": null, "after": {"row": {"time": 3723000000}}}
+{"before": null, "after": {"row": {"time": 3724000000}}}
 
 $ set schema={
     "type": "record",
@@ -130,18 +130,18 @@ $ kafka-create-topic topic=consistency
 $ kafka-create-topic topic=input
 
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"a": 1, "b": 1}}
-{"before": null, "after": {"a": 2, "b": 2}}
+{"before": null, "after": {"row": {"a": 1, "b": 1}}}
+{"before": null, "after": {"row": {"a": 2, "b": 2}}}
 
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
-{"before": null, "after": {"a": 3, "b": 1}}
-{"before": null, "after": {"a": 4, "b": 2}}
+{"before": null, "after": {"row": {"a": 3, "b": 1}}}
+{"before": null, "after": {"row": {"a": 4, "b": 2}}}
 
 $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}
+{"status":"END","id":"1","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
 {"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}
+{"status":"END","id":"2","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
 
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
@@ -163,13 +163,13 @@ a  b
   AS OF 1;
 
 $ kafka-verify format=avro sink=materialize.public.input_sink
-{"before": null, "after": {"a": 1, "b": 1}, "transaction": {"id": "1"}}
-{"before": null, "after": {"a": 2, "b": 2}, "transaction": {"id": "1"}}
-{"before": null, "after": {"a": 3, "b": 1}, "transaction": {"id": "2"}}
-{"before": null, "after": {"a": 4, "b": 2}, "transaction": {"id": "2"}}
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
+{"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
+{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
+{"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
 
 $ kafka-verify format=avro sink=materialize.public.input_sink consistency=debezium
 {"id": "1", "status": "BEGIN", "event_count": null}
 {"id": "2", "status": "BEGIN", "event_count": null}
-{"id": "1", "status": "END", "event_count": 2}
-{"id": "2", "status": "END", "event_count": 2}
+{"id": "1", "status": "END", "event_count": {"long": 2}}
+{"id": "2", "status": "END", "event_count": {"long": 2}}

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -102,9 +102,9 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"a": 1, "b": 1, "json": "null", "c": "True", "d": "False", "e": {"n1_a": 42, "n1_b": 86.5}, "f": null}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": false}}
-{"before": null, "after": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": {"n1_a": 43, "n1_b":{"n2_a": 44, "n2_b": -1}}, "f": {"n2_a": 45, "n2_b": -2}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": false}}
-{"before": null, "after": {"a": -1, "b": 7, "json": "[1, 2, 3]", "c": "FileNotFound", "d": "True", "e": null, "f": null}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": false}}
+{"before": null, "after": {"row": {"a": 1, "b": 1, "json": "null", "c": "True", "d": "False", "e": {"nested_data_1": {"n1_a": 42, "n1_b": {"double": 86.5}}}, "f": null}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}}
+{"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": {"nested_data_1": {"n1_a": 43, "n1_b":{"nested_data_2": {"n2_a": 44, "n2_b": -1}}}}, "f": {"nested_data_2": {"n2_a": 45, "n2_b": -2}}}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}}
+{"before": null, "after": {"row": {"a": -1, "b": 7, "json": "[1, 2, 3]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 # Create a source using an inline schema.
 
@@ -138,8 +138,8 @@ a  b  json            c            d
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": null, "f": null}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": false}}
-{"before": null, "after": {"a": 42, "b": 19, "json": "[4, 5, 6]", "c": "FileNotFound", "d": "True", "e": null, "f": null}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": false}}
+{"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}}
+{"before": null, "after": {"row": {"a": 42, "b": 19, "json": "[4, 5, 6]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 > SELECT a, b, json, c, d, e::text, f::text FROM data_schema_inline
 a  b  json                     c            d             e                   f
@@ -275,13 +275,13 @@ $ kafka-create-topic topic=new-dbz-data
 # We don't do anything sensible yet for snapshot "true" or "last", so just test that those are ingested.
 
 $ kafka-ingest format=avro topic=new-dbz-data schema=${new-dbz-schema} timestamp=1
-{"before": null, "after": {"a": 9, "b": 10}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": "true"}}
-{"before": null, "after": {"a": 11, "b": 11}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": "last"}}
-{"before": null, "after": {"a": 14, "b": 6}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": null}}
-{"before": null, "after": {"a": 1, "b": 1}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": "false"}}
-{"before": null, "after": {"a": 2, "b": 3}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": "false"}}
-{"before": null, "after": {"a": -1, "b": 7}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": "false"}}
-{"before": null, "after": {"a": -1, "b": 7}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": "false"}}
+{"before": null, "after": {"row":{"a": 9, "b": 10}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "true"}}}
+{"before": null, "after": {"row":{"a": 11, "b": 11}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "last"}}}
+{"before": null, "after": {"row":{"a": 14, "b": 6}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": null}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}}
 
 > CREATE MATERIALIZED SOURCE new_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-new-dbz-data-${testdrive.seed}'
@@ -319,12 +319,12 @@ a b
 $ kafka-create-topic topic=misordered-dbz-data
 
 $ kafka-ingest format=avro topic=misordered-dbz-data schema=${new-dbz-schema} timestamp=1
-{"before": null, "after": {"a": 1, "b": 1}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": "false"}}
-{"before": null, "after": {"a": 2, "b": 3}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": "false"}}
-{"before": null, "after": {"a": -1, "b": 7}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": "false"}}
-{"before": null, "after": {"a": 2, "b": 3}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": "false"}}
-{"before": null, "after": {"a": 1, "b": 1}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": "false"}}
-{"before": null, "after": {"a": 3, "b": 4}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": "false"}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": 3, "b": 4}}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
 
 > CREATE MATERIALIZED SOURCE misordered_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-data-${testdrive.seed}'
@@ -420,9 +420,9 @@ $ kafka-create-topic topic=pg-dbz-data
 
 # The third record will be skipped, since `lsn` has gone backwards.
 $ kafka-ingest format=avro topic=pg-dbz-data schema=${pg-dbz-schema} timestamp=1
-{"before": null, "after": {"a": 1, "b": 1}, "source": {"lsn": 1, "snapshot": "false"}}
-{"before": null, "after": {"a": 2, "b": 3}, "source": {"lsn": 2, "snapshot": "false"}}
-{"before": null, "after": {"a": -1, "b": 7}, "source": {"lsn": 0, "snapshot": "false"}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"lsn": {"long": 1}, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"lsn": {"long": 2}, "snapshot": {"string": "false"}}}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"lsn": {"long": 0}, "snapshot": {"string": "false"}}}
 
 > CREATE MATERIALIZED SOURCE pg_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-pg-dbz-data-${testdrive.seed}'

--- a/test/testdrive/avro-unions.td
+++ b/test/testdrive/avro-unions.td
@@ -22,9 +22,9 @@ $ set writer-schema={
   }
 
 $ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
-{"a": 1, "b": null, "c": null, "d": "d"}
-{"a": 2, "b": 2, "c": "foo", "d": 4}
-{"a": 2, "b": 2, "c": 3, "d": "d"}
+{"a": {"long": 1}, "b": null, "c": null, "d": {"string": "d"}}
+{"a": {"long": 2}, "b": {"long": 2}, "c": {"string": "foo"}, "d": {"long": 4}}
+{"a": {"long": 2}, "b": {"long": 2}, "c": {"long": 3}, "d": {"string": "d"}}
 
 > CREATE MATERIALIZED SOURCE unions
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -69,16 +69,16 @@ $ kafka-create-topic topic=data-consistency
 $ kafka-create-topic topic=names
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
-{"before": null, "after": {"num": 1, "name": "one"}}
-{"before": {"num": 1, "name": "one"}, "after": {"num": 2, "name": "two"}}
-{"before": {"num": 2, "name": "two"}, "after": {"num": 3, "name": "three"}}
+{"before": null, "after": {"row": {"num": 1, "name": "one"}}}
+{"before": {"row": {"num": 1, "name": "one"}}, "after": {"row": {"num": 2, "name": "two"}}}
+{"before": {"row": {"num": 2, "name": "two"}}, "after": {"row": {"num": 3, "name": "three"}}}
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=1 schema=${trxschemakey}
 {"id": "1"}
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":3,"data_collections":[{"event_count": 3, "data_collection": "testdrive-names-${testdrive.seed}"}]}
+{"status":"END","id":"1","event_count":{"long": 3},"data_collections":{"array": [{"event_count": 3, "data_collection": "testdrive-names-${testdrive.seed}"}]}}
 
 > CREATE MATERIALIZED SOURCE names
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
@@ -91,11 +91,11 @@ $ kafka-ingest format=avro topic=data-consistency timestamp=1 schema=${trxschema
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.snk1
-{"before": null, "after": {"num": 3, "name": "three"}}
+{"before": null, "after": {"row": {"num": 3, "name": "three"}}}
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
-{"before": {"num": 3, "name": "three"}, "after": {"num": 4, "name": "four"}}
-{"before": {"num": 4, "name": "four"}, "after": {"num": 5, "name": "five"}}
+{"before": {"row": {"num": 3, "name": "three"}}, "after": {"row": {"num": 4, "name": "four"}}}
+{"before": {"row": {"num": 4, "name": "four"}}, "after": {"row": {"num": 5, "name": "five"}}}
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=2 schema=${trxschemakey}
 {"id": "2"}
@@ -103,9 +103,9 @@ $ kafka-ingest format=avro topic=data-consistency timestamp=2 schema=${trxschema
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=2 schema=${trxschema}
 {"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":1,"data_collections":[{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}
+{"status":"END","id":"2","event_count":{"long": 1},"data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}}
 {"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":1,"data_collections":[{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}
+{"status":"END","id":"3","event_count":{"long": 1},"data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}}
 
 > SELECT * FROM names AS OF 2;
 num name
@@ -115,14 +115,14 @@ num name
 > ALTER INDEX materialize.public.names_primary_idx SET(logical_compaction_window='1ms')
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=3
-{"before": {"num": 5, "name": "five"}, "after": {"num": 6, "name": "six"}}
+{"before": {"row": {"num": 5, "name": "five"}}, "after": {"row": {"num": 6, "name": "six"}}}
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=3 schema=${trxschemakey}
 {"id": "4"}
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=3 schema=${trxschema}
 {"status":"BEGIN","id":"4","event_count":null,"data_collections":null}
-{"status":"END","id":"4","event_count":1,"data_collections":[{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}
+{"status":"END","id":"4","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}}
 
 ! SELECT * FROM names AS OF 2;
 Timestamp (2) is not valid for all inputs
@@ -131,8 +131,8 @@ Timestamp (2) is not valid for all inputs
 > ALTER INDEX materialize.public.names_primary_idx RESET(logical_compaction_window)
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=4
-{"before": {"num": 6, "name": "six"}, "after": {"num": 7, "name": "seven"}}
-{"before": {"num": 7, "name": "seven"}, "after": {"num": 8, "name": "eight"}}
+{"before": {"row": {"num": 6, "name": "six"}}, "after": {"row": {"num": 7, "name": "seven"}}}
+{"before": {"row": {"num": 7, "name": "seven"}}, "after": {"row": {"num": 8, "name": "eight"}}}
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=4 schema=${trxschemakey}
 {"id": "5"}
@@ -140,9 +140,9 @@ $ kafka-ingest format=avro topic=data-consistency timestamp=4 schema=${trxschema
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=4 schema=${trxschema}
 {"status":"BEGIN","id":"5","event_count":null,"data_collections":null}
-{"status":"END","id":"5","event_count":1,"data_collections":[{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}
+{"status":"END","id":"5","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}}
 {"status":"BEGIN","id":"6","event_count":null,"data_collections":null}
-{"status":"END","id":"6","event_count":1,"data_collections":[{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}
+{"status":"END","id":"6","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-names-${testdrive.seed}"}]}}
 
 > SELECT * FROM names AS OF 4;
 num name

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -39,10 +39,10 @@ $ kafka-create-topic topic=data
   ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=33
-{"before": null, "after": {"X": 1, "Y": 1}}
-{"before": null, "after": {"X": 2, "Y": 1}}
-{"before": null, "after": {"X": 3, "Y": 1}}
-{"before": null, "after": {"X": 1, "Y": 2}}
+{"before": null, "after": {"row":{"X": 1, "Y": 1}}}
+{"before": null, "after": {"row":{"X": 2, "Y": 1}}}
+{"before": null, "after": {"row":{"X": 3, "Y": 1}}}
+{"before": null, "after": {"row":{"X": 1, "Y": 2}}}
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=34
 {"before": null, "after": null}

--- a/test/testdrive/dates-times.td
+++ b/test/testdrive/dates-times.td
@@ -48,8 +48,8 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"d": 18135, "ts": 1566865029000000}}
-{"before": null, "after": {"d": 0, "ts": 65000000}}
+{"before": null, "after": {"row":{"d": 18135, "ts": 1566865029000000}}}
+{"before": null, "after": {"row":{"d": 0, "ts": 65000000}}}
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
 {"before": null, "after": null}

--- a/test/testdrive/decimal.td
+++ b/test/testdrive/decimal.td
@@ -42,8 +42,8 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"a": [7, 2]}}
-{"before": null, "after": {"a": [186]}}
+{"before": null, "after": {"row":{"a": [7, 2]}}}
+{"before": null, "after": {"row":{"a": [186]}}}
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
 {"before": null, "after": null}

--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -32,9 +32,9 @@ $ set names-schema={
 $ kafka-create-topic topic=names
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
-{"before": null, "after": {"num": 1, "name": "one"}}
-{"before": null, "after": {"num": 2, "name": "two"}}
-{"before": null, "after": {"num": 3, "name": "three"}}
+{"before": null, "after": {"row":{"num": 1, "name": "one"}}}
+{"before": null, "after": {"row":{"num": 2, "name": "two"}}}
+{"before": null, "after": {"row":{"num": 3, "name": "three"}}}
 
 $ set mods-schema={
     "type": "record",
@@ -61,9 +61,9 @@ $ set mods-schema={
 $ kafka-create-topic topic=mods
 
 $ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=1
-{"before": null, "after": {"num": 0, "mod": "even"}}
-{"before": null, "after": {"num": 1, "mod": "odd"}}
-{"before": null, "after": {"num": 2, "mod": "even"}}
+{"before": null, "after": {"row":{"num": 0, "mod": "even"}}}
+{"before": null, "after": {"row":{"num": 1, "mod": "odd"}}}
+{"before": null, "after": {"row":{"num": 2, "mod": "even"}}}
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
 {"before": null, "after": null}

--- a/test/testdrive/multijoins.td
+++ b/test/testdrive/multijoins.td
@@ -32,9 +32,9 @@ $ set names-schema={
 $ kafka-create-topic topic=names
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
-{"before": null, "after": {"num": 1, "name": "one"}}
-{"before": null, "after": {"num": 2, "name": "two"}}
-{"before": null, "after": {"num": 3, "name": "three"}}
+{"before": null, "after": {"row":{"num": 1, "name": "one"}}}
+{"before": null, "after": {"row":{"num": 2, "name": "two"}}}
+{"before": null, "after": {"row":{"num": 3, "name": "three"}}}
 
 $ set mods-schema={
     "type": "record",
@@ -61,9 +61,9 @@ $ set mods-schema={
 $ kafka-create-topic topic=mods
 
 $ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=1
-{"before": null, "after": {"num": 0, "mod": "even"}}
-{"before": null, "after": {"num": 1, "mod": "odd"}}
-{"before": null, "after": {"num": 2, "mod": "even"}}
+{"before": null, "after": {"row":{"num": 0, "mod": "even"}}}
+{"before": null, "after": {"row":{"num": 1, "mod": "odd"}}}
+{"before": null, "after": {"row":{"num": 2, "mod": "even"}}}
 
 $ set plurals-schema={
     "type": "record",
@@ -90,10 +90,10 @@ $ set plurals-schema={
 $ kafka-create-topic topic=plurals
 
 $ kafka-ingest format=avro topic=plurals schema=${plurals-schema} timestamp=1
-{"before": null, "after": {"num": "one", "noun": "sheep"}}
-{"before": null, "after": {"num": "two", "noun": "sheep"}}
-{"before": null, "after": {"num": "one", "noun": "mouse"}}
-{"before": null, "after": {"num": "two", "noun": "meeses"}}
+{"before": null, "after": {"row":{"num": "one", "noun": "sheep"}}}
+{"before": null, "after": {"row":{"num": "two", "noun": "sheep"}}}
+{"before": null, "after": {"row":{"num": "one", "noun": "mouse"}}}
+{"before": null, "after": {"row":{"num": "two", "noun": "meeses"}}}
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
 {"before": null, "after": null}

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -31,7 +31,7 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"a": 1}}
+{"before": null, "after": {"row": {"a": 1}}}
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -42,8 +42,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 1
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": {"a": 1}, "after": null}
-{"before": {"a": 1}, "after": null}
+{"before": {"row": {"a": 1}}, "after": null}
+{"before": {"row": {"a": 1}}, "after": null}
 
 > SELECT count(*) FROM data
 -1
@@ -52,7 +52,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 Negative multiplicity: -1
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": {"a": 1}, "after": null}
+{"before": {"row": {"a": 1}}, "after": null}
 
 > SELECT count(*) FROM data
 -2

--- a/test/testdrive/nulls.td
+++ b/test/testdrive/nulls.td
@@ -31,9 +31,9 @@ $ set foo-schema={
 $ kafka-create-topic topic=foo
 
 $ kafka-ingest format=avro topic=foo schema=${foo-schema} timestamp=1
-{"before": null, "after": {"a": 1}}
-{"before": null, "after": {"a": 2}}
-{"before": null, "after": {"a": null}}
+{"before": null, "after": {"row":{"a": {"long": 1}}}}
+{"before": null, "after": {"row":{"a": {"long": 2}}}}
+{"before": null, "after": {"row":{"a": null}}}
 
 $ kafka-ingest format=avro topic=foo schema=${foo-schema} timestamp=2
 {"before": null, "after": null}

--- a/test/testdrive/runtime-errors.td
+++ b/test/testdrive/runtime-errors.td
@@ -33,8 +33,8 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"id": "valid1", "a": 2, "b": 1}}
-{"before": null, "after": {"id": "valid2", "a": 17, "b": 5}}
+{"before": null, "after": {"row":{"id": "valid1", "a": 2, "b": 1}}}
+{"before": null, "after": {"row":{"id": "valid2", "a": 17, "b": 5}}}
 
 > CREATE SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -53,7 +53,7 @@ valid1  2   2
 valid2  85  3
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
-{"before": null, "after": {"id": "bad1", "a": 7, "b": 0}}
+{"before": null, "after": {"row": {"id": "bad1", "a": 7, "b": 0}}}
 
 > SELECT * FROM multiply
 valid1  2
@@ -67,7 +67,7 @@ division by zero
 division by zero
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=3
-{"before": {"id": "bad1", "a": 7, "b": 0}, "after": null}
+{"before": {"row": {"id": "bad1", "a": 7, "b": 0}}, "after": null}
 
 > SELECT * FROM both
 valid1  2   2

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -62,24 +62,24 @@ snk4
 snk5
 
 $ kafka-verify format=avro sink=materialize.public.snk1
-{"before": null, "after": {"a": "jack", "b": "jill", "mz_line_no": 2}}
-{"before": null, "after": {"a": "goofus", "b": "gallant", "mz_line_no": 3}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 2}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 3}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk2
-{"before": null, "after": {"a": "jack", "b": "jill", "mz_line_no": 2}}
-{"before": null, "after": {"a": "goofus", "b": "gallant", "mz_line_no": 3}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 2}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 3}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3
-{"before": null, "after": {"c": "jackjill"}}
-{"before": null, "after": {"c": "goofusgallant"}}
+{"before": null, "after": {"row":{"c": "jackjill"}}}
+{"before": null, "after": {"row":{"c": "goofusgallant"}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk4
-{"before": null, "after": {"c": "jackjill"}}
-{"before": null, "after": {"c": "goofusgallant"}}
+{"before": null, "after": {"row":{"c": "jackjill"}}}
+{"before": null, "after": {"row":{"c": "goofusgallant"}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk5
-{"before": null, "after": {"c": "jackjill"}}
-{"before": null, "after": {"c": "goofusgallant"}}
+{"before": null, "after": {"row":{"c": "jackjill"}}}
+{"before": null, "after": {"row":{"c": "goofusgallant"}}}
 
 # Test the case where we have non +/- 1 multiplicities
 
@@ -91,8 +91,8 @@ $ kafka-verify format=avro sink=materialize.public.snk5
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.snk6
-{"before": null, "after": {"c": true}}
-{"before": null, "after": {"c": true}}
+{"before": null, "after": {"row":{"c": true}}}
+{"before": null, "after": {"row":{"c": true}}}
 
 # Test AS OF and WITH/WITHOUT SNAPSHOT.
 > CREATE MATERIALIZED SOURCE dynamic_src
@@ -119,12 +119,12 @@ $ file-append path=test.csv
 extra,row
 
 $ kafka-verify format=avro sink=materialize.public.snk7
-{"before": null, "after": {"a": "extra", "b": "row", "mz_line_no": 4}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 4}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk8
-{"before": null, "after": {"a": "jack", "b": "jill", "mz_line_no": 2}}
-{"before": null, "after": {"a": "goofus", "b": "gallant", "mz_line_no": 3}}
-{"before": null, "after": {"a": "extra", "b": "row", "mz_line_no": 4}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 2}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 3}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 4}}}
 
 # Test that we are correctly handling WITH/WITHOUT SNAPSHOT on views with
 # empty upper frontier
@@ -143,9 +143,9 @@ $ kafka-verify format=avro sink=materialize.public.sink9
   WITH SNAPSHOT
 
 $ kafka-verify format=avro sink=materialize.public.sink10
-{"before": null, "after": {"column1": 1}}
-{"before": null, "after": {"column1": 2}}
-{"before": null, "after": {"column1": 3}}
+{"before": null, "after": {"row":{"column1": 1}}}
+{"before": null, "after": {"row":{"column1": 2}}}
+{"before": null, "after": {"row":{"column1": 3}}}
 
 > SHOW FULL SINKS
 SINKS       TYPE

--- a/test/testdrive/sort.td
+++ b/test/testdrive/sort.td
@@ -37,15 +37,15 @@ $ kafka-create-topic topic=foobar
   ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=foobar schema=${schema} timestamp=42
-{"before": null, "after": {"quote": "I have a theory that it's impossible to prove anything, but I can't prove it.", "val": 2079}}
-{"before": null, "after": {"quote": "It was a virgin forest, a place where the Hand of Man had never set foot.", "val": 12345}}
-{"before": null, "after": {"quote": "If it pours before seven, it has rained by eleven.", "val": 12345}}
-{"before": null, "after": {"quote": "All power corrupts, but we need electricity.", "val": 12345}}
-{"before": null, "after": {"quote": "I want to read my new poem about pork brains and outer space ...", "val": 6745}}
-{"before": null, "after": {"quote": "You are magnetic in your bearing.", "val": 24223}}
-{"before": null, "after": {"quote": "Yes, but every time I try to see things your way, I get a headache.", "val": 21243}}
-{"before": null, "after": {"quote": "Ring around the collar.", "val": 1735}}
-{"before": null, "after": {"quote": "New York is real.  The rest is done with mirrors.", "val": 25040}}
+{"before": null, "after": {"row":{"quote": "I have a theory that it's impossible to prove anything, but I can't prove it.", "val": 2079}}}
+{"before": null, "after": {"row":{"quote": "It was a virgin forest, a place where the Hand of Man had never set foot.", "val": 12345}}}
+{"before": null, "after": {"row":{"quote": "If it pours before seven, it has rained by eleven.", "val": 12345}}}
+{"before": null, "after": {"row":{"quote": "All power corrupts, but we need electricity.", "val": 12345}}}
+{"before": null, "after": {"row":{"quote": "I want to read my new poem about pork brains and outer space ...", "val": 6745}}}
+{"before": null, "after": {"row":{"quote": "You are magnetic in your bearing.", "val": 24223}}}
+{"before": null, "after": {"row":{"quote": "Yes, but every time I try to see things your way, I get a headache.", "val": 21243}}}
+{"before": null, "after": {"row":{"quote": "Ring around the collar.", "val": 1735}}}
+{"before": null, "after": {"row":{"quote": "New York is real.  The rest is done with mirrors.", "val": 25040}}}
 
 $ kafka-ingest format=avro topic=foobar schema=${schema} timestamp=43
 {"before": null, "after": null}

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -82,7 +82,7 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"id": "valid1", "a": 2, "b": 1}}
+{"before": null, "after": {"row":{"id": "valid1", "a": 2, "b": 1}}}
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -71,11 +71,11 @@ $ kafka-create-topic topic=foo
 $ kafka-create-topic topic=bar
 
 $ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
-{"before": null, "after": {"a": 1, "b": 1}}
-{"before": null, "after": {"a": 2, "b": 2}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}}
+{"before": null, "after": {"row":{"a": 2, "b": 2}}}
 
 $ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
-{"before": null, "after": {"a": 10, "b": 1}}
+{"before": null, "after": {"row":{"a": 10, "b": 1}}}
 
 > CREATE MATERIALIZED SOURCE data_foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
@@ -108,9 +108,9 @@ $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschemakey}
 
 $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":0,"data_collections":[]}
+{"status":"END","id":"1","event_count":{"long": 0},"data_collections":{"array": []}}
 {"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}
+{"status":"END","id":"2","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}}
 
 > SELECT * FROM foo;
 b  sum
@@ -129,14 +129,14 @@ b sum sum
 1  1  10
 
 $ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
-{"before": null, "after": {"a": 3, "b": 3}}
+{"before": null, "after": {"row": {"a": 3, "b": 3}}}
 
 $ kafka-ingest format=avro topic=bar schema=${schema} timestamp=1
-{"before": null, "after": {"a": 30, "b": 3}}
+{"before": null, "after": {"row": {"a": 30, "b": 3}}}
 
 $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}
+{"status":"END","id":"3","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-foo-${testdrive.seed}"},{"event_count": 1, "data_collection": "testdrive-bar-${testdrive.seed}"}]}}
 
 > SELECT * FROM foo;
 b  sum
@@ -156,7 +156,7 @@ b sum sum
 1  1  10
 
 $ kafka-ingest format=avro topic=foo schema=${schema} timestamp=1
-{"before": null, "after": {"a": 4, "b": 4}}
+{"before": null, "after": {"row": {"a": 4, "b": 4}}}
 
 > SELECT * FROM foo;
 b  sum

--- a/test/testdrive/timestamps-debezium-ocf.td
+++ b/test/testdrive/timestamps-debezium-ocf.td
@@ -68,11 +68,11 @@ $ avro-ocf-write path=consistency.ocf schema=${trxschema}
 {"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
 
 $ avro-ocf-write path=foo.ocf schema=${schema}
-{"before": null, "after": {"a": 1, "b": 1}}
-{"before": null, "after": {"a": 2, "b": 2}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}}
+{"before": null, "after": {"row":{"a": 2, "b": 2}}}
 
 $ avro-ocf-write path=bar.ocf schema=${schema}
-{"before": null, "after": {"a": 10, "b": 1}}
+{"before": null, "after": {"row":{"a": 10, "b": 1}}}
 
 > CREATE MATERIALIZED SOURCE data_foo FROM AVRO OCF '${testdrive.temp-dir}/foo.ocf' WITH (consistency='${testdrive.temp-dir}/consistency.ocf', tail=true) ENVELOPE DEBEZIUM
 
@@ -95,9 +95,9 @@ At least one input has no complete timestamps yet:
 
 $ avro-ocf-append path=consistency.ocf
 {"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":0,"data_collections":[]}
+{"status":"END","id":"1","event_count":{"long": 0},"data_collections": {"array": []}}
 {"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "${testdrive.temp-dir}/foo.ocf"},{"event_count": 1, "data_collection": "${testdrive.temp-dir}/bar.ocf"}]}
+{"status":"END","id":"2","event_count":{"long": 2},"data_collections": {"array": [{"event_count": 2, "data_collection": "${testdrive.temp-dir}/foo.ocf"},{"event_count": 1, "data_collection": "${testdrive.temp-dir}/bar.ocf"}]}}
 
 > SELECT * FROM foo;
 b  sum
@@ -116,14 +116,14 @@ b sum sum
 1  1  10
 
 $ avro-ocf-append path=foo.ocf
-{"before": null, "after": {"a": 3, "b": 3}}
+{"before": null, "after": {"row":{"a": 3, "b": 3}}}
 
 $ avro-ocf-append path=bar.ocf
-{"before": null, "after": {"a": 30, "b": 3}}
+{"before": null, "after": {"row":{"a": 30, "b": 3}}}
 
 $ avro-ocf-append path=consistency.ocf
 {"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":2,"data_collections":[{"event_count": 2, "data_collection": "${testdrive.temp-dir}/foo.ocf"},{"event_count": 1, "data_collection": "${testdrive.temp-dir}/bar.ocf"}]}
+{"status":"END","id":"3","event_count":{"long": 2},"data_collections": {"array": [{"event_count": 2, "data_collection": "${testdrive.temp-dir}/foo.ocf"},{"event_count": 1, "data_collection": "${testdrive.temp-dir}/bar.ocf"}]}}
 
 > SELECT * FROM foo;
 b  sum
@@ -143,7 +143,7 @@ b sum sum
 1  1  10
 
 $ avro-ocf-append path=foo.ocf
-{"before": null, "after": {"a": 4, "b": 4}}
+{"before": null, "after": {"row":{"a": 4, "b": 4}}}
 
 > SELECT * FROM foo;
 b  sum

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -49,7 +49,7 @@ $ set consistency={
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=avro topic=data-consistency timestamp=1  schema=${consistency}
-{"source": "dummy", "partition_count": 1, "partition_id": 0, "timestamp": 0, "offset": 0}
+{"source": "dummy", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 0, "offset": 0}
 
 $ kafka-create-topic topic=data partitions=2
 
@@ -90,13 +90,13 @@ At least one input has no complete timestamps yet:
 At least one input has no complete timestamps yet:
 
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
-{"source": "testdrive-data2-${testdrive.seed}", "partition_count": 2 , "partition_id": 0, "timestamp": 1, "offset": 0}
+{"source": "testdrive-data2-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 0}, "timestamp": 1, "offset": 0}
 
 ! SELECT * FROM view_empty;
 At least one input has no complete timestamps yet:
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data2-${testdrive.seed}", "partition_count": 2 , "partition_id": 1, "timestamp": 1, "offset": 0}
+{"source": "testdrive-data2-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 1}, "timestamp": 1, "offset": 0}
 
 
 > SELECT * FROM view_empty;
@@ -106,13 +106,13 @@ b sum
 
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 0, "timestamp": 1, "offset": 1}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 0}, "timestamp": 1, "offset": 1}
 
 ! SELECT * FROM view_byo;
 At least one input has no complete timestamps yet:
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 1, "timestamp": 1, "offset": 1}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 1}, "timestamp": 1, "offset": 1}
 
 
 > SELECT * FROM view_byo
@@ -121,7 +121,7 @@ b  sum
 1  4
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 0, "timestamp": 2, "offset": 2}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 0}, "timestamp": 2, "offset": 2}
 
 $ kafka-ingest partition=0 format=avro topic=data schema=${schema} timestamp=1
 {"a": 2, "b": 1}
@@ -135,7 +135,7 @@ b  sum
 1  4
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 1, "timestamp": 2, "offset": 2}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 1}, "timestamp": 2, "offset": 2}
 
 > SELECT * FROM view_byo
 b  sum
@@ -146,7 +146,7 @@ b  sum
 
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 1, "timestamp": 3, "offset": 5}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 1}, "timestamp": 3, "offset": 5}
 
 $ kafka-ingest partition=1 format=avro topic=data schema=${schema} timestamp=1
 {"a": 1, "b": 3}
@@ -161,8 +161,8 @@ b  sum
 
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 1, "timestamp": 4, "offset": 5}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": 0, "timestamp": 4, "offset": 2}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 1}, "timestamp": 4, "offset": 5}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 2 , "partition_id": {"int": 0}, "timestamp": 4, "offset": 2}
 
 > SELECT * FROM view_byo
 b  sum
@@ -179,8 +179,8 @@ b  sum
 3  3
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 1, "timestamp": 5, "offset": 6}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 0, "timestamp": 5, "offset": 3}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": {"int": 1}, "timestamp": 5, "offset": 6}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": {"int": 0}, "timestamp": 5, "offset": 3}
 
 $ kafka-add-partitions topic=data total-partitions=3
 
@@ -216,7 +216,7 @@ b  sum
 3  3
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": 2, "timestamp": 5, "offset": 1}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 3 , "partition_id": {"int": 2}, "timestamp": 5, "offset": 1}
 
 > SELECT * FROM view_byo
 b  sum
@@ -243,7 +243,7 @@ $ kafka-ingest partition=3 format=avro topic=data schema=${schema} timestamp=1
 {"a": 1, "b": 11}
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 7, "offset": 1}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 3}, "timestamp": 7, "offset": 1}
 
 > SELECT * FROM view_byo
 b  sum
@@ -256,9 +256,9 @@ b  sum
 7  1
 
 $ kafka-ingest format=avro topic=data-consistency  schema=${consistency}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 7, "offset": 7}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 7, "offset": 4}
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4, "partition_id": 2, "timestamp": 7, "offset": 2}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 1}, "timestamp": 7, "offset": 7}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 0}, "timestamp": 7, "offset": 4}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 4, "partition_id": {"int": 2}, "timestamp": 7, "offset": 2}
 
 > SELECT * FROM view_byo
 b  sum
@@ -279,8 +279,8 @@ $ kafka-create-topic topic=data-consistency2
 $ kafka-create-topic topic=data-multi partitions=2
 
 $ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 1, "offset": 0}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 1, "offset": 0}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 0}, "timestamp": 1, "offset": 0}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 1}, "timestamp": 1, "offset": 0}
 
 
 > CREATE MATERIALIZED SOURCE data_multi
@@ -311,10 +311,10 @@ $ kafka-ingest partition=2 format=avro topic=data-multi schema=${schema} timesta
 {"a": 2, "b": 1}
 
 $ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 2, "offset": 1}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 2, "offset": 1}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 2, "timestamp": 2, "offset": 0}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 2, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 0}, "timestamp": 2, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 1}, "timestamp": 2, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 2}, "timestamp": 2, "offset": 0}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 3}, "timestamp": 2, "offset": 1}
 
 $ kafka-ingest partition=3 format=avro topic=data-multi schema=${schema} timestamp=1
 {"a": 3, "b": 1}
@@ -336,10 +336,10 @@ $ kafka-ingest partition=1 format=avro topic=data-multi schema=${schema} timesta
 
 
 $ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 2, "timestamp": 3, "offset": 1}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 1, "timestamp": 3, "offset": 2}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 3, "timestamp": 3, "offset": 2}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": 0, "timestamp": 3, "offset": 2}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 2}, "timestamp": 3, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 1}, "timestamp": 3, "offset": 2}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 3}, "timestamp": 3, "offset": 2}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 0}, "timestamp": 3, "offset": 2}
 
 
 > SELECT * FROM data_multi

--- a/test/testdrive/timestamps-kafka-avro.td
+++ b/test/testdrive/timestamps-kafka-avro.td
@@ -48,7 +48,7 @@ $ set schema={
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
-{"source": "dummy", "partition_count": 1, "partition_id": 0, "timestamp": 0, "offset": 0}
+{"source": "dummy", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 0, "offset": 0}
 
 $ kafka-create-topic topic=data
 
@@ -106,8 +106,8 @@ $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
 At least one input has no complete timestamps yet:
 
 $ kafka-ingest format=avro schema=${consistency} topic=data-consistency timestamp=1
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 1}
-{"source": "testdrive-data2-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 4}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 1, "offset": 1}
+{"source": "testdrive-data2-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 1, "offset": 4}
 
 > SELECT * FROM view_byo
 b  sum
@@ -121,7 +121,7 @@ b  sum
 2  1
 
 $ kafka-ingest format=avro schema=${consistency} topic=data-consistency timestamp=2
-{"source": "testdrive-data-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 2, "offset": 4}
+{"source": "testdrive-data-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 2, "offset": 4}
 
 > SELECT * FROM view2_byo
 b  sum
@@ -133,7 +133,7 @@ b  sum
 At least one input has no complete timestamps yet:
 
 $ kafka-ingest format=avro schema=${consistency} topic=data-consistency timestamp=2
-{"source": "testdrive-data3-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 10, "offset": 0}
+{"source": "testdrive-data3-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 10, "offset": 0}
 
 > SELECT * FROM view_empty
 a a

--- a/test/testdrive/timestamps-ocf.td
+++ b/test/testdrive/timestamps-ocf.td
@@ -44,8 +44,8 @@ $ set schema={
   }
 
 $ avro-ocf-write path=consistency.ocf schema=${consistency}
-{"source": "dummy", "partition_count": 1, "partition_id": 0, "timestamp": 0, "offset": 0}
-{"source": "${testdrive.temp-dir}/data2.ocf", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 2}
+{"source": "dummy", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 0, "offset": 0}
+{"source": "${testdrive.temp-dir}/data2.ocf", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 1, "offset": 2}
 
 $ avro-ocf-write path=data.ocf schema=${schema}
 {"a": 1, "b": 1}
@@ -71,7 +71,7 @@ a b mz_obj_no
 2  2  2
 
 $ avro-ocf-append path=consistency.ocf
-{"source": "${testdrive.temp-dir}/data.ocf", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 2}
+{"source": "${testdrive.temp-dir}/data.ocf", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 1, "offset": 2}
 
 > SELECT * FROM data_byo;
 a b  mz_obj_no
@@ -80,8 +80,8 @@ a b  mz_obj_no
 2  2  2
 
 $ avro-ocf-append path=consistency.ocf
-{"source": "${testdrive.temp-dir}/data.ocf", "partition_count": 1, "partition_id": 0, "timestamp": 2, "offset": 4}
-{"source": "${testdrive.temp-dir}/data2.ocf", "partition_count": 1, "partition_id": 0, "timestamp": 2, "offset": 4}
+{"source": "${testdrive.temp-dir}/data.ocf", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 2, "offset": 4}
+{"source": "${testdrive.temp-dir}/data2.ocf", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 2, "offset": 4}
 
 $ avro-ocf-append path=data2.ocf
 {"a": 3, "b": 3}

--- a/test/testdrive/upsert-kafka.td
+++ b/test/testdrive/upsert-kafka.td
@@ -56,15 +56,15 @@ $ kafka-create-topic topic=avroavro
 $ kafka-create-topic topic=data-consistency
 
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 1}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 2, "offset": 2}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 3, "offset": 3}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 4, "offset": 4}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 5, "offset": 5}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 6, "offset": 6}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 7, "offset": 7}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 8, "offset": 8}
-{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 9, "offset": 9}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 1, "offset": 1}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 2, "offset": 2}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 3, "offset": 3}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 4, "offset": 4}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 5, "offset": 5}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 6, "offset": 6}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 7, "offset": 7}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 8, "offset": 8}
+{"source": "testdrive-avroavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 9, "offset": 9}
 
 $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true
 {"key": "fish"} {"f1": "fish", "f2": 1000}
@@ -94,8 +94,8 @@ mammalmore    moose    2
 $ kafka-create-topic topic=textavro
 
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
-{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 1, "offset": 2}
-{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 2, "offset": 4}
+{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 1, "offset": 2}
+{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 2, "offset": 4}
 
 $ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true
 fish: {"f1": "fish", "f2": 1000}
@@ -133,10 +133,10 @@ birdmore      geese    2
 mammal1       moose    1
 
 $ kafka-ingest format=avro topic=data-consistency schema=${consistency}
-{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 3, "offset": 5}
-{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 5, "offset": 6}
-{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 8, "offset": 7}
-{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": 0, "timestamp": 13, "offset": 8}
+{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 3, "offset": 5}
+{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 5, "offset": 6}
+{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 8, "offset": 7}
+{"source": "testdrive-textavro-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 13, "offset": 8}
 
 > select * from textavro
 key0          f1       f2
@@ -281,14 +281,14 @@ $ set keyschema2={
   }
 
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
-{"f3": "fire", "f1": "yang"} {"f1": "dog", "f2": 42}
-{"f3": null, "f1": "yin"} {"f1": "sheep", "f2": 53}
-{"f3": "water", "f1": null} {"f1":"plesiosaur", "f2": 224}
-{"f3": "earth", "f1": "dao"} {"f1": "turtle", "f2": 34}
-{"f3": null, "f1": "yin"} {"f1": "sheep", "f2": 54}
-{"f3": "earth", "f1": "dao"} {"f1": "snake", "f2": 68}
-{"f3": "water", "f1": null} {"f1": "crocodile", "f2": 7}
-{"f3": "earth", "f1":"dao"}
+{"f3": {"string": "fire"}, "f1": {"string": "yang"}} {"f1": "dog", "f2": 42}
+{"f3": null, "f1": {"string": "yin"}} {"f1": "sheep", "f2": 53}
+{"f3": {"string": "water"}, "f1": null} {"f1":"plesiosaur", "f2": 224}
+{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "turtle", "f2": 34}
+{"f3": null, "f1": {"string": "yin"}} {"f1": "sheep", "f2": 54}
+{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "snake", "f2": 68}
+{"f3": {"string": "water"}, "f1": null} {"f1": "crocodile", "f2": 7}
+{"f3": {"string": "earth"}, "f1":{"string": "dao"}}
 
 > CREATE SOURCE realtimeavroavro (f3, f4, f1, f2)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
@@ -321,14 +321,14 @@ water     <null>    crocodile    7
 
 # ensure that having deletion on a key that never existed does not break anything
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
-{"f3": "fire", "f1": "yin"}
-{"f3": "air", "f1":"qi"} {"f1": "pigeon", "f2": 10}
-{"f3": "air", "f1":"qi"} {"f1": "owl", "f2": 15}
-{"f3": "earth", "f1": "dao"} {"f1": "rhinoceros", "f2": 211}
-{"f3": "air", "f1":"qi"} {"f1": "chicken", "f2": 47}
-{"f3": null, "f1":"yin"}
-{"f3": null, "f1":"yin"} {"f1":"dog", "f2": 243}
-{"f3": "water", "f1": null}
+{"f3": {"string": "fire"}, "f1": {"string": "yin"}}
+{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "pigeon", "f2": 10}
+{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "owl", "f2": 15}
+{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "rhinoceros", "f2": 211}
+{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "chicken", "f2": 47}
+{"f3": null, "f1":{"string": "yin"}}
+{"f3": null, "f1":{"string": "yin"}} {"f1":"dog", "f2": 243}
+{"f3": {"string": "water"}, "f1": null}
 
 > select * from realtimeavroavro_view
 f3         f4          f1             f2
@@ -359,14 +359,14 @@ $ set schema2={
   }
 
 $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
-{"k1": null, "k2": 2} {"f1": "date", "f2": 5}
-{"k1": "épicerie", "k2": 10} {"f1": "melon", "f2": 2}
-{"k1": "boucherie", "k2": 5} {"f1": "apple", "f2": 7}
-{"k1": "boulangerie", "k2": null} {"f1":"date", "f2": 10}
-{"k1": "épicerie", "k2": 10} {"f1": "pear", "f2": 2}
-{"k1": null, "k2": 2} {"f1": "date", "f2": null}
-{"k1": "boulangerie", "k2": null} {"f1":null, "f2": 10}
-{"k1": "boucherie", "k2": 5} {"f1": "apple", "f2": 3}
+{"k1": null, "k2": {"long": 2}} {"f1": {"string": "date"}, "f2": {"long": 5}}
+{"k1": {"string": "épicerie"}, "k2": {"long": 10}} {"f1": {"string": "melon"}, "f2": {"long": 2}}
+{"k1": {"string": "boucherie"}, "k2": {"long": 5}} {"f1": {"string": "apple"}, "f2": {"long": 7}}
+{"k1": {"string": "boulangerie"}, "k2": null} {"f1":{"string": "date"}, "f2": {"long": 10}}
+{"k1": {"string": "épicerie"}, "k2": {"long": 10}} {"f1": {"string": "pear"}, "f2": {"long": 2}}
+{"k1": null, "k2": {"long": 2}} {"f1": {"string": "date"}, "f2": null}
+{"k1": {"string": "boulangerie"}, "k2": null} {"f1":null, "f2": {"long": 10}}
+{"k1": {"string": "boucherie"}, "k2": {"long": 5}} {"f1": {"string": "apple"}, "f2": {"long": 3}}
 
 > CREATE SOURCE realtimefilteravro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
@@ -413,10 +413,10 @@ k1       k2
 # add records that match the filter
 # make sure that rows that differ on unneeded key columns are treated as separate
 $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
-{"k1": "librairie", "k2": 10} {"f1":null, "f2": 2}
-{"k1": null, "k2": null} {"f1": "date", "f2": 5}
-{"k1": "épicerie", "k2": 6} {"f1": "pear", "f2": null}
-{"k1": "bureau", "k2": 6} {"f1": "grape", "f2": 7}
+{"k1": {"string": "librairie"}, "k2": {"long": 10}} {"f1":null, "f2": {"long": 2}}
+{"k1": null, "k2": null} {"f1": {"string": "date"}, "f2": {"long": 5}}
+{"k1": {"string": "épicerie"}, "k2": {"long": 6}} {"f1": {"string": "pear"}, "f2": null}
+{"k1": {"string": "bureau"}, "k2": {"long": 6}} {"f1": {"string": "grape"}, "f2": {"long": 7}}
 
 > SELECT * from filterforkey
 f1
@@ -444,8 +444,8 @@ librairie 10
 
 # update records so that they don't match the filter
 $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
-{"k1": "librairie", "k2": 10} {"f1":null, "f2": 6}
-{"k1": null, "k2": null} {"f1": "grape", "f2": 5}
+{"k1": {"string": "librairie"}, "k2": {"long": 10}} {"f1":null, "f2": {"long": 6}}
+{"k1": null, "k2": null} {"f1": {"string": "grape"}, "f2": {"long": 5}}
 
 > SELECT * from filterforvalue
 f2
@@ -464,8 +464,8 @@ k1        k2
 
 # update records so that they do match the filter
 $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
-{"k1": "librairie", "k2": 10} {"f1":"melon", "f2": 2}
-{"k1": null, "k2": null} {"f1": "date", "f2": 12}
+{"k1": {"string": "librairie"}, "k2": {"long": 10}} {"f1":{"string": "melon"}, "f2": {"long": 2}}
+{"k1": null, "k2": null} {"f1": {"string": "date"}, "f2": {"long": 12}}
 
 > SELECT * from filterforvalue
 f2
@@ -487,10 +487,10 @@ librairie 10
 
 # delete records
 $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
-{"k1": "boucherie", "k2": 5}
-{"k1": "épicerie", "k2": 10}
-{"k1": "boulangerie", "k2": null}
-{"k1": null, "k2": 2}
+{"k1": {"string": "boucherie"}, "k2": {"long": 5}}
+{"k1": {"string": "épicerie"}, "k2": {"long": 10}}
+{"k1": {"string": "boulangerie"}, "k2": null}
+{"k1": null, "k2": {"long": 2}}
 
 > SELECT * from filterforkey
 f1

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -41,8 +41,8 @@ $ set schema={
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}
-{"before": null, "after": {"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}
+{"before": null, "after": {"row":{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}
+{"before": null, "after": {"row":{"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}}
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
 {"before": null, "after": null}
@@ -72,5 +72,5 @@ u      NO        uuid
   INTO AVRO OCF '${testdrive.temp-dir}/uuid-sink.ocf'
 
 $ avro-ocf-verify sink=materialize.public.uuid_sink_${testdrive.seed}
-{"before": null, "after": {"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}
-{"before": null, "after": {"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}
+{"before": null, "after": {"row":{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}
+{"before": null, "after": {"row":{"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}}


### PR DESCRIPTION
See the [relevant section of the spec](https://avro.apache.org/docs/current/spec.html#json_encoding).

> The value of a union is encoded in JSON as follows:
>
> * if its type is null, then it is encoded as a JSON null;
> * otherwise it is encoded as a JSON object with one name/value pair whose name is the type's name and whose value is the recursively encoded value. For Avro's named types (record, fixed or enum) the user-specified name is used, for other types the type name is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4266)
<!-- Reviewable:end -->
