### PR TITLE
sql: support SHOW and DROP TYPE

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -399,6 +399,7 @@ lazy_static! {
         desc: RelationDesc::empty()
             .with_column("id", ScalarType::String.nullable(false))
             .with_column("oid", ScalarType::Oid.nullable(false))
+            .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("key_id", ScalarType::String.nullable(false))
             .with_column("value_id", ScalarType::String.nullable(false)),

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -141,8 +141,10 @@ pub enum ExecuteResponse {
     DroppedView,
     /// The requested index was dropped.
     DroppedIndex,
-    /// The requested sink wqs dropped.
+    /// The requested sink was dropped.
     DroppedSink,
+    /// The requested type was dropped.
+    DroppedType,
     /// The provided query was empty.
     EmptyQuery,
     /// The specified number of rows were inserted into the requested table.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1166,11 +1166,13 @@ where
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn report_map_type_update(
         &mut self,
         id: GlobalId,
         name: &str,
         oid: u32,
+        schema_id: i64,
         key_id: GlobalId,
         value_id: GlobalId,
         diff: isize,
@@ -1181,6 +1183,7 @@ where
                 Row::pack(&[
                     Datum::String(&id.to_string()),
                     Datum::Int32(oid as i32),
+                    Datum::Int64(schema_id),
                     Datum::String(name),
                     Datum::String(&key_id.to_string()),
                     Datum::String(&value_id.to_string()),
@@ -1806,6 +1809,7 @@ where
             ObjectType::Table => ExecuteResponse::DroppedTable,
             ObjectType::Sink => ExecuteResponse::DroppedSink,
             ObjectType::Index => ExecuteResponse::DroppedIndex,
+            ObjectType::Type => ExecuteResponse::DroppedType,
         })
     }
 
@@ -2440,7 +2444,7 @@ where
                             key_id, value_id, ..
                         }) => {
                             self.report_map_type_update(
-                                *id, &name.item, *oid, *key_id, *value_id, 1,
+                                *id, &name.item, *oid, *schema_id, *key_id, *value_id, 1,
                             )
                             .await;
                         }
@@ -2503,6 +2507,7 @@ where
                                 *id,
                                 &from_name.item,
                                 *oid,
+                                *schema_id,
                                 *key_id,
                                 *value_id,
                                 -1,
@@ -2512,6 +2517,7 @@ where
                                 *id,
                                 &to_name.item,
                                 *oid,
+                                *schema_id,
                                 *key_id,
                                 *value_id,
                                 1,
@@ -2643,6 +2649,7 @@ where
                                 entry.id(),
                                 &entry.name().item,
                                 entry.oid(),
+                                *schema_id,
                                 *key_id,
                                 *value_id,
                                 -1,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -657,6 +657,7 @@ where
             ExecuteResponse::DroppedSink => command_complete!("DROP SINK"),
             ExecuteResponse::DroppedTable => command_complete!("DROP TABLE"),
             ExecuteResponse::DroppedView => command_complete!("DROP VIEW"),
+            ExecuteResponse::DroppedType => command_complete!("DROP TYPE"),
             ExecuteResponse::EmptyQuery => {
                 self.conn.send(BackendMessage::EmptyQueryResponse).await?;
                 Ok(State::Ready)

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -791,6 +791,7 @@ impl AstDisplay for ShowObjectsStatement {
             ObjectType::View => "VIEWS",
             ObjectType::Source => "SOURCES",
             ObjectType::Sink => "SINKS",
+            ObjectType::Type => "TYPES",
             ObjectType::Index => unreachable!(),
         });
         if let Some(from) = &self.from {
@@ -1066,6 +1067,7 @@ pub enum ObjectType {
     Source,
     Sink,
     Index,
+    Type,
 }
 
 impl AstDisplay for ObjectType {
@@ -1077,6 +1079,7 @@ impl AstDisplay for ObjectType {
             ObjectType::Source => "SOURCE",
             ObjectType::Sink => "SINK",
             ObjectType::Index => "INDEX",
+            ObjectType::Type => "TYPE",
         })
     }
 }

--- a/src/sql-parser/src/keywords.rs
+++ b/src/sql-parser/src/keywords.rs
@@ -476,6 +476,7 @@ define_keywords!(
     TRUNCATE,
     TYPE,
     TYPED,
+    TYPES,
     UESCAPE,
     UNBOUNDED,
     UNCOMMITTED,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1645,7 +1645,7 @@ impl Parser {
 
     fn parse_drop(&mut self) -> Result<Statement, ParserError> {
         let object_type = match self.parse_one_of_keywords(&[
-            "DATABASE", "SCHEMA", "TABLE", "VIEW", "SOURCE", "SINK", "INDEX",
+            "DATABASE", "SCHEMA", "TABLE", "VIEW", "SOURCE", "SINK", "INDEX", "TYPE",
         ]) {
             Some("DATABASE") => {
                 return Ok(Statement::DropDatabase(DropDatabaseStatement {
@@ -1659,10 +1659,11 @@ impl Parser {
             Some("SOURCE") => ObjectType::Source,
             Some("SINK") => ObjectType::Sink,
             Some("INDEX") => ObjectType::Index,
+            Some("TYPE") => ObjectType::Type,
             _ => {
                 return self.expected(
                     self.peek_range(),
-                    "DATABASE, SCHEMA, TABLE, VIEW, SOURCE, SINK, or INDEX after DROP",
+                    "DATABASE, SCHEMA, TABLE, VIEW, SOURCE, SINK, INDEX, or TYPE after DROP",
                     self.peek_token(),
                 )
             }
@@ -2575,7 +2576,7 @@ impl Parser {
         let extended = self.parse_keyword("EXTENDED");
         if extended {
             self.expect_one_of_keywords(&[
-                "SCHEMAS", "INDEX", "INDEXES", "KEYS", "TABLES", "COLUMNS", "FULL",
+                "SCHEMAS", "INDEX", "INDEXES", "KEYS", "TABLES", "COLUMNS", "TYPES", "FULL",
             ])?;
             self.prev_token();
         }
@@ -2583,12 +2584,13 @@ impl Parser {
         let full = self.parse_keyword("FULL");
         if full {
             if extended {
-                self.expect_one_of_keywords(&["SCHEMAS", "COLUMNS", "TABLES"])?;
+                self.expect_one_of_keywords(&["SCHEMAS", "COLUMNS", "TABLES", "TYPES"])?;
             } else {
                 self.expect_one_of_keywords(&[
                     "SCHEMAS",
                     "COLUMNS",
                     "TABLES",
+                    "TYPES",
                     "VIEWS",
                     "SINKS",
                     "SOURCES",
@@ -2607,7 +2609,7 @@ impl Parser {
         if self.parse_one_of_keywords(&["COLUMNS", "FIELDS"]).is_some() {
             self.parse_show_columns(extended, full)
         } else if let Some(object_type) =
-            self.parse_one_of_keywords(&["SCHEMAS", "SOURCES", "VIEWS", "SINKS", "TABLES"])
+            self.parse_one_of_keywords(&["SCHEMAS", "SOURCES", "VIEWS", "SINKS", "TABLES", "TYPES"])
         {
             Ok(Statement::ShowObjects(ShowObjectsStatement {
                 object_type: match object_type {
@@ -2616,6 +2618,7 @@ impl Parser {
                     "VIEWS" => ObjectType::View,
                     "SINKS" => ObjectType::Sink,
                     "TABLES" => ObjectType::Table,
+                    "TYPES" => ObjectType::Type,
                     val => panic!(
                         "`parse_one_of_keywords` returned an impossible value: {}",
                         val

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1574,7 +1574,8 @@ fn handle_drop_objects(
         | ObjectType::Table
         | ObjectType::View
         | ObjectType::Index
-        | ObjectType::Sink => handle_drop_items(scx, object_type, if_exists, names, cascade),
+        | ObjectType::Sink
+        | ObjectType::Type => handle_drop_items(scx, object_type, if_exists, names, cascade),
     }
 }
 
@@ -1810,7 +1811,8 @@ impl PartialEq<ObjectType> for CatalogItemType {
             | (CatalogItemType::Table, ObjectType::Table)
             | (CatalogItemType::Sink, ObjectType::Sink)
             | (CatalogItemType::View, ObjectType::View)
-            | (CatalogItemType::Index, ObjectType::Index) => true,
+            | (CatalogItemType::Index, ObjectType::Index)
+            | (CatalogItemType::Type, ObjectType::Type) => true,
             (_, _) => false,
         }
     }

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -9,16 +9,42 @@
 
 > SELECT * FROM mz_map_types;
 
-> CREATE TYPE bool AS MAP (key_type=text, value_type='int4');
+> SHOW TYPES
 
-> CREATE TYPE custom AS MAP (key_type='text', value_type=bool);
+> CREATE TYPE bool AS MAP (key_type=text, value_type='int4')
+
+> CREATE TYPE custom AS MAP (key_type='text', value_type=bool)
 
 # Without qualifiers, should default to builtin bool.
 > SELECT mz_internal.mz_classify_object_id(value_id) FROM mz_map_types WHERE name = 'custom'
 system
 
-> CREATE TYPE another_custom AS MAP (key_type='text', value_type=public.bool);
+> CREATE TYPE another_custom AS MAP (key_type='text', value_type=public.bool)
 
 # Qualified name should point to user-defined bool.
 > SELECT mz_internal.mz_classify_object_id(value_id) FROM mz_map_types WHERE name = 'another_custom'
 user
+
+> SHOW TYPES
+name
+----
+another_custom
+bool
+custom
+
+> SHOW FULL TYPES
+name             type
+----------------------
+bool             user
+custom           user
+another_custom   user
+
+! DROP TYPE bool
+cannot drop item pg_catalog.bool because it is required by the database system
+
+! DROP TYPE public.bool
+cannot drop materialize.public.bool: still depended upon by catalog item 'materialize.public.another_custom'
+
+> DROP TYPE another_custom
+
+> DROP TYPE public.bool

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -1,0 +1,89 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Without EXTENDED, SHOW TYPES shouldn't have anything to return.
+> SHOW TYPES
+
+> SHOW FULL TYPES
+
+> SHOW EXTENDED TYPES
+name
+----
+_bool
+_bytea
+_date
+_float4
+_float8
+_int4
+_int8
+_interval
+_jsonb
+_numeric
+_oid
+_record
+_text
+_time
+_timestamp
+_timestamptz
+_uuid
+bool
+bytea
+date
+float4
+float8
+int4
+int8
+interval
+jsonb
+numeric
+oid
+record
+text
+time
+timestamp
+timestamptz
+uuid
+
+> SHOW EXTENDED FULL TYPES
+name             type
+----------------------
+_bool            system
+_bytea           system
+_date            system
+_float4          system
+_float8          system
+_int4            system
+_int8            system
+_interval        system
+_jsonb           system
+_numeric         system
+_oid             system
+_record          system
+_text            system
+_time            system
+_timestamp       system
+_timestamptz     system
+_uuid            system
+bool             system
+bytea            system
+date             system
+float4           system
+float8           system
+int4             system
+int8             system
+interval         system
+jsonb            system
+numeric          system
+oid              system
+record           system
+text             system
+time             system
+timestamp        system
+timestamptz      system
+uuid             system


### PR DESCRIPTION
Adds support for `SHOW TYPE` and `DROP TYPE`. `SHOW TYPE` supports the `'full'`
and `'extended'` query options. Like other system objects, builtin types cannot
be dropped. Like other catalog objects, a user-defined type can only be
dropped if there is no dependency on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4721)
<!-- Reviewable:end -->
