### PR TITLE
sql-parser: better handling of unicode characters in errors

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -53,6 +53,8 @@ Wrap your release notes at the 80 character mark.
 - [`TAIL`](/sql/tail) is now guaranteed to produce output ordered by timestamp.
 - Syntax for [`TAIL`](/sql/tail) has changed. `WITH SNAPSHOT` is now
   `WITH (SNAPSHOT)`. `WITHOUT SNAPSHOT` is now `WITH (SNAPSHOT = false)`.
+- Report an error without crashing when a query contains unexpected UTF-8
+  characters, e.g., `SELECT ’1’` {{% gh 4755 %}}.
 
 {{% version-header v0.5.1 %}}
 

--- a/src/ore/src/lex.rs
+++ b/src/ore/src/lex.rs
@@ -59,7 +59,7 @@ impl<'a> LexBuf<'a> {
     /// Panics if `prev` is called when the internal cursor is positioned at
     /// the beginning of the buffer.
     pub fn prev(&mut self) -> char {
-        if let Some(c) = self.buf.chars().rev().next() {
+        if let Some(c) = self.buf[..self.pos].chars().rev().next() {
             self.pos -= c.len_utf8();
             c
         } else {

--- a/src/sql-parser/src/lexer.rs
+++ b/src/sql-parser/src/lexer.rs
@@ -104,7 +104,7 @@ pub fn lex(query: &str) -> Result<Vec<(Token, Range<usize>)>, ParserError> {
     let buf = &mut LexBuf::new(query);
     let mut tokens = vec![];
     while let Some(ch) = buf.next() {
-        let pos = buf.pos() - 1;
+        let pos = buf.pos() - ch.len_utf8();
         let token = match ch {
             _ if ch.is_ascii_whitespace() => continue,
             '-' if buf.consume('-') => {
@@ -139,6 +139,13 @@ pub fn lex(query: &str) -> Result<Vec<(Token, Range<usize>)>, ParserError> {
         };
         tokens.push((token, pos..buf.pos()))
     }
+
+    #[cfg(debug_assertions)]
+    for (_token, pos) in &tokens {
+        assert!(query.is_char_boundary(pos.start));
+        assert!(query.is_char_boundary(pos.end));
+    }
+
     Ok(tokens)
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -108,7 +108,7 @@ impl<'a> fmt::Display for ParserError {
             .rfind('\n')
             .map(|start| start + 1)
             .unwrap_or(0);
-        let safe_end = self.range.end.min(self.sql.len() - 1);
+        let safe_end = self.range.end.min(self.sql.len());
         let line_end = self.sql[safe_end..]
             .find('\n')
             .map(|end| safe_end + end)

--- a/src/sql-parser/tests/testdata/lexer
+++ b/src/sql-parser/tests/testdata/lexer
@@ -174,3 +174,25 @@ Parse error:
 1e10.1
     ^^
 extra token after expression
+
+# Test that unexpected unicode characters do not cause the error message to
+# crash when rendered...
+parse-statement
+SELECT ’hello’
+----
+error:
+Parse error:
+SELECT ’hello’
+       ^^^
+unexpected character in input: ’
+
+# ...though we completely mishandle the width of unicode chars when positioning
+# the caret at the moment.
+parse-statement
+SELECT '’fancy quotes inside a string are ok’’’’' ’
+----
+error:
+Parse error:
+SELECT '’fancy quotes inside a string are ok’’’’' ’
+                                                            ^^^
+unexpected character in input: ’


### PR DESCRIPTION
Slicing a string in Rust requires care to only slice at unicode
boundaries, and the SQL parser was not being quite careful enough when
generating error messages about SQL queries that contained unicode
characters.

This commit fixes:

  * a bug in the lexer where the position of the "unexpected character"
    message would start in the middle of that character if the UTF-8
    encoding of that character was more than one byte long.
  * a bug in the parser error renderer where a bounds check was
    unnecessarily subtracting 1, which results in an invalid character
    offset if the last character in a SQL string is not ASCII.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4755)
<!-- Reviewable:end -->
