### PR TITLE
default to using 'physical cores / 2' number of threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,6 +1863,7 @@ dependencies = [
  "krb5-src",
  "lazy_static",
  "log",
+ "num_cpus",
  "openssl",
  "openssl-sys",
  "ore",
@@ -2276,10 +2277,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.10.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
+ "hermit-abi",
  "libc",
 ]
 

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -28,6 +28,7 @@ include_dir = "0.6.0"
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 log = "0.4.11"
+num_cpus = "1.0"
 openssl = { version = "0.10.30", features = ["vendored"] }
 openssl-sys = { version = "0.9.58", features = ["vendored"] }
 ore = { path = "../ore" }

--- a/src/materialized/tests/cli.rs
+++ b/src/materialized/tests/cli.rs
@@ -26,10 +26,9 @@ fn cmd() -> Command {
 fn test_threads() {
     let assert_fail = |cmd: &mut Command| {
         cmd.assert().failure().stderr(predicate::str::starts_with(
-            "materialized: '--workers' must be specified and greater than 0",
+            "materialized: '--workers' must be greater than 0",
         ))
     };
-    assert_fail(&mut cmd());
     assert_fail(cmd().arg("-w0"));
     assert_fail(cmd().env("MZ_WORKERS", "0"));
 


### PR DESCRIPTION
I know there's some history here, so I'm not trying to reopen _too_ big of a can of worms, but... 🙂 

Immediately asking users to make a decision that they're not equipped to make isn't a great initial experience, especially when we have a recommended default. I understand that the optimal worker count will vary by workload and will likely require tuning, but it doesn't seem worthwhile to introduce friction at the very start of the process - especially when the most likely result of that friction is simply passing the default 'cores / 2' config and carrying on. A better alternative would be to log a visible warning if the default is used, pointing to the relevant tuning docs.

I also think there's a big difference between requiring no startup parms and >=1 startup params. The extremely minimal config materialize takes to standup is a fairly unique benefit in this space and does lead to a great initial UX; I'd hate to give that up unless truly necessary.

About the default itself - physical cores / 2 seems fine, but if we wanted a more conservative config to cast a wider net for potential 'Docker on a laptop' scenarios then defaulting to 1 core if 4 cores or less and cores / 2 above that also seems good.

(not going to invest time into the test failures yet)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4407)
<!-- Reviewable:end -->
