### PR TITLE
expr: add regexp_match function

### DIFF
--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -156,6 +156,7 @@ tests=(
     test/sqllogictest/cockroach/with.slt
     # test/sqllogictest/cockroach/zero.slt
     test/sqllogictest/postgres/join-lateral.slt
+    test/sqllogictest/postgres/regex.slt
     test/sqllogictest/postgres/subselect.slt
 )
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,8 @@ Wrap your release notes at the 80 character mark.
 - Default to using a worker thread count equal to half of the machine's
   physical cores if [`--workers`](/cli/#worker-threads) is not specified.
 
+- Add the `regexp_match` function to search a string with a regular expression.
+
 {{% version-header v0.5.0 %}}
 
 - Support tables via the new [`CREATE TABLE`](/sql/create-table), [`DROP

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -145,8 +145,12 @@
   - signature: 'octet_length(b: bytea) -> int'
     description: Number of bytes in `b`
 
-  - signature: 'regexp_extract(regex: str, haystack: str) -> Col<string>'
-    description: Values of the capture groups of `regex` as matched in `haystack`
+  - signature: 'regexp_match(haystack: str, needle: str [, flags: str]]) -> str[]'
+    description: >-
+      Matches the regular expression `needle` against haystack, returning a
+      string array that contains the value of each capture group specified in
+      `needle`, in order. If `flags` is set to the string `i` matches
+      case-insensitively.
 
   - signature: 'replace(s: str, f: str, r: str) -> str'
     description: "`s` with all instances of `f` replaced with `r`"
@@ -316,6 +320,8 @@
   functions:
   - signature: 'generate_series(start: int, stop: int) -> Col<int>'
     description: Generate all integer values between `start` and `stop`, inclusive.
+  - signature: 'regexp_extract(regex: str, haystack: str) -> Col<string>'
+    description: Values of the capture groups of `regex` as matched in `haystack`
 
 - type: Array
   functions:

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1102,6 +1102,10 @@ lazy_static! {
                      WHERE o.oid = $1)"
                 )
             },
+            "regexp_match" => Scalar {
+                params!(String, String) => VariadicFunc::RegexpMatch,
+                params!(String, String, String) => VariadicFunc::RegexpMatch
+            },
             "replace" => Scalar {
                 params!(String, String, String) => VariadicFunc::Replace
             },
@@ -1693,36 +1697,36 @@ lazy_static! {
 
             // LIKE
             "~~" => Scalar {
-                params!(String, String) => MatchLikePattern
+                params!(String, String) => IsLikePatternMatch
             },
             "!~~" => Scalar {
                 params!(String, String) => binary_op(|_ecx, lhs, rhs| {
                     Ok(lhs
-                        .call_binary(rhs, MatchLikePattern)
+                        .call_binary(rhs, IsLikePatternMatch)
                         .call_unary(UnaryFunc::Not))
                 })
             },
 
             // REGEX
             "~" => Scalar {
-                params!(String, String) => MatchRegex { case_insensitive: false }
+                params!(String, String) => IsRegexpMatch { case_insensitive: false }
             },
             "~*" => Scalar {
                 params!(String, String) => binary_op(|_ecx, lhs, rhs| {
-                    Ok(lhs.call_binary(rhs, MatchRegex { case_insensitive: true }))
+                    Ok(lhs.call_binary(rhs, IsRegexpMatch { case_insensitive: true }))
                 })
             },
             "!~" => Scalar {
                 params!(String, String) => binary_op(|_ecx, lhs, rhs| {
                     Ok(lhs
-                        .call_binary(rhs, MatchRegex { case_insensitive: false })
+                        .call_binary(rhs, IsRegexpMatch { case_insensitive: false })
                         .call_unary(UnaryFunc::Not))
                 })
             },
             "!~*" => Scalar {
                 params!(String, String) => binary_op(|_ecx, lhs, rhs| {
                     Ok(lhs
-                        .call_binary(rhs, MatchRegex { case_insensitive: true })
+                        .call_binary(rhs, IsRegexpMatch { case_insensitive: true })
                         .call_unary(UnaryFunc::Not))
                 })
             },

--- a/test/sqllogictest/postgres/regex.slt
+++ b/test/sqllogictest/postgres/regex.slt
@@ -1,0 +1,56 @@
+# Copyright 1994, Regents of the University of California.
+# Copyright 1996-2019 PostgreSQL Global Development Group.
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the regression test suite in PostgreSQL.
+# The original file was retrieved on October 23, 2020 from:
+#
+#     https://github.com/postgres/postgres/blob/783f0cc64dcc05e3d112a06b1cd181e5a1ca9099/src/test/regress/expected/regex.out
+#
+# The original source code is subject to the terms of the PostgreSQL
+# license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+statement ok
+CREATE TABLE strings (s text)
+
+statement ok
+INSERT INTO strings VALUES ('abc'), ('123')
+
+query T
+select regexp_match('abc', '')
+----
+{""}
+
+query T
+select regexp_match('abc', 'bc')
+----
+{bc}
+
+query T
+select regexp_match('abc', 'd') is null
+----
+true
+
+query T
+select regexp_match('abc', '(B)(c)', 'i')
+----
+{b,c}
+
+query T
+select regexp_match('abc', '(b)(c)(d)?')
+----
+{b,c,NULL}
+
+query T rowsort
+select regexp_match(s, '^.(.)')[1] FROM strings
+----
+2
+b


### PR DESCRIPTION
Provides for basic string manipulation capabilities. Matches the
PostgreSQL function of the same name, except that the regexps we support
are a bit different.

Fix #4545.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4590)
<!-- Reviewable:end -->
