### PR TITLE
sql,pgwire: support TAIL ... FORMAT BINARY

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -151,6 +151,7 @@ pub enum ExecuteResponse {
     /// contained receiver.
     Tailing {
         rx: comm::mpsc::Receiver<Vec<Update>>,
+        format: pgrepr::Format,
     },
     /// The specified number of rows were updated in the requested table.
     Updated(usize),

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1419,8 +1419,9 @@ where
                 id,
                 ts,
                 with_snapshot,
+                format,
             } => tx.send(
-                self.sequence_tail(session.conn_id(), id, with_snapshot, ts)
+                self.sequence_tail(session.conn_id(), id, with_snapshot, ts, format)
                     .await,
                 session,
             ),
@@ -2024,6 +2025,7 @@ where
         source_id: GlobalId,
         with_snapshot: bool,
         ts: Option<Timestamp>,
+        format: pgrepr::Format,
     ) -> Result<ExecuteResponse, anyhow::Error> {
         // Determine the frontier of updates to tail *from*.
         // Updates greater or equal to this frontier will be produced.
@@ -2049,7 +2051,7 @@ where
             }),
         ))
         .await;
-        Ok(ExecuteResponse::Tailing { rx })
+        Ok(ExecuteResponse::Tailing { rx, format })
     }
 
     /// Extracts an optional projection around an optional filter.

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -907,6 +907,7 @@ pub struct TailStatement {
     pub name: ObjectName,
     pub with_snapshot: bool,
     pub as_of: Option<Expr>,
+    pub format: TailFormat,
 }
 
 impl AstDisplay for TailStatement {
@@ -926,6 +927,12 @@ impl AstDisplay for TailStatement {
     }
 }
 impl_display!(TailStatement);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TailFormat {
+    Text,
+    Binary,
+}
 
 /// `EXPLAIN ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3170,10 +3170,20 @@ impl Parser {
             true
         };
         let as_of = self.parse_optional_as_of()?;
+        let format = if self.parse_keyword("FORMAT") {
+            match self.expect_one_of_keywords(&["TEXT", "BINARY"])? {
+                "TEXT" => TailFormat::Text,
+                "BINARY" => TailFormat::Binary,
+                _ => unreachable!(),
+            }
+        } else {
+            TailFormat::Text
+        };
         Ok(Statement::Tail(TailStatement {
             name,
             with_snapshot,
             as_of,
+            format,
         }))
     }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -682,28 +682,44 @@ TAIL foo.bar
 ----
 TAIL foo.bar WITH SNAPSHOT
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: None })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: None, format: Text })
 
 parse-statement
 TAIL foo.bar AS OF 123
 ----
 TAIL foo.bar WITH SNAPSHOT AS OF 123
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Value(Number("123"))) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Value(Number("123"))), format: Text })
 
 parse-statement
 TAIL foo.bar AS OF now()
 ----
 TAIL foo.bar WITH SNAPSHOT AS OF now()
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), format: Text })
 
 parse-statement
 TAIL foo.bar WITHOUT SNAPSHOT AS OF now()
 ----
 TAIL foo.bar WITHOUT SNAPSHOT AS OF now()
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: false, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: false, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })), format: Text })
+
+parse-statement
+TAIL foo.bar WITHOUT SNAPSHOT AS OF 1 + 1 FORMAT BINARY
+----
+TAIL foo.bar WITHOUT SNAPSHOT AS OF 1 + 1
+=>
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: false, as_of: Some(BinaryOp { left: Value(Number("1")), op: Plus, right: Value(Number("1")) }), format: Binary })
+
+parse-statement
+TAIL foo.bar FORMAT blah
+----
+error:
+Parse error:
+TAIL foo.bar FORMAT blah
+                    ^^^^
+Expected one of TEXT or BINARY, found: blah
 
 parse-statement
 CREATE TABLE public.customer (

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -132,6 +132,7 @@ pub enum Plan {
         id: GlobalId,
         with_snapshot: bool,
         ts: Option<Timestamp>,
+        format: pgrepr::Format,
     },
     SendRows(Vec<Row>),
     ExplainPlan {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -40,7 +40,7 @@ use sql_parser::ast::{
     DropDatabaseStatement, DropObjectsStatement, ExplainStage, ExplainStatement, Explainee, Expr,
     Format, Ident, IfExistsBehavior, InsertStatement, ObjectName, ObjectType, Query,
     SelectStatement, SetVariableStatement, SetVariableValue, ShowVariableStatement, SqlOption,
-    Statement, TailStatement, Value,
+    Statement, TailFormat, TailStatement, Value,
 };
 
 use crate::catalog::{Catalog, CatalogItemType};
@@ -320,6 +320,7 @@ fn handle_tail(
         name,
         as_of,
         with_snapshot,
+        format,
     }: TailStatement,
 ) -> Result<Plan, anyhow::Error> {
     let from = scx.resolve_item(name)?;
@@ -332,6 +333,10 @@ fn handle_tail(
                 id: entry.id(),
                 ts,
                 with_snapshot,
+                format: match format {
+                    TailFormat::Text => pgrepr::Format::Text,
+                    TailFormat::Binary => pgrepr::Format::Binary,
+                },
             })
         }
         CatalogItemType::Index | CatalogItemType::Sink => bail!(


### PR DESCRIPTION
Proof of concept for supporting binary TAILs that work out of the box
with rust-postgres's binary copy reader.

Touches #3091.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4550)
<!-- Reviewable:end -->
