### PR TITLE
testdrive: make oid test not dependent on system oids

### DIFF
--- a/test/testdrive/oid.td
+++ b/test/testdrive/oid.td
@@ -7,10 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Assert required mz_catalog objects are inserted on startup.
-> SELECT COUNT(*) FROM mz_tables WHERE global_id LIKE 's%'
-13
+# This test exercises solely to test OIDs at the boundary (e.g., by sending them
+# through pgwire).
 
-# There is one entry in mz_indexes for each field_number/expression of the index.
-> SELECT COUNT(global_id) FROM mz_indexes WHERE global_id LIKE 's%'
-76
+> SELECT 1::oid
+1


### PR DESCRIPTION
System OIDs are not stable, so testing for the existence of any
particular OID means you have to update the test quite frequently. Just
testing that a static OID can be transmitted through pgwire provides the
same benefits with a bit less hassle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4385)
<!-- Reviewable:end -->
