### PR TITLE
sql: adjust type computation interfaces

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -215,9 +215,13 @@ impl CoercibleScalarExpr {
     }
 }
 
-pub trait ScalarTypeable {
-    type Type;
+/// An expression whose type can be ascertained.
+///
+/// Abstracts over `ScalarExpr` and `CoercibleScalarExpr`.
+pub trait AbstractExpr {
+    type Type: AbstractColumnType;
 
+    /// Computes the type of the expression.
     fn typ(
         &self,
         outers: &[RelationType],
@@ -226,7 +230,7 @@ pub trait ScalarTypeable {
     ) -> Self::Type;
 }
 
-impl ScalarTypeable for CoercibleScalarExpr {
+impl AbstractExpr for CoercibleScalarExpr {
     type Type = Option<ColumnType>;
 
     fn typ(
@@ -239,6 +243,34 @@ impl ScalarTypeable for CoercibleScalarExpr {
             CoercibleScalarExpr::Coerced(expr) => Some(expr.typ(outers, inner, params)),
             _ => None,
         }
+    }
+}
+
+/// A column type-like object whose underlying scalar type-like object can be
+/// ascertained.
+///
+/// Abstracts over `ColumnType` and `Option<ColumnType>`.
+pub trait AbstractColumnType {
+    type AbstractScalarType;
+
+    /// Converts the column type-like object into its inner scalar type-like
+    /// object.
+    fn scalar_type(self) -> Self::AbstractScalarType;
+}
+
+impl AbstractColumnType for ColumnType {
+    type AbstractScalarType = ScalarType;
+
+    fn scalar_type(self) -> Self::AbstractScalarType {
+        self.scalar_type
+    }
+}
+
+impl AbstractColumnType for Option<ColumnType> {
+    type AbstractScalarType = Option<ScalarType>;
+
+    fn scalar_type(self) -> Self::AbstractScalarType {
+        self.map(|t| t.scalar_type)
     }
 }
 
@@ -1026,7 +1058,7 @@ impl ScalarExpr {
     }
 }
 
-impl ScalarTypeable for ScalarExpr {
+impl AbstractExpr for ScalarExpr {
     type Type = ColumnType;
 
     fn typ(

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -441,10 +441,7 @@ impl<'a> ArgImplementationMatcher<'a> {
             .collect();
         let m = Self { ident, ecx };
 
-        let types: Vec<_> = cexprs
-            .iter()
-            .map(|e| ecx.column_type(e).map(|t| t.scalar_type))
-            .collect();
+        let types: Vec<_> = cexprs.iter().map(|e| ecx.scalar_type(e)).collect();
 
         // try-catch in Rust.
         match || -> Result<R, anyhow::Error> {

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -17,7 +17,7 @@ use lazy_static::lazy_static;
 use repr::{ColumnType, RelationType, ScalarType};
 
 use crate::plan::expr::{
-    AggregateFunc, BinaryFunc, RelationExpr, ScalarExpr, ScalarTypeable, UnaryFunc,
+    AbstractExpr, AggregateFunc, BinaryFunc, RelationExpr, ScalarExpr, UnaryFunc,
 };
 
 /// Rewrites predicates that contain subqueries so that the subqueries

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -544,9 +544,7 @@ pub fn plan_coerce<'a>(
             let coerce_elem_to = match &coerce_to {
                 Plain(ScalarType::Array(typ)) => Plain((**typ).clone()),
                 Plain(_) => {
-                    let typ = exprs
-                        .iter()
-                        .find_map(|e| ecx.column_type(e).map(|t| t.scalar_type));
+                    let typ = exprs.iter().find_map(|e| ecx.scalar_type(e));
                     CoerceTo::Plain(typ.unwrap_or(ScalarType::String))
                 }
                 JsonbAny => bail!("cannot coerce array literal to jsonb type"),
@@ -563,7 +561,7 @@ pub fn plan_coerce<'a>(
                 bail!("unable to infer type for empty array")
             };
             for (i, e) in out.iter().enumerate() {
-                let t = ecx.scalar_type(&e);
+                let t = ecx.scalar_type(e);
                 if t != typ {
                     bail!(
                         "Cannot create array with mixed types. \
@@ -584,9 +582,7 @@ pub fn plan_coerce<'a>(
             let coerce_elem_to = match &coerce_to {
                 Plain(ScalarType::List(typ)) => Plain((**typ).clone()),
                 Plain(_) => {
-                    let typ = exprs
-                        .iter()
-                        .find_map(|e| ecx.column_type(e).map(|t| t.scalar_type));
+                    let typ = exprs.iter().find_map(|e| ecx.scalar_type(e));
                     CoerceTo::Plain(typ.unwrap_or(ScalarType::String))
                 }
                 JsonbAny => bail!("cannot coerce list literal to jsonb type"),
@@ -603,7 +599,7 @@ pub fn plan_coerce<'a>(
                 bail!("unable to infer type for empty list")
             };
             for (i, e) in out.iter().enumerate() {
-                let t = ecx.scalar_type(&e);
+                let t = ecx.scalar_type(e);
                 if t != typ {
                     bail!(
                         "Cannot create list with mixed types. \


### PR DESCRIPTION
The SQL planner deals with both "coercible" and "coerced" scalar
expressions. The main difference is that the type of a coerced
expression is known, while the type of a coercible expression
is possibly unknown.

The ExprContext provides helper methods (column_type and scalar_type) to
determine the column type and scalar type, respectively, of expressions.
Until this patch, column_type could be called on either type of
expression, while scalar_type could only be called on coerced
expressions. Fix this wart by allowing both column_type and scalar_type
to take either type of expression and return either a ScalarType or
Option<ScalarType> as appropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4417)
<!-- Reviewable:end -->
