### PR TITLE
coord: decouple portals and prepared statements

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -747,18 +747,20 @@ impl State {
             .session()
             .get_prepared_statement(&statement_name)
             .expect("unnamed prepared statement missing");
-        let desc = stmt.desc().relation_desc.clone();
-        let result_formats = vec![pgrepr::Format::Text; stmt.desc().arity()];
+        let desc = stmt.desc().clone();
+        let stmt = stmt.sql().cloned();
+        let result_formats = vec![pgrepr::Format::Text; desc.arity()];
         self.coord_client.session().set_portal(
             portal_name.clone(),
-            statement_name,
+            desc.clone(),
+            stmt,
             vec![],
             result_formats,
         )?;
 
         // Execute.
         let res = self.coord_client.execute(portal_name).await?;
-        Ok((desc, res))
+        Ok((desc.relation_desc, res))
     }
 }
 


### PR DESCRIPTION
Previously portals would refer to the prepared statement from which
they were created. This was used to fetch a portal's description. The
upcoming feature to support DECLARE cursors is a way to create portals
that are not attached to a prepared statement.

Move the statement and its description to the portal so that portals do
not have to have an associated prepared statement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4806)
<!-- Reviewable:end -->
