### PR TITLE
draft discussion: new system table for showing source up to dateness

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -219,6 +219,14 @@ pub const MZ_PEEK_DURATIONS: BuiltinLog = BuiltinLog {
     index_id: GlobalId::System(1025),
 };
 
+pub const MZ_SOURCE_INFO: BuiltinLog = BuiltinLog {
+    name: "mz_source_info",
+    schema: MZ_CATALOG_SCHEMA,
+    variant: LogVariant::Materialized(MaterializedLog::SourceInfo),
+    id: GlobalId::System(1026),
+    index_id: GlobalId::System(1027),
+};
+
 lazy_static! {
     pub static ref MZ_VIEW_KEYS: BuiltinTable = BuiltinTable {
         name: "mz_view_keys",
@@ -653,6 +661,7 @@ lazy_static! {
             Builtin::Log(&MZ_WORKER_MATERIALIZATION_FRONTIERS),
             Builtin::Log(&MZ_PEEK_ACTIVE),
             Builtin::Log(&MZ_PEEK_DURATIONS),
+            Builtin::Log(&MZ_SOURCE_INFO),
             Builtin::Table(&MZ_VIEW_KEYS),
             Builtin::Table(&MZ_VIEW_FOREIGN_KEYS),
             Builtin::Table(&MZ_KAFKA_SINKS),

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -51,6 +51,7 @@ pub enum MaterializedLog {
     FrontierCurrent,
     PeekCurrent,
     PeekDuration,
+    SourceInfo,
 }
 
 impl LogVariant {
@@ -131,6 +132,13 @@ impl LogVariant {
                 .with_column("worker", ScalarType::Int64.nullable(false))
                 .with_key(vec![0, 1]),
 
+            LogVariant::Materialized(MaterializedLog::SourceInfo) => RelationDesc::empty()
+                .with_column("source_name", ScalarType::String.nullable(false))
+                .with_column("source_id", ScalarType::String.nullable(false))
+                .with_column("partition_id", ScalarType::String.nullable(false))
+                //.with_column("offset", ScalarType::Int64.nullable(false))
+                .with_key(vec![0, 1, 2]),
+
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
                 .with_column("dataflow", ScalarType::String.nullable(false))
                 .with_column("source", ScalarType::String.nullable(false))
@@ -189,6 +197,7 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => vec![],
             LogVariant::Materialized(MaterializedLog::FrontierCurrent) => vec![],
             LogVariant::Materialized(MaterializedLog::PeekCurrent) => vec![],
+            LogVariant::Materialized(MaterializedLog::SourceInfo) => vec![],
             LogVariant::Materialized(MaterializedLog::PeekDuration) => vec![],
         }
     }

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -25,11 +25,15 @@ use expr::{PartitionId, SourceInstanceId};
 use mz_avro::types::Value;
 use mz_avro::{AvroRead, Schema, Skip};
 
-use crate::server::{
-    TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
-};
 use crate::source::{
     ConsistencyInfo, NextMessage, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
+};
+use crate::{
+    logging::materialized::Logger,
+    server::{
+        TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
+        TimestampMetadataUpdates,
+    },
 };
 
 /// Contains all information necessary to ingest data from file sources (either
@@ -48,6 +52,8 @@ pub struct FileSourceInfo<Out> {
     /// Current File Offset. This corresponds to the offset of last processed message
     /// (initially 0 if no records have been processed)
     current_file_offset: FileOffset,
+    /// todo
+    logger: Option<Logger>,
 }
 
 #[derive(Copy, Clone)]
@@ -72,6 +78,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
         active: bool,
         _: usize,
         _: usize,
+        logger: Option<Logger>,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
@@ -106,7 +113,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
 
         consistency_info.partition_metrics.insert(
             PartitionId::File,
-            PartitionMetrics::new(&name, &source_id.to_string(), ""),
+            PartitionMetrics::new(&name, &source_id.to_string(), "", logger.clone()),
         );
         consistency_info.update_partition_metadata(PartitionId::File);
 
@@ -117,6 +124,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
             receiver_stream: receiver,
             buffer: None,
             current_file_offset: FileOffset { offset: 0 },
+            logger,
         })
     }
 }
@@ -128,6 +136,7 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
         active: bool,
         _: usize,
         _: usize,
+        logger: Option<Logger>,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
@@ -153,7 +162,7 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
         };
         consistency_info.partition_metrics.insert(
             PartitionId::File,
-            PartitionMetrics::new(&name, &source_id.to_string(), ""),
+            PartitionMetrics::new(&name, &source_id.to_string(), "", logger.clone()),
         );
         consistency_info.update_partition_metadata(PartitionId::File);
 
@@ -164,6 +173,7 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
             receiver_stream: receiver,
             buffer: None,
             current_file_offset: FileOffset { offset: 0 },
+            logger,
         })
     }
 }
@@ -230,7 +240,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
         if consistency_info.partition_metrics.len() == 0 {
             consistency_info.partition_metrics.insert(
                 pid,
-                PartitionMetrics::new(&self.name, &self.id.to_string(), ""),
+                PartitionMetrics::new(&self.name, &self.id.to_string(), "", self.logger.clone()),
             );
         }
     }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -33,13 +33,16 @@ use kafka_util::KafkaAddrs;
 use log::{debug, error, info, log_enabled, warn};
 use repr::{PersistedRecord, PersistedRecordIter, Timestamp};
 
-use crate::server::{
-    PersistenceMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
-    TimestampMetadataUpdates,
-};
 use crate::source::persistence::{PersistenceSender, RecordFileMetadata, WorkerPersistenceData};
 use crate::source::{
     ConsistencyInfo, NextMessage, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
+};
+use crate::{
+    logging::materialized::Logger,
+    server::{
+        PersistenceMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
+        TimestampMetadataUpdates,
+    },
 };
 
 /// Contains all information necessary to ingest data from Kafka
@@ -67,6 +70,8 @@ pub struct KafkaSourceInfo {
     worker_count: i32,
     /// Files to read on startup
     persisted_files: Vec<PathBuf>,
+    ///
+    logger: Option<Logger>,
 }
 
 impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
@@ -76,6 +81,7 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
         _active: bool,
         worker_id: usize,
         worker_count: usize,
+        logger: Option<Logger>,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         _: &mut ConsistencyInfo,
@@ -87,6 +93,7 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
                 source_id,
                 worker_id,
                 worker_count,
+                logger,
                 consumer_activator,
                 kc,
             )),
@@ -221,7 +228,12 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
                 self.create_partition_queue(i);
                 consistency_info.partition_metrics.insert(
                     PartitionId::Kafka(i),
-                    PartitionMetrics::new(&self.topic_name, &self.source_id, &i.to_string()),
+                    PartitionMetrics::new(
+                        &self.topic_name,
+                        &self.source_id,
+                        &i.to_string(),
+                        self.logger.clone(),
+                    ),
                 );
             }
             consistency_info.update_partition_metadata(PartitionId::Kafka(i));
@@ -431,6 +443,7 @@ impl KafkaSourceInfo {
         source_id: SourceInstanceId,
         worker_id: usize,
         worker_count: usize,
+        logger: Option<Logger>,
         consumer_activator: SyncActivator,
         kc: KafkaSourceConnector,
     ) -> KafkaSourceInfo {
@@ -499,6 +512,7 @@ impl KafkaSourceInfo {
             worker_id,
             worker_count,
             persisted_files,
+            logger,
         }
     }
 


### PR DESCRIPTION
I've got questions about the best approach here, likely for Frank/Ruchir since it's about the timely and differential side of things. Publishing as a draft PR to have it all written down, and will pick it back up week after next.

(There's some nastiness here around threading a logger through many levels. The source ingestion code needs a refactor and is pretty messy, but that's kinda tangential. What I'm more interested in feedback on is how to interact with the logging dataflow.)

Related to https://github.com/MaterializeInc/materialize/issues/4104

At a high level, I want a new system table that has a row for each current source/partition and tracks their max, ingested, and received offsets.

Right now this diff creates a new system table that will list the current source/partitions for which the received offset is greater than the ingested offset (ie. stuff lagging). That's not super interesting since it's more relevant to compare to the max, and it isn't a great user experience since stuff just pops up then vanishes within this table so it's hard to track.

I'm having trouble getting the data into the form I want for a few reasons:
1. Max is computed somewhere entirely separate from ingested/received, so I think I need a separate log stream and to merge them into the table. Which would be easy, except...
2. ...this code in materialized.rs where we output the rows all seems to be in timely, and I can' figure out how to use a join operator from differential. If I have a timely OutputHandle, is there a way to bridge it into something that differential can operate on, like a Collection?
3. It feels like I'm doing a lot of state management in the materialize application code which I would expect to instead be handled automagically in timely. Namely, I'm manually tracking state as offsets move and explicitly adding/removing them from timely - so it feels like I'm just using timely as a very complicated hashset. It seems like I should be able to simply repeatedly give() new offsets into the session and have a reduce() dataflow that calculates the max - but if I do that, will it retain all previous offsets in perpetuity? If so, is there a way to tell it to 'trim' the dataflow?

And the meta-question - do any of my questions hint at fundamental misunderstandings on my side? 🙂

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4433)
<!-- Reviewable:end -->
