### PR TITLE
Add a bunch more diagnostic info to debezium deduplication log events

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1368,7 +1368,8 @@ impl DebeziumDeduplicationState {
 
         let mut delete_full = false;
         let should_use = match &mut self.full {
-            None => should_skip.is_none(), // Always none if in snapshot, see comment above where `should_skip` is bound.
+            // Always none if in snapshot, see comment above where `should_skip` is bound.
+            None => should_skip.is_none(),
             Some(TrackFull {
                 seen_offsets,
                 seen_snapshot_keys,
@@ -1379,14 +1380,17 @@ impl DebeziumDeduplicationState {
                 if is_snapshot {
                     let key_indices = match key_indices.as_ref() {
                         None => {
-                            // No keys, so we can't do anything sensible for snapshots. Return "all OK" and hope their data isn't corrupted.
+                            // No keys, so we can't do anything sensible for snapshots.
+                            // Return "all OK" and hope their data isn't corrupted.
                             return true;
                         }
                         Some(ki) => ki,
                     };
                     let mut row_iter = match update.after.as_ref() {
                         None => {
-                            error!("Snapshot row at pos {:?}, message_time={} in {} was unexpectedly not an insert.", coord, fmt_timestamp(upstream_time_millis), debug_name);
+                            error!(
+                                "Snapshot row at pos {:?}, message_time={} in {} was unexpectedly not an insert.",
+                                coord, fmt_timestamp(upstream_time_millis), debug_name);
                             return false;
                         }
                         Some(r) => r.iter(),
@@ -1407,7 +1411,7 @@ impl DebeziumDeduplicationState {
                         // But don't worry -- since `Row`s use a 16-byte smallvec, the clone
                         // won't involve an extra allocation unless the key overflows that.
                         //
-                        // Anyway, TODO: avoid this via `get_or_insert` once rust-lang/#60896 is resolved.
+                        // Anyway, TODO: avoid this via `get_or_insert` once rust-lang/rust#60896 is resolved.
                         let is_new = seen_keys.insert(key.clone());
                         if !is_new {
                             warn!(

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1389,7 +1389,7 @@ impl DebeziumDeduplicationState {
                     let mut row_iter = match update.after.as_ref() {
                         None => {
                             error!(
-                                "Snapshot row at pos {:?}, message_time={} in {} was unexpectedly not an insert.",
+                                "Snapshot row at pos {:?}, message_time={} source={} was not an insert.",
                                 coord, fmt_timestamp(upstream_time_millis), debug_name);
                             return false;
                         }
@@ -1415,7 +1415,7 @@ impl DebeziumDeduplicationState {
                         let is_new = seen_keys.insert(key.clone());
                         if !is_new {
                             warn!(
-                                "Snapshot row with key {:?} in {} seen multiple times (most recent message_time={})",
+                                "Snapshot row with key={:?} source={} seen multiple times (most recent message_time={})",
                                 key, debug_name, fmt_timestamp(upstream_time_millis)
                             );
                         }
@@ -1457,7 +1457,7 @@ impl DebeziumDeduplicationState {
                             // position ever seen
                             (true, Some(skipinfo)) => {
                                 warn!(
-                                "Source: {}:{} created a new record behind the highest point in binlog_file={} \
+                                "Created a new record behind the highest point in source={}:{} binlog_file={} \
                                  new_record_position={}:{} new_record_kafka_offset={} old_max_position={}:{} \
                                  message_time={}",
                                 debug_name, worker_idx, file, pos, row, coord.unwrap_or(-1),
@@ -1468,7 +1468,7 @@ impl DebeziumDeduplicationState {
                             // Duplicate item below the highest seen item
                             (false, Some(skipinfo)) => {
                                 debug!(
-                                "Source: {}:{} already ingested binlog coordinates {}:{}:{} old_binlog={}:{} \
+                                "already ingested source={}:{} binlog_coordinates={}:{}:{} old_binlog={}:{} \
                                  kafka_offset={} message_time={}",
                                 debug_name, worker_idx, file, pos, row,
                                 skipinfo.old_max_pos, skipinfo.old_max_row,

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -20,7 +20,7 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::{NaiveDateTime, Timelike};
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::Sha256;
@@ -1508,6 +1508,11 @@ impl DebeziumDeduplicationState {
         };
 
         if delete_full {
+            info!(
+                "Deleting debezium deduplication tracking data source={} message_time={}",
+                debug_name,
+                fmt_timestamp(upstream_time_millis)
+            );
             self.full = None;
         }
         should_use


### PR DESCRIPTION
The various commits in this PR mostly add information about the start and end windows that may be eligible as boundaries for start and end for `deduplication_start` and `deduplication_end`.

Notably, this PR does *not* introduce a `deduplication_pad_end` parameter which I had discussed with @umanwizard. In writing tests for that functionality I realized it doesn't make any sense:

* It's impossible for us to "thrash" the tracking map (i.e. repeatedly create/destroy it), once
  it's gone we no longer have any information that says that we should start doing track full
  again.
* If we have the track full table, it is guaranteed to strictly more often state that data should
  be used. If we are at the end of the window

But see the follow-up PR that does add that logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4689)
<!-- Reviewable:end -->
