### PR TITLE
support internal representation of new map type

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -514,7 +514,7 @@ impl AggregateFunc {
 fn jsonb_each<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> Vec<(Row, Diff)> {
     let mut row_packer = RowPacker::new();
     match a {
-        Datum::Dict(dict) => dict
+        Datum::Map(dict) => dict
             .iter()
             .map(move |(k, mut v)| {
                 if stringify {
@@ -530,7 +530,7 @@ fn jsonb_each<'a>(a: Datum<'a>, temp_storage: &'a RowArena, stringify: bool) -> 
 fn jsonb_object_keys<'a>(a: Datum<'a>) -> Vec<(Row, Diff)> {
     let mut row_packer = RowPacker::new();
     match a {
-        Datum::Dict(dict) => dict
+        Datum::Map(dict) => dict
             .iter()
             .map(move |(k, _)| (row_packer.pack(&[Datum::String(k)]), 1))
             .collect(),

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -2376,6 +2376,7 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::Array(_t) => unimplemented!("array types"),
                 ScalarType::List(_t) => unimplemented!("list types"),
                 ScalarType::Record { .. } => unimplemented!("record types"),
+                ScalarType::Map { .. } => unimplemented!("map types"),
             };
             if typ.nullable {
                 val = Value::Union {
@@ -2496,6 +2497,7 @@ fn build_row_schema_json(
             ScalarType::Array(_t) => unimplemented!("array types"),
             ScalarType::List(_t) => unimplemented!("list types"),
             ScalarType::Record { .. } => unimplemented!("record types"),
+            ScalarType::Map { .. } => unimplemented!("map types"),
         };
         if typ.nullable {
             field_type = json!(["null", field_type]);

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -727,7 +727,7 @@ mod tests {
             .unwrap();
         let datums = row.iter().collect::<Vec<_>>();
         let d = datums[0];
-        if let Datum::Dict(d) = d {
+        if let Datum::Map(d) = d {
             let datumdict = d.iter().collect::<Vec<(&str, Datum)>>();
             assert_eq!(
                 datumdict,
@@ -767,7 +767,7 @@ mod tests {
         let datums = row2.iter().collect::<Vec<_>>();
 
         let d = datums[1];
-        if let Datum::Dict(d) = d {
+        if let Datum::Map(d) = d {
             let datumdict = d.iter().collect::<Vec<(&str, Datum)>>();
 
             for (name, datum) in datumdict.iter() {
@@ -825,7 +825,7 @@ mod tests {
             let datumlist = d.iter().collect::<Vec<Datum>>();
 
             for datum in datumlist {
-                if let Datum::Dict(d) = datum {
+                if let Datum::Map(d) = datum {
                     let datumdict = d.iter().collect::<Vec<(&str, Datum)>>();
                     assert_eq!(
                         datumdict,

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -506,7 +506,7 @@ impl Serialize for JsonbDatum<'_> {
                 }
                 seq.end()
             }
-            Datum::Dict(dict) => {
+            Datum::Map(dict) => {
                 let mut map = serializer.serialize_map(None)?;
                 for (k, v) in dict.iter() {
                     map.serialize_entry(k, &JsonbDatum(v))?;

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -32,7 +32,7 @@ pub mod strconv;
 
 pub use persistence::{PersistedRecord, PersistedRecordIter};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{datum_size, DatumDict, DatumList, Row, RowArena, RowPacker};
+pub use row::{datum_size, DatumList, DatumMap, Row, RowArena, RowPacker};
 pub use scalar::{Datum, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -173,7 +173,7 @@ impl PartialOrd for DatumList<'_> {
 
 /// A mapping from string keys to Datums
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct DatumDict<'a> {
+pub struct DatumMap<'a> {
     /// Points at the serialized datums, which should be sorted in key order
     data: &'a [u8],
 }
@@ -363,7 +363,7 @@ unsafe fn read_datum<'a>(data: &'a [u8], offset: &mut usize) -> Datum<'a> {
         }
         Tag::Dict => {
             let bytes = read_untagged_bytes(data, offset);
-            Datum::Dict(DatumDict { data: bytes })
+            Datum::Map(DatumMap { data: bytes })
         }
         Tag::JsonNull => Datum::JsonNull,
         Tag::Dummy => Datum::Dummy,
@@ -489,7 +489,7 @@ fn push_datum(data: &mut Vec<u8>, datum: Datum) {
             data.push(Tag::List as u8);
             push_untagged_bytes(data, &list.data);
         }
-        Datum::Dict(dict) => {
+        Datum::Map(dict) => {
             data.push(Tag::Dict as u8);
             push_untagged_bytes(data, &dict.data);
         }
@@ -523,7 +523,7 @@ pub fn datum_size(datum: &Datum) -> usize {
             1 + size_of::<u8>() + array.dims.data.len() + array.elements.data.len()
         }
         Datum::List(list) => 1 + size_of::<usize>() + list.data.len(),
-        Datum::Dict(dict) => 1 + size_of::<usize>() + dict.data.len(),
+        Datum::Map(dict) => 1 + size_of::<usize>() + dict.data.len(),
         Datum::JsonNull => 1,
         Datum::Dummy => 1,
     }
@@ -679,9 +679,9 @@ impl<'a> Iterator for DatumListIter<'a> {
     }
 }
 
-impl<'a> DatumDict<'a> {
-    pub fn empty() -> DatumDict<'static> {
-        DatumDict { data: &[] }
+impl<'a> DatumMap<'a> {
+    pub fn empty() -> DatumMap<'static> {
+        DatumMap { data: &[] }
     }
 
     pub fn iter(&self) -> DatumDictIter<'a> {
@@ -698,7 +698,7 @@ impl<'a> DatumDict<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a DatumDict<'a> {
+impl<'a> IntoIterator for &'a DatumMap<'a> {
     type Item = (&'a str, Datum<'a>);
     type IntoIter = DatumDictIter<'a>;
     fn into_iter(self) -> DatumDictIter<'a> {
@@ -910,7 +910,7 @@ impl RowPacker {
     /// let row = packer.finish();
     ///
     /// assert_eq!(
-    ///     row.unpack_first().unwrap_dict().iter().collect::<Vec<_>>(),
+    ///     row.unpack_first().unwrap_map().iter().collect::<Vec<_>>(),
     ///     vec![("age", Datum::Int64(42)), ("name", Datum::String("bob"))]
     /// );
     /// ```
@@ -1380,7 +1380,7 @@ mod tests {
         });
         let row = packer.finish();
 
-        let mut iter = row.unpack_first().unwrap_dict().iter();
+        let mut iter = row.unpack_first().unwrap_map().iter();
 
         let (k, v) = iter.next().unwrap();
         assert_eq!(k, "favourites");
@@ -1417,7 +1417,7 @@ mod tests {
         assert_eq!(pack(false), Err("fail"));
 
         let row = pack(true)?;
-        let mut dict = row.unpack_first().unwrap_dict().iter();
+        let mut dict = row.unpack_first().unwrap_map().iter();
         assert_eq!(dict.next(), Some(("key", Datum::Int32(42))));
         assert_eq!(dict.next(), None);
 

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -232,6 +232,8 @@ pub enum DataType {
     Jsonb,
     /// Object ID
     Oid,
+    /// Map
+    Map { value_type: Box<DataType> },
     /// User-defined type
     Custom(String),
 }
@@ -301,6 +303,11 @@ impl AstDisplay for DataType {
             }
             DataType::Jsonb => f.write_str("jsonb"),
             DataType::Oid => f.write_str("oid"),
+            DataType::Map { value_type } => {
+                f.write_str("map(text=>");
+                f.write_node(&value_type);
+                f.write_str(")");
+            }
             DataType::Custom(c) => f.write_str(c),
         }
     }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -104,6 +104,7 @@ impl TypeCategory {
             ScalarType::List(..) => Self::List,
             ScalarType::String => Self::String,
             ScalarType::Record { .. } => Self::Pseudo,
+            ScalarType::Map { .. } => Self::Pseudo,
         }
     }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2531,6 +2531,9 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, anyhow::
         DataType::Array(elem_type) => ScalarType::Array(Box::new(scalar_type_from_sql(elem_type)?)),
         DataType::List(elem_type) => ScalarType::List(Box::new(scalar_type_from_sql(elem_type)?)),
         DataType::Oid => ScalarType::Oid,
+        DataType::Map { value_type } => ScalarType::Map {
+            value_type: Box::new(scalar_type_from_sql(value_type)?),
+        },
         DataType::Binary(..)
         | DataType::Blob(_)
         | DataType::Clob(_)
@@ -2564,6 +2567,9 @@ pub fn scalar_type_from_pg(ty: &pgrepr::Type) -> Result<ScalarType, anyhow::Erro
             bail!("internal error: can't convert from pg record to materialize record")
         }
         pgrepr::Type::Oid => Ok(ScalarType::Oid),
+        pgrepr::Type::Map { value_type } => Ok(ScalarType::Map {
+            value_type: Box::new(scalar_type_from_pg(value_type)?),
+        }),
     }
 }
 

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1440,10 +1440,10 @@ SELECT '{{a, "", "\""}, "{a, \"\", \"\\\"\"}"}'::text list list
 {{a,"","\""},{a,"","\""}}
 
 # Unquoted elements cannot have special characters interleaved within them
-query error invalid input syntax for list: malformed list literal; must escape special character '"': "\{a"b"\}"
+query error invalid input syntax for list: malformed literal; must escape special character '"': "\{a"b"\}"
 SELECT '{a"b"}'::text list
 
-query error invalid input syntax for list: malformed list literal; must escape special character '\{': "\{a\{b\}"
+query error invalid input syntax for list: malformed literal; must escape special character '\{': "\{a\{b\}"
 SELECT '{a{b}'::text list
 
 query error invalid input syntax for list: malformed array literal; contains 'b' after terminal '\}': "\{a\}b\}"
@@ -1667,10 +1667,10 @@ query error invalid input syntax for list: invalid input syntax for list: expect
 SELECT '{1}}'::int list list
 
 # Cannot have commas followed or preceded by empty elements
-query error invalid input syntax for list: malformed list literal; missing element: "\{a,  \}"
+query error invalid input syntax for list: malformed literal; missing element: "\{a,  \}"
 SELECT '{a,  }'::text list
 
-query error invalid input syntax for list: malformed list literal; missing element: "\{  ,a\}"
+query error invalid input syntax for list: malformed literal; missing element: "\{  ,a\}"
 SELECT '{  ,a}'::text list
 
 # 🔬 Built-in operations

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -20,3 +20,66 @@ CREATE TYPE custom AS MAP (key_type=text, value_type='bool', extra_type=customth
 
 query error CREATE TYPE not yet supported
 CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
+
+query error expected '\{', found a: "a=>1"
+SELECT 'a=>1'::map[text=>int]
+
+query T
+SELECT '{a=>1}'::map[text=>int]
+----
+{a=>1}
+
+query T
+SELECT '{  c  =>3, a=>     2, a => 1 }'::map[text=>int]
+----
+{a=>1,c=>3}
+
+query error Expected TEXT, found INT
+SELECT '{1=>true}'::map[int=>bool]
+
+query T
+SELECT '{1=>true}'::map[text=>bool]
+----
+{1=>t}
+
+query error malformed literal; missing element
+SELECT '{}'::map[text=>int]
+
+query error invalid input syntax for bool: "2.0"
+SELECT '{a=>1, b=>false, c=>2.0}'::map[text=>bool]
+
+query T
+SELECT '{a\=\>=>2}'::map[text=>int]
+----
+{"a=>"=>2}
+
+query T
+SELECT '{13=>hello \[\=\>     value\], 31=>  normal  }'::map[text=>text]
+----
+{13=>"hello [=>     value]",31=>normal}
+
+query T
+SELECT '{"a"=>"hello there!", b=>"129387123"}'::map[text=>text]
+----
+{a=>"hello there!",b=>129387123}
+
+query T
+SELECT '{key=>"here is a string => with a map operator in it"}'::map[text=>text]
+----
+{key=>"here is a string => with a map operator in it"}
+
+query T
+SELECT '{31=> normal \ }'::map[text=>text]
+----
+{31=>"normal  "}
+
+query T
+SELECT '{31=> \ normal }'::map[text=>text]
+----
+{31=>" normal"}
+
+query error unterminated quoted string
+SELECT '{"a"=>"hello there!}'::map[text=>text]
+
+query error nested map types not yet supported
+SELECT '{a=>{b=>c}}'::map[text=>map[text=>text]]


### PR DESCRIPTION
This PR enables Materialize to represent maps internally by adding a `Map` variant to the
required enums. To test this, I've added the ability to parse strings as maps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4801)
<!-- Reviewable:end -->
