### PR TITLE
name our logging dataflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,7 +4195,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#a025087e1c2cb523115a6bd8e0b173271515def9"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4210,12 +4210,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#a025087e1c2cb523115a6bd8e0b173271515def9"
 
 [[package]]
 name = "timely_communication"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#a025087e1c2cb523115a6bd8e0b173271515def9"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4231,7 +4231,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#b8338e52626933a95716f65d63b96666d8199c77"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#a025087e1c2cb523115a6bd8e0b173271515def9"
 
 [[package]]
 name = "timely_sort"

--- a/src/dataflow/src/logging/differential.rs
+++ b/src/dataflow/src/logging/differential.rs
@@ -29,7 +29,7 @@ pub fn construct<A: Allocate>(
 ) -> std::collections::HashMap<LogVariant, (Vec<usize>, KeysValsHandle)> {
     let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
 
-    let traces = worker.dataflow(move |scope| {
+    let traces = worker.dataflow_named("Dataflow: differential logging", move |scope| {
         use differential_dataflow::collection::AsCollection;
         use timely::dataflow::operators::capture::Replay;
         use timely::dataflow::operators::Map;

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -83,7 +83,7 @@ pub fn construct<A: Allocate>(
 ) -> std::collections::HashMap<LogVariant, (Vec<usize>, KeysValsHandle)> {
     let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
 
-    let traces = worker.dataflow(move |scope| {
+    let traces = worker.dataflow_named("Dataflow: mz logging", move |scope| {
         use differential_dataflow::collection::AsCollection;
         use timely::dataflow::operators::capture::Replay;
         use timely::dataflow::operators::Map;

--- a/src/dataflow/src/logging/timely.rs
+++ b/src/dataflow/src/logging/timely.rs
@@ -36,7 +36,7 @@ pub fn construct<A: Allocate>(
     let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
 
     // A dataflow for multiple log-derived arrangements.
-    let traces = worker.dataflow(move |scope| {
+    let traces = worker.dataflow_named("Dataflow: timely logging", move |scope| {
         use differential_dataflow::collection::AsCollection;
         use timely::dataflow::operators::capture::Replay;
         use timely::dataflow::operators::Map;

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -381,11 +381,13 @@ where
             }),
         );
 
-        let errs = self.timely_worker.dataflow::<Timestamp, _, _>(|scope| {
-            Collection::<_, DataflowError, isize>::empty(scope)
-                .arrange()
-                .trace
-        });
+        let errs = self
+            .timely_worker
+            .dataflow_named("Dataflow: logging", |scope| {
+                Collection::<_, DataflowError, isize>::empty(scope)
+                    .arrange()
+                    .trace
+            });
 
         let logger = self
             .timely_worker


### PR DESCRIPTION
Name our logging dataflows so they're easy to tell apart when logging the loggers.

Previously:
```
materialize=> select * from mz_records_per_dataflow;
 id  |                              name                               | worker | records 
-----+-----------------------------------------------------------------+--------+---------
   7 | Dataflow                                                        |      0 |   11645
 126 | Dataflow                                                        |      0 |     335
 157 | Dataflow                                                        |      0 |     284
 405 | Dataflow: mz_catalog.mz_sinks_primary_idx                       |      0 |       0
...
```

Now:
```
materialize=> select * from mz_records_per_dataflow;
 id  |                         name                          | worker | records 
-----+-------------------------------------------------------+--------+---------
 157 | Dataflow: mz logging                                  |      0 |     119
   7 | Dataflow: timely logging                              |      0 |    8819
 126 | Dataflow: differential logging                        |      0 |     308
 405 | Dataflow: mz_catalog.mz_sinks_primary_idx             |      0 |       0
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4747)
<!-- Reviewable:end -->
