### PR TITLE
Don't reuse a RowArena for MapFilterProject

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -770,8 +770,8 @@ where
             let (ok_collection, mut err_collection) = self
                 .flat_map_ref(&input, {
                     let mut row_packer = repr::RowPacker::new();
-                    let temp_storage = RowArena::new();
                     move |row| {
+                        let temp_storage = RowArena::new();
                         mfp.evaluate(&mut row.unpack(), &temp_storage, &mut row_packer)
                             .map_err(|e| e.into())
                             .transpose()


### PR DESCRIPTION
In #4463 we introduced MapFilterProjects on top of Gets to reduce the
amount of data that we had to pack and unpack across operator
boundaries. When doing this, I made one RowArena that was used across
each invocation of MFP, which resulted in memory buildup over time. This
change changes this to occur per-row so that we can throw away
intermediate data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4578)
<!-- Reviewable:end -->
