### PR TITLE
sql: rename global_id column in sink catalog tables to sink_id

### DIFF
--- a/demo/billing/src/mz.rs
+++ b/demo/billing/src/mz.rs
@@ -74,7 +74,7 @@ pub async fn create_kafka_sink(
     // Get the topic for the newly-created sink.
     let row = mz_client
         .query_one(
-            "SELECT topic FROM mz_kafka_sinks NATURAL JOIN mz_catalog_names \
+            "SELECT topic FROM mz_kafka_sinks JOIN mz_catalog_names ON sink_id = global_id \
                  WHERE name = 'materialize.public.' || $1",
             &[&sink_name],
         )

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -102,6 +102,10 @@ Wrap your release notes at the 80 character mark.
     - [`SHOW TABLES`](/sql/show-tables)
     - [`SHOW VIEWS`](/sql/show-views)
 
+- Rename the `global_id` column of the [`mz_avro_ocf_sinks`](/sql/system-catalog#mz_avro_ocf_sinks)
+  and [`mz_kafka_sinks`](/sql/system-catalog#mz_kafka_sinks) tables to `sink_id`, for better
+  consistency with the other system catalog tables.
+
 {{% version-header v0.4.3 %}}
 
 - Permit adjusting the logical compaction window on a per-index basis via the

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -311,14 +311,16 @@ INTO AVRO OCF '/path/to/frank-sink-file.ocf;'
 Materialize stores the actual path as a byte array so we need to use the `convert_from` function to convert it to a UTF-8 string.
 
 ```sql
-SELECT global_id, name, convert_from(path, 'utf8') FROM  mz_catalog_names NATURAL JOIN mz_avro_ocf_sinks;
+SELECT sink_id, name, convert_from(path, 'utf8')
+FROM mz_sinks
+JOIN mz_avro_ocf_sinks ON mz_sinks.id = mz_avro_ocf_sinks.sink_id
 ```
 
 ```nofmt
- global_id |                 name                 |                           path
------------+--------------------------------------+----------------------------------------------------------------
- u10       | materialize.public.quotes_sink       | /path/to/sink-file-u10-1586108399-8671224166353132585.ocf
- u11       | materialize.public.frank_quotes_sink | /path/to/frank-sink-file-u11-1586108399-8671224166353132585.ocf
+ sink_id   |        name       |                           path
+-----------+-------------------+----------------------------------------------------------------
+ u10       | quotes_sink       | /path/to/sink-file-u10-1586108399-8671224166353132585.ocf
+ u11       | frank_quotes_sink | /path/to/frank-sink-file-u11-1586108399-8671224166353132585.ocf
 ```
 
 ## Related pages

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -51,6 +51,16 @@ information about the sinks available in a Materialize.
 The following sections describe the available objects in the `mz_catalog`
 schema.
 
+### `mz_avro_ocf_sinks`
+
+The `mz_avro_ocf_sinks` table contains a row for each Avro OCF sink in the
+system.
+
+Field     | Type     | Meaning
+----------|----------|--------
+`sink_id` | [`text`] | The ID of the sink.
+`path`    | `bytea`  | The path to the Avro OCF file into which the sink is writing.
+
 ### `mz_columns`
 
 The `mz_columns` contains a row for each column in each table, source, and view
@@ -92,6 +102,15 @@ Field          | Type        | Meaning
 `expression`   | [`text`]    | If not `NULL`, specifies a SQL expression that is evaluated to compute the value of this index column. The expression may contain references to any of the columns of the relation.
 `nullable`     | [`boolean`] | Can this column of the index evaluate to `NULL`?
 `seq_in_index` | [`bigint`]  | The position of this component within the index. (The order of columns in an index does not necessarily match the order of columns in the relation on which the index is built.)
+
+### `mz_kafka_sinks`
+
+The `mz_kafka_sinks` table contains a row for each Kafka sink in the system.
+
+Field     | Type     | Meaning
+----------|----------|--------
+`sink_id` | [`text`] | The ID of the sink.
+`topic`   | [`text`] | The name of the Kafka topic into which the sink is writing.
 
 ### `mz_objects`
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -247,7 +247,7 @@ lazy_static! {
         name: "mz_kafka_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("global_id", ScalarType::String.nullable(false))
+            .with_column("sink_id", ScalarType::String.nullable(false))
             .with_column("topic", ScalarType::String.nullable(false))
             .with_key(vec![0]),
         id: GlobalId::System(2005),
@@ -257,7 +257,7 @@ lazy_static! {
         name: "mz_avro_ocf_sinks",
         schema: MZ_CATALOG_SCHEMA,
         desc: RelationDesc::empty()
-            .with_column("global_id", ScalarType::String.nullable(false))
+            .with_column("sink_id", ScalarType::String.nullable(false))
             .with_column("path", ScalarType::Bytes.nullable(false))
             .with_key(vec![0]),
         id: GlobalId::System(2007),

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -151,7 +151,8 @@ impl Action for VerifyAction {
             let row = state
                 .pgclient
                 .query_one(
-                    "SELECT path FROM mz_catalog_names NATURAL JOIN mz_avro_ocf_sinks \
+                    "SELECT path FROM mz_catalog_names
+                     JOIN mz_avro_ocf_sinks ON global_id = sink_id
                      WHERE name = $1",
                     &[&self.sink],
                 )

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -57,7 +57,7 @@ impl Action for VerifyAction {
         let topic_prefix: String = state
             .pgclient
             .query_one(
-                "SELECT topic FROM mz_catalog_names NATURAL JOIN mz_kafka_sinks WHERE name = $1",
+                "SELECT topic FROM mz_catalog_names JOIN mz_kafka_sinks ON global_id = sink_id WHERE name = $1",
                 &[&self.sink],
             )
             .await


### PR DESCRIPTION
For consistency with other views in the system catalog. The system
catalog views are documented now, so best to tidy this up for wider
consumption while we still can. Confirmed to be low impact with our
customers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4510)
<!-- Reviewable:end -->
