### PR TITLE
sql: fix qualified wildcards with trivial column equivalences

### DIFF
--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -53,7 +53,6 @@ NULL  NULL  4  r4
 1     l1    1  r1
 3     l3    3  r3
 
-
 # Test that columns detected to be equivalent retain the names that the user
 # asks for. Protects against regression of #1217.
 query II colnames,rowsort
@@ -61,11 +60,23 @@ SELECT ra, r.ra FROM l JOIN r ON l.la = r.ra LIMIT 0
 ----
 ra  ra
 
-
 # Test that columns detected to be equivalent retain the names that the user
 # asks for. Protects against regression of #1217.
 query ITIT colnames,rowsort
 SELECT * FROM l JOIN r ON l.la = r.ra LIMIT 0
+----
+la  lb  ra  rb
+
+# Test that columns detected to be equivalent do not interfere with qualified
+# wildcard expansion. Protects against regression of #4477.
+query ITIT colnames
+SELECT l.*, r.* FROM l JOIN r ON l.la = r.ra LIMIT 0
+----
+la  lb  ra  rb
+
+# Like the last test, but with the equality reversed.
+query ITIT colnames
+SELECT l.*, r.* FROM l JOIN r ON r.ra = l.la LIMIT 0
 ----
 la  lb  ra  rb
 


### PR DESCRIPTION
Explicit inner joins with equality predicates trigger special behavior
to match MySQL. (See the `find_trivial_column_equivalences` function for
details.) This detection was interacting poorly with qualified wildcard
expansion; columns detected as equivalent were incorrectly being
considered part of both sides of the join.

Fix #4477.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4486)
<!-- Reviewable:end -->
