### PR TITLE
sql: minor catalog updates

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -46,7 +46,6 @@ pub use crate::catalog::config::Config;
 
 const SYSTEM_CONN_ID: u32 = 0;
 
-pub const AMBIENT_DATABASE_ID: i64 = -1;
 pub const AMBIENT_SCHEMA_ID: i64 = -1;
 
 // TODO@jldlaughlin: Better assignment strategy for system type OIDs.

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -46,8 +46,6 @@ pub use crate::catalog::config::Config;
 
 const SYSTEM_CONN_ID: u32 = 0;
 
-pub const AMBIENT_SCHEMA_ID: i64 = -1;
-
 // TODO@jldlaughlin: Better assignment strategy for system type OIDs.
 // https://github.com/MaterializeInc/materialize/pull/4316#discussion_r496238962
 pub const FIRST_USER_OID: u32 = 20_000;

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -278,7 +278,7 @@ lazy_static! {
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
             .with_column("oid", ScalarType::Oid.nullable(false))
-            .with_column("database_id", ScalarType::Int64.nullable(false))
+            .with_column("database_id", ScalarType::Int64.nullable(true))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("schema", ScalarType::String.nullable(false))
             .with_column("type", ScalarType::String.nullable(false)),
@@ -399,14 +399,10 @@ pub const MZ_CATALOG_NAMES: BuiltinView = BuiltinView {
     schema: MZ_CATALOG_SCHEMA,
     sql: "CREATE VIEW mz_catalog_names AS SELECT
     global_id,
-    CASE
-        WHEN d.id = -1
-        THEN schema || '.' || name
-        ELSE database || '.' || schema || '.' || name
-    END AS name
+    coalesce(database || '.', '') || schema || '.' || name AS name
 FROM mz_catalog.mz_objects o
 JOIN mz_catalog.mz_schemas s ON s.schema_id = o.schema_id
-JOIN mz_catalog.mz_databases d ON d.id = s.database_id",
+LEFT JOIN mz_catalog.mz_databases d ON d.id = s.database_id",
     id: GlobalId::System(3002),
     needs_logs: false,
 };

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -65,9 +65,7 @@ use crate::catalog::builtin::{
     BUILTINS, MZ_AVRO_OCF_SINKS, MZ_COLUMNS, MZ_DATABASES, MZ_INDEXES, MZ_KAFKA_SINKS, MZ_SCHEMAS,
     MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_VIEWS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS,
 };
-use crate::catalog::{
-    self, Catalog, CatalogItem, Index, SinkConnectorState, AMBIENT_DATABASE_ID, AMBIENT_SCHEMA_ID,
-};
+use crate::catalog::{self, Catalog, CatalogItem, Index, SinkConnectorState, AMBIENT_SCHEMA_ID};
 use crate::command::{
     Command, ExecuteResponse, NoSessionExecuteResponse, Response, StartupMessage,
 };
@@ -306,9 +304,6 @@ where
         }
 
         // Insert initial named objects into system tables.
-        let oid = self.catalog.allocate_oid()?;
-        self.report_database_update(oid, AMBIENT_DATABASE_ID, "AMBIENT", 1)
-            .await;
         let dbs: Vec<(
             String,
             i64,
@@ -348,7 +343,7 @@ where
             for (schema_name, schema_id, schema_oid, items) in schemas {
                 self.report_schema_update(
                     schema_oid,
-                    database_id,
+                    Some(database_id),
                     schema_id,
                     &schema_name,
                     "USER",
@@ -390,15 +385,8 @@ where
             })
             .collect();
         for (schema_name, schema_id, schema_oid, items) in ambient_schemas {
-            self.report_schema_update(
-                schema_oid,
-                AMBIENT_DATABASE_ID,
-                schema_id,
-                &schema_name,
-                "SYSTEM",
-                1,
-            )
-            .await;
+            self.report_schema_update(schema_oid, None, schema_id, &schema_name, "SYSTEM", 1)
+                .await;
 
             for (item_name, item_id) in items {
                 if let Some(oid) = tables_to_report.remove(&item_id) {
@@ -417,15 +405,8 @@ where
             }
         }
         let oid = self.catalog.allocate_oid()?;
-        self.report_schema_update(
-            oid,
-            AMBIENT_DATABASE_ID,
-            AMBIENT_SCHEMA_ID,
-            "mz_temp",
-            "system",
-            1,
-        )
-        .await;
+        self.report_schema_update(oid, None, AMBIENT_SCHEMA_ID, "mz_temp", "system", 1)
+            .await;
 
         // Announce primary and foreign key relationships.
         if self.logging_granularity.is_some() {
@@ -1042,7 +1023,7 @@ where
     async fn report_schema_update(
         &mut self,
         oid: u32,
-        database_id: i64,
+        database_id: Option<i64>,
         schema_id: i64,
         schema_name: &str,
         typ: &str,
@@ -1053,7 +1034,10 @@ where
             iter::once((
                 Row::pack(&[
                     Datum::Int32(oid as i32),
-                    Datum::Int64(database_id),
+                    match database_id {
+                        None => Datum::Null,
+                        Some(database_id) => Datum::Int64(database_id),
+                    },
                     Datum::Int64(schema_id),
                     Datum::String(schema_name),
                     Datum::String(typ),
@@ -2427,7 +2411,7 @@ where
                 } => {
                     self.report_schema_update(
                         *oid,
-                        *database_id,
+                        Some(*database_id),
                         *schema_id,
                         schema_name,
                         "USER",
@@ -2521,7 +2505,7 @@ where
                 } => {
                     self.report_schema_update(
                         *oid,
-                        *database_id,
+                        Some(*database_id),
                         *schema_id,
                         schema_name,
                         "USER",

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -65,7 +65,7 @@ use crate::catalog::builtin::{
     BUILTINS, MZ_AVRO_OCF_SINKS, MZ_COLUMNS, MZ_DATABASES, MZ_INDEXES, MZ_KAFKA_SINKS, MZ_SCHEMAS,
     MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_VIEWS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS,
 };
-use crate::catalog::{self, Catalog, CatalogItem, Index, SinkConnectorState, AMBIENT_SCHEMA_ID};
+use crate::catalog::{self, Catalog, CatalogItem, Index, SinkConnectorState};
 use crate::command::{
     Command, ExecuteResponse, NoSessionExecuteResponse, Response, StartupMessage,
 };
@@ -404,9 +404,6 @@ where
                 }
             }
         }
-        let oid = self.catalog.allocate_oid()?;
-        self.report_schema_update(oid, None, AMBIENT_SCHEMA_ID, "mz_temp", "system", 1)
-            .await;
 
         // Announce primary and foreign key relationships.
         if self.logging_granularity.is_some() {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -33,25 +33,21 @@ use expr::{GlobalId, RowSetFinishing};
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
 use ore::collections::CollectionExt;
 use ore::iter::IteratorExt;
-use repr::{strconv, Datum, RelationDesc, RelationType, Row, ScalarType};
+use repr::{strconv, RelationDesc, RelationType, ScalarType};
 use sql_parser::ast::{
     AlterIndexOptionsList, AlterIndexOptionsStatement, AlterObjectRenameStatement, AvroSchema,
     ColumnOption, Connector, CreateDatabaseStatement, CreateIndexStatement, CreateSchemaStatement,
     CreateSinkStatement, CreateSourceStatement, CreateTableStatement, CreateViewStatement,
     DropDatabaseStatement, DropObjectsStatement, ExplainStage, ExplainStatement, Explainee, Expr,
     Format, Ident, IfExistsBehavior, InsertStatement, ObjectName, ObjectType, Query,
-    SelectStatement, SetVariableStatement, SetVariableValue, ShowColumnsStatement,
-    ShowCreateIndexStatement, ShowCreateSinkStatement, ShowCreateSourceStatement,
-    ShowCreateTableStatement, ShowCreateViewStatement, ShowDatabasesStatement,
-    ShowIndexesStatement, ShowObjectsStatement, ShowStatementFilter, ShowVariableStatement,
-    SqlOption, Statement, TailStatement, Value,
+    SelectStatement, SetVariableStatement, SetVariableValue, ShowObjectsStatement,
+    ShowVariableStatement, SqlOption, Statement, TailStatement, Value,
 };
 
 use crate::catalog::{Catalog, CatalogItemType};
 use crate::kafka_util;
 use crate::names::{DatabaseSpecifier, FullName, PartialName, SchemaSpecifier};
 use crate::normalize;
-use crate::parse::parse;
 use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
 use crate::plan::{
@@ -59,6 +55,8 @@ use crate::plan::{
     Params, PeekWhen, Plan, PlanContext, Sink, Source, Table, View,
 };
 use crate::pure::Schema;
+
+mod show;
 
 lazy_static! {
     static ref SHOW_DATABASES_DESC: RelationDesc =
@@ -301,15 +299,17 @@ pub fn handle_statement(
         Statement::DropObjects(stmt) => handle_drop_objects(scx, stmt),
         Statement::AlterObjectRename(stmt) => handle_alter_object_rename(scx, stmt),
         Statement::AlterIndexOptions(stmt) => handle_alter_index_options(scx, stmt),
-        Statement::ShowColumns(stmt) => handle_show_columns(scx, stmt),
-        Statement::ShowCreateIndex(stmt) => handle_show_create_index(scx, stmt),
-        Statement::ShowCreateSink(stmt) => handle_show_create_sink(scx, stmt),
-        Statement::ShowCreateSource(stmt) => handle_show_create_source(scx, stmt),
-        Statement::ShowCreateTable(stmt) => handle_show_create_table(scx, stmt),
-        Statement::ShowCreateView(stmt) => handle_show_create_view(scx, stmt),
-        Statement::ShowDatabases(stmt) => handle_show_databases(scx, stmt),
-        Statement::ShowIndexes(stmt) => handle_show_indexes(scx, stmt),
-        Statement::ShowObjects(stmt) => handle_show_objects(scx, stmt),
+
+        Statement::ShowColumns(stmt) => show::handle_show_columns(scx, stmt),
+        Statement::ShowCreateTable(stmt) => show::handle_show_create_table(scx, stmt),
+        Statement::ShowCreateSource(stmt) => show::handle_show_create_source(scx, stmt),
+        Statement::ShowCreateView(stmt) => show::handle_show_create_view(scx, stmt),
+        Statement::ShowCreateSink(stmt) => show::handle_show_create_sink(scx, stmt),
+        Statement::ShowCreateIndex(stmt) => show::handle_show_create_index(scx, stmt),
+        Statement::ShowDatabases(stmt) => show::handle_show_databases(scx, stmt),
+        Statement::ShowObjects(stmt) => show::handle_show_objects(scx, stmt),
+        Statement::ShowIndexes(stmt) => show::handle_show_indexes(scx, stmt),
+
         Statement::SetVariable(stmt) => handle_set_variable(scx, stmt),
         Statement::ShowVariable(stmt) => handle_show_variable(scx, stmt),
 
@@ -495,500 +495,6 @@ fn handle_alter_index_options(
     };
 
     Ok(Plan::AlterIndexLogicalCompactionWindow(alter_index))
-}
-
-fn handle_show_databases(
-    scx: &StatementContext,
-    ShowDatabasesStatement { filter }: ShowDatabasesStatement,
-) -> Result<Plan, anyhow::Error> {
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => format!("database LIKE {}", Value::String(like)),
-        Some(ShowStatementFilter::Where(expr)) => expr.to_string(),
-        None => "true".to_owned(),
-    };
-    handle_generated_select(
-        scx,
-        format!(
-            "SELECT database FROM mz_catalog.mz_databases WHERE {}",
-            filter
-        ),
-    )
-}
-
-fn handle_show_objects(
-    scx: &StatementContext,
-    ShowObjectsStatement {
-        extended,
-        full,
-        materialized,
-        object_type,
-        from,
-        filter,
-    }: ShowObjectsStatement,
-) -> Result<Plan, anyhow::Error> {
-    match object_type {
-        ObjectType::Schema => handle_show_schemas(scx, extended, full, from, filter),
-        ObjectType::Table => handle_show_tables(scx, extended, full, from, filter),
-        ObjectType::Source => handle_show_sources(scx, full, materialized, from, filter),
-        ObjectType::View => handle_show_views(scx, full, materialized, from, filter),
-        ObjectType::Sink => handle_show_sinks(scx, full, from, filter),
-        ObjectType::Index => unreachable!("SHOW INDEX handled separately"),
-    }
-}
-
-fn handle_show_schemas(
-    scx: &StatementContext,
-    extended: bool,
-    full: bool,
-    from: Option<ObjectName>,
-    filter: Option<ShowStatementFilter>,
-) -> Result<Plan, anyhow::Error> {
-    let database_name = if let Some(from) = from {
-        scx.resolve_database(from)?
-    } else {
-        scx.resolve_default_database()?.to_string()
-    };
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => format!("AND schema LIKE {}", Value::String(like)),
-        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
-        None => "".to_owned(),
-    };
-
-    let query = if !full & !extended {
-        format!(
-            "SELECT schema
-            FROM mz_catalog.mz_schemas
-            JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
-            WHERE mz_catalog.mz_databases.database = '{}' {}",
-            database_name, filter
-        )
-    } else if full & !extended {
-        format!(
-            "SELECT schema, type
-            FROM mz_catalog.mz_schemas
-            JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
-            WHERE mz_catalog.mz_databases.database = '{}' {}",
-            database_name, filter
-        )
-    } else if !full & extended {
-        format!(
-            "SELECT schema
-            FROM mz_catalog.mz_schemas
-            LEFT JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
-            WHERE mz_catalog.mz_databases.database = '{}' OR mz_catalog.mz_databases.database IS NULL {}",
-            database_name, filter
-        )
-    } else {
-        format!(
-            "SELECT schema, type
-            FROM mz_catalog.mz_schemas
-            LEFT JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
-            WHERE mz_catalog.mz_databases.database = '{}' OR mz_catalog.mz_databases.database IS NULL {}",
-            database_name, filter
-        )
-    };
-    handle_generated_select(scx, query)
-}
-
-fn handle_show_sinks(
-    scx: &StatementContext,
-    full: bool,
-    from: Option<ObjectName>,
-    filter: Option<ShowStatementFilter>,
-) -> Result<Plan, anyhow::Error> {
-    let schema_spec = if let Some(from) = from {
-        scx.resolve_schema(from)?.1
-    } else {
-        scx.resolve_default_schema()?
-    };
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => format!("AND sinks LIKE {}", Value::String(like)),
-        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
-        None => "".to_owned(),
-    };
-
-    let query = if full {
-        format!(
-            "SELECT sinks, type
-            FROM mz_catalog.mz_sinks
-            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sinks.schema_id = mz_catalog.mz_schemas.schema_id
-            WHERE schema_id = {} {}
-            ORDER BY sinks, type",
-            schema_spec.id, filter
-        )
-    } else {
-        format!(
-            "SELECT sinks FROM mz_catalog.mz_sinks WHERE schema_id = {} {} ORDER BY sinks",
-            schema_spec.id, filter
-        )
-    };
-    handle_generated_select(scx, query)
-}
-
-fn handle_show_views(
-    scx: &StatementContext,
-    full: bool,
-    materialized: bool,
-    from: Option<ObjectName>,
-    filter: Option<ShowStatementFilter>,
-) -> Result<Plan, anyhow::Error> {
-    let schema_spec = if let Some(from) = from {
-        scx.resolve_schema(from)?.1
-    } else {
-        scx.resolve_default_schema()?
-    };
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => format!("AND views LIKE {}", Value::String(like)),
-        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
-        None => "".to_owned(),
-    };
-
-    let query = if !full & !materialized {
-        format!(
-            "SELECT views
-             FROM mz_catalog.mz_views
-             WHERE mz_catalog.mz_views.schema_id = {} {}
-             ORDER BY views ASC",
-            schema_spec.id, filter
-        )
-    } else if full & !materialized {
-        format!(
-            "SELECT
-                views,
-                type,
-                count > 0 as materialized
-             FROM mz_catalog.mz_views as mz_views
-             JOIN mz_catalog.mz_schemas ON mz_catalog.mz_views.schema_id = mz_catalog.mz_schemas.schema_id
-             JOIN (SELECT mz_views.global_id as global_id, count(mz_indexes.on_global_id) AS count
-                   FROM mz_views
-                   LEFT JOIN mz_indexes on mz_views.global_id = mz_indexes.on_global_id
-                   GROUP BY mz_views.global_id) as mz_indexes_count
-                ON mz_views.global_id = mz_indexes_count.global_id
-             WHERE mz_catalog.mz_views.schema_id = {} {}
-             ORDER BY views ASC",
-            schema_spec.id, filter
-        )
-    } else if !full & materialized {
-        format!(
-            "SELECT views
-             FROM mz_catalog.mz_views
-             JOIN (SELECT mz_views.global_id as global_id, count(mz_indexes.on_global_id) AS count
-                   FROM mz_views
-                   LEFT JOIN mz_indexes on mz_views.global_id = mz_indexes.on_global_id
-                   GROUP BY mz_views.global_id) as mz_indexes_count
-                ON mz_views.global_id = mz_indexes_count.global_id
-             WHERE mz_catalog.mz_views.schema_id = {}
-                AND mz_indexes_count.count > 0 {}
-             ORDER BY views ASC",
-            schema_spec.id, filter
-        )
-    } else {
-        format!(
-            "SELECT views, type
-             FROM mz_catalog.mz_views
-             JOIN mz_catalog.mz_schemas ON mz_catalog.mz_views.schema_id = mz_catalog.mz_schemas.schema_id
-             JOIN (SELECT mz_views.global_id as global_id, count(mz_indexes.on_global_id) AS count
-                   FROM mz_views
-                   LEFT JOIN mz_indexes on mz_views.global_id = mz_indexes.on_global_id
-                   GROUP BY mz_views.global_id) as mz_indexes_count
-                ON mz_views.global_id = mz_indexes_count.global_id
-             WHERE mz_catalog.mz_views.schema_id = {}
-                AND mz_indexes_count.count > 0 {}
-             ORDER BY views ASC",
-            schema_spec.id, filter
-        )
-    };
-    handle_generated_select(scx, query)
-}
-
-fn handle_show_sources(
-    scx: &StatementContext,
-    full: bool,
-    materialized: bool,
-    from: Option<ObjectName>,
-    filter: Option<ShowStatementFilter>,
-) -> Result<Plan, anyhow::Error> {
-    let schema_spec = if let Some(from) = from {
-        scx.resolve_schema(from)?.1
-    } else {
-        scx.resolve_default_schema()?
-    };
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => {
-            format!("AND sources LIKE {}", Value::String(like))
-        }
-        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
-        None => "".to_owned(),
-    };
-
-    let query = if !full & !materialized {
-        format!(
-            "SELECT sources FROM mz_catalog.mz_sources WHERE schema_id = {} {} ORDER BY sources",
-            schema_spec.id, filter
-        )
-    } else if full & !materialized {
-        format!(
-            "SELECT sources, type, CASE WHEN count > 0 then true ELSE false END materialized
-            FROM mz_catalog.mz_sources
-            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sources.schema_id = mz_catalog.mz_schemas.schema_id
-            JOIN (SELECT mz_catalog.mz_sources.global_id as global_id, count(mz_catalog.mz_indexes.on_global_id) AS count
-                  FROM mz_catalog.mz_sources
-                  LEFT JOIN mz_catalog.mz_indexes on mz_catalog.mz_sources.global_id = mz_catalog.mz_indexes.on_global_id
-                  GROUP BY mz_catalog.mz_sources.global_id) as mz_indexes_count
-                ON mz_catalog.mz_sources.global_id = mz_indexes_count.global_id
-            WHERE schema_id = {} {}
-            ORDER BY sources, type",
-            schema_spec.id, filter
-        )
-    } else if !full & materialized {
-        format!(
-            "SELECT sources
-            FROM mz_catalog.mz_sources
-            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sources.schema_id = mz_catalog.mz_schemas.schema_id
-            JOIN (SELECT mz_catalog.mz_sources.global_id as global_id, count(mz_catalog.mz_indexes.on_global_id) AS count
-                  FROM mz_catalog.mz_sources
-                  LEFT JOIN mz_catalog.mz_indexes on mz_catalog.mz_sources.global_id = mz_catalog.mz_indexes.on_global_id
-                  GROUP BY mz_catalog.mz_sources.global_id) as mz_indexes_count
-                ON mz_catalog.mz_sources.global_id = mz_indexes_count.global_id
-            WHERE schema_id = {} {} AND mz_indexes_count.count > 0
-            ORDER BY sources, type",
-            schema_spec.id, filter
-        )
-    } else {
-        format!(
-            "SELECT sources, type
-            FROM mz_catalog.mz_sources
-            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sources.schema_id = mz_catalog.mz_schemas.schema_id
-            JOIN (SELECT mz_catalog.mz_sources.global_id as global_id, count(mz_catalog.mz_indexes.on_global_id) AS count
-                  FROM mz_catalog.mz_sources
-                  LEFT JOIN mz_catalog.mz_indexes on mz_catalog.mz_sources.global_id = mz_catalog.mz_indexes.on_global_id
-                  GROUP BY mz_catalog.mz_sources.global_id) as mz_indexes_count
-                ON mz_catalog.mz_sources.global_id = mz_indexes_count.global_id
-            WHERE schema_id = {} {} AND mz_indexes_count.count > 0
-            ORDER BY sources, type",
-            schema_spec.id, filter
-        )
-    };
-    handle_generated_select(scx, query)
-}
-
-fn handle_show_tables(
-    scx: &StatementContext,
-    extended: bool,
-    full: bool,
-    from: Option<ObjectName>,
-    filter: Option<ShowStatementFilter>,
-) -> Result<Plan, anyhow::Error> {
-    if extended {
-        unsupported!("SHOW EXTENDED TABLES");
-    }
-
-    let schema_spec = if let Some(from) = from {
-        scx.resolve_schema(from)?.1
-    } else {
-        scx.resolve_default_schema()?
-    };
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => format!("AND tables LIKE {}", Value::String(like)),
-        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
-        None => "".to_owned(),
-    };
-
-    let query = if full {
-        format!(
-            "SELECT tables, type
-            FROM mz_catalog.mz_tables
-            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_tables.schema_id = mz_catalog.mz_schemas.schema_id
-            WHERE schema_id = {} {}
-            ORDER BY tables, type",
-            schema_spec.id, filter
-        )
-    } else {
-        format!(
-            "SELECT tables FROM mz_catalog.mz_tables WHERE schema_id = {} {} ORDER BY tables",
-            schema_spec.id, filter
-        )
-    };
-    handle_generated_select(scx, query)
-}
-
-fn handle_show_indexes(
-    scx: &StatementContext,
-    ShowIndexesStatement {
-        extended,
-        table_name,
-        filter,
-    }: ShowIndexesStatement,
-) -> Result<Plan, anyhow::Error> {
-    if extended {
-        unsupported!("SHOW EXTENDED INDEXES")
-    }
-    let from_name = scx.resolve_item(table_name)?;
-    let from_entry = scx.catalog.get_item(&from_name);
-    if from_entry.item_type() != CatalogItemType::View
-        && from_entry.item_type() != CatalogItemType::Source
-        && from_entry.item_type() != CatalogItemType::Table
-    {
-        bail!(
-            "cannot show indexes on {} because it is a {}",
-            from_name,
-            from_entry.item_type(),
-        );
-    }
-
-    let base_query = format!(
-        "SELECT
-            objs.name AS on_name,
-            idxs.indexes AS key_name,
-            cols.field AS column_name,
-            idxs.expression AS expression,
-            idxs.nullable AS nullable,
-            idxs.seq_in_index AS seq_in_index
-        FROM
-            mz_catalog.mz_indexes AS idxs
-            JOIN mz_catalog.mz_objects AS objs ON idxs.on_global_id = objs.global_id
-            LEFT JOIN mz_catalog.mz_columns AS cols
-                ON idxs.on_global_id = cols.global_id AND idxs.field_number = cols.field_number
-        WHERE
-            objs.global_id = '{}'
-        ORDER BY
-            key_name ASC,
-            seq_in_index ASC",
-        from_entry.id(),
-    );
-
-    let query = if let Some(filter) = filter {
-        let filter = match filter {
-            ShowStatementFilter::Like(like) => format!("key_name LIKE {}", Value::String(like)),
-            ShowStatementFilter::Where(expr) => expr.to_string(),
-        };
-        format!(
-            "SELECT on_name, key_name, column_name, expression, nullable, seq_in_index
-             FROM ({})
-             WHERE {}",
-            base_query, filter,
-        )
-    } else {
-        base_query
-    };
-    handle_generated_select(scx, query)
-}
-
-/// Create an immediate result that describes all the columns for the given table
-fn handle_show_columns(
-    scx: &StatementContext,
-    ShowColumnsStatement {
-        extended,
-        full,
-        table_name,
-        filter,
-    }: ShowColumnsStatement,
-) -> Result<Plan, anyhow::Error> {
-    if extended {
-        unsupported!("SHOW EXTENDED COLUMNS");
-    }
-    if full {
-        unsupported!("SHOW FULL COLUMNS");
-    }
-
-    let name = scx.resolve_item(table_name)?;
-    let filter = match filter {
-        Some(ShowStatementFilter::Like(like)) => format!("AND field LIKE {}", Value::String(like)),
-        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
-        None => "".to_owned(),
-    };
-    let query = format!(
-        "SELECT
-            mz_columns.field,
-            CASE WHEN mz_columns.nullable THEN 'YES' ELSE 'NO' END nullable,
-            mz_columns.type
-         FROM mz_catalog.mz_columns AS mz_columns
-         JOIN mz_catalog.mz_catalog_names AS mz_catalog_names ON mz_columns.global_id = mz_catalog_names.global_id
-         WHERE mz_catalog_names.name = '{}' {}
-         ORDER BY mz_columns.field_number ASC",
-        name, filter
-    );
-    handle_generated_select(scx, query)
-}
-
-fn handle_show_create_view(
-    scx: &StatementContext,
-    ShowCreateViewStatement { view_name }: ShowCreateViewStatement,
-) -> Result<Plan, anyhow::Error> {
-    let name = scx.resolve_item(view_name)?;
-    let entry = scx.catalog.get_item(&name);
-    if let CatalogItemType::View = entry.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
-            Datum::String(&name.to_string()),
-            Datum::String(entry.create_sql()),
-        ])]))
-    } else {
-        bail!("{} is not a view", name);
-    }
-}
-
-fn handle_show_create_source(
-    scx: &StatementContext,
-    ShowCreateSourceStatement { source_name }: ShowCreateSourceStatement,
-) -> Result<Plan, anyhow::Error> {
-    let name = scx.resolve_item(source_name)?;
-    let entry = scx.catalog.get_item(&name);
-    if let CatalogItemType::Source = entry.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
-            Datum::String(&name.to_string()),
-            Datum::String(entry.create_sql()),
-        ])]))
-    } else {
-        bail!("{} is not a source", name);
-    }
-}
-
-fn handle_show_create_table(
-    scx: &StatementContext,
-    ShowCreateTableStatement { table_name }: ShowCreateTableStatement,
-) -> Result<Plan, anyhow::Error> {
-    let name = scx.resolve_item(table_name)?;
-    let entry = scx.catalog.get_item(&name);
-    if let CatalogItemType::Table = entry.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
-            Datum::String(&name.to_string()),
-            Datum::String(entry.create_sql()),
-        ])]))
-    } else {
-        bail!("{} is not a table", name);
-    }
-}
-
-fn handle_show_create_sink(
-    scx: &StatementContext,
-    ShowCreateSinkStatement { sink_name }: ShowCreateSinkStatement,
-) -> Result<Plan, anyhow::Error> {
-    let name = scx.resolve_item(sink_name)?;
-    let entry = scx.catalog.get_item(&name);
-    if let CatalogItemType::Sink = entry.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
-            Datum::String(&name.to_string()),
-            Datum::String(entry.create_sql()),
-        ])]))
-    } else {
-        bail!("'{}' is not a sink", name);
-    }
-}
-
-fn handle_show_create_index(
-    scx: &StatementContext,
-    ShowCreateIndexStatement { index_name }: ShowCreateIndexStatement,
-) -> Result<Plan, anyhow::Error> {
-    let name = scx.resolve_item(index_name)?;
-    let entry = scx.catalog.get_item(&name);
-    if let CatalogItemType::Index = entry.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
-            Datum::String(&name.to_string()),
-            Datum::String(entry.create_sql()),
-        ])]))
-    } else {
-        bail!("'{}' is not an index", name);
-    }
 }
 
 fn kafka_sink_builder(
@@ -2070,20 +1576,6 @@ fn handle_select(
         finishing,
         materialize: true,
     })
-}
-
-fn handle_generated_select(scx: &StatementContext, query: String) -> Result<Plan, anyhow::Error> {
-    match parse(query)?.into_element() {
-        Statement::Select(SelectStatement { query, as_of: _ }) => handle_select(
-            scx,
-            SelectStatement { query, as_of: None },
-            &Params {
-                datums: Row::pack(&[]),
-                types: vec![],
-            },
-        ),
-        _ => unreachable!("known to be select statement"),
-    }
 }
 
 fn handle_explain(

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -1,0 +1,533 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Handlers for `SHOW ...` queries.
+
+use anyhow::bail;
+
+use ore::collections::CollectionExt;
+use repr::{Datum, Row};
+use sql_parser::ast::{
+    ObjectName, ObjectType, ShowColumnsStatement, ShowCreateIndexStatement,
+    ShowCreateSinkStatement, ShowCreateSourceStatement, ShowCreateTableStatement,
+    ShowCreateViewStatement, ShowDatabasesStatement, ShowIndexesStatement, ShowObjectsStatement,
+    ShowStatementFilter, Statement, Value,
+};
+
+use crate::catalog::CatalogItemType;
+use crate::parse;
+use crate::plan::statement::StatementContext;
+use crate::plan::{Params, Plan};
+
+pub fn handle_show_create_view(
+    scx: &StatementContext,
+    ShowCreateViewStatement { view_name }: ShowCreateViewStatement,
+) -> Result<Plan, anyhow::Error> {
+    let name = scx.resolve_item(view_name)?;
+    let entry = scx.catalog.get_item(&name);
+    if let CatalogItemType::View = entry.item_type() {
+        Ok(Plan::SendRows(vec![Row::pack(&[
+            Datum::String(&name.to_string()),
+            Datum::String(entry.create_sql()),
+        ])]))
+    } else {
+        bail!("{} is not a view", name);
+    }
+}
+
+pub fn handle_show_create_table(
+    scx: &StatementContext,
+    ShowCreateTableStatement { table_name }: ShowCreateTableStatement,
+) -> Result<Plan, anyhow::Error> {
+    let name = scx.resolve_item(table_name)?;
+    let entry = scx.catalog.get_item(&name);
+    if let CatalogItemType::Table = entry.item_type() {
+        Ok(Plan::SendRows(vec![Row::pack(&[
+            Datum::String(&name.to_string()),
+            Datum::String(entry.create_sql()),
+        ])]))
+    } else {
+        bail!("{} is not a table", name);
+    }
+}
+
+pub fn handle_show_create_source(
+    scx: &StatementContext,
+    ShowCreateSourceStatement { source_name }: ShowCreateSourceStatement,
+) -> Result<Plan, anyhow::Error> {
+    let name = scx.resolve_item(source_name)?;
+    let entry = scx.catalog.get_item(&name);
+    if let CatalogItemType::Source = entry.item_type() {
+        Ok(Plan::SendRows(vec![Row::pack(&[
+            Datum::String(&name.to_string()),
+            Datum::String(entry.create_sql()),
+        ])]))
+    } else {
+        bail!("{} is not a source", name);
+    }
+}
+
+pub fn handle_show_create_sink(
+    scx: &StatementContext,
+    ShowCreateSinkStatement { sink_name }: ShowCreateSinkStatement,
+) -> Result<Plan, anyhow::Error> {
+    let name = scx.resolve_item(sink_name)?;
+    let entry = scx.catalog.get_item(&name);
+    if let CatalogItemType::Sink = entry.item_type() {
+        Ok(Plan::SendRows(vec![Row::pack(&[
+            Datum::String(&name.to_string()),
+            Datum::String(entry.create_sql()),
+        ])]))
+    } else {
+        bail!("'{}' is not a sink", name);
+    }
+}
+
+pub fn handle_show_create_index(
+    scx: &StatementContext,
+    ShowCreateIndexStatement { index_name }: ShowCreateIndexStatement,
+) -> Result<Plan, anyhow::Error> {
+    let name = scx.resolve_item(index_name)?;
+    let entry = scx.catalog.get_item(&name);
+    if let CatalogItemType::Index = entry.item_type() {
+        Ok(Plan::SendRows(vec![Row::pack(&[
+            Datum::String(&name.to_string()),
+            Datum::String(entry.create_sql()),
+        ])]))
+    } else {
+        bail!("'{}' is not an index", name);
+    }
+}
+
+pub fn handle_show_databases(
+    scx: &StatementContext,
+    ShowDatabasesStatement { filter }: ShowDatabasesStatement,
+) -> Result<Plan, anyhow::Error> {
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => format!("database LIKE {}", Value::String(like)),
+        Some(ShowStatementFilter::Where(expr)) => expr.to_string(),
+        None => "true".to_owned(),
+    };
+    handle_generated_select(
+        scx,
+        format!(
+            "SELECT database FROM mz_catalog.mz_databases WHERE {}",
+            filter
+        ),
+    )
+}
+
+pub fn handle_show_objects(
+    scx: &StatementContext,
+    ShowObjectsStatement {
+        extended,
+        full,
+        materialized,
+        object_type,
+        from,
+        filter,
+    }: ShowObjectsStatement,
+) -> Result<Plan, anyhow::Error> {
+    match object_type {
+        ObjectType::Schema => handle_show_schemas(scx, extended, full, from, filter),
+        ObjectType::Table => handle_show_tables(scx, extended, full, from, filter),
+        ObjectType::Source => handle_show_sources(scx, full, materialized, from, filter),
+        ObjectType::View => handle_show_views(scx, full, materialized, from, filter),
+        ObjectType::Sink => handle_show_sinks(scx, full, from, filter),
+        ObjectType::Index => unreachable!("SHOW INDEX handled separately"),
+    }
+}
+
+fn handle_show_schemas(
+    scx: &StatementContext,
+    extended: bool,
+    full: bool,
+    from: Option<ObjectName>,
+    filter: Option<ShowStatementFilter>,
+) -> Result<Plan, anyhow::Error> {
+    let database_name = if let Some(from) = from {
+        scx.resolve_database(from)?
+    } else {
+        scx.resolve_default_database()?.to_string()
+    };
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => format!("AND schema LIKE {}", Value::String(like)),
+        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
+        None => "".to_owned(),
+    };
+
+    let query = if !full & !extended {
+        format!(
+            "SELECT schema
+            FROM mz_catalog.mz_schemas
+            JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
+            WHERE mz_catalog.mz_databases.database = '{}' {}",
+            database_name, filter
+        )
+    } else if full & !extended {
+        format!(
+            "SELECT schema, type
+            FROM mz_catalog.mz_schemas
+            JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
+            WHERE mz_catalog.mz_databases.database = '{}' {}",
+            database_name, filter
+        )
+    } else if !full & extended {
+        format!(
+            "SELECT schema
+            FROM mz_catalog.mz_schemas
+            LEFT JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
+            WHERE mz_catalog.mz_databases.database = '{}' OR mz_catalog.mz_databases.database IS NULL {}",
+            database_name, filter
+        )
+    } else {
+        format!(
+            "SELECT schema, type
+            FROM mz_catalog.mz_schemas
+            LEFT JOIN mz_catalog.mz_databases ON mz_catalog.mz_schemas.database_id = mz_catalog.mz_databases.id
+            WHERE mz_catalog.mz_databases.database = '{}' OR mz_catalog.mz_databases.database IS NULL {}",
+            database_name, filter
+        )
+    };
+    handle_generated_select(scx, query)
+}
+
+fn handle_show_tables(
+    scx: &StatementContext,
+    extended: bool,
+    full: bool,
+    from: Option<ObjectName>,
+    filter: Option<ShowStatementFilter>,
+) -> Result<Plan, anyhow::Error> {
+    if extended {
+        unsupported!("SHOW EXTENDED TABLES");
+    }
+
+    let schema_spec = if let Some(from) = from {
+        scx.resolve_schema(from)?.1
+    } else {
+        scx.resolve_default_schema()?
+    };
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => format!("AND tables LIKE {}", Value::String(like)),
+        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
+        None => "".to_owned(),
+    };
+
+    let query = if full {
+        format!(
+            "SELECT tables, type
+            FROM mz_catalog.mz_tables
+            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_tables.schema_id = mz_catalog.mz_schemas.schema_id
+            WHERE schema_id = {} {}
+            ORDER BY tables, type",
+            schema_spec.id, filter
+        )
+    } else {
+        format!(
+            "SELECT tables FROM mz_catalog.mz_tables WHERE schema_id = {} {} ORDER BY tables",
+            schema_spec.id, filter
+        )
+    };
+    handle_generated_select(scx, query)
+}
+
+fn handle_show_sources(
+    scx: &StatementContext,
+    full: bool,
+    materialized: bool,
+    from: Option<ObjectName>,
+    filter: Option<ShowStatementFilter>,
+) -> Result<Plan, anyhow::Error> {
+    let schema_spec = if let Some(from) = from {
+        scx.resolve_schema(from)?.1
+    } else {
+        scx.resolve_default_schema()?
+    };
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => {
+            format!("AND sources LIKE {}", Value::String(like))
+        }
+        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
+        None => "".to_owned(),
+    };
+
+    let query = if !full & !materialized {
+        format!(
+            "SELECT sources FROM mz_catalog.mz_sources WHERE schema_id = {} {} ORDER BY sources",
+            schema_spec.id, filter
+        )
+    } else if full & !materialized {
+        format!(
+            "SELECT sources, type, CASE WHEN count > 0 then true ELSE false END materialized
+            FROM mz_catalog.mz_sources
+            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sources.schema_id = mz_catalog.mz_schemas.schema_id
+            JOIN (SELECT mz_catalog.mz_sources.global_id as global_id, count(mz_catalog.mz_indexes.on_global_id) AS count
+                  FROM mz_catalog.mz_sources
+                  LEFT JOIN mz_catalog.mz_indexes on mz_catalog.mz_sources.global_id = mz_catalog.mz_indexes.on_global_id
+                  GROUP BY mz_catalog.mz_sources.global_id) as mz_indexes_count
+                ON mz_catalog.mz_sources.global_id = mz_indexes_count.global_id
+            WHERE schema_id = {} {}
+            ORDER BY sources, type",
+            schema_spec.id, filter
+        )
+    } else if !full & materialized {
+        format!(
+            "SELECT sources
+            FROM mz_catalog.mz_sources
+            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sources.schema_id = mz_catalog.mz_schemas.schema_id
+            JOIN (SELECT mz_catalog.mz_sources.global_id as global_id, count(mz_catalog.mz_indexes.on_global_id) AS count
+                  FROM mz_catalog.mz_sources
+                  LEFT JOIN mz_catalog.mz_indexes on mz_catalog.mz_sources.global_id = mz_catalog.mz_indexes.on_global_id
+                  GROUP BY mz_catalog.mz_sources.global_id) as mz_indexes_count
+                ON mz_catalog.mz_sources.global_id = mz_indexes_count.global_id
+            WHERE schema_id = {} {} AND mz_indexes_count.count > 0
+            ORDER BY sources, type",
+            schema_spec.id, filter
+        )
+    } else {
+        format!(
+            "SELECT sources, type
+            FROM mz_catalog.mz_sources
+            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sources.schema_id = mz_catalog.mz_schemas.schema_id
+            JOIN (SELECT mz_catalog.mz_sources.global_id as global_id, count(mz_catalog.mz_indexes.on_global_id) AS count
+                  FROM mz_catalog.mz_sources
+                  LEFT JOIN mz_catalog.mz_indexes on mz_catalog.mz_sources.global_id = mz_catalog.mz_indexes.on_global_id
+                  GROUP BY mz_catalog.mz_sources.global_id) as mz_indexes_count
+                ON mz_catalog.mz_sources.global_id = mz_indexes_count.global_id
+            WHERE schema_id = {} {} AND mz_indexes_count.count > 0
+            ORDER BY sources, type",
+            schema_spec.id, filter
+        )
+    };
+    handle_generated_select(scx, query)
+}
+
+fn handle_show_views(
+    scx: &StatementContext,
+    full: bool,
+    materialized: bool,
+    from: Option<ObjectName>,
+    filter: Option<ShowStatementFilter>,
+) -> Result<Plan, anyhow::Error> {
+    let schema_spec = if let Some(from) = from {
+        scx.resolve_schema(from)?.1
+    } else {
+        scx.resolve_default_schema()?
+    };
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => format!("AND views LIKE {}", Value::String(like)),
+        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
+        None => "".to_owned(),
+    };
+
+    let query = if !full & !materialized {
+        format!(
+            "SELECT views
+             FROM mz_catalog.mz_views
+             WHERE mz_catalog.mz_views.schema_id = {} {}
+             ORDER BY views ASC",
+            schema_spec.id, filter
+        )
+    } else if full & !materialized {
+        format!(
+            "SELECT
+                views,
+                type,
+                count > 0 as materialized
+             FROM mz_catalog.mz_views as mz_views
+             JOIN mz_catalog.mz_schemas ON mz_catalog.mz_views.schema_id = mz_catalog.mz_schemas.schema_id
+             JOIN (SELECT mz_views.global_id as global_id, count(mz_indexes.on_global_id) AS count
+                   FROM mz_views
+                   LEFT JOIN mz_indexes on mz_views.global_id = mz_indexes.on_global_id
+                   GROUP BY mz_views.global_id) as mz_indexes_count
+                ON mz_views.global_id = mz_indexes_count.global_id
+             WHERE mz_catalog.mz_views.schema_id = {} {}
+             ORDER BY views ASC",
+            schema_spec.id, filter
+        )
+    } else if !full & materialized {
+        format!(
+            "SELECT views
+             FROM mz_catalog.mz_views
+             JOIN (SELECT mz_views.global_id as global_id, count(mz_indexes.on_global_id) AS count
+                   FROM mz_views
+                   LEFT JOIN mz_indexes on mz_views.global_id = mz_indexes.on_global_id
+                   GROUP BY mz_views.global_id) as mz_indexes_count
+                ON mz_views.global_id = mz_indexes_count.global_id
+             WHERE mz_catalog.mz_views.schema_id = {}
+                AND mz_indexes_count.count > 0 {}
+             ORDER BY views ASC",
+            schema_spec.id, filter
+        )
+    } else {
+        format!(
+            "SELECT views, type
+             FROM mz_catalog.mz_views
+             JOIN mz_catalog.mz_schemas ON mz_catalog.mz_views.schema_id = mz_catalog.mz_schemas.schema_id
+             JOIN (SELECT mz_views.global_id as global_id, count(mz_indexes.on_global_id) AS count
+                   FROM mz_views
+                   LEFT JOIN mz_indexes on mz_views.global_id = mz_indexes.on_global_id
+                   GROUP BY mz_views.global_id) as mz_indexes_count
+                ON mz_views.global_id = mz_indexes_count.global_id
+             WHERE mz_catalog.mz_views.schema_id = {}
+                AND mz_indexes_count.count > 0 {}
+             ORDER BY views ASC",
+            schema_spec.id, filter
+        )
+    };
+    handle_generated_select(scx, query)
+}
+
+fn handle_show_sinks(
+    scx: &StatementContext,
+    full: bool,
+    from: Option<ObjectName>,
+    filter: Option<ShowStatementFilter>,
+) -> Result<Plan, anyhow::Error> {
+    let schema_spec = if let Some(from) = from {
+        scx.resolve_schema(from)?.1
+    } else {
+        scx.resolve_default_schema()?
+    };
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => format!("AND sinks LIKE {}", Value::String(like)),
+        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
+        None => "".to_owned(),
+    };
+
+    let query = if full {
+        format!(
+            "SELECT sinks, type
+            FROM mz_catalog.mz_sinks
+            JOIN mz_catalog.mz_schemas ON mz_catalog.mz_sinks.schema_id = mz_catalog.mz_schemas.schema_id
+            WHERE schema_id = {} {}
+            ORDER BY sinks, type",
+            schema_spec.id, filter
+        )
+    } else {
+        format!(
+            "SELECT sinks FROM mz_catalog.mz_sinks WHERE schema_id = {} {} ORDER BY sinks",
+            schema_spec.id, filter
+        )
+    };
+    handle_generated_select(scx, query)
+}
+
+pub fn handle_show_indexes(
+    scx: &StatementContext,
+    ShowIndexesStatement {
+        extended,
+        table_name,
+        filter,
+    }: ShowIndexesStatement,
+) -> Result<Plan, anyhow::Error> {
+    if extended {
+        unsupported!("SHOW EXTENDED INDEXES")
+    }
+    let from_name = scx.resolve_item(table_name)?;
+    let from_entry = scx.catalog.get_item(&from_name);
+    if from_entry.item_type() != CatalogItemType::View
+        && from_entry.item_type() != CatalogItemType::Source
+        && from_entry.item_type() != CatalogItemType::Table
+    {
+        bail!(
+            "cannot show indexes on {} because it is a {}",
+            from_name,
+            from_entry.item_type(),
+        );
+    }
+
+    let base_query = format!(
+        "SELECT
+            objs.name AS on_name,
+            idxs.indexes AS key_name,
+            cols.field AS column_name,
+            idxs.expression AS expression,
+            idxs.nullable AS nullable,
+            idxs.seq_in_index AS seq_in_index
+        FROM
+            mz_catalog.mz_indexes AS idxs
+            JOIN mz_catalog.mz_objects AS objs ON idxs.on_global_id = objs.global_id
+            LEFT JOIN mz_catalog.mz_columns AS cols
+                ON idxs.on_global_id = cols.global_id AND idxs.field_number = cols.field_number
+        WHERE
+            objs.global_id = '{}'
+        ORDER BY
+            key_name ASC,
+            seq_in_index ASC",
+        from_entry.id(),
+    );
+
+    let query = if let Some(filter) = filter {
+        let filter = match filter {
+            ShowStatementFilter::Like(like) => format!("key_name LIKE {}", Value::String(like)),
+            ShowStatementFilter::Where(expr) => expr.to_string(),
+        };
+        format!(
+            "SELECT on_name, key_name, column_name, expression, nullable, seq_in_index
+             FROM ({})
+             WHERE {}",
+            base_query, filter,
+        )
+    } else {
+        base_query
+    };
+    handle_generated_select(scx, query)
+}
+
+pub fn handle_show_columns(
+    scx: &StatementContext,
+    ShowColumnsStatement {
+        extended,
+        full,
+        table_name,
+        filter,
+    }: ShowColumnsStatement,
+) -> Result<Plan, anyhow::Error> {
+    if extended {
+        unsupported!("SHOW EXTENDED COLUMNS");
+    }
+    if full {
+        unsupported!("SHOW FULL COLUMNS");
+    }
+
+    let name = scx.resolve_item(table_name)?;
+    let filter = match filter {
+        Some(ShowStatementFilter::Like(like)) => format!("AND field LIKE {}", Value::String(like)),
+        Some(ShowStatementFilter::Where(expr)) => format!("AND {}", expr.to_string()),
+        None => "".to_owned(),
+    };
+    let query = format!(
+        "SELECT
+            mz_columns.field,
+            CASE WHEN mz_columns.nullable THEN 'YES' ELSE 'NO' END nullable,
+            mz_columns.type
+         FROM mz_catalog.mz_columns AS mz_columns
+         JOIN mz_catalog.mz_catalog_names AS mz_catalog_names ON mz_columns.global_id = mz_catalog_names.global_id
+         WHERE mz_catalog_names.name = '{}' {}
+         ORDER BY mz_columns.field_number ASC",
+        name, filter
+    );
+    handle_generated_select(scx, query)
+}
+
+fn handle_generated_select(scx: &StatementContext, query: String) -> Result<Plan, anyhow::Error> {
+    match parse::parse(query)?.into_element() {
+        Statement::Select(select) => super::handle_select(
+            scx,
+            select,
+            &Params {
+                datums: Row::pack(&[]),
+                types: vec![],
+            },
+        ),
+        _ => unreachable!("known to be select statement"),
+    }
+}

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -14,7 +14,6 @@ public
 SCHEMAS
 -------
 public
-mz_temp
 mz_catalog
 pg_catalog
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -51,7 +51,6 @@ materialize
 > SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
--1          AMBIENT
 1           materialize
 
 # Creating a database should be reflected in the output of SHOW DATABASES.
@@ -62,7 +61,7 @@ database
 d
 materialize
 
-> SELECT id, database FROM mz_catalog.mz_databases WHERE id != -1
+> SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
 1           materialize
@@ -81,7 +80,7 @@ d
 > SHOW DATABASES WHERE (id = (SELECT max(id) FROM mz_databases))
 d
 ! SHOW DATABASES WHERE 7
-WHERE clause error: no overload for bool AND i32
+WHERE clause must have type bool, not type i32
 
 # Creating a database with a name that already exists should fail.
 ! CREATE DATABASE d
@@ -147,7 +146,6 @@ materialize
 > SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
--1          AMBIENT
 1           materialize
 
 # The session database should remain set to the dropped database, but future
@@ -219,7 +217,6 @@ materialize
 > SELECT id, database FROM mz_catalog.mz_databases
 id          database
 -----------------------
--1          AMBIENT
 1           materialize
 2           d
 4           d2


### PR DESCRIPTION
@JLDLaughlin it seems a bit cleaner to me to just elide the special system databases/schemas. (I'm writing up docs for the system catalog and these were hard to explain.) And then there's a code-movement-only commit that moves the SHOW-related handlers to their own module. Long term plan is to split up all of statement.rs like this!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4475)
<!-- Reviewable:end -->
