### PR TITLE
Create a join utility to avoid repeating code everywhere in joins.

### DIFF
--- a/src/dataflow/src/render/delta_join.rs
+++ b/src/dataflow/src/render/delta_join.rs
@@ -14,7 +14,7 @@ use dogsdogsdogs::altneu::AltNeu;
 use timely::dataflow::Scope;
 
 use dataflow_types::DataflowError;
-use expr::{RelationExpr, ScalarExpr};
+use expr::{JoinUtil, RelationExpr, ScalarExpr};
 use repr::{Datum, Row, RowArena, Timestamp};
 
 use super::context::{ArrangementFlavor, Context};
@@ -59,19 +59,7 @@ where
                         // existing arrangements, to which we have access).
                         let mut delta_queries = Vec::new();
 
-                        // We'll need type information for arities, if nothing else.
-                        let types = inputs.iter().map(|input| input.typ()).collect::<Vec<_>>();
-                        let arities = types
-                            .iter()
-                            .map(|typ| typ.column_types.len())
-                            .collect::<Vec<_>>();
-
-                        let mut offset = 0;
-                        let mut prior_arities = Vec::new();
-                        for input in 0..inputs.len() {
-                            prior_arities.push(offset);
-                            offset += arities[input];
-                        }
+                        let join_util = JoinUtil::new(inputs);
 
                         let mut err_streams = Vec::with_capacity(inputs.len());
                         for relation in 0..inputs.len() {
@@ -96,7 +84,7 @@ where
                                 err_streams.push(errs);
 
                                 // We track the sources of each column in our update stream.
-                                let mut source_columns = (prior_arities[relation]..prior_arities[relation]+arities[relation])
+                                let mut source_columns = join_util.global_columns(relation)
                                     .collect::<Vec<_>>();
 
                                 let mut predicates = predicates.to_vec();
@@ -110,6 +98,7 @@ where
                                     err_streams.push(errs.leave().leave());
                                 }
 
+                                let mut bound_inputs = vec![relation];
                                 // We use the order specified by the implementation.
                                 let order = &orders[relation];
 
@@ -119,9 +108,7 @@ where
 
                                     let mut next_key_rebased = next_key.clone();
                                     for expr in next_key_rebased.iter_mut() {
-                                        expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
-                                            *c += prior_arities[*other];
-                                        });
+                                        join_util.globalize_expression(expr, *other);
                                     }
 
                                     // Keys for the incoming updates are determined by locating
@@ -129,24 +116,9 @@ where
                                     let prev_key = next_key_rebased
                                         .iter()
                                         .map(|expr| {
-                                            // We expect to find `expr` in some `equivalence` which
-                                            // has a bound expression. Otherwise, the join plan is
-                                            // defective and we should panic.
-                                            let equivalence =
-                                            equivalences
-                                                .iter()
-                                                .find(|equivs| equivs.contains(expr))
-                                                .expect("Expression in join plan is not in an equivalence relation");
-
-                                            // We expect to find exactly one bound expression, as
-                                            // multiple bound expressions should result in a filter
-                                            // and be removed once they have.
-                                            let mut bound_expr =
-                                            equivalence
-                                                .iter()
-                                                .find(|expr| expr.support().into_iter().all(|c| source_columns.contains(&c)))
-                                                .expect("Expression in join plan is not bound at time of use")
-                                                .clone();
+                                            let mut bound_expr = join_util
+                                                .find_bound_expr(expr, &bound_inputs, &equivalences)
+                                                .expect("Expression in join plan is not bound at time of use");
 
                                             bound_expr.visit_mut(&mut |e| if let ScalarExpr::Column(c) = e {
                                                 *c = source_columns.iter().position(|x| x == c).expect("Did not find bound column in source_columns");
@@ -228,7 +200,7 @@ where
 
                                     // Update our map of the sources of each column in the update stream.
                                     source_columns
-                                        .extend((0..arities[*other]).map(|c| prior_arities[*other] + c));
+                                        .extend(join_util.global_columns(*other));
 
                                     let (oks, errs) = build_filter(
                                         update_stream,
@@ -240,6 +212,8 @@ where
                                     if let Some(errs) = errs {
                                         err_streams.push(errs.leave().leave());
                                     }
+
+                                    bound_inputs.push(*other);
                                 }
 
                                 // We must now de-permute the results to return to the common order.

--- a/src/dataflow/src/render/delta_join.rs
+++ b/src/dataflow/src/render/delta_join.rs
@@ -106,10 +106,9 @@ where
                                 // other relations, in the specified order.
                                 for (other, next_key) in order.iter() {
 
-                                    let mut next_key_rebased = next_key.clone();
-                                    for expr in next_key_rebased.iter_mut() {
-                                        join_util.globalize_expression(expr, *other);
-                                    }
+                                    let next_key_rebased = next_key.iter().map(
+                                        |k| join_util.map_expr_to_global(k, *other)
+                                    ).collect::<Vec<_>>();
 
                                     // Keys for the incoming updates are determined by locating
                                     // the elements of `next_keys` among the existing `columns`.

--- a/src/dataflow/src/render/delta_join.rs
+++ b/src/dataflow/src/render/delta_join.rs
@@ -98,6 +98,9 @@ where
                                     err_streams.push(errs.leave().leave());
                                 }
 
+                                // We track the input relations as they are
+                                // added to the join so we can figure out
+                                // which expressions have been bound.
                                 let mut bound_inputs = vec![relation];
                                 // We use the order specified by the implementation.
                                 let order = &orders[relation];
@@ -107,7 +110,7 @@ where
                                 for (other, next_key) in order.iter() {
 
                                     let next_key_rebased = next_key.iter().map(
-                                        |k| input_mapper.map_expr_to_global(k, *other)
+                                        |k| input_mapper.map_expr_to_global(k.clone(), *other)
                                     ).collect::<Vec<_>>();
 
                                     // Keys for the incoming updates are determined by locating

--- a/src/dataflow/src/render/join.rs
+++ b/src/dataflow/src/render/join.rs
@@ -90,10 +90,10 @@ where
 
             let mut bound_inputs = vec![*start];
             for (input_index, (input, next_keys)) in order.iter().enumerate() {
-                let mut next_keys_rebased = next_keys.clone();
-                for expr in next_keys_rebased.iter_mut() {
-                    join_util.globalize_expression(expr, *input);
-                }
+                let next_keys_rebased = next_keys
+                    .iter()
+                    .map(|k| join_util.map_expr_to_global(k, *input))
+                    .collect::<Vec<_>>();
 
                 // Keys for the next input to be joined must be produced from
                 // ScalarExprs found in `equivalences`, re-written to bind the
@@ -141,7 +141,7 @@ where
                     .filter(|c| column_demand.contains(c))
                     .collect::<Vec<_>>();
 
-                let next_vals = join_util.localize_columns(&next_source_vals);
+                let next_vals = join_util.map_columns_to_local(&next_source_vals);
 
                 // When joining the first input, check to see if there is a
                 // convenient ready-made arrangement

--- a/src/dataflow/src/render/join.rs
+++ b/src/dataflow/src/render/join.rs
@@ -57,17 +57,7 @@ where
                 equivalence.dedup();
             }
 
-            let types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-            let arities = types
-                .iter()
-                .map(|t| t.column_types.len())
-                .collect::<Vec<_>>();
-            let mut offset = 0;
-            let mut prior_arities = Vec::new();
-            for input in 0..inputs.len() {
-                prior_arities.push(offset);
-                offset += arities[input];
-            }
+            let join_util = expr::JoinUtil::new(inputs);
 
             // Unwrap demand
             // TODO: If we pushed predicates into the operator, we could have a
@@ -79,9 +69,7 @@ where
             let (mut joined, mut errs) = self.collection(&inputs[*start]).unwrap();
 
             // Maintain sources of each in-progress column.
-            let mut source_columns = (prior_arities[*start]
-                ..prior_arities[*start] + arities[*start])
-                .collect::<Vec<_>>();
+            let mut source_columns = join_util.global_columns(*start).collect::<Vec<_>>();
 
             let mut predicates = predicates.to_vec();
             if start_arr.is_none() || inputs.len() == 1 {
@@ -100,14 +88,11 @@ where
                 }
             }
 
+            let mut bound_inputs = vec![*start];
             for (input_index, (input, next_keys)) in order.iter().enumerate() {
                 let mut next_keys_rebased = next_keys.clone();
                 for expr in next_keys_rebased.iter_mut() {
-                    expr.visit_mut(&mut |e| {
-                        if let ScalarExpr::Column(c) = e {
-                            *c += prior_arities[*input];
-                        }
-                    });
+                    join_util.globalize_expression(expr, *input);
                 }
 
                 // Keys for the next input to be joined must be produced from
@@ -116,26 +101,9 @@ where
                 let prev_keys = next_keys_rebased
                     .iter()
                     .map(|expr| {
-                        // We expect to find `expr` in some `equivalence` which
-                        // has a bound expression. Otherwise, the join plan is
-                        // defective and we should panic.
-                        let equivalence = equivalences
-                            .iter()
-                            .find(|equivs| equivs.contains(expr))
-                            .expect("Expression in join plan is not in an equivalence relation");
-
-                        // We expect to find exactly one bound expression, as
-                        // multiple bound expressions should result in a filter
-                        // and be removed once they have.
-                        let mut bound_expr = equivalence
-                            .iter()
-                            .find(|expr| {
-                                expr.support()
-                                    .into_iter()
-                                    .all(|c| source_columns.contains(&c))
-                            })
-                            .expect("Expression in join plan is not bound at time of use")
-                            .clone();
+                        let mut bound_expr = join_util
+                            .find_bound_expr(expr, &bound_inputs, &equivalences)
+                            .expect("Expression in join plan is not bound at time of use");
 
                         bound_expr.visit_mut(&mut |e| {
                             if let ScalarExpr::Column(c) = e {
@@ -168,11 +136,12 @@ where
                 }
                 column_demand.extend(demand.iter().cloned());
 
-                let next_vals = (0..arities[*input])
-                    .filter(|c| column_demand.contains(&(prior_arities[*input] + c)))
+                let next_source_vals = join_util
+                    .global_columns(*input)
+                    .filter(|c| column_demand.contains(c))
                     .collect::<Vec<_>>();
 
-                let next_source_vals = next_vals.clone();
+                let next_vals = join_util.localize_columns(&next_source_vals);
 
                 // When joining the first input, check to see if there is a
                 // convenient ready-made arrangement
@@ -255,10 +224,7 @@ where
 
                 joined = j;
                 errs = errs.concat(&es);
-                source_columns = prev_vals
-                    .into_iter()
-                    .chain(next_source_vals.iter().map(|i| prior_arities[*input] + *i))
-                    .collect();
+                source_columns = prev_vals.into_iter().chain(next_source_vals).collect();
 
                 let (j, es) = crate::render::delta_join::build_filter(
                     joined,
@@ -270,6 +236,8 @@ where
                 if let Some(es) = es {
                     errs = errs.concat(&es);
                 }
+
+                bound_inputs.push(*input);
             }
 
             // We are obliged to produce demanded columns in order, with dummy data allowed

--- a/src/dataflow/src/render/join.rs
+++ b/src/dataflow/src/render/join.rs
@@ -88,11 +88,14 @@ where
                 }
             }
 
+            // We track the input relations as they are
+            // added to the join so we can figure out
+            // which expressions have been bound.
             let mut bound_inputs = vec![*start];
             for (input_index, (input, next_keys)) in order.iter().enumerate() {
                 let next_keys_rebased = next_keys
                     .iter()
-                    .map(|k| input_mapper.map_expr_to_global(k, *input))
+                    .map(|k| input_mapper.map_expr_to_global(k.clone(), *input))
                     .collect::<Vec<_>>();
 
                 // Keys for the next input to be joined must be produced from

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -22,7 +22,7 @@ pub mod explain;
 pub use id::{DummyHumanizer, GlobalId, Id, IdHumanizer, LocalId, PartitionId, SourceInstanceId};
 pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
-pub use relation::join_util::JoinUtil;
+pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
     compare_columns, AggregateExpr, ColumnOrder, IdGen, JoinImplementation, RelationExpr,
     RowSetFinishing,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -22,6 +22,7 @@ pub mod explain;
 pub use id::{DummyHumanizer, GlobalId, Id, IdHumanizer, LocalId, PartitionId, SourceInstanceId};
 pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
+pub use relation::join_util::JoinUtil;
 pub use relation::{
     compare_columns, AggregateExpr, ColumnOrder, IdGen, JoinImplementation, RelationExpr,
     RowSetFinishing,

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -18,7 +18,7 @@ use crate::ScalarExpr;
 /// This utility focuses on taking expressions that are in terms of
 /// the local input and re-expressing them in global terms and vice versa.
 #[derive(Debug)]
-pub struct JoinUtil {
+pub struct JoinInputMapper {
     /// The number of columns per input. All other fields in this struct are
     /// derived using the information in this field.
     arities: Vec<usize>,
@@ -30,8 +30,8 @@ pub struct JoinUtil {
     prior_arities: Vec<usize>,
 }
 
-impl JoinUtil {
-    /// Creates a new `JoinUtil` and calculates the mapping of global context
+impl JoinInputMapper {
+    /// Creates a new `JoinInputMapper` and calculates the mapping of global context
     /// columns to local context columns.
     pub fn new(inputs: &[RelationExpr]) -> Self {
         let types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
@@ -53,7 +53,7 @@ impl JoinUtil {
             .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
             .collect::<Vec<_>>();
 
-        JoinUtil {
+        JoinInputMapper {
             arities,
             input_relation,
             prior_arities,
@@ -127,7 +127,7 @@ impl JoinUtil {
     ///
     /// ```
     /// use repr::{Datum, ColumnType, RelationType, ScalarType};
-    /// use expr::{JoinUtil, RelationExpr, ScalarExpr};
+    /// use expr::{JoinInputMapper, RelationExpr, ScalarExpr};
     ///
     /// // A two-column schema common to each of the three inputs
     /// let schema = RelationType::new(vec![
@@ -147,14 +147,14 @@ impl JoinUtil {
     ///   vec![ScalarExpr::Column(1), ScalarExpr::Column(2), ScalarExpr::Column(4)],
     /// ];
     ///
-    /// let join_util = JoinUtil::new(&[input0, input1, input2]);
+    /// let input_mapper = JoinInputMapper::new(&[input0, input1, input2]);
     /// assert_eq!(
     ///   Some(ScalarExpr::Column(4)),
-    ///   join_util.find_bound_expr(&ScalarExpr::Column(2), &[2], &equivalences)
+    ///   input_mapper.find_bound_expr(&ScalarExpr::Column(2), &[2], &equivalences)
     /// );
     /// assert_eq!(
     ///   None,
-    ///   join_util.find_bound_expr(&ScalarExpr::Column(0), &[1], &equivalences)
+    ///   input_mapper.find_bound_expr(&ScalarExpr::Column(0), &[1], &equivalences)
     /// );
     /// ```
     pub fn find_bound_expr(

--- a/src/expr/src/relation/join_util.rs
+++ b/src/expr/src/relation/join_util.rs
@@ -1,0 +1,181 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::ops::Range;
+
+use crate::RelationExpr;
+use crate::ScalarExpr;
+
+/// Any column in a join expression exists in two contexts:
+/// 1) It has a position relative to the result of the join (global)
+/// 2) It has a position relative to the specific input it came from (local)
+/// This utility focuses on taking expressions that are in terms of
+/// the local input and re-expressing them in global terms and vice versa.
+#[derive(Debug)]
+pub struct JoinUtil {
+    /// The number of columns per input
+    arities: Vec<usize>,
+    /// Looks up which input each column belongs to
+    input_relation: Vec<usize>,
+    /// The sum of the arities of the previous inputs in the join
+    prior_arities: Vec<usize>,
+}
+
+impl JoinUtil {
+    /// Creates a new `JoinUtil` and calculates the mapping of global context
+    /// columns to local context columns.
+    pub fn new(inputs: &[RelationExpr]) -> Self {
+        let types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
+        let arities = types
+            .iter()
+            .map(|t| t.column_types.len())
+            .collect::<Vec<_>>();
+
+        let mut offset = 0;
+        let mut prior_arities = Vec::new();
+        for input in 0..inputs.len() {
+            prior_arities.push(offset);
+            offset += arities[input];
+        }
+
+        let input_relation = arities
+            .iter()
+            .enumerate()
+            .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
+            .collect::<Vec<_>>();
+
+        JoinUtil {
+            arities,
+            input_relation,
+            prior_arities,
+        }
+    }
+
+    /// All column numbers in order for a particular input in the local context
+    #[inline]
+    pub fn local_columns(&self, index: usize) -> Range<usize> {
+        0..self.arities[index]
+    }
+
+    /// All column numbers in order for a particular input in the global context
+    #[inline]
+    pub fn global_columns(&self, index: usize) -> Range<usize> {
+        self.prior_arities[index]..(self.prior_arities[index] + self.arities[index])
+    }
+
+    /// Shift the column references in an expression from the context of the
+    /// larger join to the context of the input that the expression refers to.
+    pub fn localize_expression(&self, expr: &mut ScalarExpr) {
+        expr.visit_mut(&mut |e| {
+            if let ScalarExpr::Column(c) = e {
+                *c -= self.prior_arities[self.input_relation[*c]];
+            }
+        });
+    }
+
+    /// Shift the column references in an expression from the context of the
+    /// `index`th input to the context of the larger join.
+    pub fn globalize_expression(&self, expr: &mut ScalarExpr, index: usize) {
+        expr.visit_mut(&mut |e| {
+            if let ScalarExpr::Column(c) = e {
+                *c += self.prior_arities[index];
+            }
+        });
+    }
+
+    /// Convert column numbers to their corresponding values relative to the
+    /// input it comes from
+    pub fn localize_columns(&self, columns: &[usize]) -> Vec<usize> {
+        columns
+            .iter()
+            .map(|c| *c - self.prior_arities[self.input_relation[*c]])
+            .collect::<Vec<_>>()
+    }
+
+    /// Find the sorted, dedupped set of inputs an expression references
+    pub fn lookup_inputs(&self, expr: &ScalarExpr) -> Vec<usize> {
+        let mut result = expr
+            .support()
+            .iter()
+            .map(|c| self.input_relation[*c])
+            .collect::<Vec<_>>();
+        result.sort();
+        result.dedup();
+        result
+    }
+
+    /// Takes an expression in the global context and looks in `equivalences`
+    /// for an equivalent expression (also expressed in the global context) that
+    /// belongs to one or more of the inputs in `bound_inputs`
+    pub fn find_bound_expr(
+        &self,
+        expr: &ScalarExpr,
+        bound_inputs: &[usize],
+        equivalences: &[Vec<ScalarExpr>],
+    ) -> Option<ScalarExpr> {
+        if let Some(equivalence) = equivalences.iter().find(|equivs| equivs.contains(expr)) {
+            if let Some(bound_expr) = equivalence.iter().find(|expr| {
+                self.lookup_inputs(expr)
+                    .into_iter()
+                    .all(|i| bound_inputs.contains(&i))
+            }) {
+                return Some(bound_expr.clone());
+            }
+        }
+        None
+    }
+
+    /// Try to rewrite an subexpression referencing the larger join so that all the
+    /// column references point to the `index` input taking advantage of equivalences
+    /// in the join, if necessary.
+    /// Takes an expression in the global context and makes rewrites in the
+    /// global context so we can identify using `lookup_inputs` whether if an expression
+    /// was only partially rewritten.
+    fn try_localize_subexpression(
+        &self,
+        expr: &mut ScalarExpr,
+        index: usize,
+        equivalences: &[Vec<ScalarExpr>],
+    ) {
+        let inputs = self.lookup_inputs(expr);
+        if inputs.len() == 1 && *inputs.first().unwrap() == index {
+            // we're good. do not continue the recursion
+        } else if let Some(bound_expr) = self.find_bound_expr(expr, &[index], equivalences) {
+            // replace the subexpression with the equivalent one from input `index`
+            *expr = bound_expr;
+        } else {
+            // recurse to see if we can replace subexpressions further down
+            expr.visit1_mut(|e| self.try_localize_subexpression(e, index, equivalences))
+        }
+    }
+
+    /// Try to rewrite an expression referencing the larger join so that all the
+    /// column references point to the `index` input taking advantage of equivalences
+    /// in the join, if necessary.
+    /// The return value, if not None, is in the context local to input `index`
+    pub fn try_localize_expression(
+        &self,
+        expr: &ScalarExpr,
+        index: usize,
+        equivalences: &[Vec<ScalarExpr>],
+    ) -> Option<ScalarExpr> {
+        let mut expr = expr.clone();
+        expr.visit1_mut(&mut |e| self.try_localize_subexpression(e, index, equivalences));
+        // if the localization attempt is successful, all columns in `expr`
+        // should only come from input `index`
+        let inputs_after_localization = self.lookup_inputs(&expr);
+        if inputs_after_localization.len() == 1 {
+            if *inputs_after_localization.first().unwrap() == index {
+                self.localize_expression(&mut expr);
+                return Some(expr);
+            }
+        }
+        None
+    }
+}

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -23,7 +23,7 @@ use crate::id::DummyHumanizer;
 use crate::{GlobalId, Id, IdHumanizer, LocalId, ScalarExpr};
 
 pub mod func;
-pub mod join_util;
+pub mod join_input_mapper;
 
 /// An abstract syntax tree which defines a collection.
 ///

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -23,6 +23,7 @@ use crate::id::DummyHumanizer;
 use crate::{GlobalId, Id, IdHumanizer, LocalId, ScalarExpr};
 
 pub mod func;
+pub mod join_util;
 
 /// An abstract syntax tree which defines a collection.
 ///

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 
 use crate::TransformArgs;
-use expr::{Id, RelationExpr, ScalarExpr};
+use expr::{Id, JoinUtil, RelationExpr, ScalarExpr};
 
 /// Determines the join implementation for join operators.
 #[derive(Debug)]
@@ -82,19 +82,7 @@ impl JoinImplementation {
         } = relation
         {
             // Common information of broad utility.
-            // TODO: Figure out how to package this up for everyone who uses it.
-            let types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
-            let arities = types
-                .iter()
-                .map(|t| t.column_types.len())
-                .collect::<Vec<_>>();
-
-            let mut offset = 0;
-            let mut prior_arities = Vec::new();
-            for input in 0..inputs.len() {
-                prior_arities.push(offset);
-                offset += arities[input];
-            }
+            let join_util = JoinUtil::new(inputs);
 
             // The first fundamental question is whether we should employ a delta query or not.
             //
@@ -103,7 +91,7 @@ impl JoinImplementation {
             // with columns present in `indexes`, if it is an `ArrangeBy` with the columns present,
             // or a filter wrapped around either of these.
 
-            let unique_keys = types.iter().map(|t| t.keys.clone()).collect::<Vec<_>>();
+            let unique_keys = inputs.iter().map(|i| i.typ().keys).collect::<Vec<_>>();
             let mut available_arrangements = vec![Vec::new(); inputs.len()];
             for index in 0..inputs.len() {
                 // We can work around filters, as we can lift the predicates into the join execution.
@@ -149,11 +137,7 @@ impl JoinImplementation {
                 available_arrangements[index].retain(|key| {
                     key.iter().all(|k| {
                         let mut k = k.clone();
-                        k.visit_mut(&mut |e| {
-                            if let ScalarExpr::Column(c) = e {
-                                *c += prior_arities[index]
-                            }
-                        });
+                        join_util.globalize_expression(&mut k, index);
                         equivalences
                             .iter()
                             .any(|equivalence| equivalence.contains(&k))
@@ -164,20 +148,10 @@ impl JoinImplementation {
             // Determine if we can perform delta queries with the existing arrangements.
             // We could defer the execution if we are sure we know we want one input,
             // but we could imagine wanting the best from each and then comparing the two.
-            let delta_query_plan = delta_queries::plan(
-                relation,
-                &arities,
-                &prior_arities,
-                &available_arrangements,
-                &unique_keys,
-            );
-            let differential_plan = differential::plan(
-                relation,
-                &arities,
-                &prior_arities,
-                &available_arrangements,
-                &unique_keys,
-            );
+            let delta_query_plan =
+                delta_queries::plan(relation, &join_util, &available_arrangements, &unique_keys);
+            let differential_plan =
+                differential::plan(relation, &join_util, &available_arrangements, &unique_keys);
 
             *relation = delta_query_plan
                 .or(differential_plan)
@@ -188,15 +162,14 @@ impl JoinImplementation {
 
 mod delta_queries {
 
-    use expr::{JoinImplementation, RelationExpr, ScalarExpr};
+    use expr::{JoinImplementation, JoinUtil, RelationExpr, ScalarExpr};
 
     /// Creates a delta query plan, and any predicates that need to be lifted.
     ///
     /// The method returns `None` if it fails to find a sufficiently pleasing plan.
     pub fn plan(
         join: &RelationExpr,
-        arities: &[usize],
-        prior_arities: &[usize],
+        join_util: &JoinUtil,
         available: &[Vec<Vec<ScalarExpr>>],
         unique_keys: &[Vec<Vec<usize>>],
     ) -> Option<RelationExpr> {
@@ -217,20 +190,9 @@ mod delta_queries {
                 // filters will always be planned as delta queries.
                 return None;
             }
-            let input_relation = arities
-                .iter()
-                .enumerate()
-                .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
-                .collect::<Vec<_>>();
 
             // Determine a viable order for each relation, or return `None` if none found.
-            let orders = super::optimize_orders(
-                equivalences,
-                available,
-                unique_keys,
-                &input_relation[..],
-                prior_arities,
-            );
+            let orders = super::optimize_orders(equivalences, available, unique_keys, join_util);
 
             // A viable delta query requires that, for every order,
             // there is an arrangement for every input except for
@@ -258,7 +220,7 @@ mod delta_queries {
             super::implement_arrangements(
                 inputs,
                 available,
-                prior_arities,
+                join_util,
                 orders.iter().flatten(),
                 &mut lifted,
             );
@@ -291,13 +253,12 @@ mod delta_queries {
 
 mod differential {
 
-    use expr::{JoinImplementation, RelationExpr, ScalarExpr};
+    use expr::{JoinImplementation, JoinUtil, RelationExpr, ScalarExpr};
 
     /// Creates a linear differential plan, and any predicates that need to be lifted.
     pub fn plan(
         join: &RelationExpr,
-        arities: &[usize],
-        prior_arities: &[usize],
+        join_util: &JoinUtil,
         available: &[Vec<Vec<ScalarExpr>>],
         unique_keys: &[Vec<Vec<usize>>],
     ) -> Option<RelationExpr> {
@@ -315,24 +276,13 @@ mod differential {
             }
             equivalences.sort();
 
-            let input_relation = arities
-                .iter()
-                .enumerate()
-                .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
-                .collect::<Vec<_>>();
-
             // We prefer a starting point based on the characteristics of the other input arrangements.
             // We could change this preference at any point, but the list of orders should still inform.
             // Important, we should choose something stable under re-ordering, to converge under fixed
             // point iteration; we choose to start with the first input optimizing our criteria, which
             // should remain stable even when promoted to the first position.
-            let mut orders = super::optimize_orders(
-                equivalences,
-                available,
-                unique_keys,
-                &input_relation[..],
-                prior_arities,
-            );
+            let mut orders =
+                super::optimize_orders(equivalences, available, unique_keys, join_util);
 
             // For differential join, it is not as important for the starting
             // input to have good characteristics because the other ones
@@ -375,13 +325,7 @@ mod differential {
 
             // Implement arrangements in each of the inputs.
             let mut lifted = Vec::new();
-            super::implement_arrangements(
-                inputs,
-                available,
-                prior_arities,
-                order.iter(),
-                &mut lifted,
-            );
+            super::implement_arrangements(inputs, available, join_util, order.iter(), &mut lifted);
 
             if !lifted.is_empty() {
                 // We must add the support of expression in `lifted` to the `demand`
@@ -423,7 +367,7 @@ mod differential {
 fn implement_arrangements<'a>(
     inputs: &mut [RelationExpr],
     available_arrangements: &[Vec<Vec<ScalarExpr>>],
-    prior_arities: &[usize],
+    join_util: &JoinUtil,
     needed_arrangements: impl Iterator<Item = &'a (usize, Vec<ScalarExpr>)>,
     lifted_predicates: &mut Vec<ScalarExpr>,
 ) {
@@ -450,11 +394,7 @@ fn implement_arrangements<'a>(
             } = &mut inputs[index]
             {
                 lifted_predicates.extend(predicates.drain(..).map(|mut expr| {
-                    expr.visit_mut(&mut |e| {
-                        if let ScalarExpr::Column(c) = e {
-                            *c += prior_arities[index]
-                        }
-                    });
+                    join_util.globalize_expression(&mut expr, index);
                     expr
                 }));
                 inputs[index] = inner.take_dangerous();
@@ -474,16 +414,9 @@ fn optimize_orders(
     equivalences: &[Vec<ScalarExpr>],
     available: &[Vec<Vec<ScalarExpr>>],
     unique_keys: &[Vec<Vec<usize>>],
-    input_relation: &[usize],
-    prior_arities: &[usize],
+    join_util: &JoinUtil,
 ) -> Vec<Vec<(Characteristics, Vec<ScalarExpr>, usize)>> {
-    let mut orderer = Orderer::new(
-        equivalences,
-        available,
-        unique_keys,
-        input_relation,
-        prior_arities,
-    );
+    let mut orderer = Orderer::new(equivalences, available, unique_keys, join_util);
     (0..available.len())
         .map(move |i| orderer.optimize_order_for(i))
         .collect::<Vec<_>>()
@@ -524,8 +457,7 @@ struct Orderer<'a> {
     equivalences: &'a [Vec<ScalarExpr>],
     arrangements: &'a [Vec<Vec<ScalarExpr>>],
     unique_keys: &'a [Vec<Vec<usize>>],
-    input_relation: &'a [usize],
-    prior_arities: &'a [usize],
+    join_util: &'a JoinUtil,
     reverse_equivalences: Vec<Vec<(usize, usize)>>,
     unique_arrangement: Vec<Vec<bool>>,
 
@@ -542,16 +474,15 @@ impl<'a> Orderer<'a> {
         equivalences: &'a [Vec<ScalarExpr>],
         arrangements: &'a [Vec<Vec<ScalarExpr>>],
         unique_keys: &'a [Vec<Vec<usize>>],
-        input_relation: &'a [usize],
-        prior_arities: &'a [usize],
+        join_util: &'a JoinUtil,
     ) -> Self {
         let inputs = arrangements.len();
         // A map from inputs to the equivalence classes in which they are referenced.
         let mut reverse_equivalences = vec![Vec::new(); inputs];
         for (index, equivalence) in equivalences.iter().enumerate() {
             for (index2, expr) in equivalence.iter().enumerate() {
-                for column in expr.support() {
-                    reverse_equivalences[input_relation[column]].push((index, index2));
+                for input in join_util.lookup_inputs(expr) {
+                    reverse_equivalences[input].push((index, index2));
                 }
             }
         }
@@ -578,8 +509,7 @@ impl<'a> Orderer<'a> {
             equivalences,
             arrangements,
             unique_keys,
-            input_relation,
-            prior_arities,
+            join_util,
             reverse_equivalences,
             unique_arrangement,
             order,
@@ -650,50 +580,19 @@ impl<'a> Orderer<'a> {
         // use an arrangement if there exists one that lines up with the keys of
         // the second input
         if let Some((_, key, second)) = self.order.get(0) {
-            // for each element in key ...
+            // for each key of the second input, try to find the corresponding key in
+            // the starting input
             let candidate_start_key = key
                 .iter()
                 .filter_map(|k| {
                     let mut k = k.clone();
-                    k.visit_mut(&mut |e| {
-                        if let ScalarExpr::Column(c) = e {
-                            *c += self.prior_arities[*second]
-                        }
-                    });
-                    // ... find the equivalence it belongs to ...
-                    if let Some(key_equivalence) = self
-                        .equivalences
-                        .iter()
-                        .position(|e| e.iter().any(|expr| expr == &k))
-                    {
-                        // ... then within that equivalence, find the position
-                        // of an expression that came from start ...
-                        let key_pos =
-                            self.reverse_equivalences[start]
-                                .iter()
-                                .find_map(|(idx, idx2)| {
-                                    if idx == &key_equivalence {
-                                        Some(idx2)
-                                    } else {
-                                        None
-                                    }
-                                });
-                        // ... extract the expression that came from start
-                        // and shift the column numbers
-                        if let Some(key_pos) = key_pos {
-                            let mut result = self.equivalences[key_equivalence][*key_pos].clone();
-                            result.visit_mut(&mut |e| {
-                                if let ScalarExpr::Column(c) = e {
-                                    *c -= self.prior_arities[start]
-                                }
-                            });
-                            Some(result)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    }
+                    self.join_util.globalize_expression(&mut k, *second);
+                    self.join_util
+                        .find_bound_expr(&k, &[start], self.equivalences)
+                        .map(|mut bound_key| {
+                            self.join_util.localize_expression(&mut bound_key);
+                            bound_key
+                        })
                 })
                 .collect::<Vec<_>>();
             if candidate_start_key.len() == key.len() {
@@ -727,19 +626,16 @@ impl<'a> Orderer<'a> {
                 // Placing `input` *may* activate the equivalence. Each of its columns
                 // come in to scope, which may result in an expression in `equivalence`
                 // becoming fully defined (when its support is contained in placed inputs)
-                let fully_supported = self.equivalences[*equivalence][*expr_index]
-                    .support()
-                    .iter()
-                    .all(|c| self.placed[self.input_relation[*c]]);
+                let fully_supported = self
+                    .join_util
+                    .lookup_inputs(&self.equivalences[*equivalence][*expr_index])
+                    .into_iter()
+                    .all(|i| self.placed[i]);
                 if fully_supported {
                     self.equivalences_active[*equivalence] = true;
                     for expr in self.equivalences[*equivalence].iter() {
                         // find the relations that columns in the expression belong to
-                        let rels = expr
-                            .support()
-                            .into_iter()
-                            .map(|c| self.input_relation[c])
-                            .collect::<Vec<_>>();
+                        let rels = self.join_util.lookup_inputs(expr);
                         // Skip the expression if
                         // * the expression is a literal -> this would translate
                         //   to `rels` being empty
@@ -748,16 +644,11 @@ impl<'a> Orderer<'a> {
                         //   this case. Arguably, if this happens, it would
                         //   not be unreasonable to ask the user to write the
                         //   query better.
-                        let rel = rels
-                            .get(0)
-                            .filter(|first_rel| rels[1..].iter().all(|rel| *first_rel == rel));
-                        if let Some(rel) = rel {
+                        if rels.len() == 1 {
+                            let rel = rels.first().unwrap();
                             let mut expr = expr.clone();
-                            expr.visit_mut(&mut |e| {
-                                if let ScalarExpr::Column(c) = e {
-                                    *c -= self.prior_arities[*rel];
-                                }
-                            });
+                            self.join_util.localize_expression(&mut expr);
+
                             // Update bound columns.
                             self.bound[*rel].push(expr);
                             self.bound[*rel].sort();

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -182,7 +182,7 @@ impl PredicatePushdown {
                         // We want to scan `predicates` for any that can apply
                         // to individual elements of `inputs`.
 
-                        let join_util = expr::JoinUtil::new(inputs);
+                        let input_mapper = expr::JoinInputMapper::new(inputs);
 
                         // Predicates to push at each input, and to retain.
                         let mut push_downs = vec![Vec::new(); inputs.len()];
@@ -197,7 +197,7 @@ impl PredicatePushdown {
                                 if let RelationExpr::ArrangeBy { .. } = inputs[index] {
                                     // do nothing. We do not want to push down a filter and block
                                     // usage of an index
-                                } else if let Some(localized) = join_util
+                                } else if let Some(localized) = input_mapper
                                     .try_map_to_input_with_bound_expr(
                                         &predicate,
                                         index,
@@ -258,8 +258,8 @@ impl PredicatePushdown {
                                         && i != &pos
                                         && equivalence[*i].support() == support
                                 }) {
-                                    let expr1 = join_util.map_expr_to_local(&equivalence[pos]);
-                                    let expr2 = join_util.map_expr_to_local(&equivalence[pos2]);
+                                    let expr1 = input_mapper.map_expr_to_local(&equivalence[pos]);
+                                    let expr2 = input_mapper.map_expr_to_local(&equivalence[pos2]);
                                     use expr::BinaryFunc;
                                     push_downs[support.into_iter().next().unwrap()].push(
                                         ScalarExpr::CallBinary {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -199,7 +199,7 @@ impl PredicatePushdown {
                                     // usage of an index
                                 } else if let Some(localized) = input_mapper
                                     .try_map_to_input_with_bound_expr(
-                                        &predicate,
+                                        predicate.clone(),
                                         index,
                                         &equivalences[..],
                                     )
@@ -258,8 +258,10 @@ impl PredicatePushdown {
                                         && i != &pos
                                         && equivalence[*i].support() == support
                                 }) {
-                                    let expr1 = input_mapper.map_expr_to_local(&equivalence[pos]);
-                                    let expr2 = input_mapper.map_expr_to_local(&equivalence[pos2]);
+                                    let expr1 =
+                                        input_mapper.map_expr_to_local(equivalence[pos].clone());
+                                    let expr2 =
+                                        input_mapper.map_expr_to_local(equivalence[pos2].clone());
                                     use expr::BinaryFunc;
                                     push_downs[support.into_iter().next().unwrap()].push(
                                         ScalarExpr::CallBinary {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -197,11 +197,13 @@ impl PredicatePushdown {
                                 if let RelationExpr::ArrangeBy { .. } = inputs[index] {
                                     // do nothing. We do not want to push down a filter and block
                                     // usage of an index
-                                } else if let Some(localized) = join_util.try_localize_expression(
-                                    &predicate,
-                                    index,
-                                    &equivalences[..],
-                                ) {
+                                } else if let Some(localized) = join_util
+                                    .try_map_to_input_with_bound_expr(
+                                        &predicate,
+                                        index,
+                                        &equivalences[..],
+                                    )
+                                {
                                     push_down.push(localized);
                                     pushed = true;
                                 }
@@ -256,10 +258,8 @@ impl PredicatePushdown {
                                         && i != &pos
                                         && equivalence[*i].support() == support
                                 }) {
-                                    let mut expr1 = equivalence[pos].clone();
-                                    let mut expr2 = equivalence[pos2].clone();
-                                    join_util.localize_expression(&mut expr1);
-                                    join_util.localize_expression(&mut expr2);
+                                    let expr1 = join_util.map_expr_to_local(&equivalence[pos]);
+                                    let expr2 = join_util.map_expr_to_local(&equivalence[pos2]);
                                     use expr::BinaryFunc;
                                     push_downs[support.into_iter().next().unwrap()].push(
                                         ScalarExpr::CallBinary {

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -20,13 +20,77 @@ statement ok
 INSERT INTO foo VALUES (1, 2), (-1, 4), (null, 3)
 
 statement ok
-CREATE INDEX foo_idx on foo(a);
-
-statement ok
 CREATE TABLE bar(a int, b int)
 
 statement ok
 INSERT INTO bar VALUES (1, 3), (-1, null), (null, 5)
+
+# no indexes other than the default foo(a,b) and bar(a,b)
+query T multiline
+EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = bar.a where foo.a = 1
+----
+%0 =
+| Get materialize.public.foo (u1)
+| Filter !(isnull(#0)), (#0 = 1)
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.bar (u3)
+| Filter !(isnull(#0)), (#0 = 1)
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0, #1, #3)
+| Project (#0, #1, #0, #3)
+
+EOF
+
+query IIII
+select * from foo inner join bar on foo.a = bar.a where foo.a = 1
+----
+1
+2
+1
+3
+
+# This is supposed to test that the `mod(foo.a, 2) = 1` gets pushed down to both
+# inputs, but it is not happening due to materialize#4411
+
+# no indexes other than the default foo(a,b) and bar(a,b)
+query T multiline
+EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = abs(bar.a) where mod(foo.a, 2) = 1
+----
+%0 =
+| Get materialize.public.foo (u1)
+| Filter !(isnull(#0)), (1 = (#0 % 2))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.bar (u3)
+| Filter !(isnull(abs(#0)))
+
+%2 =
+| Join %0 %1 (= #0 abs(#2))
+| | implementation = Differential %1 %0.(#0)
+| | demand = (#0..#3)
+
+EOF
+
+query IIII
+select * from foo inner join bar on foo.a = abs(bar.a) where mod(foo.a, 2) = 1
+----
+1
+2
+-1
+NULL
+1
+2
+1
+3
+
+statement ok
+CREATE INDEX foo_idx on foo(a);
 
 statement ok
 CREATE INDEX bar_idx on bar(a);
@@ -50,7 +114,7 @@ where foo.a = bar.a
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.bar (u4)
+| Get materialize.public.bar (u3)
 | Filter !(isnull(#0))
 
 %2 =
@@ -100,7 +164,7 @@ where foo.a = bar.a
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.bar (u4)
+| Get materialize.public.bar (u3)
 | ArrangeBy (#0)
 
 %2 =
@@ -144,7 +208,7 @@ where nullif(foo.a, 0) = -bar.a
 | ArrangeBy (if (#0 = 0) then {null} else {#0})
 
 %1 =
-| Get materialize.public.bar (u4)
+| Get materialize.public.bar (u3)
 | ArrangeBy (-(#0))
 
 %2 =
@@ -189,7 +253,7 @@ where foo.a = bar.a
 | ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.bar (u4)
+| Get materialize.public.bar (u3)
 | ArrangeBy ((#0 + 4))
 
 %2 =


### PR DESCRIPTION
I figured if I was going to make more changes to #2164, I might as well start packaging up commonly used join constructs into a common utility. I haven't yet removed instances where `prior_arities` is constructed from some of the other transforms yet, but I figure this is a good start.

In the process, discovered that we could achieve a decent amount of code reuse by packaging this stuff up. 

Also, discovered that the method `localize_predicate` in `predicate_pushdown.rs` only handles join equivalence classes that are all columns. Expanded `localize_predicate` to work with join equivalence classes that contain expressions (and renamed it to `try_localize_expression` in `JoinUtil`).

Suggestions welcome on renaming stuff or making the comments clearer. 

TODO: 
* Add some unit testing. (Especially due to the fact that #4411 prevents me from adequately testing `try_localize_expressions` from SLT). Maybe with the new transform testing framework
* A full SLT run to ensure that I haven't accidentally broken something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4414)
<!-- Reviewable:end -->
