### PR TITLE
dataflow: prefer hashing positions when distributing uniformly across workers

### DIFF
--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -44,7 +44,7 @@ where
         .collect::<Vec<_>>();
 
     stream.unary(
-        SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
+        SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         "CsvDecode",
         |_, _| {
             // Temporary storage, and a re-useable CSV reader.

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -456,7 +456,7 @@ where
             )
             .expect("Failed to create Avro decoder"),
             &op_name,
-            SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
+            SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         ),
         (DataEncoding::AvroOcf { .. }, _) => {
             unreachable!("Internal error: Cannot decode Avro OCF separately from reading")
@@ -471,19 +471,19 @@ where
             stream,
             protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
             &op_name,
-            SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
+            SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         ),
         (DataEncoding::Bytes, Envelope::None) => decode_values_inner(
             stream,
             OffsetDecoderState::from(bytes_to_datum),
             &op_name,
-            SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
+            SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         ),
         (DataEncoding::Text, Envelope::None) => decode_values_inner(
             stream,
             OffsetDecoderState::from(text_to_datum),
             &op_name,
-            SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
+            SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         ),
     }
 }

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -29,7 +29,7 @@ where
 {
     let name = String::from(name);
     stream.unary(
-        SourceOutput::<Vec<u8>, Vec<u8>>::value_contract(),
+        SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         "RegexDecode",
         |_, _| {
             let mut row_packer = repr::RowPacker::new();


### PR DESCRIPTION
Closes #4197

Previously, when we wanted to distribute records across workers uniformly
randomly, we distributed them based on the hash of their values. The reasoning
behind this was that in many potential sources, the distribution of keys might
be sufficiently skewed (or keys may not even exist) which makes keys a poor
choice uniformly distributing data (except in cases where we need records
with the same key to go to the same worker).

Unfortunately, all of those same arguments apply for values as well. This commit
changes the behavior to distribute records based on the hash of the position if
the position exists and otherwise fall back to a hash on the value. The
distribution of positions is much better known to us than the distribution of
potential values, and its more likely to be amenable to what we are trying to
accomplish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4267)
<!-- Reviewable:end -->
