### PR TITLE
sql: implement CREATE TYPE .. AS MAP

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -125,6 +125,8 @@ pub enum ExecuteResponse {
     CreatedView {
         existed: bool,
     },
+    /// The requested type was created.
+    CreatedType,
     /// The specified number of rows were deleted from the requested table.
     Deleted(usize),
     /// The requested database was dropped.

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -648,6 +648,7 @@ where
             ExecuteResponse::CreatedView { existed } => {
                 created!(existed, SqlState::DUPLICATE_OBJECT, "view")
             }
+            ExecuteResponse::CreatedType => command_complete!("CREATE TYPE"),
             ExecuteResponse::Deleted(n) => command_complete!("DELETE {}", n),
             ExecuteResponse::DroppedDatabase => command_complete!("DROP DATABASE"),
             ExecuteResponse::DroppedSchema => command_complete!("DROP SCHEMA"),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1108,15 +1108,21 @@ impl_display!(ShowStatementFilter);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SqlOption {
-    Value { name: Ident, value: Value },
-    Ident { name: Ident, ident: Ident },
+    Value {
+        name: Ident,
+        value: Value,
+    },
+    ObjectName {
+        name: Ident,
+        object_name: ObjectName,
+    },
 }
 
 impl SqlOption {
     pub fn name(&self) -> &Ident {
         match self {
             SqlOption::Value { name, .. } => name,
-            SqlOption::Ident { name, .. } => name,
+            SqlOption::ObjectName { name, .. } => name,
         }
     }
 }
@@ -1129,10 +1135,10 @@ impl AstDisplay for SqlOption {
                 f.write_str(" = ");
                 f.write_node(value);
             }
-            SqlOption::Ident { name, ident } => {
+            SqlOption::ObjectName { name, object_name } => {
                 f.write_node(name);
                 f.write_str(" = ");
-                f.write_node(ident);
+                f.write_node(object_name);
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1940,13 +1940,13 @@ impl Parser {
         let token = self.peek_token();
         let option = if let Ok(value) = self.parse_value() {
             SqlOption::Value { name, value }
-        } else if let Some(Token::Word(ident)) = token {
-            SqlOption::Ident {
-                name,
-                ident: ident.to_ident(),
-            }
         } else {
-            self.expected(self.peek_range(), "option value", token)?
+            self.prev_token();
+            if let Ok(object_name) = self.parse_object_name() {
+                SqlOption::ObjectName { name, object_name }
+            } else {
+                self.expected(self.peek_range(), "option value", token)?
+            }
         };
         Ok(option)
     }

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -18,39 +18,39 @@ CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool )
 =>
-CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Ident { name: Ident("key_type"), ident: Ident("text") }, Ident { name: Ident("value_type"), ident: Ident("bool") }] })
+CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }, ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("bool")]) }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY_TYPE='text', VaLuE_tYpE=custom_type)
 ----
 CREATE TYPE custom AS MAP ( key_type = 'text', value_type = custom_type )
 =>
-CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Value { name: Ident("key_type"), value: String("text") }, Ident { name: Ident("value_type"), ident: Ident("custom_type") }] })
+CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Value { name: Ident("key_type"), value: String("text") }, ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("custom_type")]) }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text)
 ----
 CREATE TYPE custom AS MAP ( key_type = text )
 =>
-CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Ident { name: Ident("key_type"), ident: Ident("text") }] })
+CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( value_type = bool )
 =>
-CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Ident { name: Ident("value_type"), ident: Ident("bool") }] })
+CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("bool")]) }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, value_type=bool, random_type=int)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool, random_type = int )
 =>
-CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Ident { name: Ident("key_type"), ident: Ident("text") }, Ident { name: Ident("value_type"), ident: Ident("bool") }, Ident { name: Ident("random_type"), ident: Ident("int") }] })
+CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }, ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("bool")]) }, ObjectName { name: Ident("random_type"), object_name: ObjectName([Ident("int")]) }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, random_type=int)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, random_type = int )
 =>
-CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [Ident { name: Ident("key_type"), ident: Ident("text") }, Ident { name: Ident("random_type"), ident: Ident("int") }] })
+CreateMapType(CreateMapTypeStatement { name: ObjectName([Ident("custom")]), with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }, ObjectName { name: Ident("random_type"), object_name: ObjectName([Ident("int")]) }] })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -102,6 +102,10 @@ pub enum Plan {
         index: Index,
         if_not_exists: bool,
     },
+    CreateType {
+        name: FullName,
+        typ: Type,
+    },
     DropDatabase {
         name: String,
     },
@@ -194,6 +198,13 @@ pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
     pub keys: Vec<::expr::ScalarExpr>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Type {
+    pub create_sql: String,
+    pub key_id: GlobalId,
+    pub value_id: GlobalId,
 }
 
 /// Specifies when a `Peek` should occur.

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -52,7 +52,7 @@ use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
 use crate::plan::{
     query, scalar_type_from_sql, AlterIndexLogicalCompactionWindow, CopyFormat, Index,
-    LogicalCompactionWindow, Params, PeekWhen, Plan, PlanContext, Sink, Source, Table, View,
+    LogicalCompactionWindow, Params, PeekWhen, Plan, PlanContext, Sink, Source, Table, Type, View,
 };
 use crate::pure::Schema;
 
@@ -273,7 +273,7 @@ pub fn handle_statement(
         Statement::CreateSource(stmt) => handle_create_source(scx, stmt),
         Statement::CreateTable(stmt) => handle_create_table(scx, stmt),
         Statement::CreateView(stmt) => handle_create_view(scx, stmt, params),
-        Statement::CreateMapType(stmt) => handle_create_type(scx, stmt),
+        Statement::CreateMapType(stmt) => handle_create_map_type(scx, stmt),
         Statement::DropDatabase(stmt) => handle_drop_database(scx, stmt),
         Statement::DropObjects(stmt) => handle_drop_objects(scx, stmt),
         Statement::AlterObjectRename(stmt) => handle_alter_object_rename(scx, stmt),
@@ -865,21 +865,45 @@ fn handle_create_view(
     })
 }
 
-fn handle_create_type(
+fn handle_create_map_type(
     scx: &StatementContext,
-    CreateMapTypeStatement { name, with_options }: CreateMapTypeStatement,
+    stmt: CreateMapTypeStatement,
 ) -> Result<Plan, anyhow::Error> {
-    let mut with_options = normalize::options(&with_options);
-    let _key_type = match with_options.remove("key_type") {
-        Some(Value::String(s)) => Some(s),
-        Some(_) => bail!("key_type must be a string"),
+    let create_sql = normalize::create_statement(scx, Statement::CreateMapType(stmt.clone()))?;
+    let CreateMapTypeStatement { name, with_options } = stmt;
+
+    let mut with_options = normalize::option_objects(&with_options);
+    let key_name = match with_options.remove("key_type") {
+        Some(SqlOption::Value {
+            value: Value::String(val),
+            ..
+        }) => ObjectName(vec![Ident::new(val)]),
+        Some(SqlOption::ObjectName { object_name, .. }) => object_name,
+        Some(_) => bail!("key_type must be a string or identifier"),
         None => bail!("key_type parameter required"),
     };
-    let _value_type = match with_options.remove("value_type") {
-        Some(Value::String(s)) => Some(s),
-        Some(_) => bail!("value_type must be a string"),
+    let key = scx
+        .catalog
+        .resolve_item(&normalize::object_name(key_name)?)?;
+    if key.item.to_uppercase().as_str() != "TEXT" {
+        bail!("key_type must be text")
+    }
+    let key_id = scx.catalog.get_item(&key).id();
+
+    let value_name = match with_options.remove("value_type") {
+        Some(SqlOption::Value {
+            value: Value::String(val),
+            ..
+        }) => ObjectName(vec![Ident::new(val)]),
+        Some(SqlOption::ObjectName { object_name, .. }) => object_name,
+        Some(_) => bail!("value_type must be a string or identifier"),
         None => bail!("value_type parameter required"),
     };
+    let value = scx
+        .catalog
+        .resolve_item(&normalize::object_name(value_name)?)?;
+    let value_id = scx.catalog.get_item(&value).id();
+
     if !with_options.is_empty() {
         bail!(
             "unexpected parameters for CREATE TYPE: {}",
@@ -892,8 +916,14 @@ fn handle_create_type(
         bail!("type \"{}\" already exists", name.to_string());
     }
 
-    // todo@jldlaughlin: Return an error for any non-String, integral key types.
-    unsupported!("CREATE TYPE");
+    Ok(Plan::CreateType {
+        name,
+        typ: Type {
+            create_sql,
+            key_id,
+            value_id,
+        },
+    })
 }
 
 fn extract_timestamp_frequency_option(

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT * FROM mz_map_types;
+
+> CREATE TYPE bool AS MAP (key_type=text, value_type='int4');
+
+> CREATE TYPE custom AS MAP (key_type='text', value_type=bool);
+
+# Without qualifiers, should default to builtin bool.
+> SELECT mz_internal.mz_classify_object_id(value_id) FROM mz_map_types WHERE name = 'custom'
+system
+
+> CREATE TYPE another_custom AS MAP (key_type='text', value_type=public.bool);
+
+# Qualified name should point to user-defined bool.
+> SELECT mz_internal.mz_classify_object_id(value_id) FROM mz_map_types WHERE name = 'another_custom'
+user


### PR DESCRIPTION
Implements creating a user-defined map type. Map types are stored in the
catalog and follow the namespacing conventions of other catalog objects.
Each map type will also be written to the mz_map_types system table. Further
work is required to drop map types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4712)
<!-- Reviewable:end -->
