### PR TITLE
Tail in order

### DIFF
--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -11,7 +11,7 @@ use std::collections::BinaryHeap;
 
 use differential_dataflow::AsCollection;
 use differential_dataflow::{operators::consolidate::Consolidate, Hashable};
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -7,7 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use timely::dataflow::channels::pact::Pipeline;
+use std::collections::BinaryHeap;
+
+use differential_dataflow::AsCollection;
+use differential_dataflow::{operators::consolidate::Consolidate, Hashable};
+use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 
@@ -18,6 +22,21 @@ use dataflow_types::{TailSinkConnector, Update};
 use expr::GlobalId;
 use repr::{Diff, Row, Timestamp};
 
+#[derive(PartialEq, Eq, Debug)]
+struct TsOrder(Row, Timestamp, Diff);
+
+impl Ord for TsOrder {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.1.cmp(&self.1)
+    }
+}
+
+impl PartialOrd for TsOrder {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 pub fn tail<G>(
     stream: &Stream<G, (Row, Timestamp, Diff)>,
     id: GlobalId,
@@ -26,29 +45,46 @@ pub fn tail<G>(
     G: Scope<Timestamp = Timestamp>,
 {
     let mut tx = block_on(connector.tx.connect()).expect("tail transmitter failed");
-    stream.sink(Pipeline, &format!("tail-{}", id), move |input| {
-        input.for_each(|_, rows| {
-            let mut results: Vec<Update> = Vec::new();
-            for (row, time, diff) in rows.iter() {
-                let should_emit = if connector.strict {
-                    connector.frontier.less_than(time)
-                } else {
-                    connector.frontier.less_equal(time)
-                };
-                if should_emit {
-                    results.push(Update {
-                        row: row.clone(),
-                        timestamp: *time,
-                        diff: *diff,
-                    });
-                }
-            }
+    let hash = id.hashed();
+    let consolidated = stream.as_collection().consolidate();
 
-            // TODO(benesch): this blocks the Timely thread until the send
-            // completes. Hopefully it's just a quick write to a kernel buffer,
-            // but perhaps not if the batch gets too large? We may need to do
-            // something smarter, like offloading to a networking thread.
-            block_on(tx.send(results)).expect("tail send failed");
-        });
-    })
+    let mut stash = BinaryHeap::new();
+    consolidated.inner.sink(
+        Exchange::new(move |_| hash),
+        &format!("tail-{}", id),
+        move |input| {
+            input.for_each(|_, rows| {
+                for (row, time, diff) in rows.replace(vec![]) {
+                    let should_emit = if connector.strict {
+                        connector.frontier.less_than(&time)
+                    } else {
+                        connector.frontier.less_equal(&time)
+                    };
+                    if should_emit {
+                        stash.push(TsOrder(row, time, diff));
+                    }
+                }
+            });
+            let mut results = Vec::new();
+            while stash
+                .peek()
+                .map(|elt| !input.frontier().less_equal(&elt.1))
+                .unwrap_or(false)
+            {
+                let TsOrder(row, timestamp, diff) = stash.pop().unwrap();
+                results.push(Update {
+                    row,
+                    timestamp,
+                    diff,
+                })
+            }
+            if !results.is_empty() {
+                // TODO(benesch): this blocks the Timely thread until the send
+                // completes. Hopefully it's just a quick write to a kernel buffer,
+                // but perhaps not if the batch gets too large? We may need to do
+                // something smarter, like offloading to a networking thread.
+                block_on(tx.send(results)).expect("tail send failed");
+            }
+        },
+    )
 }


### PR DESCRIPTION
This causes tail to output things in timestamp order, by waiting for the frontier to advance before shipping anything.

Haven't written tests or anything yet, since I wanted to get people's feedback on whether this is actually a good approach first.

Note that this requires all processing to be single-threaded, but since we are sending the results back to the single-threaded coordinator anyway, maybe that's fine. (Also, it seems unlikely that the tail operator will be the bottleneck for anyone).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4393)
<!-- Reviewable:end -->
