### PR TITLE
update libz-sys to v1.1.2 to fix build with new xcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Materialize can't build with the latest version of Xcode - @JLDLaughlin looked into it and found it was due to some errors in an older version of `libz-sys`: https://github.com/rust-lang/rust/pull/76879 . Hopefully this PR will fix things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4271)
<!-- Reviewable:end -->
