### PR TITLE
Fix ScalarType::Oid panic

### DIFF
--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -89,6 +89,7 @@ impl Value {
             (Datum::True, ScalarType::Bool) => Some(Value::Bool(true)),
             (Datum::False, ScalarType::Bool) => Some(Value::Bool(false)),
             (Datum::Int32(i), ScalarType::Int32) => Some(Value::Int4(i)),
+            (Datum::Int32(i), ScalarType::Oid) => Some(Value::Int4(i)),
             (Datum::Int64(i), ScalarType::Int64) => Some(Value::Int8(i)),
             (Datum::Float32(f), ScalarType::Float32) => Some(Value::Float4(*f)),
             (Datum::Float64(f), ScalarType::Float64) => Some(Value::Float8(*f)),

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -367,6 +367,7 @@ fn decode_row(row: Row) -> Result<Vec<String>, String> {
                 }),
                 Type::INT4 => row.get::<_, Option<i32>>(i).map(|x| x.to_string()),
                 Type::INT8 => row.get::<_, Option<i64>>(i).map(|x| x.to_string()),
+                Type::OID => row.get::<_, Option<u32>>(i).map(|x| x.to_string()),
                 Type::NUMERIC => row.get::<_, Option<Numeric>>(i).map(|x| x.to_string()),
                 Type::TIMESTAMP => row
                     .get::<_, Option<chrono::NaiveDateTime>>(i)

--- a/test/testdrive/mz-catalog.td
+++ b/test/testdrive/mz-catalog.td
@@ -14,3 +14,6 @@
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(global_id) FROM mz_indexes WHERE global_id LIKE 's%'
 76
+
+> SELECT oid FROM mz_tables ORDER BY oid ASC LIMIT 1
+20031


### PR DESCRIPTION
Materialize currently panics for any query that returns a `ScalarType::Oid` column. This PR fixes that panic and adds a quick test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4347)
<!-- Reviewable:end -->
