### PR TITLE
Add a SourceData struct to abstract ingest dataflow data

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -104,6 +104,17 @@ where
     pub position: Option<i64>,
 }
 
+/// The data that we send from sources to the decode process
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub(crate) struct SourceData {
+    /// The actual value
+    pub(crate) value: Vec<u8>,
+    /// The source's reported position for this record
+    ///
+    /// e.g. kafka offset or file location
+    pub(crate) position: Option<i64>,
+}
+
 impl<K, V> SourceOutput<K, V>
 where
     K: Data,


### PR DESCRIPTION
Instead of having a constantly-growing Tuple for everything at the ingest side, we can
now create and use named fields. Follow up PRs will use this to pipe more kafka
information through to Avro decode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4533)
<!-- Reviewable:end -->
