### PR TITLE
sql: support array types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,7 @@ dependencies = [
  "pgwire",
  "postgres",
  "postgres-openssl",
+ "postgres_array",
  "predicates",
  "prof",
  "prometheus",
@@ -2655,6 +2656,18 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "postgres_array"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45e166dedb061744a082a6009459840c038660382f1b6ab82bf7a4cdfc7e42a"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+ "postgres-types",
 ]
 
 [[package]]

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use ore::collections::CollectionExt;
 use ore::fmt::FormatBuffer;
 use ore::result::ResultExt;
+use repr::adt::array::ArrayDimension;
 use repr::adt::datetime::DateTimeUnits;
 use repr::adt::decimal::MAX_DECIMAL_PRECISION;
 use repr::adt::interval::Interval;
@@ -2964,6 +2965,52 @@ fn jsonb_build_object<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> D
     }
 }
 
+/// Constructs a new multidimensional array out of an arbitrary number of
+/// lower-dimensional arrays.
+///
+/// For example, if given three 1D arrays of length 2, this function will
+/// construct a 2D array with dimensions 3x2.
+///
+/// The input datums in `datums` must all be arrays of the same dimensions.
+/// (The arrays must also be of the same element type, but that is checked by
+/// the SQL type system, rather than checked here at runtime.)
+///
+/// The lower bound of the additional dimension is always one. The length of
+/// the new dimension is equal to `datums.len()`.
+fn array_create_multidim<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let mut dims = vec![ArrayDimension {
+        lower_bound: 1,
+        length: datums.len(),
+    }];
+    if let Some(d) = datums.first() {
+        dims.extend(d.unwrap_array().dims());
+    };
+    let elements = datums
+        .iter()
+        .flat_map(|d| d.unwrap_array().elements().iter());
+    let datum = temp_storage.try_make_datum(move |packer| packer.push_array(&dims, elements))?;
+    Ok(datum)
+}
+
+/// Constructs a new 1D array out of an arbitrary number of scalars.
+///
+/// The lower bound of the array is always one. The length of the array is equal
+/// to `datums.len()`.
+fn array_create_scalar<'a>(
+    datums: &[Datum<'a>],
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let dims = &[ArrayDimension {
+        lower_bound: 1,
+        length: datums.len(),
+    }];
+    let datum = temp_storage.try_make_datum(|packer| packer.push_array(dims, datums))?;
+    Ok(datum)
+}
+
 fn list_create<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
     temp_storage.make_datum(|packer| packer.push_list(datums))
 }
@@ -3006,6 +3053,18 @@ where
                 }
             })
         }
+        Array(elem_type) => strconv::format_array(
+            buf,
+            &d.unwrap_array().dims().into_iter().collect::<Vec<_>>(),
+            &d.unwrap_array().elements(),
+            |buf, d| {
+                if d.is_null() {
+                    buf.write_null()
+                } else {
+                    stringify_datum(buf.nonnull_buffer(), d, elem_type)
+                }
+            },
+        ),
         List(elem_type) => strconv::format_list(buf, &d.unwrap_list(), |buf, d| {
             if d.is_null() {
                 buf.write_null()
@@ -3219,8 +3278,12 @@ pub enum VariadicFunc {
     Replace,
     JsonbBuildArray,
     JsonbBuildObject,
+    ArrayCreate {
+        // We need to know the element type to type empty arrays.
+        elem_type: ScalarType,
+    },
     ListCreate {
-        // we need to know this to type exprs with empty lists
+        // We need to know the element type to type empty lists.
         elem_type: ScalarType,
     },
     RecordCreate {
@@ -3258,6 +3321,10 @@ impl VariadicFunc {
             VariadicFunc::Replace => Ok(eager!(replace, temp_storage)),
             VariadicFunc::JsonbBuildArray => Ok(eager!(jsonb_build_array, temp_storage)),
             VariadicFunc::JsonbBuildObject => Ok(eager!(jsonb_build_object, temp_storage)),
+            VariadicFunc::ArrayCreate {
+                elem_type: ScalarType::Array(_),
+            } => eager!(array_create_multidim, temp_storage),
+            VariadicFunc::ArrayCreate { .. } => eager!(array_create_scalar, temp_storage),
             VariadicFunc::ListCreate { .. } | VariadicFunc::RecordCreate { .. } => {
                 Ok(eager!(list_create, temp_storage))
             }
@@ -3286,6 +3353,16 @@ impl VariadicFunc {
             Substr => ScalarType::String.nullable(true),
             Replace => ScalarType::String.nullable(true),
             JsonbBuildArray | JsonbBuildObject => ScalarType::Jsonb.nullable(true),
+            ArrayCreate { elem_type } => {
+                debug_assert!(
+                    input_types.iter().all(|t| t.scalar_type == *elem_type),
+                    "Args to ArrayCreate should have types that are compatible with the elem_type"
+                );
+                match elem_type {
+                    ScalarType::Array(_) => elem_type.clone().nullable(false),
+                    _ => ScalarType::Array(Box::new(elem_type.clone())).nullable(false),
+                }
+            }
             ListCreate { elem_type } => {
                 debug_assert!(
                     input_types.iter().all(|t| t.scalar_type == *elem_type),
@@ -3314,7 +3391,8 @@ impl VariadicFunc {
             | VariadicFunc::JsonbBuildArray
             | VariadicFunc::JsonbBuildObject
             | VariadicFunc::ListCreate { .. }
-            | VariadicFunc::RecordCreate { .. } => false,
+            | VariadicFunc::RecordCreate { .. }
+            | VariadicFunc::ArrayCreate { .. } => false,
             _ => true,
         }
     }
@@ -3331,6 +3409,7 @@ impl fmt::Display for VariadicFunc {
             VariadicFunc::Replace => f.write_str("replace"),
             VariadicFunc::JsonbBuildArray => f.write_str("jsonb_build_array"),
             VariadicFunc::JsonbBuildObject => f.write_str("jsonb_build_object"),
+            VariadicFunc::ArrayCreate { .. } => f.write_str("array_create"),
             VariadicFunc::ListCreate { .. } => f.write_str("list_create"),
             VariadicFunc::RecordCreate { .. } => f.write_str("record_create"),
             VariadicFunc::ListSlice => f.write_str("list_slice"),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -8,10 +8,12 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::HashSet;
+use std::fmt;
 use std::mem;
 
 use serde::{Deserialize, Serialize};
 
+use repr::adt::array::InvalidArrayError;
 use repr::adt::datetime::DateTimeUnits;
 use repr::adt::regex::Regex;
 use repr::strconv::ParseError;
@@ -564,6 +566,7 @@ pub enum EvalError {
         max_dim: usize,
         val: i64,
     },
+    InvalidArray(InvalidArrayError),
     InvalidEncodingName(String),
     InvalidByteSequence {
         byte_sequence: String,
@@ -578,8 +581,8 @@ pub enum EvalError {
     Parse(ParseError),
 }
 
-impl std::fmt::Display for EvalError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             EvalError::DivisionByZero => f.write_str("division by zero"),
             EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
@@ -591,6 +594,7 @@ impl std::fmt::Display for EvalError {
                 "invalid dimension: {}; must use value within [1, {}]",
                 val, max_dim
             ),
+            EvalError::InvalidArray(e) => e.fmt(f),
             EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
             EvalError::InvalidByteSequence {
                 byte_sequence,
@@ -620,6 +624,12 @@ impl std::error::Error for EvalError {}
 impl From<ParseError> for EvalError {
     fn from(e: ParseError) -> EvalError {
         EvalError::Parse(e)
+    }
+}
+
+impl From<InvalidArrayError> for EvalError {
+    fn from(e: InvalidArrayError) -> EvalError {
+        EvalError::InvalidArray(e)
     }
 }
 

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1618,6 +1618,7 @@ fn build_schema(columns: &[(ColumnName, ColumnType)], include_transaction: bool)
                 "type": "string",
                 "logicalType": "uuid",
             }),
+            ScalarType::Array(_t) => unimplemented!("array types"),
             ScalarType::List(_t) => unimplemented!("list types"),
             ScalarType::Record { .. } => unimplemented!("record types"),
         };
@@ -1979,6 +1980,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::String => Value::String(datum.unwrap_str().to_owned()),
                 ScalarType::Jsonb => Value::Json(JsonbRef::from_datum(datum).to_serde_json()),
                 ScalarType::Uuid => Value::Uuid(datum.unwrap_uuid()),
+                ScalarType::Array(_t) => unimplemented!("array types"),
                 ScalarType::List(_t) => unimplemented!("list types"),
                 ScalarType::Record { .. } => unimplemented!("record types"),
             };
@@ -2267,6 +2269,7 @@ pub mod cdc_v2 {
                     "type": "string",
                     "logicalType": "uuid",
                 }),
+                ScalarType::Array(_t) => unimplemented!("array types"),
                 ScalarType::List(_t) => unimplemented!("list types"),
                 ScalarType::Record { .. } => unimplemented!("record types"),
             };

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -31,6 +31,7 @@ openssl = { version = "0.10.30", features = ["vendored"] }
 openssl-sys = { version = "0.9.58", features = ["vendored"] }
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
+postgres_array = "0.10.0"
 postgres-openssl = "0.3.0"
 pgwire = { path = "../pgwire" }
 prof = { path = "../prof", features = ["auto-jemalloc"] }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -375,6 +375,13 @@ impl<'a> Datum<'a> {
                     (Datum::String(_), _) => false,
                     (Datum::Uuid(_), ScalarType::Uuid) => true,
                     (Datum::Uuid(_), _) => false,
+                    (Datum::Array(array), ScalarType::Array(t)) => {
+                        array.elements.iter().all(|e| match e {
+                            Datum::Null => true,
+                            Datum::Array(_) => is_instance_of_scalar(e, scalar_type),
+                            _ => is_instance_of_scalar(e, t),
+                        })
+                    }
                     (Datum::Array(_), _) => false,
                     (Datum::List(list), ScalarType::List(t)) => list
                         .iter()
@@ -654,6 +661,12 @@ pub enum ScalarType {
     Jsonb,
     /// The type of [`Datum::Uuid`].
     Uuid,
+    /// The type of [`Datum::Array`].
+    ///
+    /// Elements within the array are of the specified type. It is illegal for
+    /// the element type to be itself an array type. Array elements may always
+    /// be [`Datum::Null`].
+    Array(Box<ScalarType>),
     /// The type of [`Datum::List`].
     ///
     /// Elements within the list are of the specified type. List elements may
@@ -758,7 +771,7 @@ impl PartialEq for ScalarType {
             | (Jsonb, Jsonb)
             | (Oid, Oid) => true,
 
-            (List(a), List(b)) => a.eq(b),
+            (List(a), List(b)) | (Array(a), Array(b)) => a.eq(b),
             (Record { fields: fields_a }, Record { fields: fields_b }) => fields_a.eq(fields_b),
 
             (Bool, _)
@@ -776,6 +789,7 @@ impl PartialEq for ScalarType {
             | (String, _)
             | (Jsonb, _)
             | (Uuid, _)
+            | (Array(_), _)
             | (List(_), _)
             | (Record { .. }, _)
             | (Oid, _) => false,
@@ -806,16 +820,20 @@ impl Hash for ScalarType {
             Bytes => state.write_u8(11),
             String => state.write_u8(12),
             Jsonb => state.write_u8(13),
-            List(t) => {
+            Array(t) => {
                 state.write_u8(14);
                 t.hash(state);
             }
-            Record { fields } => {
+            List(t) => {
                 state.write_u8(15);
+                t.hash(state);
+            }
+            Record { fields } => {
+                state.write_u8(16);
                 fields.hash(state);
             }
             Uuid => state.write_u8(16),
-            Oid => state.write_u8(16),
+            Oid => state.write_u8(17),
         }
     }
 }
@@ -844,6 +862,7 @@ impl fmt::Display for ScalarType {
             String => f.write_str("string"),
             Jsonb => f.write_str("jsonb"),
             Uuid => f.write_str("uuid"),
+            Array(t) => write!(f, "{}[]", t),
             List(t) => write!(f, "{} list", t),
             Record { fields } => {
                 f.write_str("record(")?;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -180,6 +180,7 @@ pub enum CoercibleScalarExpr {
     Parameter(usize),
     LiteralNull,
     LiteralString(String),
+    LiteralArray(Vec<CoercibleScalarExpr>),
     LiteralList(Vec<CoercibleScalarExpr>),
     LiteralRecord(Vec<CoercibleScalarExpr>),
 }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -44,6 +44,7 @@ use crate::names::PartialName;
 /// [typcategory]:
 /// https://www.postgresql.org/docs/9.6/catalog-pg-type.html#CATALOG-TYPCATEGORY-TABLE
 pub enum TypeCategory {
+    Array,
     Bool,
     DateTime,
     Numeric,
@@ -67,6 +68,7 @@ impl TypeCategory {
     /// ```
     fn from_type(typ: &ScalarType) -> Self {
         match typ {
+            ScalarType::Array(_) => Self::Array,
             ScalarType::Bool => Self::Bool,
             ScalarType::Bytes | ScalarType::Jsonb | ScalarType::Uuid | ScalarType::List(_) => {
                 Self::UserDefined
@@ -108,7 +110,7 @@ impl TypeCategory {
             Self::Numeric => Some(ScalarType::Float64),
             Self::String => Some(ScalarType::String),
             Self::Timespan => Some(ScalarType::Interval),
-            Self::Pseudo | Self::UserDefined => None,
+            Self::Array | Self::Pseudo | Self::UserDefined => None,
         }
     }
 }


### PR DESCRIPTION
Split from #4305. Touches #1248.

This commit adds enough support for PostgreSQL-style array types to the
SQL layer that they can be constructed (in experimental mode) and sent
over the wire in either the text or binary format.

The goal here is to unlock pg_catalog views that require arrays, not to
make these arrays generally usable for end users. Users should in
general use lists, not arrays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4331)
<!-- Reviewable:end -->
