### PR TITLE
Detailed diagnostics around full/precise deduplication logic

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1540,6 +1540,7 @@ impl DebeziumDeduplicationState {
                 started_padding,
                 started,
             }) => {
+                *max_seen_time = max(upstream_time_millis.unwrap_or(0), *max_seen_time);
                 if is_snapshot {
                     let key_indices = match key_indices.as_ref() {
                         None => {
@@ -1590,7 +1591,6 @@ impl DebeziumDeduplicationState {
                         true
                     }
                 } else {
-                    *max_seen_time = max(upstream_time_millis.unwrap_or(0), *max_seen_time);
                     if let Some(seen_offsets) = seen_offsets.get_mut(file) {
                         // first check if we are in a special case of range-bounded track full
                         if let Some(range) = range {
@@ -1644,6 +1644,8 @@ impl DebeziumDeduplicationState {
                                     // don't abort early, but we will clean up after this validation
                                     delete_full = true;
                                 }
+                            } else {
+                                warn!("message has no creation time")
                             }
                         }
 

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1717,8 +1717,8 @@ fn log_duplication_info(
     worker_idx: usize,
     is_new: bool,
     should_skip: &Option<SkipInfo>,
-    original_time: &mut i64,
-    max_seen_time: &mut i64,
+    original_time: &i64,
+    max_seen_time: &i64,
 ) {
     let file_name = file_name_repr(file);
     match (is_new, should_skip) {
@@ -1728,10 +1728,12 @@ fn log_duplication_info(
         // records will ever be sent with a position below the highest
         // position ever seen
         (true, Some(skipinfo)) => {
+            // original time is guaranteed to be the same as message time, so
+            // that label is omitted from this log message
             warn!(
                 "Created a new record behind the highest point in source={}:{} binlog_file={} \
                  new_record_position={}:{} new_record_kafka_offset={} old_max_position={}:{} \
-                 message_time={} message_first_seen={} max_seen_time={}",
+                 message_time={} max_seen_time={}",
                 debug_name,
                 worker_idx,
                 file_name,
@@ -1741,7 +1743,6 @@ fn log_duplication_info(
                 skipinfo.old_max_pos,
                 skipinfo.old_max_row,
                 fmt_timestamp(upstream_time_millis),
-                fmt_timestamp(*original_time),
                 fmt_timestamp(*max_seen_time),
             );
         }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1338,6 +1338,7 @@ struct DebeziumDeduplicationState {
     full: Option<TrackFull>,
     /// Whether we have printed a warning due to seeing unknown source coordinates
     warned_on_unknown: bool,
+    messages_processed: u64,
 }
 
 /// If we need to deal with debezium possibly going back after it hasn't seen things.
@@ -1355,6 +1356,7 @@ struct TrackFull {
     /// Optimization to avoid re-allocating the row packer over and over when extracting the key..
     key_buf: RowPacker,
     range: Option<TrackRange>,
+    started_padding: bool,
     /// Whether we have started full deduplication mode
     started: bool,
 }
@@ -1411,6 +1413,7 @@ impl TrackFull {
             key_indices,
             key_buf: Default::default(),
             range: None,
+            started_padding: false,
             started: false,
         }
     }
@@ -1454,6 +1457,7 @@ impl DebeziumDeduplicationState {
             binlog_offsets: Default::default(),
             full,
             warned_on_unknown: false,
+            messages_processed: 0,
         }
     }
 
@@ -1490,6 +1494,7 @@ impl DebeziumDeduplicationState {
                 return true;
             }
         };
+        self.messages_processed += 1;
 
         // If in the initial snapshot, binlog (pos, row) is meaningless for detecting
         // duplicates, since it is always the same.
@@ -1532,6 +1537,7 @@ impl DebeziumDeduplicationState {
                 key_indices,
                 key_buf,
                 range,
+                started_padding,
                 started,
             }) => {
                 if is_snapshot {
@@ -1590,21 +1596,48 @@ impl DebeziumDeduplicationState {
                         if let Some(range) = range {
                             if let Some(upstream_time_millis) = upstream_time_millis {
                                 if upstream_time_millis < range.pad_start {
+                                    if *started_padding {
+                                        warn!("went back to before padding start, after entering padding\
+                                               source={}:{} message_time={} messages_processed={}",
+                                              debug_name, worker_idx, fmt_timestamp(upstream_time_millis),
+                                              self.messages_processed);
+                                    }
+                                    if *started {
+                                        warn!("went back to before padding start, after entering full dedupe\
+                                               source={}:{} message_time={} messages_processed={}",
+                                              debug_name, worker_idx, fmt_timestamp(upstream_time_millis),
+                                              self.messages_processed);
+                                    }
+                                    *started_padding = false;
                                     *started = false;
                                     return should_skip.is_none();
                                 }
                                 if upstream_time_millis < range.start {
-                                    seen_offsets.insert((pos, row), upstream_time_millis);
+                                    // in the padding time range
+                                    *started_padding = true;
+                                    if *started {
+                                        warn!("went back to before padding start, after entering full dedupe\
+                                               source={}:{} message_time={} messages_processed={}",
+                                              debug_name, worker_idx, fmt_timestamp(upstream_time_millis),
+                                              self.messages_processed);
+                                    }
                                     *started = false;
+
+                                    seen_offsets
+                                        .entry((pos, row))
+                                        .or_insert_with(|| upstream_time_millis);
                                     return should_skip.is_none();
                                 }
                                 if upstream_time_millis <= range.end && !*started {
                                     *started = true;
                                     info!(
-                                        "starting full deduplication source={}:{} buffer_size={}",
+                                        "starting full deduplication source={}:{} buffer_size={} \
+                                         messages_processed={} message_time={}",
                                         debug_name,
                                         worker_idx,
-                                        seen_offsets.len()
+                                        seen_offsets.len(),
+                                        self.messages_processed,
+                                        fmt_timestamp(upstream_time_millis)
                                     );
                                 }
                                 if upstream_time_millis > range.end {


### PR DESCRIPTION
This is only alerted on if the user requested tracking in a range, in which
case messages without time info make handling ranges impossible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4803)
<!-- Reviewable:end -->
