### PR TITLE
mzcompose: downgrade required compose version to v1.24

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -28,7 +28,7 @@ from materialize import ui
 announce = ui.speaker("==> ")
 say = ui.speaker("")
 
-MIN_COMPOSE_VERSION = (1, 25, 0)
+MIN_COMPOSE_VERSION = (1, 24, 0)
 
 
 def assert_docker_compose_version() -> None:


### PR DESCRIPTION
v1.24 is what the cloud infrastructure uses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4532)
<!-- Reviewable:end -->
