### PR TITLE
expr: don't explicitly match on type in map_contains_key

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1197,12 +1197,9 @@ fn jsonb_contains_string<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
 }
 
 fn map_contains_key<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
-    // Map keys are always text.
-    let k = b.unwrap_str();
-    match a {
-        Datum::Map(dict) => dict.iter().any(|(k2, _v)| k == k2).into(),
-        _ => false.into(),
-    }
+    let map = a.unwrap_map();
+    let k = b.unwrap_str(); // Map keys are always text.
+    map.iter().any(|(k2, _v)| k == k2).into()
 }
 
 // TODO(jamii) nested loops are possibly not the fastest way to do this


### PR DESCRIPTION
@JLDLaughlin noticed this very minor nit in a very slow (post-merge) review of #4840, so didn't want to waste your time with it!

Unlike the similar JSON function, which has to handle the dynamic
typing of JSON values, the map_contains_key function can and should
assert that its input is a map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4843)
<!-- Reviewable:end -->
