### PR TITLE
repr: add support for storing arrays

### DIFF
--- a/src/repr/src/adt.rs
+++ b/src/repr/src/adt.rs
@@ -17,6 +17,7 @@
 //!
 //! [PostgreSQL ADTs]: https://github.com/postgres/postgres/tree/master/src/backend/utils/adt
 
+pub mod array;
 pub mod datetime;
 pub mod decimal;
 pub mod interval;

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -1,0 +1,150 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A multi-dimensional array data type.
+
+use std::convert::TryInto;
+use std::error::Error;
+use std::fmt;
+use std::mem;
+
+use serde::{Deserialize, Serialize};
+
+use crate::row::DatumList;
+
+/// The maximum number of dimensions permitted in an array.
+pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
+
+/// A variable-length multi-dimensional array.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct Array<'a> {
+    /// The dimensions of the array.
+    pub(crate) dims: ArrayDimensions<'a>,
+    /// The elements in the array.
+    pub(crate) elements: DatumList<'a>,
+}
+
+impl<'a> Array<'a> {
+    /// Returns the dimensions of the array.
+    pub fn dims(&self) -> ArrayDimensions<'a> {
+        self.dims
+    }
+
+    /// Returns the elements of the array.
+    pub fn elements(&self) -> DatumList<'a> {
+        self.elements
+    }
+}
+
+/// The dimensions of an [`Array`].
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ArrayDimensions<'a> {
+    pub(crate) data: &'a [u8],
+}
+
+impl ArrayDimensions<'_> {
+    /// Returns the number of dimensions in the array as a [`u8`].
+    pub fn ndims(&self) -> u8 {
+        let ndims = self.data.len() / (mem::size_of::<usize>() * 2);
+        ndims.try_into().expect("ndims is known to fit in a u8")
+    }
+
+    /// Returns the number of the dimensions in the array as a [`usize`].
+    pub fn len(&self) -> usize {
+        self.ndims().into()
+    }
+
+    /// Reports whether the number of dimensions in the array is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl fmt::Debug for ArrayDimensions<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_list().entries(self.into_iter()).finish()
+    }
+}
+
+impl<'a> IntoIterator for ArrayDimensions<'a> {
+    type Item = ArrayDimension;
+    type IntoIter = ArrayDimensionsIter<'a>;
+
+    fn into_iter(self) -> ArrayDimensionsIter<'a> {
+        ArrayDimensionsIter { data: self.data }
+    }
+}
+
+/// An iterator over the dimensions in an [`ArrayDimensions`].
+#[derive(Debug)]
+pub struct ArrayDimensionsIter<'a> {
+    data: &'a [u8],
+}
+
+impl Iterator for ArrayDimensionsIter<'_> {
+    type Item = ArrayDimension;
+
+    fn next(&mut self) -> Option<ArrayDimension> {
+        if self.data.is_empty() {
+            None
+        } else {
+            let sz = mem::size_of::<usize>();
+            let lower_bound = usize::from_ne_bytes(self.data[..sz].try_into().unwrap());
+            self.data = &self.data[sz..];
+            let length = usize::from_ne_bytes(self.data[..sz].try_into().unwrap());
+            self.data = &self.data[sz..];
+            Some(ArrayDimension {
+                lower_bound,
+                length,
+            })
+        }
+    }
+}
+
+/// The specification of one dimension of an [`Array`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub struct ArrayDimension {
+    /// The index at which this dimension begins.
+    pub lower_bound: usize,
+    /// The number of elements in this array.
+    pub length: usize,
+}
+
+/// An error that can occur when constructing an array.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+pub enum InvalidArrayError {
+    /// The number of dimensions in the array exceedes [`MAX_ARRAY_DIMENSIONS]`.
+    TooManyDimensions(usize),
+    /// The number of array elements does not match the cardinality derived from
+    /// its dimensions.
+    WrongCardinality { actual: usize, expected: usize },
+}
+
+impl fmt::Display for InvalidArrayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            InvalidArrayError::TooManyDimensions(n) => write!(
+                f,
+                "number of array dimensions ({}) exceeds the maximum allowed ({})",
+                n, MAX_ARRAY_DIMENSIONS
+            ),
+            InvalidArrayError::WrongCardinality { actual, expected } => write!(
+                f,
+                "number of array elements ({}) does not match declared cardinality ({})",
+                actual, expected
+            ),
+        }
+    }
+}
+
+impl Error for InvalidArrayError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}


### PR DESCRIPTION
Split out from #4305. Touches #1248. Important for PostgreSQL
compatibility.

This commit only includes the support for packing arrays into rows.
Nothing besides unit tests actually uses these arrays yet. Future
commits will wire up array creation to the SQL layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4329)
<!-- Reviewable:end -->
