### PR TITLE
repr: fix undefined behavior in RowArena::push_row

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -479,7 +479,7 @@ fn cast_bytes_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'
 fn cast_string_to_jsonb<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
     match strconv::parse_jsonb(a.unwrap_str()) {
         Err(_) => Datum::Null,
-        Ok(jsonb) => temp_storage.push_row(jsonb.into_row()).unpack_first(),
+        Ok(jsonb) => temp_storage.push_unary_row(jsonb.into_row()),
     }
 }
 

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -161,10 +161,7 @@ impl Value {
             ),
             Value::Bytea(b) => (Datum::Bytes(buf.push_bytes(b)), ScalarType::Bytes),
             Value::Text(s) => (Datum::String(buf.push_string(s)), ScalarType::String),
-            Value::Jsonb(js) => (
-                buf.push_row(js.0.into_row()).unpack_first(),
-                ScalarType::Jsonb,
-            ),
+            Value::Jsonb(js) => (buf.push_unary_row(js.0.into_row()), ScalarType::Jsonb),
             Value::Uuid(u) => (Datum::Uuid(u), ScalarType::Uuid),
             Value::Array { .. } => {
                 // This situation is handled gracefully by Value::decode; if we
@@ -183,7 +180,7 @@ impl Value {
                     None => Datum::Null,
                 }));
                 (
-                    buf.push_row(packer.finish()).unpack_first(),
+                    buf.push_unary_row(packer.finish()),
                     ScalarType::List(Box::new(elem_type)),
                 )
             }


### PR DESCRIPTION
RowArena::push_row resulted in undefined behavior, since the
reference to the returned Row could be invalidated if
RowArena::owned_rows reallocated. In practice, we didn't trigger the UB,
because every call to push_row had the following form:

    arena.push_row(row).unpack_first()

That is, we immediately unpacked the returned row, and only held onto a
reference to the first datum in the row. This *is* ok, because even if
owned_rows reallocates and the row moves, the data in the row will not.
Adjust the API of RowArena to only support this pattern via

    fn push_unary_row(&'a self, row: Row) -> Datum<'a>

which is actually a safe API that cannot be misused.

h/t @umanwizard for spotting the UB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4640)
<!-- Reviewable:end -->
