### PR TITLE
dataflow: enable reading zstd-compressed Kafka topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,9 @@ name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "ccsr"
@@ -1614,6 +1617,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 dependencies = [
  "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
  "libc",
 ]
 
@@ -3011,6 +3023,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "sasl2-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -4672,3 +4685,15 @@ name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
+
+[[package]]
+name = "zstd-sys"
+version = "1.4.17+zstd.1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
+dependencies = [
+ "cc",
+ "glob",
+ "itertools",
+ "libc",
+]

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -31,7 +31,7 @@ pdqselect = "0.1.0"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prometheus-static-metric = { git = "https://github.com/MaterializeInc/rust-prometheus.git" }
 rand = "0.7.3"
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static", "zstd"] }
 regex = "1.3.9"
 repr = { path = "../repr" }
 rusoto_core = "0.45.0"

--- a/test/testdrive/kafka-compression.td
+++ b/test/testdrive/kafka-compression.td
@@ -1,0 +1,62 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test support for compressed Kafka topics.
+
+$ kafka-create-topic topic=gzip compression=gzip
+
+$ kafka-ingest format=bytes topic=gzip timestamp=1
+hello
+world
+
+> CREATE MATERIALIZED SOURCE gzip
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-gzip-${testdrive.seed}'
+  FORMAT TEXT
+> SELECT text FROM gzip
+hello
+world
+
+$ kafka-create-topic topic=snappy compression=snappy
+
+$ kafka-ingest format=bytes topic=snappy timestamp=1
+hello
+world
+
+> CREATE MATERIALIZED SOURCE snappy
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-snappy-${testdrive.seed}'
+  FORMAT TEXT
+> SELECT text FROM snappy
+hello
+world
+
+$ kafka-create-topic topic=lz4 compression=lz4
+
+$ kafka-ingest format=bytes topic=lz4 timestamp=1
+hello
+world
+
+> CREATE MATERIALIZED SOURCE lz4
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-lz4-${testdrive.seed}'
+  FORMAT TEXT
+> SELECT text FROM lz4
+hello
+world
+
+$ kafka-create-topic topic=zstd compression=zstd
+
+$ kafka-ingest format=bytes topic=zstd timestamp=1
+hello
+world
+
+> CREATE MATERIALIZED SOURCE zstd
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
+  FORMAT TEXT
+> SELECT text FROM zstd
+hello
+world


### PR DESCRIPTION
Support for this is already builtin into librdkafka. Just needed to
enable the "zstd" feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4342)
<!-- Reviewable:end -->
