### PR TITLE
sql: support qualified function names

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -437,9 +437,9 @@ impl Expr {
         self.binop(BinaryOperator::Divide, right)
     }
 
-    pub fn call(name: &str, args: Vec<Expr>) -> Expr {
+    pub fn call(name: Vec<&str>, args: Vec<Expr>) -> Expr {
         Expr::Function(Function {
-            name: ObjectName(vec![name.into()]),
+            name: ObjectName(name.into_iter().map(Into::into).collect()),
             args: FunctionArgs::Args(args),
             filter: None,
             over: None,
@@ -447,11 +447,11 @@ impl Expr {
         })
     }
 
-    pub fn call_nullary(name: &str) -> Expr {
+    pub fn call_nullary(name: Vec<&str>) -> Expr {
         Expr::call(name, vec![])
     }
 
-    pub fn call_unary(self, name: &str) -> Expr {
+    pub fn call_unary(self, name: Vec<&str>) -> Expr {
         Expr::call(name, vec![self])
     }
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -9,7 +9,6 @@
 
 use std::collections::HashMap;
 
-use ore::collections::CollectionExt;
 use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::{self, VisitMut};
@@ -25,13 +24,6 @@ use crate::plan::statement::StatementContext;
 
 pub fn ident(ident: Ident) -> String {
     ident.as_str().into()
-}
-
-pub fn function_name(name: ObjectName) -> Result<String, PlanError> {
-    if name.0.len() != 1 {
-        unsupported!("qualified function names");
-    }
-    Ok(ident(name.0.into_element()))
 }
 
 pub fn column_name(id: Ident) -> ColumnName {
@@ -264,6 +256,8 @@ mod tests {
     use std::collections::BTreeMap;
     use std::error::Error;
     use std::rc::Rc;
+
+    use ore::collections::CollectionExt;
 
     use super::*;
     use crate::catalog::DummyCatalog;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -67,7 +67,7 @@ pub fn plan_root_query(
     mut query: Query,
     lifetime: QueryLifetime,
 ) -> Result<(RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
-    transform_ast::transform_query(&mut query)?;
+    transform_ast::transform_query(scx, &mut query)?;
     let qcx = QueryContext::root(scx, lifetime);
     let (mut expr, scope, mut finishing) = plan_query(&qcx, &query)?;
 
@@ -142,7 +142,7 @@ pub fn plan_insert_query(
             && offset.is_none()
             && fetch.is_none() =>
         {
-            transform_ast::transform_values(&mut values)?;
+            transform_ast::transform_values(scx, &mut values)?;
             let type_hints = Some(desc.iter_types().map(|typ| &typ.scalar_type).collect());
             let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
             let (expr, _scope) = plan_values(&qcx, &values.0, type_hints)?;
@@ -197,7 +197,7 @@ pub fn eval_as_of<'a>(
         allow_subqueries: false,
     };
 
-    transform_ast::transform_expr(&mut expr)?;
+    transform_ast::transform_expr(scx, &mut expr)?;
     let ex = plan_expr(ecx, &expr)?
         .type_as_any(ecx)?
         .lower_uncorrelated()?;
@@ -234,7 +234,7 @@ pub fn plan_index_exprs<'a>(
     };
     let mut out = vec![];
     for mut expr in exprs {
-        transform_ast::transform_expr(&mut expr)?;
+        transform_ast::transform_expr(scx, &mut expr)?;
         let expr = plan_expr_or_col_index(ecx, &expr)?;
         out.push(expr.lower_uncorrelated()?);
     }
@@ -595,7 +595,7 @@ fn plan_view_select_intrusive(
 
     // Step 3. Gather aggregates.
     let aggregates = {
-        let mut aggregate_visitor = AggregateFuncVisitor::new();
+        let mut aggregate_visitor = AggregateFuncVisitor::new(&qcx.scx);
         for p in projection {
             aggregate_visitor.visit_select_item(p);
         }
@@ -1038,23 +1038,23 @@ fn plan_table_function(
     alias: Option<&TableAlias>,
     args: &FunctionArgs,
 ) -> Result<(RelationExpr, Scope), anyhow::Error> {
-    let ident = normalize::function_name(name.clone())?;
+    let name = normalize::object_name(name.clone())?;
 
-    if ident == "values" {
+    if name.database.is_none() && name.schema.is_none() && name.item == "values" {
         // Produce a nice error message for the common typo
         // `SELECT * FROM VALUES (1)`.
         bail!("VALUES expression in FROM clause must be surrounded by parentheses");
     }
 
-    let impls = match func::resolve(&*ident)? {
+    let impls = match func::resolve(&ecx.qcx.scx, &name)? {
         Func::Table(impls) => impls,
-        _ => bail!("{} is not a table function", ident),
+        _ => bail!("{} is not a table function", name),
     };
     let args = match args {
-        FunctionArgs::Star => bail!("{} does not accept * as an argument", ident),
+        FunctionArgs::Star => bail!("{} does not accept * as an argument", name),
         FunctionArgs::Args(args) => args,
     };
-    let tf = func::select_impl(ecx, &*ident, impls, args)?;
+    let tf = func::select_impl(ecx, &name, impls, args)?;
     let call = RelationExpr::CallTable {
         func: tf.func,
         exprs: tf.exprs,
@@ -1063,7 +1063,7 @@ fn plan_table_function(
         Some(PartialName {
             database: None,
             schema: None,
-            item: ident,
+            item: name.item,
         }),
         tf.column_names,
         Some(ecx.qcx.outer_scope.clone()),
@@ -1132,11 +1132,14 @@ fn plan_table_alias(mut scope: Scope, alias: Option<&TableAlias>) -> Result<Scop
 fn invent_column_name(ecx: &ExprContext, expr: &Expr) -> Option<ScopeItemName> {
     let name = match expr {
         Expr::Identifier(names) => names.last().map(|n| normalize::column_name(n.clone())),
-        Expr::Function(func) => match func.name.0.last() {
-            None => None,
-            Some(name) if name.as_str().starts_with("internal_") => None,
-            Some(name) => Some(normalize::column_name(name.clone())),
-        },
+        Expr::Function(func) => {
+            let name = normalize::object_name(func.name.clone()).ok()?;
+            if name.schema.as_deref() == Some("mz_internal") {
+                None
+            } else {
+                Some(name.item.into())
+            }
+        }
         Expr::Coalesce { .. } => Some("coalesce".into()),
         Expr::List { .. } => Some("list".into()),
         Expr::Cast { expr, .. } => return invent_column_name(ecx, expr),
@@ -1790,8 +1793,8 @@ pub fn plan_homogeneous_exprs(
 }
 
 fn plan_aggregate(ecx: &ExprContext, sql_func: &Function) -> Result<AggregateExpr, anyhow::Error> {
-    let name = normalize::function_name(sql_func.name.clone())?;
-    let impls = match func::resolve(&name)? {
+    let name = normalize::object_name(sql_func.name.clone())?;
+    let impls = match func::resolve(&ecx.qcx.scx, &name)? {
         Func::Aggregate(impls) => impls,
         _ => unreachable!("plan_aggregate called on non-aggregate function,"),
     };
@@ -1923,9 +1926,8 @@ fn plan_function<'a>(
     ecx: &ExprContext,
     sql_func: &'a Function,
 ) -> Result<ScalarExpr, anyhow::Error> {
-    let name = normalize::function_name(sql_func.name.clone())?;
-    let ident = &*name;
-    let impls = match func::resolve(ident)? {
+    let name = normalize::object_name(sql_func.name.clone())?;
+    let impls = match func::resolve(&ecx.qcx.scx, &name)? {
         Func::Aggregate(_) if ecx.allow_aggregates => {
             // should already have been caught by `scope.resolve_expr` in `plan_expr`
             bail!(
@@ -1939,7 +1941,7 @@ fn plan_function<'a>(
         Func::Table(_) => {
             unsupported!(
                 1546,
-                format!("table function ({}) in scalar position", ident)
+                format!("table function ({}) in scalar position", name)
             );
         }
         Func::Scalar(impls) => impls,
@@ -1951,18 +1953,15 @@ fn plan_function<'a>(
     if sql_func.filter.is_some() {
         bail!(
             "FILTER specified but {}() is not an aggregate function",
-            ident
+            name
         );
     }
     let args = match &sql_func.args {
-        FunctionArgs::Star => bail!(
-            "* argument is invalid with non-aggregate function {}",
-            ident
-        ),
+        FunctionArgs::Star => bail!("* argument is invalid with non-aggregate function {}", name),
         FunctionArgs::Args(args) => args,
     };
 
-    func::select_impl(ecx, ident, impls, args)
+    func::select_impl(ecx, &name, impls, args)
 }
 
 fn plan_is_null_expr<'a>(
@@ -2171,15 +2170,17 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
 
 /// This is used to collect aggregates from within an `Expr`.
 /// See the explanation of aggregate handling at the top of the file for more details.
-struct AggregateFuncVisitor<'ast> {
+struct AggregateFuncVisitor<'a, 'ast> {
+    scx: &'a StatementContext<'a>,
     aggs: Vec<&'ast Function>,
     within_aggregate: bool,
     err: Option<anyhow::Error>,
 }
 
-impl<'ast> AggregateFuncVisitor<'ast> {
-    fn new() -> AggregateFuncVisitor<'ast> {
+impl<'a, 'ast> AggregateFuncVisitor<'a, 'ast> {
+    fn new(scx: &'a StatementContext<'a>) -> AggregateFuncVisitor<'a, 'ast> {
         AggregateFuncVisitor {
+            scx,
             aggs: Vec::new(),
             within_aggregate: false,
             err: None,
@@ -2203,10 +2204,10 @@ impl<'ast> AggregateFuncVisitor<'ast> {
     }
 }
 
-impl<'ast> Visit<'ast> for AggregateFuncVisitor<'ast> {
+impl<'a, 'ast> Visit<'ast> for AggregateFuncVisitor<'a, 'ast> {
     fn visit_function(&mut self, func: &'ast Function) {
-        if let Ok(name) = normalize::function_name(func.name.clone()) {
-            if let Ok(Func::Aggregate(_)) = func::resolve(&name) {
+        if let Ok(name) = normalize::object_name(func.name.clone()) {
+            if let Ok(Func::Aggregate(_)) = func::resolve(self.scx, &name) {
                 if self.within_aggregate {
                     self.err = Some(anyhow!("nested aggregate functions are not allowed"));
                     return;

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -437,3 +437,45 @@ EXPLAIN PLAN FOR SELECT (a::bool AND b::bool) IS NULL FROM t
 | Project (#2)
 
 EOF
+
+# Test qualified function names.
+
+query I
+SELECT abs(-1)
+----
+1
+
+query I
+SELECT pg_catalog.abs(1)
+----
+1
+
+query I
+SELECT materialize.pg_catalog.abs(1)
+----
+1
+
+query error function "mz_catalog.abs" does not exist
+SELECT mz_catalog.abs(1)
+
+query error unknown database 'noexist'
+SELECT noexist.pg_catalog.abs(1)
+
+# mod is a special case for qualified function names, since it is transformed
+# away by an early pass in the planner.
+
+query I
+SELECT mod(7, 4)
+----
+3
+
+query I
+SELECT pg_catalog.mod(7, 4)
+----
+3
+
+query error function "mz_catalog.mod" does not exist
+SELECT mz_catalog.mod(7, 4)
+
+query error unknown database 'noexist'
+SELECT noexist.pg_catalog.mod(7, 4)


### PR DESCRIPTION
In PostgreSQL functions belong to a schema and can be referred to by
their fully-qualified name, like "pg_catalog.abs". This commit adds
support for that feature.

Fix #4258.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4293)
<!-- Reviewable:end -->
