### PR TITLE
Add limited relkind information to pg_catalog.pg_class

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -630,7 +630,13 @@ pub const PG_CLASS: BuiltinView = BuiltinView {
     mz_objects.oid,
     name AS relname,
     mz_schemas.oid AS relnamespace,
-    NULL::oid AS relowner
+    NULL::oid AS relowner,
+    CASE
+        WHEN mz_objects.type = 'table' THEN 'r'
+        WHEN mz_objects.type = 'source' THEN 'r'
+        WHEN mz_objects.type = 'index' THEN 'i'
+        WHEN mz_objects.type = 'view' THEN 'v'
+    END relkind
 FROM mz_catalog.mz_objects
 JOIN mz_catalog.mz_schemas ON mz_schemas.schema_id = mz_objects.schema_id",
     id: GlobalId::System(3016),

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -22,6 +22,7 @@ oid          NO        oid
 relname      NO        text
 relnamespace NO        oid
 relowner     YES       oid
+relkind      YES       text
 
 ! SELECT current_schemas()
 Cannot call function current_schemas(): arguments cannot be implicitly cast to any implementation's parameters;


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/4279.

This adds some `relkind` information to [`pg_class`](https://www.postgresql.org/docs/13/catalog-pg-class.html), but it's quirky!
- I've excluded sources entirely. It feels wrong to add a new `s` option for sources, and it also feels wrong to call them views (`v`) and confuse users.
- We can't currently differentiate between views (`v`) and materialized views (`m`), so I've marked everything as a plain view. Knowing whether or not a view is materialized requires a call to `is_materialized`. We currently return that information via `SHOW FULL VIEWS`, but we can't just join to that output because it doesn't include an `oid`.. Some more work will have to be done here in some direction. In the short term, this is mildly misleading.

If we're okay with these quirks, I will create follow up issues so they aren't forgotten.

Other note: I tried casting the new `relkind` strings to `char`, but they kept coming back as `text`!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4424)
<!-- Reviewable:end -->
