### PR TITLE
Allocate OIDs for each catalog object

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -275,6 +275,7 @@ lazy_static! {
         name: "mz_databases",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("id", ScalarType::Int64.nullable(false))
             .with_column("database", ScalarType::String.nullable(false)),
         id: GlobalId::System(2011),
@@ -284,6 +285,7 @@ lazy_static! {
         name: "mz_schemas",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("database_id", ScalarType::Int64.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("schema", ScalarType::String.nullable(false))
@@ -307,6 +309,7 @@ lazy_static! {
         name: "mz_indexes",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("global_id", ScalarType::String.nullable(false))
             .with_column("on_global_id", ScalarType::String.nullable(false))
             .with_column("field_number", ScalarType::Int64.nullable(true))
@@ -320,6 +323,7 @@ lazy_static! {
         name: "mz_tables",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("global_id", ScalarType::String.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("tables", ScalarType::String.nullable(false)),
@@ -330,6 +334,7 @@ lazy_static! {
         name: "mz_sources",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("global_id", ScalarType::String.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("sources", ScalarType::String.nullable(false)),
@@ -340,6 +345,7 @@ lazy_static! {
         name: "mz_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("global_id", ScalarType::String.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("sinks", ScalarType::String.nullable(false)),
@@ -350,6 +356,7 @@ lazy_static! {
         name: "mz_views",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
+            .with_column("oid", ScalarType::Int32.nullable(false))
             .with_column("global_id", ScalarType::String.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("views", ScalarType::String.nullable(false)),

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -25,6 +25,7 @@ pub(crate) enum ErrorKind {
         detail: String,
     },
     IdExhaustion,
+    OidExhaustion,
     Sql(SqlCatalogError),
     DatabaseAlreadyExists(String),
     SchemaAlreadyExists(String),
@@ -74,6 +75,7 @@ impl std::error::Error for Error {
         match &self.kind {
             ErrorKind::Corruption { .. }
             | ErrorKind::IdExhaustion
+            | ErrorKind::OidExhaustion
             | ErrorKind::DatabaseAlreadyExists(_)
             | ErrorKind::SchemaAlreadyExists(_)
             | ErrorKind::ItemAlreadyExists(_)
@@ -98,6 +100,7 @@ impl fmt::Display for Error {
         match &self.kind {
             ErrorKind::Corruption { detail } => write!(f, "corrupt catalog: {}", detail),
             ErrorKind::IdExhaustion => write!(f, "id counter overflows i64"),
+            ErrorKind::OidExhaustion => write!(f, "oid counter overflows u32"),
             ErrorKind::Sql(e) => write!(f, "{}", e),
             ErrorKind::DatabaseAlreadyExists(name) => {
                 write!(f, "database '{}' already exists", name)

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -48,7 +48,7 @@ database
 ----
 materialize
 
-> SELECT * FROM mz_catalog.mz_databases
+> SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
 -1          AMBIENT
@@ -62,7 +62,7 @@ database
 d
 materialize
 
-> SELECT * FROM mz_catalog.mz_databases WHERE id != -1
+> SELECT id, database FROM mz_catalog.mz_databases WHERE id != -1
 id          database
 -----------------------
 1           materialize
@@ -121,7 +121,7 @@ Expected end of statement, found: RESTRICT
 database
 ----
 materialize
-> SELECT * FROM mz_catalog.mz_databases
+> SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
 -1          AMBIENT
@@ -187,7 +187,7 @@ database
 d
 d2
 materialize
-> SELECT * FROM mz_catalog.mz_databases
+> SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
 -1          AMBIENT


### PR DESCRIPTION
This PR adds support for [Postgres `OID`s](https://www.postgresql.org/docs/13/datatype-oid.html) in Materialize. `OID`s are object identifiers implemented as unsigned four-byte integers. This addition is necessary to unblock future work to support `pg_catalog`.

Related: https://github.com/MaterializeInc/materialize/issues/4289

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4316)
<!-- Reviewable:end -->
