### PR TITLE
deps: downgrade to zstd v1.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,12 +4689,11 @@ checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.17+zstd.1.4.5"
+version = "1.4.15+zstd.1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
+checksum = "89719b034dc22d240d5b407fb0a3fe6d29952c181cff9a9f95c0bd40b4f8f7d8"
 dependencies = [
  "cc",
  "glob",
- "itertools",
  "libc",
 ]


### PR DESCRIPTION
v1.4.5 has a bug that can cause librdkafka to fail to decompress valid
messages. See facebook/zstd#2222. Apparently v1.4.4 does not exhibit
this bug.

v1.4.6 will contain a proper fix, but it's not been released yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4355)
<!-- Reviewable:end -->
