### PR TITLE
materialized: sync description of -p/-n opts with docs

### DIFF
--- a/src/materialized/src/bin/materialized.rs
+++ b/src/materialized/src/bin/materialized.rs
@@ -73,13 +73,13 @@ fn run() -> Result<(), anyhow::Error> {
     opts.optopt(
         "p",
         "process",
-        "identity of this process (default 0)",
+        "identity of this node when coordinating with other nodes (default 0)",
         "INDEX",
     );
     opts.optopt(
         "n",
         "processes",
-        "total number of processes (default 1)",
+        "total number of coordinating nodes (default 1)",
         "N",
     );
     opts.optopt(


### PR DESCRIPTION
The docs are a bit more clear than the help text for the distributed
mode options (-p and -n), so make the help text match the docs.

Fix #4600.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4602)
<!-- Reviewable:end -->
