### PR TITLE
chaos: increase kafka topic creation max sleep

### DIFF
--- a/test/chaos/src/main.rs
+++ b/test/chaos/src/main.rs
@@ -64,7 +64,7 @@ async fn mysql_debezium_kafka(args: Args) -> Result<(), anyhow::Error> {
                            ENVELOPE DEBEZIUM;";
     log::info!("creating source=> {}", src_query);
     // Retry in case the topic has not been created yet.
-    retry::retry_for(Duration::from_secs(30), |_| {
+    retry::retry_for(Duration::from_secs(60), |_| {
         mz_client.execute(&*src_query, &[])
     })
     .await?;
@@ -124,7 +124,7 @@ async fn bytes_to_kafka(args: Args) -> Result<(), anyhow::Error> {
         "materialize.chaos",
         &[("enable.idempotence", "true")],
     )?;
-    retry::retry_for(Duration::from_secs(10), |_| {
+    retry::retry_for(Duration::from_secs(60), |_| {
         kafka_client.create_topic(
             &topic,
             args.kafka_partitions.unwrap_or(1),


### PR DESCRIPTION
The chaos tests apply "chaos" to random Docker containers immediately. This
can prevent the required initial state of the tests (a Kafka topic) from
getting set up correctly. This change bumps the max sleep around Kafka topic
creation to try to avoid that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4519)
<!-- Reviewable:end -->
