### PR TITLE
sql: expose version information via SQL functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-info"
+version = "0.1.0"
+
+[[package]]
 name = "build_const"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +507,7 @@ dependencies = [
  "aws-util",
  "backtrace",
  "bincode",
+ "build-info",
  "byteorder",
  "ccsr",
  "chrono",
@@ -1879,6 +1884,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "backtrace",
+ "build-info",
  "cfg-if 1.0.0",
  "chrono",
  "comm",
@@ -3753,6 +3759,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aws-arn",
+ "build-info",
  "ccsr",
  "chrono",
  "dataflow-types",
@@ -3805,6 +3812,7 @@ name = "sqllogictest"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "build-info",
  "bytes",
  "chrono",
  "comm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "src/avro",
     "src/avro-derive",
     "src/aws-util",
+    "src/build-info",
     "src/ccsr",
     "src/comm",
     "src/coord",

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -95,6 +95,14 @@ Wrap your release notes at the 80 character mark.
 
 - Allow slightly more complicated [`INSERT`](/sql/insert) bodies, e.g. inserting
   `SELECT`ed literals {{% gh 4748 %}}.
+  characters, e.g., `SELECT ’1’` {{% gh 4755 %}}.
+- [`TAIL`](/sql/tail) now supports timestamp progress.
+- Log messages are no longer emitted to stderr if an explicit `--log-file` is
+  supplied at startup. {{ gh 4777 }}
+- Add the [`version`](/sql/functions#postgresql-compatibility-func) and
+  [`mz_version`](/sql/functions/#system-information-func) functions to report
+  PostgreSQL-specific and Materialize-specific version information,
+  respectively.
 
 {{% version-header v0.5.1 %}}
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -353,6 +353,12 @@
       Null elements are omitted unless `ifnull` is non-null, in which case
       null elements are replaced with the value of `ifnull`.
 
+- type: System information
+  description: Functions that return information about the system
+  functions:
+  - signature: 'mz_version() -> text'
+    description: Returns the server's version information as a human-readable string.
+
 - type: PostgreSQL compatibility
   description: Functions whose primary purpose is to facilitate compatibility with PostgreSQL tools
   functions:
@@ -369,3 +375,5 @@
     description: Returns the type of its input argument as a string.
   - signature: 'pg_encoding_to_char(encoding_id: integer) -> text'
     description: PostgreSQL compatibility shim. Not intended for direct use.
+  - signature: 'version() -> text'
+    description: Returns a PostgreSQL-compatible version string.

--- a/src/build-info/Cargo.toml
+++ b/src/build-info/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "build-info"
+description = "Metadata about a Materialize build."
+version = "0.1.0"
+edition = "2018"
+publish = false

--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Metadata about a Materialize build.
+//!
+//! These types are located in a dependency-free crate so they can be used
+//! from any layer of the stack.
+
+/// Build information.
+#[derive(Debug, Clone)]
+pub struct BuildInfo {
+    /// The version number of the build.
+    pub version: &'static str,
+    /// The 40-character SHA-1 hash identifying the Git commit of the build.
+    pub sha: &'static str,
+    /// The time of the build in UTC as an ISO 8601-complaint string.
+    pub time: &'static str,
+    /// The target triple of the platform.
+    pub target_triple: &'static str,
+}
+
+/// Dummy build information.
+///
+/// Intended for use in contexts where getting the correct build information is
+/// impossible or unnecessary, like in tests.
+pub const DUMMY_BUILD_INFO: BuildInfo = BuildInfo {
+    version: "",
+    sha: "",
+    time: "",
+    target_triple: "",
+};
+
+impl BuildInfo {
+    /// Constructs a human-readable version string.
+    pub fn human_version(&self) -> String {
+        format!("v{} ({})", self.version, &self.sha[..9])
+    }
+}

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.34"
 aws-util = { path = "../aws-util" }
 backtrace = "0.3.54"
 bincode = { version = "1.3", optional = true }
+build-info = { path = "../build-info" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -20,6 +20,7 @@ use ore::collections::CollectionExt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use build_info::DUMMY_BUILD_INFO;
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector};
 use expr::{GlobalId, IdHumanizer, OptimizedRelationExpr, ScalarExpr};
 use repr::RelationDesc;
@@ -385,6 +386,7 @@ impl Catalog {
                 experimental_mode,
                 cluster_id,
                 cache_directory: config.cache_directory,
+                build_info: config.build_info,
             },
         };
         let mut events = vec![];
@@ -1714,6 +1716,7 @@ pub fn dump(path: &Path) -> Result<String, anyhow::Error> {
         enable_logging: true,
         experimental_mode: None,
         cache_directory: None,
+        build_info: &DUMMY_BUILD_INFO,
     })?;
     Ok(catalog.dump())
 }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1810,15 +1810,6 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
         self.catalog.get_by_id(id)
     }
 
-    fn is_queryable(&self, id: GlobalId) -> bool {
-        let (_, complete) = self.catalog.nearest_indexes(&[id]);
-        complete
-    }
-
-    fn is_materialized(&self, id: GlobalId) -> bool {
-        !self.catalog.indexes[&id].is_empty()
-    }
-
     fn type_exists(&self, name: &FullName) -> bool {
         self.catalog.try_get(name, self.conn_id).is_some()
     }
@@ -1894,5 +1885,3 @@ impl sql::catalog::CatalogItem for CatalogEntry {
         self.used_by()
     }
 }
-
-impl sql::catalog::Type for Type {}

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -9,6 +9,8 @@
 
 use std::path::{Path, PathBuf};
 
+use build_info::BuildInfo;
+
 /// Configures a catalog.
 #[derive(Debug)]
 pub struct Config<'a> {
@@ -25,4 +27,6 @@ pub struct Config<'a> {
     ///
     /// If set to `None`, indicates that source caching is disabled.
     pub cache_directory: Option<PathBuf>,
+    /// Information about this build of Materialize.
+    pub build_info: &'static BuildInfo,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -34,6 +34,7 @@ use timely::progress::{Antichain, ChangeBatch, Timestamp as _};
 use tokio::runtime::Handle;
 use uuid::Uuid;
 
+use build_info::BuildInfo;
 use dataflow::source::cache::CacheSender;
 use dataflow::{CacheMessage, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};
 use dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
@@ -123,6 +124,7 @@ where
     pub cache: Option<CacheConfig>,
     pub logical_compaction_window: Option<Duration>,
     pub experimental_mode: bool,
+    pub build_info: &'static BuildInfo,
 }
 
 /// Glues the external world to the Timely workers.
@@ -3108,6 +3110,7 @@ pub async fn serve<C>(
         cache: cache_config,
         logical_compaction_window,
         experimental_mode,
+        build_info,
     }: Config<'_, C>,
 ) -> Result<(JoinHandle<()>, Uuid), anyhow::Error>
 where
@@ -3175,6 +3178,7 @@ where
             experimental_mode: Some(experimental_mode),
             enable_logging: logging.is_some(),
             cache_directory: cache_config.map(|c| c.path),
+            build_info,
         })?;
         let cluster_id = catalog.config().cluster_id;
 

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.34"
 askama = { version = "0.10.5", features = ["serde-json"] }
 async-trait = "0.1.42"
 backtrace = { version = "0.3.54" }
+build-info = { path = "../build-info" }
 cfg-if = "1.0.0"
 comm = { path = "../comm" }
 compile-time-run = "0.2.11"

--- a/src/materialized/build.rs
+++ b/src/materialized/build.rs
@@ -1,0 +1,17 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::env;
+use std::error::Error;
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-env=TARGET_TRIPLE={}", env::var("TARGET")?);
+    Ok(())
+}

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -170,11 +170,7 @@ fn run() -> Result<(), anyhow::Error> {
         print!("{}", opts.usage("usage: materialized [options]"));
         return Ok(());
     } else if popts.opt_present("v") {
-        println!(
-            "materialized v{} ({})",
-            materialized::VERSION,
-            materialized::BUILD_SHA
-        );
+        println!("materialized {}", materialized::BUILD_INFO.human_version());
         if popts.opt_count("v") > 1 {
             for bi in build_info() {
                 println!("{}", bi);
@@ -398,7 +394,7 @@ cpus: {ncpus_logical} logical, {ncpus_physical} physical
 cpu0: {cpu0}
 memory: {memory_total}KB total, {memory_used}KB used
 swap: {swap_total}KB total, {swap_used}KB used",
-        mz_version = materialized::version(),
+        mz_version = materialized::BUILD_INFO.human_version(),
         dep_versions = build_info().join("\n"),
         invocation = {
             use shell_words::quote as escape;
@@ -496,7 +492,7 @@ For more details, see https://materialize.com/docs/cli#experimental-mode
 
     println!(
         "materialized {} listening on {}...",
-        materialized::version(),
+        materialized::BUILD_INFO.human_version(),
         server.local_addr(),
     );
 

--- a/src/materialized/src/http/memory.rs
+++ b/src/materialized/src/http/memory.rs
@@ -14,6 +14,7 @@ use futures::future;
 use hyper::{Body, Request, Response};
 
 use crate::http::{util, Server};
+use crate::BUILD_INFO;
 
 #[derive(Template)]
 #[template(path = "http/templates/memory.html")]
@@ -27,7 +28,7 @@ impl Server {
         _: Request<Body>,
     ) -> impl Future<Output = anyhow::Result<Response<Body>>> {
         future::ok(util::template_response(MemoryTemplate {
-            version: crate::VERSION,
+            version: BUILD_INFO.version,
         }))
     }
 }

--- a/src/materialized/src/http/metrics.rs
+++ b/src/materialized/src/http/metrics.rs
@@ -23,6 +23,7 @@ use prometheus::{
 };
 
 use crate::http::{util, Server};
+use crate::BUILD_INFO;
 
 lazy_static! {
     static ref SERVER_METADATA_RAW: GaugeVec = register_gauge_vec!(
@@ -32,9 +33,9 @@ lazy_static! {
     )
     .expect("can build mz_server_metadata");
     static ref SERVER_METADATA: Gauge = SERVER_METADATA_RAW.with_label_values(&[
-        crate::BUILD_TIME,
-        crate::VERSION,
-        crate::BUILD_SHA,
+        BUILD_INFO.time,
+        BUILD_INFO.version,
+        BUILD_INFO.sha,
     ]);
     pub static ref WORKER_COUNT: IntGaugeVec = register_int_gauge_vec!(
         "mz_server_metadata_timely_worker_threads",
@@ -153,7 +154,7 @@ impl Server {
             .unwrap_or(0);
 
         future::ok(util::template_response(StatusTemplate {
-            version: crate::VERSION,
+            version: BUILD_INFO.version,
             query_count,
             start_time: self.start_time,
             metrics: metrics.values().collect(),

--- a/src/materialized/src/http/root.rs
+++ b/src/materialized/src/http/root.rs
@@ -16,6 +16,7 @@ use futures::future;
 use hyper::{Body, Method, Request, Response, StatusCode};
 
 use crate::http::{util, Server};
+use crate::BUILD_INFO;
 
 #[derive(Template)]
 #[template(path = "http/templates/home.html")]
@@ -31,9 +32,9 @@ impl Server {
         _: Request<Body>,
     ) -> impl Future<Output = anyhow::Result<Response<Body>>> {
         future::ok(util::template_response(HomeTemplate {
-            version: crate::VERSION,
-            build_time: crate::BUILD_TIME,
-            build_sha: crate::BUILD_SHA,
+            version: BUILD_INFO.version,
+            build_time: BUILD_INFO.time,
+            build_sha: BUILD_INFO.sha,
         }))
     }
 

--- a/src/materialized/src/version_check.rs
+++ b/src/materialized/src/version_check.rs
@@ -16,18 +16,19 @@ use serde::{Deserialize, Serialize};
 
 use ore::retry::RetryBuilder;
 
-use crate::VERSION;
+use crate::BUILD_INFO;
 
 // Runs fetch_latest_version in a backoff loop until it succeeds once, prints a
 // warning if there is a newer version, then returns.
 pub async fn check_version_loop(telemetry_url: String, cluster_id: String) {
-    let current_version = Version::parse(VERSION).expect("crate version is not valid semver");
+    let current_version =
+        Version::parse(BUILD_INFO.version).expect("crate version is not valid semver");
 
     let latest_version = RetryBuilder::new()
         .max_sleep(None)
         .initial_backoff(Duration::from_secs(1))
         .build()
-        .retry(|_state| fetch_latest_version(&telemetry_url, &cluster_id, &VERSION))
+        .retry(|_state| fetch_latest_version(&telemetry_url, &cluster_id, &BUILD_INFO.version))
         .await
         .expect("retry loop never terminates");
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.34"
 aws-arn = "0.1.1"
+build-info = { path = "../build-info" }
 ccsr = { path = "../ccsr" }
 chrono = "0.4"
 dataflow-types = { path = "../dataflow-types" }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+use build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use expr::{GlobalId, ScalarExpr};
 use repr::RelationDesc;
 use uuid::Uuid;
@@ -139,6 +140,8 @@ pub struct CatalogConfig {
     /// The path in which source caching data is stored, if source caching is
     /// enabled.
     pub cache_directory: Option<PathBuf>,
+    /// Information about this build of Materialize.
+    pub build_info: &'static BuildInfo,
 }
 
 /// An item in a [`Catalog`].
@@ -267,6 +270,7 @@ const DUMMY_CONFIG: CatalogConfig = CatalogConfig {
     cluster_id: Uuid::from_u128(0),
     experimental_mode: false,
     cache_directory: None,
+    build_info: &DUMMY_BUILD_INFO,
 };
 
 impl Catalog for DummyCatalog {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -127,22 +127,6 @@ pub trait Catalog: fmt::Debug {
     /// Panics if `id` does not specify a valid item.
     fn get_item_by_id(&self, id: &GlobalId) -> &dyn CatalogItem;
 
-    /// Reports whether the specified catalog item is queryable.
-    ///
-    /// A queryable catalog item is one for which a timestamp can be determined.
-    /// In practice, this means a catalog item whose transitive dependency set
-    /// does not include any unmaterialized sources.
-    ///
-    /// Panics if `id` does not specify an object on which indexes can be built.
-    fn is_queryable(&self, id: GlobalId) -> bool;
-
-    /// Reports whether the specified catalog item is materialized.
-    ///
-    /// A materialized catalog item has at least one index.
-    ///
-    /// Panics if `id` does not specify an object on which indexes can be built.
-    fn is_materialized(&self, id: GlobalId) -> bool;
-
     /// Reports whether the specified type exists in the catalog.
     fn type_exists(&self, name: &FullName) -> bool;
 
@@ -193,9 +177,6 @@ pub trait CatalogItem {
     /// catalog item is an index.
     fn index_details(&self) -> Option<(&[ScalarExpr], GlobalId)>;
 }
-
-/// A type in a [`Catalog`].
-pub trait Type {}
 
 /// The type of a [`CatalogItem`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -329,14 +310,6 @@ impl Catalog for DummyCatalog {
 
     fn get_item_by_id(&self, _: &GlobalId) -> &dyn CatalogItem {
         unimplemented!();
-    }
-
-    fn is_queryable(&self, _: GlobalId) -> bool {
-        false
-    }
-
-    fn is_materialized(&self, _: GlobalId) -> bool {
-        false
     }
 
     fn type_exists(&self, _: &FullName) -> bool {

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1379,12 +1379,12 @@ lazy_static! {
                         None => bail!("source passed to internal_read_cached_data must be literal string"),
                     };
                     let item = ecx.qcx.scx.resolve_item(ObjectName(vec![Ident::new(source.clone())]))?;
-                    let entry = ecx.qcx.scx.catalog.get_item(&item);
+                    let entry = ecx.catalog().get_item(&item);
                     match entry.item_type() {
                         CatalogItemType::Source => {},
                         _ =>  bail!("{} is a {}, but internal_read_cached_data requires a source", source, entry.item_type()),
                     }
-                    let cache_directory = ecx.qcx.scx.catalog.cache_directory();
+                    let cache_directory = ecx.catalog().config().cache_directory.as_deref();
                     if cache_directory.is_none() {
                         bail!("source caching is currently disabled. Try rerunning Materialize with '--experimental'.");
                     }
@@ -1551,7 +1551,7 @@ fn plan_current_timestamp(ecx: &ExprContext, name: &str) -> Result<ScalarExpr, a
 
 fn mz_cluster_id(ecx: &ExprContext) -> Result<ScalarExpr, anyhow::Error> {
     Ok(ScalarExpr::literal(
-        Datum::from(ecx.qcx.scx.catalog.cluster_id()),
+        Datum::from(ecx.catalog().config().cluster_id),
         ScalarType::Uuid,
     ))
 }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1229,6 +1229,16 @@ lazy_static! {
             "to_timestamp" => Scalar {
                 params!(Float64) => UnaryFunc::ToTimestamp
             },
+            "version" => Scalar {
+                params!() => Operation::nullary(|ecx| {
+                    let build_info = ecx.catalog().config().build_info;
+                    let version = format!(
+                        "PostgreSQL 9.6 on {} (materialized {})",
+                        build_info.target_triple, build_info.version,
+                    );
+                    Ok(ScalarExpr::literal(Datum::String(&version), ScalarType::String))
+                })
+            },
 
             // Aggregates.
             "array_agg" => Aggregate {
@@ -1447,11 +1457,17 @@ lazy_static! {
             "list_prepend" => Scalar {
                 vec![ListElementAny, ListAny] => BinaryFunc::ElementListConcat
             },
+            "mz_cluster_id" => Scalar {
+                params!() => Operation::nullary(mz_cluster_id)
+            },
             "mz_logical_timestamp" => Scalar {
                 params!() => NullaryFunc::MzLogicalTimestamp
             },
-            "mz_cluster_id" => Scalar {
-                params!() => Operation::nullary(mz_cluster_id)
+            "mz_version" => Scalar {
+                params!() => Operation::nullary(|ecx| {
+                    let version = ecx.catalog().config().build_info.human_version();
+                    Ok(ScalarExpr::literal(Datum::String(&version), ScalarType::String))
+                })
             },
             "regexp_extract" => Table {
                 params!(String, String) => Operation::binary(move |_ecx, regex, haystack| {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -55,6 +55,7 @@ use crate::plan::scope::{Scope, ScopeItem, ScopeItemName};
 use crate::plan::statement::StatementContext;
 use crate::plan::transform_ast;
 use crate::plan::typeconv::{self, CastContext};
+use crate::plan::Catalog;
 
 /// Plans a top-level query, returning the `RelationExpr` describing the query
 /// plan, the `RelationDesc` describing the shape of the result set, a
@@ -2843,6 +2844,10 @@ pub struct ExprContext<'a> {
 }
 
 impl<'a> ExprContext<'a> {
+    pub fn catalog(&self) -> &dyn Catalog {
+        self.qcx.scx.catalog
+    }
+
     fn with_name(&self, name: &'static str) -> ExprContext<'a> {
         let mut ecx = self.clone();
         ecx.name = name;

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -679,10 +679,11 @@ fn handle_create_sink(
     let suffix = format!(
         "{}-{}",
         scx.catalog
-            .startup_time()
+            .config()
+            .startup_time
             .duration_since(UNIX_EPOCH)?
             .as_secs(),
-        scx.catalog.nonce()
+        scx.catalog.config().nonce
     );
 
     let as_of = as_of.map(|e| query::eval_as_of(scx, e)).transpose()?;
@@ -1945,7 +1946,7 @@ impl<'a> StatementContext<'a> {
     }
 
     pub fn experimental_mode(&self) -> bool {
-        self.catalog.experimental_mode()
+        self.catalog.config().experimental_mode
     }
 
     pub fn require_experimental_mode(&self, feature_name: &str) -> Result<(), anyhow::Error> {

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
+build-info = { path = "../build-info" }
 bytes = "0.5"
 chrono = "0.4"
 comm = { path = "../comm" }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -41,6 +41,7 @@ use lazy_static::lazy_static;
 use md5::{Digest, Md5};
 use regex::Regex;
 
+use build_info::DUMMY_BUILD_INFO;
 use coord::session::Session;
 use coord::{ExecuteResponse, TimestampConfig};
 use dataflow_types::PeekResponse;
@@ -402,6 +403,7 @@ impl State {
             cache: None,
             logical_compaction_window: None,
             experimental_mode: true,
+            build_info: &DUMMY_BUILD_INFO,
         })
         .await?;
         let coord_thread = coord_thread.join_on_drop();


### PR DESCRIPTION
Add the version() and mz_version() functions to report
PostgreSQL-specific and Materialize-specific version information,
respectively.

Fix #4776.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4784)
<!-- Reviewable:end -->
