### PR TITLE
doc/user: fix demo irritants

### DIFF
--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -111,31 +111,31 @@ Putting this all together, our deployment looks like this:
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine, and [follow our Docker
-   configuration guide](/third-party/docker).
+1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
+   already.
 
    **Note for macOS users:** Be sure to [increase Docker
    resources](/third-party/docker/#increase-docker-resources) to at least 2 CPUs
    and 8GB memory. Running Docker for Mac with less resources may cause the demo
    to fail.
 
-1. Clone the Materialize repo:
+1. Clone the Materialize repository:
 
     ```shell
-    git clone git@github.com:MaterializeInc/materialize.git
+    git clone https://github.com/MaterializeInc/materialize.git
     ```
 
-1. Deploy and start all of the components we've listed above.
+   You can also view the demo's code on
+   [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/chbench).
 
-    Note that pulling down all of the Docker images necessary for the demo takes
-    quite a bit of time (up to 10 minutes, even on very fast connections).
+1. Download and start all of the components we've listed above by running:
 
-    ```shell
-    bin/mzconduct run chbench --workflow demo-load
-    ```
+   ```shell
+   bin/mzconduct run chbench --workflow demo-load
+   ```
 
-    you can also find the demo's code on
-    [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/chbench).
+   Note that downloading the Docker images necessary for the demo can take quite
+   a bit of time (upwards of 10 minutes, even on very fast connections).
 
 ### Define sources & views
 

--- a/doc/user/content/demos/log-parsing.md
+++ b/doc/user/content/demos/log-parsing.md
@@ -237,8 +237,8 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine, and [follow our Docker integration
-   guide](/third-party/docker).
+1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
+   already.
 
 1. Verify that you have Python 3 or greater installed.
 
@@ -250,7 +250,7 @@ In a future iteration, we'll make this demo more interactive.
 1. Clone the Materialize repo:
 
     ```shell
-    git clone git@github.com:MaterializeInc/materialize.git
+    git clone https://github.com/MaterializeInc/materialize.git
     ```
 
 1. Move to the `demo/http_logs` dir:
@@ -262,15 +262,14 @@ In a future iteration, we'll make this demo more interactive.
     You can also find the demo's code on
     [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/http_logs).
 
-1. Deploy and start all of the components we've listed above.
+1. Download and start all of the components we've listed above by running:
 
-    Note that pulling down all of the Docker images necessary for the demo takes
-    some time (upwards of 3 minutes, even on very fast connections).
+   ```shell
+   ./mzcompose up
+   ```
 
-    ```shell
-    # Deploy the web server, load generator, and Materialize
-    ./mzcompose up
-    ```
+   Note that downloading the Docker images necessary for the demo can take quite
+   a bit of time (upwards of 3 minutes, even on very fast connections).
 
 ### Understanding sources & views
 

--- a/doc/user/content/demos/microservice.md
+++ b/doc/user/content/demos/microservice.md
@@ -400,35 +400,35 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. Start the Docker daemon for your machine, and [follow our Docker integration
-   guide](/third-party/docker).
+1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
+   already.
 
-1. Clone the Materialize repo:
+1. Clone the Materialize repository:
 
     ```shell
-    git clone git@github.com:MaterializeInc/materialize.git
+    git clone https://github.com/MaterializeInc/materialize.git
     ```
 
-1. Move to the `demo/billing` dir:
+1. Move to the `demo/billing` directory:
 
     ```shell
     cd <path to materialize>/demo/billing
     ```
 
-    You can also find the demo's code on
+    You can also view the demo's code on
     [GitHub](https://github.com/MaterializeInc/materialize/tree/main/demo/billing).
 
-1. Deploy and start all of the components we've listed above.
-
-    Note that pulling down all of the Docker images necessary for the demo takes
-    some time (upwards of 3 minutes, even on very fast connections).
+1. Download and start all of the components we've listed above by running:
 
     ```shell
-    # Deploy the web server, load generator, and Materialize
     ./mzcompose up
     ```
 
-    This will start up all of our infrastructure and generate ~1000 events.
+   Note that downloading the Docker images necessary for the demo can take quite
+   a bit of time (upwards of 3 minutes, even on very fast connections).
+
+   If the command succeeds, it will have started all of the necessary
+   infrastructure will be started and will have generated ~1000 events.
 
 ### Understanding sources & views
 

--- a/doc/user/content/third-party/docker.md
+++ b/doc/user/content/third-party/docker.md
@@ -12,6 +12,13 @@ Materialize, along with any other infrastructure the demo needs.
 For the best experience using Docker, we recommend following the guidelines
 outlined here.
 
+### Installation
+
+Follow the official instructions to install Docker and Docker Compose:
+
+* [Install Docker](https://docs.docker.com/get-docker/)
+* [Install Docker Compose](https://docs.docker.com/compose/install/)
+
 ### Increase Docker Resources
 
 Because many of our Docker-based demos leverage a large number of pieces of


### PR DESCRIPTION
For the demos, use the HTTPS URL to clone the Materialize repository,
since users might not have GitHuB SSH configured. Also reword part of
the BI demo to more clearly indicate that mzcompose handles downloading
and starting components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4555)
<!-- Reviewable:end -->
