### PR TITLE
document the new --workers default

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -42,9 +42,11 @@ found.
 
 A `materialized` instance runs a specified number of timely dataflow worker
 threads. Worker threads can only be specified at startup by setting the
-required `--workers` flag, and cannot be changed without shutting down
-`materialized` and restarting. In the future, dynamically changing the number
-of worker threads will be possible over distributed clusters, see
+`--workers` flag, and cannot be changed without shutting down `materialized`
+and restarting. If `--workers` is not set, `materialized` will default to using
+half of the machine's physical cores as the thread count.  In the future,
+dynamically changing the number of worker threads will be possible over
+distributed clusters, see
 [#2449](https://github.com/MaterializeInc/materialize/issues/2449).
 
 {{< version-changed v0.4.0 >}}

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,11 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.5.1 %}}
+
+- Default to using a worker thread count equal to half of the machine's
+  physical cores if [`--workers`](/cli/#worker-threads) is not specified.
+
 {{% version-header v0.5.0 %}}
 
 - Support tables via the new [`CREATE TABLE`](/sql/create-table), [`DROP


### PR DESCRIPTION
Is v0.5.1 the correct next release version?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4586)
<!-- Reviewable:end -->
