### PR TITLE
deps: always compile adler + rustc-demangle with optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,12 @@ members = [
 # in dev builds, since otherwise backtraces can take 20s+ to symbolize. With
 # optimizations enabled, symbolizing a backtrace takes less than 1s.
 addr2line = { opt-level = 3 }
+adler = { opt-level = 3 }
 backtrace = { opt-level = 3 }
 gimli = { opt-level = 3 }
 miniz_oxide = { opt-level = 3 }
 object = { opt-level = 3 }
+rustc-demangle = { opt-level = 3 }
 
 [profile.release]
 # Emit only the line info tables, not full debug info, in release builds, to


### PR DESCRIPTION
adler in particular is critical to the speed of backtrace generation.
If compiled without optimizations, generating a backtrace in a debug
build takes nearly a minute. With optimizations, generating a backtrace
takes only a few seconds.

rustc-demangle is included for good measure, so that the rule is that
any transitive dependency of the backtrace crate is compiled with
optimizations, even in debug builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4358)
<!-- Reviewable:end -->
