### PR TITLE
dataflow: order TAIL output by timestamp

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -50,6 +50,7 @@ Wrap your release notes at the 80 character mark.
 
 - Support the [`pg_typeof` function](/sql/functions#postgresql-compatibility-func).
 - [`COPY TO`](/sql/copy-to) now supports `FORMAT binary`.
+- [`TAIL`](/sql/tail) is now guaranteed to produce output ordered by timestamp.
 
 {{% version-header v0.5.1 %}}
 

--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -32,7 +32,7 @@ _timestamp&lowbar;expression_ | The logical time to tail from onwards (either a 
 
 Field | Represents
 ------|-----------
-`timestamp` | Materialize's internal logical timestamp.
+`timestamp` | Materialize's internal logical timestamp. This is guaranteed to never decrease from any previous timestamp.
 `diff` | Whether the record is an insert (`1`), delete (`-1`), or update (delete for old value, followed by insert of new value).
 column values | The row's columns' values, each as its own column.
 

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -7,6 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::rc::Rc;
+
+use differential_dataflow::trace::cursor::Cursor;
+use differential_dataflow::trace::implementations::ord::OrdValBatch;
+use differential_dataflow::trace::BatchReader;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
@@ -21,7 +26,7 @@ use repr::adt::decimal::Significand;
 use repr::{Datum, Diff, Row, RowPacker, Timestamp};
 
 pub fn tail<G>(
-    stream: &Stream<G, (Row, Timestamp, Diff)>,
+    stream: Stream<G, Rc<OrdValBatch<GlobalId, Row, Timestamp, Diff>>>,
     id: GlobalId,
     connector: TailSinkConnector,
 ) where
@@ -30,21 +35,38 @@ pub fn tail<G>(
     let mut tx = block_on(connector.tx.connect()).expect("tail transmitter failed");
     let mut packer = RowPacker::new();
     stream.sink(Pipeline, &format!("tail-{}", id), move |input| {
-        input.for_each(|_, rows| {
-            let mut results: Vec<Row> = Vec::new();
-            for (row, time, diff) in rows.iter() {
-                let should_emit = if connector.strict {
-                    connector.frontier.less_than(time)
-                } else {
-                    connector.frontier.less_equal(time)
-                };
-                if should_emit {
-                    packer.push(Datum::Decimal(Significand::new(i128::from(*time))));
-                    packer.push(Datum::Int64(i64::cast_from(*diff)));
-                    packer.extend_by_row(row);
-                    results.push(packer.finish_and_reuse());
+        input.for_each(|_, batches| {
+            let mut results = vec![];
+            for batch in batches.iter() {
+                let mut cursor = batch.cursor();
+                while cursor.key_valid(&batch) {
+                    while cursor.val_valid(&batch) {
+                        let row = cursor.val(&batch);
+                        cursor.map_times(&batch, |time, diff| {
+                            let should_emit = if connector.strict {
+                                connector.frontier.less_than(time)
+                            } else {
+                                connector.frontier.less_equal(time)
+                            };
+                            if should_emit {
+                                packer.push(Datum::Decimal(Significand::new(i128::from(*time))));
+                                packer.push(Datum::Int64(i64::cast_from(*diff)));
+                                packer.extend_by_row(row);
+                                // Add the unpacked timestamp so we can sort by them later.
+                                results.push((*time, packer.finish_and_reuse()));
+                            }
+                        });
+                        cursor.step_val(&batch);
+                    }
+                    cursor.step_key(&batch);
                 }
             }
+
+            // Sort results by time and convert to Vec<Row>. We use stable sort here even
+            // though it is slower because it will produce deterministic results since the
+            // cursor will always produce rows in the same order.
+            results.sort_by_key(|(time, _)| *time);
+            let results: Vec<Row> = results.into_iter().map(|(_, row)| row).collect();
 
             // TODO(benesch): this blocks the Timely thread until the send
             // completes. Hopefully it's just a quick write to a kernel buffer,

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -103,7 +103,7 @@ fn test_current_timestamp_and_now() -> Result<(), Box<dyn Error>> {
 fn test_tail_basic() -> Result<(), Box<dyn Error>> {
     ore::test::init_logging();
 
-    let config = util::Config::default();
+    let config = util::Config::default().threads(2);
     let (_server, mut client) = util::start_server(config)?;
 
     let temp_dir = tempfile::tempdir()?;

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -28,6 +28,7 @@ pub struct Config {
     logging_granularity: Option<Duration>,
     tls: Option<materialized::TlsConfig>,
     experimental_mode: bool,
+    threads: usize,
 }
 
 impl Default for Config {
@@ -37,6 +38,7 @@ impl Default for Config {
             logging_granularity: Some(Duration::from_millis(10)),
             tls: None,
             experimental_mode: false,
+            threads: 1,
         }
     }
 }
@@ -68,6 +70,11 @@ impl Config {
         self.experimental_mode = true;
         self
     }
+
+    pub fn threads(mut self, threads: usize) -> Self {
+        self.threads = threads;
+        self
+    }
 }
 
 pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dyn Error>> {
@@ -82,7 +89,7 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
         timestamp_frequency: Duration::from_millis(10),
         persistence: None,
         logical_compaction_window: None,
-        threads: 1,
+        threads: config.threads,
         process: 0,
         addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],
         data_directory: config.data_directory,


### PR DESCRIPTION
Change the tail test to use multiple threads, which (before this change)
will fail under stress because TAIL output order was not guaranteed,
but this would never happen under a single thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4718)
<!-- Reviewable:end -->
