### PR TITLE
materialized: include causes in error messages

### DIFF
--- a/src/materialized/src/bin/materialized.rs
+++ b/src/materialized/src/bin/materialized.rs
@@ -38,7 +38,7 @@ use log::{info, trace, warn};
 
 fn main() {
     if let Err(err) = run() {
-        eprintln!("materialized: {}", err);
+        eprintln!("materialized: {:#}", err);
         process::exit(1);
     }
 }


### PR DESCRIPTION
anyhow::Error only prints causes if you use the alternate display
implementation (`{:#}`) rather than the normal display implementation
(`{}`). Correct the top-level error printing routine in materialized
accordingly.

This ensures that the underlying error when recreating a sink is
actually printed, which helps in debugging #4401.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4415)
<!-- Reviewable:end -->
