### PR TITLE
Include keys when creating BuiltinTable Indexes

### DIFF
--- a/test/testdrive/mz-catalog.td
+++ b/test/testdrive/mz-catalog.td
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Assert required mz_catalog objects are inserted on startup.
+> SELECT COUNT(*) FROM mz_tables WHERE global_id LIKE 's%'
+13
+
+# There is one entry in mz_indexes for each field_number/expression of the index.
+> SELECT COUNT(global_id) FROM mz_indexes WHERE global_id LIKE 's%'
+75


### PR DESCRIPTION
In trying to implement `pg_class`, I found that we weren't inserting the indexes of `Builtin::Table`s on startup. Because the current code indicates that `Builtin::Table`'s indexes don't have keys, no updates were being sent to the `mz_indexes` table (code here: https://github.com/MaterializeInc/materialize/blob/main/src/coord/src/coord.rs#L1110).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4330)
<!-- Reviewable:end -->
