### PR TITLE
avro dedupe: Add a deduplication_pad_end

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1368,7 +1368,8 @@ impl DebeziumDeduplicationState {
 
         let mut delete_full = false;
         let should_use = match &mut self.full {
-            None => should_skip.is_none(), // Always none if in snapshot, see comment above where `should_skip` is bound.
+            // Always none if in snapshot, see comment above where `should_skip` is bound.
+            None => should_skip.is_none(),
             Some(TrackFull {
                 seen_offsets,
                 seen_snapshot_keys,
@@ -1379,14 +1380,17 @@ impl DebeziumDeduplicationState {
                 if is_snapshot {
                     let key_indices = match key_indices.as_ref() {
                         None => {
-                            // No keys, so we can't do anything sensible for snapshots. Return "all OK" and hope their data isn't corrupted.
+                            // No keys, so we can't do anything sensible for snapshots.
+                            // Return "all OK" and hope their data isn't corrupted.
                             return true;
                         }
                         Some(ki) => ki,
                     };
                     let mut row_iter = match update.after.as_ref() {
                         None => {
-                            error!("Snapshot row at pos {:?}, message_time={} in {} was unexpectedly not an insert.", coord, fmt_timestamp(upstream_time_millis), debug_name);
+                            error!(
+                                "Snapshot row at pos {:?}, message_time={} in {} was unexpectedly not an insert.",
+                                coord, fmt_timestamp(upstream_time_millis), debug_name);
                             return false;
                         }
                         Some(r) => r.iter(),
@@ -1407,7 +1411,7 @@ impl DebeziumDeduplicationState {
                         // But don't worry -- since `Row`s use a 16-byte smallvec, the clone
                         // won't involve an extra allocation unless the key overflows that.
                         //
-                        // Anyway, TODO: avoid this via `get_or_insert` once rust-lang/#60896 is resolved.
+                        // Anyway, TODO: avoid this via `get_or_insert` once rust-lang/rust#60896 is resolved.
                         let is_new = seen_keys.insert(key.clone());
                         if !is_new {
                             warn!(

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1389,7 +1389,7 @@ impl DebeziumDeduplicationState {
                     let mut row_iter = match update.after.as_ref() {
                         None => {
                             error!(
-                                "Snapshot row at pos {:?}, message_time={} in {} was unexpectedly not an insert.",
+                                "Snapshot row at pos {:?}, message_time={} source={} was not an insert.",
                                 coord, fmt_timestamp(upstream_time_millis), debug_name);
                             return false;
                         }
@@ -1415,7 +1415,7 @@ impl DebeziumDeduplicationState {
                         let is_new = seen_keys.insert(key.clone());
                         if !is_new {
                             warn!(
-                                "Snapshot row with key {:?} in {} seen multiple times (most recent message_time={})",
+                                "Snapshot row with key={:?} source={} seen multiple times (most recent message_time={})",
                                 key, debug_name, fmt_timestamp(upstream_time_millis)
                             );
                         }
@@ -1457,7 +1457,7 @@ impl DebeziumDeduplicationState {
                             // position ever seen
                             (true, Some(skipinfo)) => {
                                 warn!(
-                                "Source: {}:{} created a new record behind the highest point in binlog_file={} \
+                                "Created a new record behind the highest point in source={}:{} binlog_file={} \
                                  new_record_position={}:{} new_record_kafka_offset={} old_max_position={}:{} \
                                  message_time={}",
                                 debug_name, worker_idx, file, pos, row, coord.unwrap_or(-1),
@@ -1468,7 +1468,7 @@ impl DebeziumDeduplicationState {
                             // Duplicate item below the highest seen item
                             (false, Some(skipinfo)) => {
                                 debug!(
-                                "Source: {}:{} already ingested binlog coordinates {}:{}:{} old_binlog={}:{} \
+                                "already ingested source={}:{} binlog_coordinates={}:{}:{} old_binlog={}:{} \
                                  kafka_offset={} message_time={}",
                                 debug_name, worker_idx, file, pos, row,
                                 skipinfo.old_max_pos, skipinfo.old_max_row,

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -20,7 +20,7 @@ use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::{NaiveDateTime, Timelike};
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::Sha256;
@@ -1508,6 +1508,11 @@ impl DebeziumDeduplicationState {
         };
 
         if delete_full {
+            info!(
+                "Deleting debezium deduplication tracking data source={} message_time={}",
+                debug_name,
+                fmt_timestamp(upstream_time_millis)
+            );
             self.full = None;
         }
         should_use

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1237,41 +1237,42 @@ fn handle_create_source(
         sql_parser::ast::Envelope::Debezium => {
             let dedup_strat = match with_options.remove("deduplication") {
                 None => DebeziumDeduplicationStrategy::Ordered,
-                Some(Value::String(s)) => {
-                    match s.as_str() {
-                        "full" => DebeziumDeduplicationStrategy::Full,
-                        "ordered" => DebeziumDeduplicationStrategy::Ordered,
-                        "full_in_range" => {
-                            match (
-                                with_options.remove("deduplication_start"),
-                                with_options.remove("deduplication_end"),
-                            ) {
-                                (Some(Value::String(start)), Some(Value::String(end))) => {
-                                    let deduplication_pad_start = match with_options.remove("deduplication_pad_start") {
-                                        Some(Value::String(start)) => Some(start),
-                                        Some(v) => bail!("Expected string for deduplication_pad_start, got: {:?}", v),
-                                        None => None
-                                    };
-                                    DebeziumDeduplicationStrategy::full_in_range(
-                                        &start,
-                                        &end,
-                                        deduplication_pad_start.as_deref(),
-                                    )
-                                    .map_err(|e| {
-                                        anyhow!("Unable to create deduplication strategy: {}", e)
-                                    })?
-                                }
-                                (_, _) => bail!(
-                                    "deduplication full_in_range requires both \
-                                 'deduplication_start' and 'deduplication_end' parameters"
-                                ),
+                Some(Value::String(s)) => match s.as_str() {
+                    "full" => DebeziumDeduplicationStrategy::Full,
+                    "ordered" => DebeziumDeduplicationStrategy::Ordered,
+                    "full_in_range" => {
+                        match (
+                            with_options.remove("deduplication_start"),
+                            with_options.remove("deduplication_end"),
+                        ) {
+                            (Some(Value::String(start)), Some(Value::String(end))) => {
+                                let mut extract_pad = |field| match with_options.remove(field) {
+                                    Some(Value::String(start)) => Ok(Some(start)),
+                                    Some(v) => bail!("Expected string for {}, got: {:?}", field, v),
+                                    None => Ok(None),
+                                };
+                                let pad_start = extract_pad("deduplication_pad_start")?;
+                                let pad_end = extract_pad("deduplication_pad_end")?;
+                                DebeziumDeduplicationStrategy::full_in_range(
+                                    &start,
+                                    &end,
+                                    pad_start.as_deref(),
+                                    pad_end.as_deref(),
+                                )
+                                .map_err(|e| {
+                                    anyhow!("Unable to create deduplication strategy: {}", e)
+                                })?
                             }
+                            (_, _) => bail!(
+                                "deduplication full_in_range requires both \
+                                 'deduplication_start' and 'deduplication_end' parameters"
+                            ),
                         }
-                        _ => bail!(
-                            "deduplication must be one of 'ordered' 'full', or 'full_in_range'."
-                        ),
                     }
-                }
+                    _ => {
+                        bail!("deduplication must be one of 'ordered' 'full', or 'full_in_range'.")
+                    }
+                },
                 _ => bail!("deduplication must be one of 'ordered', 'full' or 'full_in_range'."),
             };
             dataflow_types::Envelope::Debezium(dedup_strat)

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -207,7 +207,6 @@ a b
 1 2
 2 3
 
-
 # Source with new-style three-valued "snapshot".
 $ set new-dbz-schema={
     "type": "record",
@@ -351,9 +350,10 @@ $ kafka-create-topic topic=misordered-dbz-in-range-data
 
 # timestamps:
 # * 1599990000000 = 2020-09-13 09:40 -- more than an hour before the duplicate items
-# * 1599999600000 = 2020-09-13 12:20 -- in the hard-coded padding window
+# * 1599999600000 = 2020-09-13 12:20 -- in the default pad start window
 # * 1600000000000 = 2020-09-13 12:26 -- duplicate items
-# * 1600005000000 = 2020-09-13 13:50 -- no longer possibly duplicate
+# * 1600005000000 = 2020-09-13 13:50 -- no longer possibly duplicate, but before pad_end
+# * 1600006500000 = 2020-09-13 14:15 -- after pad end, used for misordered_dbz_after_pad source
 
 $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1599990000000
 {"before": null, "after": {"row":{"a": 1, "b": 0}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}}
@@ -381,7 +381,8 @@ $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-s
   WITH (
       deduplication = 'full_in_range',
       deduplication_start = '2020-09-13 12:26:00',
-      deduplication_end = '2020-09-13 13:00:00'
+      deduplication_end = '2020-09-13 13:00:00',
+      deduplication_pad_end = '2020-09-13 14:00:00'
   )
   FORMAT AVRO USING SCHEMA '${new-dbz-schema}'
   ENVELOPE DEBEZIUM
@@ -396,14 +397,15 @@ a b
 5 0
 8 0
 
-# same thing, but with an explicit pad start
+# same thing, but with explicit pad start and end
 > CREATE MATERIALIZED SOURCE misordered_dbz_in_range_with_start
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-in-range-data-${testdrive.seed}'
   WITH (
       deduplication = 'full_in_range',
       deduplication_pad_start = '2020-09-13 10:00:00',
       deduplication_start = '2020-09-13 12:26:00',
-      deduplication_end = '2020-09-13 13:00:00'
+      deduplication_end = '2020-09-13 13:00:00',
+      deduplication_pad_end = '2020-09-13 14:00:00'
   )
   FORMAT AVRO USING SCHEMA '${new-dbz-schema}'
   ENVELOPE DEBEZIUM
@@ -418,6 +420,33 @@ a b
 5 0
 8 0
 
+# full dedupe catches reversed, invalid data, even after we have entered the
+# padding zone, but only in the full-check zone
+$ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1600000000000
+{"before": null, "after": {"row":{"a": 5, "b": 1}}, "source": {"file": "binlog", "pos": 5, "row": 1, "snapshot": {"string": "false"}}}
+
+# but inserting past the end of the pad_end...
+$ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1600006500000
+{"before": null, "after": {"row":{"a": 9, "b": 0}}, "source": {"file": "binlog", "pos": 9, "row": 0, "snapshot": {"string": "false"}}}
+
+# ...means we no longer have any way of checking for not-dupe messages in the window.
+# This should not show up in the final check.
+$ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1600000000000
+{"before": null, "after": {"row":{"a": 5, "b": 2}}, "source": {"file": "binlog", "pos": 5, "row": 2, "snapshot": {"string": "false"}}}
+
+> SELECT * FROM misordered_dbz_in_range_with_start
+a b
+---
+1 0
+4 0
+3 1
+6 0
+5 0
+8 0
+5 1
+9 0
+
+# end dbz misordering tests
 
 ! CREATE SOURCE recurisve
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'


### PR DESCRIPTION
This adds only one commit relative to #4689 , and I'm not sure that we want it.

This allows us to have a period after the end of deduplication where we do not
trust the deduplication information, but we keep it around and keep adding to
it in case we go back in time again.

This seems like it may be strictly worse than just extending the end of the
deduplication window to pad end, since especially at the end of the dedupe
window we should trust the full deduplication logic more than the "debezium
never time travels" invariant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4690)
<!-- Reviewable:end -->
