### PR TITLE
Enable configuring OLTP threads in chbench load-test

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -599,7 +599,7 @@ mzconduct:
          run
          --dsn=mysql --gen-dir=/var/lib/mysql-files
          --analytic-threads=0
-         --transactional-threads=1
+         --transactional-threads=${OLTP_THREADS:-1}
          --run-seconds=864000
          -l /dev/stdout
          --config-file-path=/etc/chbenchmark/mz-default-mysql.cfg
@@ -614,7 +614,7 @@ mzconduct:
          run
          --dsn=postgres --gen-dir=/var/lib/postgres-files
          --analytic-threads=0
-         --transactional-threads=1
+         --transactional-threads=${OLTP_THREADS:-1}
          --run-seconds=864000
          -l /dev/stdout
          --config-file-path=/etc/chbenchmark/mz-default-postgres.cfg


### PR DESCRIPTION
These tests hardcoded the number of writing threads at 1, severely
limiting the number of messages being written to Kafka. Enable
configuring this parameter in 'load-test' and 'load-test-postgres', just
like we can configure this in 'cloud-load-test'.

Fixes #4437

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4483)
<!-- Reviewable:end -->
