### PR TITLE
Convert the docker-compose version check to a warning, support 1.24

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -28,7 +28,7 @@ from materialize import ui
 announce = ui.speaker("==> ")
 say = ui.speaker("")
 
-MIN_COMPOSE_VERSION = (1, 25, 0)
+MIN_COMPOSE_VERSION = (1, 24, 0)
 
 
 def assert_docker_compose_version() -> None:
@@ -40,8 +40,10 @@ def assert_docker_compose_version() -> None:
     output = spawn.capture(cmd, unicode=True).strip()
     version = tuple(int(i) for i in output.split("."))
     if version < MIN_COMPOSE_VERSION:
-        msg = f"Unsupported docker-compose version: {version}, min required: {MIN_COMPOSE_VERSION}"
-        raise errors.MzConfigurationError(msg)
+        this_version = ".".join(str(p) for p in version)
+        min_version = ".".join(str(p) for p in MIN_COMPOSE_VERSION)
+        msg = f"WARNING: Unsupported docker-compose version: {this_version} min officially supported: {min_version}"
+        print(msg, file=sys.stderr)
 
 
 def main(argv: List[str]) -> int:


### PR DESCRIPTION
We don't know exactly what versions of docker-compose we test with. 1.24 is the version
that we test with in cloud, so we know it is supported. If folks observe that we work
with a lower version then we can make this number lower.

That said, the purpose of this check is to provide a bit of a warning in case users see
surprising behavior, hard-stopping them doesn't seem as useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4531)
<!-- Reviewable:end -->
