### PR TITLE
Log only to the explicitly-requested destination

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -56,7 +56,7 @@ Wrap your release notes at the 80 character mark.
 - Report an error without crashing when a query contains unexpected UTF-8
   characters, e.g., `SELECT ’1’` {{% gh 4755 %}}.
 - [`TAIL`](/sql/tail) now supports timestamp progress.
-- Log messages are no longer emit to stderr if an explicit `--log-file` is
+- Log messages are no longer emitted to stderr if an explicit `--log-file` is
   supplied at startup. {{ gh 4777 }}
 
 {{% version-header v0.5.1 %}}

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -56,6 +56,8 @@ Wrap your release notes at the 80 character mark.
 - Report an error without crashing when a query contains unexpected UTF-8
   characters, e.g., `SELECT ’1’` {{% gh 4755 %}}.
 - [`TAIL`](/sql/tail) now supports timestamp progress.
+- Log messages are no longer emit to stderr if an explicit `--log-file` is
+  supplied at startup. {{ gh 4777 }}
 
 {{% version-header v0.5.1 %}}
 


### PR DESCRIPTION
If users specify a --log-file we should assume that they know what they're
doing and write logs to exactly that destination, and nowhere else.

This removes the secondary stderr `WARN` logs that were impossible to silence,
if users provide a `--log-file` (that is not stderr).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4777)
<!-- Reviewable:end -->
