### PR TITLE
xcompile: Make the error message a bit more visible and precise

### DIFF
--- a/bin/xcompile
+++ b/bin/xcompile
@@ -45,7 +45,7 @@ do_cargo() {
         # Docker for Mac is unusably slow.
 
         if [[ ! -d "$root/target/sysroot" ]]; then
-            die "xcompile: fatal: run \`bin/xcompile bootstrap\` first"
+            die "$(red "xcompile: fatal:") run \`$0 bootstrap\` first"
         fi
 
         export CMAKE_SYSTEM_NAME=Linux

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -136,33 +136,45 @@ mapfile_shim() {
 
 # [m]essage-[s]uccess: message to the user that something went well
 ms() {
-    echo -ne "\e[32m$*\e[0m"
+    green "$@"
 }
 
 # [u]sage-[s]ubcommand: Paint the argument as a subcmd
 #
 # In usage text, write: "usage: $0 `us CMD`"
 us() {
-    echo -ne "\e[34m$*\e[0m"
+    blue "$@"
 }
 
 # [u]sage-[f]lag: Paint the argument as a flag
 #
 # In usage text, write: "usage: $0 `uf --FLAG`"
 uf() {
-    echo -ne "\e[32m$*\e[0m"
+    green "$@"
 }
 
 # [u]sage-[o]ption: Paint the argument as an option
 #
 # In usage text, write: "usage: $0 `uf --FLAG` `uo OPT`"
 uo() {
-    echo -ne "\e[32m$*\e[0m"
+    green "$@"
 }
 
 # [u]sage-[w]arn: Paint the argument as a warning
 #
 # In usage text, write: "usage: $0 `uw WILL DELETE EVERYTHING`"
 uw() {
+    red "$@"
+}
+
+red() {
     echo -ne "\e[31m$*\e[0m"
+}
+
+blue() {
+    echo -ne "\e[34m$*\e[0m"
+}
+
+green() {
+    echo -ne "\e[32m$*\e[0m"
 }


### PR DESCRIPTION
Since the error message is often before a full Python Traceback it takes me sometimes a bit too long to notice it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4691)
<!-- Reviewable:end -->
