### PR TITLE
materialized: disable version check for "-dev" versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "repr",
  "reqwest",
  "rlimit",
+ "semver",
  "serde",
  "serde_json",
  "shell-words",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -44,6 +44,7 @@ rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features =
 repr = { path = "../repr" }
 reqwest = { version = "0.10.8", features = ["json"] }
 rlimit = "0.5.2"
+semver = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 shell-words = "1.0"


### PR DESCRIPTION
Versions that end in "-dev" are development versions, so it doesn't make
much sense to warn users about new versions.

Fix #4701.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4702)
<!-- Reviewable:end -->
