### PR TITLE
doc/user: update identifier docs

### DIFF
--- a/doc/user/content/sql/identifiers.md
+++ b/doc/user/content/sql/identifiers.md
@@ -1,23 +1,46 @@
 ---
 title: "Identifiers"
-description: "SQL identifiers are names of elements such as sources and views."
+description: "SQL identifiers are names of columns and database objects such as sources and views."
 weight: 11
 menu:
   main:
     parent: 'sql'
 ---
 
-In Materialize, identifiers are used to refer to SQL elements like sources, views, and indexes.
+In Materialize, identifiers are used to refer to columns and database objects
+like sources, views, and indexes.
 
 ## Naming restrictions
 
-Identifiers must:
+- The first character of an identifer must be an ASCII letter
+  (`a`-`z` and `A`-`Z`), an underscore (`_`), or any non-ASCII character.
 
-- Begin with an ASCII letter (i.e. `[a-zA-Z]` in terms of regex)
-- Only contain ASCII characters
+- The remaining characters of an identifier must be ASCII letters
+  (`a`-`z` and `A`-`Z`), ASCII digits (`0`-`9`), underscores (`_`),
+  dollar signs (`$`), or any non-ASCII characters.
 
-You can circumvent any of the above rules by double-quoting the the identifier, e.g. `"123_source"` or `"fun_source_😀"`. When using double-quoted identifiers, the quotation marks are part of the identifier and must be used whenever referring to the element.
+You can circumvent any of the above rules by double-quoting the the identifier,
+e.g. `"123_source"` or `"fun_source_@"`. All characters inside a quoted
+identifier are taken literally, except that double-quotes must be escaped by
+writing two adjacent double-quotes, as in `"includes""quote"`.
 
 ## Keyword collision
 
-Materialize is very permissive with letting users typical SQL keywords as identifiers (e.g. `name`, `user`). If Materialize cannot use a keyword as an identifier in a particular location, it throws a syntax error.
+Materialize is very permissive with accepting SQL keywords as identifiers (e.g.
+`offset`, `user`). If Materialize cannot use a keyword as an
+identifier in a particular location, it throws a syntax error. You can wrap the
+identifier in double quotes to force Materialize to interpret the word as an
+identifier instead of a keyword.
+
+For example, `SELECT offset` is invalid, because it looks like a mistyping of
+`SELECT OFFSET <n>`. You can wrap the identifier in double quotes, as in
+`SELECT "offset"`, to resolve the error.
+
+We recommend that you avoid using keywords as identifiers whenever possible, as
+the syntax errors that result are not always obvious.
+
+The keywords known to the latest [unstable build](/versions/#unstable-builds)
+of Materialize are listed below. Note that new keywords may be added in any
+release.
+
+{{< kwlist >}}

--- a/doc/user/layouts/shortcodes/kwlist.html
+++ b/doc/user/layouts/shortcodes/kwlist.html
@@ -1,0 +1,7 @@
+<ul>
+{{range split (readFile ("sql-grammar/keywords.txt")) "\n"}}
+  {{if and (not (hasPrefix . "#")) .}}
+    <li><code>{{.|upper}}</code></li>
+  {{end}}
+{{end}}
+</ul>

--- a/doc/user/sql-grammar/keywords.txt
+++ b/doc/user/sql-grammar/keywords.txt
@@ -1,0 +1,1 @@
+../../../src/sql-parser/src/keywords.txt


### PR DESCRIPTION
Identifiers have gotten more permissive in Materialize and allow any
non-ASCII character to match PostgreSQL. Also add a bit more precision
to various parts of the identifier docs, in particular listing the
current set of keywords.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4764)
<!-- Reviewable:end -->
