### PR TITLE
*: simplify async/sync glue code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ name = "comm"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "backtrace",
  "bincode",
  "bytes",
  "futures",

--- a/fuzz/fuzz_targets/fuzz_sqllogictest.rs
+++ b/fuzz/fuzz_targets/fuzz_sqllogictest.rs
@@ -10,9 +10,11 @@
 #![cfg_attr(not(test), no_main)]
 
 use libfuzzer_sys::fuzz_target;
+use tokio::runtime::Runtime;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(string) = std::str::from_utf8(data) {
-        sqllogictest::fuzz::fuzz(string)
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(sqllogictest::fuzz::fuzz(string))
     };
 });

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+backtrace = "0.3"
 bincode = "1.3"
 bytes = "0.5"
 futures = "0.3"

--- a/src/comm/examples/pingpong.rs
+++ b/src/comm/examples/pingpong.rs
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut listener = runtime.block_on(TcpListener::bind(&nodes[id]))?;
     println!("listening on {}...", listener.local_addr()?);
 
-    let switchboard = Switchboard::new(nodes, id, runtime.handle().clone());
+    let switchboard = Switchboard::new(nodes, id);
     runtime.spawn({
         let switchboard = switchboard.clone();
         async move {

--- a/src/comm/src/broadcast.rs
+++ b/src/comm/src/broadcast.rs
@@ -42,12 +42,15 @@
 //!     }
 //! }
 //!
-//! let (switchboard, mut runtime) = Switchboard::local()?;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let switchboard = Switchboard::local()?;
 //! let mut tx = switchboard.broadcast_tx(UniversalAnswersToken);
 //! let mut rx = switchboard.broadcast_rx(UniversalAnswersToken);
-//! runtime.block_on(tx.send(42))?;
-//! assert_eq!(runtime.block_on(rx.next()).transpose()?, Some(42));
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! tx.send(42).await?;
+//! assert_eq!(rx.next().await.transpose()?, Some(42));
+//! # Ok(())
+//! # }
 //! ```
 
 use std::fmt;

--- a/src/comm/src/lib.rs
+++ b/src/comm/src/lib.rs
@@ -31,15 +31,16 @@
 //! use std::time::Duration;
 //! use tokio::net::TcpListener;
 //!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let nodes = vec![
 //!     (Ipv4Addr::new(192, 168, 1, 1), 1234),
 //!     (Ipv4Addr::new(192, 168, 1, 2), 1234),
 //! ];
 //! let node_id = 0;
-//! let mut runtime = tokio::runtime::Runtime::new()?;
-//! let switchboard = Switchboard::new(nodes, node_id, runtime.handle().clone());
-//! let mut listener = runtime.block_on(TcpListener::bind("0.0.0.0:1234"))?;
-//! runtime.spawn({
+//! let switchboard = Switchboard::new(nodes, node_id);
+//! let mut listener = TcpListener::bind("0.0.0.0:1234").await?;
+//! tokio::spawn({
 //!     let switchboard = switchboard.clone();
 //!     async move {
 //!         let mut incoming = listener.incoming();
@@ -50,10 +51,11 @@
 //! });
 //!
 //! // Wait for other nodes to become available.
-//! runtime.block_on(switchboard.rendezvous(Duration::from_secs(1)))?;
+//! switchboard.rendezvous(Duration::from_secs(1)).await?;
 //!
 //! // Allocate channels and do work.
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! In this example, the switchboard is configured for a cluster of size two,

--- a/src/comm/src/mpsc.rs
+++ b/src/comm/src/mpsc.rs
@@ -17,16 +17,19 @@
 //! use futures::stream::StreamExt;
 //! use tokio::net::UnixStream;
 //!
-//! let (switchboard, mut runtime) = Switchboard::local()?;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let switchboard = Switchboard::local()?;
 //! let (tx, mut rx) = switchboard.mpsc();
-//! runtime.spawn(async move {
+//! tokio::spawn(async move {
 //!     // Do work.
 //!     let answer = 42;
 //!     tx.connect().await?.send(answer).await?;
 //!     Ok::<_, comm::Error>(())
 //! });
-//! assert_eq!(runtime.block_on(rx.next()).transpose()?, Some(42));
-//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! assert_eq!(rx.next().await.transpose()?, Some(42));
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! Unconnected senders are quite flexible. They implement

--- a/src/comm/tests/mpsc.rs
+++ b/src/comm/tests/mpsc.rs
@@ -13,7 +13,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tokio::net::TcpListener;
-use tokio::runtime::Runtime;
 
 use comm::Switchboard;
 use ore::future::{OreStreamExt, OreTryStreamExt};
@@ -22,129 +21,119 @@ use ore::future::{OreStreamExt, OreTryStreamExt};
 /// simultaneously. The original implementation had a bug in which streams were
 /// exhausted in order, i.e., messages from the second stream were only
 /// presented after the first stream was closed.
-#[test]
-fn test_mpsc_select() -> Result<(), Box<dyn Error>> {
-    let (switchboard, mut runtime) = Switchboard::local()?;
-    runtime.block_on(async {
-        let (tx, mut rx) = switchboard.mpsc();
-        let mut tx1 = tx.clone().connect().await?;
-        let mut tx2 = tx.connect().await?;
+#[tokio::test]
+async fn test_mpsc_select() -> Result<(), Box<dyn Error>> {
+    let switchboard = Switchboard::local()?;
+    let (tx, mut rx) = switchboard.mpsc();
+    let mut tx1 = tx.clone().connect().await?;
+    let mut tx2 = tx.connect().await?;
 
-        tx1.send(1).await?;
-        tx2.send(2).await?;
-        let msgs = rx.by_ref().take(2).try_collect::<Vec<_>>().await?;
-        if msgs != [1, 2] && msgs != [2, 1] {
-            panic!("received unexpected messages: {:#?}", msgs);
-        }
+    tx1.send(1).await?;
+    tx2.send(2).await?;
+    let msgs = rx.by_ref().take(2).try_collect::<Vec<_>>().await?;
+    if msgs != [1, 2] && msgs != [2, 1] {
+        panic!("received unexpected messages: {:#?}", msgs);
+    }
 
-        tx1.send(3).await?;
-        tx2.send(4).await?;
-        let msgs = rx.take(2).try_collect::<Vec<_>>().await?;
-        if msgs != [3, 4] && msgs != [4, 3] {
-            panic!("received unexpected messages: {:#?}", msgs);
-        }
+    tx1.send(3).await?;
+    tx2.send(4).await?;
+    let msgs = rx.take(2).try_collect::<Vec<_>>().await?;
+    if msgs != [3, 4] && msgs != [4, 3] {
+        panic!("received unexpected messages: {:#?}", msgs);
+    }
 
-        Ok(())
-    })
+    Ok(())
 }
 
 /// Verifies that `mpsc_limited` will close the receiver after the expected
 /// number of producers have connected and then disconnected.
-#[test]
-fn test_mpsc_limited_close() -> Result<(), Box<dyn Error>> {
-    let (switchboard, mut runtime) = Switchboard::local()?;
-    runtime.block_on(async {
-        let (tx, rx) = switchboard.mpsc_limited(2);
-        let mut tx1 = tx.clone().connect().await?;
-        let mut tx2 = tx.clone().connect().await?;
+#[tokio::test]
+async fn test_mpsc_limited_close() -> Result<(), Box<dyn Error>> {
+    let switchboard = Switchboard::local()?;
+    let (tx, rx) = switchboard.mpsc_limited(2);
+    let mut tx1 = tx.clone().connect().await?;
+    let mut tx2 = tx.clone().connect().await?;
 
-        tx1.send_all(&mut stream::iter(vec![Ok(1), Ok(2)])).await?;
-        tx2.send_all(&mut stream::iter(vec![Ok(3), Ok(4), Ok(5)]))
-            .await?;
-        drop(tx1);
-        drop(tx2);
+    tx1.send_all(&mut stream::iter(vec![Ok(1), Ok(2)])).await?;
+    tx2.send_all(&mut stream::iter(vec![Ok(3), Ok(4), Ok(5)]))
+        .await?;
+    drop(tx1);
+    drop(tx2);
 
-        // If had created an unlimited channel, or specified more than two
-        // expected producers, we'd be here forever waiting for the channel to
-        // close.
-        let mut msgs = rx.try_collect::<Vec<_>>().await?;
-        msgs.sort();
-        assert_eq!(msgs, &[1, 2, 3, 4, 5]);
+    // If had created an unlimited channel, or specified more than two
+    // expected producers, we'd be here forever waiting for the channel to
+    // close.
+    let mut msgs = rx.try_collect::<Vec<_>>().await?;
+    msgs.sort();
+    assert_eq!(msgs, &[1, 2, 3, 4, 5]);
 
-        Ok(())
-    })
+    Ok(())
 }
 
 /// Verifies that TCP connections are reused by repeatedly connecting the same
 /// MPSC transmitter. Without connection reuse, the test should crash with an
 /// AddrNotAvailable error because the OS will run out of outgoing TCP ports.
-#[test]
-fn test_mpsc_connection_reuse() -> Result<(), Box<dyn Error>> {
+#[tokio::test]
+async fn test_mpsc_connection_reuse() -> Result<(), Box<dyn Error>> {
     ore::test::init_logging();
 
-    let mut runtime = Runtime::new()?;
-    let executor = runtime.handle().clone();
-    runtime.block_on(async {
-        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
-        let mut listener = TcpListener::bind(&addr).await?;
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
+    let mut listener = TcpListener::bind(&addr).await?;
 
-        let switchboard = Switchboard::new(vec![listener.local_addr()?], 0, executor.clone());
-        executor.spawn({
-            let switchboard = switchboard.clone();
-            async move {
-                let mut incoming = listener.incoming();
-                while let Some(conn) = incoming.next().await {
-                    let conn = conn.expect("test switchboard: accept failed");
-                    switchboard
-                        .handle_connection(conn)
-                        .await
-                        .expect("test switchboard: handle connection failed");
-                }
+    let switchboard = Switchboard::new(vec![listener.local_addr()?], 0);
+    tokio::spawn({
+        let switchboard = switchboard.clone();
+        async move {
+            let mut incoming = listener.incoming();
+            while let Some(conn) = incoming.next().await {
+                let conn = conn.expect("test switchboard: accept failed");
+                switchboard
+                    .handle_connection(conn)
+                    .await
+                    .expect("test switchboard: handle connection failed");
             }
-        });
-
-        let (tx, rx) = switchboard.mpsc();
-        let (result_tx, result_rx) = futures::channel::oneshot::channel();
-
-        // This is the empirically-determined number that exhausts ports on macOS
-        // without connection reuse.
-        const N: usize = 1 << 14;
-
-        executor.spawn(async {
-            rx.take(N).drain().await;
-            result_tx.send(()).unwrap();
-        });
-
-        for i in 0..N {
-            let mut tx = tx.connect().await?;
-            tx.send(i).await?;
         }
+    });
 
-        result_rx.await?;
-        Ok(())
-    })
+    let (tx, rx) = switchboard.mpsc();
+    let (result_tx, result_rx) = futures::channel::oneshot::channel();
+
+    // This is the empirically-determined number that exhausts ports on macOS
+    // without connection reuse.
+    const N: usize = 1 << 14;
+
+    tokio::spawn(async {
+        rx.take(N).drain().await;
+        result_tx.send(()).unwrap();
+    });
+
+    for i in 0..N {
+        let mut tx = tx.connect().await?;
+        tx.send(i).await?;
+    }
+
+    result_rx.await?;
+    Ok(())
 }
 
 /// Test that we can send a largeish frame (64MiB) over the channel. The true
 /// limit is higher, but we don't test that here to minimize the runtime of this
 /// test. The goal is just to make sure we're not using Tokio's default limit of
 /// 8MiB, which is too low.
-#[test]
-fn test_mpsc_big_frame() -> Result<(), Box<dyn Error>> {
+#[tokio::test]
+async fn test_mpsc_big_frame() -> Result<(), Box<dyn Error>> {
     const BIG_LEN: usize = 64 * (1 << 20); // 64MiB
-    let (switchboard, mut runtime) = Switchboard::local()?;
-    runtime.block_on(async {
-        let (tx, mut rx) = switchboard.mpsc::<String>();
+    let switchboard = Switchboard::local()?;
+    let (tx, mut rx) = switchboard.mpsc::<String>();
 
-        tokio::spawn(async move {
-            let msg = rx.try_recv().await.expect("recv failed");
-            assert_eq!(msg.len(), BIG_LEN);
-        });
+    tokio::spawn(async move {
+        let msg = rx.try_recv().await.expect("recv failed");
+        assert_eq!(msg.len(), BIG_LEN);
+    });
 
-        let msg = " ".repeat(BIG_LEN);
-        let mut tx = tx.clone().connect().await?;
-        tx.send(msg).await?;
+    let msg = " ".repeat(BIG_LEN);
+    let mut tx = tx.clone().connect().await?;
+    tx.send(msg).await?;
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -22,16 +22,16 @@ use std::convert::{TryFrom, TryInto};
 use std::iter;
 use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime};
 
 use anyhow::{bail, Context};
 use differential_dataflow::lattice::Lattice;
-use futures::executor::block_on;
 use futures::future::{self, TryFutureExt};
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use timely::progress::{Antichain, ChangeBatch, Timestamp as _};
+use tokio::runtime::Handle;
 
 use dataflow::source::persistence::PersistenceSender;
 use dataflow::{PersistenceMessage, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};
@@ -104,11 +104,11 @@ where
     C: comm::Connection,
 {
     pub switchboard: comm::Switchboard<C>,
+    pub cmd_rx: futures::channel::mpsc::UnboundedReceiver<Command>,
     pub num_timely_workers: usize,
     pub symbiosis_url: Option<&'a str>,
     pub logging_granularity: Option<Duration>,
     pub data_directory: Option<&'a Path>,
-    pub executor: &'a tokio::runtime::Handle,
     pub timestamp: TimestampConfig,
     pub persistence: Option<PersistenceConfig>,
     pub logical_compaction_window: Option<Duration>,
@@ -121,6 +121,7 @@ where
     C: comm::Connection,
 {
     switchboard: comm::Switchboard<C>,
+    cmd_rx: Option<futures::channel::mpsc::UnboundedReceiver<Command>>,
     broadcast_tx: comm::broadcast::Sender<SequencedCommand>,
     num_timely_workers: usize,
     optimizer: Optimizer,
@@ -139,7 +140,6 @@ where
     /// Instance count: number of times sources have been instantiated in views. This is used
     /// to associate each new instance of a source with a unique instance id (iid)
     logging_granularity: Option<u64>,
-    executor: tokio::runtime::Handle,
     feedback_rx: Option<comm::mpsc::Receiver<WorkerFeedbackWithMeta>>,
     // Temporary place to stash Persister thread startup data between when the coordinator thread
     // is initialized and when the persister thread gets spawned.
@@ -163,24 +163,20 @@ impl<C> Coordinator<C>
 where
     C: comm::Connection,
 {
-    pub fn new(config: Config<C>) -> Result<Self, anyhow::Error> {
+    async fn new(config: Config<'_, C>) -> Result<Self, anyhow::Error> {
         let mut broadcast_tx = config.switchboard.broadcast_tx(dataflow::BroadcastToken);
-        config.executor.enter(|| {
-            let res = Self::new_core(config);
-            if res.is_err() {
-                broadcast(&mut broadcast_tx, SequencedCommand::Shutdown);
-            }
-            res
-        })
+        let res = Self::new_core(config).await;
+        if res.is_err() {
+            broadcast(&mut broadcast_tx, SequencedCommand::Shutdown).await;
+        }
+        res
     }
 
-    fn new_core(config: Config<C>) -> Result<Self, anyhow::Error> {
+    async fn new_core(config: Config<'_, C>) -> Result<Self, anyhow::Error> {
         let mut broadcast_tx = config.switchboard.broadcast_tx(dataflow::BroadcastToken);
 
         let symbiosis = if let Some(symbiosis_url) = config.symbiosis_url {
-            Some(block_on(symbiosis::Postgres::open_and_erase(
-                symbiosis_url,
-            ))?)
+            Some(symbiosis::Postgres::open_and_erase(symbiosis_url).await?)
         } else {
             None
         };
@@ -195,7 +191,7 @@ where
             .logical_compaction_window
             .map(duration_to_timestamp_millis);
         let (tx, rx) = config.switchboard.mpsc_limited(config.num_timely_workers);
-        broadcast(&mut broadcast_tx, SequencedCommand::EnableFeedback(tx));
+        broadcast(&mut broadcast_tx, SequencedCommand::EnableFeedback(tx)).await;
 
         if let Some(granularity) = config.logging_granularity {
             broadcast(
@@ -207,29 +203,36 @@ where
                         .map(|src| (src.variant.clone(), src.index_id))
                         .collect(),
                 }),
-            );
+            )
+            .await;
         }
 
-        let (persister, persistence_tx, persistence_path) = if let Some(persistence_config) =
-            config.persistence
-        {
-            let (persistence_tx, persistence_rx) = config.switchboard.mpsc();
-            broadcast(
-                &mut broadcast_tx,
-                SequencedCommand::EnablePersistence(persistence_tx.clone()),
-            );
-            let path = persistence_config.path.clone();
-            (
-                Some(Persister::new(persistence_rx, persistence_config)),
-                Some(block_on(persistence_tx.connect()).expect("failed to connect persistence tx")),
-                Some(path),
-            )
-        } else {
-            (None, None, None)
-        };
+        let (persister, persistence_tx, persistence_path) =
+            if let Some(persistence_config) = config.persistence {
+                let (persistence_tx, persistence_rx) = config.switchboard.mpsc();
+                broadcast(
+                    &mut broadcast_tx,
+                    SequencedCommand::EnablePersistence(persistence_tx.clone()),
+                )
+                .await;
+                let path = persistence_config.path.clone();
+                (
+                    Some(Persister::new(persistence_rx, persistence_config)),
+                    Some(
+                        persistence_tx
+                            .connect()
+                            .await
+                            .expect("failed to connect persistence tx"),
+                    ),
+                    Some(path),
+                )
+            } else {
+                (None, None, None)
+            };
 
         let mut coord = Self {
             switchboard: config.switchboard,
+            cmd_rx: Some(config.cmd_rx),
             broadcast_tx,
             num_timely_workers: config.num_timely_workers,
             optimizer: Default::default(),
@@ -241,7 +244,6 @@ where
             logging_granularity: config
                 .logging_granularity
                 .and_then(|c| c.as_millis().try_into().ok()),
-            executor: config.executor.clone(),
             timestamp_config: config.timestamp,
             logical_compaction_window_ms,
             feedback_rx: Some(rx),
@@ -270,7 +272,7 @@ where
                 //using a single dataflow, we have to make sure the rebuild process re-runs
                 //the same multiple-build dataflow.
                 CatalogItem::Source(source) => {
-                    coord.maybe_begin_persistence(*id, &source.connector);
+                    coord.maybe_begin_persistence(*id, &source.connector).await;
                 }
                 CatalogItem::Index(_) => {
                     if BUILTINS.logs().any(|log| log.index_id == *id) {
@@ -287,7 +289,7 @@ where
                             .indexes
                             .insert(*id, Frontiers::new(coord.num_timely_workers, Some(1_000)));
                     } else {
-                        coord.ship_dataflow(coord.build_index_dataflow(*id));
+                        coord.ship_dataflow(coord.build_index_dataflow(*id)).await;
                     }
                 }
                 _ => (), // Handled in next loop.
@@ -304,14 +306,15 @@ where
                             panic!("sink already initialized during catalog boot")
                         }
                     };
-                    let connector = block_on(sink_connector::build(
+                    let connector = sink_connector::build(
                         builder.clone(),
                         sink.with_snapshot,
                         coord.determine_frontier(sink.as_of, sink.from)?,
                         *id,
-                    ))
+                    )
+                    .await
                     .with_context(|| format!("recreating sink {}", name))?;
-                    coord.handle_sink_connector_ready(*id, connector);
+                    coord.handle_sink_connector_ready(*id, connector).await;
                 }
                 _ => (), // Handled in prior loop.
             }
@@ -323,13 +326,13 @@ where
         let mut sinks_to_report = HashSet::new();
         for (id, name, item) in catalog_entries {
             // Mirror each recovered catalog entry.
-            coord.report_catalog_update(id, name.to_string(), 1);
+            coord.report_catalog_update(id, name.to_string(), 1).await;
 
             if let Ok(desc) = item.desc(&name) {
-                coord.report_column_updates(desc, id, 1);
+                coord.report_column_updates(desc, id, 1).await;
             }
             match item {
-                CatalogItem::Index(index) => coord.report_index_update(id, &index, 1),
+                CatalogItem::Index(index) => coord.report_index_update(id, &index, 1).await,
                 CatalogItem::Table(_) => {
                     tables_to_report.insert(id);
                 }
@@ -346,7 +349,9 @@ where
         }
 
         // Insert initial named objects into system tables.
-        coord.report_database_update(AMBIENT_DATABASE_ID, "AMBIENT", 1);
+        coord
+            .report_database_update(AMBIENT_DATABASE_ID, "AMBIENT", 1)
+            .await;
         let dbs: Vec<(String, i64, Vec<(String, i64, Vec<(String, GlobalId)>)>)> = coord
             .catalog
             .databases()
@@ -373,20 +378,32 @@ where
             })
             .collect();
         for (database_name, database_id, schemas) in dbs {
-            coord.report_database_update(database_id, &database_name, 1);
+            coord
+                .report_database_update(database_id, &database_name, 1)
+                .await;
 
             for (schema_name, schema_id, items) in schemas {
-                coord.report_schema_update(database_id, schema_id, &schema_name, "USER", 1);
+                coord
+                    .report_schema_update(database_id, schema_id, &schema_name, "USER", 1)
+                    .await;
 
                 for (item_name, item_id) in items {
                     if tables_to_report.remove(&item_id) {
-                        coord.report_table_update(&item_id, schema_id, &item_name, 1);
+                        coord
+                            .report_table_update(&item_id, schema_id, &item_name, 1)
+                            .await;
                     } else if sources_to_report.remove(&item_id) {
-                        coord.report_source_update(&item_id, schema_id, &item_name, 1);
+                        coord
+                            .report_source_update(&item_id, schema_id, &item_name, 1)
+                            .await;
                     } else if views_to_report.remove(&item_id) {
-                        coord.report_view_update(&item_id, schema_id, &item_name, 1);
+                        coord
+                            .report_view_update(&item_id, schema_id, &item_name, 1)
+                            .await;
                     } else if sinks_to_report.remove(&item_id) {
-                        coord.report_sink_update(&item_id, schema_id, &item_name, 1);
+                        coord
+                            .report_sink_update(&item_id, schema_id, &item_name, 1)
+                            .await;
                     }
                 }
             }
@@ -407,71 +424,87 @@ where
             })
             .collect();
         for (schema_name, schema_id, items) in ambient_schemas {
-            coord.report_schema_update(AMBIENT_DATABASE_ID, schema_id, &schema_name, "SYSTEM", 1);
+            coord
+                .report_schema_update(AMBIENT_DATABASE_ID, schema_id, &schema_name, "SYSTEM", 1)
+                .await;
 
             for (item_name, item_id) in items {
                 if tables_to_report.remove(&item_id) {
-                    coord.report_table_update(&item_id, schema_id, &item_name, 1);
+                    coord
+                        .report_table_update(&item_id, schema_id, &item_name, 1)
+                        .await;
                 } else if sources_to_report.remove(&item_id) {
-                    coord.report_source_update(&item_id, schema_id, &item_name, 1);
+                    coord
+                        .report_source_update(&item_id, schema_id, &item_name, 1)
+                        .await;
                 } else if views_to_report.remove(&item_id) {
-                    coord.report_view_update(&item_id, schema_id, &item_name, 1);
+                    coord
+                        .report_view_update(&item_id, schema_id, &item_name, 1)
+                        .await;
                 } else if sinks_to_report.remove(&item_id) {
-                    coord.report_sink_update(&item_id, schema_id, &item_name, 1);
+                    coord
+                        .report_sink_update(&item_id, schema_id, &item_name, 1)
+                        .await;
                 }
             }
         }
-        coord.report_schema_update(
-            AMBIENT_DATABASE_ID,
-            AMBIENT_SCHEMA_ID,
-            "mz_temp",
-            "system",
-            1,
-        );
+        coord
+            .report_schema_update(
+                AMBIENT_DATABASE_ID,
+                AMBIENT_SCHEMA_ID,
+                "mz_temp",
+                "system",
+                1,
+            )
+            .await;
 
         // Announce primary and foreign key relationships.
         if coord.logging_granularity.is_some() {
             for log in BUILTINS.logs() {
                 let log_id = &log.id.to_string();
-                coord.update_catalog_view(
-                    MZ_VIEW_KEYS.id,
-                    log.variant.desc().typ().keys.iter().enumerate().flat_map(
-                        move |(index, key)| {
-                            key.iter().map(move |k| {
-                                let row = Row::pack(&[
-                                    Datum::String(log_id),
-                                    Datum::Int64(*k as i64),
-                                    Datum::Int64(index as i64),
-                                ]);
-                                (row, 1)
-                            })
-                        },
-                    ),
-                );
+                coord
+                    .update_catalog_view(
+                        MZ_VIEW_KEYS.id,
+                        log.variant.desc().typ().keys.iter().enumerate().flat_map(
+                            move |(index, key)| {
+                                key.iter().map(move |k| {
+                                    let row = Row::pack(&[
+                                        Datum::String(log_id),
+                                        Datum::Int64(*k as i64),
+                                        Datum::Int64(index as i64),
+                                    ]);
+                                    (row, 1)
+                                })
+                            },
+                        ),
+                    )
+                    .await;
 
-                coord.update_catalog_view(
-                    MZ_VIEW_FOREIGN_KEYS.id,
-                    log.variant.foreign_keys().into_iter().enumerate().flat_map(
-                        move |(index, (parent, pairs))| {
-                            let parent_id = BUILTINS
-                                .logs()
-                                .find(|src| src.variant == parent)
-                                .unwrap()
-                                .id
-                                .to_string();
-                            pairs.into_iter().map(move |(c, p)| {
-                                let row = Row::pack(&[
-                                    Datum::String(&log_id),
-                                    Datum::Int64(c as i64),
-                                    Datum::String(&parent_id),
-                                    Datum::Int64(p as i64),
-                                    Datum::Int64(index as i64),
-                                ]);
-                                (row, 1)
-                            })
-                        },
-                    ),
-                );
+                coord
+                    .update_catalog_view(
+                        MZ_VIEW_FOREIGN_KEYS.id,
+                        log.variant.foreign_keys().into_iter().enumerate().flat_map(
+                            move |(index, (parent, pairs))| {
+                                let parent_id = BUILTINS
+                                    .logs()
+                                    .find(|src| src.variant == parent)
+                                    .unwrap()
+                                    .id
+                                    .to_string();
+                                pairs.into_iter().map(move |(c, p)| {
+                                    let row = Row::pack(&[
+                                        Datum::String(&log_id),
+                                        Datum::Int64(c as i64),
+                                        Datum::String(&parent_id),
+                                        Datum::Int64(p as i64),
+                                        Datum::Int64(index as i64),
+                                    ]);
+                                    (row, 1)
+                                })
+                            },
+                        ),
+                    )
+                    .await;
             }
         }
         Ok(coord)
@@ -519,14 +552,13 @@ where
         }
     }
 
-    pub fn serve(&mut self, cmd_rx: futures::channel::mpsc::UnboundedReceiver<Command>) {
-        self.executor.clone().enter(|| self.serve_core(cmd_rx))
-    }
-
-    fn serve_core(&mut self, cmd_rx: futures::channel::mpsc::UnboundedReceiver<Command>) {
+    async fn serve(&mut self) {
         let (internal_cmd_tx, internal_cmd_stream) = futures::channel::mpsc::unbounded();
 
-        let cmd_stream = cmd_rx
+        let cmd_stream = self
+            .cmd_rx
+            .take()
+            .unwrap()
             .map(Message::Command)
             .chain(stream::once(future::ready(Message::Shutdown)));
 
@@ -538,7 +570,7 @@ where
         let (ts_tx, ts_rx) = std::sync::mpsc::channel();
         let mut timestamper =
             Timestamper::new(&self.timestamp_config, internal_cmd_tx.clone(), ts_rx);
-        let executor = self.executor.clone();
+        let executor = Handle::current();
         let _timestamper_thread =
             thread::spawn(move || executor.enter(|| timestamper.update())).join_on_drop();
 
@@ -557,7 +589,7 @@ where
             cmd_stream.boxed(),
         ]);
 
-        while let Some(msg) = block_on(messages.next()) {
+        while let Some(msg) = messages.next().await {
             match msg {
                 Message::Command(Command::Startup { session, tx }) => {
                     let mut messages = vec![];
@@ -631,8 +663,14 @@ where
                     tx,
                     result,
                     params,
-                } => match result.and_then(|stmt| self.handle_statement(&session, stmt, &params)) {
-                    Ok((pcx, plan)) => self.sequence_plan(&internal_cmd_tx, tx, session, pcx, plan),
+                } => match future::ready(result)
+                    .and_then(|stmt| self.handle_statement(&session, stmt, &params))
+                    .await
+                {
+                    Ok((pcx, plan)) => {
+                        self.sequence_plan(&internal_cmd_tx, tx, session, pcx, plan)
+                            .await
+                    }
                     Err(e) => tx.send(Err(e), session),
                 },
 
@@ -648,7 +686,7 @@ where
                         // a Kafka topic) that's been created on our behalf. If
                         // we fail now, we'll leak that external state.
                         if self.catalog.try_get_by_id(id).is_some() {
-                            self.handle_sink_connector_ready(id, connector);
+                            self.handle_sink_connector_ready(id, connector).await;
                         } else {
                             // Another session dropped the sink while we were
                             // creating the connector. Report to the client that
@@ -678,7 +716,7 @@ where
                 }
 
                 Message::Command(Command::CancelRequest { conn_id }) => {
-                    self.handle_cancel(conn_id);
+                    self.handle_cancel(conn_id).await;
                 }
 
                 Message::Command(Command::DumpCatalog { tx }) => {
@@ -686,7 +724,7 @@ where
                 }
 
                 Message::Command(Command::Terminate { conn_id }) => {
-                    self.handle_terminate(conn_id);
+                    self.handle_terminate(conn_id).await;
                 }
 
                 Message::Worker(WorkerFeedbackWithMeta {
@@ -696,7 +734,7 @@ where
                     for (name, changes) in updates {
                         self.update_upper(&name, changes);
                     }
-                    self.maintenance();
+                    self.maintenance().await;
                 }
 
                 Message::Worker(WorkerFeedbackWithMeta {
@@ -729,16 +767,19 @@ where
                     broadcast(
                         &mut self.broadcast_tx,
                         SequencedCommand::AdvanceSourceTimestamp { id, update },
-                    );
+                    )
+                    .await;
                 }
                 Message::Shutdown => {
                     ts_tx.send(TimestampMessage::Shutdown).unwrap();
 
                     if let Some(persistence_tx) = &mut self.persistence_tx {
-                        block_on(persistence_tx.send(PersistenceMessage::Shutdown))
+                        persistence_tx
+                            .send(PersistenceMessage::Shutdown)
+                            .await
                             .expect("failed to send shutdown message to persistence thread");
                     }
-                    broadcast(&mut self.broadcast_tx, SequencedCommand::Shutdown);
+                    broadcast(&mut self.broadcast_tx, SequencedCommand::Shutdown).await;
                     break;
                 }
             }
@@ -762,7 +803,8 @@ where
                         SequencedCommand::AdvanceAllLocalInputs {
                             advance_to: next_ts,
                         },
-                    );
+                    )
+                    .await;
                     self.closed_up_to = next_ts;
                 }
             }
@@ -771,7 +813,7 @@ where
         // Cleanly drain any pending messages from the worker before shutting
         // down.
         drop(internal_cmd_tx);
-        while block_on(messages.next()).is_some() {}
+        while messages.next().await.is_some() {}
     }
 
     /// Updates the upper frontier of a named view.
@@ -816,7 +858,7 @@ where
     ///
     /// Primarily, this involves sequencing compaction commands, which should be
     /// issued whenever available.
-    fn maintenance(&mut self) {
+    async fn maintenance(&mut self) {
         // Take this opportunity to drain `since_update` commands.
         // Don't try to compact to an empty frontier. There may be a good reason to do this
         // in principle, but not in any current Mz use case.
@@ -830,11 +872,12 @@ where
                     &mut self.since_updates,
                     Vec::new(),
                 )),
-            );
+            )
+            .await;
         }
     }
 
-    fn handle_statement(
+    async fn handle_statement(
         &mut self,
         session: &Session,
         stmt: sql::ast::Statement,
@@ -857,8 +900,9 @@ where
         | Statement::Insert { .. } = &stmt
         {
             if let Some(ref mut postgres) = self.symbiosis {
-                let plan =
-                    block_on(postgres.execute(&pcx, &self.catalog.for_session(session), &stmt))?;
+                let plan = postgres
+                    .execute(&pcx, &self.catalog.for_session(session), &stmt)
+                    .await?;
                 return Ok((pcx, plan));
             }
         }
@@ -872,11 +916,9 @@ where
             Ok(plan) => Ok((pcx, plan)),
             Err(err) => match self.symbiosis {
                 Some(ref mut postgres) if postgres.can_handle(&stmt) => {
-                    let plan = block_on(postgres.execute(
-                        &pcx,
-                        &self.catalog.for_session(session),
-                        &stmt,
-                    ))?;
+                    let plan = postgres
+                        .execute(&pcx, &self.catalog.for_session(session), &stmt)
+                        .await?;
                     Ok((pcx, plan))
                 }
                 _ => Err(err),
@@ -921,12 +963,12 @@ where
     /// NOTE(benesch): this function makes the assumption that a connection can
     /// only have one active query at a time. This is true today, but will not
     /// be true once we have full support for portals.
-    fn handle_cancel(&mut self, conn_id: u32) {
+    async fn handle_cancel(&mut self, conn_id: u32) {
         if let Some(name) = self.active_tails.remove(&conn_id) {
             // A TAIL is known to be active, so drop the dataflow that is
             // servicing it. No need to try to cancel PEEKs in this case,
             // because if a TAIL is active, a PEEK cannot be.
-            self.drop_sinks(vec![name]);
+            self.drop_sinks(vec![name]).await;
         } else {
             // No TAIL is known to be active, so drop the PEEK that may be
             // active on this connection. This is a no-op if no PEEKs are
@@ -934,27 +976,29 @@ where
             broadcast(
                 &mut self.broadcast_tx,
                 SequencedCommand::CancelPeek { conn_id },
-            );
+            )
+            .await;
         }
     }
 
     /// Terminate any temporary objects created by the named `conn_id`
     /// stored on the Coordinator.
-    fn handle_terminate(&mut self, conn_id: u32) {
+    async fn handle_terminate(&mut self, conn_id: u32) {
         if let Some(name) = self.active_tails.remove(&conn_id) {
-            self.drop_sinks(vec![name]);
+            self.drop_sinks(vec![name]).await;
         }
 
         // Remove all temporary items created by the conn_id.
         let ops = self.catalog.drop_temp_item_ops(conn_id);
         self.catalog_transact(ops)
+            .await
             .expect("unable to drop temporary items for conn_id");
         self.catalog
             .drop_temporary_schema(conn_id)
             .expect("unable to drop temporary schema");
     }
 
-    fn handle_sink_connector_ready(&mut self, id: GlobalId, connector: SinkConnector) {
+    async fn handle_sink_connector_ready(&mut self, id: GlobalId, connector: SinkConnector) {
         // Update catalog entry with sink connector.
         let entry = self.catalog.get_by_id(&id);
         let name = entry.name().clone();
@@ -976,10 +1020,11 @@ where
             .expect("replacing a sink cannot fail");
 
         self.ship_dataflow(self.build_sink_dataflow(name.to_string(), id, sink.from, connector))
+            .await
     }
 
     /// Insert a single row into a given catalog view.
-    fn update_catalog_view<I>(&mut self, index_id: GlobalId, updates: I)
+    async fn update_catalog_view<I>(&mut self, index_id: GlobalId, updates: I)
     where
         I: IntoIterator<Item = (Row, isize)>,
     {
@@ -998,15 +1043,17 @@ where
                 id: index_id,
                 updates,
             },
-        );
+        )
+        .await;
     }
 
-    fn report_catalog_update(&mut self, id: GlobalId, name: String, diff: isize) {
+    async fn report_catalog_update(&mut self, id: GlobalId, name: String, diff: isize) {
         let row = Row::pack(&[Datum::String(&id.to_string()), Datum::String(&name)]);
-        self.update_catalog_view(MZ_CATALOG_NAMES.id, iter::once((row, diff)));
+        self.update_catalog_view(MZ_CATALOG_NAMES.id, iter::once((row, diff)))
+            .await;
     }
 
-    fn report_database_update(&mut self, database_id: i64, name: &str, diff: isize) {
+    async fn report_database_update(&mut self, database_id: i64, name: &str, diff: isize) {
         self.update_catalog_view(
             MZ_DATABASES.id,
             iter::once((
@@ -1014,9 +1061,10 @@ where
                 diff,
             )),
         )
+        .await
     }
 
-    fn report_schema_update(
+    async fn report_schema_update(
         &mut self,
         database_id: i64,
         schema_id: i64,
@@ -1036,9 +1084,15 @@ where
                 diff,
             )),
         )
+        .await
     }
 
-    fn report_column_updates(&mut self, desc: &RelationDesc, global_id: GlobalId, diff: isize) {
+    async fn report_column_updates(
+        &mut self,
+        desc: &RelationDesc,
+        global_id: GlobalId,
+        diff: isize,
+    ) {
         for (i, (column_name, column_type)) in desc.iter().enumerate() {
             self.update_catalog_view(
                 MZ_COLUMNS.id,
@@ -1057,10 +1111,11 @@ where
                     diff,
                 )),
             )
+            .await
         }
     }
 
-    fn report_index_update(&mut self, global_id: GlobalId, index: &Index, diff: isize) {
+    async fn report_index_update(&mut self, global_id: GlobalId, index: &Index, diff: isize) {
         self.report_index_update_inner(
             global_id,
             index,
@@ -1074,12 +1129,13 @@ where
                 .collect(),
             diff,
         )
+        .await
     }
 
     // When updating the mz_indexes system table after dropping an index, it may no longer be possible
     // to generate the 'nullable' information for that index. This function allows callers to bypass
     // that computation and provide their own value, instead.
-    fn report_index_update_inner(
+    async fn report_index_update_inner(
         &mut self,
         global_id: GlobalId,
         index: &Index,
@@ -1123,10 +1179,11 @@ where
                     diff,
                 )),
             )
+            .await
         }
     }
 
-    fn report_table_update(
+    async fn report_table_update(
         &mut self,
         global_id: &GlobalId,
         schema_id: i64,
@@ -1144,9 +1201,10 @@ where
                 diff,
             )),
         )
+        .await
     }
 
-    fn report_source_update(
+    async fn report_source_update(
         &mut self,
         global_id: &GlobalId,
         schema_id: i64,
@@ -1164,9 +1222,10 @@ where
                 diff,
             )),
         )
+        .await
     }
 
-    fn report_view_update(
+    async fn report_view_update(
         &mut self,
         global_id: &GlobalId,
         schema_id: i64,
@@ -1184,9 +1243,10 @@ where
                 diff,
             )),
         )
+        .await
     }
 
-    fn report_sink_update(
+    async fn report_sink_update(
         &mut self,
         global_id: &GlobalId,
         schema_id: i64,
@@ -1204,9 +1264,10 @@ where
                 diff,
             )),
         )
+        .await
     }
 
-    fn sequence_plan(
+    async fn sequence_plan(
         &mut self,
         internal_cmd_tx: &futures::channel::mpsc::UnboundedSender<Message>,
         tx: ClientTransmitter<ExecuteResponse>,
@@ -1218,14 +1279,18 @@ where
             Plan::CreateDatabase {
                 name,
                 if_not_exists,
-            } => tx.send(self.sequence_create_database(name, if_not_exists), session),
+            } => tx.send(
+                self.sequence_create_database(name, if_not_exists).await,
+                session,
+            ),
 
             Plan::CreateSchema {
                 database_name,
                 schema_name,
                 if_not_exists,
             } => tx.send(
-                self.sequence_create_schema(database_name, schema_name, if_not_exists),
+                self.sequence_create_schema(database_name, schema_name, if_not_exists)
+                    .await,
                 session,
             ),
 
@@ -1234,7 +1299,8 @@ where
                 table,
                 if_not_exists,
             } => tx.send(
-                self.sequence_create_table(pcx, name, table, if_not_exists),
+                self.sequence_create_table(pcx, name, table, if_not_exists)
+                    .await,
                 session,
             ),
 
@@ -1244,7 +1310,8 @@ where
                 if_not_exists,
                 materialized,
             } => tx.send(
-                self.sequence_create_source(pcx, name, source, if_not_exists, materialized),
+                self.sequence_create_source(pcx, name, source, if_not_exists, materialized)
+                    .await,
                 session,
             ),
 
@@ -1254,17 +1321,20 @@ where
                 with_snapshot,
                 as_of,
                 if_not_exists,
-            } => self.sequence_create_sink(
-                pcx,
-                internal_cmd_tx.clone(),
-                tx,
-                session,
-                name,
-                sink,
-                with_snapshot,
-                as_of,
-                if_not_exists,
-            ),
+            } => {
+                self.sequence_create_sink(
+                    pcx,
+                    internal_cmd_tx.clone(),
+                    tx,
+                    session,
+                    name,
+                    sink,
+                    with_snapshot,
+                    as_of,
+                    if_not_exists,
+                )
+                .await
+            }
 
             Plan::CreateView {
                 name,
@@ -1281,7 +1351,8 @@ where
                     session.conn_id(),
                     materialize,
                     if_not_exists,
-                ),
+                )
+                .await,
                 session,
             ),
 
@@ -1290,32 +1361,39 @@ where
                 index,
                 if_not_exists,
             } => tx.send(
-                self.sequence_create_index(pcx, name, index, if_not_exists),
+                self.sequence_create_index(pcx, name, index, if_not_exists)
+                    .await,
                 session,
             ),
 
-            Plan::DropDatabase { name } => tx.send(self.sequence_drop_database(name), session),
+            Plan::DropDatabase { name } => {
+                tx.send(self.sequence_drop_database(name).await, session)
+            }
 
             Plan::DropSchema {
                 database_name,
                 schema_name,
             } => tx.send(
-                self.sequence_drop_schema(database_name, schema_name),
+                self.sequence_drop_schema(database_name, schema_name).await,
                 session,
             ),
 
-            Plan::DropItems { items, ty } => tx.send(self.sequence_drop_items(items, ty), session),
+            Plan::DropItems { items, ty } => {
+                tx.send(self.sequence_drop_items(items, ty).await, session)
+            }
 
             Plan::EmptyQuery => tx.send(Ok(ExecuteResponse::EmptyQuery), session),
 
-            Plan::ShowAllVariables => tx.send(self.sequence_show_all_variables(&session), session),
+            Plan::ShowAllVariables => {
+                tx.send(self.sequence_show_all_variables(&session).await, session)
+            }
 
             Plan::ShowVariable(name) => {
-                tx.send(self.sequence_show_variable(&session, name), session)
+                tx.send(self.sequence_show_variable(&session, name).await, session)
             }
 
             Plan::SetVariable { name, value } => tx.send(
-                self.sequence_set_variable(&mut session, name, value),
+                self.sequence_set_variable(&mut session, name, value).await,
                 session,
             ),
 
@@ -1340,7 +1418,8 @@ where
                 finishing,
                 materialize,
             } => tx.send(
-                self.sequence_peek(session.conn_id(), source, when, finishing, materialize),
+                self.sequence_peek(session.conn_id(), source, when, finishing, materialize)
+                    .await,
                 session,
             ),
 
@@ -1349,7 +1428,8 @@ where
                 ts,
                 with_snapshot,
             } => tx.send(
-                self.sequence_tail(session.conn_id(), id, with_snapshot, ts),
+                self.sequence_tail(session.conn_id(), id, with_snapshot, ts)
+                    .await,
                 session,
             ),
 
@@ -1378,18 +1458,20 @@ where
                 affected_rows,
                 kind,
             } => tx.send(
-                self.sequence_send_diffs(id, updates, affected_rows, kind),
+                self.sequence_send_diffs(id, updates, affected_rows, kind)
+                    .await,
                 session,
             ),
 
-            Plan::Insert { id, values } => tx.send(self.sequence_insert(id, values), session),
+            Plan::Insert { id, values } => tx.send(self.sequence_insert(id, values).await, session),
 
             Plan::AlterItemRename {
                 id,
                 to_name,
                 object_type,
             } => tx.send(
-                self.sequence_alter_item_rename(id, to_name, object_type),
+                self.sequence_alter_item_rename(id, to_name, object_type)
+                    .await,
                 session,
             ),
 
@@ -1400,7 +1482,7 @@ where
         }
     }
 
-    fn sequence_create_database(
+    async fn sequence_create_database(
         &mut self,
         name: String,
         if_not_exists: bool,
@@ -1412,14 +1494,14 @@ where
                 schema_name: "public".into(),
             },
         ];
-        match self.catalog_transact(ops) {
+        match self.catalog_transact(ops).await {
             Ok(_) => Ok(ExecuteResponse::CreatedDatabase { existed: false }),
             Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedDatabase { existed: true }),
             Err(err) => Err(err),
         }
     }
 
-    fn sequence_create_schema(
+    async fn sequence_create_schema(
         &mut self,
         database_name: DatabaseSpecifier,
         schema_name: String,
@@ -1429,14 +1511,14 @@ where
             database_name,
             schema_name,
         };
-        match self.catalog_transact(vec![op]) {
+        match self.catalog_transact(vec![op]).await {
             Ok(_) => Ok(ExecuteResponse::CreatedSchema { existed: false }),
             Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedSchema { existed: true }),
             Err(err) => Err(err),
         }
     }
 
-    fn sequence_create_table(
+    async fn sequence_create_table(
         &mut self,
         pcx: PlanContext,
         name: FullName,
@@ -1454,20 +1536,24 @@ where
         index_name.item += "_primary_idx";
         let index =
             auto_generate_primary_idx(index_name.item.clone(), name.clone(), table_id, &table.desc);
-        match self.catalog_transact(vec![
-            catalog::Op::CreateItem {
-                id: table_id,
-                name,
-                item: CatalogItem::Table(table),
-            },
-            catalog::Op::CreateItem {
-                id: index_id,
-                name: index_name,
-                item: CatalogItem::Index(index),
-            },
-        ]) {
+        match self
+            .catalog_transact(vec![
+                catalog::Op::CreateItem {
+                    id: table_id,
+                    name,
+                    item: CatalogItem::Table(table),
+                },
+                catalog::Op::CreateItem {
+                    id: index_id,
+                    name: index_name,
+                    item: CatalogItem::Index(index),
+                },
+            ])
+            .await
+        {
             Ok(_) => {
-                self.ship_dataflow(self.build_index_dataflow(index_id));
+                self.ship_dataflow(self.build_index_dataflow(index_id))
+                    .await;
                 Ok(ExecuteResponse::CreatedTable { existed: false })
             }
             Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedTable { existed: true }),
@@ -1475,7 +1561,7 @@ where
         }
     }
 
-    fn sequence_create_source(
+    async fn sequence_create_source(
         &mut self,
         pcx: PlanContext,
         name: FullName,
@@ -1510,13 +1596,15 @@ where
         } else {
             None
         };
-        match self.catalog_transact(ops) {
+        match self.catalog_transact(ops).await {
             Ok(()) => {
                 if let Some(index_id) = index_id {
-                    self.ship_dataflow(self.build_index_dataflow(index_id));
+                    self.ship_dataflow(self.build_index_dataflow(index_id))
+                        .await;
                 }
 
-                self.maybe_begin_persistence(source_id, &source.connector);
+                self.maybe_begin_persistence(source_id, &source.connector)
+                    .await;
                 Ok(ExecuteResponse::CreatedSource { existed: false })
             }
             Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedSource { existed: true }),
@@ -1525,7 +1613,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn sequence_create_sink(
+    async fn sequence_create_sink(
         &mut self,
         pcx: PlanContext,
         mut internal_cmd_tx: futures::channel::mpsc::UnboundedSender<Message>,
@@ -1572,7 +1660,7 @@ where
                 as_of,
             }),
         };
-        match self.catalog_transact(vec![op]) {
+        match self.catalog_transact(vec![op]).await {
             Ok(()) => (),
             Err(_) if if_not_exists => {
                 tx.send(Ok(ExecuteResponse::CreatedSink { existed: true }), session);
@@ -1602,7 +1690,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn sequence_create_view(
+    async fn sequence_create_view(
         &mut self,
         pcx: PlanContext,
         name: FullName,
@@ -1647,10 +1735,11 @@ where
         } else {
             None
         };
-        match self.catalog_transact(ops) {
+        match self.catalog_transact(ops).await {
             Ok(()) => {
                 if let Some(index_id) = index_id {
-                    self.ship_dataflow(self.build_index_dataflow(index_id));
+                    self.ship_dataflow(self.build_index_dataflow(index_id))
+                        .await;
                 }
                 Ok(ExecuteResponse::CreatedView { existed: false })
             }
@@ -1659,7 +1748,7 @@ where
         }
     }
 
-    fn sequence_create_index(
+    async fn sequence_create_index(
         &mut self,
         pcx: PlanContext,
         name: FullName,
@@ -1678,9 +1767,9 @@ where
             name,
             item: CatalogItem::Index(index),
         };
-        match self.catalog_transact(vec![op]) {
+        match self.catalog_transact(vec![op]).await {
             Ok(()) => {
-                self.ship_dataflow(self.build_index_dataflow(id));
+                self.ship_dataflow(self.build_index_dataflow(id)).await;
                 Ok(ExecuteResponse::CreatedIndex { existed: false })
             }
             Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedIndex { existed: true }),
@@ -1688,35 +1777,40 @@ where
         }
     }
 
-    fn sequence_drop_database(&mut self, name: String) -> Result<ExecuteResponse, anyhow::Error> {
+    async fn sequence_drop_database(
+        &mut self,
+        name: String,
+    ) -> Result<ExecuteResponse, anyhow::Error> {
         let ops = self.catalog.drop_database_ops(name);
-        self.catalog_transact(ops)?;
+        self.catalog_transact(ops).await?;
         Ok(ExecuteResponse::DroppedDatabase)
     }
 
-    fn sequence_drop_schema(
+    async fn sequence_drop_schema(
         &mut self,
         database_name: DatabaseSpecifier,
         schema_name: String,
     ) -> Result<ExecuteResponse, anyhow::Error> {
         let ops = self.catalog.drop_schema_ops(database_name, schema_name);
-        self.catalog_transact(ops)?;
+        self.catalog_transact(ops).await?;
         Ok(ExecuteResponse::DroppedSchema)
     }
 
-    fn sequence_drop_items(
+    async fn sequence_drop_items(
         &mut self,
         items: Vec<GlobalId>,
         ty: ObjectType,
     ) -> Result<ExecuteResponse, anyhow::Error> {
         let ops = self.catalog.drop_items_ops(&items);
-        self.catalog_transact(ops)?;
+        self.catalog_transact(ops).await?;
         Ok(match ty {
             ObjectType::Schema => unreachable!(),
             ObjectType::Source => {
                 for id in items.iter() {
                     if let Some(persistence_tx) = &mut self.persistence_tx {
-                        block_on(persistence_tx.send(PersistenceMessage::DropSource(*id)))
+                        persistence_tx
+                            .send(PersistenceMessage::DropSource(*id))
+                            .await
                             .expect("failed to send DROP SOURCE to persistence thread");
                     }
                 }
@@ -1729,7 +1823,7 @@ where
         })
     }
 
-    fn sequence_show_all_variables(
+    async fn sequence_show_all_variables(
         &mut self,
         session: &Session,
     ) -> Result<ExecuteResponse, anyhow::Error> {
@@ -1749,7 +1843,7 @@ where
         ))
     }
 
-    fn sequence_show_variable(
+    async fn sequence_show_variable(
         &self,
         session: &Session,
         name: String,
@@ -1759,7 +1853,7 @@ where
         Ok(send_immediate_rows(vec![row]))
     }
 
-    fn sequence_set_variable(
+    async fn sequence_set_variable(
         &self,
         session: &mut Session,
         name: String,
@@ -1769,7 +1863,7 @@ where
         Ok(ExecuteResponse::SetVariable { name })
     }
 
-    fn sequence_peek(
+    async fn sequence_peek(
         &mut self,
         conn_id: u32,
         mut source: RelationExpr,
@@ -1853,7 +1947,7 @@ where
                 self.import_view_into_dataflow(&view_id, &source, &mut dataflow);
                 dataflow.add_index_to_build(index_id, view_id, typ.clone(), key.clone());
                 dataflow.add_index_export(index_id, view_id, typ, key);
-                self.ship_dataflow(dataflow);
+                self.ship_dataflow(dataflow).await;
             }
 
             broadcast(
@@ -1867,10 +1961,11 @@ where
                     project,
                     filter,
                 },
-            );
+            )
+            .await;
 
             if !fast_path {
-                self.drop_indexes(vec![index_id]);
+                self.drop_indexes(vec![index_id]).await;
             }
 
             let rows_rx = rows_rx
@@ -1900,7 +1995,7 @@ where
         }
     }
 
-    fn sequence_tail(
+    async fn sequence_tail(
         &mut self,
         conn_id: u32,
         source_id: GlobalId,
@@ -1929,7 +2024,8 @@ where
                 frontier,
                 strict: !with_snapshot,
             }),
-        ));
+        ))
+        .await;
         Ok(ExecuteResponse::Tailing { rx })
     }
 
@@ -2160,7 +2256,7 @@ where
         Ok(send_immediate_rows(rows))
     }
 
-    fn sequence_send_diffs(
+    async fn sequence_send_diffs(
         &mut self,
         id: GlobalId,
         updates: Vec<(Row, isize)>,
@@ -2180,7 +2276,8 @@ where
         broadcast(
             &mut self.broadcast_tx,
             SequencedCommand::Insert { id, updates },
-        );
+        )
+        .await;
 
         Ok(match kind {
             MutationKind::Delete => ExecuteResponse::Deleted(affected_rows),
@@ -2189,7 +2286,7 @@ where
         })
     }
 
-    fn sequence_insert(
+    async fn sequence_insert(
         &mut self,
         id: GlobalId,
         values: expr::RelationExpr,
@@ -2214,12 +2311,13 @@ where
 
                 let affected_rows = rows.len();
                 self.sequence_send_diffs(id, rows, affected_rows, MutationKind::Insert)
+                    .await
             }
             other => bail!("INSERT statement expected values, found {:?}", other),
         }
     }
 
-    fn sequence_alter_item_rename(
+    async fn sequence_alter_item_rename(
         &mut self,
         id: Option<GlobalId>,
         to_name: String,
@@ -2231,7 +2329,7 @@ where
             None => return Ok(ExecuteResponse::AlteredObject(object_type)),
         };
         let op = catalog::Op::RenameItem { id, to_name };
-        match self.catalog_transact(vec![op]) {
+        match self.catalog_transact(vec![op]).await {
             Ok(()) => Ok(ExecuteResponse::AlteredObject(object_type)),
             Err(err) => Err(err),
         }
@@ -2267,7 +2365,7 @@ where
         }
     }
 
-    fn catalog_transact(&mut self, ops: Vec<catalog::Op>) -> Result<(), anyhow::Error> {
+    async fn catalog_transact(&mut self, ops: Vec<catalog::Op>) -> Result<(), anyhow::Error> {
         let mut sources_to_drop = vec![];
         let mut sinks_to_drop = vec![];
         let mut indexes_to_drop = vec![];
@@ -2276,14 +2374,15 @@ where
         for status in &statuses {
             match status {
                 catalog::OpStatus::CreatedDatabase { name, id } => {
-                    self.report_database_update(*id, name, 1);
+                    self.report_database_update(*id, name, 1).await;
                 }
                 catalog::OpStatus::CreatedSchema {
                     database_id,
                     schema_id,
                     schema_name,
                 } => {
-                    self.report_schema_update(*database_id, *schema_id, schema_name, "USER", 1);
+                    self.report_schema_update(*database_id, *schema_id, schema_name, "USER", 1)
+                        .await;
                 }
                 catalog::OpStatus::CreatedItem {
                     schema_id,
@@ -2295,24 +2394,27 @@ where
                         *id,
                         self.catalog.humanize_id(expr::Id::Global(*id)).unwrap(),
                         1,
-                    );
+                    )
+                    .await;
 
                     if let Ok(desc) = item.desc(&name) {
-                        self.report_column_updates(desc, *id, 1);
+                        self.report_column_updates(desc, *id, 1).await;
                     }
                     match item {
-                        CatalogItem::Index(index) => self.report_index_update(*id, index, 1),
+                        CatalogItem::Index(index) => self.report_index_update(*id, index, 1).await,
                         CatalogItem::Table(_) => {
                             self.report_table_update(id, *schema_id, &name.item, 1)
+                                .await
                         }
                         CatalogItem::Source(_) => {
-                            self.report_source_update(id, *schema_id, &name.item, 1);
+                            self.report_source_update(id, *schema_id, &name.item, 1)
+                                .await;
                         }
                         CatalogItem::View(_) => {
-                            self.report_view_update(id, *schema_id, &name.item, 1);
+                            self.report_view_update(id, *schema_id, &name.item, 1).await;
                         }
                         CatalogItem::Sink(_) => {
-                            self.report_sink_update(id, *schema_id, &name.item, 1);
+                            self.report_sink_update(id, *schema_id, &name.item, 1).await;
                         }
                     }
                 }
@@ -2324,52 +2426,66 @@ where
                     item,
                 } => {
                     // Remove old name from mz_catalog_names.
-                    self.report_catalog_update(*id, from_name.to_string(), -1);
+                    self.report_catalog_update(*id, from_name.to_string(), -1)
+                        .await;
 
                     // Add new name to mz_catalog_names.
-                    self.report_catalog_update(*id, to_name.to_string(), 1);
+                    self.report_catalog_update(*id, to_name.to_string(), 1)
+                        .await;
 
                     // Remove old name and add new name to relevant mz system tables.
                     match item {
                         CatalogItem::Source(_) => {
-                            self.report_source_update(id, *schema_id, &from_name.item, -1);
-                            self.report_source_update(id, *schema_id, &to_name.item, 1);
+                            self.report_source_update(id, *schema_id, &from_name.item, -1)
+                                .await;
+                            self.report_source_update(id, *schema_id, &to_name.item, 1)
+                                .await;
                         }
                         CatalogItem::View(_) => {
-                            self.report_view_update(id, *schema_id, &from_name.item, -1);
-                            self.report_view_update(id, *schema_id, &to_name.item, 1);
+                            self.report_view_update(id, *schema_id, &from_name.item, -1)
+                                .await;
+                            self.report_view_update(id, *schema_id, &to_name.item, 1)
+                                .await;
                         }
                         CatalogItem::Sink(_) => {
-                            self.report_sink_update(id, *schema_id, &from_name.item, -1);
-                            self.report_sink_update(id, *schema_id, &to_name.item, 1);
+                            self.report_sink_update(id, *schema_id, &from_name.item, -1)
+                                .await;
+                            self.report_sink_update(id, *schema_id, &to_name.item, 1)
+                                .await;
                         }
                         CatalogItem::Table(_) => {
-                            self.report_table_update(id, *schema_id, &from_name.item, -1);
-                            self.report_table_update(id, *schema_id, &to_name.item, 1);
+                            self.report_table_update(id, *schema_id, &from_name.item, -1)
+                                .await;
+                            self.report_table_update(id, *schema_id, &to_name.item, 1)
+                                .await;
                         }
                         _ => (),
                     }
                 }
                 catalog::OpStatus::DroppedDatabase { name, id } => {
-                    self.report_database_update(*id, name, -1);
+                    self.report_database_update(*id, name, -1).await;
                 }
                 catalog::OpStatus::DroppedSchema {
                     database_id,
                     schema_id,
                     schema_name,
                 } => {
-                    self.report_schema_update(*database_id, *schema_id, schema_name, "USER", -1);
+                    self.report_schema_update(*database_id, *schema_id, schema_name, "USER", -1)
+                        .await;
                 }
                 catalog::OpStatus::DroppedIndex { entry, nullable } => match entry.item() {
                     CatalogItem::Index(index) => {
                         indexes_to_drop.push(entry.id());
-                        self.report_catalog_update(entry.id(), entry.name().to_string(), -1);
+                        self.report_catalog_update(entry.id(), entry.name().to_string(), -1)
+                            .await;
                         self.report_index_update_inner(entry.id(), index, nullable.to_owned(), -1)
+                            .await
                     }
                     _ => unreachable!("DroppedIndex for non-index item"),
                 },
                 catalog::OpStatus::DroppedItem { schema_id, entry } => {
-                    self.report_catalog_update(entry.id(), entry.name().to_string(), -1);
+                    self.report_catalog_update(entry.id(), entry.name().to_string(), -1)
+                        .await;
                     match entry.item() {
                         CatalogItem::Table(_) => {
                             sources_to_drop.push(entry.id());
@@ -2378,7 +2494,8 @@ where
                                 *schema_id,
                                 &entry.name().item,
                                 -1,
-                            );
+                            )
+                            .await;
                         }
                         CatalogItem::Source(_) => {
                             sources_to_drop.push(entry.id());
@@ -2387,7 +2504,8 @@ where
                                 *schema_id,
                                 &entry.name().item,
                                 -1,
-                            );
+                            )
+                            .await;
                         }
                         CatalogItem::View(_) => {
                             self.report_view_update(
@@ -2395,7 +2513,8 @@ where
                                 *schema_id,
                                 &entry.name().item,
                                 -1,
-                            );
+                            )
+                            .await;
                         }
                         CatalogItem::Sink(catalog::Sink {
                             connector: SinkConnectorState::Ready(connector),
@@ -2407,7 +2526,8 @@ where
                                 *schema_id,
                                 &entry.name().item,
                                 -1,
-                            );
+                            )
+                            .await;
                             match connector {
                                 SinkConnector::Kafka(KafkaSinkConnector { topic, .. }) => {
                                     let row = Row::pack(&[
@@ -2417,7 +2537,8 @@ where
                                     self.update_catalog_view(
                                         MZ_KAFKA_SINKS.id,
                                         iter::once((row, -1)),
-                                    );
+                                    )
+                                    .await;
                                 }
                                 SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
                                     let row = Row::pack(&[
@@ -2427,7 +2548,8 @@ where
                                     self.update_catalog_view(
                                         MZ_AVRO_OCF_SINKS.id,
                                         iter::once((row, -1)),
-                                    );
+                                    )
+                                    .await;
                                 }
                                 _ => (),
                             }
@@ -2444,7 +2566,7 @@ where
                         }
                     }
                     if let Ok(desc) = entry.desc() {
-                        self.report_column_updates(desc, entry.id(), -1);
+                        self.report_column_updates(desc, entry.id(), -1).await;
                     }
                 }
                 _ => (),
@@ -2455,29 +2577,32 @@ where
             broadcast(
                 &mut self.broadcast_tx,
                 SequencedCommand::DropSources(sources_to_drop),
-            );
+            )
+            .await;
         }
         if !sinks_to_drop.is_empty() {
             broadcast(
                 &mut self.broadcast_tx,
                 SequencedCommand::DropSinks(sinks_to_drop),
-            );
+            )
+            .await;
         }
         if !indexes_to_drop.is_empty() {
-            self.drop_indexes(indexes_to_drop);
+            self.drop_indexes(indexes_to_drop).await;
         }
 
         Ok(())
     }
 
-    fn drop_sinks(&mut self, dataflow_names: Vec<GlobalId>) {
+    async fn drop_sinks(&mut self, dataflow_names: Vec<GlobalId>) {
         broadcast(
             &mut self.broadcast_tx,
             SequencedCommand::DropSinks(dataflow_names),
         )
+        .await
     }
 
-    fn drop_indexes(&mut self, indexes: Vec<GlobalId>) {
+    async fn drop_indexes(&mut self, indexes: Vec<GlobalId>) {
         let mut trace_keys = Vec::new();
         for id in indexes {
             if self.indexes.remove(&id).is_some() {
@@ -2489,6 +2614,7 @@ where
                 &mut self.broadcast_tx,
                 SequencedCommand::DropIndexes(trace_keys),
             )
+            .await
         }
     }
 
@@ -2647,7 +2773,7 @@ where
     /// In particular, there are requirement on the `as_of` field for the dataflow
     /// and the `since` frontiers of created arrangements, as a function of the `since`
     /// frontiers of dataflow inputs (sources and imported arrangements).
-    fn ship_dataflow(&mut self, mut dataflow: DataflowDesc) {
+    async fn ship_dataflow(&mut self, mut dataflow: DataflowDesc) {
         // The identity for `join` is the minimum element.
         let mut since = Antichain::from_elem(Timestamp::minimum());
 
@@ -2683,14 +2809,16 @@ where
                         Datum::String(&id.to_string()),
                         Datum::String(topic.as_str()),
                     ]);
-                    self.update_catalog_view(MZ_KAFKA_SINKS.id, iter::once((row, 1)));
+                    self.update_catalog_view(MZ_KAFKA_SINKS.id, iter::once((row, 1)))
+                        .await;
                 }
                 SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
                     let row = Row::pack(&[
                         Datum::String(&id.to_string()),
                         Datum::Bytes(&path.clone().into_os_string().into_vec()),
                     ]);
-                    self.update_catalog_view(MZ_AVRO_OCF_SINKS.id, iter::once((row, 1)));
+                    self.update_catalog_view(MZ_AVRO_OCF_SINKS.id, iter::once((row, 1)))
+                        .await;
                 }
                 _ => (),
             }
@@ -2731,18 +2859,21 @@ where
         broadcast(
             &mut self.broadcast_tx,
             SequencedCommand::CreateDataflows(vec![dataflow]),
-        );
+        )
+        .await;
     }
 
     // Tell the persister to start persisting data for `id` if that source
     // has persistence enabled and Materialize has persistence enabled.
     // This function is a no-op if the persister has already started persisting
     // this source.
-    fn maybe_begin_persistence(&mut self, id: GlobalId, source_connector: &SourceConnector) {
+    async fn maybe_begin_persistence(&mut self, id: GlobalId, source_connector: &SourceConnector) {
         if let SourceConnector::External { connector, .. } = source_connector {
             if connector.persistence_enabled() {
                 if let Some(persistence_tx) = &mut self.persistence_tx {
-                    block_on(persistence_tx.send(PersistenceMessage::AddSource(id)))
+                    persistence_tx
+                        .send(PersistenceMessage::AddSource(id))
+                        .await
                         .expect("failed to send CREATE SOURCE notification to persistence thread");
                 } else {
                     log::error!(
@@ -2755,9 +2886,27 @@ where
     }
 }
 
-fn broadcast(tx: &mut comm::broadcast::Sender<SequencedCommand>, cmd: SequencedCommand) {
+/// Begins coordinating user requests to the dataflow layer based on the
+/// provided configuration. Returns the thread that hosts the coordinator.
+///
+/// To gracefully shut down the coordinator, send a `Message::Shutdown` to the
+/// `cmd_rx` in the configuration, then join on the thread.
+pub async fn serve<C>(config: Config<'_, C>) -> Result<JoinHandle<()>, anyhow::Error>
+where
+    C: comm::Connection,
+{
+    let mut coord = Coordinator::new(config).await?;
+    // The future returned by `Coordinator::serve` does not implement `Send` as
+    // it holds various non-thread-safe state across await points. This means we
+    // can't use `tokio::spawn`, but instead have to spawn a dedicated thread to
+    // run the future.
+    let executor = Handle::current();
+    Ok(thread::spawn(move || executor.block_on(coord.serve())))
+}
+
+async fn broadcast(tx: &mut comm::broadcast::Sender<SequencedCommand>, cmd: SequencedCommand) {
     // TODO(benesch): avoid flushing after every send.
-    block_on(tx.send(cmd)).unwrap();
+    tx.send(cmd).await.unwrap();
 }
 
 /// Constructs an [`ExecuteResponse`] that that will send some rows to the

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -32,6 +32,6 @@ pub mod session;
 
 pub use crate::catalog::dump as dump_catalog;
 pub use crate::command::{Command, ExecuteResponse, Response, RowsFuture, StartupMessage};
-pub use crate::coord::{Config, Coordinator};
+pub use crate::coord::{serve, Config};
 pub use crate::persistence::PersistenceConfig;
 pub use crate::timestamp::TimestampConfig;

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -192,7 +192,6 @@ pub fn serve<C>(
     threads: usize,
     process: usize,
     switchboard: comm::Switchboard<C>,
-    executor: tokio::runtime::Handle,
 ) -> Result<WorkerGuards<()>, String>
 where
     C: comm::Connection,
@@ -208,7 +207,7 @@ where
     let command_rxs = {
         let mut rx = switchboard.broadcast_rx(BroadcastToken).fanout();
         let command_rxs = Mutex::new((0..threads).map(|_| Some(rx.attach())).collect::<Vec<_>>());
-        executor.spawn(
+        tokio::spawn(
             rx.shuttle()
                 .map_err(|err| panic!("failure shuttling dataflow receiver commands: {}", err)),
         );
@@ -220,8 +219,9 @@ where
         .map_err(|err| format!("failed to initialize networking: {}", err))?;
     let builders = builders.into_iter().map(GenericBuilder::ZeroCopy).collect();
 
+    let tokio_executor = tokio::runtime::Handle::current();
     timely::execute::execute_from(builders, Box::new(guard), move |timely_worker| {
-        executor.enter(|| {
+        tokio_executor.enter(|| {
             let command_rx = command_rxs.lock().unwrap()[timely_worker.index() % threads]
                 .take()
                 .unwrap()
@@ -992,5 +992,5 @@ impl PendingPeek {
 /// doesn't really become slower, because you needed to instantiate these
 /// templates anyway to run tests.
 pub fn __explicit_instantiation__() {
-    ore::hint::black_box(serve::<tokio::net::TcpStream> as fn(_, _, _, _, _) -> _);
+    ore::hint::black_box(serve::<tokio::net::TcpStream> as fn(_, _, _, _) -> _);
 }

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -225,7 +225,7 @@ where
             let command_rx = command_rxs.lock().unwrap()[timely_worker.index() % threads]
                 .take()
                 .unwrap()
-                .request_unparks(&executor);
+                .request_unparks();
             let worker_idx = timely_worker.index();
             Worker {
                 timely_worker,

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -17,5 +17,5 @@ rand = "0.7"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = "0.2"
+tokio = { version = "0.2", features = ["macros"] }
 url = "2"

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -443,7 +443,8 @@ impl<'a> ValueGenerator<'a> {
     }
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let matches = App::new("kgen")
         .about("Put random data in Kafka")
         .arg(
@@ -555,9 +556,9 @@ fn main() -> anyhow::Result<()> {
             let schema = matches.value_of("avro-schema").unwrap();
             let ccsr =
                 ccsr::ClientConfig::new(Url::parse("http://localhost:8081").unwrap()).build();
-            let schema_id = Runtime::new()
-                .unwrap()
-                .block_on(ccsr.publish_schema(&format!("{}-value", topic), schema))?;
+            let schema_id = ccsr
+                .publish_schema(&format!("{}-value", topic), schema)
+                .await?;
             _schema_holder = Some(Schema::parse_str(schema)?);
             let schema = _schema_holder.as_ref().unwrap();
             let annotations = matches.value_of("avro-distribution").unwrap();

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -7,34 +7,33 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::{TryFrom, TryInto};
+use std::ops::Add;
+use std::rc::Rc;
+use std::thread;
+use std::time::Duration;
+
 use anyhow::bail;
 use chrono::{NaiveDate, NaiveDateTime};
 use clap::{App, Arg};
-use mz_avro::{
-    schema::{SchemaNode, SchemaPiece, SchemaPieceOrNamed},
-    types::Value,
-    Schema,
+use rand::distributions::{
+    uniform::SampleUniform, Alphanumeric, Bernoulli, Uniform, WeightedIndex,
 };
-use rand::{
-    distributions::{uniform::SampleUniform, Alphanumeric, Bernoulli, Uniform, WeightedIndex},
-    prelude::{Distribution, ThreadRng},
-    thread_rng,
-};
-use rdkafka::{
-    error::KafkaError,
-    producer::{BaseRecord, DefaultProducerContext, ThreadedProducer},
-    types::RDKafkaError,
-    util::Timeout,
-    ClientConfig,
-};
+use rand::prelude::{Distribution, ThreadRng};
+use rand::thread_rng;
+use rdkafka::error::KafkaError;
+use rdkafka::producer::{BaseRecord, DefaultProducerContext, ThreadedProducer};
+use rdkafka::types::RDKafkaError;
+use rdkafka::util::Timeout;
+use rdkafka::ClientConfig;
 use serde_json::Map;
-use std::convert::{TryFrom, TryInto};
-use std::ops::Add;
-
-use std::time::Duration;
-use std::{cell::RefCell, collections::HashMap, rc::Rc, thread::sleep};
-use tokio::runtime::Runtime;
 use url::Url;
+
+use mz_avro::schema::{SchemaNode, SchemaPiece, SchemaPieceOrNamed};
+use mz_avro::types::Value;
+use mz_avro::Schema;
 
 struct RandomAvroGenerator<'a> {
     // generators
@@ -608,7 +607,7 @@ async fn main() -> anyhow::Result<()> {
                 Ok(()) => break,
                 Err((KafkaError::MessageProduction(RDKafkaError::QueueFull), rec2)) => {
                     rec = rec2;
-                    sleep(Duration::from_secs(1));
+                    thread::sleep(Duration::from_secs(1));
                 }
                 Err((e, _)) => {
                     return Err(e.into());

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -253,7 +253,6 @@ pub async fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
         config.threads,
         config.process,
         switchboard.clone(),
-        Handle::current(),
     )
     .map_err(|s| anyhow!("{}", s))?;
 

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
         SocketAddr::new(listen_addr.ip(), local_addr.port()),
     );
 
-    let switchboard = Switchboard::new(config.addresses, config.process, Handle::current());
+    let switchboard = Switchboard::new(config.addresses, config.process);
 
     // Launch task to serve connections.
     //

--- a/src/ore/src/future/channel.rs
+++ b/src/ore/src/future/channel.rs
@@ -44,7 +44,7 @@ pub mod mpsc {
         /// is unparked, even if another thread holds the receiver.
         ///
         /// TODO(benesch): `impl !Send` once anti-traits land.
-        fn request_unparks(self, executor: &tokio::runtime::Handle) -> Self
+        fn request_unparks(self) -> Self
         where
             Self: Sized;
     }
@@ -53,10 +53,10 @@ pub mod mpsc {
     where
         T: Unpin + Send + 'static,
     {
-        fn request_unparks(self, executor: &tokio::runtime::Handle) -> Self {
+        fn request_unparks(self) -> Self {
             let (tx, rx) = unbounded();
             let fut = UnparkingForward::new(tx, self, thread::current()).map(|_| ());
-            let _ = executor.spawn(fut);
+            let _ = tokio::spawn(fut);
             rx
         }
     }

--- a/src/sqllogictest/src/fuzz.rs
+++ b/src/sqllogictest/src/fuzz.rs
@@ -15,8 +15,8 @@ use coord::ExecuteResponse;
 
 use crate::runner::State;
 
-pub fn fuzz(sqls: &str) {
-    let mut state = State::start().unwrap();
+pub async fn fuzz(sqls: &str) {
+    let mut state = State::start().await.unwrap();
     for sql in sqls.split(';') {
         if let Ok((Some(desc), ExecuteResponse::SendingRows(rx))) = state.run_sql(sql) {
             for row in block_on(rx).unwrap().unwrap_rows() {
@@ -37,8 +37,8 @@ mod test {
 
     use walkdir::WalkDir;
 
-    #[test]
-    fn fuzz_artifacts() {
+    #[tokio::test]
+    async fn fuzz_artifacts() {
         let mut input = String::new();
         for entry in WalkDir::new("../../fuzz/artifacts/fuzz_sqllogictest/") {
             let entry = entry.unwrap();
@@ -48,7 +48,7 @@ mod test {
                     .unwrap()
                     .read_to_string(&mut input)
                     .unwrap();
-                fuzz(&input);
+                fuzz(&input).await;
             }
         }
     }

--- a/src/sqllogictest/src/fuzz.rs
+++ b/src/sqllogictest/src/fuzz.rs
@@ -9,8 +9,6 @@
 
 //! Fuzz testing via sqllogictest.
 
-use futures::executor::block_on;
-
 use coord::ExecuteResponse;
 
 use crate::runner::State;
@@ -18,8 +16,8 @@ use crate::runner::State;
 pub async fn fuzz(sqls: &str) {
     let mut state = State::start().await.unwrap();
     for sql in sqls.split(';') {
-        if let Ok((Some(desc), ExecuteResponse::SendingRows(rx))) = state.run_sql(sql) {
-            for row in block_on(rx).unwrap().unwrap_rows() {
+        if let Ok((Some(desc), ExecuteResponse::SendingRows(rx))) = state.run_sql(sql).await {
+            for row in rx.await.unwrap().unwrap_rows() {
                 for (typ, datum) in desc.iter_types().zip(row.iter()) {
                     assert!(datum.is_instance_of(typ));
                 }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -382,7 +382,6 @@ impl State {
             NUM_TIMELY_WORKERS,
             process_id,
             switchboard.clone(),
-            tokio::runtime::Handle::current(),
         )
         .unwrap();
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -38,7 +38,6 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail};
 use bytes::BytesMut;
-use futures::executor::block_on;
 use itertools::izip;
 use lazy_static::lazy_static;
 use md5::{Digest, Md5};
@@ -412,7 +411,10 @@ impl State {
         })
     }
 
-    fn run_record<'a>(&mut self, record: &'a Record) -> Result<Outcome<'a>, anyhow::Error> {
+    async fn run_record<'a>(
+        &mut self,
+        record: &'a Record<'a>,
+    ) -> Result<Outcome<'a>, anyhow::Error> {
         match &record {
             Record::Statement {
                 expected_error,
@@ -420,7 +422,10 @@ impl State {
                 sql,
                 location,
             } => {
-                match self.run_statement(*expected_error, *rows_affected, sql, location.clone())? {
+                match self
+                    .run_statement(*expected_error, *rows_affected, sql, location.clone())
+                    .await?
+                {
                     Outcome::Success => Ok(Outcome::Success),
                     other => {
                         if expected_error.is_some() {
@@ -441,12 +446,12 @@ impl State {
                 sql,
                 output,
                 location,
-            } => self.run_query(sql, output, location.clone()),
+            } => self.run_query(sql, output, location.clone()).await,
             _ => Ok(Outcome::Success),
         }
     }
 
-    fn run_statement<'a>(
+    async fn run_statement<'a>(
         &mut self,
         expected_error: Option<&'a str>,
         expected_rows_affected: Option<usize>,
@@ -462,7 +467,7 @@ impl State {
             return Ok(Outcome::Success);
         }
 
-        match self.run_sql(sql) {
+        match self.run_sql(sql).await {
             Ok((_desc, resp)) => {
                 if let Some(expected_error) = expected_error {
                     return Ok(Outcome::UnexpectedPlanSuccess {
@@ -505,10 +510,10 @@ impl State {
         }
     }
 
-    fn run_query<'a>(
+    async fn run_query<'a>(
         &mut self,
         sql: &'a str,
-        output: &'a Result<QueryOutput, &'a str>,
+        output: &'a Result<QueryOutput<'_>, &'a str>,
         location: Location,
     ) -> Result<Outcome<'a>, anyhow::Error> {
         // get statement
@@ -540,10 +545,10 @@ impl State {
         }
 
         // send plan, read response
-        let (desc, rows) = match self.run_sql(sql) {
+        let (desc, rows) = match self.run_sql(sql).await {
             Ok((desc, ExecuteResponse::SendingRows(rx))) => {
                 let desc = desc.expect("RelationDesc missing for query that returns rows");
-                let rows = match block_on(rx)? {
+                let rows = match rx.await? {
                     PeekResponse::Rows(rows) => Ok(rows),
                     PeekResponse::Error(e) => Err(anyhow!("{}", e)),
                     PeekResponse::Canceled => {
@@ -722,7 +727,7 @@ impl State {
         Ok(Outcome::Success)
     }
 
-    pub(crate) fn run_sql(
+    pub(crate) async fn run_sql(
         &mut self,
         sql: &str,
     ) -> Result<(Option<RelationDesc>, ExecuteResponse), anyhow::Error> {
@@ -747,7 +752,7 @@ impl State {
                     tx,
                 })
                 .expect("futures channel should not fail");
-            let resp = block_on(rx).expect("futures channel should not fail");
+            let resp = rx.await.expect("futures channel should not fail");
             resp.result?;
             self.session = resp.session;
         }
@@ -772,7 +777,7 @@ impl State {
                     tx,
                 })
                 .expect("futures channel should not fail");
-            let resp = block_on(rx).expect("futures channel should not fail");
+            let resp = rx.await.expect("futures channel should not fail");
             self.session = resp.session;
             Ok((desc, resp.result?))
         }
@@ -807,6 +812,7 @@ pub async fn run_string(
 
         let outcome = state
             .run_record(&record)
+            .await
             .map_err(|err| format!("In {}:\n{}", source, err))
             .unwrap();
 
@@ -859,7 +865,7 @@ pub async fn rewrite_file(filename: &Path, _verbosity: usize) -> Result<(), anyh
     println!("==> {}", filename.display());
     for record in parser.parse_records()? {
         let record = record;
-        let outcome = state.run_record(&record)?;
+        let outcome = state.run_record(&record).await?;
 
         // If we see an output failure for a query, rewrite the expected output
         // to match the observed output.


### PR DESCRIPTION
Make the boundary between async/sync glue code simpler by pushing most of the interop to the very edges of the system. This means most everything in Materialize that interacts with any async code, outside of the dataflow layer becomes an `async fn` itself. Previously we'd sprinkle manual calls to `block_on` about, which are much less performant than using `.await` and unidiomatic to boot.

This hopefully makes it easier to onboard new users into the ecosystem. Most of the existing confusion was fallout from the imperfect transition from the futures v0.1 ecosystem to the async/await ecosystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4287)
<!-- Reviewable:end -->
