### PR TITLE
pgcompat: fix array_lower bug

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3354,7 +3354,7 @@ fn array_lower<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     if i < 1 {
         return Datum::Null;
     }
-    match a.unwrap_array().elements().iter().nth(i as usize - 1) {
+    match a.unwrap_array().dims().into_iter().nth(i as usize - 1) {
         Some(_) => Datum::Int64(1),
         None => Datum::Null,
     }

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -517,3 +517,19 @@ query I
 SELECT array_lower(ARRAY[ARRAY[1, 2]], 2)
 ----
 1
+
+# Additional array_lower tests
+query I
+SELECT array_lower(ARRAY[[[9]]], 2)
+----
+1
+
+query I
+SELECT array_lower(ARRAY[[['a', 'b']]], 3)
+----
+1
+
+query I
+SELECT array_lower(ARRAY[[['a', 'b']]], 4)
+----
+NULL


### PR DESCRIPTION
Fixes #4517 by descending an array's dimensions instead of its individual elements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4534)
<!-- Reviewable:end -->
