### PR TITLE
dataflow: only block when decoding formats that need it

### DIFF
--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
 use log::error;
 
 use interchange::protobuf::{self, Decoder};
@@ -34,9 +33,8 @@ impl ProtobufDecoderState {
     }
 }
 
-#[async_trait(?Send)]
 impl DecoderState for ProtobufDecoderState {
-    async fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
         match self.decoder.decode(bytes) {
             Ok(row) => {
                 if let Some(row) = row {
@@ -55,7 +53,7 @@ impl DecoderState for ProtobufDecoderState {
     }
 
     /// give a session a key-value pair
-    async fn give_key_value<'a>(
+    fn give_key_value<'a>(
         &mut self,
         key: Row,
         bytes: &[u8],
@@ -76,7 +74,7 @@ impl DecoderState for ProtobufDecoderState {
     }
 
     /// give a session a plain value
-    async fn give_value<'a>(
+    fn give_value<'a>(
         &mut self,
         bytes: &[u8],
         _: Option<i64>,


### PR DESCRIPTION
Figured it was easier to talk over a pr.

Context: I've been testing mz with reading in a 4 partition Kafka topic as a text source. Removing the `block_on` call seems to improve performance but I still need to do a bit of work to quantify exactly how much.

I think this is a pretty minimal and uncontroversial change -- we now only block in the decode functions that use async functionality and leave the rest alone. Nikhil I know you said you want us to use more async not less -- wdyt of this change / more generally limiting async usage in the dataflow crate?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4278)
<!-- Reviewable:end -->
