### PR TITLE
materialized: compress share link in memory page

### DIFF
--- a/ci/www/public/memory-visualization/index.html
+++ b/ci/www/public/memory-visualization/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>materialized memory viewer</title>
     <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@0.3/dist/index.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pako@1/dist/pako.min.js"></script>
   </head>
   <body>
     <div><button onClick="copy()">copy graph.dot to clipboard</button></div>
@@ -11,7 +12,12 @@
     <script>
       const hpccWasm = window['@hpcc-js/wasm'];
 
-      const hash = JSON.parse(decodeURIComponent(location.hash.slice(1)));
+      // Strip off the initial '#', decode any % that were added, convert from
+      // base64, uncompress, parse as JSON.
+      let hash = decodeURIComponent(location.hash.slice(1));
+      hash = atob(hash);
+      hash = pako.inflate(hash, { to: 'string' });
+      hash = JSON.parse(hash);
       const graph = hash.dot;
 
       hpccWasm.graphviz.layout(graph, 'svg', 'dot').then((svg) => {

--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -398,9 +398,12 @@ function View(props) {
     // Pass information as a JSON object to allow for easily extending this in
     // the future. The hash is used instead of search because it reduces privacy
     // concerns and avoids server-side URL size limits.
-    link.hash = JSON.stringify({
+    let data = JSON.stringify({
       dot: dot,
     });
+    // Compress data and encode as base64 so it's URL-safe.
+    data = pako.deflate(data, { to: 'string' });
+    link.hash = btoa(data);
     dotLink = <a href={link}>share</a>;
   }
 

--- a/src/materialized/src/http/templates/memory.html
+++ b/src/materialized/src/http/templates/memory.html
@@ -11,6 +11,8 @@
 <script src="https://cdn.jsdelivr.net/npm/babel-standalone@6/babel.min.js"></script>
 <!-- hpcc-js/wasm has GraphViz compiled to wasm -->
 <script src="https://cdn.jsdelivr.net/npm/@hpcc-js/wasm@0.3/dist/index.min.js"></script>
+<!-- pako is used for zlib compression -->
+<script src="https://cdn.jsdelivr.net/npm/pako@1/dist/pako.min.js"></script>
 <script src="/js/memory.jsx" type="text/babel"></script>
 {% endblock %}
 


### PR DESCRIPTION
Use pako, a zlib port to javascript, to compress share links. A test
example went from 7.2k to 1.2k total characters in the URL hash. This
should help with URL limits imposed when attempting to share links (i.e.,
in slack or bit.ly).

Fixes #4495

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4501)
<!-- Reviewable:end -->
