### PR TITLE
sql: support timestamp done messages in TAIL

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -55,6 +55,7 @@ Wrap your release notes at the 80 character mark.
   `WITH (SNAPSHOT)`. `WITHOUT SNAPSHOT` is now `WITH (SNAPSHOT = false)`.
 - Report an error without crashing when a query contains unexpected UTF-8
   characters, e.g., `SELECT ’1’` {{% gh 4755 %}}.
+- [`TAIL`](/sql/tail) now supports timestamp progress.
 
 {{% version-header v0.5.1 %}}
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1357,9 +1357,19 @@ where
                 ts,
                 with_snapshot,
                 copy_to,
+                emit_progress,
+                object_columns,
             } => tx.send(
-                self.sequence_tail(session.conn_id(), id, with_snapshot, ts, copy_to)
-                    .await,
+                self.sequence_tail(
+                    session.conn_id(),
+                    id,
+                    with_snapshot,
+                    ts,
+                    copy_to,
+                    emit_progress,
+                    object_columns,
+                )
+                .await,
                 session,
             ),
 
@@ -2010,6 +2020,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn sequence_tail(
         &mut self,
         conn_id: u32,
@@ -2017,6 +2028,8 @@ where
         with_snapshot: bool,
         ts: Option<Timestamp>,
         copy_to: Option<CopyFormat>,
+        emit_progress: bool,
+        object_columns: usize,
     ) -> Result<ExecuteResponse, anyhow::Error> {
         // Determine the frontier of updates to tail *from*.
         // Updates greater or equal to this frontier will be produced.
@@ -2039,6 +2052,8 @@ where
                 tx,
                 frontier,
                 strict: !with_snapshot,
+                emit_progress,
+                object_columns,
             }),
         ))
         .await;

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -667,6 +667,8 @@ pub struct TailSinkConnector {
     pub tx: comm::mpsc::Sender<Vec<Row>>,
     pub frontier: Antichain<Timestamp>,
     pub strict: bool,
+    pub emit_progress: bool,
+    pub object_columns: usize,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -99,6 +99,14 @@ fn test_current_timestamp_and_now() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+fn extract_ts(data: &[u8]) -> Result<u64, Box<dyn Error>> {
+    Ok(str::from_utf8(data)?
+        .split_whitespace()
+        .next()
+        .unwrap()
+        .parse()?)
+}
+
 #[test]
 fn test_tail_basic() -> Result<(), Box<dyn Error>> {
     ore::test::init_logging();
@@ -114,14 +122,6 @@ fn test_tail_basic() -> Result<(), Box<dyn Error>> {
         file.sync_all()?;
         Ok(())
     };
-
-    fn extract_ts(data: &[u8]) -> Result<u64, Box<dyn Error>> {
-        Ok(str::from_utf8(data)?
-            .split_whitespace()
-            .next()
-            .unwrap()
-            .parse()?)
-    }
 
     client.batch_execute(&*format!(
         "CREATE MATERIALIZED SOURCE dynamic_csv FROM FILE '{}' WITH (tail = true)
@@ -213,6 +213,77 @@ fn test_tail_basic() -> Result<(), Box<dyn Error>> {
     thread::sleep(Duration::from_millis(100));
     append(b"Glendale,AZ,85310\n")?;
     thread::sleep(Duration::from_millis(100));
+    Ok(())
+}
+
+#[test]
+fn test_tail_progress() -> Result<(), Box<dyn Error>> {
+    ore::test::init_logging();
+
+    let config = util::Config::default().threads(2);
+    let (_server, mut client) = util::start_server(config)?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let path = Path::join(temp_dir.path(), "dynamic.csv");
+    let mut file = File::create(&path)?;
+    let mut append = |data| -> Result<_, Box<dyn Error>> {
+        file.write_all(data)?;
+        file.sync_all()?;
+        Ok(())
+    };
+
+    client.batch_execute(&*format!(
+        "CREATE MATERIALIZED SOURCE dynamic_csv FROM FILE '{}' WITH (tail = true)
+         FORMAT CSV WITH 3 COLUMNS",
+        path.display()
+    ))?;
+
+    // Test the TAIL SQL command on the tailed file source. This is end-to-end
+    // tailing: changes to the file will propagate through Materialize and
+    // into the user's SQL console.
+    let cancel_token = client.cancel_token();
+    let mut tail_reader = client
+        .copy_out("COPY (TAIL dynamic_csv WITH (PROGRESS)) TO STDOUT")?
+        .split(b'\n');
+
+    // Test the done messages by sending inserting a single row and waiting to
+    // observe it. Since TAIL always sends a done message at the end of its batches
+    // and we won't yet insert a second row, we know that if we've seen a data row
+    // we will also see one done message.
+
+    append(b"City 1,ST,00001\n")?;
+    let next = tail_reader.next().unwrap()?;
+    println!("{}", String::from_utf8_lossy(&next));
+    assert!(next.ends_with(&b"f\t1\tCity 1\tST\t00001\t1"[..]));
+    let ts = extract_ts(&next)?;
+    let next = tail_reader.next().unwrap()?;
+    assert!(next.ends_with(&b"t\t\\N\t\\N\t\\N\t\\N\t\\N"[..]));
+    assert!(ts < extract_ts(&next)?);
+
+    append(b"City 2,ST,00002\n")?;
+    let next = tail_reader.next().unwrap()?;
+    println!("{}", String::from_utf8_lossy(&next));
+    assert!(next.ends_with(&b"f\t1\tCity 2\tST\t00002\t2"[..]));
+    let ts = extract_ts(&next)?;
+    let next = tail_reader.next().unwrap()?;
+    assert!(next.ends_with(&b"t\t\\N\t\\N\t\\N\t\\N\t\\N"[..]));
+    assert!(ts < extract_ts(&next)?);
+
+    append(b"City 3,ST,00003\n")?;
+    let next = tail_reader.next().unwrap()?;
+    println!("{}", String::from_utf8_lossy(&next));
+    assert!(next.ends_with(&b"f\t1\tCity 3\tST\t00003\t3"[..]));
+    let ts = extract_ts(&next)?;
+    let next = tail_reader.next().unwrap()?;
+    assert!(next.ends_with(&b"t\t\\N\t\\N\t\\N\t\\N\t\\N"[..]));
+    assert!(ts < extract_ts(&next)?);
+
+    // The tail won't end until a cancellation request is sent.
+    cancel_token.cancel_query(postgres::NoTls)?;
+
+    assert!(tail_reader.next().is_none());
+    drop(tail_reader);
+
     Ok(())
 }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -722,11 +722,11 @@ TAIL foo.bar WITH (snapshot) AS OF now()
 Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
 
 parse-statement
-TAIL foo.bar WITH (SNAPSHOT = false) AS OF now()
+TAIL foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
 ----
-TAIL foo.bar WITH (snapshot = false) AS OF now()
+TAIL foo.bar WITH (snapshot = false, timestamps) AS OF now()
 =>
-Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }], as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
+Tail(TailStatement { name: ObjectName([Ident("foo"), Ident("bar")]), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }, WithOption { key: Ident("timestamps"), value: None }], as_of: Some(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT false)

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -137,6 +137,8 @@ pub enum Plan {
         with_snapshot: bool,
         ts: Option<Timestamp>,
         copy_to: Option<CopyFormat>,
+        emit_progress: bool,
+        object_columns: usize,
     },
     SendRows(Vec<Row>),
     ExplainPlan {


### PR DESCRIPTION
Add a `WITH (TIMESTAMPS)` option to TAIL that adds a `done` bool column
to the output. At the end of each set of batches send a new row with
the timestamp, a true `done`, and NULL for all columns to indicate
the timestamp is done and no other rows will appear at or before that
timestamp. Otherwise `done` is false.

This works because each batch represents a disjoint and increasing bound
of time. Thus we only need to send a done message for the last batch of
a group of batches.

Closes #4539

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4752)
<!-- Reviewable:end -->
