### PR TITLE
Make protobuf error messages more useful

### DIFF
--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -47,7 +47,7 @@ impl DecoderState for ProtobufDecoderState {
             }
             Err(err) => {
                 self.events_error += 1;
-                Err(format!("protobuf deserialization error: {}", err))
+                Err(format!("protobuf deserialization error: {:#}", err))
             }
         }
     }
@@ -68,7 +68,7 @@ impl DecoderState for ProtobufDecoderState {
             }
             Err(err) => {
                 self.events_error += 1;
-                error!("protobuf deserialization error: {}", err)
+                error!("protobuf deserialization error: {:#}", err)
             }
         }
     }
@@ -93,7 +93,7 @@ impl DecoderState for ProtobufDecoderState {
             }
             Err(err) => {
                 self.events_error += 1;
-                error!("protobuf deserialization error: {}", err)
+                error!("protobuf deserialization error: {:#}", err)
             }
         }
     }


### PR DESCRIPTION
Print the underlying errors, not just the outermost piece of context. Fixes #4402

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4404)
<!-- Reviewable:end -->
