### PR TITLE
sql: support complicated INSERT bodies

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2318,7 +2318,10 @@ where
                 self.sequence_send_diffs(id, rows, affected_rows, MutationKind::Insert)
                     .await
             }
-            other => bail!("INSERT statement expected values, found {:?}", other),
+            // If we couldn't optimize the INSERT statement to a constant, it
+            // must depend on another relation. We're not yet sophisticated
+            // enough to handle this.
+            _ => bail!("INSERT statements cannot reference other relations"),
         }
     }
 

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
     Expr, Function, FunctionArgs, Ident, ObjectName, Query, Select, SelectItem, TableAlias,
-    TableWithJoins, Value, Values,
+    TableWithJoins, Value,
 };
 
 use crate::normalize;
@@ -34,10 +34,6 @@ pub fn transform_query<'a>(
 
 pub fn transform_expr(scx: &StatementContext, expr: &mut Expr) -> Result<(), anyhow::Error> {
     run_transforms(scx, |t, expr| t.visit_expr_mut(expr), expr)
-}
-
-pub fn transform_values(scx: &StatementContext, expr: &mut Values) -> Result<(), anyhow::Error> {
-    run_transforms(scx, |t, expr| t.visit_values_mut(expr), expr)
 }
 
 fn run_transforms<F, A>(scx: &StatementContext, mut f: F, ast: &mut A) -> Result<(), anyhow::Error>

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -116,20 +116,20 @@ a    b
 1    "a"
 > DROP INDEX t_custom_idx
 
-> INSERT INTO t VALUES (2, 'b'), (3, 'c');
+> INSERT INTO t VALUES (2, 'b'), (NULL, 'c');
 
 > SELECT * FROM t;
-a    b
----------
-1    "a"
-2    "b"
-3    "c"
+a      b
+----------
+1      "a"
+2      "b"
+<null> "c"
 
 ! INSERT INTO t DEFAULT VALUES;
 INSERT ... DEFAULT VALUES not yet supported
 
 ! INSERT INTO t SELECT * FROM t;
-complicated INSERT bodies not yet supported
+INSERT statements cannot reference other relations
 
 ! INSERT INTO t VALUES (1);
 INSERT statement specifies 1 columns, but table has 2 columns
@@ -140,13 +140,15 @@ NULL value in column b violates not-null constraint
 ! INSERT INTO t VALUES ('d', 4);
 invalid input syntax for int4: invalid digit found in string: "d"
 
-! INSERT INTO t WITH v AS (SELECT 1) VALUES (1)
-complicated INSERT bodies not yet supported
+# Test that the INSERT body can be a SELECT query.
+> INSERT INTO t SELECT 3, 'd'
 
-> INSERT INTO t VALUES (NULL, 'd');
-
-# Test that literal coercion occurs.
+# Test that literal coercion occurs in simple VALUES clauses....
 > INSERT INTO t VALUES ('4', 'e')
+
+# ...but not in complicated VALUES clauses, per PostgreSQL.
+! INSERT INTO t VALUES ('4', 'e') LIMIT 0
+column "a" is of type int4 but expression is of type text
 
 # Test that assignment casts occur when possible...
 > INSERT INTO t VALUES (5.0, 'f');
@@ -168,8 +170,8 @@ a       b
 ------------
 1       "a"
 2       "b"
-3       "c"
-<null>  "d"
+<null>  "c"
+3       "d"
 4       "e"
 5       "f"
 7       "g"

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -285,7 +285,7 @@ INSERT statement with incomplete column set not yet supported
 INSERT statement with incomplete column set not yet supported
 
 ! INSERT INTO t (a, b) VALUES (1);
-INSERT statement specifies 1 expressions, but table has 2 columns
+INSERT statement specifies 1 columns, but table has 2 columns
 
 ! INSERT INTO t (a, a) VALUES (1, 'str')
 INSERT statement specifies duplicate column


### PR DESCRIPTION
@sploiselle since Jessica is still out, could you take this one?

----

We don't presently support INSERT statements like

    INSERT INTO t1 SELECT * FROM t2

where another table is used as the source of the INSERT. But restricting
the set of allowable queries to

    INSERT INTO t1 VALUES (...)

is a bit *too* restrictive, because a query like

    INSERT INTO t1 SELECT 1, 2

is quite easy to support today. This patch adds support for such
queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4748)
<!-- Reviewable:end -->
