### PR TITLE
avro: replace strum with enum-kinds crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-kinds"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30ea541ff8aec761976f2eadf20371fa06fbc0f2cb2f8fb505a7f1340d459a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2102,7 @@ dependencies = [
  "chrono",
  "crc",
  "digest",
+ "enum-kinds",
  "itertools",
  "lazy_static",
  "libflate",
@@ -2102,8 +2114,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "snap",
- "strum",
- "strum_macros",
  "uuid",
 ]
 
@@ -3831,24 +3841,6 @@ checksum = "8fc47de4dfba76248d1e9169ccff240eea2a4dc1e34e309b95b2393109b4b383"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "strum"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3924a58d165da3b7b2922c667ab0673c7b5fd52b5c19ea3442747bcb3cd15abe"
-
-[[package]]
-name = "strum_macros"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2ab682ecdcae7f5f45ae85cd7c1e6c8e68ea42c8a612d47fedf831c037146a"
-dependencies = [
- "heck",
  "proc-macro2",
  "quote",
  "syn",

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,12 @@ skip = [
     # Waiting on chrono to migrate to time v0.2.
     { name = "time", version = "0.1.42" },
 ]
+deny = [
+    # Strum has suspect code quality and includes many unneeded features. Use
+    # more targeted enum macro crates, e.g. `enum-kinds`.
+    { name = "strum" },
+    { name = "strum-macros" },
+]
 
 [licenses]
 allow = [

--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = "1.0"
+syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = { version = "1.0.0", optional = true }
 crc = { version = "1.3.0", optional = true }
 chrono = { version = "0.4" }
 digest = "0.9"
+enum-kinds = "0.5.0"
 itertools = "0.9"
 libflate = "1.0"
 log = "0.4.11"
@@ -28,8 +29,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.1"
 snap = { version = "1", optional = true }
-strum = "0.19"
-strum_macros = "0.19"
 uuid = "0.8"
 
 [dev-dependencies]

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -8,8 +8,8 @@ use std::hash::BuildHasher;
 use std::u8;
 
 use chrono::{NaiveDate, NaiveDateTime};
+use enum_kinds::EnumKind;
 use serde_json::Value as JsonValue;
-use strum_macros::EnumDiscriminants;
 
 use crate::schema::{RecordField, SchemaNode, SchemaPiece, SchemaPieceOrNamed};
 
@@ -42,8 +42,8 @@ pub struct DecimalValue {
     pub scale: usize,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, EnumDiscriminants)] // Can't be Eq because there are floats
-#[strum_discriminants(name(ScalarKind))]
+#[derive(Clone, Copy, Debug, PartialEq, EnumKind)] // Can't be Eq because there are floats
+#[enum_kind(ScalarKind)]
 pub enum Scalar {
     Null,
     Boolean(bool),


### PR DESCRIPTION
I'm suspicious of the code quality in strum; the crate also includes
many more features than we need. Swap it for the much lighter and
higher-quality enum-kinds crate.

Fix #4456.
Fix #4458.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4462)
<!-- Reviewable:end -->
