### PR TITLE
coord: use default compaction for log indexes

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -239,12 +239,13 @@ where
                         // `SequencedCommand::EnableLogging`. Just teach the
                         // coordinator of their existence, without creating a
                         // dataflow for the index.
-                        //
-                        // TODO(benesch): why is this hardcoded to 1000?
-                        // Should it not be the same logical compaction window
-                        // that everything else uses?
-                        self.indexes
-                            .insert(*id, Frontiers::new(self.num_timely_workers, Some(1_000)));
+                        self.indexes.insert(
+                            *id,
+                            Frontiers::new(
+                                self.num_timely_workers,
+                                self.logical_compaction_window_ms,
+                            ),
+                        );
                     } else {
                         self.ship_dataflow(self.build_index_dataflow(*id)).await;
                     }


### PR DESCRIPTION
mz_catalog log indexes have had a compaction time of 1s, instead of
the default logical-compaction-window. The removed comment documented
a general lack of knowledge about why this was, unsure if there was a
specific reason that these log indexes needed a shorter time, or if it
was that way because this number had just been diligently copied down
through many changes without a reason.

Investigation revealed the following commit:
1cd5749.
This commit included comments "Constant chosen arbitrarily; choose better"
and "1000 ms compaction lag. Change!", describing that the 1s duration
is not meaningful.

We have also observed is #3983 that mz_catalog will often return a
timestamp error, which we suspected was contributed to by this short
compaction window. That problem was worked around (perhaps not quite
fixed) by #4467. But that workaround results in sometimes choosing a
future time and waiting, resulting in slow mz_catalog queries. Using
the default compaction window for mz_catalog will hopefully reduce the
amount or frequency of needing to wait.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4516)
<!-- Reviewable:end -->
