### PR TITLE
sql: make TAIL a normal rows-sending statement

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -50,6 +50,12 @@ Wrap your release notes at the 80 character mark.
 
 - Default to using a worker thread count equal to half of the machine's
   physical cores if [`--workers`](/cli/#worker-threads) is not specified.
+- [`TAIL`](/sql/tail) now sends rows instead of being implemented as a
+  `COPY TO` operation. It has gained `timestamp` and `diff` columns.
+- [`COPY TO`](/sql/copy-to) has been added to
+  allow any query to send data via the [Postgres
+  COPY](https://www.postgresql.org/docs/current/sql-copy.html)
+  protocol. This can be used to replace the old `TAIL` behavior.
 
 {{% version-header v0.5.0 %}}
 

--- a/doc/user/content/sql/copy-to.md
+++ b/doc/user/content/sql/copy-to.md
@@ -1,0 +1,36 @@
+---
+title: "COPY TO"
+description: "`COPY TO` outputs a query via the COPY protocol."
+menu:
+    main:
+        parent: "sql"
+---
+
+`COPY TO` sends rows using the [Postgres COPY protocol](https://www.postgresql.org/docs/current/sql-copy.html).
+
+## Syntax
+
+{{< diagram "copy-to.svg" >}}
+
+Field | Use
+------|-----
+_query_ | The [`SELECT`](/sql/select) or [`TAIL`](/sql/tail) query to send
+_option_ |
+
+Name | Value
+-----|-------
+`FORMAT` | `TEXT` for text output (the default)
+
+## Example
+
+### Copying a view
+
+```sql
+COPY (SELECT * FROM some_view) TO STDOUT
+```
+
+### Tailing a view
+
+```sql
+COPY (TAIL some_view) TO STDOUT
+```

--- a/doc/user/layouts/partials/sql-grammar/copy-to.svg
+++ b/doc/user/layouts/partials/sql-grammar/copy-to.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="427" height="195">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="58" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">COPY</text>
+   <rect x="109" y="3" width="24" height="32" rx="10"/>
+   <rect x="107"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="117" y="21">(</text>
+   <rect x="153" y="3" width="54" height="32"/>
+   <rect x="151" y="1" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="161" y="21">query</text>
+   <rect x="227" y="3" width="24" height="32" rx="10"/>
+   <rect x="225"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="235" y="21">)</text>
+   <rect x="271" y="3" width="38" height="32" rx="10"/>
+   <rect x="269"
+         y="1"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="279" y="21">TO</text>
+   <rect x="329" y="3" width="76" height="32" rx="10"/>
+   <rect x="327"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="337" y="21">STDOUT</text>
+   <rect x="97" y="145" width="56" height="32" rx="10"/>
+   <rect x="95"
+         y="143"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="163">WITH</text>
+   <rect x="193" y="113" width="24" height="32" rx="10"/>
+   <rect x="191"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="131">(</text>
+   <rect x="257" y="113" width="58" height="32"/>
+   <rect x="255" y="111" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="265" y="131">option</text>
+   <rect x="257" y="69" width="24" height="32" rx="10"/>
+   <rect x="255"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="87">,</text>
+   <rect x="355" y="113" width="24" height="32" rx="10"/>
+   <rect x="353"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="363" y="131">)</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m58 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m24 0 h10 m20 0 h10 m58 0 h10 m-98 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m78 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-78 0 h10 m24 0 h10 m0 0 h34 m20 44 h10 m24 0 h10 m-342 0 h20 m322 0 h20 m-362 0 q10 0 10 10 m342 0 q0 -10 10 -10 m-352 10 v46 m342 0 v-46 m-342 46 q0 10 10 10 m322 0 q10 0 10 -10 m-332 10 h10 m0 0 h312 m23 -66 h-3"/>
+   <polygon points="417 127 425 123 425 131"/>
+   <polygon points="417 127 409 123 409 131"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -9,6 +9,9 @@ avro_schema_spec ::=
 connector_spec ::=
   'FILE' path ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')? |
   'KAFKA BROKER' host 'TOPIC' topic?
+copy_to ::=
+  'COPY' '(' query ')' 'TO' 'STDOUT'
+  ( 'WITH'? '(' option ( ',' option )* ')' )?
 create_database ::=
     'CREATE' 'DATABASE' ('IF NOT EXISTS')? database_name
 create_index ::=

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -12,7 +12,8 @@ use std::pin::Pin;
 
 use derivative::Derivative;
 
-use dataflow_types::{PeekResponse, Update};
+use dataflow_types::PeekResponse;
+use repr::Row;
 use sql::ast::{ObjectType, Statement};
 
 use crate::session::Session;
@@ -94,7 +95,7 @@ pub enum ExecuteResponse {
     CopyTo {
         format: sql::plan::CopyFormat,
         #[derivative(Debug = "ignore")]
-        rx: RowsFuture,
+        resp: Box<ExecuteResponse>,
     },
     /// The requested database was created.
     CreatedDatabase {
@@ -155,7 +156,7 @@ pub enum ExecuteResponse {
     /// Updates to the requested source or view will be streamed to the
     /// contained receiver.
     Tailing {
-        rx: comm::mpsc::Receiver<Vec<Update>>,
+        rx: comm::mpsc::Receiver<Vec<Row>>,
     },
     /// The specified number of rows were updated in the requested table.
     Updated(usize),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -662,7 +662,7 @@ impl SinkConnector {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TailSinkConnector {
-    pub tx: comm::mpsc::Sender<Vec<Update>>,
+    pub tx: comm::mpsc::Sender<Vec<Row>>,
     pub frontier: Antichain<Timestamp>,
     pub strict: bool,
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -155,7 +155,8 @@ pub enum CopyRelation {
         name: ObjectName,
         columns: Vec<Ident>,
     },
-    Query(Query),
+    Select(SelectStatement),
+    Tail(TailStatement),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -231,7 +232,12 @@ impl AstDisplay for CopyStatement {
                     f.write_str(")");
                 }
             }
-            CopyRelation::Query(query) => {
+            CopyRelation::Select(query) => {
+                f.write_str("(");
+                f.write_node(query);
+                f.write_str(")");
+            }
+            CopyRelation::Tail(query) => {
                 f.write_str("(");
                 f.write_node(query);
                 f.write_str(")");

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -32,7 +32,7 @@ COPY (select 1) TO STDOUT
 ----
 COPY (SELECT 1) TO STDOUT
 =>
-Copy(CopyStatement { relation: Query(Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }), direction: To, target: Stdout, options: [] })
+Copy(CopyStatement { relation: Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: false, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None }), order_by: [], limit: None, offset: None, fetch: None }, as_of: None }), direction: To, target: Stdout, options: [] })
 
 parse-statement
 COPY t(a, b) TO STDOUT

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -133,6 +133,7 @@ pub enum Plan {
         id: GlobalId,
         with_snapshot: bool,
         ts: Option<Timestamp>,
+        copy_to: Option<CopyFormat>,
     },
     SendRows(Vec<Row>),
     ExplainPlan {
@@ -210,18 +211,6 @@ pub enum MutationKind {
     Insert,
     Update,
     Delete,
-}
-
-#[derive(Debug)]
-pub enum CopyRelationKind {
-    Table {
-        id: GlobalId,
-        column_names: Vec<ColumnName>,
-    },
-    Query {
-        expr: ::expr::RelationExpr,
-        finishing: RowSetFinishing,
-    },
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
TAIL has transitioned to be send rows similar to a SELECT. It has
grown two new columns: timestamp and diff. Peek and Tail still operate
differently, but they implement a common interface that can be used by
the row send operation.

Additionally, COPY TO has been taught how to send TAIL operations such
that TAIL can be accessed similarly to how it was before, but now with
greater ability to parse the output columns.

Closes #4540
Closes #3091

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4666)
<!-- Reviewable:end -->
