### PR TITLE
materialized: drop dependency on stream-cancel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,6 @@ dependencies = [
  "serde_json",
  "sql",
  "sql-parser",
- "stream-cancel",
  "sysctl",
  "tempfile",
  "tokio",
@@ -3791,18 +3790,6 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "stream-cancel"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c701433009034f047e385aa930890e6c1d717c7e6374bbd9b81795dee55aff72"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "tokio",
-]
 
 [[package]]
 name = "stringprep"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -45,7 +45,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 sql = { path = "../sql" }
 sql-parser = { path = "../sql-parser" }
-stream-cancel = "0.6.1"
 sysctl = "0.4.0"
 tempfile = "3.1"
 tokio = { version = "0.2", features = ["sync"] }


### PR DESCRIPTION
It's incompatibile with Tokio v0.3, and it's easy enough to replace now
with StreamExt::take_until from the futures crate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4535)
<!-- Reviewable:end -->
