### PR TITLE
doc/user: add CPU requirement to the Docker configuration guide

### DIFF
--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -111,11 +111,13 @@ Putting this all together, our deployment looks like this:
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine, and [follow our Docker integration
-   guide](/third-party/docker).
+1. Start the Docker daemon for your machine, and [follow our Docker
+   configuration guide](/third-party/docker).
 
-   **Note for Mac Users:** We recommend running this demo with 2 CPUs + 8GB Memory.
-   With less RAM exposed, the demo may fail.
+   **Note for macOS users:** Be sure to [increase Docker
+   resources](/third-party/docker/#increase-docker-resources) to at least 2 CPUs
+   and 8GB memory. Running Docker for Mac with less resources may cause the demo
+   to fail.
 
 1. Clone the Materialize repo:
 

--- a/doc/user/content/third-party/docker.md
+++ b/doc/user/content/third-party/docker.md
@@ -12,10 +12,11 @@ Materialize, along with any other infrastructure the demo needs.
 For the best experience using Docker, we recommend following the guidelines
 outlined here.
 
-### Increase Docker Memory
+### Increase Docker Resources
 
 Because many of our Docker-based demos leverage a large number of pieces of
-infrastructure, we recommend running Docker with at least **8 GB** of memory.
+infrastructure, we recommend running Docker with at least **2 CPUs** and
+**8 GB** of memory.
 
 On macOS:
 
@@ -24,6 +25,8 @@ On macOS:
 1. Click **Resources**.
 
 1. Click **Advanced**.
+
+1. Move the **CPUs** slider to at least **2**.
 
 1. Move the **Memory** slider to at least **8.00 GB**.
 


### PR DESCRIPTION
It turns out CPU count is important for running demos, too, so note that
in the "Using Docker" doc in addition to the BI demo doc. Also adjust
the wording in the BI demo doc to be a bit more precise about what
precisely needs its resources adjusted (i.e., Docker for Mac).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4277)
<!-- Reviewable:end -->
