### PR TITLE
dataflow: optimize TopK memory usage

### DIFF
--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -9,6 +9,7 @@
 
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::operators::Consolidate;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 
@@ -129,73 +130,82 @@ where
                 use differential_dataflow::operators::Reduce;
                 let order_clone = order_key.to_vec();
 
-                collection
-                    .map(move |((key, hash), row)| ((key, hash % modulus), row))
-                    .reduce_named("TopK", {
-                        move |_key, source, target: &mut Vec<(Row, isize)>| {
-                            // Determine if we must actually shrink the result set.
-                            let must_shrink = offset > 0
-                                || limit
-                                    .map(|l| {
-                                        source.iter().map(|(_, d)| *d).sum::<isize>() as usize > l
+                let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
+                // We only want to arrange parts of the input that are not part of the actal output
+                // such that `input.concat(&negated_output.negate())` yields the correct TopK
+                let negated_output = input.reduce_named("TopK", {
+                    move |_key, source, target: &mut Vec<(Row, isize)>| {
+                        // First go ahead and emit all records
+                        for (row, diff) in source.iter() {
+                            target.push(((*row).clone(), diff.clone()));
+                        }
+                        // Determine if we must actually shrink the result set.
+                        let must_shrink = offset > 0
+                            || limit
+                                .map(|l| source.iter().map(|(_, d)| *d).sum::<isize>() as usize > l)
+                                .unwrap_or(false);
+                        if must_shrink {
+                            // local copies that may count down to zero.
+                            let mut offset = offset;
+                            let mut limit = limit;
+
+                            // The order in which we should produce rows.
+                            let mut indexes = (0..source.len()).collect::<Vec<_>>();
+                            if !order_clone.is_empty() {
+                                // We decode the datums once, into a common buffer for efficiency.
+                                // Each row should contain `arity` columns; we should check that.
+                                let mut buffer = Vec::with_capacity(arity * source.len());
+                                for (index, row) in source.iter().enumerate() {
+                                    buffer.extend(row.0.iter());
+                                    assert_eq!(buffer.len(), arity * (index + 1));
+                                }
+                                let width = buffer.len() / source.len();
+
+                                //todo: use arrangements or otherwise make the sort more performant?
+                                indexes.sort_by(|left, right| {
+                                    let left = &buffer[left * width..][..width];
+                                    let right = &buffer[right * width..][..width];
+                                    expr::compare_columns(&order_clone, left, right, || {
+                                        left.cmp(right)
                                     })
-                                    .unwrap_or(false);
-                            if must_shrink {
-                                // local copies that may count down to zero.
-                                let mut offset = offset;
-                                let mut limit = limit;
+                                });
+                            }
 
-                                // The order in which we should produce rows.
-                                let mut indexes = (0..source.len()).collect::<Vec<_>>();
-                                if !order_clone.is_empty() {
-                                    // We decode the datums once, into a common buffer for efficiency.
-                                    // Each row should contain `arity` columns; we should check that.
-                                    let mut buffer = Vec::with_capacity(arity * source.len());
-                                    for (index, row) in source.iter().enumerate() {
-                                        buffer.extend(row.0.iter());
-                                        assert_eq!(buffer.len(), arity * (index + 1));
+                            // We now need to lay out the data in order of `buffer`, but respecting
+                            // the `offset` and `limit` constraints.
+                            for index in indexes.into_iter() {
+                                let (row, mut diff) = source[index];
+                                if diff > 0 {
+                                    // If we are still skipping early records ...
+                                    if offset > 0 {
+                                        let to_skip = std::cmp::min(offset, diff as usize);
+                                        offset -= to_skip;
+                                        diff -= to_skip as isize;
                                     }
-                                    let width = buffer.len() / source.len();
-
-                                    //todo: use arrangements or otherwise make the sort more performant?
-                                    indexes.sort_by(|left, right| {
-                                        let left = &buffer[left * width..][..width];
-                                        let right = &buffer[right * width..][..width];
-                                        expr::compare_columns(&order_clone, left, right, || {
-                                            left.cmp(right)
-                                        })
-                                    });
-                                }
-
-                                // We now need to lay out the data in order of `buffer`, but respecting
-                                // the `offset` and `limit` constraints.
-                                for index in indexes.into_iter() {
-                                    let (row, mut diff) = source[index];
+                                    // We should produce at most `limit` records.
+                                    if let Some(limit) = &mut limit {
+                                        diff = std::cmp::min(diff, *limit as isize);
+                                        *limit -= diff as usize;
+                                    }
+                                    // Output the indicated number of rows.
                                     if diff > 0 {
-                                        // If we are still skipping early records ...
-                                        if offset > 0 {
-                                            let to_skip = std::cmp::min(offset, diff as usize);
-                                            offset -= to_skip;
-                                            diff -= to_skip as isize;
-                                        }
-                                        // We should produce at most `limit` records.
-                                        if let Some(limit) = &mut limit {
-                                            diff = std::cmp::min(diff, *limit as isize);
-                                            *limit -= diff as usize;
-                                        }
-                                        // Output the indicated number of rows.
-                                        if diff > 0 {
-                                            target.push((row.clone(), diff));
-                                        }
+                                        // Emit retractions for the elements actually part of
+                                        // the set of TopK elements.
+                                        target.push((row.clone(), -diff));
                                     }
-                                }
-                            } else {
-                                for (row, diff) in source.iter() {
-                                    target.push(((*row).clone(), diff.clone()));
                                 }
                             }
+                        } else {
+                            for (row, diff) in source.iter() {
+                                // Emit retractions for the elements actually part of
+                                // the set of TopK elements.
+                                target.push(((*row).clone(), -diff.clone()));
+                            }
                         }
-                    })
+                    }
+                });
+
+                negated_output.negate().concat(&input).consolidate()
             }
         }
     }

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -135,16 +135,16 @@ where
                 // such that `input.concat(&negated_output.negate())` yields the correct TopK
                 let negated_output = input.reduce_named("TopK", {
                     move |_key, source, target: &mut Vec<(Row, isize)>| {
-                        // First go ahead and emit all records
-                        for (row, diff) in source.iter() {
-                            target.push(((*row).clone(), diff.clone()));
-                        }
                         // Determine if we must actually shrink the result set.
                         let must_shrink = offset > 0
                             || limit
                                 .map(|l| source.iter().map(|(_, d)| *d).sum::<isize>() as usize > l)
                                 .unwrap_or(false);
                         if must_shrink {
+                            // First go ahead and emit all records
+                            for (row, diff) in source.iter() {
+                                target.push(((*row).clone(), diff.clone()));
+                            }
                             // local copies that may count down to zero.
                             let mut offset = offset;
                             let mut limit = limit;
@@ -194,12 +194,6 @@ where
                                         target.push((row.clone(), -diff));
                                     }
                                 }
-                            }
-                        } else {
-                            for (row, diff) in source.iter() {
-                                // Emit retractions for the elements actually part of
-                                // the set of TopK elements.
-                                target.push(((*row).clone(), -diff.clone()));
                             }
                         }
                     }


### PR DESCRIPTION
Closes #4325

Do the exact same optimization that we recently performed for the
reduce operator in `8c98df5` for the exact same reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4546)
<!-- Reviewable:end -->
