### PR TITLE
ci-builder: run with --init

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -86,6 +86,7 @@ case "$cmd" in
     run)
         args=(
             --rm --interactive
+            --init
             --volume "$(pwd):$(pwd)"
             --workdir "$(pwd)"
             --env AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Pass --init when running the CI builder Docker container. This causes
Docker to run a proper init system in the container, which tends to make
signal handling work better. In particular this makes Ctrl+C work
correctly on my Linux machine locally. It may also fix the sporadic race
condition we see in CI where cancellation fails to interrupt `cargo
build`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4554)
<!-- Reviewable:end -->
