### PR TITLE
testdrive: Disallow duplicate arguments to commands

### DIFF
--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -122,7 +122,12 @@ fn parse_builtin(line_reader: &mut LineReader) -> Result<BuiltinCommand, InputEr
                 pos,
             });
         }
-        args.insert(pieces[0].to_owned(), pieces[1].to_owned());
+        if let Some(original) = args.insert(pieces[0].to_owned(), pieces[1].to_owned()) {
+            return Err(InputError {
+                msg: format!("argument '{}' specified twice", original),
+                pos,
+            });
+        };
     }
     Ok(BuiltinCommand {
         name,


### PR DESCRIPTION
Since it is impossible to use arguments that appear multiple times in one command we
should disallow it, it is always a bug.

----

This definitely didn't cause me to assume all my new code was broken at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4547)
<!-- Reviewable:end -->
