### PR TITLE
Deduplicate expressions in group key

### DIFF
--- a/src/transform/src/projection_extraction.rs
+++ b/src/transform/src/projection_extraction.rs
@@ -71,7 +71,6 @@ impl ProjectionExtraction {
         {
             // Populate a projection, and track its non-triviality.
             let mut projection = Vec::new();
-            let mut must_project = false;
 
             // If any key is an exact duplicate, we can remove it and use a projection.
             let mut finger = 0;
@@ -82,13 +81,11 @@ impl ProjectionExtraction {
                 {
                     projection.push(position);
                     group_key.remove(finger);
-                    must_project = true;
                 } else {
                     projection.push(finger);
                     finger += 1;
                 }
             }
-            let group_key_len = projection.len();
 
             // If any entry of aggregates exists earlier in aggregates, we can remove it
             // and replace it with a projection that points to the first instance of it.
@@ -98,15 +95,14 @@ impl ProjectionExtraction {
                     .iter()
                     .position(|x| x == &aggregates[finger])
                 {
-                    projection.push(group_key_len + position);
+                    projection.push(group_key.len() + position);
                     aggregates.remove(finger);
-                    must_project = true;
                 } else {
-                    projection.push(group_key_len + finger);
+                    projection.push(group_key.len() + finger);
                     finger += 1;
                 }
             }
-            if must_project {
+            if projection.iter().enumerate().any(|(i, p)| i != *p) {
                 *relation = relation.take_dangerous().project(projection);
             }
         }

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1430,16 +1430,15 @@ ORDER BY
 | |   delta %5 %6.(#0)
 | |   delta %6 %5.(#0)
 | | demand = (#0, #5)
-| Reduce group=(#0, #0)
+| Reduce group=(#0)
 | | agg sum(#5)
-| Filter (#2 > 30000dec)
-| Distinct group=(#0)
 | ArrangeBy (#0)
 
 %8 =
 | Join %4 %7 (= #8 #33)
 | | implementation = Differential %4 %7.(#0)
-| | demand = (#0, #1, #8, #11, #12, #21)
+| | demand = (#0, #1, #8, #11, #12, #21, #34)
+| Filter (#34 > 30000dec)
 | Reduce group=(#1, #0, #8, #12, #11)
 | | agg sum(#21)
 


### PR DESCRIPTION
Duplicate expressions in a `RelationExpr::Reduce` expressions `group_key` field can be removed, and replaced with a projection that places the correct value in the right place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4368)
<!-- Reviewable:end -->
