### PR TITLE
track lag time of sources in mz_perf_dependency_frontiers

### DIFF
--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -137,9 +137,11 @@ impl LogVariant {
             LogVariant::Materialized(MaterializedLog::SourceInfo) => RelationDesc::empty()
                 .with_column("source_name", ScalarType::String.nullable(false))
                 .with_column("source_id", ScalarType::String.nullable(false))
+                .with_column("dataflow_id", ScalarType::Int64.nullable(false))
                 .with_column("partition_id", ScalarType::String.nullable(false))
                 .with_column("offset", ScalarType::Int64.nullable(false))
-                .with_key(vec![0, 1, 2]),
+                .with_column("timestamp", ScalarType::Int64.nullable(false))
+                .with_key(vec![0, 1, 2, 3]),
 
             LogVariant::Materialized(MaterializedLog::DataflowDependency) => RelationDesc::empty()
                 .with_column("dataflow", ScalarType::String.nullable(false))

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -640,13 +640,6 @@ where
         let mut needed_additional_tokens = Vec::new();
         for import_id in import_ids {
             if let Some(addls) = self.additional_tokens.get(&import_id) {
-                // if let Some(logger) = &mut materialized_logging {
-                //     // Log the dependency.
-                //     logger.log(MaterializedEvent::DataflowDependency {
-                //         dataflow: idx_id,
-                //         source: import_id,
-                //     });
-                // }
                 needed_additional_tokens.extend_from_slice(addls);
             }
             if let Some(source_token) = self.source_tokens.get(&import_id) {

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -113,7 +113,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
 
         consistency_info.partition_metrics.insert(
             PartitionId::File,
-            PartitionMetrics::new(&name, &source_id.to_string(), "", logger.clone()),
+            PartitionMetrics::new(&name, source_id, "", logger.clone()),
         );
         consistency_info.update_partition_metadata(PartitionId::File);
 
@@ -162,7 +162,7 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
         };
         consistency_info.partition_metrics.insert(
             PartitionId::File,
-            PartitionMetrics::new(&name, &source_id.to_string(), "", logger.clone()),
+            PartitionMetrics::new(&name, source_id, "", logger.clone()),
         );
         consistency_info.update_partition_metadata(PartitionId::File);
 
@@ -240,7 +240,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
         if consistency_info.partition_metrics.len() == 0 {
             consistency_info.partition_metrics.insert(
                 pid,
-                PartitionMetrics::new(&self.name, &self.id.to_string(), "", self.logger.clone()),
+                PartitionMetrics::new(&self.name, self.id, "", self.logger.clone()),
             );
         }
     }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -148,7 +148,7 @@ impl KinesisSourceInfo {
                 kinesis_id.clone(),
                 PartitionMetrics::new(
                     &self.name,
-                    &self.id.to_string(),
+                    self.id,
                     &kinesis_id.to_string(),
                     self.logger.clone(),
                 ),
@@ -377,12 +377,7 @@ async fn create_state(
         consistency_info.update_partition_metadata(kinesis_id.clone());
         consistency_info.partition_metrics.insert(
             kinesis_id.clone(),
-            PartitionMetrics::new(
-                name,
-                &id.to_string(),
-                &kinesis_id.to_string(),
-                logger.clone(),
-            ),
+            PartitionMetrics::new(name, id, &kinesis_id.to_string(), logger.clone()),
         );
     }
 


### PR DESCRIPTION
Related to https://github.com/MaterializeInc/materialize/issues/3546

This seems like a good way of tracking how long our dataflows are taking to execute and if they're able to keep up with the ingestion rate. Let me know your thoughts or if there's anything I'm missing; timestamps in sources are more complex than I initially thought. 🙂 

Two main changes here:
1. The `source_info` table now tracks the logical timestamp we minted for the latest offset per partition
2. `mz_perf_dependency_frontiers` now includes info for parent sources instead of only parent dataflows

And there are some quirks:
1. sources are reinstantiated each time they're depended on, so they're uniquely identified by source_id + dataflow_id. However, I don't consider dataflow_id when doing the dependency join.
2. A source may have multiple partitions, each stamped at different timestamps. timestamps per partition are not tracked separately.

1/2 combine to make this a (slightly) pessimistic notion of lag, because we take the latest timestamp across all source instantiations/partitions and compare this to dependent dataflows to determine up to date-ness.

A final quirk: sources continue to drop capabilities even when no data is being ingested. I don't bother updating `source_info` with these empty timestamps, thus the need for the CASE in the new `mz_perf_dependency_frontiers` query (otherwise a source with no new data would cause a negative lag_ms).

Example output from the `simple` demo:
```
materialize=> select * from mz_perf_dependency_frontiers;
                       dataflow                        |           source            | lag_ms 
-------------------------------------------------------+-----------------------------+--------
 materialize.public.purchase_sum_by_region_primary_idx | materialize.public.user     |      0
 materialize.public.purchase_sum_by_region_primary_idx | materialize.public.region   |   1000
 materialize.public.purchase_sum_by_region_primary_idx | materialize.public.purchase |   1000
(3 rows)

materialize=> select * from mz_perf_dependency_frontiers;
                       dataflow                        |           source            | lag_ms 
-------------------------------------------------------+-----------------------------+--------
 materialize.public.purchase_sum_by_region_primary_idx | materialize.public.user     |      0
 materialize.public.purchase_sum_by_region_primary_idx | materialize.public.region   |      0
 materialize.public.purchase_sum_by_region_primary_idx | materialize.public.purchase |      0
(3 rows)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4696)
<!-- Reviewable:end -->
