### PR TITLE
comm: attempt to deflake test_mpsc_connection_reuse

### DIFF
--- a/src/comm/tests/mpsc.rs
+++ b/src/comm/tests/mpsc.rs
@@ -73,7 +73,7 @@ async fn test_mpsc_limited_close() -> Result<(), Box<dyn Error>> {
 /// Verifies that TCP connections are reused by repeatedly connecting the same
 /// MPSC transmitter. Without connection reuse, the test should crash with an
 /// AddrNotAvailable error because the OS will run out of outgoing TCP ports.
-#[tokio::test]
+#[tokio::test(threaded_scheduler)]
 async fn test_mpsc_connection_reuse() -> Result<(), Box<dyn Error>> {
     ore::test::init_logging();
 


### PR DESCRIPTION
This test is sometimes hanging forever in CI. I'm unable to reproduce
this failure locally, but a common cause for failures of this sort is
using Tokio's basic runtime instead of its multi-threaded runtime.
Successfully using the basic runtime requires being very careful to not
require any actual parallelism, since everything runs on only one
thread, and likely this test is not that careful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4297)
<!-- Reviewable:end -->
