### PR TITLE
pgcompat: support array_lower

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1790,6 +1790,7 @@ pub enum BinaryFunc {
     ListLengthMax { max_dim: usize },
     ArrayContains,
     ArrayIndex,
+    ArrayLower,
 }
 
 impl BinaryFunc {
@@ -1903,6 +1904,7 @@ impl BinaryFunc {
             BinaryFunc::ListLengthMax { max_dim } => eager!(list_length_max, *max_dim),
             BinaryFunc::ArrayContains => Ok(eager!(array_contains)),
             BinaryFunc::ArrayIndex => Ok(eager!(array_index)),
+            BinaryFunc::ArrayLower => Ok(eager!(array_lower)),
         }
     }
 
@@ -2043,7 +2045,7 @@ impl BinaryFunc {
                 .clone()
                 .nullable(true),
 
-            ListLengthMax { .. } => ScalarType::Int64.nullable(true),
+            ListLengthMax { .. } | ArrayLower => ScalarType::Int64.nullable(true),
         }
     }
 
@@ -2173,7 +2175,8 @@ impl BinaryFunc {
             | ListIndex
             | MatchRegex { .. }
             | ArrayContains
-            | ArrayIndex => true,
+            | ArrayIndex
+            | ArrayLower => true,
             MatchLikePattern
             | ToCharTimestamp
             | ToCharTimestampTz
@@ -2280,6 +2283,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::ListLengthMax { .. } => f.write_str("list_length_max"),
             BinaryFunc::ArrayContains => f.write_str("array_contains"),
             BinaryFunc::ArrayIndex => f.write_str("array_index"),
+            BinaryFunc::ArrayLower => f.write_str("array_lower"),
         }
     }
 }
@@ -3302,6 +3306,17 @@ fn array_index<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
         .iter()
         .nth(i as usize - 1)
         .unwrap_or(Datum::Null)
+}
+
+fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
+    let i = b.unwrap_int64();
+    if i < 1 {
+        return Datum::Null;
+    }
+    match a.unwrap_array().elements().iter().nth(i as usize - 1) {
+        Some(_) => Datum::Int64(1),
+        None => Datum::Null,
+    }
 }
 
 fn list_length_max<'a>(a: Datum<'a>, b: Datum<'a>, max_dim: usize) -> Result<Datum<'a>, EvalError> {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -707,6 +707,7 @@ impl<'a> ArgImplementationMatcher<'a> {
             ParamType::Plain(List(..)) if matches!(arg_type, List(..)) => return Ok(arg),
             ParamType::Plain(s) => CastTo::Implicit(s.clone()),
             ParamType::Any => return Ok(arg),
+            ParamType::ArrayAny if matches!(arg_type, Array(..)) => return Ok(arg),
             ParamType::ArrayAny => CastTo::Explicit(Array(Box::new(String))),
             ParamType::JsonbAny => CastTo::JsonbAny,
             ParamType::StringAny => CastTo::Explicit(String),
@@ -770,6 +771,9 @@ lazy_static! {
                 params!(Decimal(0, 0)) => UnaryFunc::AbsDecimal,
                 params!(Float32) => UnaryFunc::AbsFloat32,
                 params!(Float64) => UnaryFunc::AbsFloat64
+            },
+            "array_lower" => Scalar {
+                params!(ArrayAny, Int64) => BinaryFunc::ArrayLower
             },
             "array_to_string" => Scalar {
                 params!(ArrayAny, String) => variadic_op(array_to_string),

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -489,3 +489,31 @@ query T
 SELECT pg_catalog.pg_encoding_to_char(7)
 ----
 NULL
+
+# The following tests are taken from cockroach/builtin_function.slt
+# todo@jldlaughlin: remove these duplicates
+
+query I
+SELECT array_lower(ARRAY['a', 'b'], 1)
+----
+1
+
+query I
+SELECT array_lower(ARRAY['a'], 1)
+----
+1
+
+query I
+SELECT array_lower(ARRAY['a'], 0)
+----
+NULL
+
+query I
+SELECT array_lower(ARRAY['a'], 2)
+----
+NULL
+
+query I
+SELECT array_lower(ARRAY[ARRAY[1, 2]], 2)
+----
+1


### PR DESCRIPTION
Required for: https://github.com/MaterializeInc/materialize/issues/4506

Adds support for [`array_lower`](https://www.postgresql.org/docs/13/functions-array.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4514)
<!-- Reviewable:end -->
