### PR TITLE
Relax minimum docker compose version to 1.25 (from 1.27)

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -28,7 +28,7 @@ from materialize import ui
 announce = ui.speaker("==>")
 say = ui.speaker("")
 
-MIN_COMPOSE_VERSION = (1, 27, 0)
+MIN_COMPOSE_VERSION = (1, 25, 0)
 
 
 def assert_docker_compose_version() -> None:


### PR DESCRIPTION
Our CI tests use Docker Compose 1.25.4, so let's relax the version
check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4489)
<!-- Reviewable:end -->
