### PR TITLE
materialized: fix telemetry URL

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -316,7 +316,7 @@ fn run() -> Result<(), anyhow::Error> {
             }
             Err(VarError::NotPresent) => match cfg!(debug_assertions) {
                 true => None,
-                false => Some("https://telemetry.materialize.com/".to_string()),
+                false => Some("https://telemetry.materialize.com".to_string()),
             },
         },
     };


### PR DESCRIPTION
Trailing / meant there were two when the full URL was built which the
server didn't recognize.

Fixes #4678

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4682)
<!-- Reviewable:end -->
