### PR TITLE
Log the first (and subsequent) times that we enter full dedupe mode

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1221,6 +1221,8 @@ struct TrackFull {
     /// Optimization to avoid re-allocating the row packer over and over when extracting the key..
     key_buf: RowPacker,
     range: Option<TrackRange>,
+    /// Whether we have started full deduplication mode
+    started: bool,
 }
 
 /// When to start and end full-range tracking
@@ -1275,6 +1277,7 @@ impl TrackFull {
             key_indices,
             key_buf: Default::default(),
             range: None,
+            started: false,
         }
     }
 
@@ -1378,6 +1381,7 @@ impl DebeziumDeduplicationState {
                 key_indices,
                 key_buf,
                 range,
+                started,
             }) => {
                 if is_snapshot {
                     let key_indices = match key_indices.as_ref() {
@@ -1435,11 +1439,22 @@ impl DebeziumDeduplicationState {
                         if let Some(range) = range {
                             if let Some(upstream_time_millis) = upstream_time_millis {
                                 if upstream_time_millis < range.pad_start {
+                                    *started = false;
                                     return should_skip.is_none();
                                 }
                                 if upstream_time_millis < range.start {
                                     seen_offsets.insert((pos, row), upstream_time_millis);
+                                    *started = false;
                                     return should_skip.is_none();
+                                }
+                                if upstream_time_millis <= range.end && !*started {
+                                    *started = true;
+                                    info!(
+                                        "starting full deduplication source={}:{} buffer_size={}",
+                                        debug_name,
+                                        worker_idx,
+                                        seen_offsets.len()
+                                    );
                                 }
                                 if upstream_time_millis > range.end {
                                     // don't abort early, but we will clean up after this validation


### PR DESCRIPTION
The size of the deduplication buffer reported by buffer_size here is more
interesting in general.

If the same source enters full deduplication mode multiple times that could
potentially be -- but is not necessarily -- an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4773)
<!-- Reviewable:end -->
