### PR TITLE
Change warn -> debug for double-deletion of metrics

### DIFF
--- a/src/dataflow/src/arrangement/manager.rs
+++ b/src/dataflow/src/arrangement/manager.rs
@@ -69,12 +69,12 @@ impl MaintenanceMetrics {
             doing_maintenance: DeleteOnDropGauge::new_with_error_handler(
                 DOING_MAINTENANCE.with_label_values(labels),
                 &DOING_MAINTENANCE,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+                |e, v| log::debug!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
             total_maintenance_time: DeleteOnDropCounter::new_with_error_handler(
                 TOTAL_MAINTENANCE_TIME.with_label_values(labels),
                 &TOTAL_MAINTENANCE_TIME,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+                |e, v| log::debug!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
         }
     }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -767,22 +767,22 @@ impl PartitionMetrics {
             offset_ingested: DeleteOnDropGauge::new_with_error_handler(
                 OFFSET_INGESTED.with_label_values(labels),
                 &OFFSET_INGESTED,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+                |e, v| log::debug!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
             offset_received: DeleteOnDropGauge::new_with_error_handler(
                 OFFSET_RECEIVED.with_label_values(labels),
                 &OFFSET_RECEIVED,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+                |e, v| log::debug!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
             closed_ts: DeleteOnDropGauge::new_with_error_handler(
                 CLOSED_TS.with_label_values(labels),
                 &CLOSED_TS,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+                |e, v| log::debug!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
             messages_ingested: DeleteOnDropCounter::new_with_error_handler(
                 MESSAGES_INGESTED.with_label_values(labels),
                 &MESSAGES_INGESTED,
-                |e, v| log::warn!("unable to delete metric {}: {}", v.fq_name(), e),
+                |e, v| log::debug!("unable to delete metric {}: {}", v.fq_name(), e),
             ),
         }
     }


### PR DESCRIPTION
These warn logs caused us to create MaterializeInc/rust-prometheus#12 , which I'll fix
soon, but as it is these were only put in at warn level to ensure that we did know if
that was a potential bug. Now that we know that it *is* a bug the warn is spurious and is
unnecessarily concerning, because there's nothing anyone can do about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4564)
<!-- Reviewable:end -->
