### PR TITLE
sql: refactor casting/function selection to support pg_typeof

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,10 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.5.2 %}}
+
+- Support the [`pg_typeof` function](/sql/functions#postgresql-compatibility-func).
+
 {{% version-header v0.5.1 %}}
 
 - Default to using a worker thread count equal to half of the machine's

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -343,5 +343,7 @@
     description: PostgreSQL compatibility shim. Currently always returns `NULL`.
   - signature: 'pg_table_is_visible(relation: oid) -> boolean'
     description: Reports whether the relation with the specified OID is visible in the search path.
+  - signature: 'pg_typeof(expr: any) -> text'
+    description: Returns the type of its input argument as a string.
   - signature: 'pg_encoding_to_char(encoding_id: integer) -> text'
     description: PostgreSQL compatibility shim. Not intended for direct use.

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -23,7 +23,7 @@ use ore::collections::CollectionExt;
 use repr::*;
 
 use crate::plan::query::ExprContext;
-use crate::plan::typeconv::{self, CoerceTo};
+use crate::plan::typeconv;
 use crate::plan::Params;
 
 // these happen to be unchanged at the moment, but there might be additions later
@@ -186,7 +186,7 @@ pub enum CoercibleScalarExpr {
 
 impl CoercibleScalarExpr {
     pub fn type_as(self, ecx: &ExprContext, ty: ScalarType) -> Result<ScalarExpr, anyhow::Error> {
-        let expr = typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ty.clone()))?;
+        let expr = typeconv::plan_coerce(ecx, self, ty.clone())?;
         let expr_ty = ecx.scalar_type(&expr);
         if ty != expr_ty {
             bail!("{} must have type {}, not type {}", ecx.name, ty, expr_ty);
@@ -195,7 +195,7 @@ impl CoercibleScalarExpr {
     }
 
     pub fn type_as_any(self, ecx: &ExprContext) -> Result<ScalarExpr, anyhow::Error> {
-        typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ScalarType::String))
+        typeconv::plan_coerce(ecx, self, ScalarType::String)
     }
 
     pub fn explicit_cast_to(
@@ -204,7 +204,7 @@ impl CoercibleScalarExpr {
         ecx: &ExprContext,
         ty: ScalarType,
     ) -> Result<ScalarExpr, anyhow::Error> {
-        let expr = typeconv::plan_coerce(ecx, self, CoerceTo::Plain(ty.clone()))?;
+        let expr = typeconv::plan_coerce(ecx, self, ty.clone())?;
         if ty != ecx.scalar_type(&expr) {
             typeconv::plan_cast(op, ecx, expr, typeconv::CastTo::Explicit(ty))
         } else {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -54,7 +54,7 @@ use crate::plan::func::{self, Func, FuncSpec};
 use crate::plan::scope::{Scope, ScopeItem, ScopeItemName};
 use crate::plan::statement::StatementContext;
 use crate::plan::transform_ast;
-use crate::plan::typeconv::{self, CastContext, CastTo, CoerceTo};
+use crate::plan::typeconv::{self, CastContext, CastTo};
 
 /// Plans a top-level query, returning the `RelationExpr` describing the query
 /// plan, the `RelationDesc` describing the shape of the result set, a
@@ -1822,7 +1822,7 @@ pub fn plan_expr<'a>(ecx: &'a ExprContext, e: &Expr) -> Result<CoercibleScalarEx
                 Expr::List(exprs) => plan_list(ecx, exprs, Some(to_scalar_type.clone()))?,
                 _ => plan_expr(ecx, expr)?,
             };
-            let expr = typeconv::plan_coerce(ecx, expr, CoerceTo::Plain(to_scalar_type.clone()))?;
+            let expr = typeconv::plan_coerce(ecx, expr, to_scalar_type.clone())?;
             typeconv::plan_cast("CAST", ecx, expr, CastTo::Explicit(to_scalar_type))?.into()
         }
         Expr::Function(func) => plan_function(ecx, func)?.into(),
@@ -2164,7 +2164,7 @@ pub fn coerce_homogeneous_exprs(
     // Try to cast all expressions to `target`.
     let mut out = Vec::new();
     for expr in exprs {
-        let arg = typeconv::plan_coerce(ecx, expr, CoerceTo::Plain(target.clone()))?;
+        let arg = typeconv::plan_coerce(ecx, expr, target.clone())?;
 
         match typeconv::plan_cast(name, ecx, arg.clone(), CastTo::Implicit(target.clone())) {
             Ok(expr) => out.push(expr),

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -59,7 +59,7 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
         ("SELECT NOT $1", vec![Type::Bool]),
         ("SELECT $1 AND $2", vec![Type::Bool, Type::Bool]),
         ("SELECT $1 OR $2", vec![Type::Bool, Type::Bool]),
-        ("SELECT +$1", vec![Type::Text]),
+        ("SELECT +$1", vec![Type::Float8]),
         ("SELECT $1 < 1", vec![Type::Int4]),
         ("SELECT $1 < $2", vec![Type::Text, Type::Text]),
         ("SELECT $1 + 1", vec![Type::Int4]),

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -479,10 +479,10 @@ SELECT '1'::JSONB
 ----
 1.0
 
-# query T
-# SELECT pg_typeof('1'::JSONB)
-# ----
-# jsonb
+query T
+SELECT pg_typeof('1'::JSONB)
+----
+jsonb
 
 query T
 SELECT '{'::JSONB
@@ -494,10 +494,10 @@ SELECT '{"a":1}'::JSONB->'a'
 ----
 1.0
 
-# query T
-# SELECT pg_typeof('{"a":1}'::JSONB->'a')
-# ----
-# jsonb
+query T
+SELECT pg_typeof('{"a":1}'::JSONB->'a')
+----
+jsonb
 
 query T
 SELECT '{"a":1,"b":2}'::JSONB->'b'
@@ -544,10 +544,10 @@ SELECT '{"a":null}'::JSONB->>'a'
 ----
 NULL
 
-# query T
-# SELECT pg_typeof('{"a":1}'::JSONB->>'a')
-# ----
-# string
+query T
+SELECT pg_typeof('{"a":1}'::JSONB->>'a')
+----
+text
 
 query T
 SELECT '{"a":1,"b":2}'::JSONB->>'b'

--- a/test/sqllogictest/postgres/subselect.slt
+++ b/test/sqllogictest/postgres/subselect.slt
@@ -319,16 +319,14 @@ q1  ?column?
 4567890123456789  0.6
 
 # Unspecified-type literals in output columns should resolve as text
-#
-# TODO(benesch): support pg_typeof.
-# query IT colnames
-# SELECT *, pg_typeof(f1) FROM
-#   (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1
-# ----
-# f1  pg_typeof
-# foo  text
-# foo  text
-# foo  text
+query TT colnames
+SELECT *, pg_typeof(f1) FROM
+  (SELECT 'foo' AS f1 FROM generate_series(1,3)) ss ORDER BY 1
+----
+f1   pg_typeof
+foo  text
+foo  text
+foo  text
 
 query T colnames
 select 1 = all (select (select 1))

--- a/test/sqllogictest/typeof.slt
+++ b/test/sqllogictest/typeof.slt
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the logic test suite in CockroachDB. The
+# original file was retrieved on June 10, 2019 from:
+#
+# The original source code is subject to the terms of the Apache
+# 2.0 license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+query error could not determine data type of parameter \$1
+SELECT pg_typeof($1)
+
+query T
+SELECT pg_typeof('1')
+----
+unknown
+
+query T
+SELECT pg_typeof(text '1')
+----
+text
+
+query T
+SELECT pg_typeof(1)
+----
+int4
+
+query T
+SELECT pg_typeof(1.0)
+----
+numeric


### PR DESCRIPTION
@sploiselle I went to add support for `pg_typeof`—something I've wanted for debugging purposes for a while—and, well, things just spiraled a bit out of control. It's late, and I'm tired, so definitely let me know if you want more explanation of any of the changes, or if I should split things up. (The diffstat is large, but many of the changes are mechanical, so never sure how to weigh!)

The tl;dr is basically that JsonbAny and StringAny were getting in the way of simplifying a lot of the cast code, and making pg_typeof possible. The refactors squeeze as much orthogonality out of coercion, casting, and overload selection as I think is possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4713)
<!-- Reviewable:end -->
