### PR TITLE
Grafana Dashboard Improvements

### DIFF
--- a/misc/monitoring/dashboard/README.md
+++ b/misc/monitoring/dashboard/README.md
@@ -9,6 +9,8 @@ production monitoring pointing at materialized.
 User documentation is at https://materialize.com/docs/monitoring/ (or
 [doc/user/content/monitoring/_index.md][doc] locally).
 
+If you would like to import our Grafana dashboard into your grafana instance, you should use the
+[`materialize-public.json`](./materialize-public.json) configuration in this directory.
 
 ## Updating the dashboard
 

--- a/misc/monitoring/dashboard/README.md
+++ b/misc/monitoring/dashboard/README.md
@@ -30,18 +30,8 @@ the dashboard from grafana.mz to this directory, using the following procedure:
   ```console
   $ bin/dashboard-clean /tmp/dashboard.json > misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
   ```
-* building the dashboard locally `mzimage build dashboard`
-* running the dashboard inside a demo: `mzconduct run billing -w load-test`
-* opening the dashboard and editing it to remove some _more_ of our cruft:
-  ```console
-  $ mzconduct web billing dashboard
-  ```
-  specifically, remove the "Meta" panel and make the "Materialize Build
-  Info" panel wide enough to look reasonable.
-* copying the json model into `/tmp/dashboard.json` again
-* running the `bin/dashboard-clean` comamnd from above, again
 * Run `mzimage build dashboard` and restart the load test to verify that
-  the changes look reasonable on a reload:
+  the new dashboard lookds reasonable:
   ```console
   $ mzconduct down billing && mzimage build dashboard && mzconduct run billing -w load-test
   ```

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -2,6 +2,16 @@
   "annotations": {
     "list": [
       {
+        "datasource": null,
+        "enable": true,
+        "expr": "increase(up[1m])",
+        "hide": true,
+        "iconColor": "#DEB6F2",
+        "name": "start time",
+        "showIn": 0,
+        "titleFormat": "Materialized Started"
+      },
+      {
         "builtIn": 1,
         "datasource": "-- Grafana --",
         "enable": true,
@@ -15,8 +25,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "id": 1,
-  "iteration": 1598992520939,
+  "id": null,
+  "iteration": 1605821758407,
   "links": [],
   "panels": [
     {
@@ -72,7 +82,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.0",
+      "pluginVersion": "7.0.3",
       "targets": [
         {
           "expr": "sum(mz_kafka_messages_ingested)",
@@ -131,7 +141,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.0",
+      "pluginVersion": "7.0.3",
       "targets": [
         {
           "expr": "sum(rate(mz_kafka_messages_ingested[$__interval]))",
@@ -190,7 +200,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.0",
+      "pluginVersion": "7.0.3",
       "targets": [
         {
           "expr": "sum(mz_perf_arrangement_records)",
@@ -252,7 +262,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.0",
+      "pluginVersion": "7.0.3",
       "targets": [
         {
           "expr": "sum(rate(mz_command_durations_count{command=~\"execute|query\",status=\"success\"}[$__interval]))",
@@ -265,6 +275,29 @@
       "timeShift": null,
       "title": "Client queries per second",
       "type": "stat"
+    },
+    {
+      "content": "Timely Workers: $timely_workers<br/>\nBuilt At: $built_at<br/>\nBuild Version: $build_version<br/>\nBuild sha: $build_sha<br/>",
+      "datasource": null,
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 1
+      },
+      "id": 74,
+      "mode": "html",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Materialize Build Info",
+      "type": "text"
     },
     {
       "datasource": null,
@@ -292,8 +325,8 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 15,
-        "y": 1
+        "x": 12,
+        "y": 5
       },
       "id": 76,
       "options": {
@@ -309,7 +342,7 @@
           "values": false
         }
       },
-      "pluginVersion": "7.0.0",
+      "pluginVersion": "7.0.3",
       "targets": [
         {
           "expr": "sum(rate(mz_command_durations_count{status=\"error\"}[5m]))",
@@ -324,36 +357,13 @@
       "type": "stat"
     },
     {
-      "content": "Timely Workers: $timely_workers<br/>\nBuilt At: $built_at<br/>\nBuild Version: $build_version<br/>\nBuild sha: <code>$build_sha</code><br/>",
-      "datasource": null,
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 1
-      },
-      "id": 74,
-      "mode": "html",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Materialize Build Info",
-      "type": "text"
-    },
-    {
       "collapsed": true,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 9
       },
       "id": 39,
       "panels": [
@@ -495,33 +505,38 @@
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\"}[$__interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
               "legendFormat": "p99",
               "refId": "B"
             },
             {
-              "expr": "histogram_quantile(0.95, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\"}[$__interval])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
               "legendFormat": "p95",
               "refId": "C"
             },
             {
-              "expr": "histogram_quantile(0.5, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\"}[$__interval])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
               "legendFormat": "median",
               "refId": "D"
             },
             {
-              "expr": "histogram_quantile(0.001, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\"}[$__interval])) by (le))",
+              "expr": "histogram_quantile(0.001, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
               "legendFormat": "p001",
               "refId": "E"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"error\"}[$__interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"error\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
               "interval": "",
               "legendFormat": "error p99",
               "refId": "F"
             },
             {
-              "expr": "histogram_quantile(1, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"error\"}[$__interval])) by (le))",
+              "expr": "histogram_quantile(1, sum(rate(mz_command_durations_bucket{command=~\"$command\",status=\"error\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
               "legendFormat": "error max",
               "refId": "G"
             }
@@ -618,6 +633,7 @@
             {
               "expr": "rate(mz_command_durations_count[$__interval])",
               "hide": false,
+              "interval": "",
               "legendFormat": "{{command}}",
               "refId": "A"
             }
@@ -716,11 +732,13 @@
           "targets": [
             {
               "expr": "rate(mz_pg_sent_rows[$__interval])",
+              "interval": "",
               "legendFormat": "rows/sec",
               "refId": "A"
             },
             {
               "expr": "rate(mz_pg_sent_bytes[$__interval])",
+              "interval": "",
               "legendFormat": "bytes/sec",
               "refId": "B"
             }
@@ -777,7 +795,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 10
       },
       "id": 32,
       "panels": [
@@ -1463,7 +1481,234 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 11
+      },
+      "id": 89,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "The number of messages we've written through a Kafka Sink.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 87,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_messages_sent_total[$__interval])",
+              "interval": "",
+              "legendFormat": "{{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_kafka_messages_sent_total",
+              "interval": "",
+              "legendFormat": "total {{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Messages Written",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "wps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "description": "The number of errors we've received when writing messages to Kafka",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 91,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_message_send_errors_total[$__interval])",
+              "interval": "",
+              "legendFormat": "{{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_kafka_message_send_errors_total",
+              "interval": "",
+              "legendFormat": "total {{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Message Write Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "eps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "total",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Sinks",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
       },
       "id": 68,
       "panels": [
@@ -1486,7 +1731,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 77,
@@ -1586,7 +1831,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 37,
@@ -1685,7 +1930,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 21
           },
           "hiddenSeries": false,
           "id": 79,
@@ -1784,19 +2029,22 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 20
+            "y": 21
           },
           "hiddenSeries": false,
           "id": 6,
           "legend": {
-            "avg": false,
-            "current": false,
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
             "hideEmpty": true,
-            "max": false,
-            "min": false,
+            "max": true,
+            "min": true,
             "show": true,
+            "sort": null,
+            "sortDesc": null,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -1815,6 +2063,7 @@
           "targets": [
             {
               "expr": "topk(10, mz_perf_dependency_frontiers)",
+              "interval": "",
               "legendFormat": "{{source}} -> {{dataflow}}",
               "refId": "A"
             }
@@ -1871,7 +2120,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 13
       },
       "id": 30,
       "panels": [
@@ -2392,7 +2641,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 14
       },
       "id": 83,
       "panels": [
@@ -2415,7 +2664,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 14
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 16,
@@ -2510,7 +2759,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 14
+            "y": 15
           },
           "hiddenSeries": false,
           "id": 81,
@@ -2605,7 +2854,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 52,
@@ -2706,7 +2955,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 23
           },
           "hiddenSeries": false,
           "id": 58,
@@ -2815,7 +3064,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 50,
@@ -2984,7 +3233,7 @@
         "current": {},
         "datasource": "Prometheus",
         "definition": "label_values(mz_server_metadata_timely_worker_threads, count)",
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "label": "Timely Workers",
         "multi": true,
@@ -3092,5 +3341,5 @@
   "timezone": "",
   "title": "Materialize Overview",
   "uid": "materialize-overview",
-  "version": 1
+  "version": 0
 }

--- a/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+++ b/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
@@ -26,7 +26,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1605821758407,
+  "iteration": 1605829563062,
   "links": [],
   "panels": [
     {
@@ -1367,7 +1367,22 @@
             "align": false,
             "alignLevel": null
           }
-        },
+        }
+      ],
+      "title": "Ingest",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 93,
+      "panels": [
         {
           "aliasColors": {},
           "bars": false,
@@ -1386,8 +1401,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 27
+            "x": 0,
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 47,
@@ -1471,7 +1486,7 @@
           }
         }
       ],
-      "title": "Ingest",
+      "title": "Kinesis",
       "type": "row"
     },
     {
@@ -1481,7 +1496,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 89,
       "panels": [
@@ -1504,7 +1519,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 87,
@@ -1610,7 +1625,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 91,
@@ -1708,7 +1723,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 68,
       "panels": [
@@ -2120,7 +2135,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 30,
       "panels": [
@@ -2641,7 +2656,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 83,
       "panels": [
@@ -3322,7 +3337,7 @@
     ]
   },
   "time": {
-    "from": "now/d",
+    "from": "now-24h/d",
     "to": "now/d"
   },
   "timepicker": {

--- a/misc/monitoring/dashboard/materialize-public.json
+++ b/misc/monitoring/dashboard/materialize-public.json
@@ -1,0 +1,3382 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$datasource",
+        "enable": true,
+        "expr": "increase(up{instance=~\"$instance\"}[1m])",
+        "hide": true,
+        "iconColor": "#DEB6F2",
+        "name": "start time",
+        "showIn": 0,
+        "titleFormat": "Materialized Started"
+      },
+      {
+        "builtIn": 1,
+        "datasource": "$datasource",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1605821758407,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 62,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(mz_kafka_messages_ingested{instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(mz_messages_ingested{instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Kafka Messages Ingested",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "How many messages per second materialized is currently ingesting",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 64,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(rate(mz_kafka_messages_ingested{instance=~\"$instance\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(mz_messages_ingested{instance=~\"$instance\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Kafka Message Ingest Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "A record is equivalent to a row in a traditional database",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 70,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(mz_perf_arrangement_records{instance=~\"$instance\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total Number of Records",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Total number of sql data queries being executed per second.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "light-green",
+                "value": 100
+              },
+              {
+                "color": "super-light-purple",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 66,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(rate(mz_command_durations_count{instance=~\"$instance\",command=~\"execute|query\",status=\"success\"}[$__interval]))",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client queries per second",
+      "type": "stat"
+    },
+    {
+      "content": "Timely Workers: $timely_workers<br/>\nBuilt At: $built_at<br/>\nBuild Version: $build_version<br/>\nBuild sha: $build_sha<br/>",
+      "datasource": "$datasource",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 17,
+        "y": 1
+      },
+      "id": 74,
+      "mode": "html",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Materialize Build Info",
+      "type": "text"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 5
+      },
+      "id": 76,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum(rate(mz_command_durations_count{instance=~\"$instance\",status=\"error\"}[5m]))",
+          "interval": "",
+          "legendFormat": "{{purpose}}/{{test}}/{{workflow}}/{{id}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Query Error Rate",
+      "type": "stat"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 39,
+      "panels": [
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "#77e04c",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateGreens",
+            "exponent": 0.9,
+            "min": null,
+            "mode": "spectrum"
+          },
+          "dataFormat": "tsbuckets",
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "heatmap": {},
+          "hideZeroBuckets": true,
+          "highlightCards": true,
+          "id": 26,
+          "interval": "",
+          "legend": {
+            "show": true
+          },
+          "maxDataPoints": 500,
+          "reverseYBuckets": false,
+          "targets": [
+            {
+              "expr": "sum(increase(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"success\"}[$__interval])) by (le)",
+              "format": "heatmap",
+              "instant": false,
+              "interval": "10s",
+              "intervalFactor": 1,
+              "legendFormat": "{{le}}",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "command=$command server latency heatmap",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "tooltipDecimals": 0,
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": 0,
+            "format": "s",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketBound": "auto",
+          "yBucketNumber": null,
+          "yBucketSize": null
+        },
+        {
+          "aliasColors": {
+            "error p99": "super-light-yellow",
+            "max": "purple",
+            "median": "blue",
+            "p001": "green",
+            "p95": "orange",
+            "p99": "red"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "the view of how long things took, from inside pgwire",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 25,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(1, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"success\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "max",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "p99",
+              "refId": "B"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "p95",
+              "refId": "C"
+            },
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "median",
+              "refId": "D"
+            },
+            {
+              "expr": "histogram_quantile(0.001, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"success\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "p001",
+              "refId": "E"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"error\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "error p99",
+              "refId": "F"
+            },
+            {
+              "expr": "histogram_quantile(1, sum(rate(mz_command_durations_bucket{instance=~\"$instance\",command=~\"$command\",status=\"error\",num_warehouses=\"$num_warehouses\"}[$__interval])) by (le))",
+              "interval": "",
+              "legendFormat": "error max",
+              "refId": "G"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "command=$command server latency quantiles",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 2,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_command_durations_count{instance=~\"$instance\"}[$__interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{command}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "queries/second",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "reqps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "hiddenSeries": false,
+          "id": 41,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "bytes/sec",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_pg_sent_rows{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "rows/sec",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(mz_pg_sent_bytes{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "bytes/sec",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "query rows|bytes/second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Queries",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 32,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "avro events total success",
+              "yaxis": 2
+            },
+            {
+              "alias": "avro events total error",
+              "yaxis": 2
+            },
+            {
+              "alias": "protobuf events total success",
+              "yaxis": 2
+            },
+            {
+              "alias": "protobuf events total error",
+              "yaxis": 2
+            },
+            {
+              "alias": "csv events total success",
+              "yaxis": 2
+            },
+            {
+              "alias": "csv events total error",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_dataflow_events_read_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "{{format}} events {{status}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_dataflow_events_read_total{instance=~\"$instance\"}",
+              "instant": false,
+              "legendFormat": "{{format}} events total {{status}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Messages Ingested by Message Format",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "Unlike the Messages Ingested by Format, this shows the raw number of messages we've received\n\nCurrently only shows Kafka",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "hiddenSeries": false,
+          "id": 57,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_messages_ingested{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "rate {{topic}} {{source_id}} {{partition_id}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_kafka_messages_ingested{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "total {{topic}} {{source_id}} {{partition_id}}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(mz_messages_ingested{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "rate {{topic}} {{source_id}} {{partition_id}}",
+              "refId": "C"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Messages Ingested",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "rps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "The raw kafka offset as seen at ingest time by materialized.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 51,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "mz_kafka_partition_offset_received{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "{{topic}}/{{partition_id}} {{source_id}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_partition_offset_received{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "{{topic}}/{{partition_id}} {{source_id}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Offsets Received",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 19
+          },
+          "hiddenSeries": false,
+          "id": 12,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_bytes_read_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "rate",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_kafka_bytes_read_total{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "total",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(mz_bytes_read_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "rate",
+              "refId": "C"
+            },
+            {
+              "expr": "mz_bytes_read_total{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "total",
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka bytes read",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "Bps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "This shows the number of messages that materialize knows it is behind an kafka source.\n\nFor example, if there are 1,000 messages in kafka and materialized has processed 750, this value will be 250.\n\nThis is limited by the (low) frequency at which we request metadata from kafka -- it is common for all values to be zero, and there is only a problem if the number is not decreasing.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
+          },
+          "hiddenSeries": false,
+          "id": 49,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(50, clamp_min(\nmz_kafka_partition_offset_max{instance=~\"$instance\"} \n  - mz_kafka_partition_offset_ingested{instance=~\"$instance\"}, \n  0))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{topic}}/{{partition_id}} source={{source_id}}",
+              "refId": "A"
+            },
+            {
+              "expr": "topk(50, clamp_min(\nmz_kafka_partition_offset_max{instance=~\"$instance\"} \n  - mz_partition_offset_ingested{instance=~\"$instance\"}, \n  0))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{topic}}/{{partition_id}} source={{source_id}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Messages behind Kafka",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 10,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "This is only reported for Kinesis sources at the moment.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "hiddenSeries": false,
+          "id": 47,
+          "legend": {
+            "avg": false,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "mysql.tpcch.customer",
+              "yaxis": 1
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "mz_kinesis_shard_millis_behind_latest{instance=~\"$instance\"}",
+              "legendFormat": "{{ stream_name }} {{ shard_id }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time behind external source",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "ms",
+              "label": null,
+              "logBase": 10,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Ingest",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 89,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "The number of messages we've written through a Kafka Sink.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 87,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_messages_sent_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "{{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_kafka_messages_sent_total{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "total {{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Messages Written",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "wps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "The number of errors we've received when writing messages to Kafka",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "hiddenSeries": false,
+          "id": 91,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_message_send_errors_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "{{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_kafka_message_send_errors_total{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "total {{sink_id}}/{{worker_id}} {{topic}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Message Write Errors",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "eps",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": "total",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Sinks",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 68,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "A worker is the underlying thread of computation in materialized. In general materialized should send similar amounts of work to each worker, and therefore the commands processed per worker should be similar.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 77,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "sort": null,
+            "sortDesc": null,
+            "total": true,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "expr": "rate(mz_worker_commands_processed_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "{{command}}/{{worker}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Worker commands processing rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "A worker is the underlying thread of computation in materialized. In general materialized should send similar amounts of work to each worker, and the queue depths should be similar to each other.\n\nIf a queue is growing without bound, or queues are very unbalanced, that could signify a problem.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 37,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": true,
+          "targets": [
+            {
+              "expr": "mz_worker_command_queue_size{instance=~\"$instance\"}",
+              "legendFormat": "pending commands worker={{worker}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_worker_pending_peeks_queue_size{instance=~\"$instance\"}",
+              "legendFormat": "pending peeks worker={{worker}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Worker queue sizes",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "Proportion of time spent in maintenance, per arrangement,  for the top 50 arrangements.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 79,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "show": true,
+            "sort": "max",
+            "sortDesc": true,
+            "total": true,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(50, rate(mz_arrangement_maintenance_seconds_total{instance=~\"$instance\"}[$__interval]))",
+              "interval": "",
+              "legendFormat": "{{worker_id}}/{{arrangement_id}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Time spent in maintenance",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "This shows the top 10 dataflow operators that are introducing lag into the system.\n\nAn operator can introduce lag either because its source is running behind, or because it is doing lots of work.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "hideEmpty": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "sort": null,
+            "sortDesc": null,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(10, mz_perf_dependency_frontiers{instance=~\"$instance\"})",
+              "interval": "",
+              "legendFormat": "{{source}} -> {{dataflow}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Frontier lags",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": "Lag (from -> to)",
+              "logBase": 2,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Internal Latency and Throughput Measures",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 30,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "See also the CPU row in the [node-state dashboard](/d/node-state?var-job=load_test). \n\nYou will need to filter to the current instance: $instances",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 20,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(process_cpu_seconds_total{instance=~\"$instance\"}[$__interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "materialized",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(process_cpu_seconds_total{instance=~\".*16875\"}[$__interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "peeker",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "materialized: CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "Per-thread-name CPU usage, multiple trheads (e.g. in a pool) often share the same name. \n\nSee the thread-name-count panel for how many threads exist with a given name.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "hiddenSeries": false,
+          "id": 84,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(process_thread_cpu_seconds_total{instance=~\"$instance\"}[$__interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{thread_name}}",
+              "refId": "B"
+            },
+            {
+              "expr": "rate(process_thread_cpu_seconds_total{instance=~\".*16875\"}[$__interval])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "peeker",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "materialized: per-thread-name CPU usage",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "See also the Memory/Meminfo row in the [node-state dashboard](/d/node-state?var-job=load_test). \n\nYou will need to filter to the current instance: $instances",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 24,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "process_resident_memory_bytes{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "rss {{job}}",
+              "refId": "A"
+            },
+            {
+              "expr": "process_swap_memory_bytes{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "swap {{job}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "materialized: memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "How many threads exist with a given name in materialized.\n\nHelps think about per-thread CPU usage, in case it's over 100%",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "hiddenSeries": false,
+          "id": 85,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "process_thread_count{instance=~\"$instance\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{thread_name}}",
+              "refId": "B"
+            },
+            {
+              "expr": "process_thread_count{instance=~\".*:16875\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "peeker",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "materialized: thread-name counts",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "An arrangement is where materialize stores state, records are equivalent to rows in a database or messages in a stream.\n\nThis shows the top 10 arrangements by number of records, and should be similar to the Arrangement Batches panel.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "hiddenSeries": false,
+          "id": 35,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(10, mz_perf_arrangement_records{instance=~\"$instance\"})",
+              "interval": "",
+              "legendFormat": "w={{worker}} op={{operator}} name={{name}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Arrangement Records",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Resource Consumption",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 83,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "A batch is a slab of memory, arrangements with a large number of batches have allocated a large number of records, which should be represented in the Arrangement Records panel.\n\nThis shows the top 10 arrangements by number of batches, and should be similar to the Arrangement Records panel.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "topk(10, mz_perf_arrangements_batches{instance=~\"$instance\"})",
+              "interval": "",
+              "legendFormat": "w={{worker}} op={{operator}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Arrangement Batches",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "This is expected to be primarily at zero, with very brief spikes.\n\nIf any time series is above zero for multiple points that suggests that we are stuck.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 81,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum by (worker_id) (mz_arrangement_maintenance_active_info{instance=~\"$instance\"})",
+              "interval": "",
+              "legendFormat": "worker {{worker_id}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Number of arrangements in mainenance",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "The difference between the most-consumed and least-consumed kafka partition, in terms of when we last released messages into the dataflow layer.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 23
+          },
+          "hiddenSeries": false,
+          "id": 52,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "max by (topic, source_id) (mz_kafka_partition_closed_ts{instance=~\"$instance\"}) - min by (topic, source_id) (mz_kafka_partition_closed_ts{instance=~\"$instance\"})",
+              "interval": "",
+              "legendFormat": "{{topic}}-{{source_id}}",
+              "refId": "A"
+            },
+            {
+              "expr": "max by (topic, source_id) (mz_partition_closed_ts{instance=~\"$instance\"}) - min by (topic, source_id) (mz_partition_closed_ts{instance=~\"$instance\"})",
+              "interval": "",
+              "legendFormat": "{{topic}}-{{source_id}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Kafka Partition Imbalance Amount",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "The total number of times that a source has been scheduled, and the rate at which they're scheduled.\n\nIn a well-behaved system, sources should be activated approximately in proportion to how much data they have to read. If sources are being scheduled at significantly different proportions it could mean that the more-scheduled sources are having a hard time keeping up.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 23
+          },
+          "hiddenSeries": false,
+          "id": 58,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "/.*total.*/",
+              "fill": 0,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_operator_scheduled_total{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "kafka {{topic}} {{source_id}}",
+              "refId": "A"
+            },
+            {
+              "expr": "mz_operator_scheduled_total{instance=~\"$instance\"}",
+              "interval": "",
+              "legendFormat": "kafka total {{topic}} {{source_id}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Source Scheduled Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$datasource",
+          "description": "This is a measure of when we last stated that ingested data was valid for computation. Another way of thinking about this is how many seconds of data do we ingest per second of real time. In a steady state this should be approximately 1s/s.\n\nAll sources that have a rate of 0 are *stalled* and are either not ingesting new data or have no new data to ingest.\n\nInternally, this is the capability, and the underlying measure is what capability we have released.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 31
+          },
+          "hiddenSeries": false,
+          "id": 50,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(mz_kafka_capability{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "{{topic}}-{{source_id}}",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(mz_capability{instance=~\"$instance\"}[$__interval])",
+              "interval": "",
+              "legendFormat": "{{topic}}-{{source_id}}",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": " Capability Closing Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 10,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "decbytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Internal Debugging",
+      "type": "row"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(up{instance=~\".*:6875\"}, instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance",
+        "multi": false,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(up{instance=~\".*:6875\"}, instance)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "execute + query",
+          "value": [
+            "execute",
+            "query"
+          ]
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(mz_command_durations_bucket, command)",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": true,
+        "name": "command",
+        "options": [
+          {
+            "selected": false,
+            "text": "bind",
+            "value": "bind"
+          },
+          {
+            "selected": false,
+            "text": "describe_portal",
+            "value": "describe_portal"
+          },
+          {
+            "selected": false,
+            "text": "describe_statement",
+            "value": "describe_statement"
+          },
+          {
+            "selected": true,
+            "text": "execute",
+            "value": "execute"
+          },
+          {
+            "selected": false,
+            "text": "parse",
+            "value": "parse"
+          },
+          {
+            "selected": true,
+            "text": "query",
+            "value": "query"
+          },
+          {
+            "selected": false,
+            "text": "sync",
+            "value": "sync"
+          },
+          {
+            "selected": false,
+            "text": "terminate",
+            "value": "terminate"
+          }
+        ],
+        "query": "label_values(mz_command_durations_bucket, command)",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(mz_server_metadata_timely_worker_threads, count)",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Timely Workers",
+        "multi": true,
+        "name": "timely_workers",
+        "options": [],
+        "query": "label_values(mz_server_metadata_timely_worker_threads, count)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(mz_server_metadata_seconds, build_time)",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Built at",
+        "multi": false,
+        "name": "built_at",
+        "options": [],
+        "query": "label_values(mz_server_metadata_seconds, build_time)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(mz_server_metadata_seconds, build_version)",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Version",
+        "multi": false,
+        "name": "build_version",
+        "options": [],
+        "query": "label_values(mz_server_metadata_seconds, build_version)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allFormat": "glob",
+        "allValue": null,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": "label_values(mz_server_metadata_seconds, build_sha)",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Git commit",
+        "multi": false,
+        "name": "build_sha",
+        "options": [],
+        "query": "label_values(mz_server_metadata_seconds, build_sha)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now/d",
+    "to": "now/d"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Materialize Overview",
+  "uid": "materialize",
+  "version": 0
+}

--- a/misc/monitoring/dashboard/materialize-public.json
+++ b/misc/monitoring/dashboard/materialize-public.json
@@ -26,7 +26,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "iteration": 1605821758407,
+  "iteration": 1605829563062,
   "links": [],
   "panels": [
     {
@@ -1367,7 +1367,22 @@
             "align": false,
             "alignLevel": null
           }
-        },
+        }
+      ],
+      "title": "Ingest",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": "$datasource",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 93,
+      "panels": [
         {
           "aliasColors": {},
           "bars": false,
@@ -1386,8 +1401,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 12,
-            "y": 27
+            "x": 0,
+            "y": 12
           },
           "hiddenSeries": false,
           "id": 47,
@@ -1471,7 +1486,7 @@
           }
         }
       ],
-      "title": "Ingest",
+      "title": "Kinesis",
       "type": "row"
     },
     {
@@ -1481,7 +1496,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 12
       },
       "id": 89,
       "panels": [
@@ -1504,7 +1519,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 87,
@@ -1610,7 +1625,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 12
+            "y": 13
           },
           "hiddenSeries": false,
           "id": 91,
@@ -1708,7 +1723,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 68,
       "panels": [
@@ -2120,7 +2135,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 14
       },
       "id": 30,
       "panels": [
@@ -2641,7 +2656,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 83,
       "panels": [
@@ -3359,7 +3374,7 @@
     ]
   },
   "time": {
-    "from": "now/d",
+    "from": "now-24h/d",
     "to": "now/d"
   },
   "timepicker": {

--- a/misc/python/materialize/cli/dashboard_clean.py
+++ b/misc/python/materialize/cli/dashboard_clean.py
@@ -71,6 +71,12 @@ def main(source: os.PathLike, inplace: bool) -> None:
     data["title"] = "Materialize Overview"
 
     lst = data["templating"]["list"]
+    # adjust for public not needing meta
+    data["panels"] = [p for p in data["panels"] if p["title"] != "Meta"]
+    for p in data["panels"]:
+        if p["title"] == "Materialize Build Info":
+            p["gridPos"] = {"h": 4, "w": 7, "x": 17, "y": 1}
+
     data["templating"]["list"] = [
         clean_var(i) for i in lst if i["name"] in VAR_ALLOWLIST
     ]

--- a/misc/python/materialize/cli/dashboard_clean.py
+++ b/misc/python/materialize/cli/dashboard_clean.py
@@ -36,6 +36,10 @@ LOAD_TEST_LABELS = [
     r'''test=~\"$test\"''',
     r'''purpose=~\"$purpose\"''',
     r'''workflow=~\"$workflow\"''',
+    r'''num_warehouses=~\"$num_warehouses\"''',
+    r'''instance_type=~\"$ec2_instance_type\"''',
+    r'''oltp_threads=~\"$oltp_threads\"''',
+    r'''olap_threads=~\"$olap_threads\"''',
 ]
 
 VAR_ALLOWLIST = set(

--- a/misc/python/materialize/cli/dashboard_clean.py
+++ b/misc/python/materialize/cli/dashboard_clean.py
@@ -22,7 +22,7 @@ import json
 import re
 import sys
 import os
-from typing import Dict, Any
+from typing import List, Dict, Any, Optional
 
 import click
 
@@ -43,16 +43,86 @@ LOAD_TEST_LABELS = [
 ]
 
 VAR_ALLOWLIST = set(
-    ["command", "timely_workers", "built_at", "build_version", "build_sha"]
+    [
+        "datasource",
+        "command",
+        "instance",
+        "timely_workers",
+        "built_at",
+        "build_version",
+        "build_sha",
+    ]
 )
+
+VARS_FOR_WEB: List[Dict[str, Any]] = [
+    {
+        "current": None,
+        "hide": 0,
+        "includeAll": False,
+        "label": "Datasource",
+        "multi": False,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": False,
+        "type": "datasource",
+    },
+    {
+        "allFormat": "glob",
+        "allValue": None,
+        "current": {},
+        "datasource": "$datasource",
+        "definition": r'label_values(up{instance=~".*:6875"}, instance)',
+        "hide": 0,
+        "includeAll": False,
+        "label": "Instance",
+        "multi": False,
+        "name": "instance",
+        "options": [],
+        "query": r'label_values(up{instance=~".*:6875"}, instance)',
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": False,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": False,
+    },
+]
 
 
 @click.command()
 @click.argument("source", type=click.Path(exists=True))
 @click.option("-i", "--inplace/--no-inplace", default=False)
-def main(source: os.PathLike, inplace: bool) -> None:
-    """Clean the overview dashboard json model for public consumption
-    """
+@click.option(
+    "--for-web/--no-for-web",
+    help="Update for our multi-datasource dashboard, instead of our user dashboard",
+    default=False,
+)
+@click.option("--uid")
+@click.option("--id")
+@click.option("--version", type=click.INT)
+@click.option("--title")
+def main(
+    source: os.PathLike,
+    inplace: bool,
+    for_web: bool,
+    uid: Optional[str],
+    id: Optional[str],
+    version: Optional[int],
+    title: Optional[str],
+) -> None:
+    """Clean the overview dashboard json model for public consumption"""
+    if for_web and any(v is None for v in (uid, id, version, title)):
+        print(
+            "ERROR: --version, --uid, --title, and --id are all required with --for-web",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     with open(source) as fh:
         content = fh.read()
     for label in LOAD_TEST_LABELS:
@@ -60,25 +130,46 @@ def main(source: os.PathLike, inplace: bool) -> None:
     content = re.sub(r",,+", ",", content)
     content = content.replace("{,", "{").replace(",}", "}")
     data = json.loads(content)
-    for panel in data["panels"]:
-        for target in panel.get("targets", []):
-            target["expr"] = strip_empty_labels(target["expr"])
-        # rows show up as panels, and so can hold panels
-        for panel_ in panel.get("panels", {}):
-            for target in panel_.get("targets", []):
-                target["expr"] = strip_empty_labels(target["expr"])
-    data["version"] = 1
-    data["title"] = "Materialize Overview"
 
-    lst = data["templating"]["list"]
+    for annotation in data["annotations"]["list"]:
+        clean_prop(annotation, for_web)
+    for panel in data["panels"]:
+        clean_prop(panel, for_web)
+        for target in panel.get("targets", []):
+            clean_prop(target, for_web)
+        # rows show up as panels, and so can hold panels
+        for row_panel in panel.get("panels", {}):
+            clean_prop(row_panel, for_web)
+            for target in row_panel.get("targets", []):
+                clean_prop(target, for_web)
+
     # adjust for public not needing meta
     data["panels"] = [p for p in data["panels"] if p["title"] != "Meta"]
     for p in data["panels"]:
         if p["title"] == "Materialize Build Info":
             p["gridPos"] = {"h": 4, "w": 7, "x": 17, "y": 1}
 
+    if for_web:
+        data["uid"] = uid
+        if id is not None:
+            data["id"] = None if id in ("null", "None") else int(id)
+        else:
+            data["id"] = None
+        data["version"] = version
+        data["title"] = title
+    else:
+        # this is used by the docker dashboard startup script, so be careful about changing it
+        data["uid"] = "materialize-overview"
+        data["id"] = None
+        data["version"] = 0
+        data["title"] = "Materialize Overview"
+
+    lst = []
+    if for_web:
+        lst.extend(VARS_FOR_WEB)
+    lst.extend(data["templating"]["list"])
     data["templating"]["list"] = [
-        clean_var(i) for i in lst if i["name"] in VAR_ALLOWLIST
+        clean_var(i, for_web) for i in lst if i["name"] in VAR_ALLOWLIST
     ]
 
     if inplace:
@@ -90,19 +181,56 @@ def main(source: os.PathLike, inplace: bool) -> None:
         print()
 
 
-def clean_var(var: Dict[str, Any]) -> Dict[str, Any]:
+def clean_prop(prop: Dict[str, Any], for_web: bool) -> None:
+    if for_web:
+        if "expr" in prop:
+            prop["expr"] = insert_instance_filter(prop["expr"])
+        if "datasource" in prop:
+            prop["datasource"] = "$datasource"
+    else:
+        if "expr" in prop:
+            prop["expr"] = strip_empty_labels(prop["expr"])
+
+
+def clean_var(var: Dict[str, Any], for_web: bool) -> Dict[str, Any]:
     # Command is the only one that has a default that we want to preserve
     if var["name"] != "command":
         var["current"] = {}
 
+    if var["name"] == "timely_workers":
+        var["hide"] = 2
+
     for key in ("definition", "query"):
         if key in var:
             var[key] = strip_empty_labels(var[key])
+
+    if for_web and var["name"] != "datasource":
+        var["datasource"] = "$datasource"
+
     return var
 
 
 def strip_empty_labels(val: str) -> str:
     return re.sub(r"{,*}", "", val)
+
+
+def insert_instance_filter(val: str) -> str:
+    if re.search("instance=~.*:6875", val) is not None:
+        new_val = re.sub(r'instance=~"[^"]+"', r'instance=~"$instance"', val)
+        if new_val == val:
+            print(f"warning: val did not get instance filter: {val}", file=sys.stderr)
+        val = new_val
+    elif "instance" not in val:
+        new_val = val.replace("{", r'{instance=~"$instance",')
+        if new_val == val:
+            print(f"warning: val did not get instance filter: {val}", file=sys.stderr)
+        val = new_val
+    elif "16875" in val:
+        # TODO: handle stripping peeker metrics from this dashboard
+        pass
+    else:
+        print(f"warning: couldn't insert instance in {val}", file=sys.stderr)
+    return val.replace(",}", "}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The big improvements in this PR are

* the dashboard-clean script now just works, instead of requiring modification to the dashboard
  after running it.
* we now support modifying the dashboard for environments that have multiple datasources. This
  makes the dashboard actually importable trivially by anyone into their infrastructure, and is
  one step closer to us publishing it on grafana.com.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4839)
<!-- Reviewable:end -->
