### PR TITLE
doc/user: add simple versions API

### DIFF
--- a/doc/user/content/api/versions.md
+++ b/doc/user/content/api/versions.md
@@ -1,0 +1,8 @@
+---
+layout: versions
+outputs: [json]
+url: /versions.json
+---
+
+This page is a stub for rendering the released versions of Materialize as
+JSON. The actual rendering logic lives in layouts/api/versions.json.

--- a/doc/user/layouts/api/versions.json
+++ b/doc/user/layouts/api/versions.json
@@ -1,0 +1,1 @@
+{{.Site.Params.Versions | jsonify}}


### PR DESCRIPTION
This commit adds a new JSON endpoint that lists the versions of
Materialize at:

    https://materialize.io/docs/versions.json

The docs site already maintains the list of Materialize versions, so
this amounts to a simple rendering problem. Having this API available
simplifies the implementation of tools that want to ask questions like
"what is the latest available Materialize version?"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4406)
<!-- Reviewable:end -->
