### PR TITLE
sql: CTEs

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -34,6 +34,8 @@ use repr::adt::array::ArrayDimension;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Just like expr::RelationExpr, except where otherwise noted below.
+///
+/// - There is no equivalent to `expr::RelationExpr::Let`.
 pub enum RelationExpr {
     Constant {
         rows: Vec<Row>,
@@ -43,12 +45,6 @@ pub enum RelationExpr {
         id: expr::Id,
         typ: RelationType,
     },
-    // only needed for CTEs
-    // Let {
-    //     name: Name,
-    //     value: Box<RelationExpr>,
-    //     body: Box<RelationExpr>,
-    // },
     Project {
         input: Box<RelationExpr>,
         outputs: Vec<usize>,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -70,8 +70,8 @@ pub fn plan_root_query(
     lifetime: QueryLifetime,
 ) -> Result<(RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
     transform_ast::transform_query(scx, &mut query)?;
-    let qcx = QueryContext::root(scx, lifetime);
-    let (mut expr, scope, mut finishing) = plan_query(&qcx, &query)?;
+    let mut qcx = QueryContext::root(scx, lifetime);
+    let (mut expr, scope, mut finishing) = plan_query(&mut qcx, &query)?;
 
     // Attempt to push the finishing's ordering past its projection. This allows
     // data to be projected down on the workers rather than the coordinator. It
@@ -130,7 +130,7 @@ pub fn plan_insert_query(
     columns: Vec<Ident>,
     source: InsertSource,
 ) -> Result<(GlobalId, RelationExpr), anyhow::Error> {
-    let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
+    let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     let name = scx.resolve_item(table_name)?;
     let table = scx.catalog.get_item(&name);
     let desc = table.desc()?;
@@ -204,7 +204,7 @@ pub fn plan_insert_query(
                     expr
                 }
                 _ => {
-                    let (expr, _scope) = plan_subquery(&qcx, &query)?;
+                    let (expr, _scope) = plan_subquery(&mut qcx, &query)?;
                     expr
                 }
             }
@@ -396,11 +396,33 @@ fn check_col_index(name: &str, e: &Expr, max: usize) -> Result<Option<usize>, an
 }
 
 fn plan_query(
-    qcx: &QueryContext,
+    qcx: &mut QueryContext,
     q: &Query,
 ) -> Result<(RelationExpr, Scope, RowSetFinishing), anyhow::Error> {
-    if !q.ctes.is_empty() {
-        unsupported!(2617, "CTEs");
+    for cte in &q.ctes {
+        let cte_name = normalize::ident(cte.alias.name.clone());
+        if qcx.ctes.get(&cte_name).is_some() {
+            bail!("WITH query name \"{}\" specified more than once", cte_name)
+        }
+
+        // Plan CTE.
+        let (val, scope) = plan_subquery(qcx, &cte.query)?;
+        let typ = qcx.relation_type(&val);
+        let mut val_desc = RelationDesc::new(typ, scope.column_names());
+        val_desc = crate::plan::statement::maybe_rename_columns(
+            format!("CTE {}", cte.alias.name),
+            val_desc,
+            &cte.alias.columns,
+        )?;
+
+        qcx.ctes.insert(
+            cte_name,
+            CteDesc {
+                val,
+                val_desc,
+                level_offset: 0,
+            },
+        );
     }
     let limit = match &q.limit {
         None => None,
@@ -422,6 +444,7 @@ fn plan_query(
         Some(Expr::Value(Value::Number(x))) => x.parse()?,
         _ => bail!("OFFSET must be an integer constant"),
     };
+
     match &q.body {
         SetExpr::Select(s) => {
             let plan = plan_view_select(qcx, s, &q.order_by)?;
@@ -455,7 +478,10 @@ fn plan_query(
     }
 }
 
-fn plan_subquery(qcx: &QueryContext, q: &Query) -> Result<(RelationExpr, Scope), anyhow::Error> {
+fn plan_subquery(
+    qcx: &mut QueryContext,
+    q: &Query,
+) -> Result<(RelationExpr, Scope), anyhow::Error> {
     let (mut expr, scope, finishing) = plan_query(qcx, q)?;
     if finishing.limit.is_some() || finishing.offset > 0 {
         expr = RelationExpr::TopK {
@@ -469,7 +495,10 @@ fn plan_subquery(qcx: &QueryContext, q: &Query) -> Result<(RelationExpr, Scope),
     Ok((expr.project(finishing.project), scope))
 }
 
-fn plan_set_expr(qcx: &QueryContext, q: &SetExpr) -> Result<(RelationExpr, Scope), anyhow::Error> {
+fn plan_set_expr(
+    qcx: &mut QueryContext,
+    q: &SetExpr,
+) -> Result<(RelationExpr, Scope), anyhow::Error> {
     match q {
         SetExpr::Select(select) => {
             let order_by_exprs = &[];
@@ -1185,17 +1214,7 @@ fn plan_table_factor(
 
     let (expr, scope) = match table_factor {
         TableFactor::Table { name, alias } => {
-            let name = qcx.scx.resolve_item(name.clone())?;
-            let item = qcx.scx.catalog.get_item(&name);
-            let expr = RelationExpr::Get {
-                id: Id::Global(item.id()),
-                typ: item.desc()?.typ().clone(),
-            };
-            let scope = Scope::from_source(
-                Some(name.into()),
-                item.desc()?.iter_names().map(|n| n.cloned()),
-                Some(qcx.outer_scope.clone()),
-            );
+            let (expr, scope) = qcx.resolve_table_name(name.clone())?;
             let scope = plan_table_alias(scope, alias.as_ref())?;
             (expr, scope)
         }
@@ -1217,7 +1236,8 @@ fn plan_table_factor(
             subquery,
             alias,
         } => {
-            let (expr, scope) = plan_subquery(&qcx, &subquery)?;
+            let mut qcx = (*qcx).clone();
+            let (expr, scope) = plan_subquery(&mut qcx, &subquery)?;
             let scope = plan_table_alias(scope, alias.as_ref())?;
             (expr, scope)
         }
@@ -1366,7 +1386,7 @@ fn invent_column_name(ecx: &ExprContext, expr: &Expr) -> Option<ScopeItemName> {
             // A bit silly to have to plan the query here just to get its column
             // name, since we throw away the planned expression, but fixing this
             // requires a separate semantic analysis phase.
-            let (_expr, scope) = plan_subquery(&ecx.derived_query_context(), query).ok()?;
+            let (_expr, scope) = plan_subquery(&mut ecx.derived_query_context(), query).ok()?;
             scope
                 .items
                 .first()
@@ -2020,16 +2040,16 @@ pub fn plan_expr<'a>(ecx: &'a ExprContext, e: &Expr) -> Result<CoercibleScalarEx
             if !ecx.allow_subqueries {
                 bail!("{} does not allow subqueries", ecx.name)
             }
-            let qcx = ecx.derived_query_context();
-            let (expr, _scope) = plan_subquery(&qcx, query)?;
+            let mut qcx = ecx.derived_query_context();
+            let (expr, _scope) = plan_subquery(&mut qcx, query)?;
             expr.exists().into()
         }
         Expr::Subquery(query) => {
             if !ecx.allow_subqueries {
                 bail!("{} does not allow subqueries", ecx.name)
             }
-            let qcx = ecx.derived_query_context();
-            let (expr, _scope) = plan_subquery(&qcx, query)?;
+            let mut qcx = ecx.derived_query_context();
+            let (expr, _scope) = plan_subquery(&mut qcx, query)?;
             let column_types = qcx.relation_type(&expr).column_types;
             if column_types.len() != 1 {
                 bail!(
@@ -2654,6 +2674,19 @@ pub enum QueryLifetime {
     Static,
 }
 
+/// Stores planned CTEs for later use.
+#[derive(Debug, Clone)]
+pub struct CteDesc {
+    /// The CTE's expression.
+    val: RelationExpr,
+    val_desc: RelationDesc,
+    /// We evaluate CTEs when they're defined and not when they're referred to
+    /// (i.e. it's like a pointer, not a macro). This means that we need to
+    /// adjust the level of correlated columns to retain their original
+    /// references.
+    level_offset: usize,
+}
+
 /// The state required when planning a `Query`.
 #[derive(Debug, Clone)]
 pub struct QueryContext<'a> {
@@ -2665,6 +2698,8 @@ pub struct QueryContext<'a> {
     pub outer_scope: Scope,
     /// The type of the outer relation expressions.
     pub outer_relation_types: Vec<RelationType>,
+    /// CTEs for this query.
+    pub ctes: HashMap<String, CteDesc>,
 }
 
 impl<'a> QueryContext<'a> {
@@ -2674,6 +2709,7 @@ impl<'a> QueryContext<'a> {
             lifetime,
             outer_scope: Scope::empty(None),
             outer_relation_types: vec![],
+            ctes: HashMap::new(),
         }
     }
 
@@ -2681,7 +2717,14 @@ impl<'a> QueryContext<'a> {
         expr.typ(&self.outer_relation_types, &self.scx.param_types.borrow())
     }
 
+    /// Generate a new `QueryContext` appropriate to be used in subqueries of
+    /// `self`.
     fn derived_context(&self, scope: Scope, relation_type: &RelationType) -> QueryContext<'a> {
+        let mut ctes = self.ctes.clone();
+        for (_, cte) in ctes.iter_mut() {
+            cte.level_offset += 1;
+        }
+
         QueryContext {
             scx: self.scx,
             lifetime: self.lifetime,
@@ -2692,7 +2735,59 @@ impl<'a> QueryContext<'a> {
                 .chain(std::iter::once(relation_type))
                 .cloned()
                 .collect(),
+            ctes,
         }
+    }
+
+    /// Resolves `name` to a table expr, i.e. getting a catalog table or
+    /// inlining a CTE.
+    pub fn resolve_table_name(&self, name: ObjectName) -> Result<(RelationExpr, Scope), PlanError> {
+        // Check if unqualified name refers to a CTE.
+        if name.0.len() == 1 {
+            let norm_name = normalize::ident(name.0[0].clone());
+            if let Some(cte) = self.ctes.get(&norm_name) {
+                let mut val = cte.val.clone();
+                val.visit_columns(0, &mut |depth, col| {
+                    if col.level > depth {
+                        col.level += cte.level_offset;
+                    }
+                });
+
+                let name = PartialName {
+                    database: None,
+                    schema: None,
+                    item: norm_name,
+                };
+
+                let scope = Scope::from_source(
+                    Some(name),
+                    cte.val_desc.iter_names().map(|n| n.cloned()),
+                    Some(self.outer_scope.clone()),
+                );
+
+                // Inline `val` where its name was referenced. In an ideal
+                // world, multiple instances of this expression would be
+                // de-duplicated.
+                return Ok((val, scope));
+            }
+        }
+
+        // Non-CTE table names must be retrieved from the catalog.
+        let name = self.scx.resolve_item(name)?;
+        let item = self.scx.catalog.get_item(&name);
+        let desc = item.desc()?.clone();
+        let expr = RelationExpr::Get {
+            id: Id::Global(item.id()),
+            typ: desc.typ().clone(),
+        };
+
+        let scope = Scope::from_source(
+            Some(name.into()),
+            desc.iter_names().map(|n| n.cloned()),
+            Some(self.outer_scope.clone()),
+        );
+
+        Ok((expr, scope))
     }
 }
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1549,7 +1549,7 @@ fn handle_create_table(
 ///
 /// Returns an error if the length of `column_names` is not either zero or the
 /// arity of `desc`.
-fn maybe_rename_columns(
+pub fn maybe_rename_columns(
     context: impl fmt::Display,
     desc: RelationDesc,
     column_names: &[Ident],
@@ -1560,10 +1560,16 @@ fn maybe_rename_columns(
 
     if column_names.len() != desc.typ().column_types.len() {
         bail!(
-            "{0} definition names {1} columns, but {0} has {2} columns",
+            "{0} definition names {1} column{2}, but {0} has {3} column{4}",
             context,
             column_names.len(),
-            desc.typ().column_types.len()
+            if column_names.len() == 1 { "" } else { "s" },
+            desc.typ().column_types.len(),
+            if desc.typ().column_types.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
         )
     }
 

--- a/test/sqllogictest/cockroach/with.slt
+++ b/test/sqllogictest/cockroach/with.slt
@@ -17,19 +17,23 @@
 # 2.0 license, a copy of which can be found in the LICENSE file at the
 # root of this repository.
 
-# not supported yet
-halt
-
 mode cockroach
 
-query error unsupported multiple use of CTE clause "a"
-WITH a AS (SELECT 1) SELECT * FROM a CROSS JOIN a
+# https://github.com/MaterializeInc/materialize/issues/4756
+# query error unsupported multiple use of CTE clause "a"
+# WITH a AS (SELECT 1) SELECT * FROM a CROSS JOIN a
 
 statement ok
-CREATE TABLE x(a) AS SELECT generate_series(1, 3)
+CREATE TABLE x (a int)
 
 statement ok
-CREATE TABLE y(a) AS SELECT generate_series(2, 4)
+INSERT INTO x VALUES (1), (2), (3)
+
+statement ok
+CREATE TABLE y (a int)
+
+statement ok
+INSERT INTO y VALUES (2), (3), (4)
 
 query I rowsort
 WITH t AS (SELECT a FROM y WHERE a < 3)
@@ -78,17 +82,17 @@ WITH t(b, a) AS (SELECT true a, false b)
 ----
 false  true
 
-statement error WITH query name t specified more than once
+statement error WITH query name "t" specified more than once
 WITH
     t AS (SELECT true),
     t AS (SELECT false)
 SELECT * FROM t
 
-query error source "t" has 1 columns available but 2 columns specified
+query error CTE t definition names 2 columns, but CTE t has 1 column
 WITH t(b, c) AS (SELECT a FROM x) SELECT b, t.b FROM t
 
 # Ensure you can't reference the original table name
-query error no data source matches prefix: x
+query error column "x.t" does not exist
 WITH t AS (SELECT a FROM x) SELECT a, x.t FROM t
 
 # Nested WITH, name shadowing
@@ -96,6 +100,9 @@ query I
 WITH t(x) AS (WITH t(x) AS (SELECT 1) SELECT x * 10 FROM t) SELECT x + 2 FROM t
 ----
 12
+
+# not supported yet
+halt
 
 # CTEs with DMLs
 

--- a/test/sqllogictest/cte.slt
+++ b/test/sqllogictest/cte.slt
@@ -1,0 +1,173 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Additional tests in test/sqllogictest/cockroach/with.slt
+
+mode cockroach
+
+statement ok
+CREATE TABLE x (a int)
+
+statement ok
+INSERT INTO x VALUES (1), (2), (3)
+
+statement ok
+CREATE TABLE y (a int)
+
+statement ok
+INSERT INTO y VALUES (2), (3), (4)
+
+# Check that a CTE on the lhs of a join works
+query I
+WITH t AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM t NATURAL JOIN x
+----
+2
+
+# Using a CTE inside a correlated subquery
+query I
+WITH t(x) AS (SELECT * FROM y WHERE a < 3)
+  SELECT * FROM x WHERE a IN (
+    SELECT a FROM t WHERE x.a = t.x
+  )
+----
+2
+
+# Using a correlated subquery inside a CTE
+query I
+SELECT * FROM x WHERE a IN
+  (WITH t AS (SELECT * FROM y WHERE y.a = x.a) SELECT * FROM t);
+----
+2
+3
+
+# Ensure trivial nesting doesn't crash
+query I rowsort
+WITH c AS (SELECT a + 1 FROM x) SELECT (SELECT * FROM c);
+----
+2
+3
+4
+
+statement ok
+CREATE TABLE squares (x int, y int);
+
+statement ok
+CREATE TABLE roots (x int, y int);
+
+statement ok
+CREATE TABLE cubes (x int, y int);
+
+statement ok
+INSERT INTO squares VALUES
+    (1, 1), (2, 4), (3, 9), (4, 16);
+
+statement ok
+INSERT INTO roots VALUES
+    (1, 1), (4, 2), (9, 3), (16, 4);
+
+statement ok
+INSERT INTO cubes VALUES
+    (1, 1), (2, 8), (3, 27), (4, 16);
+
+# Correlated expression––this should only return values where squares.y is
+# in roots.y and sqaures.x
+query II
+SELECT * FROM squares
+WHERE x IN (
+    SELECT y FROM roots
+    WHERE y IN (
+        SELECT squares.y
+    )
+);
+----
+1 1
+
+# Correlated CTE
+query II
+SELECT * FROM squares
+WHERE x IN (
+    WITH squares_y AS (
+        SELECT squares.y
+    )
+    SELECT y FROM roots
+    WHERE y IN (
+        SELECT y FROM squares_y
+    )
+);
+----
+1 1
+
+# Correlated CTE in different level than it was introduced. This is needlessly
+# convoluted but caused crashes in early iterations of CTE's development.
+query II
+SELECT * FROM squares
+WHERE x IN (
+    WITH squares_x AS (
+        SELECT squares.x
+    )
+    SELECT t0.x
+    FROM (
+        SELECT roots.x
+        FROM roots
+        JOIN (
+            SELECT t2.x FROM (
+                SELECT cubes.x FROM cubes
+                JOIN squares_x
+                ON squares_x.x = cubes.x
+                WHERE cubes.x IN (SELECT x FROM squares_x)
+            ) t2
+        ) AS t1
+        ON t1.x = roots.x
+    ) AS t0
+);
+----
+1 1
+4 16
+
+# Use same query at two levels. Obtusely check for quadratic powers.
+query I rowsort
+WITH squares_y AS (
+    SELECT y FROM squares
+  )
+SELECT * FROM squares_y WHERE y IN (
+  SELECT y * y FROM squares_y
+)
+----
+1
+16
+
+# PostgreSQL tests
+query TT
+WITH q AS (SELECT 'foo' AS x)
+SELECT x, pg_typeof(x)  FROM q;
+----
+foo text
+
+query I rowsort
+WITH outermost(x) AS (
+  SELECT 1
+  UNION (WITH innermost as (SELECT 2)
+         SELECT * FROM innermost
+         UNION SELECT 3)
+)
+SELECT * FROM outermost ORDER BY 1;
+----
+1
+2
+3
+
+query error unknown catalog item 'outermost'
+WITH outermost(x) AS (
+  SELECT 1
+  UNION (WITH innermost as (SELECT 2)
+         SELECT * FROM outermost  -- fail
+         UNION SELECT * FROM innermost)
+)
+SELECT * FROM outermost ORDER BY 1;


### PR DESCRIPTION
We had originally planned to use a `Let`/`Get` pattern for CTEs, but decorrelating them was more complex than originally scoped. Instead, this approach maintains the CTE's planned `RelationExpr` and inlines it wherever the CTE's reference.

This is a draft PR largely because I haven't yet sufficiently tested the expressions and haven't done any non-`.slt` tests.

Closes #2617

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4825)
<!-- Reviewable:end -->
