### PR TITLE
coord: support transactions

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -145,6 +145,8 @@ pub enum ExecuteResponse {
     SetVariable {
         name: String,
     },
+    /// The current transaction had characteristics set.
+    SetTransaction,
     /// A new transaction was started.
     StartedTransaction,
     /// Updates to the requested source or view will be streamed to the

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -237,7 +237,7 @@ where
         });
         messages.extend(notices);
         messages.push(BackendMessage::ReadyForQuery(
-            self.coord_client.session().transaction().into(),
+            self.coord_client.session().transaction_status().into(),
         ));
         self.conn.send_all(messages).await?;
         self.flush().await
@@ -555,7 +555,7 @@ where
     async fn sync(&mut self) -> Result<State, comm::Error> {
         self.conn
             .send(BackendMessage::ReadyForQuery(
-                self.coord_client.session().transaction().into(),
+                self.coord_client.session().transaction_status().into(),
             ))
             .await?;
         self.flush().await
@@ -697,6 +697,7 @@ where
                 command_complete!("SET")
             }
             ExecuteResponse::StartedTransaction => command_complete!("BEGIN"),
+            ExecuteResponse::SetTransaction => command_complete!("SET"),
             ExecuteResponse::CommittedTransaction => command_complete!("COMMIT"),
             ExecuteResponse::AbortedTransaction => command_complete!("ROLLBACK"),
             ExecuteResponse::Tailing { rx } => {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1031,6 +1031,7 @@ impl_display!(SqlOption);
 pub enum TransactionMode {
     AccessMode(TransactionAccessMode),
     IsolationLevel(TransactionIsolationLevel),
+    WithReadsFrom(Vec<ObjectName>),
 }
 
 impl AstDisplay for TransactionMode {
@@ -1041,6 +1042,10 @@ impl AstDisplay for TransactionMode {
             IsolationLevel(iso_level) => {
                 f.write_str("ISOLATION LEVEL ");
                 f.write_node(iso_level);
+            }
+            WithReadsFrom(reads) => {
+                f.write_str("WITH READS FROM ");
+                f.write_node(&display::comma_separated(reads));
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3117,7 +3117,7 @@ impl Parser {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadOnly)
             } else if self.parse_keywords(vec!["READ", "WRITE"]) {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadWrite)
-            } else if required || self.peek_token().is_some() {
+            } else if required {
                 self.expected(self.peek_range(), "transaction mode", self.peek_token())?
             } else {
                 break;

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3117,6 +3117,14 @@ impl Parser {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadOnly)
             } else if self.parse_keywords(vec!["READ", "WRITE"]) {
                 TransactionMode::AccessMode(TransactionAccessMode::ReadWrite)
+            } else if self.parse_keywords(vec!["WITH", "READS", "FROM"]) {
+                TransactionMode::WithReadsFrom(
+                    self.parse_comma_separated(Parser::parse_object_name)?,
+                )
+            } else if self.parse_keywords(vec!["AS", "OF"]) {
+                TransactionMode::WithReadsFrom(
+                    self.parse_comma_separated(Parser::parse_object_name)?,
+                )
             } else if required {
                 self.expected(self.peek_range(), "transaction mode", self.peek_token())?
             } else {

--- a/src/sql-parser/tests/testdata/txn
+++ b/src/sql-parser/tests/testdata/txn
@@ -60,6 +60,14 @@ START TRANSACTION
 =>
 StartTransaction(StartTransactionStatement { modes: [] })
 
+# Semicolon at EOS.
+parse-statement
+BEGIN TRANSACTION;
+----
+START TRANSACTION
+=>
+StartTransaction(StartTransactionStatement { modes: [] })
+
 parse-statement
 START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED
 ----
@@ -104,7 +112,7 @@ error:
 Parse error:
 START TRANSACTION BAD
                   ^^^
-Expected transaction mode, found: BAD
+Expected end of statement, found: BAD
 
 parse-statement
 START TRANSACTION READ ONLY,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -119,7 +119,12 @@ pub enum Plan {
         name: String,
         value: String,
     },
-    StartTransaction,
+    StartTransaction {
+        reads: Vec<GlobalId>,
+    },
+    SetTransaction {
+        reads: Vec<GlobalId>,
+    },
     CommitTransaction,
     AbortTransaction,
     Peek {

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -7,18 +7,27 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-mode cockroach
-
 statement ok
 CREATE TABLE t (a int)
 
 statement ok
 INSERT INTO t (a) VALUES (1)
 
-#### next transaction
-
+# Must specify read tables.
 statement ok
 BEGIN
+
+query error t not included in transaction WITH READS FROM
+SELECT * FROM t
+----
+1
+
+statement ok
+COMMIT
+
+# Specify read table.
+statement ok
+BEGIN WITH READS FROM t
 
 query I rowsort
 SELECT * FROM t
@@ -28,23 +37,12 @@ SELECT * FROM t
 statement ok
 COMMIT
 
-#### next transaction
-
+# Can also use SET.
 statement ok
 BEGIN
 
-query I rowsort
-SELECT * FROM t
-----
-1
-
 statement ok
-ROLLBACK
-
-#### next transaction
-
-statement ok
-START TRANSACTION
+SET TRANSACTION WITH READS FROM t
 
 query I rowsort
 SELECT * FROM t
@@ -54,15 +52,37 @@ SELECT * FROM t
 statement ok
 COMMIT
 
-#### next transaction
-
+# Can't SET after query.
 statement ok
-START TRANSACTION
+BEGIN WITH READS FROM t
 
 query I rowsort
 SELECT * FROM t
 ----
 1
 
+statement error timestamp already set
+SET TRANSACTION WITH READS FROM t
+
 statement ok
-ROLLBACK
+COMMIT
+
+# No mutations.
+statement ok
+BEGIN
+
+statement error within transactions only Peeks supported
+INSERT INTO t VALUES (1)
+
+statement ok
+COMMIT
+
+# Enforce that at least 1 read source exists.
+statement ok
+BEGIN
+
+query error transaction must have at least 1 read source
+SELECT 1
+
+statement ok
+COMMIT


### PR DESCRIPTION
Support transactions by enforcing that all queries in between `BEGIN`
and `COMMIT` execute at the same `AS OF` time. Do this by enforcing
transactions to first declare all relations (tables, views, sources)
from which they will query. Then, at the time of first query, find
a timestamp at which all of those relations can be queried (possibly
in some future). At the same time, prevent those relations from being
compacted, which will guarantee they will be available until the end of
the transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4625)
<!-- Reviewable:end -->
