### PR TITLE
coord: add stub nspacl column to pg_namespace

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -576,14 +576,14 @@ UNION
     id: GlobalId::System(3013),
 };
 
-// TODO(benesch): add `nspowner`, and `nspacl` columns.
 pub const PG_NAMESPACE: BuiltinView = BuiltinView {
     name: "pg_namespace",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_namespace AS SELECT
 oid,
 schema AS nspname,
-NULL::oid AS nspowner
+NULL::oid AS nspowner,
+NULL::text[] AS nspacl
 FROM mz_catalog.mz_schemas",
     id: GlobalId::System(3014),
 };

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -13,6 +13,7 @@ Field    Nullable  Type
 oid      NO        oid
 nspname  NO        text
 nspowner YES       oid
+nspacl   YES       _text
 
 > SHOW COLUMNS FROM pg_class
 Field        Nullable  Type


### PR DESCRIPTION
pg_namespace now has all the columns that are present in PostgreSQL,
though nspowner and nspacl are stubs because we don't support users or
role-based access control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4343)
<!-- Reviewable:end -->
