### PR TITLE
packaging: Emit logs to only stderr in the apt systemd unit file

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -58,6 +58,8 @@ Wrap your release notes at the 80 character mark.
 - [`TAIL`](/sql/tail) now supports timestamp progress.
 - Log messages are no longer emitted to stderr if an explicit `--log-file` is
   supplied at startup. {{ gh 4777 }}
+- The systemd package configured by our apt package now writes all logs to
+  the systemd journal, instead of a file in the mzdata directory. {{ gh 4781 }}
 
 {{% version-header v0.5.1 %}}
 

--- a/misc/dist/materialized.service
+++ b/misc/dist/materialized.service
@@ -16,7 +16,7 @@ Type=exec
 User=_Materialize
 Group=_Materialize
 
-ExecStart=/usr/bin/materialized -D /var/lib/materialize/mzdata
+ExecStart=/usr/bin/materialized --data-directory /var/lib/materialize/mzdata --log-file=stderr
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This more closely matches the intended use of systemd, and also of the /var/lib
directory, which explicitly is not supposed to have log files[2].

[2]: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4781)
<!-- Reviewable:end -->
