### PR TITLE
Deduplicate snapshot rows based on key.

### DIFF
--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -32,6 +32,7 @@ impl AvroDecoderState {
         debug_name: String,
         worker_index: usize,
         dedup_strat: Option<DebeziumDeduplicationStrategy>,
+        key_indices: Option<Vec<usize>>,
     ) -> Result<Self, anyhow::Error> {
         Ok(AvroDecoderState {
             decoder: Decoder::new(
@@ -41,6 +42,7 @@ impl AvroDecoderState {
                 debug_name,
                 worker_index,
                 dedup_strat,
+                key_indices,
             )?,
             events_success: 0,
             events_error: 0,

--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -24,6 +24,7 @@ pub struct AvroDecoderState {
 }
 
 impl AvroDecoderState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         reader_schema: &str,
         schema_registry_config: Option<ccsr::ClientConfig>,

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -497,7 +497,6 @@ where
         .desc(envelope)
         .ok()
         .and_then(|desc| desc.typ().keys.get(0).cloned());
-    eprintln!("key_indices: {:#?}", key_indices);
     match (encoding, envelope) {
         (_, Envelope::Upsert(_)) => {
             unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -299,6 +299,7 @@ where
                 format!("{}-values", debug_name),
                 worker_index,
                 None,
+                None,
             )
             .expect(avro_err),
             &op_name,
@@ -314,6 +315,7 @@ where
                 format!("{}-values", debug_name),
                 worker_index,
                 None,
+                None,
             )
             .expect(avro_err),
             &op_name,
@@ -328,6 +330,7 @@ where
                 format!("{}-keys", debug_name),
                 worker_index,
                 None,
+                None,
             )
             .expect(avro_err),
             avro::AvroDecoderState::new(
@@ -337,6 +340,7 @@ where
                 false,
                 format!("{}-values", debug_name),
                 worker_index,
+                None,
                 None,
             )
             .expect(avro_err),
@@ -489,6 +493,11 @@ where
 {
     let op_name = format!("{}Decode", encoding.op_name());
     let worker_index = stream.scope().index();
+    let key_indices = encoding
+        .desc(envelope)
+        .ok()
+        .and_then(|desc| desc.typ().keys.get(0).cloned());
+    eprintln!("key_indices: {:#?}", key_indices);
     match (encoding, envelope) {
         (_, Envelope::Upsert(_)) => {
             unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")
@@ -510,6 +519,7 @@ where
                 Envelope::Debezium(ds) => *ds,
                 _ => unreachable!(),
             };
+
             (
                 decode_values_inner(
                     stream,
@@ -521,6 +531,7 @@ where
                         debug_name.to_string(),
                         worker_index,
                         Some(dedup_strat),
+                        key_indices,
                     )
                     .expect("Failed to create Avro decoder"),
                     &op_name,
@@ -540,6 +551,7 @@ where
                     debug_name.to_string(),
                     worker_index,
                     None,
+                    key_indices,
                 )
                 .expect("Failed to create Avro decoder"),
                 &op_name,

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -396,6 +396,7 @@ pub fn bench_avro(c: &mut Criterion) {
         "avro_bench".to_string(),
         0,
         Some(DebeziumDeduplicationStrategy::Ordered),
+        None,
     )
     .unwrap();
 

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1191,6 +1191,7 @@ impl DebeziumDeduplicationState {
     }
 
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     fn should_use_record(
         &mut self,
         file: &str,

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1150,28 +1150,39 @@ struct DebeziumDeduplicationState {
     /// [`DebeziumDeduplicationstrategy`] determines whether messages that are not ahead
     /// of the last recorded pos/row will be skipped.
     binlog_offsets: HashMap<String, (usize, usize, Option<i64>)>,
-    /// Whether or not to track every message we've ever seen.
-    ///
-    /// If we track full
-    full: TrackFull,
+    /// Whether or not to track every message we've ever seen
+    full: Option<TrackFull>,
 }
 
 /// If we need to deal debezium possibly going back after it hasn't seen things
 #[derive(Debug)]
-enum TrackFull {
-    /// Trust that Debezium never sends non-duplicate messages that have a lower binlog
-    /// position than its highest-ever sent.
-    No,
-    /// Track all offsets that have ever been seen
+struct TrackFull {
     /// binlog filename to offset
-    SeenOffsets(HashMap<String, HashSet<(usize, usize)>>),
+    seen_offsets: HashMap<String, HashSet<(usize, usize)>>,
+    seen_snapshot_keys: HashMap<String, HashSet<Row>>,
+    key_indices: Option<Vec<usize>>,
+    key_buf: RowPacker,
+}
+
+impl TrackFull {
+    fn from_keys(mut key_indices: Option<Vec<usize>>) -> Self {
+        if let Some(key_indices) = key_indices.as_mut() {
+            key_indices.sort_unstable();
+        }
+        Self {
+            seen_offsets: Default::default(),
+            seen_snapshot_keys: Default::default(),
+            key_indices,
+            key_buf: Default::default(),
+        }
+    }
 }
 
 impl DebeziumDeduplicationState {
-    fn new(strat: DebeziumDeduplicationStrategy) -> Self {
+    fn new(strat: DebeziumDeduplicationStrategy, key_indices: Option<Vec<usize>>) -> Self {
         let full = match strat {
-            DebeziumDeduplicationStrategy::Ordered => TrackFull::No,
-            DebeziumDeduplicationStrategy::Full => TrackFull::SeenOffsets(Default::default()),
+            DebeziumDeduplicationStrategy::Ordered => None,
+            DebeziumDeduplicationStrategy::Full => Some(TrackFull::from_keys(key_indices)),
         };
         DebeziumDeduplicationState {
             binlog_offsets: Default::default(),
@@ -1188,6 +1199,8 @@ impl DebeziumDeduplicationState {
         upstream_time_millis: Option<i64>,
         debug_name: &str,
         worker_idx: usize,
+        is_snapshot: bool,
+        update: &DiffPair<Row>,
     ) -> bool {
         let (pos, row) = match row {
             RowCoordinates::MySql { pos, row } => (pos, row),
@@ -1198,44 +1211,88 @@ impl DebeziumDeduplicationState {
             old_max_row: &'a usize,
             old_offset: &'a Option<i64>,
         }
-        let should_skip = match self.binlog_offsets.get_mut(file) {
-            Some((old_max_pos, old_max_row, old_offset)) => {
-                if (*old_max_pos, *old_max_row) >= (pos, row) {
-                    Some(SkipInfo {
-                        old_max_pos,
-                        old_max_row,
-                        old_offset,
-                    })
-                } else {
-                    // update the debezium high water mark
-                    *old_max_pos = pos;
-                    *old_max_row = row;
-                    *old_offset = coord;
+        let should_skip = if is_snapshot {
+            None
+        } else {
+            match self.binlog_offsets.get_mut(file) {
+                Some((old_max_pos, old_max_row, old_offset)) => {
+                    if (*old_max_pos, *old_max_row) >= (pos, row) {
+                        Some(SkipInfo {
+                            old_max_pos,
+                            old_max_row,
+                            old_offset,
+                        })
+                    } else {
+                        // update the debezium high water mark
+                        *old_max_pos = pos;
+                        *old_max_row = row;
+                        *old_offset = coord;
+                        None
+                    }
+                }
+                None => {
+                    // The extra lookup is fine - this is the cold path.
+                    self.binlog_offsets
+                        .insert(file.to_owned(), (pos, row, coord));
                     None
                 }
-            }
-            None => {
-                // The extra lookup is fine - this is the cold path.
-                self.binlog_offsets
-                    .insert(file.to_owned(), (pos, row, coord));
-                None
             }
         };
 
         match &mut self.full {
-            TrackFull::No => should_skip.is_none(),
-            TrackFull::SeenOffsets(seen_offsets) => {
-                if let Some(seen_offsets) = seen_offsets.get_mut(file) {
-                    let is_new = seen_offsets.insert((pos, row));
+            None => is_snapshot || should_skip.is_none(),
+            Some(TrackFull {
+                seen_offsets,
+                seen_snapshot_keys,
+                key_indices,
+                key_buf,
+            }) => {
+                if is_snapshot {
+                    let key_indices = match key_indices.as_ref() {
+                        None => {
+                            // No keys, so we can't do anything sensible for snapshots. Return "all OK" and hope their data isn't corrupted.
+                            return true;
+                        }
+                        Some(ki) => ki,
+                    };
+                    let mut row_iter = match update.after.as_ref() {
+                        None => {
+                            error!("Snapshot row was unexpectedly not an insert.");
+                            return false;
+                        }
+                        Some(r) => r.iter(),
+                    };
+                    let key = {
+                        let mut cumsum = 0;
+                        for k in key_indices.iter() {
+                            let adjusted_idx = *k - cumsum;
+                            cumsum += adjusted_idx + 1;
+                            key_buf.push(row_iter.nth(adjusted_idx).unwrap());
+                        }
+                        key_buf.finish_and_reuse()
+                    };
 
-                    match (is_new, should_skip) {
-                        // new item that correctly is past the highest item we've ever seen
-                        (true, None) => {}
-                        // new item that violates Debezium "guarantee" that the no new
-                        // records will ever be sent with a position below the highest
-                        // position ever seen
-                        (true, Some(skipinfo)) => {
-                            warn!(
+                    if let Some(seen_keys) = seen_snapshot_keys.get_mut(file) {
+                        let is_new = seen_keys.insert(key);
+                        is_new
+                    } else {
+                        let mut hs = HashSet::new();
+                        hs.insert(key);
+                        seen_snapshot_keys.insert(file.to_owned(), hs);
+                        true
+                    }
+                } else {
+                    if let Some(seen_offsets) = seen_offsets.get_mut(file) {
+                        let is_new = seen_offsets.insert((pos, row));
+
+                        match (is_new, should_skip) {
+                            // new item that correctly is past the highest item we've ever seen
+                            (true, None) => {}
+                            // new item that violates Debezium "guarantee" that the no new
+                            // records will ever be sent with a position below the highest
+                            // position ever seen
+                            (true, Some(skipinfo)) => {
+                                warn!(
                                 "Source: {}:{} created a new record behind the highest point in binlog_file={} \
                                  new_record_position={}:{} new_record_kafka_offset={} old_max_position={}:{} \
                                  message_time={}",
@@ -1243,10 +1300,10 @@ impl DebeziumDeduplicationState {
                                 skipinfo.old_max_pos, skipinfo.old_max_row,
                                 fmt_timestamp(upstream_time_millis)
                             );
-                        }
-                        // Duplicate item below the highest seen item
-                        (false, Some(skipinfo)) => {
-                            debug!(
+                            }
+                            // Duplicate item below the highest seen item
+                            (false, Some(skipinfo)) => {
+                                debug!(
                                 "Source: {}:{} already ingested binlog coordinates {}:{}:{} old_binlog={}:{} \
                                  kafka_offset={} message_time={}",
                                 debug_name, worker_idx, file, pos, row,
@@ -1254,25 +1311,27 @@ impl DebeziumDeduplicationState {
                                 skipinfo.old_offset.unwrap_or(-1),
                                 fmt_timestamp(upstream_time_millis)
                             );
-                        }
-                        // already exists, but is past the debezium high water mark.
-                        //
-                        // This should be impossible because we set the high-water mark
-                        // every time we insert something
-                        (false, None) => {
-                            error!("We surprisingly are seeing a duplicate record that \
+                            }
+                            // already exists, but is past the debezium high water mark.
+                            //
+                            // This should be impossible because we set the high-water mark
+                            // every time we insert something
+                            (false, None) => {
+                                error!("We surprisingly are seeing a duplicate record that \
                                     is beyond the highest record we've ever seen. {}:{}:{} kafka_offset={} \
                                     message_time={}",
-                                   file, pos, row, coord.unwrap_or(-1), fmt_timestamp(upstream_time_millis));
+                                   file, pos, row, coord.unwrap_or(-1),
+                                   fmt_timestamp(upstream_time_millis));
+                            }
                         }
-                    }
 
-                    is_new
-                } else {
-                    let mut hs = HashSet::new();
-                    hs.insert((pos, row));
-                    seen_offsets.insert(file.to_owned(), hs);
-                    true
+                        is_new
+                    } else {
+                        let mut hs = HashSet::new();
+                        hs.insert((pos, row));
+                        seen_offsets.insert(file.to_owned(), hs);
+                        true
+                    }
                 }
             }
         }
@@ -1354,7 +1413,7 @@ impl DebeziumDecodeState {
         Some(Self {
             before_idx,
             after_idx,
-            dedup: DebeziumDeduplicationState::new(dedup_strat),
+            dedup: DebeziumDeduplicationState::new(dedup_strat, None),
             binlog_schema_indices,
             debug_name,
             worker_idx,
@@ -1430,6 +1489,11 @@ impl DebeziumDecodeState {
                             upstream_time_millis,
                             &self.debug_name,
                             self.worker_idx,
+                            false,
+                            &DiffPair {
+                                before: None,
+                                after: None,
+                            },
                         ) {
                             return Ok(DiffPair {
                                 before: None,
@@ -1559,12 +1623,14 @@ impl Decoder {
         debug_name: String,
         worker_index: usize,
         debezium_dedup: Option<DebeziumDeduplicationStrategy>,
+        key_indices: Option<Vec<usize>>,
     ) -> anyhow::Result<Decoder> {
         assert!(
             (envelope == EnvelopeType::Debezium && debezium_dedup.is_some())
                 || (envelope != EnvelopeType::Debezium && debezium_dedup.is_none())
         );
-        let debezium_dedup = debezium_dedup.map(DebeziumDeduplicationState::new);
+        let debezium_dedup =
+            debezium_dedup.map(|strat| DebeziumDeduplicationState::new(strat, key_indices));
         let csr_avro = ConfluentAvroResolver::new(reader_schema, schema_registry)?;
 
         Ok(Decoder {
@@ -1599,6 +1665,7 @@ impl Decoder {
             // Unwrap is OK: we assert in Decoder::new that this is non-none when envelope == dbz.
             let dedup = self.debezium_dedup.as_mut().unwrap();
             let (diff, coords) = dsr.deserialize(&mut bytes, dec)?;
+            let ss;
             let should_use = if let Some(source) = coords {
                 // This would have ideally been `Option<&str>`,
                 // but that can't be used to lookup in a `HashMap` of `Option<String>` without cloning.
@@ -1608,21 +1675,25 @@ impl Decoder {
                     RowCoordinates::MySql { .. } => std::str::from_utf8(&self.buf2)?,
                     RowCoordinates::Postgres { .. } => "",
                 };
-                source.snapshot
-                    || dedup.should_use_record(
-                        file,
-                        source.row,
-                        coord,
-                        upstream_time_millis,
-                        &self.debug_name,
-                        self.worker_index,
-                    )
+                ss = source.snapshot;
+                dedup.should_use_record(
+                    file,
+                    source.row,
+                    coord,
+                    upstream_time_millis,
+                    &self.debug_name,
+                    self.worker_index,
+                    source.snapshot,
+                    &diff,
+                )
             } else {
+                ss = false;
                 true
             };
             if should_use {
                 diff
             } else {
+                eprintln!("Skipping diff: {:?}, ss {}", diff, ss);
                 DiffPair {
                     before: None,
                     after: None,

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -321,14 +321,14 @@ $ kafka-create-topic topic=misordered-dbz-data
 $ set new-dbz-key-schema={"type": "record", "name": "row", "fields": [{"name": "a", "type": "long"}]}
 
 $ kafka-ingest format=avro key-format=avro topic=misordered-dbz-data schema=${new-dbz-schema} key-schema=${new-dbz-key-schema} timestamp=1 publish=true
+{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}}
+{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}}
 {"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
 {"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
 {"a": -1} {"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}}
 {"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
 {"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
 {"a": 3} {"before": null, "after": {"row":{"a": 3, "b": 4}}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
-{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}}
-{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}}
 
 > CREATE MATERIALIZED SOURCE misordered_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-data-${testdrive.seed}'

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -318,18 +318,22 @@ a b
 
 $ kafka-create-topic topic=misordered-dbz-data
 
-$ kafka-ingest format=avro topic=misordered-dbz-data schema=${new-dbz-schema} timestamp=1600000000000
-{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
-{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
-{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}}
-{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
-{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
-{"before": null, "after": {"row":{"a": 3, "b": 4}}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
+$ set new-dbz-key-schema={"type": "record", "name": "row", "fields": [{"name": "a", "type": "long"}]}
+
+$ kafka-ingest format=avro key-format=avro topic=misordered-dbz-data schema=${new-dbz-schema} key-schema=${new-dbz-key-schema} timestamp=1 publish=true
+{"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
+{"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
+{"a": -1} {"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}}
+{"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
+{"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
+{"a": 3} {"before": null, "after": {"row":{"a": 3, "b": 4}}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": {"string": "false"}}}
+{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}}
+{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}}
 
 > CREATE MATERIALIZED SOURCE misordered_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-data-${testdrive.seed}'
   WITH (deduplication = 'full')
-  FORMAT AVRO USING SCHEMA '${new-dbz-schema}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
 
 > SELECT * FROM misordered_dbz
@@ -339,6 +343,7 @@ a b
 2 3
 -1 7
 3 4
+5 3
 
 ! CREATE SOURCE recurisve
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'


### PR DESCRIPTION
In certain situations, Debezium rows may be deduplicated during the initial snapshot. Unfortunately, we can't rely on binlog coords (pos, row) to deduplicate here,  because during a snapshot they will always be the same.

However, in cases with a primary key, we should be able to deduplicate based on those. This diff implements that logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4556)
<!-- Reviewable:end -->
