### PR TITLE
pgwire: stream rows

### DIFF
--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -38,5 +38,5 @@ mod transaction;
 mod var;
 
 pub use session::Session;
-pub use statement::{Portal, PreparedStatement};
+pub use statement::{Portal, PreparedStatement, RowBatchStream};
 pub use transaction::TransactionStatus;


### PR DESCRIPTION
Previously all rows had to be present at once before sending them to a
client. Change the interface to instead accept a `Stream<Result<Vec<Row>,
Error>>`. This will allow us in the future to send batches of rows from
the dataflow layer. This is also required for an upcoming PR that will
convert `TAIL` to a normal rows-sending operation.

Some of the changes here were needed to prevent a reference
to a portal from being held across an await point. See:
https://meltware.com/2020/10/21/rust-async-nonsense.html.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4587)
<!-- Reviewable:end -->
