### PR TITLE
sql-parser: standardize WITH options parsing

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,8 @@ Wrap your release notes at the 80 character mark.
 - Support the [`pg_typeof` function](/sql/functions#postgresql-compatibility-func).
 - [`COPY TO`](/sql/copy-to) now supports `FORMAT binary`.
 - [`TAIL`](/sql/tail) is now guaranteed to produce output ordered by timestamp.
+- Syntax for [`TAIL`](/sql/tail) has changed. `WITH SNAPSHOT` is now
+  `WITH (SNAPSHOT)`. `WITHOUT SNAPSHOT` is now `WITH (SNAPSHOT = false)`.
 
 {{% version-header v0.5.1 %}}
 
@@ -352,7 +354,7 @@ Wrap your release notes at the 80 character mark.
   for `CREATE SINK` to provide more control over what data the sink will
   produce.
 
-- Change the default [`TAIL` snapshot behavior](/sql/tail/#with-snapshot-or-without-snapshot)
+- Change the default [`TAIL` snapshot behavior](/sql/tail/#snapshot)
   from `WITHOUT SNAPSHOT` to `WITH SNAPSHOT`. **Backwards-incompatible change.**
 
 - Actively shut down [Kafka sinks](https://materialize.com/docs/sql/create-sink/#kafka-sinks)

--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -24,6 +24,12 @@ Field | Use
 _object&lowbar;name_ | The item you want to tail
 _timestamp&lowbar;expression_ | The logical time to tail from onwards (either a number of milliseconds since the Unix epoch, or a `TIMESTAMP` or `TIMESTAMPTZ`).
 
+Supported `option` values:
+
+Name | Type
+-----|-------
+`SNAPSHOT` | `bool`, see [SNAPSHOT](#snapshot)
+
 ## Details
 
 ### Output
@@ -48,16 +54,25 @@ string in a trailing [`text`](/sql/types/text) column.
 a [`COPY TO`](/sql/copy-to) statement.
 {{</ version-changed >}}
 
+{{< version-changed v0.5.2 >}}
+`TAIL` is now guaranteed to send timestamps in non-decreasing order.
+{{</ version-changed >}}
+
+{{< version-changed v0.5.2 >}}
+Syntax has changed. `WITH SNAPSHOT` is now `WITH (SNAPSHOT)`.
+`WITHOUT SNAPSHOT` is now `WITH (SNAPSHOT = false)`.
+{{</ version-changed >}}
+
 ### AS OF
 
 `AS OF` is the specific point in time to start reporting all events for a given `TAIL`. If you don't
 use `AS OF`, Materialize will pick a timestamp itself.
 
-### WITH SNAPSHOT or WITHOUT SNAPSHOT
+### SNAPSHOT
 
 By default, each TAIL is created with a `SNAPSHOT` which contains the results of the query at its `AS OF` timestamp.
 Any further updates to these results are produced at the time when they occur. To only see results after the
-`AS OF` timestamp, specify `WITHOUT SNAPSHOT`.
+`AS OF` timestamp, specify `WITH (SNAPSHOT = false)`.
 
 ## Example
 

--- a/doc/user/layouts/partials/sql-grammar/tail-stmt.svg
+++ b/doc/user/layouts/partials/sql-grammar/tail-stmt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="447" height="199">
+<svg xmlns="http://www.w3.org/2000/svg" width="635" height="281">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="50" height="32" rx="10"/>
@@ -12,35 +12,65 @@
    <rect x="101" y="3" width="100" height="32"/>
    <rect x="99" y="1" width="100" height="32" class="nonterminal"/>
    <text class="nonterminal" x="109" y="21">object_name</text>
-   <rect x="241" y="35" width="136" height="32" rx="10"/>
-   <rect x="239"
-         y="33"
-         width="136"
+   <rect x="65" y="145" width="56" height="32" rx="10"/>
+   <rect x="63"
+         y="143"
+         width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="249" y="53">WITH SNAPSHOT</text>
-   <rect x="241" y="79" width="164" height="32" rx="10"/>
-   <rect x="239"
-         y="77"
-         width="164"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="249" y="97">WITHOUT SNAPSHOT</text>
-   <rect x="161" y="165" width="60" height="32" rx="10"/>
+   <text class="terminal" x="73" y="163">WITH</text>
+   <rect x="161" y="113" width="24" height="32" rx="10"/>
    <rect x="159"
-         y="163"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="169" y="131">(</text>
+   <rect x="225" y="113" width="100" height="32"/>
+   <rect x="223" y="111" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="233" y="131">option_name</text>
+   <rect x="365" y="145" width="26" height="32" rx="10"/>
+   <rect x="363"
+         y="143"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="373" y="163">=</text>
+   <rect x="411" y="145" width="98" height="32"/>
+   <rect x="409" y="143" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="419" y="163">option_value</text>
+   <rect x="225" y="69" width="24" height="32" rx="10"/>
+   <rect x="223"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="233" y="87">,</text>
+   <rect x="569" y="113" width="24" height="32" rx="10"/>
+   <rect x="567"
+         y="111"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="577" y="131">)</text>
+   <rect x="349" y="247" width="60" height="32" rx="10"/>
+   <rect x="347"
+         y="245"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="169" y="183">AS OF</text>
-   <rect x="241" y="165" width="158" height="32"/>
-   <rect x="239" y="163" width="158" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="249" y="183">timestamp_expression</text>
+   <text class="terminal" x="357" y="265">AS OF</text>
+   <rect x="429" y="247" width="158" height="32"/>
+   <rect x="427" y="245" width="158" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="437" y="265">timestamp_expression</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m50 0 h10 m0 0 h10 m100 0 h10 m20 0 h10 m0 0 h174 m-204 0 h20 m184 0 h20 m-224 0 q10 0 10 10 m204 0 q0 -10 10 -10 m-214 10 v12 m204 0 v-12 m-204 12 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m136 0 h10 m0 0 h28 m-194 -10 v20 m204 0 v-20 m-204 20 v24 m204 0 v-24 m-204 24 q0 10 10 10 m184 0 q10 0 10 -10 m-194 10 h10 m164 0 h10 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-328 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
-   <polygon points="437 147 445 143 445 151"/>
-   <polygon points="437 147 429 143 429 151"/>
+         d="m17 17 h2 m0 0 h10 m50 0 h10 m0 0 h10 m100 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-220 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m24 0 h10 m20 0 h10 m100 0 h10 m20 0 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h10 m98 0 h10 m-324 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m324 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-324 0 h10 m24 0 h10 m0 0 h280 m20 44 h10 m24 0 h10 m-588 0 h20 m568 0 h20 m-608 0 q10 0 10 10 m588 0 q0 -10 10 -10 m-598 10 v46 m588 0 v-46 m-588 46 q0 10 10 10 m568 0 q10 0 10 -10 m-578 10 h10 m0 0 h558 m22 -66 l2 0 m2 0 l2 0 m2 0 l2 0 m-328 102 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
+   <polygon points="625 229 633 225 633 233"/>
+   <polygon points="625 229 617 225 617 233"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -246,7 +246,7 @@ table_ref ::=
   ) ('AS'? table_alias ('(' col_alias (',' col_alias)* ')'))?
 tail_stmt ::=
     'TAIL' object_name
-    ('WITH SNAPSHOT' | 'WITHOUT SNAPSHOT')?
+    ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
     ('AS OF' timestamp_expression)?
 time_unit ::=
   'YEAR' | 'MONTH' | 'DAY' | 'HOUR' | 'MINUTE' | 'SECOND'

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -160,12 +160,12 @@ fn test_tail_basic() -> Result<(), Box<dyn Error>> {
     assert!(tail_reader.next().is_none());
     drop(tail_reader);
 
-    // Now tail WITHOUT SNAPSHOT AS OF each timestamp, verifying that when we do so we only see events
+    // Now tail WITH (SNAPSHOT = false) AS OF each timestamp, verifying that when we do so we only see events
     // that occur as of or later than that timestamp.
     for (ts, _) in &events {
         let cancel_token = client.cancel_token();
         let q = format!(
-            "COPY (TAIL dynamic_csv WITHOUT SNAPSHOT AS OF {}) TO STDOUT",
+            "COPY (TAIL dynamic_csv WITH (SNAPSHOT = false) AS OF {}) TO STDOUT",
             ts - 1
         );
         let mut tail_reader = client.copy_out(q.as_str())?.split(b'\n');
@@ -228,7 +228,7 @@ fn test_tail_empty_upper_frontier() -> Result<(), Box<dyn Error>> {
     thread::sleep(Duration::from_millis(100));
 
     let mut tail_reader = client
-        .copy_out("COPY (TAIL foo WITHOUT SNAPSHOT) TO STDOUT")?
+        .copy_out("COPY (TAIL foo WITH (SNAPSHOT = false)) TO STDOUT")?
         .split(b'\n');
     let mut without_snapshot_count = 0;
     while let Some(_value) = tail_reader.next().transpose()? {
@@ -238,7 +238,7 @@ fn test_tail_empty_upper_frontier() -> Result<(), Box<dyn Error>> {
     drop(tail_reader);
 
     let mut tail_reader = client
-        .copy_out("COPY (TAIL foo WITH SNAPSHOT) TO STDOUT")?
+        .copy_out("COPY (TAIL foo WITH (SNAPSHOT)) TO STDOUT")?
         .split(b'\n');
     let mut with_snapshot_count = 0;
     while let Some(_value) = tail_reader.next().transpose()? {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -35,7 +35,6 @@ Avro
 Begin
 Between
 Bigint
-Binary
 Bool
 Boolean
 Both

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -44,16 +44,16 @@ Copy(CopyStatement { relation: Table { name: ObjectName([Ident("t")]), columns: 
 parse-statement
 COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
-COPY t TO STDOUT WITH (FORMAT TEXT)
+COPY t TO STDOUT WITH (format = text)
 =>
-Copy(CopyStatement { relation: Table { name: ObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [Format("TEXT")] })
+Copy(CopyStatement { relation: Table { name: ObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(ObjectName([Ident("text")]))) }] })
 
 parse-statement
-COPY t TO STDOUT (FORMAT text)
+COPY t TO STDOUT (format = text)
 ----
-COPY t TO STDOUT WITH (FORMAT TEXT)
+COPY t TO STDOUT WITH (format = text)
 =>
-Copy(CopyStatement { relation: Table { name: ObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [Format("TEXT")] })
+Copy(CopyStatement { relation: Table { name: ObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(ObjectName([Ident("text")]))) }] })
 
 parse-statement
 COPY t TO STDOUT ()
@@ -62,7 +62,7 @@ error:
 Parse error:
 COPY t TO STDOUT ()
                   ^
-Expected one of FORMAT, found right parenthesis
+Expected identifier, found right parenthesis
 
 parse-statement
 COPY t TO STDIN

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -696,30 +696,46 @@ DropObjects(DropObjectsStatement { object_type: Index, if_exists: true, names: [
 parse-statement
 TAIL foo.bar
 ----
-TAIL foo.bar WITH SNAPSHOT
+TAIL foo.bar
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: None })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [], as_of: None })
 
 parse-statement
 TAIL foo.bar AS OF 123
 ----
-TAIL foo.bar WITH SNAPSHOT AS OF 123
+TAIL foo.bar AS OF 123
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Value(Number("123"))) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [], as_of: Some(Value(Number("123"))) })
 
 parse-statement
 TAIL foo.bar AS OF now()
 ----
-TAIL foo.bar WITH SNAPSHOT AS OF now()
+TAIL foo.bar AS OF now()
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: true, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [], as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
 
 parse-statement
-TAIL foo.bar WITHOUT SNAPSHOT AS OF now()
+TAIL foo.bar WITH (SNAPSHOT) AS OF now()
 ----
-TAIL foo.bar WITHOUT SNAPSHOT AS OF now()
+TAIL foo.bar WITH (snapshot) AS OF now()
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), with_snapshot: false, as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+
+parse-statement
+TAIL foo.bar WITH (SNAPSHOT = false) AS OF now()
+----
+TAIL foo.bar WITH (snapshot = false) AS OF now()
+=>
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }], as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+
+parse-statement
+TAIL foo.bar WITH (SNAPSHOT false)
+----
+error:
+Parse error:
+TAIL foo.bar WITH (SNAPSHOT false)
+                            ^^^^^
+Expected equals sign, found FALSE
 
 parse-statement
 CREATE TABLE public.customer (


### PR DESCRIPTION
There are currently five ways `WITH` is used in our grammar when configuring options:

1. `WITH SNAPSHOT`
2. `WITHOUT SNAPSHOT`
3. `WITH (option value)`
4. `WITH (option = value)`
5. `WITH (option)`

We want to reduce this to some more standard form. Postgres has historic
support for `WITHOUT` but does not appear to have used it since, and
so we would like to remove that keyword. `WITH KEYWORD` doesn't support
multiple options or arguments to them, so we would also like to remove
it. Both of these have been replaced with 4 and 5 from the above list.

`COPY` is a bit special in that we would like to preserve its backward
compat with most existing Postgres applications, so it is allowed to
omit the `=` between option names and values. `COPY` has no user-facing
changes due to this.

`TAIL` has thus had a breaking syntax change. Due to all of the recent
churn with `TAIL` we think it's ok to not preserve backward compat in
its syntax.

Other statements that use `WITH` and `WITHOUT` will be changed in
the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4740)
<!-- Reviewable:end -->
