### PR TITLE
materialized: improve warn/error logs in the mux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,7 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "getopts",
+ "hex",
  "hyper",
  "include_dir",
  "itertools",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -22,6 +22,7 @@ dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
 futures = "0.3"
 getopts = "0.2"
+hex = "0.4"
 hyper = "0.13.8"
 include_dir = "0.6.0"
 krb5-src = { version = "0.2.3", features = ["binaries"] }


### PR DESCRIPTION
These were broken by 47d1347, resulting in error messages like:

    materialized::mux: error handling connection: in pgwire server

with no information about the actual error. This patch fixes the issue
by ensuring that the underlying error is printed along with all of its
causes.

It also makes adding the name of the handler to the error message the
responsibility of the mux, rather than the handler, so that handlers
don't forget to add the appropriate context.

Fix #4441.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4443)
<!-- Reviewable:end -->
