### PR TITLE
Bump Linux deploy timeout to 30m

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -17,7 +17,7 @@ steps:
     concurrency_group: deploy/devsite
 
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.deploy.linux
-    timeout_in_minutes: 10
+    timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/linux
 


### PR DESCRIPTION
Sometimes Docker Hub is slow enough that we bump into the 10m limit; see https://buildkite.com/materialize/deploy/builds/2864 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4350)
<!-- Reviewable:end -->
