### PR TITLE
Joins: Use the new struct in various transformations.

### DIFF
--- a/src/dataflow/src/render/join.rs
+++ b/src/dataflow/src/render/join.rs
@@ -144,7 +144,10 @@ where
                     .filter(|c| column_demand.contains(c))
                     .collect::<Vec<_>>();
 
-                let next_vals = input_mapper.map_columns_to_local(&next_source_vals);
+                let next_vals = next_source_vals
+                    .iter()
+                    .map(|c| input_mapper.map_column_to_local(*c).0)
+                    .collect::<Vec<_>>();
 
                 // When joining the first input, check to see if there is a
                 // convenient ready-made arrangement

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -81,6 +81,67 @@ impl JoinInputMapper {
         self.arities.len()
     }
 
+    /// Using the keys that came from each local input,
+    /// figures out which keys remain unique in the larger join
+    /// Currently, we only figure out a small subset of the keys that
+    /// can remain unique.
+    pub fn global_keys(
+        &self,
+        local_keys: &[Vec<Vec<usize>>],
+        equivalences: &[Vec<ScalarExpr>],
+    ) -> Vec<Vec<usize>> {
+        // A relation's uniqueness constraint holds if there is a
+        // sequence of the other relations such that each one has
+        // a uniqueness constraint whose columns are used in join
+        // constraints with relations prior in the sequence.
+        //
+        // Currently, we only:
+        // 1. test for whether the uniqueness constraints for the first input will hold
+        // 2. try one sequence, namely the inputs in order
+        // 3. check that the column themselves are used in the join constraints
+        //    Technically uniqueness constraint would still hold if a 1-to-1
+        //    expression on a unique key is used in the join constraint.
+
+        // for inputs `1..self.total_inputs()`, store a set of columns from that
+        // input that exist in join constraints that have expressions belonging to
+        // earlier inputs.
+        let mut column_with_prior_bound_by_input = vec![HashSet::new(); self.total_inputs() - 1];
+        for equivalence in equivalences {
+            // do a scan to find the first input represented in the constraint
+            let min_bound_input = equivalence
+                .iter()
+                .flat_map(|expr| self.lookup_inputs(expr).max())
+                .min();
+            if let Some(min_bound_input) = min_bound_input {
+                for expr in equivalence {
+                    // then store all columns in the constraint that don't come
+                    // from the first input
+                    if let ScalarExpr::Column(c) = expr {
+                        let (col, input) = self.map_column_to_local(*c);
+                        if input > min_bound_input {
+                            column_with_prior_bound_by_input[input - 1].insert(col);
+                        }
+                    }
+                }
+            }
+        }
+
+        // for inputs `1..self.total_inputs()`, checks the keys belong to each
+        // input against the storage of columns that exist in join constraints
+        // that have expressions belonging to earlier inputs.
+        let remains_unique = local_keys.iter().skip(1).enumerate().all(|(index, keys)| {
+            keys.iter().any(|ks| {
+                ks.iter()
+                    .all(|k| column_with_prior_bound_by_input[index].contains(k))
+            })
+        });
+
+        if remains_unique && self.total_inputs() > 0 {
+            return local_keys[0].clone();
+        }
+        vec![]
+    }
+
     /// returns the arity for a particular input
     #[inline]
     pub fn input_arity(&self, index: usize) -> usize {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -10,6 +10,7 @@
 #![deny(missing_docs)]
 
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::fmt;
 
 use itertools::Itertools;
@@ -338,23 +339,11 @@ impl RelationExpr {
                     .collect::<Vec<_>>();
                 let mut typ = RelationType::new(column_types);
 
-                let input_arities = input_types
-                    .iter()
-                    .map(|i| i.column_types.len())
-                    .collect::<Vec<_>>();
-
-                let mut offset = 0;
-                let mut prior_arities = Vec::new();
-                for input in 0..inputs.len() {
-                    prior_arities.push(offset);
-                    offset += input_arities[input];
-                }
-
-                let input_relation = input_arities
-                    .iter()
-                    .enumerate()
-                    .flat_map(|(r, a)| std::iter::repeat(r).take(*a))
-                    .collect::<Vec<_>>();
+                // It is important the `new_from_input_types` constructor is
+                // used. Otherwise, Materialize may potentially end up in an
+                // infinite loop.
+                let input_mapper =
+                    join_input_mapper::JoinInputMapper::new_from_input_types(&input_types);
 
                 // A relation's uniqueness constraint holds if there is a
                 // sequence of the other relations such that each one has
@@ -363,24 +352,27 @@ impl RelationExpr {
                 //
                 // We are going to use the uniqueness constraints of the
                 // first relation, and attempt to use the presented order.
-                let remains_unique = (1..inputs.len()).all(|index| {
-                    let mut prior_bound = Vec::new();
-                    for equivalence in equivalences {
-                        if equivalence.iter().any(|expr| {
-                            expr.support()
-                                .into_iter()
-                                .all(|i| input_relation[i] < index)
-                        }) {
-                            for expr in equivalence {
-                                if let ScalarExpr::Column(c) = expr {
-                                    prior_bound.push(c);
+                let mut column_with_prior_bound_by_input = vec![HashSet::new(); inputs.len() - 1];
+                for equivalence in equivalences {
+                    let min_bound_input = equivalence
+                        .iter()
+                        .flat_map(|expr| input_mapper.lookup_inputs(expr).max())
+                        .min();
+                    if let Some(min_bound_input) = min_bound_input {
+                        for expr in equivalence {
+                            if let ScalarExpr::Column(c) = expr {
+                                let (col, input) = input_mapper.map_column_to_local(*c);
+                                if input > min_bound_input {
+                                    column_with_prior_bound_by_input[input - 1].insert(col);
                                 }
                             }
                         }
                     }
+                }
+                let remains_unique = (1..inputs.len()).all(|index| {
                     input_types[index].keys.iter().any(|ks| {
                         ks.iter()
-                            .all(|k| prior_bound.contains(&&(prior_arities[index] + k)))
+                            .all(|k| column_with_prior_bound_by_input[index - 1].contains(k))
                     })
                 });
                 if remains_unique && !inputs.is_empty() {
@@ -593,20 +585,13 @@ impl RelationExpr {
     /// let result = joined.project(vec![0, 1, 3]);
     /// ```
     pub fn join(inputs: Vec<RelationExpr>, variables: Vec<Vec<(usize, usize)>>) -> Self {
-        let arities = inputs.iter().map(|input| input.arity()).collect::<Vec<_>>();
-
-        let mut offset = 0;
-        let mut prior_arities = Vec::new();
-        for input in 0..inputs.len() {
-            prior_arities.push(offset);
-            offset += arities[input];
-        }
+        let input_mapper = join_input_mapper::JoinInputMapper::new(&inputs);
 
         let equivalences = variables
             .into_iter()
             .map(|vs| {
                 vs.into_iter()
-                    .map(|(r, c)| ScalarExpr::Column(prior_arities[r] + c))
+                    .map(|(r, c)| input_mapper.map_expr_to_global(ScalarExpr::Column(c), r))
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -81,8 +81,9 @@ impl JoinImplementation {
             ..
         } = relation
         {
+            let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
             // Common information of broad utility.
-            let input_mapper = JoinInputMapper::new(inputs);
+            let input_mapper = JoinInputMapper::new_from_input_types(&input_types);
 
             // The first fundamental question is whether we should employ a delta query or not.
             //
@@ -91,7 +92,10 @@ impl JoinImplementation {
             // with columns present in `indexes`, if it is an `ArrangeBy` with the columns present,
             // or a filter wrapped around either of these.
 
-            let unique_keys = inputs.iter().map(|i| i.typ().keys).collect::<Vec<_>>();
+            let unique_keys = input_types
+                .into_iter()
+                .map(|typ| typ.keys)
+                .collect::<Vec<_>>();
             let mut available_arrangements = vec![Vec::new(); inputs.len()];
             for index in 0..inputs.len() {
                 // We can work around filters, as we can lift the predicates into the join execution.


### PR DESCRIPTION
Removed `prior_arities` and co from places where I had not done so yet.

Also, this is a new opportunity to rename `JoinInputMapper` if desired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4505)
<!-- Reviewable:end -->
