### PR TITLE
*: rename all externally visible interfaces from persistence -> caching

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -18,7 +18,7 @@ Flag | Default | Modifies
 [`--experimental`](#experimental-mode) | Disabled | Get more details [here](#experimental-mode)
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
 [`--logical-compaction-window`](#compaction-window) | 60s | The amount of historical detail to retain in arrangements
-[`--persistence-max-pending-records`](#persistence) | 1000000 | Maximum number of input records buffered before flushing immediately to disk.
+[`--cache-max-pending-records`](#source-cache) | 1000000 | Maximum number of input records buffered before flushing immediately to disk.
 [`--process`](#horizontally-scaled-clusters) | 0 | This node's ID when coordinating with other Materialize nodes
 [`--processes`](#horizontally-scaled-clusters) | 1 | Number of coordinating Materialize nodes
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
@@ -225,16 +225,16 @@ etc.), and then create a new node with those items.
 [scv]: /sql/show-create-view
 [scs]: /sql/show-create-source
 
-### Persistence
+### Source Cache
 
-The `--persistence-max-pending-records` specifies the number of input messages
+The `--cache-max-pending-records` specifies the number of input messages
 Materialize buffers in memory before flushing them all to disk when using
-[persisted sources][persistence]. The default value is 1000000 messages. Note
+[cached sources][cache]. The default value is 1000000 messages. Note
 that Materialize will also flush buffered records every 10 minutes as well. See
-the [Deployment section][persistence] for more guidance on how to tune this
+the [Deployment section][cache] for more guidance on how to tune this
 parameter.
 
-[persistence]: /ops/deployment/#persistence
+[cache]: /ops/deployment/#source-caching
 
 ### Telemetry
 

--- a/doc/user/content/sql/create-source/avro-kafka.md
+++ b/doc/user/content/sql/create-source/avro-kafka.md
@@ -158,12 +158,12 @@ This creates a source that...
   `broker.tld:9092`.
 - Is append-only.
 
-### Persisting records to local disk
+### Caching records to local disk
 
 ```sql
-CREATE MATERIALIZED SOURCE persisted_source
+CREATE MATERIALIZED SOURCE cached_source
 FROM KAFKA BROKER 'broker.tld:9092' TOPIC 'data' WITH (
-    persistence = true
+    cache = true
 )
 FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://schema-registry.tld'
 ```
@@ -174,7 +174,7 @@ This creates a source that...
 - Decodes data received from the `data` topic published by Kafka running on
   `tld:9092`.
 - Decodes using an Avro schema.
-- Persists messages from the `data` topic to local disk.
+- Caches messages from the `data` topic to local disk.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/csv-kafka.md
+++ b/doc/user/content/sql/create-source/csv-kafka.md
@@ -32,12 +32,12 @@ This creates a source that...
 - Has 3 columns (`col_foo`, `col_bar`, `col_baz`). Materialize will not ingest
   any row without 3 columns.
 
-### Persisting records to local disk
+### Caching records to local disk
 
 ```sql
 CREATE SOURCE csv_kafka (col_foo, col_bar, col_baz)
 FROM KAFKA BROKER 'localhost:9092' TOPIC 'csv'
-WITH (persistence = true)
+WITH (cache = true)
 FORMAT CSV WITH 3 COLUMNS;
 ```
 
@@ -46,7 +46,7 @@ This creates a source that...
 - Is append-only.
 - Has 3 columns (`col_foo`, `col_bar`, `col_baz`). Materialize will not ingest
   any row without 3 columns.
-- Persists messages from the `csv` topic to local disk.
+- Caches messages from the `csv` topic to local disk.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/json-kafka.md
+++ b/doc/user/content/sql/create-source/json-kafka.md
@@ -43,12 +43,12 @@ CREATE MATERIALIZED VIEW jsonified_kafka_source AS
   )
 ```
 
-### Persisting records to local disk
+### Caching records to local disk
 
 ```sql
 CREATE SOURCE json_kafka
 FROM KAFKA BROKER 'localhost:9092' TOPIC 'json'
-WITH (persistence = true)
+WITH (cache = true)
 FORMAT BYTES;
 ```
 
@@ -56,7 +56,7 @@ This creates a source that...
 
 - Is append-only.
 - Has one column, `data`, which represents the stream's incoming bytes.
-- Persists messages from the `json` topic to local disk.
+- Caches messages from the `json` topic to local disk.
 
 ## Related pages
 

--- a/doc/user/content/sql/create-source/protobuf-kafka.md
+++ b/doc/user/content/sql/create-source/protobuf-kafka.md
@@ -42,7 +42,7 @@ This creates a source that...
 - Decodes data as the `Batch` message from the `billing` package, as described
   in the [generated `FileDescriptorSet`](#filedescriptorset).
 
-### Persisting records to local disk
+### Caching records to local disk
 
 Assuming you've already generated a [`FileDescriptorSet`](#filedescriptorset)
 named `SCHEMA`:
@@ -50,7 +50,7 @@ named `SCHEMA`:
 ```sql
 CREATE SOURCE batches
 KAFKA BROKER 'localhost:9092' TOPIC 'billing'
-WITH (persistence = true)
+WITH (cache = true)
 FORMAT PROTOBUF MESSAGE '.billing.Batch' USING '[path to schema]';
 ```
 
@@ -61,7 +61,7 @@ This creates a source that...
   `localhost:9092`.
 - Decodes data as the `Batch` message from the `billing` package, as described
   in the [generated `FileDescriptorSet`](#filedescriptorset).
-- Persists messages from the `billing` topic to local disk.
+- Caches messages from the `billing` topic to local disk.
 
 ### Connecting to a Kafka broker using SSL authentication
 

--- a/doc/user/content/sql/create-source/text-kafka.md
+++ b/doc/user/content/sql/create-source/text-kafka.md
@@ -37,12 +37,12 @@ This creates a source that...
 - Uses message keys to determine what should be inserted, deleted, and updated.
 - Treats both message keys and values as text.
 
-### Persisting records to local disk
+### Caching records to local disk
 
 ```sql
-CREATE SOURCE persisted_records
+CREATE SOURCE cached_records
 FROM KAFKA BROKER 'localhost:9092' TOPIC 'data'
-WITH (persistence = true)
+WITH (cache = true)
 FORMAT TEXT
 ```
 
@@ -51,7 +51,7 @@ This creates a source that...
 - Is append-only.
 - Decodes data received from the `data` topic published by Kafka running on
   `localhost:9092` as text.
-- Persists messages from the `data` topic to local disk.
+- Caches messages from the `data` topic to local disk.
 
 ## Related pages
 

--- a/doc/user/layouts/partials/create-source/connector/kafka/details.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/details.html
@@ -9,17 +9,17 @@
   [SSL-encrypted](#ssl-encrypted-kafka-details) or
   [Kerberized Kafka clusters](#kerberized-kafka-details).
 
-#### Persisted Kafka sources
+#### Cached Kafka sources
 
 To avoid re-reading data from Kafka on restart, Materialize lets you create
-persistent sources, which persist input messages from Kafka topics to files on
-the Materialize instance's local hard drive. For more details on persistence,
-see [Deployment: Persistence][persistence].
+cached sources, which cache input messages from Kafka topics to files on
+the Materialize instance's local hard drive. For more details on source caching,
+see [Deployment: Source Caching][caching].
 
 [Example][example]
 
-[persistence]: /ops/deployment/#persistence
-[example]: #persisting-records-to-local-disk
+[caching]: /ops/deployment/#source-caching
+[example]: #caching-records-to-local-disk
 
 #### SSL-encrypted Kafka details
 

--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -1,6 +1,6 @@
 `client_id` | `text` | Use the supplied value as the Kafka client identifier.
 `group_id_prefix` | `text` | Prefix Materialize Kafka users' `group.id` with the provided value. The resulting `group.id` looks like `<group_id_prefix>materialize-X-Y`, where `X` and `Y` are values that allow multiple concurrent Kafka consumers from the same topic.
-`persistence` | `bool` | Persist data from this source to local files. Requires [experimental mode](/cli/#experimental-mode).
+`cache` | `bool` | Cache data from this source to local files. Requires [experimental mode](/cli/#experimental-mode).
 `security_protocol` | `text` | Use either [`ssl`](#ssl-with-options) or [`sasl_plaintext` (Kerberos)](#kerberos-with-options) to connect to the Kafka cluster.
 `statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics.
 `ignore_source_keys` | `bool` | Default: `false`. If `true`, do not perform optimizations assuming uniqueness of primary keys in schemas.

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -116,8 +116,8 @@ fn run() -> Result<(), anyhow::Error> {
     );
     opts.optopt(
         "",
-        "persistence-max-pending-records",
-        "maximum number of records that have to be present before materialize will persist them immediately. (default 1000000)",
+        "cache-max-pending-records",
+        "maximum number of records that have to be present before materialize will cache them immediately. (default 1000000)",
         "N",
     );
 
@@ -255,7 +255,7 @@ fn run() -> Result<(), anyhow::Error> {
         Some(d) => parse_duration::parse(&d)?,
     };
     let persistence_max_pending_records =
-        popts.opt_get_default("persistence-max-pending-records", 1000000)?;
+        popts.opt_get_default("cache-max-pending-records", 1000000)?;
 
     // Configure connections.
     let listen_addr = popts.opt_get("listen-addr")?;
@@ -280,10 +280,10 @@ fn run() -> Result<(), anyhow::Error> {
 
     // Configure source persistence.
     let persistence = if experimental_mode {
-        let persistence_directory = data_directory.join("persistence/");
+        let persistence_directory = data_directory.join("cache/");
         fs::create_dir_all(&persistence_directory).with_context(|| {
             format!(
-                "creating persistence directory: {}",
+                "creating source caching directory: {}",
                 persistence_directory.display()
             )
         })?;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1108,14 +1108,14 @@ fn handle_create_source(
                 bail!("`start_offset` is not yet implemented for BYO consistency sources.")
             }
 
-            let enable_persistence = match with_options.remove("persistence") {
+            let enable_persistence = match with_options.remove("cache") {
                 None => false,
                 Some(Value::Boolean(b)) => b,
-                Some(_) => bail!("persistence must be a bool!"),
+                Some(_) => bail!("cache must be a bool!"),
             };
 
             if enable_persistence && consistency != Consistency::RealTime {
-                unsupported!("BYO source persistence")
+                unsupported!("BYO source caching")
             }
 
             let mut start_offsets = HashMap::new();

--- a/test/performance/perf-upsert/src/main.rs
+++ b/test/performance/perf-upsert/src/main.rs
@@ -147,7 +147,7 @@ async fn create_upsert_text_source(
 
     let query = if enable_persistence {
         format!(
-            "{} WITH (persistence = true) FORMAT TEXT ENVELOPE UPSERT",
+            "{} WITH (cache = true) FORMAT TEXT ENVELOPE UPSERT",
             query_prefix
         )
     } else {

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -38,7 +38,7 @@ services:
     depends_on: [kafka, zookeeper, schema-registry, materialized]
   materialized:
     mzbuild: materialized
-    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1 --experimental --persistence-max-pending-records 1
+    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1 --experimental --cache-max-pending-records 1
     environment:
     - MZ_DEV=1
     volumes:

--- a/test/testdrive/persistence.td
+++ b/test/testdrive/persistence.td
@@ -17,7 +17,7 @@ $ kafka-ingest format=bytes topic=bytes timestamp=1
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
-  WITH (persistence=true) FORMAT BYTES
+  WITH (cache=true) FORMAT BYTES
 
 > SELECT offset, value FROM internal_read_persisted_data('data') ORDER BY OFFSET
  offset  value


### PR DESCRIPTION
This commit also updates docs to reflect the name change. We need to make a larger
refactor to have the internal structure reflect this name as well, but have carved
this commit out to get it into a release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4705)
<!-- Reviewable:end -->
