### PR TITLE
SQL+docs: Fix `SHOW FULL MATERIALIZED SOURCES` crash

### DIFF
--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -16,12 +16,26 @@ instances.
 Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show sources from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+**MATERIALIZED** | Only return materialized sources, i.e. those with [indexes](../create-index). Without specifying this option, this command returns all sources, including non-materialized sources.
+**FULL** | Return details about your sources.
 
 ## Details
 
-### Output format
+### Output format for `SHOW FULL SOURCES`
 
-`SHOW SOURCES`'s output is a table with one column, `name`.
+`SHOW FULL SOURCES`'s output is a table, with this structure:
+
+```nofmt
+ name  | type | materialized
+-------+------+--------------
+ ...   | ...  | ...
+```
+
+Field | Meaning
+------|--------
+**name** | The name of the source
+**type** | Whether the source was created by the `user` or the `system`
+**materialized** | Does the source have an in-memory index? For more details, see [`CREATE INDEX`](../create-index)
 
 {{< version-changed v0.5.0 >}}
 The output column is renamed from `SOURCES` to `name`.
@@ -33,7 +47,7 @@ Materialize comes with a number of sources that contain internal statistics
 about the instance's behavior. These are kept in a "hidden" schema called
 `mz_catalog`.
 
-To view the internal statistic sources using:
+To view the internal statistic sources use:
 
 ```sql
 SHOW SOURCES FROM mz_catalog;
@@ -43,6 +57,8 @@ To select from these sources, you must specify that you want to read from the
 source in the `mz_catalog` schema.
 
 ## Examples
+
+### Default behavior
 
 ```sql
 SHOW SCHEMAS;
@@ -63,6 +79,29 @@ SHOW SOURCES;
 ```nofmt
 my_stream_source
 my_file_source
+```
+
+### Only show materialized sources
+
+```sql
+SHOW MATERIALIZED SOURCES;
+```
+```nofmt
+        name
+----------------------
+ my_materialized_source
+```
+
+### Show details about sources
+
+```sql
+SHOW FULL SOURCES
+```
+```nofmt
+            name           | type | materialized
+---------------------------+------+--------------
+ my_nonmaterialized_source | user | f
+ my_materialized_source    | user | t
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -14,15 +14,15 @@ menu:
 
 Field | Use
 ------|-----
-_schema&lowbar;name_ | The schema to show sources from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+_schema&lowbar;name_ | The schema to show views from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
 **MATERIALIZED** | Only return materialized views, i.e. those with [indexes](../create-index). Without specifying this option, this command returns all views, including non-materialized views.
 **FULL** | Return details about your views.
 
 ## Details
 
-### Output format for `SHOW FULL VIEW`
+### Output format for `SHOW FULL VIEWS`
 
-`SHOW FULL VIEW`'s output is a table, with this structure:
+`SHOW FULL VIEWS`'s output is a table, with this structure:
 
 ```nofmt
  name  | type | materialized
@@ -33,7 +33,7 @@ _schema&lowbar;name_ | The schema to show sources from. Defaults to `public` in 
 Field | Meaning
 ------|--------
 **name** | The name of the view
-**type** | Whether the view was created by the user or the system
+**type** | Whether the view was created by the `user` or the `system`
 **materialized** | Does the view have an in-memory index? For more details, see [`CREATE INDEX`](../create-index)
 
 {{< version-changed v0.5.0 >}}
@@ -76,11 +76,6 @@ SHOW FULL VIEWS
 -------------------------+------+--------------
  my_nonmaterialized_view | user | f
  my_materialized_view    | user | t
-```
-
-```sql
-CREATE VIEW my_nonmaterialized_view AS
-    SELECT col2, col3 FROM my_materialized_view;
 ```
 
 ## Related pages

--- a/doc/user/layouts/partials/sql-grammar/show-sources.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-sources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="477" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="513" height="155">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="62" height="32" rx="10"/>
@@ -9,27 +9,43 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="113" y="3" width="86" height="32" rx="10"/>
-   <rect x="111"
+   <rect x="133" y="35" width="52" height="32" rx="10"/>
+   <rect x="131"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="141" y="53">FULL</text>
+   <rect x="245" y="35" width="120" height="32" rx="10"/>
+   <rect x="243"
+         y="33"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="253" y="53">MATERIALIZED</text>
+   <rect x="405" y="3" width="86" height="32" rx="10"/>
+   <rect x="403"
          y="1"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="121" y="21">SOURCES</text>
-   <rect x="239" y="35" width="60" height="32" rx="10"/>
-   <rect x="237"
-         y="33"
+   <text class="terminal" x="413" y="21">SOURCES</text>
+   <rect x="275" y="121" width="60" height="32" rx="10"/>
+   <rect x="273"
+         y="119"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="247" y="53">FROM</text>
-   <rect x="319" y="35" width="110" height="32"/>
-   <rect x="317" y="33" width="110" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="53">schema_name</text>
+   <text class="terminal" x="283" y="139">FROM</text>
+   <rect x="355" y="121" width="110" height="32"/>
+   <rect x="353" y="119" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="363" y="139">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m62 0 h10 m0 0 h10 m86 0 h10 m20 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m60 0 h10 m0 0 h10 m110 0 h10 m23 -32 h-3"/>
-   <polygon points="467 17 475 13 475 21"/>
-   <polygon points="467 17 459 13 459 21"/>
+         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h62 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v12 m92 0 v-12 m-92 12 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m40 -32 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m86 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-280 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m60 0 h10 m0 0 h10 m110 0 h10 m23 -32 h-3"/>
+   <polygon points="503 103 511 99 511 107"/>
+   <polygon points="503 103 495 99 495 107"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-views.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-views.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="379" height="199">
+<svg xmlns="http://www.w3.org/2000/svg" width="491" height="155">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="62" height="32" rx="10"/>
@@ -9,43 +9,43 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="133" y="35" width="120" height="32" rx="10"/>
+   <rect x="133" y="35" width="52" height="32" rx="10"/>
    <rect x="131"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="141" y="53">FULL</text>
+   <rect x="245" y="35" width="120" height="32" rx="10"/>
+   <rect x="243"
          y="33"
          width="120"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="141" y="53">MATERIALIZED</text>
-   <rect x="133" y="79" width="52" height="32" rx="10"/>
-   <rect x="131"
-         y="77"
-         width="52"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="141" y="97">FULL</text>
-   <rect x="293" y="3" width="64" height="32" rx="10"/>
-   <rect x="291"
+   <text class="terminal" x="253" y="53">MATERIALIZED</text>
+   <rect x="405" y="3" width="64" height="32" rx="10"/>
+   <rect x="403"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="21">VIEWS</text>
-   <rect x="141" y="165" width="60" height="32" rx="10"/>
-   <rect x="139"
-         y="163"
+   <text class="terminal" x="413" y="21">VIEWS</text>
+   <rect x="253" y="121" width="60" height="32" rx="10"/>
+   <rect x="251"
+         y="119"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="149" y="183">FROM</text>
-   <rect x="221" y="165" width="110" height="32"/>
-   <rect x="219" y="163" width="110" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="229" y="183">schema_name</text>
+   <text class="terminal" x="261" y="139">FROM</text>
+   <rect x="333" y="121" width="110" height="32"/>
+   <rect x="331" y="119" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="341" y="139">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m-150 -10 v20 m160 0 v-20 m-160 20 v24 m160 0 v-24 m-160 24 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m52 0 h10 m0 0 h68 m20 -76 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-280 130 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m60 0 h10 m0 0 h10 m110 0 h10 m23 -32 h-3"/>
-   <polygon points="369 147 377 143 377 151"/>
-   <polygon points="369 147 361 143 361 151"/>
+         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h62 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v12 m92 0 v-12 m-92 12 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m40 -32 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m64 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-280 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m60 0 h10 m0 0 h10 m110 0 h10 m23 -32 h-3"/>
+   <polygon points="481 103 489 99 489 107"/>
+   <polygon points="481 103 473 99 473 107"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -232,11 +232,11 @@ show_schemas ::=
 show_sinks ::=
    'SHOW' 'SINKS'
 show_sources ::=
-  'SHOW' 'SOURCES' ('FROM' schema_name)?
+  'SHOW' 'FULL'? 'MATERIALIZED'? 'SOURCES' ('FROM' schema_name)?
 show_tables ::=
   'SHOW' 'TABLES' ('FROM' schema_name)?
 show_views ::=
-  'SHOW' ('MATERIALIZED' | 'FULL')? 'VIEWS' ('FROM' schema_name)?
+  'SHOW' 'FULL'? 'MATERIALIZED'? 'VIEWS' ('FROM' schema_name)?
 table_ref ::=
   (
     table_name

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -247,9 +247,9 @@ fn show_sources<'a>(
         )
     } else {
         format!(
-            "SELECT name, mz_internal.mz_classify_object_id(id) AS type,
+            "SELECT name, mz_internal.mz_classify_object_id(id) AS type
             FROM mz_catalog.mz_sources
-            WHERE schema_id = {} AND mz_internal.mz_is_materialized(id) AS materialized",
+            WHERE schema_id = {} AND mz_internal.mz_is_materialized(id)",
             schema_spec.id,
         )
     };

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -311,6 +311,28 @@ a  b
 3  4
 1  2
 
+> SHOW SOURCES
+name
+--------
+data
+mat_data
+
+> SHOW MATERIALIZED SOURCES
+name
+----
+mat_data
+
+> SHOW FULL SOURCES
+name     type materialized
+-------------------------
+data     user false
+mat_data user true
+
+> SHOW FULL MATERIALIZED SOURCES
+name     type
+-------------
+mat_data user
+
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the
 # default index name is already taken.


### PR DESCRIPTION
It turns out Materialize crashes if you try the command `SHOW FULL MATERIALIZED SOURCES`. The crash looks like this: 

```
ERROR panic: <unnamed>: ShowSelect::new called with invalid SQL: ParserError { sql: "SELECT * FROM (SELECT name, mz_internal.mz_classify_object_id(id) AS type,\n            FROM mz_catalog.mz_sources\n            WHERE schema_id = 3 AND mz_internal.mz_is_materialized(id) AS materialized) q WHERE true ORDER BY q.*", range: 26..27, message: "Expected joined table, found comma" }
```

I fixed the sql query so that Materialize no longer crashes, and added a test for SHOW SOURCES in testdrive.

I also noticed that the keywords FULL and MATERIALIZED were missing from SHOW SOURCES documentation, so I added that in. Fixed some typos in SHOW VIEWS docs, including the fact the railroad diagram was wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4751)
<!-- Reviewable:end -->
