### PR TITLE
sqllogictest: fail during rewrite on unexpected error

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -898,10 +898,10 @@ pub async fn rewrite_file(filename: &Path, _verbosity: usize) -> Result<(), anyh
                     }
                 }
             }
-        }
-
-        if let Outcome::Bail { .. } = outcome {
-            break;
+        } else if let Outcome::Success = outcome {
+            // Ok.
+        } else {
+            bail!("unexpected: {}", outcome);
         }
     }
 


### PR DESCRIPTION
If there's any kind of unexpected output we should fail during
rewrite. Otherwise some kind of "query I ..." statement that failed to
execute (i.e., should have been a "query error ...") will be silently
ignored. This is different from what we want, which is that the statement
succeeded, but the output is different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4623)
<!-- Reviewable:end -->
