### PR TITLE
Add a docker resource limits warning to mzconduct start commands

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -47,7 +47,11 @@ try "$root"/bin/pyactivate --dev -m mypy --pretty "${py_files[@]}"
 
 (
     cd misc/python
-    try "$root"/bin/pyactivate --dev -m pytest -q
+    try "$root"/bin/pyactivate --dev --ci -m \
+        pytest \
+            --quiet \
+            --doctest-modules \
+            ;
 )
 if $failed; then
     exit 1

--- a/misc/python/materialize/cli/mzconduct.py
+++ b/misc/python/materialize/cli/mzconduct.py
@@ -80,6 +80,7 @@ def up(composition: str, workflow: Optional[str], services: Iterable[str],) -> N
 
     With the --workflow flag, perform all the steps in the workflow together.
     """
+    ui.warn_docker_resource_limits()
     comp = Composition.find(composition)
     if workflow is not None:
         say(f"Executing {comp.name} -> {workflow}")
@@ -100,6 +101,7 @@ def run(composition: str, workflow: Optional[str], services: Iterable[str],) -> 
 
     With the --workflow flag, perform all the steps in the workflow together.
     """
+    ui.warn_docker_resource_limits()
     comp = Composition.find(composition)
     if workflow is not None:
         say(f"Executing {comp.name} -> {workflow}")

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Tools to help interacting with docker
+"""
+
+from typing import NamedTuple
+
+from materialize import spawn
+
+RECOMMENDED_MIN_MEM = 8 * 1024 ** 3  # 8GiB
+RECOMMENDED_MIN_CPUS = 2
+
+
+class DockerInfo(NamedTuple):
+    "Total number of bytes available to docker"
+    mem_total: int
+    "Total number of cpus available to docker"
+    ncpus: int
+
+
+def resource_limits() -> DockerInfo:
+    args = ["docker", "system", "info", "--format", "{{.MemTotal}} {{.NCPU}}"]
+    memtotal, ncpu = spawn.capture(args, unicode=True).split()
+    return DockerInfo(int(memtotal), int(ncpu))

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -15,7 +15,9 @@ import os
 import shlex
 import sys
 import time
-from typing import Any, Callable, Generator, Iterable, Optional
+from typing import Any, Callable, Generator, Iterable, Optional, NamedTuple, Union
+
+from materialize import docker
 
 
 class Verbosity:
@@ -112,3 +114,42 @@ def env_is_truthy(env_var: str) -> bool:
     if env is not None:
         return env not in ("", "0", "no")
     return False
+
+
+def warn_docker_resource_limits() -> None:
+    """Check docker for recommended resource limits
+    """
+    warn = speaker("WARN:")
+
+    limits = docker.resource_limits()
+    if limits.mem_total < docker.RECOMMENDED_MIN_MEM:
+        actual = humanize(limits.mem_total)
+        desired = humanize(docker.RECOMMENDED_MIN_MEM)
+        warn(
+            f"Docker only has {actual} memory, "
+            f"less than {desired} can cause demos to fail in unexpected ways.\n"
+            "    See https://materialize.io/docs/third-party/docker/\n"
+        )
+    if limits.ncpus < docker.RECOMMENDED_MIN_CPUS:
+        warn(
+            f"Docker only has access to {limits.ncpus}, "
+            f"fewer than {docker.RECOMMENDED_MIN_CPUS} can cause demos to fail in unexpected ways.\n"
+            "    See https://materialize.io/docs/third-party/docker/\n"
+        )
+
+
+def humanize(val: Union[int, float], kind: str = "B") -> str:
+    """A convert val to a human-readable number
+
+    ::
+
+        >>> humanize(16795869184, "B")
+        '15.6 GiB'
+    """
+    suffixes = ["", "Ki", "Mi", "Gi", "Ti"]
+    index = 0
+    while val > 1024:
+        val /= 1024
+        index += 1
+    suffix = suffixes[index]
+    return f"{val:.1f} {suffix}{kind}"

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -42,7 +42,7 @@ def speaker(prefix: str, for_progress: bool = False) -> Callable[..., None]:
     Example::
 
         >>> say = speaker("mz")
-        >>> say("hello")
+        >>> say("hello")  # doctest: +SKIP
         mz> hello
     """
 


### PR DESCRIPTION
Changing the `1024 ** 3` to `1024 ** 4` causes the following message to get printed:

    $ mzconduct run chbench -w ci
    WARN: Docker only has 15.6 GiB memory, less than 8.0 TiB can cause demos to fail in unexpected ways.
        See https://materialize.io/docs/third-party/docker/

    C> Executing chbench -> ci

This is not limited to the BI demo, but in general we are memory hungry and the demos
need to all run multiple processes so folks may have a bad experience with less resources
than that when running the demos.

Inspired by #4223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4304)
<!-- Reviewable:end -->
