### PR TITLE
Add debugging script to dump kafka topics

### DIFF
--- a/demo/chbench/bin/dump_topics
+++ b/demo/chbench/bin/dump_topics
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Script to list and dump all topics from a Kafka cluster
+# Dumps files into the working directory of the script
+
+if ! topics=$(kafkacat -L -b localhost:9092 | grep debezium | cut -d '"' -f 2); then
+    echo "Failed to list topics!"
+    exit 1
+fi
+
+for topic in $topics; do
+    readonly snapfile="${topic}.snap"
+    if ! kafkacat -C -b 127.0.0.1:9092 -t "${topic}" -e > "${snapfile}"; then
+        echo "Failed to dump topic ${topic}"
+        exit 1
+    fi
+    echo "Saved ${topic} to file ${snapfile}"
+done


### PR DESCRIPTION
This script will be used to snapshot Kafka topics so that we can reload
them and test Materialize ingest performance by itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4485)
<!-- Reviewable:end -->
