### PR TITLE
Document demo discussion

### DIFF
--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -28,6 +28,9 @@ land, and then browsed as reference material as you skill up on the codebase.
 * [debugging.md](debugging.md) is a guide to debugging Materialize using
   rust-gdb / rust-lldb.
 
+* [demos.md](demos.md) explains the two tiers of demos in this codebase and
+  how to add a new one.
+
 * [guide.md](guide.md) walks you through hacking on this codebase and our
   development philosophy.
 

--- a/doc/developer/demos.md
+++ b/doc/developer/demos.md
@@ -1,0 +1,29 @@
+# Demos
+
+Creating and sharing demos that highlight Materialize's feature set is a great
+way to market our product. However, continuously adding new demos to the repository
+increases the maintenance burden shared by the team. To balance the costs and benefits
+of creating new demos, we've agreed to split demos into two tiers: 1) officially supported
+demos, and 2) play demos.
+
+## Officially Supported Demos
+
+Officially supported demos are (as the name suggests) officially supported by the
+engineering team. From a maintenance perspective, fixes to breakages in these demos
+should have the same priority as fixes to breakages in the underlying product. To qualify
+as an officially supported demo, a new demo must:
+- Have consensus from the engineering team to become a supported demo.
+- Be up to the regular coding standards of the repository, including tests.
+- Have CI tests that run for every PR.
+
+Currently, there are three officially supported demos:
+- [Business Intelligence](https://materialize.io/docs/demos/business-intelligence/)
+- [Log Parsing](https://materialize.io/docs/demos/log-parsing/)
+- [Microservice](https://materialize.io/docs/demos/microservice/)
+
+## Play Demos
+
+By contrast, play demos are not actively supported by the engineering team and do not
+require tests. These demos may be created to show off a single feature or to write a
+blog post. Play demos can be merged to the repository without involving the engineering
+team.


### PR DESCRIPTION
This new document is intended to capture what was discussed in the demo meeting today. Some pending action items:
- Create a `/play` directory in the repository and move non-supported demos there.
- Split the testing code from the demo code (ex: chbench). This seems a bit harder, so I didn't list that in this document. I think we'll need follow up issues and engineers to work on that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4357)
<!-- Reviewable:end -->
