### PR TITLE
update testdrive docs to mention -v on mzcompose down

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -307,7 +307,7 @@ and materialized binaries if you have changed them locally. From the
 `test/testdrive` directory:
 
 ```
-./mzcompose down
+./mzcompose down -v
 BUILD_MODE=debug AWS_REGION= ./mzcompose run testdrive
 ```
 


### PR DESCRIPTION
-v is important so the materialize catalog is wiped across test runs.
Witout this materialized is likely going to try writing sinks into
kafka/schema registry as soon as it starts up - which isn't clean test
state and may actually fail the testsuite if those dependencies aren't
yet healthy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4585)
<!-- Reviewable:end -->
