### PR TITLE
Fixup broken variable in dump-topics

### DIFF
--- a/demo/chbench/bin/dump_topics
+++ b/demo/chbench/bin/dump_topics
@@ -18,7 +18,7 @@ if ! topics=$(kafkacat -L -b localhost:9092 | grep debezium | cut -d '"' -f 2); 
 fi
 
 for topic in $topics; do
-    readonly snapfile="${topic}.snap"
+    snapfile="${topic}.snap"
     if ! kafkacat -C -b 127.0.0.1:9092 -t "${topic}" -e > "${snapfile}"; then
         echo "Failed to dump topic ${topic}"
         exit 1


### PR DESCRIPTION
Somehow this `readonly` snuck into the original PR, even though the
variable is being set multiple times within a loop. Fix the script by
removing the readonly annotation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4513)
<!-- Reviewable:end -->
