### PR TITLE
sql-parser: support semicolon at end of transaction

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3117,7 +3117,7 @@ impl Parser {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadOnly)
             } else if self.parse_keywords(vec!["READ", "WRITE"]) {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadWrite)
-            } else if required || self.peek_token().is_some() {
+            } else if required {
                 self.expected(self.peek_range(), "transaction mode", self.peek_token())?
             } else {
                 break;

--- a/src/sql-parser/tests/testdata/txn
+++ b/src/sql-parser/tests/testdata/txn
@@ -60,6 +60,14 @@ START TRANSACTION
 =>
 StartTransaction(StartTransactionStatement { modes: [] })
 
+# Semicolon at EOS.
+parse-statement
+BEGIN TRANSACTION;
+----
+START TRANSACTION
+=>
+StartTransaction(StartTransactionStatement { modes: [] })
+
 parse-statement
 START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 ----
@@ -104,7 +112,7 @@ error:
 Parse error:
 START TRANSACTION BAD
                   ^^^
-Expected transaction mode, found: BAD
+Expected end of statement, found: BAD
 
 parse-statement
 START TRANSACTION READ ONLY,


### PR DESCRIPTION
See: https://github.com/ballista-compute/sqlparser-rs/pull/139

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4624)
<!-- Reviewable:end -->
