### PR TITLE
coord: always remember to replace mz_logical_timestamp

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -287,6 +287,12 @@ impl<R> fmt::Debug for FuncImpl<R> {
     }
 }
 
+impl From<NullaryFunc> for Operation<ScalarExpr> {
+    fn from(n: NullaryFunc) -> Operation<ScalarExpr> {
+        Operation::nullary(move |_ecx| Ok(ScalarExpr::CallNullary(n.clone())))
+    }
+}
+
 impl From<UnaryFunc> for Operation<ScalarExpr> {
     fn from(u: UnaryFunc) -> Operation<ScalarExpr> {
         Operation::unary(move |_ecx, e| Ok(e.call_unary(u.clone())))
@@ -1450,14 +1456,7 @@ lazy_static! {
                 vec![ListElementAny, ListAny] => BinaryFunc::ElementListConcat
             },
             "mz_logical_timestamp" => Scalar {
-                params!() => Operation::nullary(|ecx| {
-                    match ecx.qcx.lifetime {
-                        QueryLifetime::OneShot => {
-                            Ok(ScalarExpr::CallNullary(NullaryFunc::MzLogicalTimestamp))
-                        }
-                        QueryLifetime::Static => bail!("mz_logical_timestamp cannot be used in static queries"),
-                    }
-                })
+                params!() => NullaryFunc::MzLogicalTimestamp
             },
             "mz_cluster_id" => Scalar {
                 params!() => Operation::nullary(mz_cluster_id)

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -617,7 +617,7 @@ pub mod negate_predicate {
     impl NegatePredicate {
         /// Transforms `NOT(a <op> b)` to `a negate(<op>) b` if it exists.
         pub fn action(&self, relation: &mut RelationExpr) {
-            relation.visit_scalars_mut(&mut |x| negate_predicate(x))
+            relation.visit_scalars_mut(&mut |x| x.visit_mut(&mut negate_predicate))
         }
     }
 

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -226,3 +226,13 @@ EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW ordered_view
 | | keys = ()
 
 EOF
+
+# Ensure mz_logical_timestamp doesn't panic in the context of EXPLAIN, which
+# doesn't actually execute the query at any particular timestamp.
+query T multiline
+EXPLAIN SELECT mz_logical_timestamp()
+----
+%0 =
+| Constant (0dec)
+
+EOF

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -179,12 +179,15 @@ a       b
 ! INSERT INTO s VALUES (1 + NULL);
 NULL value in column a violates not-null constraint
 
-> CREATE TABLE v (a timestamptz);
+> CREATE TABLE v (a timestamptz, b decimal(38, 0));
 
-> INSERT INTO v VALUES (now());
+> INSERT INTO v VALUES (now(), mz_logical_timestamp());
 
-! INSERT INTO v VALUES (mz_logical_timestamp());
-column "a" is of type timestamptz but expression is of type numeric
+! CREATE INDEX ON v (now())
+now cannot be used in static queries
+
+! CREATE INDEX ON v (mz_logical_timestamp())
+mz_logical_timestamp cannot be used in static queries
 
 > DROP TABLE IF EXISTS s;
 


### PR DESCRIPTION
Optimizing an expression that calls mz_logical_timestamp will panic. Previously, the coordinator was responsible for replacing calls to mz_logical_timestamp, except for in contexts where the SQL planner had promised not to permit calls to mz_logical_timestamp. This was hard to keep track of, and several code paths miscommunicated on their responsibilities.

Rework so that the SQL planner is always willing to plan a call to mz_logical_timestamp, and the coordinator has the sole responsibility of either replacing that call with the actual timestamp, or rejecting the query. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4736)
<!-- Reviewable:end -->
