### PR TITLE
Use enter_region to enter regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 [[package]]
 name = "differential-dataflow"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#470db958f55c44111210a69ab5788444d99cdf49"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#3aa0952ec8cdefe0ef3cd1b3969dab5f08fc3c74"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -872,7 +872,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#470db958f55c44111210a69ab5788444d99cdf49"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#3aa0952ec8cdefe0ef3cd1b3969dab5f08fc3c74"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/dataflow/src/render/delta_join.rs
+++ b/src/dataflow/src/render/delta_join.rs
@@ -91,7 +91,7 @@ where
                                 let (update_stream, errs) = self
                                     .collection(&inputs[relation])
                                     .expect("Failed to render update stream");
-                                let update_stream = update_stream.enter(inner).enter(region);
+                                let update_stream = update_stream.enter(inner).enter_region(region);
                                 scope_errs.push(errs);
 
                                 // We track the sources of each column in our update stream.
@@ -174,7 +174,7 @@ where
                                                         |_, _, t| AltNeu::alt(t.clone()),
                                                         move |t| subtract(&t.time),
                                                     )
-                                                    .enter(region);
+                                                    .enter_region(region);
                                                 build_lookup(update_stream, oks, prev_key)
                                             } else {
                                                 let oks = oks
@@ -183,7 +183,7 @@ where
                                                         |_, _, t| AltNeu::neu(t.clone()),
                                                         move |t| subtract(&t.time),
                                                     )
-                                                    .enter(region);
+                                                    .enter_region(region);
                                                 build_lookup(update_stream, oks, prev_key)
                                             }
                                         }
@@ -198,7 +198,7 @@ where
                                                         |_, _, t| AltNeu::alt(t.clone()),
                                                         move |t| subtract(&t.time),
                                                     )
-                                                    .enter(region);
+                                                    .enter_region(region);
                                                 build_lookup(update_stream, oks, prev_key)
                                             } else {
                                                 let oks = oks

--- a/src/dataflow/src/render/delta_join.rs
+++ b/src/dataflow/src/render/delta_join.rs
@@ -207,7 +207,7 @@ where
                                                         |_, _, t| AltNeu::neu(t.clone()),
                                                         move |t| subtract(&t.time),
                                                     )
-                                                    .enter(region);
+                                                    .enter_region(region);
                                                 build_lookup(update_stream, oks, prev_key)
                                             }
                                         }


### PR DESCRIPTION
The methods `enter_region` and `leave_region` are specialized to cross scope boundaries without a `map` operator to transform timestamps as they go. This simplifies our dataflows slightly, in cases that we move collection streams across dataflows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4816)
<!-- Reviewable:end -->
