### PR TITLE
Add an emacs testdrive mode

### DIFF
--- a/misc/editor/emacs/README.md
+++ b/misc/editor/emacs/README.md
@@ -1,0 +1,29 @@
+Additional support for hacking on Materialize in Emacs
+======================================================
+
+This directory contains a major mode that allows syntax-highlighting testdrive (`.td`)
+files.
+
+## Installation
+
+This major mode depends on [`polymode`](https://github.com/polymode/polymode).
+
+There are several possible ways to install, but the only one that I know works for sure
+is to use the builtin package.el:
+
+Call `package-install-file` and point it at the mz-testdrive.el file:
+
+> <kbd>M-x</kbd> `package-install-file` <kbd>RET</kbd> `mz-testdrive.el`
+
+Then add `(mz-testdrive-enable)` to your `init.el`.
+
+Testdrive files will be registered as fundamentally `shell-script-mode` files, which
+means any hooks you have for `shell-script-mode` will run, but they may not make sense.
+For example, `shellcheck` doesn't make sense in testdrive files. I recommend adding
+something like the following to your `init.el` just after `(mz-testdrive-enable)`:
+
+```elisp
+(add-hook 'mz-testdrive-mode-hook
+    (lambda ()
+        (flymake-mode 0))) ; same thing would work for flycheck-mode if you use that
+```

--- a/misc/editor/emacs/mz-testdrive.el
+++ b/misc/editor/emacs/mz-testdrive.el
@@ -1,0 +1,98 @@
+;;; mz-testdrive.el --- Major Mode for testdrive files
+;
+;; Copyright Materialize, Inc. All rights reserved.
+;;
+;; Use of this software is governed by the Business Source License
+;; included in the LICENSE file at the root of this repository.
+;;
+;; As of the Change Date specified in that file, in accordance with
+;; the Business Source License, use of this software will be governed
+;; by the Apache License, Version 2.0.
+
+;; Author: Brandon W Maister <bwm@materialize.io>
+;; Version: 0.1
+;; Package-Requires: ((polymode "0.2.2"))
+;; Keywords: testing
+;; URL: https://github.com/MaterializeInc/materialize/tree/main/misc/editor/emacs
+
+;;; Commentary:
+
+;; This package provides a major mode which makes interacting with testdrive files
+;; somewhat more pleasant.
+
+(require 'polymode)
+
+;;;###autoload
+(setq poly-mztd-subsec-end
+      (rx (or
+           (seq line-start (not whitespace))
+           "
+
+")))
+
+;;;###autoload
+(define-innermode poly-mztd-sql-innermode
+  :mode 'sql-mode
+  :head-matcher (rx (seq line-start (or ">" "!") " "))
+  :tail-matcher poly-mztd-subsec-end
+  :head-mode 'host
+  :tail-mode 'host
+  )
+
+;;;###autoload
+(define-innermode poly-mztd-set-json-innermode
+  :mode 'json-mode
+  :head-matcher (rx "set " (+ word) "=")
+  :tail-matcher poly-mztd-subsec-end
+  :head-mode 'host
+  :tail-mode 'host)
+
+;;;###autoload
+(define-auto-innermode poly-mztd-file-contents-innermode
+  :head-matcher (rx line-start "$ file-append")
+  :tail-matcher "
+
+"
+  :mode-matcher (cons (rx "path=" (+ word) "." (group (+ word))) 1)
+  :head-mode 'host
+  :tail-mode 'host)
+
+;;;###autoload
+(define-innermode poly-mztd-line-delimited-json-innermode
+  :mode 'json-mode
+  :head-matcher (rx line-start "{")
+  :tail-matcher (rx "}" line-end)
+  :head-mode 'host
+  :tail-mode 'host)
+
+
+;;;###autoload
+(define-hostmode poly-mztd-hostmode :mode 'shell-script-mode)
+
+;;;###autoload
+(defvar poly-mz-testdrive-mode-hook ()
+  "hooks that are run for `mz-testdrive-mode' and all submodes")
+
+;;;###autoload
+(define-polymode mz-testdrive-mode
+  :hostmode 'poly-mztd-hostmode
+  :innermodes '(poly-mztd-sql-innermode
+                poly-mztd-set-json-innermode
+                poly-mztd-line-delimited-json-innermode
+                poly-mztd-file-contents-innermode))
+
+;;;###autoload
+(defun mz-testdrive-enable ()
+  "Enable mz-testdrive mode for all files that end in \\.td, and configure some sub-modes"
+  (add-hook 'mz-testdrive-mode-hook
+            (lambda ()
+              (cond
+               ((eql major-mode 'sql-mode)
+                (sql-set-product "materialize")))))
+
+  (add-to-list 'auto-mode-alist '("\\.td\\'" . mz-testdrive-mode))
+  'mz-testdrive-mode)
+
+(provide 'mz-testdrive)
+
+;;; mz-testdrive.el ends here

--- a/misc/editor/emacs/mz-testdrive.el
+++ b/misc/editor/emacs/mz-testdrive.el
@@ -88,7 +88,10 @@
             (lambda ()
               (cond
                ((eql major-mode 'sql-mode)
-                (sql-set-product "materialize")))))
+                (sql-set-product
+                 (if (assoc 'materialize sql-product-alist)
+                     "materialize"
+                   "postgres"))))))
 
   (add-to-list 'auto-mode-alist '("\\.td\\'" . mz-testdrive-mode))
   'mz-testdrive-mode)

--- a/misc/lint/copyright.awk
+++ b/misc/lint/copyright.awk
@@ -28,6 +28,6 @@ function done()
 }
 
 /^#![ \t\n]*\//             { next }
-/^(\/\/|#|--)?.*Copyright/  { copyright=$0; copyright_line=NR }
+/^(\/\/|#|--|;)?.*Copyright/  { copyright=$0; copyright_line=NR }
 /^[ \t\n]*$/                { next }
-!/^(<!--|<\?xml|\/\/|#|--)/ { done() }
+!/^(<!--|<\?xml|\/\/|#|--|;)/ { done() }


### PR DESCRIPTION
This uses `polymode` to actually enter the various meaningful submodes for different
parts of testdrive files, which is (so far) a pretty nice experience.

This adds enough syntax highlighting to make testdrive _much_ more pleasant in emacs:

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/277161/96948798-71274580-14b4-11eb-89b7-4f1d860a8377.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4588)
<!-- Reviewable:end -->
