### PR TITLE
Use MapFilterProject and arrangement keys for fast path queries

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1782,7 +1782,7 @@ where
         // constant expression that originally contains a global get? Is
         // there anything not containing a global get that cannot be
         // optimized to a constant expression?
-        let mut source = self.optimizer.optimize(source, self.catalog.indexes())?;
+        let source = self.optimizer.optimize(source, self.catalog.indexes())?;
 
         // If this optimizes to a constant expression, we can immediately return the result.
         if let RelationExpr::Constant { rows, typ: _ } = source.as_ref() {
@@ -1811,12 +1811,19 @@ where
             // need to block on the arrival of further input data.
             let (rows_tx, rows_rx) = self.switchboard.mpsc_limited(self.num_timely_workers);
 
-            let (mut project, mut filter) = Self::plan_peek(source.as_mut());
+            // Extract any surrounding linear operators to determine if we can simply read
+            // out the contents from an existing arrangement.
+            let (mut map_filter_project, inner) =
+                expr::MapFilterProject::extract_from_expression(source.as_ref());
 
+            // We can use a fast path approach if our query corresponds to a read out of
+            // an existing materialization. This is the case if the expression is now a
+            // `RelationExpr::Get` and its target is something we have materialized.
+            // Otherwise, we will need to build a new dataflow.
             let (fast_path, index_id) = if let RelationExpr::Get {
                 id: Id::Global(id),
                 typ: _,
-            } = source.as_ref()
+            } = inner
             {
                 if let Some(index_id) = self.catalog.default_index_for(*id) {
                     (true, index_id)
@@ -1831,17 +1838,8 @@ where
                 // Slow path. We need to perform some computation, so build
                 // a new transient dataflow that will be dropped after the
                 // peek completes.
-                // Re-install the filter and projection for dataflow rendering.
-                if !filter.is_empty() {
-                    let source_mut = source.as_mut();
-                    *source_mut = source_mut.take_dangerous().filter(filter.drain(..));
-                }
-                if let Some(columns) = project {
-                    let source_mut = source.as_mut();
-                    *source_mut = source_mut.take_dangerous().project(columns);
-                    project = None;
-                }
                 let typ = source.as_ref().typ();
+                map_filter_project = expr::MapFilterProject::new(typ.arity());
                 let key: Vec<_> = (0..typ.arity()).map(ScalarExpr::Column).collect();
                 let view_id = self.allocate_transient_id()?;
                 let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id));
@@ -1860,8 +1858,7 @@ where
                     tx: rows_tx,
                     timestamp,
                     finishing: finishing.clone(),
-                    project,
-                    filter,
+                    map_filter_project,
                 },
             )
             .await;
@@ -1929,39 +1926,6 @@ where
         ))
         .await;
         Ok(ExecuteResponse::Tailing { rx })
-    }
-
-    /// Extracts an optional projection around an optional filter.
-    ///
-    /// This extraction is done to allow workers to process a larger class of queries
-    /// without building explicit dataflows, avoiding latency, allocation and general
-    /// load on the system. The worker performs the filter and projection in place.
-    fn plan_peek(expr: &mut RelationExpr) -> (Option<Vec<usize>>, Vec<expr::ScalarExpr>) {
-        let mut outputs_plan = None;
-        if let RelationExpr::Project { input, outputs } = expr {
-            outputs_plan = Some(outputs.clone());
-            *expr = input.take_dangerous();
-        }
-        let mut predicates_plan = Vec::new();
-        if let RelationExpr::Filter { input, predicates } = expr {
-            predicates_plan.extend(predicates.iter().cloned());
-            *expr = input.take_dangerous();
-        }
-
-        // We only apply this transformation if the result is a `Get`.
-        // It is harmful to apply it otherwise, as we materialize more data than
-        // we would have if we applied the filter and projection beforehand.
-        if let RelationExpr::Get { .. } = expr {
-            (outputs_plan, predicates_plan)
-        } else {
-            if !predicates_plan.is_empty() {
-                *expr = expr.take_dangerous().filter(predicates_plan);
-            }
-            if let Some(outputs) = outputs_plan {
-                *expr = expr.take_dangerous().project(outputs);
-            }
-            (None, Vec::new())
-        }
     }
 
     /// A policy for determining the timestamp for a peek.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1840,12 +1840,7 @@ where
                             let literal_row = map_filter_project.literal_constraints(exprs);
                             // Prefer non-trivial literal rows foremost, then long expressions,
                             // then we don't really care at that point.
-                            (
-                                literal_row.is_some() && exprs.len() > 0,
-                                exprs.len(),
-                                literal_row,
-                                *id,
-                            )
+                            (literal_row.is_some(), exprs.len(), literal_row, *id)
                         })
                         .max()
                         .map(|(_some, _len, literal, id)| (id, literal));

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -746,27 +746,15 @@ where
             let mfp2 = mfp.clone();
             self.ensure_rendered(&input, scope, worker_index);
             let (ok_collection, mut err_collection) = self
-                .flat_map_ref(
-                    &input,
-                    move |exprs| {
-                        let constraints: Vec<_> =
-                            exprs.iter().map(|e| mfp2.literal_constraint(e)).collect();
-                        if constraints.iter().all(|c| c.is_some()) {
-                            Some(Row::pack(constraints.iter().map(|x| x.unwrap())))
-                        } else {
-                            None
-                        }
-                    },
-                    {
-                        let mut row_packer = repr::RowPacker::new();
-                        move |row| {
-                            let temp_storage = RowArena::new();
-                            mfp.evaluate(&mut row.unpack(), &temp_storage, &mut row_packer)
-                                .map_err(|e| e.into())
-                                .transpose()
-                        }
-                    },
-                )
+                .flat_map_ref(&input, move |exprs| mfp2.literal_constraints(exprs), {
+                    let mut row_packer = repr::RowPacker::new();
+                    move |row| {
+                        let temp_storage = RowArena::new();
+                        mfp.evaluate(&mut row.unpack(), &temp_storage, &mut row_packer)
+                            .map_err(|e| e.into())
+                            .transpose()
+                    }
+                })
                 .unwrap();
 
             use timely::dataflow::operators::ok_err::OkErr;

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -730,31 +730,6 @@ impl<G> Context<G, RelationExpr, Row, Timestamp>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    fn extract_map_filter_project(
-        &mut self,
-        relation_expr: &RelationExpr,
-    ) -> Option<(MapFilterProject, RelationExpr)> {
-        match relation_expr {
-            RelationExpr::Map { input, scalars } => {
-                let (mfp, input) = self.extract_map_filter_project(input)?;
-                Some((mfp.map(scalars.iter().cloned()), input))
-            }
-            RelationExpr::Filter { input, predicates } => {
-                let (mfp, input) = self.extract_map_filter_project(input)?;
-                Some((mfp.filter(predicates.iter().cloned()), input))
-            }
-            RelationExpr::Project { input, outputs } => {
-                let (mfp, input) = self.extract_map_filter_project(input)?;
-                Some((mfp.project(outputs.iter().cloned()), input))
-            }
-            RelationExpr::Get { .. } => Some((
-                MapFilterProject::new(relation_expr.arity()),
-                relation_expr.clone(),
-            )),
-            _ => None,
-        }
-    }
-
     /// Attempt to extract a chain of map/filter/project operators on top of a Get. Returns true if
     /// it was successful and false otherwise. We still fall back to individual implementations for
     /// the various operators so that ones like Filter, that special-case being on top of a join,
@@ -765,7 +740,9 @@ where
         scope: &mut G,
         worker_index: usize,
     ) -> bool {
-        if let Some((mfp, input)) = self.extract_map_filter_project(relation_expr) {
+        // Extract a MapFilterProject and residual from `relation_expr`.
+        let (mfp, input) = MapFilterProject::extract_from_expression(relation_expr);
+        if let RelationExpr::Get { .. } = input {
             let mfp2 = mfp.clone();
             self.ensure_rendered(&input, scope, worker_index);
             let (ok_collection, mut err_collection) = self

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -44,9 +44,9 @@ use dataflow_types::logging::LoggingConfig;
 use dataflow_types::{
     DataflowDesc, DataflowError, MzOffset, PeekResponse, TimestampSourceUpdate, Update,
 };
-use expr::{GlobalId, PartitionId, RowSetFinishing, SourceInstanceId};
+use expr::{GlobalId, MapFilterProject, PartitionId, RowSetFinishing, SourceInstanceId};
 use ore::future::channel::mpsc::ReceiverExt;
-use repr::{Datum, Diff, Row, RowArena, Timestamp};
+use repr::{Diff, Row, RowArena, Timestamp};
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
@@ -104,10 +104,8 @@ pub enum SequencedCommand {
         timestamp: Timestamp,
         /// Actions to apply to the result set before returning them.
         finishing: RowSetFinishing,
-        /// A projection that should be applied to results.
-        project: Option<Vec<usize>>,
-        /// A list of predicates that should restrict the set of results.
-        filter: Vec<expr::ScalarExpr>,
+        /// Linear operation to apply in-line on each result.
+        map_filter_project: MapFilterProject,
     },
     /// Cancel the peek associated with the given `conn_id`.
     CancelPeek {
@@ -631,8 +629,7 @@ where
                 conn_id,
                 tx,
                 finishing,
-                project,
-                filter,
+                map_filter_project,
             } => {
                 // Acquire a copy of the trace suitable for fulfilling the peek.
                 let mut trace_bundle = self.render_state.traces.get(&id).unwrap().clone();
@@ -658,8 +655,7 @@ where
                     timestamp,
                     finishing,
                     trace_bundle,
-                    project,
-                    filter,
+                    map_filter_project,
                 };
                 // Log the receipt of the peek.
                 if let Some(logger) = self.materialized_logger.as_mut() {
@@ -847,8 +843,8 @@ struct PendingPeek {
     /// Finishing operations to perform on the peek, like an ordering and a
     /// limit.
     finishing: RowSetFinishing,
-    project: Option<Vec<usize>>,
-    filter: Vec<expr::ScalarExpr>,
+    /// Linear operators to apply in-line to all results.
+    map_filter_project: MapFilterProject,
     /// The data from which the trace derives.
     trace_bundle: TraceBundle,
 }
@@ -917,44 +913,43 @@ impl PendingPeek {
             cursor.step_key(&storage);
         }
 
+        // Cursor and bound lifetime for `Row` data in the backing trace.
         let (mut cursor, storage) = self.trace_bundle.oks_mut().cursor();
+        // Accumulated `Vec<Datum>` results that we are likely to return.
         let mut results = Vec::new();
-
-        // We can limit the record enumeration if i. there is a limit set,
-        // and ii. if the specified ordering is empty (specifies no order).
-        let limit = if self.finishing.order_by.is_empty() {
-            self.finishing.limit.map(|l| l + self.finishing.offset)
-        } else {
-            None
-        };
-
+        // Temporary storage for datums we are considering.
         let mut datums = Vec::new();
-        while cursor.key_valid(&storage) && limit.map(|l| results.len() < l).unwrap_or(true) {
-            while cursor.val_valid(&storage) && limit.map(|l| results.len() < l).unwrap_or(true) {
-                let row = cursor.val(&storage);
 
-                let mut retain = true;
-                if !self.filter.is_empty() {
-                    datums.clear();
-                    datums.extend(row.iter());
-                    // Before (expensively) determining how many copies of a row
-                    // we have, let's eliminate rows that we don't care about.
-                    let temp_storage = RowArena::new();
-                    for predicate in &self.filter {
-                        let d = predicate
-                            .eval(&datums, &temp_storage)
-                            .map_err(|e| e.to_string())?;
-                        if d != Datum::True {
-                            retain = false;
-                            break;
-                        }
-                    }
-                }
-                if retain {
-                    // Differential dataflow represents collections with binary counts,
-                    // but our output representation is unary (as many rows as reported
-                    // by the count). We should determine this count, and especially if
-                    // it is non-zero, before producing any output data.
+        let mut row_packer = repr::RowPacker::new();
+        let arena = RowArena::new();
+
+        // There are roughly two paths we can take here, where we split
+        // based on whether there is an ordering or not. If there is not
+        // an ordering, we power through all the elements perhaps bailing
+        // early if a limit is reached. We hit each row with any operators
+        // for post-processing (map, filter, project).
+        // If there is an ordering, we want to more carefully pilot things
+        // to leave the data as `[Datum]` and use this representation to
+        // maintain the top so-many results. We would love to use a heap
+        // to maintain this efficiently, but Rust makes this tricky.
+
+        // When set, a bound on the number of records we need to return.
+        // The requirements on the records are driven by the finishing's
+        // `order_by` field. Further limiting will happen when the results
+        // are collected, so we don't need to have exactly this many results,
+        // just at least the results.
+        let max_results = self.finishing.limit.map(|l| l + self.finishing.offset);
+
+        while cursor.key_valid(&storage) {
+            while cursor.val_valid(&storage) {
+                let row = cursor.val(&storage);
+                datums.clear();
+                datums.extend(row.iter());
+                if let Some(result) = self
+                    .map_filter_project
+                    .evaluate(&mut datums, &arena, &mut row_packer)
+                    .map_err(|e| e.to_string())?
+                {
                     let mut copies = 0;
                     cursor.map_times(&storage, |time, diff| {
                         if time.less_equal(&self.timestamp) {
@@ -969,65 +964,51 @@ impl PendingPeek {
                         ));
                     }
 
-                    // TODO: We could push a count here, as we create owned output later.
+                    // TODO: In and ORDER BY .. LIMIT .. setting, once we have a full output
+                    // we could compare each of these to the "least" current output, and
+                    // avoid stashing the result and growing results.
                     for _ in 0..copies {
-                        results.push(row);
+                        results.push(result.clone());
+                    }
+
+                    // If we hold many more than `max_results` records, we can thin down
+                    // `results` using `self.finishing.ordering`.
+                    if let Some(max_results) = max_results {
+                        // We use a threshold twice what we intend, to amortize the work
+                        // across all of the insertions. We could tighten this, but it
+                        // works for the moment.
+                        if results.len() >= 2 * max_results {
+                            if self.finishing.order_by.is_empty() {
+                                results.truncate(max_results);
+                                return Ok(results);
+                            } else {
+                                // We can sort `results` and then truncate to `max_results`.
+                                // This has an effect similar to a priority queue, without
+                                // its interactive dequeueing properties.
+                                // TODO: Had we left these as `Vec<Datum>` we would avoid
+                                // the unpacking; we should consider doing that, although
+                                // it will require a re-pivot of the code to branch on this
+                                // inner test (as we prefer not to maintain `Vec<Datum>`
+                                // in the other case).
+                                results.sort_by(|left, right| {
+                                    expr::compare_columns(
+                                        &self.finishing.order_by,
+                                        &left.unpack(),
+                                        &right.unpack(),
+                                        || left.cmp(right),
+                                    )
+                                });
+                                results.truncate(max_results);
+                            }
+                        }
                     }
                 }
                 cursor.step_val(&storage);
             }
-            cursor.step_key(&storage)
+            cursor.step_key(&storage);
         }
 
-        // If we have extracted a projection, we should re-write the order_by columns.
-        if let Some(columns) = &self.project {
-            for key in self.finishing.order_by.iter_mut() {
-                key.column = columns[key.column];
-            }
-        }
-
-        // TODO: We could sort here in any case, as it allows a merge sort at the coordinator.
-        if let Some(limit) = self.finishing.limit {
-            let offset_plus_limit = limit + self.finishing.offset;
-            if results.len() > offset_plus_limit {
-                // The `results` should be sorted by `Row`, which means we only
-                // need to re-order `results` when there is a non-empty order_by.
-                if !self.finishing.order_by.is_empty() {
-                    // Re-usable storage for unpacking rows.
-                    let mut unpack_left = Vec::new();
-                    let mut unpack_right = Vec::new();
-                    pdqselect::select_by(&mut results, offset_plus_limit, |left, right| {
-                        // Unpack rows into re-used allocations.
-                        unpack_left.clear();
-                        unpack_left.extend(left.iter());
-                        unpack_right.clear();
-                        unpack_right.extend(right.iter());
-                        expr::compare_columns(
-                            &self.finishing.order_by,
-                            &unpack_left[..],
-                            &unpack_right[..],
-                            || left.cmp(right),
-                        )
-                    });
-                }
-                results.truncate(offset_plus_limit);
-            }
-        }
-
-        Ok(if let Some(columns) = &self.project {
-            let mut row_packer = repr::RowPacker::new();
-            results
-                .iter()
-                .map({
-                    move |row| {
-                        let datums = row.unpack();
-                        row_packer.pack(columns.iter().map(|i| datums[*i]))
-                    }
-                })
-                .collect()
-        } else {
-            results.iter().map(|row| (*row).clone()).collect()
-        })
+        Ok(results)
     }
 }
 

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -925,21 +925,11 @@ impl PendingPeek {
         let mut results = Vec::new();
         let mut row_packer = repr::RowPacker::new();
 
-        // There are roughly two paths we can take here, where we split
-        // based on whether there is an ordering or not. If there is not
-        // an ordering, we power through all the elements perhaps bailing
-        // early if a limit is reached. We hit each row with any operators
-        // for post-processing (map, filter, project).
-        // If there is an ordering, we want to more carefully pilot things
-        // to leave the data as `[Datum]` and use this representation to
-        // maintain the top so-many results. We would love to use a heap
-        // to maintain this efficiently, but Rust makes this tricky.
-
         // When set, a bound on the number of records we need to return.
         // The requirements on the records are driven by the finishing's
         // `order_by` field. Further limiting will happen when the results
         // are collected, so we don't need to have exactly this many results,
-        // just at least the results.
+        // just at least those results that would have been returned.
         let max_results = self.finishing.limit.map(|l| l + self.finishing.offset);
 
         if let Some(literal) = &self.key {
@@ -978,7 +968,7 @@ impl PendingPeek {
                         ));
                     }
 
-                    // TODO: In and ORDER BY .. LIMIT .. setting, once we have a full output
+                    // TODO: In an ORDER BY .. LIMIT .. setting, once we have a full output
                     // we could compare each of these to the "least" current output, and
                     // avoid stashing the result and growing results.
                     for _ in 0..copies {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -211,6 +211,19 @@ impl MapFilterProject {
         None
     }
 
+    /// Determines if a sequence of scalar expressions must be equal to a literal row.
+    pub fn literal_constraints(&self, exprs: &[ScalarExpr]) -> Option<Row> {
+        let mut row_packer = RowPacker::new();
+        for expr in exprs {
+            if let Some(literal) = self.literal_constraint(expr) {
+                row_packer.push(literal);
+            } else {
+                return None;
+            }
+        }
+        Some(row_packer.finish_and_reuse())
+    }
+
     /// Extracts any MapFilterProject at the root of the expression.
     ///
     /// The expression will be modified to extract any maps, filters, and

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -212,7 +212,15 @@ impl MapFilterProject {
     }
 
     /// Determines if a sequence of scalar expressions must be equal to a literal row.
+    ///
+    /// This method returns `None` on an empty `exprs`, which might be surprising, but
+    /// seems to line up with its callers' expectations of that being a non-constraint.
+    /// The caller knows if `exprs` is empty, and can modify their behavior appopriately.
+    /// if they would rather have a literal empty row.
     pub fn literal_constraints(&self, exprs: &[ScalarExpr]) -> Option<Row> {
+        if exprs.is_empty() {
+            return None;
+        }
         let mut row_packer = RowPacker::new();
         for expr in exprs {
             if let Some(literal) = self.literal_constraint(expr) {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -80,7 +80,7 @@ impl MapFilterProject {
     /// miss some errors that would occur later in evaluation.
     pub fn evaluate<'a>(
         &'a self,
-        datums: &'a mut Vec<Datum<'a>>,
+        datums: &mut Vec<Datum<'a>>,
         arena: &'a RowArena,
         row_packer: &mut RowPacker,
     ) -> Result<Option<Row>, EvalError> {
@@ -98,11 +98,11 @@ impl MapFilterProject {
     /// This version is used internally by `evaluate` and can be useful
     /// when one wants to capture the resulting datums without packing
     /// and then unpacking a row.
-    pub fn evaluate_iter<'a>(
+    pub fn evaluate_iter<'b, 'a: 'b>(
         &'a self,
-        datums: &'a mut Vec<Datum<'a>>,
+        datums: &'b mut Vec<Datum<'a>>,
         arena: &'a RowArena,
-    ) -> Result<Option<impl Iterator<Item = Datum> + 'a>, EvalError> {
+    ) -> Result<Option<impl Iterator<Item = Datum<'a>> + 'b>, EvalError> {
         let mut expression = 0;
         for (support, predicate) in self.predicates.iter() {
             while self.input_arity + expression < *support {


### PR DESCRIPTION
Our fast path queries are able to directly read values out of arrangements when the query has a certain "easy" structure.

This PR broadens that structure to include arbitrary map, filter, and project statements around a `Get` for a materialized arrangement. Additionally, the filter statements are used to drive index selection, where we attempt to choose an index whose keys are all constrained to be literal values, allowing us to seek directly to the key in each worker (and in some glorious future, not even bother the workers we know will not have the key).

Some additional performance changes were made to how the worker reads results out of arrangements. They are generally improvements, but can be a performance regression for `ORDER BY .. LIMIT <large>` from a large collection. Mainly, we no longer extract all records and then quick-select them, but rather maintain something like a priority queue, performing amortized per-record work logarithmic in the limit. For large limits this can be worse, but for small limits we avoid allocations proportional to the number of records in the arrangement. If the PR lands we should monitor this to see if the regressions in the uncommon case (large limit) are something we should improve.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4649)
<!-- Reviewable:end -->

fixes #4579
