### PR TITLE
expr: remove dead GlobalId constructors

### DIFF
--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -65,18 +65,6 @@ pub enum GlobalId {
 }
 
 impl GlobalId {
-    /// Constructs a new global identifier in the system namespace. It is the
-    /// caller's responsibility to provide a unique `v`.
-    pub fn system(v: u64) -> GlobalId {
-        GlobalId::System(v)
-    }
-
-    /// Constructs a new global identifier in the user namespace. It is the
-    /// caller's responsiblity to provide a unique `v`.
-    pub fn user(v: u64) -> GlobalId {
-        GlobalId::User(v)
-    }
-
     /// Reports whether this ID is in the system namespace.
     pub fn is_system(&self) -> bool {
         match self {


### PR DESCRIPTION
These were always rather silly, since the enum variants are public
and these methods didn't do anything special.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4291)
<!-- Reviewable:end -->
