### PR TITLE
www/public: add static memory vizualization page

### DIFF
--- a/ci/www/public/memory-visualization/index.html
+++ b/ci/www/public/memory-visualization/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>materialized memory viewer</title>
+    <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@0.3/dist/index.min.js"></script>
+  </head>
+  <body>
+    <div><button onClick="copy()">copy graph.dot to clipboard</button></div>
+    <div id="graph"></div>
+    <script>
+      const hpccWasm = window['@hpcc-js/wasm'];
+
+      const hash = JSON.parse(decodeURIComponent(location.hash.slice(1)));
+      const graph = hash.dot;
+
+      hpccWasm.graphviz.layout(graph, 'svg', 'dot').then((svg) => {
+        document.getElementById('graph').innerHTML = svg;
+      });
+
+      function copy() {
+        navigator.clipboard.writeText(graph);
+      }
+    </script>
+  </body>
+</html>

--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -392,6 +392,18 @@ function View(props) {
     hpccWasm.graphviz.layout(dot, 'svg', 'dot').then(setGraph);
   }, [loading]);
 
+  let dotLink = null;
+  if (dot) {
+    const link = new URL('https://materialize.io/memory-visualization/');
+    // Pass information as a JSON object to allow for easily extending this in
+    // the future. The hash is used instead of search because it reduces privacy
+    // concerns and avoids server-side URL size limits.
+    link.hash = JSON.stringify({
+      dot: dot,
+    });
+    dotLink = <a href={link}>share</a>;
+  }
+
   return (
     <div style={{ marginTop: '2em' }}>
       {loading ? (
@@ -404,6 +416,7 @@ function View(props) {
             Name: {stats.name}, dataflow_id: {props.dataflow_id}, records:{' '}
             {stats.records}
           </h3>
+          {dotLink}
           <div dangerouslySetInnerHTML={{ __html: graph }}></div>
         </div>
       )}


### PR DESCRIPTION
Memory graphs now present a share link that uses our static
site. Information is passed via the URL hash as a JSON object. This will
allow for it to be extended in the future. The hash is used instead of
search ('?search') because the hash is not passed to the server by the
browser. This reduces privacy issues and also avoids any URL limits
by netlify (browsers may impose their own limits, but they are likely
much higher).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4480)
<!-- Reviewable:end -->
