### PR TITLE
sql: support array -> string casts

### DIFF
--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -750,6 +750,7 @@ impl<'a> ScalarType {
         match self {
             ScalarType::Decimal(..) => ScalarType::Decimal(0, 0),
             ScalarType::List(..) => ScalarType::List(Box::new(ScalarType::String)),
+            ScalarType::Array(..) => ScalarType::Array(Box::new(ScalarType::String)),
             ScalarType::Record { .. } => ScalarType::Record { fields: vec![] },
             _ => self.clone(),
         }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -346,6 +346,12 @@ lazy_static! {
                 Ok(e.call_unary(CastRecordToString { ty }))
             }),
 
+            // ARRAY
+            (Array(Box::new(String)), Explicit(String)) => CastOp::F(|ecx, e, _to_type| {
+                let ty = ecx.scalar_type(&e);
+                Ok(e.call_unary(CastArrayToString { ty }))
+            }),
+
             // JSONB
             (Jsonb, Explicit(Bool)) => CastJsonbToBool,
             (Jsonb, Explicit(Int32)) => CastOp::F(from_jsonb_f64_cast),

--- a/test/testdrive/array.td
+++ b/test/testdrive/array.td
@@ -14,3 +14,8 @@
 array
 ----
 {{a,b},{NULL,d}}
+
+> SELECT ARRAY[ARRAY['a', 'b'], ARRAY[NULL, 'd']]::text
+array
+----
+{{a,b},{NULL,d}}


### PR DESCRIPTION
The code for this conversion already existed to facilitate the pgwire
text encoding, but it wasn't possible to explicitly request that cast
in SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4398)
<!-- Reviewable:end -->
