### PR TITLE
coord,dataflow: tie persistence data to catalog versions (cluster_id)

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1518,6 +1518,10 @@ impl Catalog {
     pub fn persistence_directory(&self) -> Option<&Path> {
         self.persistence_directory.as_deref()
     }
+
+    pub fn cluster_id(&self) -> Uuid {
+        self.cluster_id
+    }
 }
 
 impl IdHumanizer for Catalog {

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Configures a catalog.
 #[derive(Debug)]
@@ -21,4 +21,8 @@ pub struct Config<'a> {
     pub experimental_mode: Option<bool>,
     /// Whether to enable logging sources and the views that depend upon them.
     pub enable_logging: bool,
+    /// Path to persist source data to disk.
+    ///
+    /// If set to `None`, indicates that source persistence is disabled.
+    pub persistence_directory: Option<PathBuf>,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2669,6 +2669,7 @@ where
                         match crate::persistence::augment_connector(
                             source.connector.clone(),
                             path,
+                            self.catalog.cluster_id(),
                             *id,
                         ) {
                             Ok(Some(connector)) => Some(connector),
@@ -2886,7 +2887,7 @@ where
             if connector.persistence_enabled() {
                 if let Some(persistence_tx) = &mut self.persistence_tx {
                     persistence_tx
-                        .send(PersistenceMessage::AddSource(id))
+                        .send(PersistenceMessage::AddSource(self.catalog.cluster_id(), id))
                         .await
                         .expect("failed to send CREATE SOURCE notification to persistence thread");
                 } else {

--- a/src/coord/src/persistence.rs
+++ b/src/coord/src/persistence.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
@@ -340,7 +340,7 @@ impl Persister {
 /// which may or may not have new data around previously persisted files.
 pub fn augment_connector(
     mut source_connector: SourceConnector,
-    persistence_directory: PathBuf,
+    persistence_directory: &Path,
     source_id: GlobalId,
 ) -> Result<Option<SourceConnector>, anyhow::Error> {
     match &mut source_connector {
@@ -361,7 +361,7 @@ pub fn augment_connector(
 
 fn augment_connector_inner(
     connector: &mut ExternalSourceConnector,
-    persistence_directory: PathBuf,
+    persistence_directory: &Path,
     source_id: GlobalId,
 ) -> Result<(), anyhow::Error> {
     match connector {

--- a/src/coord/src/persistence.rs
+++ b/src/coord/src/persistence.rs
@@ -16,6 +16,7 @@ use anyhow::{anyhow, bail, Context};
 use futures::select;
 use futures::stream::StreamExt;
 use log::{error, info, trace};
+use uuid::Uuid;
 
 use dataflow::source::persistence::RecordFileMetadata;
 use dataflow::PersistenceMessage;
@@ -46,6 +47,7 @@ struct Source {
     // Multiple source instances will send data to the same Source object
     // but the data will be deduplicated before it is persisted.
     id: GlobalId,
+    cluster_id: Uuid,
     path: PathBuf,
     // Number of records currently waiting to be written out.
     pending_records: usize,
@@ -58,9 +60,10 @@ struct Source {
 }
 
 impl Source {
-    fn new(id: GlobalId, path: PathBuf, max_pending_records: usize) -> Self {
+    fn new(id: GlobalId, cluster_id: Uuid, path: PathBuf, max_pending_records: usize) -> Self {
         Source {
             id,
+            cluster_id,
             path,
             pending_records: 0,
             max_pending_records,
@@ -130,6 +133,7 @@ impl Source {
                 // MzOffsets, so the starting number is off by 1 for something like
                 // Kafka
                 let file_name = RecordFileMetadata::generate_file_name(
+                    self.cluster_id,
                     self.id,
                     *partition_id,
                     prefix_start_offset,
@@ -265,34 +269,39 @@ impl Persister {
                     source.insert_record(data.partition_id, data.record)?;
                 }
             }
-            PersistenceMessage::AddSource(id) => {
+            PersistenceMessage::AddSource(cluster_id, source_id) => {
                 // Check if we already have a source
-                if self.sources.contains_key(&id) {
+                if self.sources.contains_key(&source_id) {
                     error!(
                             "Received signal to enable persistence for {} but it is already persisted. Ignoring.",
-                            id
+                            source_id
                         );
                     return Ok(false);
                 }
 
-                if self.disabled_sources.contains(&id) {
-                    error!("Received signal to enable persistence for {} but it has already been disabled. Ignoring.", id);
+                if self.disabled_sources.contains(&source_id) {
+                    error!("Received signal to enable persistence for {} but it has already been disabled. Ignoring.", source_id);
                     return Ok(false);
                 }
 
                 // Create a new subdirectory to store this source's data.
-                let source_path = self.config.path.join(id.to_string());
+                let source_path = self.config.path.join(source_id.to_string());
                 fs::create_dir_all(&source_path).with_context(|| {
                     anyhow!(
                         "trying to create persistence directory: {:#?} for source: {}",
                         source_path,
-                        id
+                        source_id
                     )
                 })?;
 
-                let source = Source::new(id, source_path, self.config.max_pending_records);
-                self.sources.insert(id, source);
-                info!("Enabled persistence for source: {}", id);
+                let source = Source::new(
+                    source_id,
+                    cluster_id,
+                    source_path,
+                    self.config.max_pending_records,
+                );
+                self.sources.insert(source_id, source);
+                info!("Enabled persistence for source: {}", source_id);
             }
             PersistenceMessage::DropSource(id) => {
                 if !self.sources.contains_key(&id) {
@@ -341,6 +350,7 @@ impl Persister {
 pub fn augment_connector(
     mut source_connector: SourceConnector,
     persistence_directory: &Path,
+    cluster_id: Uuid,
     source_id: GlobalId,
 ) -> Result<Option<SourceConnector>, anyhow::Error> {
     match &mut source_connector {
@@ -351,7 +361,7 @@ pub fn augment_connector(
                 // This connector has no persistence, so do nothing.
                 Ok(None)
             } else {
-                augment_connector_inner(connector, persistence_directory, source_id)?;
+                augment_connector_inner(connector, persistence_directory, cluster_id, source_id)?;
                 Ok(Some(source_connector))
             }
         }
@@ -362,6 +372,7 @@ pub fn augment_connector(
 fn augment_connector_inner(
     connector: &mut ExternalSourceConnector,
     persistence_directory: &Path,
+    cluster_id: Uuid,
     source_id: GlobalId,
 ) -> Result<(), anyhow::Error> {
     match connector {
@@ -390,6 +401,18 @@ fn augment_connector_inner(
                     let path = file.path();
                     if let Some(metadata) = RecordFileMetadata::from_path(&path)? {
                         if metadata.source_id != source_id {
+                            error!("Ignoring persistence file with invalid source id. Received: {} expected: {} path: {}",
+                                   metadata.source_id,
+                                   source_id,
+                                   path.display());
+                            continue;
+                        }
+
+                        if metadata.cluster_id != cluster_id {
+                            error!("Ignoring persistence file with invalid cluster id. Received: {} expected: {} path: {}",
+                            metadata.cluster_id,
+                            cluster_id,
+                            path.display());
                             continue;
                         }
 

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -38,6 +38,7 @@ use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::progress::ChangeBatch;
 use timely::worker::Worker as TimelyWorker;
+use uuid::Uuid;
 
 use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
@@ -165,7 +166,7 @@ pub enum PersistenceMessage {
     /// Data to be persisted (sent from dataflow workers)
     Data(WorkerPersistenceData),
     /// Add source to persist
-    AddSource(GlobalId),
+    AddSource(Uuid, GlobalId),
     /// Drop source to persist
     DropSource(GlobalId),
     /// Shut down persistence thread

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -13,6 +13,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::path::Path;
 use std::time::SystemTime;
 
 use expr::{GlobalId, ScalarExpr};
@@ -144,6 +145,11 @@ pub trait Catalog: fmt::Debug {
 
     /// Expresses whether or not the catalog allows experimental mode features.
     fn experimental_mode(&self) -> bool;
+
+    /// Reports the top level directory where source persistence information is stored.
+    ///
+    /// If set to `None`, indicates that source persistence is disabled.
+    fn persistence_directory(&self) -> Option<&Path>;
 }
 
 /// An item in a [`Catalog`].
@@ -319,5 +325,9 @@ impl Catalog for DummyCatalog {
 
     fn experimental_mode(&self) -> bool {
         false
+    }
+
+    fn persistence_directory(&self) -> Option<&Path> {
+        None
     }
 }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1124,9 +1124,14 @@ lazy_static! {
                         CatalogItemType::Source => {},
                         _ =>  bail!("{} is a {}, but internal_read_persisted_data requires a source", source, entry.item_type()),
                     }
+                    let persistence_directory = ecx.qcx.scx.catalog.persistence_directory();
+                    if persistence_directory.is_none() {
+                        bail!("source persistence is currently disabled. Try rerunning Materialize with '--experimental'.");
+                    }
                     Ok(TableFuncPlan {
                         func: TableFunc::ReadPersistedData {
                             source: entry.id(),
+                            persistence_directory: persistence_directory.expect("known to exist").to_path_buf(),
                         },
                         exprs: vec![],
                         column_names: vec!["filename", "offset", "key", "value"].iter().map(|c| Some(ColumnName::from(*c))).collect(),

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -38,7 +38,7 @@ services:
     depends_on: [kafka, zookeeper, schema-registry, materialized]
   materialized:
     mzbuild: materialized
-    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1 --experimental
+    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1 --experimental --persistence-max-pending-records 1
     environment:
     - MZ_DEV=1
     volumes:

--- a/test/testdrive/persistence.td
+++ b/test/testdrive/persistence.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test ingestion of and selection from a simple bytes-formatted topic.
+
+$ kafka-create-topic topic=bytes
+
+$ kafka-ingest format=bytes topic=bytes timestamp=1
+©1
+©2
+
+> CREATE MATERIALIZED SOURCE data
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
+  WITH (persistence=true) FORMAT BYTES
+
+> SELECT offset, value FROM internal_read_persisted_data('data') ORDER BY OFFSET
+ offset  value
+--------------------
+1  "\\xc2\\xa91"
+2  "\\xc2\\xa92"
+
+> SELECT DISTINCT split_part(filename, '-', 4) AS partition,
+  split_part(filename, '-', 5) AS start_offset,
+  split_part(filename, '-', 6) AS end_offset
+  FROM internal_read_persisted_data('data')
+partition  start_offset  end_offset
+--------------------------------------
+0          0            2


### PR DESCRIPTION
Closes #4029

Previously, we had a ABA type of problem in source persistence where a user
could take some previously persisted data, and swap out the corresponding catalog,
at which point its possible that source global ids used in the persistent data
no longer correspond to those in the catalog.

This change makes it so that all persistent data remembers what catalog
version it was created from, and refuses to ingest persistent data that does not
belong to the same catalog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4367)
<!-- Reviewable:end -->
