### PR TITLE
Clippy seems to have fixed this bug in our toolchain

### DIFF
--- a/src/materialized/src/http/root.rs
+++ b/src/materialized/src/http/root.rs
@@ -37,7 +37,6 @@ impl Server {
         }))
     }
 
-    #[allow(clippy::manual_async_fn)] // clippy bug: https://github.com/rust-lang/rust-clippy/issues/5765
     pub fn handle_static(
         &self,
         req: Request<Body>,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4787)
<!-- Reviewable:end -->
