### PR TITLE
sql: add various map operators

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1822,7 +1822,7 @@ lazy_static! {
                 params!(ListElementAny, ListAny) => ElementListConcat
             },
 
-            //JSON
+            //JSON and MAP
             "->" => Scalar {
                 params!(Jsonb, Int64) => JsonbGetInt64 { stringify: false },
                 params!(Jsonb, String) => JsonbGetString { stringify: false },
@@ -1844,7 +1844,8 @@ lazy_static! {
                 params!(String, Jsonb) => Operation::binary(|_ecx, lhs, rhs| {
                     Ok(lhs.call_unary(UnaryFunc::CastStringToJsonb)
                           .call_binary(rhs, JsonbContainsJsonb))
-                })
+                }),
+                params!(MapAny, MapAny) => MapContainsMap
             },
             "<@" => Scalar {
                 params!(Jsonb, Jsonb) =>  Operation::binary(|_ecx, lhs, rhs| {
@@ -1862,11 +1863,20 @@ lazy_static! {
                         lhs.call_unary(UnaryFunc::CastStringToJsonb),
                         BinaryFunc::JsonbContainsJsonb,
                     ))
+                }),
+                params!(MapAny, MapAny) => Operation::binary(|_ecx, lhs, rhs| {
+                    Ok(rhs.call_binary(lhs, MapContainsMap))
                 })
             },
             "?" => Scalar {
                 params!(Jsonb, String) => JsonbContainsString,
                 params!(MapAny, String) => MapContainsKey
+            },
+            "?&" => Scalar {
+                params!(MapAny, Plain(Array(Box::new(String)))) => MapContainsAllKeys
+            },
+            "?|" => Scalar {
+                params!(MapAny, Plain(Array(Box::new(String)))) => MapContainsAnyKeys
             },
             // COMPARISON OPS
             // n.b. Decimal impls are separated from other types because they

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -87,7 +87,7 @@ SELECT '{a=>{b=>c}}'::map[text=>map[text=>text]]
 
 # Test map operators.
 
-## Test ?
+## ?
 query T
 SELECT '{a=>1, b=>2}'::map[text=>int] ? 'a'
 ----
@@ -113,6 +113,150 @@ false
 
 query T
 SELECT '{""=>1}'::map[text=>int] ? ''
+----
+true
+
+## ?&
+query error string literal does not support casting from string to string\[\]
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& 'a'
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY[1]
+
+query error cannot determine type of empty array
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY[]
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY[NULL]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY['a']
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY['b', 'a']
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?& ARRAY['c', 'b']
+----
+false
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{1=>t, 2=>f}'::map[text=>bool] ?& ARRAY[1]
+
+query T
+SELECT '{1=>t, 2=>f}'::map[text=>bool] ?& ARRAY['1']
+----
+true
+
+query T
+SELECT '{1=>t, 2=>f}'::map[text=>bool] ?& ARRAY['']
+----
+false
+
+query T
+SELECT '{1=>t, 2=>f}'::map[text=>bool] ?& ARRAY['']
+----
+false
+
+## ?|
+query error string literal does not support casting from string to string\[\]
+SELECT '{a=>1, b=>2}'::map[text=>int] ?| 'a'
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY[1]
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY[NULL]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY['a']
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY['c', 'b']
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] ?| ARRAY['c', 'd', '1']
+----
+false
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{1=>t, 2=>f}'::map[text=>bool] ?| ARRAY[1]
+
+query T
+SELECT '{1=>t, 2=>f}'::map[text=>bool] ?| ARRAY['1']
+----
+true
+
+## @>
+query error could not determine polymorphic type because input has type unknown
+SELECT '{a=>1, b=>2}'::map[text=>int] @> 'a'
+
+query error  arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{a=>1, b=>2}'::map[text=>int] @> 'a'::text
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{a=>1, b=>2}'::map[text=>int] @> ARRAY[1]
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>t}'::map[text=>bool]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>1}'::map[text=>int]
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>1, b=>2}'::map[text=>int]
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>10, b=>20}'::map[text=>int]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>1, b=>2, c=>3}'::map[text=>int]
+----
+false
+
+## <@
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>t}'::map[text=>bool]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>1}'::map[text=>int]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>1, b=>2}'::map[text=>int]
+----
+true
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>10, b=>20}'::map[text=>int]
+----
+false
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>1, b=>2, c=>3}'::map[text=>int]
 ----
 true
 


### PR DESCRIPTION
Adds support for the following map operators:
- `?&`: checks if a given map contains **all** keys provided in an array
- `?|`: checks if a given map contains **any** keys provided in an array
- `<@`: given two maps, checks if the lhs map contains the rhs map
- `>@`: given two maps, checks if the rhs map contains the lhs map

All of the operators listed above return a boolean value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4844)
<!-- Reviewable:end -->
