### PR TITLE
sql: support column specification in INSERTs

### DIFF
--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -66,6 +66,20 @@ SELECT * FROM t;
 In the above example, the second tuple provides a `NULL` value for column `a`, which
 is nullable. `NULL` values may not be inserted into column `b`, which is not nullable.
 
+You may also insert data using a column specification.
+
+```sql
+CREATE TABLE t (a int, b text NOT NULL);
+
+INSERT INTO t (b, a) VALUES ('a', 1), ('b', NULL);
+
+SELECT * FROM t;
+ a | b
+---+---
+   | b
+ 1 | a
+```
+
 ## Related pages
 
 - [`CREATE TABLE`](../create-table)

--- a/src/ore/src/iter.rs
+++ b/src/ore/src/iter.rs
@@ -27,7 +27,8 @@ where
     where
         Self::Item: Hash + Eq,
     {
-        let mut seen = HashSet::new();
+        let (lower, _) = self.size_hint();
+        let mut seen = HashSet::with_capacity(lower);
         for item in self {
             if !seen.insert(item) {
                 return true;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -31,6 +31,7 @@ use dataflow_types::{
 use expr::{GlobalId, RowSetFinishing};
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
 use ore::collections::CollectionExt;
+use ore::iter::IteratorExt;
 use repr::{strconv, Datum, RelationDesc, RelationType, Row, ScalarType};
 use sql_parser::ast::{
     AlterIndexOptionsList, AlterIndexOptionsStatement, AlterObjectRenameStatement, AvroSchema,
@@ -1820,6 +1821,10 @@ fn handle_create_table(
         .iter()
         .map(|c| Some(normalize::column_name(c.name.clone())))
         .collect();
+
+    if names.iter().has_duplicates() {
+        bail!("cannot CREATE TABLE with duplicate column names");
+    }
 
     // Build initial relation type that handles declared data types
     // and NOT NULL constraints.

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -254,9 +254,12 @@ pub fn describe_statement(
             (Some(desc), scx.finalize_param_types()?)
         }
         Statement::Insert(InsertStatement {
-            table_name, source, ..
+            table_name,
+            columns,
+            source,
+            ..
         }) => {
-            query::plan_insert_query(&scx, table_name, source)?;
+            query::plan_insert_query(&scx, table_name, columns, source)?;
             (None, scx.finalize_param_types()?)
         }
 
@@ -2037,11 +2040,7 @@ fn handle_insert(
     }: InsertStatement,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
-    if !columns.is_empty() {
-        unsupported!("INSERT statement with specified columns");
-    }
-
-    let (id, mut expr) = query::plan_insert_query(scx, table_name, source)?;
+    let (id, mut expr) = query::plan_insert_query(scx, table_name, columns, source)?;
     expr.bind_parameters(&params)?;
     let expr = expr.decorrelate();
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -23,6 +23,9 @@ materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" int,
 ! CREATE TABLE s (a int DEFAULT 1)
 CREATE TABLE with column constraint: DEFAULT 1 not yet supported
 
+! CREATE TABLE t (a int, b int, a int);
+cannot CREATE TABLE with duplicate column names
+
 > SELECT * FROM t;
 
 > SHOW TABLES;

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -109,12 +109,6 @@ a    b
 1    "a"
 > DROP INDEX t_custom_idx
 
-! INSERT INTO t (a) VALUES (1, 'a');
-INSERT statement with specified columns not yet supported
-
-! INSERT INTO t (b, a) VALUES (1, 'a');
-INSERT statement with specified columns not yet supported
-
 > INSERT INTO t VALUES (2, 'b'), (3, 'c');
 
 > SELECT * FROM t;
@@ -131,7 +125,7 @@ INSERT ... DEFAULT VALUES not yet supported
 complicated INSERT bodies not yet supported
 
 ! INSERT INTO t VALUES (1);
-INSERT statement specifies 2 columns, but table has 1 columns
+INSERT statement specifies 1 columns, but table has 2 columns
 
 ! INSERT INTO t VALUES (1, NULL);
 NULL value in column b violates not-null constraint
@@ -226,3 +220,38 @@ cannot insert into system table 'mz_catalog.mz_kafka_sinks'
     (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15), (16), (17), (18), (19), (20), (21), (22), (23), (24), (25), (26), (27), (28), (29), (30), (31), (32), (33), (34), (35), (36), (37), (38), (39), (40), (41), (42), (43), (44), (45), (46), (47), (48), (49), (50), (51), (52), (53), (54), (55), (56), (57), (58), (59), (60), (61), (62), (63), (64), (65), (66), (67), (68), (69), (70), (71), (72), (73), (74), (75), (76), (77), (78), (79), (80), (81), (82), (83), (84), (85), (86), (87), (88), (89), (90), (91), (92), (93), (94), (95), (96), (97), (98), (99), (100), (101), (102), (103), (104), (105), (106), (107), (108), (109), (110), (111), (112), (113), (114), (115), (116), (117), (118), (119), (120), (121), (122), (123), (124), (125), (126), (127), (128),
     (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15), (16), (17), (18), (19), (20), (21), (22), (23), (24), (25), (26), (27), (28), (29), (30), (31), (32), (33), (34), (35), (36), (37), (38), (39), (40), (41), (42), (43), (44), (45), (46), (47), (48), (49), (50), (51), (52), (53), (54), (55), (56), (57), (58), (59), (60), (61), (62), (63), (64), (65), (66), (67), (68), (69), (70), (71), (72), (73), (74), (75), (76), (77), (78), (79), (80), (81), (82), (83), (84), (85), (86), (87), (88), (89), (90), (91), (92), (93), (94), (95), (96), (97), (98), (99), (100), (101), (102), (103), (104), (105), (106), (107), (108), (109), (110), (111), (112), (113), (114), (115), (116), (117), (118), (119), (120), (121), (122), (123), (124), (125), (126), (127), (128),
     (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (11), (12), (13), (14), (15), (16), (17), (18), (19), (20), (21), (22), (23), (24), (25), (26), (27), (28), (29), (30), (31), (32), (33), (34), (35), (36), (37), (38), (39), (40), (41), (42), (43), (44), (45), (46), (47), (48), (49), (50), (51), (52), (53), (54), (55), (56), (57), (58), (59), (60), (61), (62), (63), (64), (65), (66), (67), (68), (69), (70), (71), (72), (73), (74), (75), (76), (77), (78), (79), (80), (81), (82), (83), (84), (85), (86), (87), (88), (89), (90), (91), (92), (93), (94), (95), (96), (97), (98), (99), (100), (101), (102), (103), (104), (105), (106), (107), (108), (109), (110), (111), (112), (113), (114), (115), (116), (117), (118), (119), (120), (121), (122), (123), (124), (125), (126), (127), (128);
+
+# Test INSERT with column specifiers
+> DROP TABLE IF EXISTS t;
+> CREATE TABLE t (a int, b text not null)
+> INSERT INTO t (b, a) VALUES ('a', 1), ('b', NULL);
+
+> select * from t;
+a    b
+---------
+1    "a"
+<null> "b"
+
+! INSERT INTO t (notpresent, a) VALUES ('str', 1);
+INSERT statement specifies column notpresent, but it is not present in table
+
+! INSERT INTO t (a, b) VALUES ('str', 1);
+expected type string for column b, found i32
+
+! INSERT INTO t (b, a) VALUES (1, 'str');
+expected type string for column b, found i32
+
+! INSERT INTO t (c, b, a) VALUES (1, 1, 'str');
+INSERT statement specifies column c, but it is not present in table
+
+! INSERT INTO t (a) VALUES (1);
+INSERT statement with incomplete column set not yet supported
+
+! INSERT INTO t (a) VALUES (1, 'str');
+INSERT statement with incomplete column set not yet supported
+
+! INSERT INTO t (a, b) VALUES (1);
+INSERT statement specifies 1 expressions, but table has 2 columns
+
+! INSERT INTO t (a, a) VALUES (1, 'str')
+INSERT statement specifies duplicate column


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/issues/3911

This adds support for fully-specified column specs in INSERT. Note that non-fully specified column specs are still unsupported (ie. default values are not inserted for missing columns).

One area I could use feedback on - the RelationDesc type is more flexible than I expected, supporting duplicate and unnamed columns. It's not clear to me if or when that could happen along the INSERT path, but either would lead to a rejection if a column specification is used (which seems like correct behavior).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4354)
<!-- Reviewable:end -->
