### PR TITLE
Add psql meta command support to release notes

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -63,6 +63,8 @@ Wrap your release notes at the 80 character mark.
   `pg_catalog` schemas, this support improves compatibility with various
   PostgreSQL tools that generate SQL queries with qualified function references.
 
+- Add support for the following psql meta commands: `\l`, `\d`, `\dv`, `\dt`, `\di`.
+
 - Add support for the [`oid`](/sql/types/oid) type to represent PostgreSQL object IDs.
 
 - Add support for [array types](/sql/types/array) for compatibility with


### PR DESCRIPTION
`psql` meta command tracking issue: https://github.com/MaterializeInc/materialize/issues/4265

I'm not sure if we need to add this!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4430)
<!-- Reviewable:end -->
