### PR TITLE
coord: allocate persistent and temporary IDs from separate namespaces

### DIFF
--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -62,6 +62,8 @@ pub enum GlobalId {
     System(u64),
     /// User namespace.
     User(u64),
+    /// Transient namespace.
+    Transient(u64),
 }
 
 impl GlobalId {
@@ -81,15 +83,23 @@ impl GlobalId {
     pub fn is_system(&self) -> bool {
         match self {
             GlobalId::System(_) => true,
-            GlobalId::User(_) => false,
+            _ => false,
         }
     }
 
     /// Reports whether this ID is in the user namespace.
     pub fn is_user(&self) -> bool {
         match self {
-            GlobalId::System(_) => false,
             GlobalId::User(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Reports whether this ID is in the transient namespace.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            GlobalId::Transient(_) => true,
+            _ => false,
         }
     }
 }
@@ -105,6 +115,7 @@ impl FromStr for GlobalId {
         match s.chars().next().unwrap() {
             's' => Ok(GlobalId::System(val)),
             'u' => Ok(GlobalId::User(val)),
+            't' => Ok(GlobalId::Transient(val)),
             _ => Err(anyhow!("couldn't parse id {}", s)),
         }
     }
@@ -115,6 +126,7 @@ impl fmt::Display for GlobalId {
         match self {
             GlobalId::System(id) => write!(f, "s{}", id),
             GlobalId::User(id) => write!(f, "u{}", id),
+            GlobalId::Transient(id) => write!(f, "t{}", id),
         }
     }
 }

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -223,7 +223,7 @@ EXPLAIN PLAN FOR SELECT
 FROM x
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 | Map (#0 != #1), (#0 = #1), (#0 >= #1), (#0 <= #1), (#0 < #1), (#0 > #1), !((#2 @> {}))
 | Project (#4..#9, #3, #10)
 
@@ -239,7 +239,7 @@ EXPLAIN PLAN FOR SELECT
 FROM y
 ----
 %0 =
-| Get materialize.public.y (u7)
+| Get materialize.public.y (u5)
 | Project (#0)
 
 EOF
@@ -251,7 +251,7 @@ EXPLAIN PLAN FOR SELECT
 FROM y
 ----
 %0 =
-| Get materialize.public.y (u7)
+| Get materialize.public.y (u5)
 | Map (!(#1) || null)
 | Project (#2)
 
@@ -265,7 +265,7 @@ EXPLAIN PLAN FOR SELECT
 FROM y
 ----
 %0 =
-| Get materialize.public.y (u7)
+| Get materialize.public.y (u5)
 | Map (#1 && null)
 | Project (#2)
 
@@ -278,7 +278,7 @@ EXPLAIN PLAN FOR SELECT
 FROM y
 ----
 %0 =
-| Get materialize.public.y (u7)
+| Get materialize.public.y (u5)
 | Map (#1 || null)
 | Project (#2)
 
@@ -291,7 +291,7 @@ EXPLAIN PLAN FOR SELECT
 FROM y
 ----
 %0 =
-| Get materialize.public.y (u7)
+| Get materialize.public.y (u5)
 | Map (!(#1) && null)
 | Project (#2)
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -137,7 +137,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT date_trunc('day', ts) FROM date_trunc_timestamps
 ----
 %0 =
-| Get materialize.public.date_trunc_timestamps (u7)
+| Get materialize.public.date_trunc_timestamps (u3)
 | Map date_trunc_day_ts(#0)
 | Project (#1)
 
@@ -151,7 +151,7 @@ EXPLAIN PLAN FOR SELECT date_trunc(field, ts) FROM date_trunc_fields, date_trunc
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.date_trunc_timestamps (u7)
+| Get materialize.public.date_trunc_timestamps (u3)
 
 %2 =
 | Join %0 %1
@@ -398,7 +398,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT a IS NULL FROM t
 ----
 %0 =
-| Get materialize.public.t (u21)
+| Get materialize.public.t (u9)
 | Map isnull(#0)
 | Project (#2)
 
@@ -408,7 +408,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT a + a + a + a + a IS NULL FROM t
 ----
 %0 =
-| Get materialize.public.t (u21)
+| Get materialize.public.t (u9)
 | Map isnull(#0)
 | Project (#2)
 
@@ -418,7 +418,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT a + b IS NULL FROM t
 ----
 %0 =
-| Get materialize.public.t (u21)
+| Get materialize.public.t (u9)
 | Map isnull(#0)
 | Project (#2)
 
@@ -432,7 +432,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT (a::bool AND b::bool) IS NULL FROM t
 ----
 %0 =
-| Get materialize.public.t (u21)
+| Get materialize.public.t (u9)
 | Map isnull((i32tobool(#0) && i32tobool(#1)))
 | Project (#2)
 

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -252,10 +252,10 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2)
 ----
 %0 =
-| Get materialize.public.t1 (u39)
+| Get materialize.public.t1 (u17)
 
 %1 =
-| Get materialize.public.t2 (u41)
+| Get materialize.public.t2 (u19)
 | Distinct group=()
 | ArrangeBy ()
 
@@ -270,14 +270,14 @@ query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2)
 ----
 %0 =
-| Get materialize.public.t1 (u39)
+| Get materialize.public.t1 (u17)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t3 (u43)
+| Get materialize.public.t3 (u21)
 
 %2 =
-| Get materialize.public.t2 (u41)
+| Get materialize.public.t2 (u19)
 | Distinct group=()
 | ArrangeBy ()
 
@@ -293,11 +293,11 @@ query T multiline
 EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FROM t2 WHERE t3.b = t2.b)
 ----
 %0 =
-| Get materialize.public.t1 (u39)
+| Get materialize.public.t1 (u17)
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t3 (u43)
+| Get materialize.public.t3 (u21)
 
 %2 =
 | Join %0 %1 (= #0 #1)
@@ -313,7 +313,7 @@ EXPLAIN PLAN FOR SELECT *  FROM t1, t3 WHERE t1.a = t3.a AND EXISTS (SELECT * FR
 | ArrangeBy (#0)
 
 %5 =
-| Get materialize.public.t2 (u41)
+| Get materialize.public.t2 (u19)
 | ArrangeBy (#0)
 
 %6 =
@@ -355,7 +355,7 @@ SELECT age, ascii_num * 2 as result FROM (
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.age (u23)
+| Get materialize.public.age (u9)
 | Filter !(isnull(#0))
 
 %2 =
@@ -471,7 +471,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 ----
 %0 =
-| Get materialize.public.y (u59)
+| Get materialize.public.y (u27)
 | Distinct group=(#0)
 
 %1 =
@@ -479,7 +479,7 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.x (u57)
+| Get materialize.public.x (u25)
 | ArrangeBy (#0)
 
 %3 =
@@ -491,7 +491,7 @@ EXPLAIN PLAN FOR SELECT b IN (SELECT a FROM x) FROM y
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u59)
+| Get materialize.public.y (u27)
 | ArrangeBy (#0)
 
 %5 =
@@ -524,7 +524,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 ----
 %0 =
-| Get materialize.public.y (u59)
+| Get materialize.public.y (u27)
 | Distinct group=(#0)
 
 %1 =
@@ -532,7 +532,7 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.x (u57)
+| Get materialize.public.x (u25)
 | ArrangeBy (#0)
 
 %3 =
@@ -544,7 +544,7 @@ EXPLAIN PLAN FOR SELECT b != ALL(SELECT a FROM x) FROM y
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u59)
+| Get materialize.public.y (u27)
 | ArrangeBy (#0)
 
 %5 =
@@ -579,7 +579,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 ----
 %0 =
-| Get materialize.public.y (u59)
+| Get materialize.public.y (u27)
 | Distinct group=(#0)
 
 %1 =
@@ -587,7 +587,7 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 | ArrangeBy ()
 
 %2 =
-| Get materialize.public.x (u57)
+| Get materialize.public.x (u25)
 
 %3 =
 | Join %1 %2
@@ -597,7 +597,7 @@ EXPLAIN PLAN FOR SELECT b > ALL(SELECT a FROM x) FROM y
 | Distinct group=(#0)
 
 %4 =
-| Get materialize.public.y (u59)
+| Get materialize.public.y (u27)
 | ArrangeBy (#0)
 
 %5 =

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -181,7 +181,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(1, a)
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 
 %1 =
 | CallTable generate_series(1, #^0)
@@ -195,7 +195,7 @@ query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(100::bigint, a)
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 
 %1 =
 | CallTable generate_series(i32toi64(100), i32toi64(#^0))
@@ -209,7 +209,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, 10)
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 | FlatMap generate_series(1, 10)
 | | demand = (#0..#2)
 
@@ -219,7 +219,7 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x, generate_series(1, a)
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 | FlatMap generate_series(1, #0)
 | | demand = (#0..#2)
 
@@ -229,11 +229,11 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 
 %2 =
 | Join %0 %1
@@ -249,11 +249,11 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.b = x2.b
 ----
 %0 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 | ArrangeBy ()
 
 %1 =
-| Get materialize.public.x (u5)
+| Get materialize.public.x (u3)
 
 %2 =
 | Join %0 %1

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -104,7 +104,7 @@ where foo.a = bar.a
 | ArrangeBy (#0)
 
 %2 =
-| Get materialize.public.baz (u11)
+| Get materialize.public.baz (u9)
 | ArrangeBy (#0)
 
 %3 =


### PR DESCRIPTION
Introduce a new temporary ID namespace so that queries like "SELECT *
FROM t" do not unnecessarily run up the ID counter for persistent
catalog objects. The old behavior had confused users on a few occasions,
since the first view created might be assigned "u1" but later views
would easily be assigned much greater and discontiguous IDs, like
"u10238".

There's no technical reason this was problematic. Just a matter of
aesthetics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4292)
<!-- Reviewable:end -->
