### PR TITLE
func: add ? operator support for map types

### DIFF
--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -801,6 +801,12 @@ impl<'a> ScalarType {
     pub fn is_vec(&self) -> bool {
         matches!(self, ScalarType::List(_) | ScalarType::Array(_))
     }
+
+    /// Returns whether or not `self` is a [`ScalarType::Map`] irrespective
+    /// of its inner value type.
+    pub fn is_map(&self) -> bool {
+        matches!(self, ScalarType::Map { .. })
+    }
 }
 
 // TODO(benesch): the implementations of PartialEq and Hash for ScalarType can

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -171,7 +171,7 @@ pub enum ScalarExpr {
 ///
 /// the `WHERE` clause will coerce the contained unconstrained type parameter
 /// `$1` to have type bool.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum CoercibleScalarExpr {
     Coerced(ScalarExpr),
     Parameter(usize),

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -554,7 +554,7 @@ impl ParamType {
             MapAny => match t {
                 Map { value_type } => !value_type.is_map(),
                 _ => false,
-            }
+            },
             Plain(to) => typeconv::get_cast(CastContext::Implicit, t, to).is_some(),
         }
     }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -114,7 +114,8 @@ impl TypeCategory {
             | ParamType::ArrayAny
             | ParamType::ListAny
             | ParamType::ListElementAny
-            | ParamType::NonVecAny => Self::Pseudo,
+            | ParamType::NonVecAny
+            | ParamType::MapAny => Self::Pseudo,
             ParamType::Plain(t) => Self::from_type(t),
         }
     }
@@ -374,6 +375,8 @@ impl ParamList {
     /// - All arguments passed to `ListAny` must be `ScalarType::List`s with the
     ///   same types of elements. All arguments passed to `ListElementAny` must
     ///   also be of these elements' type.
+    /// - All arguments passed to `MapAny` must be `ScalarType::Map`s with the
+    ///   same type of value in each key, value pair.
     ///
     /// # Errors
     /// - If `typs` is inconsistent with these constraints.
@@ -408,7 +411,8 @@ impl ParamList {
             let param = &self[i];
             match (param, typ) {
                 (ParamType::ListAny, Some(ScalarType::List(typ)))
-                | (ParamType::ArrayAny, Some(ScalarType::Array(typ))) => {
+                | (ParamType::ArrayAny, Some(ScalarType::Array(typ)))
+                | (ParamType::MapAny, Some(ScalarType::Map { value_type: typ })) => {
                     set_or_check_constrained_type(typ)?
                 }
                 (ParamType::ListElementAny, Some(typ)) | (ParamType::NonVecAny, Some(typ)) => {
@@ -451,6 +455,11 @@ impl ParamList {
                     param_types.push(ParamType::Plain(ScalarType::List(Box::new(
                         constrained_type.clone(),
                     ))));
+                }
+                (ParamType::MapAny, None) => {
+                    param_types.push(ParamType::Plain(ScalarType::Map {
+                        value_type: Box::new(constrained_type.clone()),
+                    }));
                 }
                 (ParamType::ListElementAny, None) => {
                     param_types.push(ParamType::Plain(constrained_type.clone()));
@@ -520,6 +529,9 @@ pub enum ParamType {
     /// except it does not permit either `ScalarType::Array` or
     /// `ScalarType::List`.
     NonVecAny,
+    /// A polymorphic pseudotype permitting a `ScalarType::Map` of any non-nested
+    /// value type. For more details, see [`resolve_polymorphic_types`].
+    MapAny,
     /// A standard parameter that accepts arguments that match its embedded
     /// `ScalarType`.
     Plain(ScalarType),
@@ -539,6 +551,10 @@ impl ParamType {
             ListAny => matches!(t, List(..) | String),
             Any | ListElementAny => true,
             NonVecAny => !t.is_vec(),
+            MapAny => match t {
+                Map { value_type } => !value_type.is_map(),
+                _ => false,
+            }
             Plain(to) => typeconv::get_cast(CastContext::Implicit, t, to).is_some(),
         }
     }
@@ -908,7 +924,7 @@ fn coerce_arg_to_type(
 
         // Polymorphic pseudotypes. As in PostgreSQL, these bail on
         // uncoerced arguments.
-        ArrayAny | ListAny | ListElementAny | NonVecAny => match arg {
+        ArrayAny | ListAny | ListElementAny | NonVecAny | MapAny => match arg {
             CoercibleScalarExpr::Coerced(arg) => Ok(arg),
             _ => bail!("could not determine polymorphic type because input has type unknown"),
         },
@@ -1847,7 +1863,8 @@ lazy_static! {
                 })
             },
             "?" => Scalar {
-                params!(Jsonb, String) => JsonbContainsString
+                params!(Jsonb, String) => JsonbContainsString,
+                params!(MapAny, String) => MapContainsKey
             },
             // COMPARISON OPS
             // n.b. Decimal impls are separated from other types because they

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -9,6 +9,7 @@
 
 mode cockroach
 
+# Test basic string to map casts.
 query error value_type parameter required
 CREATE TYPE custom AS MAP (key_type=text)
 
@@ -83,3 +84,34 @@ SELECT '{"a"=>"hello there!}'::map[text=>text]
 
 query error nested map types not yet supported
 SELECT '{a=>{b=>c}}'::map[text=>map[text=>text]]
+
+# Test map operators.
+
+## Test ?
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ? 'a'
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ? 'b'
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ? 'c'
+----
+false
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{a=>1, b=>2}'::map[text=>int] ? 1
+
+query T
+SELECT '{a=>1}'::map[text=>int] ? ''
+----
+false
+
+query T
+SELECT '{""=>1}'::map[text=>int] ? ''
+----
+true


### PR DESCRIPTION
The `?` operator checks if a map contains a given key, returning true
if the key is found and false otherwise. For example:

        SELECT '{a=>1, b=>2}'::map[text=>int] ? 'a'

Returns true.

As we only support text keys for maps, the expression provided as the
right hand side of the operator must be of type text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4840)
<!-- Reviewable:end -->
