### PR TITLE
Update .deb package

### DIFF
--- a/misc/dist/materialized.service
+++ b/misc/dist/materialized.service
@@ -17,3 +17,6 @@ User=_Materialize
 Group=_Materialize
 
 ExecStart=/usr/bin/materialized -D /var/lib/materialize/mzdata -w 1
+
+[Install]
+WantedBy=multi-user.target

--- a/misc/dist/materialized.service
+++ b/misc/dist/materialized.service
@@ -16,7 +16,7 @@ Type=exec
 User=_Materialize
 Group=_Materialize
 
-ExecStart=/usr/bin/materialized -D /var/lib/materialize/mzdata -w 1
+ExecStart=/usr/bin/materialized -D /var/lib/materialize/mzdata
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Two changes:
1. Provides an install target so `systemctl enable materialized.service` will succeed
2. Removes the hard-coded number of workers to take advantage of the new default behavior in 0.5.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4737)
<!-- Reviewable:end -->
