### PR TITLE
sql-parser: fix regression in parsing of field accesses

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,10 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.5.3 %}}
 
+- Fix a regression in the SQL parser, introduced in v0.5.2, in which nested
+  field accesses, e.g. `SELECT ((col).field1).field2`, would fail to parse
+  {{% gh 4827 %}}.
+
 {{% version-header v0.5.2 %}}
 
 - Provide the [`list`](/sql/types/list/) type, which is an ordered sequences of

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -85,16 +85,16 @@ Wrap your release notes at the 80 character mark.
   characters, e.g., `SELECT ’1’`. {{% gh 4755 %}}
 
 - Suppress logging of warnings and errors to stderr when users supply the
-  [`--log-file` command line flag](/cli/#command-line-flags). {{% gh 4777 %}}
+  [`--log-file` command line flag](/cli/#command-line-flags) {{% gh 4777 %}}.
 
 - When using the systemd service distributed in the APT package, write log
-  messages to the systemd journal instead of a file in the `mzdata` directory. {{%
-  gh 4781 %}}
+  messages to the systemd journal instead of a file in the `mzdata` directory
+  {{% gh 4781 %}}.
 
-- Ingest SQL Server-style Debezium data. {{% gh 4762 %}}
+- Ingest SQL Server-style Debezium data {{% gh 4762 %}}.
 
 - Allow slightly more complicated [`INSERT`](/sql/insert) bodies, e.g. inserting
-  `SELECT`ed literals. {{% gh 4748 %}}
+  `SELECT`ed literals {{% gh 4748 %}}.
 
 {{% version-header v0.5.1 %}}
 

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -445,3 +445,50 @@ parse-scalar
 1</*embedded comment*/2
 ----
 Op { op: "<", expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) }
+
+parse-scalar
+(x).a
+----
+FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }
+
+parse-scalar
+(x).a.b.c
+----
+FieldAccess { expr: FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }, field: Ident("c") }
+
+parse-scalar
+((x).a.b.c)
+----
+Nested(FieldAccess { expr: FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }, field: Ident("c") })
+
+parse-scalar
+(((x).a.b).c)
+----
+Nested(FieldAccess { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }), field: Ident("c") })
+
+parse-scalar
+(((x).a.b)[1].c)
+----
+Nested(FieldAccess { expr: SubscriptIndex { expr: Nested(FieldAccess { expr: FieldAccess { expr: Nested(Identifier([Ident("x")])), field: Ident("a") }, field: Ident("b") }), subscript: Value(Number("1")) }, field: Ident("c") })
+
+parse-scalar roundtrip
+(((x).a.b)[1].c)
+----
+(((x).a.b)[1].c)
+
+parse-scalar
+(1.a)
+----
+error: Expected right parenthesis, found identifier
+(1.a)
+   ^
+
+parse-scalar
+(x).*.*
+----
+WildcardAccess(WildcardAccess(Nested(Identifier([Ident("x")]))))
+
+parse-scalar
+((x).*.*)
+----
+Nested(WildcardAccess(WildcardAccess(Nested(Identifier([Ident("x")])))))

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -249,9 +249,9 @@ SELECT (1.a)
 parse-statement
 SELECT (x).*.*
 ----
-error: Expected end of statement, found dot
 SELECT (x).*.*
-            ^
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: WildcardAccess(WildcardAccess(Nested(Identifier([Ident("x")])))), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement roundtrip
 SELECT count(employee.*) FROM "order" JOIN employee ON "order".employee = employee.id


### PR DESCRIPTION
We previously supported field accesses like:

     ((col).field1).field2

but recent SQL parser refactors broke this. Restore support for this
syntax. The SQL parser now treats both field accesses and subscripting
as a maximum-precedence infix operation.

This is at variance with PostgreSQL, which severly limits where field
accesses and subscripting can occur, but matching PostgreSQL here is
more trouble than it's worth. Their restrictions seem to be mostly a
result of Yacc limitations rather than an intentional design.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4827)
<!-- Reviewable:end -->
