### PR TITLE
Update next version to v0.5.3, not v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "materialized"
-version = "0.6.0"
+version = "0.5.3-dev"
 dependencies = [
  "anyhow",
  "askama",

--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 0.6.0
+Licensed Work:             Materialize Version 0.5.3-dev
                            The Licensed Work is © 2020 Materialize, Inc.
 
 Additional Use Grant:      You may use one single server instance of the

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "materialized"
 description = "Streaming SQL materialized views."
-version = "0.6.0"
+version = "0.5.3-dev"
 edition = "2018"
 publish = false
 default-run = "materialized"


### PR DESCRIPTION
Caught by @quodlibetor, more details here: https://github.com/MaterializeInc/materialize/pull/4808.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4809)
<!-- Reviewable:end -->
