### PR TITLE
sql: remove dead materialized parameter for peeks

### DIFF
--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -126,7 +126,6 @@ pub enum Plan {
         source: ::expr::RelationExpr,
         when: PeekWhen,
         finishing: RowSetFinishing,
-        materialize: bool,
     },
     Tail {
         id: GlobalId,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1556,7 +1556,6 @@ fn handle_select(
         source: relation_expr,
         when,
         finishing,
-        materialize: true,
     })
 }
 


### PR DESCRIPTION
In the old days, PEEKs were not permitted to cause a dataflow to be
created, while SELECTs were. Put another way: PEEKs were guaranteed to
take the fast path, while SELECTs could optionally take the slow path if
they were too complicated.

The `materialized: bool` parameter to Plan::Peek captured this
distinction. But PEEK was removed in 878b715f5, so we no longer need it;
its value is always implicitly true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4606)
<!-- Reviewable:end -->
