### PR TITLE
pgcompat: support array_upper

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -779,6 +779,9 @@ lazy_static! {
                 params!(ArrayAny, String) => variadic_op(array_to_string),
                 params!(ArrayAny, String, String) => variadic_op(array_to_string)
             },
+            "array_upper" => Scalar {
+                params!(ArrayAny, Int64) => BinaryFunc::ArrayUpper
+            },
             "ascii" => Scalar {
                 params!(String) => UnaryFunc::Ascii
             },

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -518,7 +518,32 @@ SELECT array_lower(ARRAY[ARRAY[1, 2]], 2)
 ----
 1
 
-# Additional array_lower tests
+query I
+SELECT array_upper(ARRAY['a', 'b'], 1)
+----
+2
+
+query I
+SELECT array_upper(ARRAY['a'], 1)
+----
+1
+
+query I
+SELECT array_upper(ARRAY['a'], 0)
+----
+NULL
+
+query I
+SELECT array_upper(ARRAY['a'], 2)
+----
+NULL
+
+query I
+SELECT array_upper(ARRAY[ARRAY[1, 2]], 2)
+----
+2
+
+# Additional array_lower, array_upper tests
 query I
 SELECT array_lower(ARRAY[[[9]]], 2)
 ----
@@ -531,5 +556,31 @@ SELECT array_lower(ARRAY[[['a', 'b']]], 3)
 
 query I
 SELECT array_lower(ARRAY[[['a', 'b']]], 4)
+----
+NULL
+
+query I
+SELECT array_upper(ARRAY[[[1, 2]]], 3)
+----
+2
+
+query I
+SELECT array_upper(ARRAY[[[1, 2]]], 4)
+----
+NULL
+
+# This result diverges from Postgres #4549
+query I
+SELECT array_upper(NULL, 1)
+----
+NULL
+
+query I
+SELECT array_upper(ARRAY[NULL], 1)
+----
+1
+
+query I
+SELECT array_upper(ARRAY[1], NULL)
 ----
 NULL


### PR DESCRIPTION
Fixes part of: https://github.com/MaterializeInc/materialize/issues/4506

Adds support for [`array_upper`](https://www.postgresql.org/docs/13/functions-array.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4515)
<!-- Reviewable:end -->
