### PR TITLE
sql: add support for the oid type

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -64,6 +64,8 @@ Wrap your release notes at the 80 character mark.
   `pg_catalog` schemas, this support improves compatibility with various
   PostgreSQL tools that generate SQL queries with qualified function references.
 
+- Add support for the [`oid`] type to represent PostgreSQL object IDs.
+
 <span id="v0.4.3"></span>
 ## v0.4.3
 

--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -22,7 +22,8 @@ Type | Aliases | Use | Size (bytes) | Syntax
 [`integer`](integer) | `int4`, `int` | Signed integer | 4 | `123`
 [`interval`](interval) | | Duration of time | 32 | `INTERVAL '1-2 3 4:5:6.7'`
 [`jsonb`](jsonb) | `json` | JSON | Variable | `'{"1":2,"3":4}'::jsonb`
-[`record`](record) | | Tuple with arbitrary contents | Variable | `ROW($expr, ...)`
+[`record`](record) | | Tuple with arbitrary contents | Variable | `ROW($expr, ...)
+[`oid`](oid) | | PostgreSQL object identifier | 4 | `123`
 [`text`](text) | `string` | Unicode string | Variable | `'foo'`
 [`time`](time) | | Time without date | 4 | `TIME '01:23:45'`
 [`timestamp`](timestamp) | | Date and time | 8 | `TIMESTAMP '2007-02-01 15:04:05'`

--- a/doc/user/content/sql/types/oid.md
+++ b/doc/user/content/sql/types/oid.md
@@ -1,0 +1,27 @@
+---
+title: "oid Data Type"
+description: "Express a PostgreSQL-compatible object identifier"
+menu:
+  main:
+    parent: 'sql-types'
+---
+
+`oid` expresses a PostgreSQL-compatible object identifier.
+
+## Details
+
+`oid` types in Materialize are provided for compatibility with PostgreSQL . You
+typically will not interact with the `oid` type unless you are working with a
+tool that was developed for PostgreSQL.
+
+See the [Object Identifier Types][pg-oid] section of the PostgreSQL
+documentation for more details.
+
+### Valid casts
+
+You can [cast](../../functions/cast) `oid` to and from:
+
+- [`int`](../integer)
+- [`text`](../text)
+
+[pg-oid]: https://www.postgresql.org/docs/current/datatype-oid.html

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2935,7 +2935,7 @@ where
     use ScalarType::*;
     match &ty {
         Bool => strconv::format_bool(buf, d.unwrap_bool()),
-        Int32 => strconv::format_int32(buf, d.unwrap_int32()),
+        Int32 | Oid => strconv::format_int32(buf, d.unwrap_int32()),
         Int64 => strconv::format_int64(buf, d.unwrap_int64()),
         Float32 => strconv::format_float32(buf, d.unwrap_float32()),
         Float64 => strconv::format_float64(buf, d.unwrap_float64()),

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1548,7 +1548,7 @@ fn build_schema(columns: &[(ColumnName, ColumnType)], include_transaction: bool)
     for (name, typ) in columns.iter() {
         let mut field_type = match &typ.scalar_type {
             ScalarType::Bool => json!("boolean"),
-            ScalarType::Int32 => json!("int"),
+            ScalarType::Int32 | ScalarType::Oid => json!("int"),
             ScalarType::Int64 => json!("long"),
             ScalarType::Float32 => json!("float"),
             ScalarType::Float64 => json!("double"),
@@ -1914,7 +1914,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
         } else {
             let mut val = match &typ.scalar_type {
                 ScalarType::Bool => Value::Boolean(datum.unwrap_bool()),
-                ScalarType::Int32 => Value::Int(datum.unwrap_int32()),
+                ScalarType::Int32 | ScalarType::Oid => Value::Int(datum.unwrap_int32()),
                 ScalarType::Int64 => Value::Long(datum.unwrap_int64()),
                 ScalarType::Float32 => Value::Float(datum.unwrap_float32()),
                 ScalarType::Float64 => Value::Double(datum.unwrap_float64()),
@@ -2199,7 +2199,7 @@ pub mod cdc_v2 {
         for (name, typ) in columns.iter() {
             let mut field_type = match &typ.scalar_type {
                 ScalarType::Bool => json!("boolean"),
-                ScalarType::Int32 => json!("int"),
+                ScalarType::Int32 | ScalarType::Oid => json!("int"),
                 ScalarType::Int64 => json!("long"),
                 ScalarType::Float32 => json!("float"),
                 ScalarType::Float64 => json!("double"),

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -47,6 +47,8 @@ pub enum Type {
     TimestampTz,
     /// A universally unique identifier.
     Uuid,
+    /// An object identifier.
+    Oid,
 }
 
 lazy_static! {
@@ -105,6 +107,7 @@ impl Type {
             Type::Uuid => &postgres_types::Type::UUID,
             Type::List(_) => &LIST,
             Type::Record(_) => &postgres_types::Type::RECORD,
+            Type::Oid => &postgres_types::Type::OID,
         }
     }
 
@@ -141,6 +144,7 @@ impl Type {
             Type::Uuid => 16,
             Type::List(_) => -1,
             Type::Record(_) => -1,
+            Type::Oid => 4,
         }
     }
 }
@@ -167,6 +171,7 @@ impl From<&ScalarType> for Type {
             ScalarType::Record { fields } => {
                 Type::Record(fields.iter().map(|(_name, ty)| Type::from(ty)).collect())
             }
+            ScalarType::Oid => Type::Oid,
         }
     }
 }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -638,6 +638,8 @@ pub enum ScalarType {
         /// to right.
         fields: Vec<(ColumnName, ScalarType)>,
     },
+    /// A PostgreSQL object identifier.
+    Oid,
 }
 
 impl<'a> ScalarType {
@@ -726,7 +728,8 @@ impl PartialEq for ScalarType {
             | (Bytes, Bytes)
             | (String, String)
             | (Uuid, Uuid)
-            | (Jsonb, Jsonb) => true,
+            | (Jsonb, Jsonb)
+            | (Oid, Oid) => true,
 
             (List(a), List(b)) => a.eq(b),
             (Record { fields: fields_a }, Record { fields: fields_b }) => fields_a.eq(fields_b),
@@ -747,7 +750,8 @@ impl PartialEq for ScalarType {
             | (Jsonb, _)
             | (Uuid, _)
             | (List(_), _)
-            | (Record { .. }, _) => false,
+            | (Record { .. }, _)
+            | (Oid, _) => false,
         }
     }
 }
@@ -784,6 +788,7 @@ impl Hash for ScalarType {
                 fields.hash(state);
             }
             Uuid => state.write_u8(16),
+            Oid => state.write_u8(16),
         }
     }
 }
@@ -818,6 +823,7 @@ impl fmt::Display for ScalarType {
                 write_delimited(f, ", ", fields, |f, (n, t)| write!(f, "{}: {}", n, t))?;
                 f.write_str(")")
             }
+            Oid => f.write_str("oid"),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -228,6 +228,8 @@ pub enum DataType {
     List(Box<DataType>),
     /// Binary JSON
     Jsonb,
+    /// Object ID
+    Oid,
 }
 
 impl AstDisplay for DataType {
@@ -290,6 +292,7 @@ impl AstDisplay for DataType {
                 f.write_str(" list");
             }
             DataType::Jsonb => f.write_str("jsonb"),
+            DataType::Oid => f.write_str("oid"),
         }
     }
 }

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -326,6 +326,7 @@ define_keywords!(
     OLD,
     ON,
     ONLY,
+    OID,
     OPEN,
     OPTIMIZED,
     OR,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2131,6 +2131,7 @@ impl Parser {
                 "SMALLINT" => DataType::SmallInt,
                 "INT" | "INTEGER" | "INT4" => DataType::Int,
                 "INT8" | "BIGINT" => DataType::BigInt,
+                "OID" => DataType::Oid,
                 "VARCHAR" => DataType::Varchar(self.parse_optional_precision()?),
                 "CHAR" | "CHARACTER" => {
                     if self.parse_keyword("VARYING") {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -75,7 +75,8 @@ impl TypeCategory {
             | ScalarType::Float32
             | ScalarType::Float64
             | ScalarType::Int32
-            | ScalarType::Int64 => Self::Numeric,
+            | ScalarType::Int64
+            | ScalarType::Oid => Self::Numeric,
             ScalarType::Interval => Self::Timespan,
             ScalarType::String => Self::String,
             ScalarType::Record { .. } => Self::Pseudo,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2135,6 +2135,7 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, anyhow::
         DataType::Jsonb => ScalarType::Jsonb,
         DataType::Uuid => ScalarType::Uuid,
         DataType::List(elem_type) => ScalarType::List(Box::new(scalar_type_from_sql(elem_type)?)),
+        DataType::Oid => ScalarType::Oid,
         other @ DataType::Binary(..)
         | other @ DataType::Blob(_)
         | other @ DataType::Clob(_)
@@ -2165,6 +2166,7 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
         pgrepr::Type::Record(_) => {
             bail!("internal error: can't convert from pg record to materialize record")
         }
+        pgrepr::Type::Oid => Ok(ScalarType::Oid),
     }
 }
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -198,6 +198,7 @@ lazy_static! {
 
             //INT32
             (Int32, Explicit(Bool)) => CastInt32ToBool,
+            (Int32, Explicit(Oid)) => CastOp::F(noop_cast),
             (Int32, Implicit(Int64)) => CastInt32ToInt64,
             (Int32, Implicit(Float32)) => CastInt32ToFloat32,
             (Int32, Implicit(Float64)) => CastInt32ToFloat64,
@@ -219,6 +220,10 @@ lazy_static! {
             (Int64, Implicit(Float64)) => CastInt64ToFloat64,
             (Int64, Explicit(String)) => CastInt64ToString,
             (Int64, JsonbAny) => CastOp::F(to_jsonb_any_f64_cast),
+
+            // OID
+            (Oid, Explicit(Int32)) => CastOp::F(noop_cast),
+            (Int32, Explicit(String)) => CastInt32ToString,
 
             // FLOAT32
             (Float32, Explicit(Int64)) => CastFloat32ToInt64,
@@ -317,6 +322,7 @@ lazy_static! {
             (String, Explicit(Bool)) => CastStringToBool,
             (String, Explicit(Int32)) => CastStringToInt32,
             (String, Explicit(Int64)) => CastStringToInt64,
+            (String, Explicit(Oid)) => CastStringToInt32,
             (String, Explicit(Float32)) => CastStringToFloat32,
             (String, Explicit(Float64)) => CastStringToFloat64,
             (String, Explicit(Decimal(0,0))) => CastOp::F(|_ecx, e, to_type| {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -351,6 +351,8 @@ fn format_row(
                 str::from_utf8(&buf).unwrap().to_owned()
             }
 
+            (Type::Oid, ScalarType::Int32) => format!("{}", d.unwrap_int32()),
+
             other => panic!("Don't know how to format {:?}", other),
         }
     });

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -366,7 +366,7 @@ fn push_column(
             let i = get_column_inner::<i16>(postgres_row, i, nullable)?.map(i32::from);
             row.push(i.into());
         }
-        DataType::Int => {
+        DataType::Int | DataType::Oid => {
             let i = get_column_inner::<i32>(postgres_row, i, nullable)?;
             row.push(i.into());
         }

--- a/test/sqllogictest/cockroach/pgoidtype.slt
+++ b/test/sqllogictest/cockroach/pgoidtype.slt
@@ -17,9 +17,6 @@
 # 2.0 license, a copy of which can be found in the LICENSE file at the
 # root of this repository.
 
-# not supported yet
-halt
-
 mode cockroach
 
 query OO
@@ -31,6 +28,9 @@ query O
 SELECT 3::OID::INT::OID
 ----
 3
+
+# The rest of this file is not yet supported.
+halt
 
 query OOOOOO
 SELECT 1::OID, 1::REGCLASS, 1::REGNAMESPACE, 1::REGPROC, 1::REGPROCEDURE, 1::REGTYPE


### PR DESCRIPTION
The oid type is just a wrapper around int4 that PostgreSQL uses to
identify its system objects. (It is similar to a newtype in Rust.) Add
support for the oid type to Materialize to facilitate upcoming
pg_catalog compatibility work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4302)
<!-- Reviewable:end -->
