### PR TITLE
Move documentation links from .io to .com

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -174,10 +174,10 @@ in the infrastructure repository. All of these tests can be run in parallel.
   - Use the following contents as the description, updating the version
     number appropriately:
     ```markdown
-    * [Release notes](https://materialize.io/docs/release-notes/#v0.#.#)
-    * [Binary tarballs](https://materialize.io/docs/versions/)
-    * [Installation instructions](https://materialize.io/docs/install/)
-    * [Documentation](https://materialize.io/docs/)
+    * [Release notes](https://materialize.com/docs/release-notes/#v0.#.#)
+    * [Binary tarballs](https://materialize.com/docs/versions/)
+    * [Installation instructions](https://materialize.com/docs/install/)
+    * [Documentation](https://materialize.com/docs/)
     ```
 
 ### Update the main branch for the next version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ If you have questions, please [create a Github issue](https://github.com/Materia
 
 ## Getting started
 
-The best place to start using Materialize is probably the documentation [instructions](https://materialize.io/docs).
+The best place to start using Materialize is probably the documentation [instructions](https://materialize.com/docs).
 
 ## Developing Materialize
 
@@ -28,8 +28,8 @@ printed from the `materialized` binary.
 
 When landing large or substantial changes, we want to make sure users are aware of the work you're doing! This means we require:
 
-- Coordination with a technical writer to generate or update user-facing documentation that will show up on <materialize.io/docs>. If you have questions, open an issue with the `A-docs` tag.
-- Generating release notes by describing your change in `doc/user/release-notes.md`. If there any questions about which version the feature will be released in, consult <materialize.io/docs/versions> or chat with us.
+- Coordination with a technical writer to generate or update user-facing documentation that will show up on <materialize.com/docs>. If you have questions, open an issue with the `A-docs` tag.
+- Generating release notes by describing your change in `doc/user/release-notes.md`. If there any questions about which version the feature will be released in, consult <materialize.com/docs/versions> or chat with us.
 
 #### Changes that require documentation
 

--- a/LICENSE
+++ b/LICENSE
@@ -35,7 +35,7 @@ Change License:            Apache License, Version 2.0
 
 
 For information about alternative licensing arrangements for the Software,
-please visit https://materialize.io/cloud.
+please visit https://materialize.com/cloud.
 
 Notice
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build status](https://badge.buildkite.com/97d6604e015bf633d1c2a12d166bb46f3b43a927d3952c999a.svg?branch=main)](https://buildkite.com/materialize/tests)
-[![Doc reference](https://img.shields.io/badge/doc-reference-orange)](https://materialize.io/docs)
+[![Doc reference](https://img.shields.io/badge/doc-reference-orange)](https://materialize.com/docs)
 [![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-purple)](https://join.slack.com/t/materializecommunity/shared_invite/zt-igbcmoxh-5V7XXMBIeDe7PFHO6sG6Dw)
 
-[<img src="https://materialize.io/wp-content/uploads/2020/01/materialize_logo_primary.png" width=60%>](https://materialize.io)
+[<img src="https://materialize.com/wp-content/uploads/2020/01/materialize_logo_primary.png" width=60%>](https://materialize.com)
 
 Materialize is a streaming database for real-time applications.
 
@@ -89,17 +89,17 @@ If you want to use an ORM, [chat with us](https://github.com/MaterializeInc/mate
 
 ## Get started
 
-Check out [our getting started guide](https://materialize.io/docs/get-started/).
+Check out [our getting started guide](https://materialize.com/docs/get-started/).
 
 ## Documentation
 
-Check out [our documentation](https://materialize.io/docs/).
+Check out [our documentation](https://materialize.com/docs/).
 
 ## License
 
 Materialize is source-available and [licensed](LICENSE) under the BSL 1.1, converting to the open-source Apache 2.0 license after 4 years. As stated in the BSL, Materialize is free forever on a single node.
 
-Materialize is also available as [a paid cloud service](https://materialize.io/download/) with additional features such as high availability via multi-active replication.
+Materialize is also available as [a paid cloud service](https://materialize.com/download/) with additional features such as high availability via multi-active replication.
 
 ## How does it work?
 

--- a/ci/www/lint.sh
+++ b/ci/www/lint.sh
@@ -14,6 +14,6 @@
 set -euo pipefail
 
 git clean -ffdX ci/www/public
-hugo --gc --baseURL https://ci.materialize.io/docs --source doc/user --destination ../../ci/www/public/docs
+hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destination ../../ci/www/public/docs
 echo "<!doctype html>" > ci/www/public/index.html
 htmltest -s ci/www/public -c doc/user/.htmltest.yml

--- a/ci/www/public/_redirects
+++ b/ci/www/public/_redirects
@@ -1,9 +1,13 @@
+# Redirect materialize.io to materialize.com
+http://materialize.io/* https://materialize.com/:splat 301!
+https://materialize.io/* https://materialize.com/:splat 301!
+
 # Force HTTP to HTTPS.
-http://materialize.io/* https://materialize.io/:splat 301!
+http://materialize.com/* https://materialize.com/:splat 301!
 
 # Evergreen, readable shortlinks.
 #
-# The materialize.io/s/ namespace is reserved for shortlinks. The idea is that
+# The materialize.com/s/ namespace is reserved for shortlinks. The idea is that
 # even if we change hosting providers, or switch platforms for the marketing
 # website, the /s path can always be easily reserved for shortlinks.
 #

--- a/demo/billing/README.md
+++ b/demo/billing/README.md
@@ -93,4 +93,4 @@ for client 1 you could run:
 SELECT * FROM billing_monthly_statement WHERE client_id = 1;
 ```
 
-Check out our [docs](https://materialize.io/docs/) for more info on what you can do!
+Check out our [docs](https://materialize.com/docs/) for more info on what you can do!

--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -14,7 +14,7 @@
 //! a Kafka topic and a local file, and perform time based aggregates.
 //!
 //! Further details can be found on the Materialize docs:
-//! <https://materialize.io/docs/demos/microservice/>
+//! <https://materialize.com/docs/demos/microservice/>
 
 #![deny(missing_debug_implementations, missing_docs)]
 

--- a/demo/simple/README.md
+++ b/demo/simple/README.md
@@ -11,7 +11,7 @@ series of Docker images glued together via Docker Compose. As a secondary
 benefit, you can run the demo via Linux, an EC2 VM instance, or a Mac laptop.
 
 For a better sense of what this deployment looks like, see our [architecture
-documentation](https://materialize.io/docs/overview/architecture)––the only
+documentation](https://materialize.com/docs/overview/architecture)––the only
 components not accounted for there are:
 
 - Kafka's infrastructure (e.g. Zookeeper)

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -4,7 +4,7 @@ This is the root directory of the Materialize developer documentation, which
 describes our engineering process and philosophy.
 
 For a more general introduction to Materialize, see the [user
-documentation](https://materialize.io/docs). For API documentation, see
+documentation](https://materialize.com/docs). For API documentation, see
 [mtrlz.dev](https://mtrlz.dev).
 
 ## New contributors
@@ -12,9 +12,9 @@ documentation](https://materialize.io/docs). For API documentation, see
 If you're a new contributor, we recommend reading the following chapters in the
 user documentation, if you haven't already:
 
-  1. [Get Started](https://materialize.io/docs/get-started/)
-  2. [What Is Materialized?](https://materialize.io/docs/overview/what-is-materialize/)
-  3. [Architecture Overview](https://materialize.io/docs/overview/architecture/)
+  1. [Get Started](https://materialize.com/docs/get-started/)
+  2. [What Is Materialized?](https://materialize.com/docs/overview/what-is-materialize/)
+  3. [Architecture Overview](https://materialize.com/docs/overview/architecture/)
 
 Then, once you're up to speed, dive into the [developer guide](guide.md). The
 guide is intended to be skimmed from start to finish, to give you the lay of the

--- a/doc/developer/demos.md
+++ b/doc/developer/demos.md
@@ -17,9 +17,9 @@ as an officially supported demo, a new demo must:
 - Have CI tests that run for every PR.
 
 Currently, there are three officially supported demos:
-- [Business Intelligence](https://materialize.io/docs/demos/business-intelligence/)
-- [Log Parsing](https://materialize.io/docs/demos/log-parsing/)
-- [Microservice](https://materialize.io/docs/demos/microservice/)
+- [Business Intelligence](https://materialize.com/docs/demos/business-intelligence/)
+- [Log Parsing](https://materialize.com/docs/demos/log-parsing/)
+- [Microservice](https://materialize.com/docs/demos/microservice/)
 
 ## Play Demos
 

--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -816,7 +816,7 @@ submit a PR to fix it!
 [google-guide]: https://google.github.io/eng-practices/review/
 [imperative]: https://en.wikipedia.org/wiki/Imperative_mood
 [pr-phrasings]: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-[release notes]: https://materialize.io/docs/release-notes/
+[release notes]: https://materialize.com/docs/release-notes/
 [reqwest]: https://github.com/seanmonstar/reqwest
 [rust-rdkafka]: https://github.com/fede1024/rust-rdkafka
 [rust-prometheus]: https://github.com/MaterializeInc/rust-prometheus

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -209,9 +209,9 @@ See the [symbiosis crate documentation](https://mtrlz.dev/api/symbiosis) for
 more details.
 
 **Note:** As of August 2020, we're laying the groundwork to phase out symbiosis
-mode with [tables](https://materialize.io/docs/sql/create-table). But we're
+mode with [tables](https://materialize.com/docs/sql/create-table). But we're
 stuck with symbiosis mode until tables support `UPDATE` and `DELETE`—at the time
-of writing they only support [`INSERT`](https://materialize.io/docs/sql/insert).
+of writing they only support [`INSERT`](https://materialize.com/docs/sql/insert).
 
 ## Web UI
 

--- a/doc/developer/project-management.md
+++ b/doc/developer/project-management.md
@@ -133,8 +133,8 @@ When filing an issue, these are the rules to adhere to:
 
 When landing large or substantial changes, we want to make sure users are aware of the work you're doing! This means we require:
 
-- Coordination with a technical writer to generate or update user-facing documentation that will show up on <materialize.io/docs>. If you have questions, open an issue with the `A-docs` tag.
-- Generating release notes by describing your change in `doc/user/release-notes.md`. If there any questions about which version the feature will be released in, consult <materialize.io/docs/versions> or chat with us.
+- Coordination with a technical writer to generate or update user-facing documentation that will show up on <materialize.com/docs>. If you have questions, open an issue with the `A-docs` tag.
+- Generating release notes by describing your change in `doc/user/release-notes.md`. If there any questions about which version the feature will be released in, consult <materialize.com/docs/versions> or chat with us.
 
 ### Changes that require documentation
 

--- a/doc/user/README.md
+++ b/doc/user/README.md
@@ -1,7 +1,7 @@
 # User docs
 
 This is the root directory of the Materialize user documentation, which are
-rendered by [Hugo] locally and published by CI to <https://materialize.io/docs>.
+rendered by [Hugo] locally and published by CI to <https://materialize.com/docs>.
 
 ## Viewing the docs locally
 

--- a/doc/user/assets/sass/_fonts.scss
+++ b/doc/user/assets/sass/_fonts.scss
@@ -1,63 +1,63 @@
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Bold.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Bold.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Bold.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Bold.woff") format("woff");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-BoldItalic.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Bold.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-BoldItalic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Bold.woff") format("woff");
   font-weight: bold;
   font-style: italic;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-SemiBold.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-SemiBold.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBold.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBold.woff") format("woff");
   font-weight: 600;
   font-style: normal;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-SemiBoldItalic.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-SemiBoldItalic.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBoldItalic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-SemiBoldItalic.woff") format("woff");
   font-weight: 600;
   font-style: italic;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Regular.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Regular.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Regular.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Regular.woff") format("woff");
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Italic.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Italic.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Italic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Italic.woff") format("woff");
   font-weight: 500;
   font-style: italic;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Light.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-Light.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Light.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-Light.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: "RM Neue";
-  src: url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-LightItalic.woff2") format("woff2"),
-    url("https://materialize.io/wp-content/themes/materialize/fonts/RMNeue-LightItalic.woff") format("woff");
+  src: url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-LightItalic.woff2") format("woff2"),
+    url("https://materialize.com/wp-content/themes/materialize/fonts/RMNeue-LightItalic.woff") format("woff");
   font-weight: normal;
   font-style: italic;
 }

--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -240,4 +240,4 @@ parameter.
 
 Unless disabled with `--disable-telemetry`, upon startup `materialized`
 reports its current version and cluster id to a central server operated by
-materialize.io. If a newer version is available a warning will be logged.
+materialize.com. If a newer version is available a warning will be logged.

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -17,7 +17,7 @@ instructions install the latest release of Materialize, **{{< version >}}**. The
 developer builds are available at https://mtrlz.dev/. For prior releases,
 see the [Versions page](/versions).
 
-**Have any questions?** [Contact us](https://materialize.io/contact/)
+**Have any questions?** [Contact us](https://materialize.com/contact/)
 
 ## Docker
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -41,7 +41,7 @@ Strive for some variety of verbs. "Support new feature" gets boring as a release
 note.
 
 Use relative links (/path/to/doc), not absolute links
-(https://materialize.io/docs/path/to/doc).
+(https://materialize.com/docs/path/to/doc).
 
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
@@ -313,7 +313,7 @@ Wrap your release notes at the 80 character mark.
 - Change the default [`TAIL` snapshot behavior](/sql/tail/#with-snapshot-or-without-snapshot)
   from `WITHOUT SNAPSHOT` to `WITH SNAPSHOT`. **Backwards-incompatible change.**
 
-- Actively shut down [Kafka sinks](https://materialize.io/docs/sql/create-sink/#kafka-sinks)
+- Actively shut down [Kafka sinks](https://materialize.com/docs/sql/create-sink/#kafka-sinks)
   that encounter an unrecoverable error, rather than attempting to produce data
   until the sink is dropped {{% gh 3419 %}}.
 
@@ -387,7 +387,7 @@ Wrap your release notes at the 80 character mark.
   created if you had used [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view).
 
 - Permit control over the timestamp selection logic on a per-Kafka-source basis
-  via three new [`WITH` options](https://materialize.io/docs/sql/create-source/avro-kafka/#with-options):
+  via three new [`WITH` options](https://materialize.com/docs/sql/create-source/avro-kafka/#with-options):
     - `timestamp_frequency_ms`
     - `max_timestamp_batch_size`
     - `topic_metadata_refresh_interval_ms`

--- a/doc/user/content/versions.md
+++ b/doc/user/content/versions.md
@@ -53,7 +53,7 @@ are using an unsupported version, please check that the issue reproduces on a
 supported version before engaging with our support team.
 
 Additional support options, including guaranteed SLAs, can be arranged upon
-request. Please reach out to our sales team at <https://materialize.io/contact/>.
+request. Please reach out to our sales team at <https://materialize.com/contact/>.
 
 ## Versioning policy
 

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -1,17 +1,17 @@
 <header id="main">
   <a href="/">
-    <img src="https://materialize.io/wp-content/uploads/2020/02/materialize_logo_primary-1.png" alt="Materialize Logo">
+    <img src="https://materialize.com/wp-content/uploads/2020/02/materialize_logo_primary-1.png" alt="Materialize Logo">
   </a>
 
   <ul class="menu">
-    <li><a href="https://materialize.io/">Home</a></li>
-    <li><a href="https://materialize.io/product/">Product</a></li>
-    <li><a href="https://materialize.io/docs/">Docs</a></li>
-    <li><a href="https://materialize.io/blog/">Blog</a></li>
-    <li><a href="https://materialize.io/about/">About</a></li>
-    <li><a href="https://materialize.io/careers/">Careers</a></li>
-    <li><a href="https://materialize.io/contact/">Contact</a></li>
+    <li><a href="https://materialize.com/">Home</a></li>
+    <li><a href="https://materialize.com/product/">Product</a></li>
+    <li><a href="https://materialize.com/docs/">Docs</a></li>
+    <li><a href="https://materialize.com/blog/">Blog</a></li>
+    <li><a href="https://materialize.com/about/">About</a></li>
+    <li><a href="https://materialize.com/careers/">Careers</a></li>
+    <li><a href="https://materialize.com/contact/">Contact</a></li>
     <li><a class="button button-purple" href="https://github.com/MaterializeInc/materialize">Github</a></li>
-    <li><a class="button button-lime" href="https://materialize.io/download/">Download</a></li>
+    <li><a class="button button-lime" href="https://materialize.com/download/">Download</a></li>
   </ul>
 </header>

--- a/misc/monitoring/dashboard/README.md
+++ b/misc/monitoring/dashboard/README.md
@@ -6,7 +6,7 @@ contains both Prometheus and Grafana (and some other tools) so that folks can ve
 quickly introspect their materialized, before they're ready to necessarily spin up
 production monitoring pointing at materialized.
 
-User documentation is at https://materialize.io/docs/monitoring/ (or
+User documentation is at https://materialize.com/docs/monitoring/ (or
 [doc/user/content/monitoring/_index.md][doc] locally).
 
 

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -135,13 +135,13 @@ def warn_docker_resource_limits() -> None:
         warn(
             f"Docker only has {actual} memory, "
             f"less than {desired} can cause demos to fail in unexpected ways.\n"
-            "    See https://materialize.io/docs/third-party/docker/\n"
+            "    See https://materialize.com/docs/third-party/docker/\n"
         )
     if limits.ncpus < docker.RECOMMENDED_MIN_CPUS:
         warn(
             f"Docker only has access to {limits.ncpus}, "
             f"fewer than {docker.RECOMMENDED_MIN_CPUS} can cause demos to fail in unexpected ways.\n"
-            "    See https://materialize.io/docs/third-party/docker/\n"
+            "    See https://materialize.com/docs/third-party/docker/\n"
         )
 
 

--- a/misc/tb/README.md
+++ b/misc/tb/README.md
@@ -10,7 +10,7 @@ from your database in a lightweight de-coupled fashion, which would
 traditionally require database triggers or something more involved.
 
 [ocf]: https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files
-[mz-avro-ocf]: https://materialize.io/docs/sql/create-source/avro-file/
+[mz-avro-ocf]: https://materialize.com/docs/sql/create-source/avro-file/
 
 ## Usage
 

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -20,7 +20,7 @@
 //! definitions of existing builtins!
 //!
 //! More information about builtin system tables and types can be found in
-//! https://materialize.io/docs/sql/system-tables/.
+//! https://materialize.com/docs/sql/system-tables/.
 
 use std::collections::BTreeMap;
 

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -161,12 +161,12 @@ impl fmt::Display for Error {
                 r#"Materialize previously started with --experimental to
 enable experimental features, so now must be started in experimental
 mode. For more details, see
-https://materialize.io/docs/cli#experimental-mode"#
+https://materialize.com/docs/cli#experimental-mode"#
             ),
             ErrorKind::ExperimentalModeUnavailable => write!(
                 f,
                 r#"Experimental mode is only available on new nodes. For
-more details, see https://materialize.io/docs/cli#experimental-mode"#
+more details, see https://materialize.com/docs/cli#experimental-mode"#
             ),
         }
     }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -455,7 +455,7 @@ Thank you for trying Materialize!
 We are interested in any and all feedback you have, which may be able
 to improve both our software and your queries! Please reach out at:
 
-    Web: https://materialize.io
+    Web: https://materialize.com
     GitHub issues: https://github.com/MaterializeInc/materialize/issues
     Email: support@materialize.io
     Twitter: @MaterializeInc
@@ -480,7 +480,7 @@ the node anew.
 - You must always start this node in experimental mode; it can no
 longer be started in non-experimental/regular mode.
 
-For more details, see https://materialize.io/docs/cli#experimental-mode
+For more details, see https://materialize.com/docs/cli#experimental-mode
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 "
         );
@@ -544,7 +544,7 @@ fn handle_panic(panic_info: &PanicInfo) {
 We rely on bug reports to diagnose and fix these errors. Please
 copy and paste the above details and file a report at:
 
-    https://materialize.io/s/bug
+    https://materialize.com/s/bug
 
 To protect your privacy, we do not collect crash reports automatically."#,
     );

--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -424,7 +424,7 @@ function View(props) {
 
   let dotLink = null;
   if (dot) {
-    const link = new URL('https://materialize.io/memory-visualization/');
+    const link = new URL('https://materialize.com/memory-visualization/');
     // Pass information as a JSON object to allow for easily extending this in
     // the future. The hash is used instead of search because it reduces privacy
     // concerns and avoids server-side URL size limits.

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -67,7 +67,7 @@ pub const BUILD_SHA: &str = run_command_str!(
         git rev-parse --verify HEAD 2>/dev/null || {
             printf "error: unable to determine Git SHA; " >&2
             printf "either build from working Git clone " >&2
-            printf "(see https://materialize.io/docs/install/#build-from-source), " >&2
+            printf "(see https://materialize.com/docs/install/#build-from-source), " >&2
             printf "or specify SHA manually by setting MZ_DEV_BUILD_SHA environment variable" >&2
             exit 1
         }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1902,7 +1902,7 @@ impl<'a> StatementContext<'a> {
         if !self.experimental_mode() {
             bail!(
                 "{} requires experimental mode; see \
-                https://materialize.io/docs/cli/#experimental-mode",
+                https://materialize.com/docs/cli/#experimental-mode",
                 feature_name
             )
         }

--- a/test/lang/java/smoketest/pom.xml
+++ b/test/lang/java/smoketest/pom.xml
@@ -18,7 +18,7 @@ the Business Source License, use of this software will be governed
   <version>1.0-SNAPSHOT</version>
 
   <name>test-pgjdbc</name>
-  <url>https://materialize.io/</url>
+  <url>https://materialize.com/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -33,7 +33,7 @@ goofus,gallant
 
 ! CREATE SINK bad_schema_registry FROM src
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialize.io:8080'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialize.com:8080'
 unable to publish value schema to registry in kafka sink
 
 > SHOW SINKS


### PR DESCRIPTION
Add a 301 from materialize.io to materialize.com for netlify
Update all references to materialize.io with two exceptions:
- packages.materialize.io
- email addresses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4715)
<!-- Reviewable:end -->
