### PR TITLE
sql-parser: parse ANY(ARRAY[]) array comparison function

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2446,6 +2446,16 @@ impl Parser {
             SetExpr::Query(Box::new(subquery))
         } else if self.parse_keyword("VALUES") {
             SetExpr::Values(self.parse_values()?)
+        } else if self.parse_keyword("ARRAY") {
+            match self.parse_array()? {
+                Expr::Array(array) => {
+                    SetExpr::Values(Values(array.iter().map(|e| vec![e.clone()]).collect()))
+                }
+                _ => {
+                    let range = self.peek_prev_range();
+                    return parser_err!(self, range.start..range.end, "Cannot parse ARRAY values");
+                }
+            }
         } else {
             return self.expected(
                 self.peek_range(),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -497,7 +497,7 @@ fn plan_values(
 ) -> Result<(RelationExpr, Scope), anyhow::Error> {
     ensure!(
         !values.is_empty(),
-        "Can't infer a type for empty VALUES expression"
+        "can't infer a type for empty VALUES expression"
     );
     let ecx = &ExprContext {
         qcx,

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -23,3 +23,45 @@ query TT
 SELECT array_to_string(NULL, ','), array_to_string(NULL, 'foo', 'zerp')
 ----
 NULL  NULL
+
+query T
+SELECT * FROM (ARRAY[1, 2, 3])
+----
+1
+2
+3
+
+# Test array functions
+query B
+SELECT 1 = ANY(ARRAY[1])
+----
+true
+
+query B
+SELECT 1 = ANY(ARRAY[2])
+----
+false
+
+query error no overload for i32 = string
+SELECT 1 = ANY(ARRAY['hi'::text])
+
+query error can't infer a type for empty VALUES expression
+SELECT 'hi'::text = ANY(ARRAY[])
+
+query error VALUES does not have uniform type
+SELECT 123.4 = ANY(ARRAY[1, true, 'hi'::text])
+
+query B
+SELECT 1 != ANY(ARRAY[1])
+----
+false
+
+query B
+select -1+3 > ANY(ARRAY[-1, 0, 1])
+----
+true
+
+query B
+select 'hello'::text <= ANY(ARRAY['there'::text])
+----
+true


### PR DESCRIPTION
Implements part of https://github.com/MaterializeInc/materialize/issues/4353.

Updates `parse_query_body` to optionally parse an ARRAY[] clause. The
rest of the expected [ANY(ARRAY[]) behavior](https://www.postgresql.org/docs/9.1/functions-comparisons.html) is already implemented.

From this change, we will also now be able to support the following query:
```
> SELECT * FROM (ARRAY[1, 2, 3])
```
Postgres does not support the above query. However, we also support the
following, which is not supported by Postgres either:
```
SELECT * FROM (VALUES (1, 2));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4384)
<!-- Reviewable:end -->
