### PR TITLE
lint: make errors more visible and consistent

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -17,42 +17,23 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-failed=false
-
-try() {
-    last_failed=false
-    if ! "$@"; then
-        failed=true
-        last_failed=true
-    fi
-}
-
 if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
     if ! command_exists shellcheck; then
-        printf "lint: fatal: unable to find \`shellcheck\` command on your system\n" >&2
-        printf "hint: https://github.com/koalaman/shellcheck#installing\n" >&2
-        printf "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1\n" >&2
+        echo -e "lint: $(red fatal:) unable to find \`shellcheck\` command on your system" >&2
+        echo -e "hint: https://github.com/koalaman/shellcheck#installing" >&2
+        echo -e "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1" >&2
         exit 1
     fi
     version=$(shellcheck --version | grep version: | grep -oE "[0-9]\.[0-9]\.[0-9]" || echo "0.0.0+unknown")
     if ! version_compat "0.7.0" "$version"; then
-        printf "lint: fatal: shellcheck v0.7.0+ is required\n" >&2
-        printf "hint: detected version %q\n" "$version" >&2
-        printf "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1\n" >&2
+        echo -e "lint: $(red fatal:) shellcheck v0.7.0+ is required" >&2
+        echo -e "hint: detected version \"$version\"" >&2
+        echo -e "hint: you can disable shellcheck locally by setting \$MZDEV_NO_SHELLCHECK=1" >&2
         exit 1
     fi
 fi
 
-# This Git incantation lists the source files in this repository. If you change
-# it, please preserve the following properties:
-#
-#     1. files matched by a gitignore rule are excluded,
-#     2. deleted but unstaged files are excluded,
-#     3. symlinks are excluded.
-#
-empty_tree=$(git hash-object -t tree /dev/null)
-files=$(git diff --ignore-submodules=all --raw "$empty_tree" \
-    | awk '$2 != 120000 {print $6}')
+files=$(git_files)
 
 copyright_files=$(grep -vE \
     -e '(^|/)LICENSE$' \
@@ -85,11 +66,11 @@ copyright_files=$(grep -vE \
 # a trailing newline to the text file instead.
 newline_files=$(grep -vE '\.(png|jpe?g|pb|avro|ico)$' <<< "$files")
 
-shell_files=$(sort -u <(git ls-files '*.sh' '*.bash') <(git grep -l '#!.*bash' -- ':!*.*'))
+shell_files=$(sort -u <(git_files '*.sh' '*.bash') <(git grep -l '#!.*bash' -- ':!*.*'))
 
 try xargs -n1 awk -f misc/lint/copyright.awk <<< "$copyright_files"
 try xargs misc/lint/trailing-newline.sh <<< "$newline_files"
-try xargs git --no-pager diff --check "$empty_tree" <<< "$newline_files"
+try xargs git --no-pager diff --check "$(git_empty_tree)" <<< "$newline_files"
 
 if [[ ! "${MZDEV_NO_SHELLCHECK:-}" ]]; then
     try xargs shellcheck -P SCRIPTDIR <<< "$shell_files"
@@ -97,12 +78,11 @@ fi
 
 if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
     try bin/pycheck
-    try bin/pyfmt --diff --check
-    if $last_failed; then
-        echo "$(uf hint): run bin/pyfmt"
+    try bin/pyfmt --diff --check --quiet
+    if try_last_failed; then
+        echo "lint: $(red error:) python formatting discrepancies found"
+        echo "hint: run bin/pyfmt" >&2
     fi
 fi
 
-if $failed; then
-    exit 1
-fi
+try_finish

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -9,48 +9,24 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# pycheck — an attempt to get something equivalent to cargo check for python
-#
-# * Compiles python in our officially support version of pyth
-# * Run mypy to check types
+# pycheck — `cargo check` for python.
 
 set -euo pipefail
 
-# work from the root of the repo, even if being executed from somewhere else
 cd "$(dirname "$0")/.."
-root=$(pwd)
 
-# shellcheck source=SCRIPTDIR/../misc/shlib/shlib.bash
-. "$root"/misc/shlib/shlib.bash
+. misc/shlib/shlib.bash
 
-failed=false
+py_files=$(git_files "ci/*.py" "misc/python/*.py")
 
-try() {
-    last_failed=false
-    if ! "$@"; then
-        failed=true
-        last_failed=true
-    fi
-}
-
-py_files=
-mapfile_shim py_files < <(git ls-files "ci/*.py" "misc/python/*.py")
-py_dirs=
-mapfile_shim py_dirs < <(echo "${py_files[@]}" | xargs -n 1 dirname | sort -u)
-
-try "$root"/bin/pyactivate --dev -m compileall -q -l "${py_dirs[@]}"
-if $last_failed; then
-    echo "$(uw Error): python syntax errors found"
-fi
-
-try "$root"/bin/pyactivate --dev -m mypy --pretty "${py_files[@]}"
-
-try "$root"/bin/pyactivate --dev -m \
-    pytest \
-        --quiet \
-        --doctest-modules \
-        misc/python
-
-if $failed; then
+# Bail out with a nice error message if we discover any syntax errors, so that
+# mypy and pytest don't spew nonsense.
+if ! bin/pyactivate --dev -m compileall -q -l -i - <<< "$py_files"; then
+    echo "pycheck: $(red error:) python syntax errors found"
     exit 1
 fi
+
+try xargs bin/pyactivate --dev -m mypy --pretty --no-error-summary <<< "$py_files"
+try bin/pyactivate --dev -m pytest -qq --doctest-modules misc/python
+
+try_finish

--- a/misc/lint/copyright.awk
+++ b/misc/lint/copyright.awk
@@ -9,19 +9,25 @@
 #
 # copyright.awk — checks file for missing copyright header.
 
+function err(s)
+{
+    print "lint: \033[31merror:\033[0m copyright: " s > "/dev/stderr"
+}
+
 function done()
 {
     if (!copyright) {
-        print "lint: copyright: " FILENAME " is missing copyright header" > "/dev/stderr"
+        err(FILENAME " is missing copyright header")
         exit 1
-    } else if (copyright !~ /Copyright Materialize, Inc./) {
-        print "lint: copyright: " FILENAME " has malformatted copyright header" > "/dev/stderr"
+    } else if (copyright !~ /Copyright Materialize, Inc\./) {
+        err(FILENAME " has malformatted copyright header")
+        print "hint: line " copyright_line " does not include the exact text \"Copyright Materialize, Inc.\""
         exit 1
     }
     exit 0
 }
 
 /^#![ \t\n]*\//          { next }
-/^(\/\/|#)?.*Copyright/  { copyright=$0 }
+/^(\/\/|#)?.*Copyright/  { copyright=$0; copyright_line=NR }
 /^[ \t\n]*$/             { next }
 !/^(<!--|<\?xml|\/\/|#)/ { done() }

--- a/misc/lint/trailing-newline.sh
+++ b/misc/lint/trailing-newline.sh
@@ -13,6 +13,9 @@
 
 set -euo pipefail
 
+# shellcheck source=misc/shlib/shlib.bash
+. "$(dirname "$0")/../shlib/shlib.bash"
+
 if [[ $# -lt 1 ]]; then
     echo "usage: $0 <file>" >&2
     exit 1
@@ -20,13 +23,13 @@ fi
 
 for file in "$@"; do
     if [[ ! -f "$file" ]]; then
-        echo "lint: trailing-newline: internal error: $file is not a file" >&2
+        echo "lint: $(red error:) trailing-newline: internal error: $file is not a file" >&2
         exit 1
     fi
 
     last_byte=$(tail -c1 "$file")
     if [[ "$last_byte" != $'\n' && "$last_byte" != "" ]] &> /dev/null; then
-        echo "lint: trailing-newline: $file is missing a trailing newline" >&2
+        echo "lint: $(red error:) trailing-newline: $file is missing a trailing newline" >&2
         exit 1
     fi
 done


### PR DESCRIPTION
Make linter errors more visible by using the format

    lint: SEVERITY: program: message

where SEVERITY is either "error" or "fatal" and is printed in red.
Use this format consistently across all the lint and lint-like scripts,
like pycheck. Also make things quieter when successful, so the errors
are easier to spot.

In the course of thsi change, clean things up so that lint and pycheck
share more code, since they are very similar in nature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4822)
<!-- Reviewable:end -->
