### PR TITLE
Support current_schemas(bool)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "ore",
  "parse_duration",
  "pgrepr",
+ "postgres_array",
  "predicates",
  "protobuf",
  "protoc",

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -62,6 +62,9 @@ pub trait Catalog: fmt::Debug {
     /// Returns a persistent UUID for the the catalog.
     fn cluster_id(&self) -> Uuid;
 
+    /// Returns the search path used by the catalog.
+    fn search_path(&self, include_system_schemas: bool) -> Vec<&str>;
+
     /// Returns the database to use if one is not explicitly specified.
     fn default_database(&self) -> &str;
 
@@ -264,6 +267,10 @@ impl Catalog for DummyCatalog {
 
     fn cluster_id(&self) -> Uuid {
         Uuid::from_u128(0)
+    }
+
+    fn search_path(&self, _: bool) -> Vec<&str> {
+        vec!["dummy"]
     }
 
     fn default_database(&self) -> &str {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -797,6 +797,21 @@ lazy_static! {
             "convert_from" => Scalar {
                 params!(Bytes, String) => BinaryFunc::ConvertFrom
             },
+            "current_schemas" => Scalar {
+                params!(Bool) => unary_op(|ecx, e| {
+                    let with_sys = ScalarExpr::literal_1d_array(
+                        ecx.qcx.scx.catalog.search_path(true).iter().map(|s| Datum::String(s)).collect(),
+                        ScalarType::String)?;
+                    let without_sys = ScalarExpr::literal_1d_array(
+                        ecx.qcx.scx.catalog.search_path(false).iter().map(|s| Datum::String(s)).collect(),
+                        ScalarType::String)?;
+                    Ok(ScalarExpr::If {
+                        cond: Box::new(e),
+                        then: Box::new(with_sys),
+                        els: Box::new(without_sys),
+                    })
+                })
+            },
             "current_timestamp" => Scalar {
                 params!() => nullary_op(|ecx| plan_current_timestamp(ecx, "current_timestamp"))
             },

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -27,6 +27,7 @@ ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }
 tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-serde_json-1"] }
+postgres_array = "0.10.0"
 protobuf = { version = "2.17", features = ["with-serde"] }
 rand = "0.7.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use md5::{Digest, Md5};
+use postgres_array::Array;
 use tokio_postgres::error::DbError;
 use tokio_postgres::row::Row;
 use tokio_postgres::types::Type;
@@ -357,6 +358,9 @@ fn decode_row(row: Row) -> Result<Vec<String>, String> {
             match *ty {
                 Type::BOOL => row.get::<_, Option<bool>>(i).map(|x| x.to_string()),
                 Type::CHAR | Type::TEXT => row.get::<_, Option<String>>(i),
+                Type::TEXT_ARRAY => row
+                    .get::<_, Option<Array<String>>>(i)
+                    .map(|a| a.to_string()),
                 Type::BYTEA => row.get::<_, Option<Vec<u8>>>(i).map(|x| {
                     let s = x.into_iter().map(ascii::escape_default).flatten().collect();
                     String::from_utf8(s).unwrap()

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -21,3 +21,12 @@ oid          NO        int4
 relname      NO        text
 relnamespace NO        text
 relowner     YES       oid
+
+! SELECT current_schemas()
+Cannot call function current_schemas(): arguments cannot be implicitly cast to any implementation's parameters;
+
+> SELECT current_schemas(true)
+{mz_catalog,pg_catalog,public,mz_temp}
+
+> SELECT current_schemas(false)
+{public}


### PR DESCRIPTION
Adds support for Postgres' [`current_schemas(include_implicit boolean)`](https://www.postgresql.org/docs/13/functions-info.html). This is required to support [`pg_catalog.pg_table_is_visible`](https://github.com/MaterializeInc/materialize/issues/4289).

This PR also update's testdrive's `decode_row` function to properly handle `TEXT_ARRAY` types.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4344)
<!-- Reviewable:end -->
