### PR TITLE
Updates for COPY panic

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,6 +54,13 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.5.1 %}}
 
+- **Known issue.** [`COPY TO`](/sql/copy-to) panics if executed via the
+  ["simple query" protocol][pgwire-simple], which is notably used by the `psql` command-line client {{% gh 4742 %}}.
+
+  A fix is available in the latest [unstable builds](/versions/#unstable-builds)
+  and will ship in v0.5.2. In the meantime, you can use a PostgreSQL driver that supports the ["extended query" protocol][pgwire-extended], and use only the
+  extended query protocol to issue `COPY TO` statements.
+
 - Send the rows returned by the [`TAIL`](/sql/tail) statement to the client
   normally (i.e., as if the rows were returned by a [`SELECT`](/sql/select)
   statement) rather than via the PostgreSQL [`COPY` protocol][pg-copy]. The new
@@ -706,4 +713,6 @@ Wrap your release notes at the 80 character mark.
 [`timestamp`]: /sql/types/timestamp
 [`timestamptz`]: /sql/types/timestamptz
 [pg-copy]: https://www.postgresql.org/docs/current/sql-copy.html
+[pgwire-simple]: https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4
+[pgwire-extended]: https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY
 [PgJDBC]: https://jdbc.postgresql.org

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -55,11 +55,16 @@ Wrap your release notes at the 80 character mark.
 {{% version-header v0.5.1 %}}
 
 - **Known issue.** [`COPY TO`](/sql/copy-to) panics if executed via the
-  ["simple query" protocol][pgwire-simple], which is notably used by the `psql` command-line client {{% gh 4742 %}}.
+  ["simple query" protocol][pgwire-simple], which is notably used by the
+  `psql` command-line client {{% gh 4742 %}}.
 
   A fix is available in the latest [unstable builds](/versions/#unstable-builds)
-  and will ship in v0.5.2. In the meantime, you can use a PostgreSQL driver that supports the ["extended query" protocol][pgwire-extended], and use only the
-  extended query protocol to issue `COPY TO` statements.
+  and will ship in v0.5.2.
+
+  Note that some PostgreSQL clients instead use the
+  ["extended query" protocol][pgwire-extended] to issue `COPY TO` statements,
+  or let you choose which protocol to use. If you are using one of these
+  clients, you can safely issue `COPY TO` statements in v0.5.1.
 
 - Send the rows returned by the [`TAIL`](/sql/tail) statement to the client
   normally (i.e., as if the rows were returned by a [`SELECT`](/sql/select)

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -188,21 +188,12 @@ impl Session {
 pub struct PreparedStatement {
     sql: Option<Statement>,
     desc: StatementDesc,
-    param_types: Vec<pgrepr::Type>,
 }
 
 impl PreparedStatement {
     /// Constructs a new prepared statement.
-    pub fn new(
-        sql: Option<Statement>,
-        desc: StatementDesc,
-        param_types: Vec<pgrepr::Type>,
-    ) -> PreparedStatement {
-        PreparedStatement {
-            sql,
-            desc,
-            param_types,
-        }
+    pub fn new(sql: Option<Statement>, desc: StatementDesc) -> PreparedStatement {
+        PreparedStatement { sql, desc }
     }
 
     /// Returns the raw SQL string associated with this prepared statement,
@@ -211,25 +202,9 @@ impl PreparedStatement {
         self.sql.as_ref()
     }
 
-    /// Returns the type of the rows that will be returned by this prepared
-    /// statement, if this prepared statement will return rows at all.
+    /// Returns the description of the prepared statement.
     pub fn desc(&self) -> &StatementDesc {
         &self.desc
-    }
-
-    /// Returns the types of any parameters in this prepared statement.
-    pub fn param_types(&self) -> &[pgrepr::Type] {
-        &self.param_types
-    }
-
-    /// Reports the number of columns in the statement's result set, or zero if
-    /// the statement does not return rows.
-    pub fn result_width(&self) -> usize {
-        self.desc
-            .relation_desc
-            .as_ref()
-            .map(|desc| desc.typ().column_types.len())
-            .unwrap_or(0)
     }
 }
 

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -195,6 +195,13 @@ impl PgTest {
                         )?,
                     ),
                     Message::CopyDone => ("CopyDone", "".to_string()),
+                    Message::ParameterDescription(body) => (
+                        "ParameterDescription",
+                        serde_json::to_string(&ParameterDescription {
+                            parameters: body.parameters().collect().unwrap(),
+                        })?,
+                    ),
+                    Message::NoData => ("NoData", "".to_string()),
                     _ => ("UNKNOWN", format!("'{}'", ch)),
                 };
                 let mut s = typ.to_string();
@@ -260,6 +267,11 @@ pub struct DataRow {
 pub struct CopyOut {
     pub format: String,
     pub column_formats: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct ParameterDescription {
+    parameters: Vec<u32>,
 }
 
 #[derive(Serialize)]
@@ -339,6 +351,9 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: &str, user: &str, timeout: 
                             {
                                 panic!("bind error");
                             }
+                        }
+                        "Describe" => {
+                            frontend::describe(b'S', "", buf).unwrap();
                         }
                         "Execute" => {
                             let v: Execute = serde_json::from_str(args).unwrap();

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -34,7 +34,6 @@ use serde::{Deserialize, Serialize};
 use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{SinkConnectorBuilder, SourceConnector};
 use repr::{ColumnName, RelationDesc, Row, ScalarType, Timestamp};
-use statement::describe_statement;
 
 use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use crate::catalog::Catalog;
@@ -292,17 +291,13 @@ pub fn plan(
     statement::handle_statement(pcx, catalog, stmt, params)
 }
 
-/// Determines the type of the rows that will be returned by `stmt` and the type
-/// of the parameters required by `stmt`. If the statement will not produce a
-/// result set (e.g., most `CREATE` or `DROP` statements), no `RelationDesc`
-/// will be returned. If the query uses no parameters, then the returned vector
-/// of types will be empty.
+/// Creates a description of the purified statement `stmt`.
+///
+/// See the documentation of [`StatementDesc`] for details.
 pub fn describe(
     catalog: &dyn Catalog,
     stmt: Statement,
     param_types: &[Option<pgrepr::Type>],
-) -> Result<(StatementDesc, Vec<pgrepr::Type>), anyhow::Error> {
-    let desc = describe_statement(catalog, stmt, param_types)?;
-    let types = desc.param_types.iter().map(pgrepr::Type::from).collect();
-    Ok((desc, types))
+) -> Result<StatementDesc, anyhow::Error> {
+    statement::describe_statement(catalog, stmt, param_types)
 }

--- a/src/sql/tests/parameters.rs
+++ b/src/sql/tests/parameters.rs
@@ -78,8 +78,8 @@ fn test_parameter_type_inference() -> Result<(), Box<dyn Error>> {
     for (sql, types) in test_cases {
         println!("> {}", sql);
         let stmt = sql::parse::parse(sql.into())?.into_element();
-        let (_desc, param_types) = sql::plan::describe(&DummyCatalog, stmt, &[])?;
-        assert_eq!(param_types, types);
+        let desc = sql::plan::describe(&DummyCatalog, stmt, &[])?;
+        assert_eq!(desc.param_types, types);
     }
     Ok(())
 }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -748,7 +748,7 @@ impl State {
             .get_prepared_statement(&statement_name)
             .expect("unnamed prepared statement missing");
         let desc = stmt.desc().relation_desc.clone();
-        let result_formats = vec![pgrepr::Format::Text; stmt.result_width()];
+        let result_formats = vec![pgrepr::Format::Text; stmt.desc().arity()];
         self.coord_client.session().set_portal(
             portal_name.clone(),
             statement_name,

--- a/test/pgtest/copy.pt
+++ b/test/pgtest/copy.pt
@@ -19,6 +19,7 @@ ReadyForQuery {"status":"I"}
 send
 Parse {"query": "COPY (VALUES (1, '2'), (3, '4'), (5, '\\\t\n\rtest\\N'), (6, NULL) ORDER BY column1) TO STDOUT"}
 Bind
+Describe
 Execute
 Sync
 ----
@@ -28,6 +29,8 @@ ReadyForQuery
 ----
 ParseComplete
 BindComplete
+ParameterDescription {"parameters":[]}
+NoData
 CopyOut {"format":"text","column_formats":["text","text"]}
 CopyData "1\t2\n"
 CopyData "3\t4\n"


### PR DESCRIPTION
`COPY ... TO STDOUT` panics on v0.5.1 if executed via the simple query protocol, as psql does (#4742). The bug is already fixed on main, but document it as a known issue with v0.5.1.

Also clean up the `StatementDesc` interface a bit in a way that I think would have made the bug less likely to occur in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4746)
<!-- Reviewable:end -->
