### PR TITLE
doc: specify toolchain requirements

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -25,6 +25,30 @@ better availability and durability story.
 
 ## Installing
 
+### C components
+
+Materialize depends on several components that are written in C, so you'll need
+a working C compiler. You'll also need to install the [CMake] build system.
+
+On macOS, if you install [Homebrew], you'll be guided through the process of
+installing Apple's developer tools, which includes a C compiler. Then it's a
+cinch to install CMake:
+
+```
+brew install cmake
+```
+
+On Debian-based Linux variants, it's even easier:
+
+```shell
+sudo apt update
+sudo apt install build-essential cmake
+```
+
+On other platforms, you'll have to figure out how to get these tools yourself.
+
+[CMake]: https://cmake.org
+
 ### Rust
 
 Install Rust via [rustup]:
@@ -35,6 +59,10 @@ curl https://sh.rustup.rs -sSf | sh
 
 Rustup will automatically select the correct toolchain version specified in
 [materialize/rust-toolchain](/rust-toolchain).
+
+We recommend that you do _not_ install Rust via your system's package manager.
+We closely track the most recent version of Rust. The version of Rust in your
+package manager is likely too old to build Materialize.
 
 [rustup]: https://www.rust-lang.org/tools/install
 

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -72,15 +72,33 @@ curl -L https://downloads.mtrlz.dev/materialized-{{< version >}}-x86_64-unknown-
 
 ## Build from source
 
-Materialize is written in Rust and requires a recent Rust toolchain to build
-from source. Follow [Rust's getting started
-guide](https://www.rust-lang.org/learn/get-started) if you don't already have
-Rust installed.
+Materialize is written primarily in Rust, but incorporates several components
+written in C. To build Materialize, you will need to acquire the following
+tools:
 
-Then, to build your own `materialized` binary, you can clone the
-[`MaterializeInc/materialize` repo from GitHub](https://github.com/MaterializeInc/materialize),
-and build it using `cargo build`. Be sure to check out the tag for the correct
-release.
+  * A recent version of Git
+
+  * A C compiler that supports C11
+
+  * CMake v3.2+
+
+  * Rust v{{< rust-version >}}+
+
+Your system's package manager, like Homebrew on macOS or APT on Debian, likely
+contains sufficiently recent versions of Git, a C compiler, and CMake. However,
+we recommend installing Rust via [rustup]. rustup configures your system so that
+running `cargo build` in the Materialize repository will automatically download
+and use the correct version of Rust.
+
+{{< warning >}}
+Materialize requires a very recent version of Rust. The version of Rust
+available in your package manager is likely too old.
+{{< /warning >}}
+
+Once you've installed the prerequisites, to build your own `materialized`
+binary, you can clone the [`MaterializeInc/materialize` repo from
+GitHub][mz-repo], and build it using `cargo build`. Be sure to check out the tag
+for the correct release.
 
 ```shell
 git clone https://github.com/MaterializeInc/materialize.git
@@ -112,3 +130,6 @@ For more information, see [CLI Connections](/connect/cli/).
 {{< cta href="/get-started" >}}
 Next, let's get started with Materialize →
 {{</ cta >}}
+
+[Rustup]: https://rustup.rs
+[mz-repo]: https://github.com/MaterializeInc/materialize

--- a/doc/user/layouts/shortcodes/rust-version.html
+++ b/doc/user/layouts/shortcodes/rust-version.html
@@ -1,0 +1,1 @@
+{{- trim (readFile "rust-toolchain") "\n" -}}

--- a/doc/user/rust-toolchain
+++ b/doc/user/rust-toolchain
@@ -1,0 +1,1 @@
+../../rust-toolchain


### PR DESCRIPTION
In a perfect world, we'd be able to pin this down in Cargo.toml. See
rust-lang/rust#65262. For now, though, some aggressive documentation
will have to do.

Fix #4544.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4548)
<!-- Reviewable:end -->
