### PR TITLE
WIP: use filters to index into arrangement

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -218,17 +218,19 @@ where
                                     let batch = &wrapper;
                                     let mut cursor = batch.cursor();
                                     cursor.seek_key(batch, &row);
-                                    while let Some(val) = cursor.get_val(batch) {
-                                        for datum in logic(val) {
-                                            cursor.map_times(batch, |time, diff| {
-                                                session.give((
-                                                    datum.clone(),
-                                                    time.clone(),
-                                                    diff.clone(),
-                                                ));
-                                            });
+                                    if cursor.get_key(batch) == Some(&row) {
+                                        while let Some(val) = cursor.get_val(batch) {
+                                            for datum in logic(val) {
+                                                cursor.map_times(batch, |time, diff| {
+                                                    session.give((
+                                                        datum.clone(),
+                                                        time.clone(),
+                                                        diff.clone(),
+                                                    ));
+                                                });
+                                            }
+                                            cursor.step_val(batch);
                                         }
-                                        cursor.step_val(batch);
                                     }
                                 }
                             });
@@ -263,17 +265,19 @@ where
                                     let batch = &wrapper;
                                     let mut cursor = batch.cursor();
                                     cursor.seek_key(batch, &row);
-                                    while let Some(val) = cursor.get_val(batch) {
-                                        for datum in logic(val) {
-                                            cursor.map_times(batch, |time, diff| {
-                                                session.give((
-                                                    datum.clone(),
-                                                    time.clone(),
-                                                    diff.clone(),
-                                                ));
-                                            });
+                                    if cursor.get_key(batch) == Some(&row) {
+                                        while let Some(val) = cursor.get_val(batch) {
+                                            for datum in logic(val) {
+                                                cursor.map_times(batch, |time, diff| {
+                                                    session.give((
+                                                        datum.clone(),
+                                                        time.clone(),
+                                                        diff.clone(),
+                                                    ));
+                                                });
+                                            }
+                                            cursor.step_val(batch);
                                         }
-                                        cursor.step_val(batch);
                                     }
                                 }
                             });


### PR DESCRIPTION
This PR demonstrates how one can use filter statements in a `MapFilterProject` structure to index directly in to an arrangement and avoid the linear scan over all records. There is clearly some repetition in here that could be factored out, but I didn't want to start on that without discussing the structure first.

cc: @justinj @wangandi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4524)
<!-- Reviewable:end -->
