### PR TITLE
better move filters between dataflows

### DIFF
--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -96,11 +96,13 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
     for build_desc in dataflow.objects_to_build.iter_mut().rev() {
         let transform = crate::predicate_pushdown::PredicatePushdown;
         if let Some(list) = predicates.get(&Id::Global(build_desc.id)).clone() {
-            *build_desc.relation_expr.as_mut() = build_desc
-                .relation_expr
-                .as_mut()
-                .take_dangerous()
-                .filter(list.iter().cloned());
+            if !list.is_empty() {
+                *build_desc.relation_expr.as_mut() = build_desc
+                    .relation_expr
+                    .as_mut()
+                    .take_dangerous()
+                    .filter(list.iter().cloned());
+            }
         }
         transform.dataflow_transform(build_desc.relation_expr.as_mut(), &mut predicates);
     }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -100,7 +100,7 @@ impl PredicatePushdown {
                         .or_insert_with(|| predicates.iter().cloned().collect())
                         .retain(|p| predicates.contains(p));
                 } else {
-                    input.visit1_mut(|e| self.dataflow_transform(e, get_predicates));
+                    self.dataflow_transform(input, get_predicates);
                 }
             }
             RelationExpr::Get { id, .. } => {


### PR DESCRIPTION
This PR improves the inter-view predicate pushdown, which previously had 1. defective behavior when one filter wrapped another and 2. communicated predicate pushdown by installing a new filter atop a prior dataflow. There remains the issue that the resulting view should be re-optimized, which can fuse the filters, but at least we no longer miss one of the filters along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4636)
<!-- Reviewable:end -->
