### PR TITLE
editor/vscode: fix bug in testdrive grammar

### DIFF
--- a/misc/editor/vscode/syntaxes/testdrive.tmLanguage.json
+++ b/misc/editor/vscode/syntaxes/testdrive.tmLanguage.json
@@ -19,7 +19,7 @@
             "patterns": [{
                 "name": "meta.command",
                 "begin": "^(\\$)\\s*(\\S+)?",
-                "end": "^(?=[^ ])",
+                "while": "^(?= )",
                 "beginCaptures": {
                     "1": { "name": "keyword.operator.testdrive" },
                     "2": { "name": "storage.type.testdrive" }
@@ -56,23 +56,23 @@
         "sql": {
             "patterns": [{
                 "begin": "^(>|!)",
-                "end": "^(?=[^ ])",
+                "while": "^(?= )",
                 "beginCaptures": {
                     "1": { "name": "keyword.operator.testdrive" }
                 },
                 "patterns": [{ "include": "source.mzsql" }]
             }]
         },
-		"string": {
-			"name": "string.quoted.double.testdrive",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.testdrive",
-					"match": "\\\\(\"|n|t|r|0)"
-				}
-			]
+        "string": {
+          "name": "string.quoted.double.testdrive",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.testdrive",
+              "match": "\\\\(\"|n|t|r|0)"
+            }
+          ]
         },
         "symbol": {
             "name": "string.unquoted.testdrive",


### PR DESCRIPTION
This fixes a syntax highlighting bug in the testdrive grammar, in which
`$` command lines were not properly terminated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4583)
<!-- Reviewable:end -->
