### PR TITLE
Support pg_catalog.pg_encoding_to_char

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -902,6 +902,11 @@ lazy_static! {
                     Ok(ScalarExpr::literal_null(ScalarType::String))
                 })
             },
+            "pg_encoding_to_char" => Scalar {
+                // Materialize only supports UT8-encoded databases. Return 'UTF8' if Postgres'
+                // encoding id for UTF8 (6) is provided, otherwise return 'NULL'.
+                params!(Int64) => sql_op!("CASE WHEN $1 = 6 THEN 'UTF8' ELSE NULL END")
+            },
             "pg_get_userbyid" => Scalar {
                 params!(Oid) => sql_op!("'unknown (OID=' || $1 || ')'")
             },

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -479,3 +479,13 @@ SELECT mz_catalog.mod(7, 4)
 
 query error unknown database 'noexist'
 SELECT noexist.pg_catalog.mod(7, 4)
+
+query T
+SELECT pg_catalog.pg_encoding_to_char(6)
+----
+UTF8
+
+query T
+SELECT pg_catalog.pg_encoding_to_char(7)
+----
+NULL


### PR DESCRIPTION
Adds limited support for [`pg_catalog.pg_encoding_to_char`](https://www.postgresql.org/docs/13/libpq-control.html). 

Given an encoding id as an input, `pg_encoding_to_char` returns the matching encoding name. Materialize only supports `UTF8`-encoded databases. As such, our implementation of `pg_encoding_to_char` only returns a value for encoding id 6 (Postgres' hardcoded id for `UTF8`), returning `NULL` otherwise. This implementation idea was [borrowed from Cockroach](https://github.com/cockroachdb/cockroach/blob/8d0e6366cad1612ec6f30b5f24c93a59b83817be/pkg/sql/logictest/testdata/logic_test/builtin_function#L2319)!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4423)
<!-- Reviewable:end -->
