### PR TITLE
expr: restrict IdHumanizer to GlobalIds

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector};
-use expr::{GlobalId, Id, IdHumanizer, OptimizedRelationExpr, ScalarExpr};
+use expr::{GlobalId, IdHumanizer, OptimizedRelationExpr, ScalarExpr};
 use repr::RelationDesc;
 use sql::ast::display::AstDisplay;
 use sql::catalog::CatalogError as SqlCatalogError;
@@ -1590,11 +1590,8 @@ impl Catalog {
 }
 
 impl IdHumanizer for Catalog {
-    fn humanize_id(&self, id: Id) -> Option<String> {
-        match id {
-            Id::Global(id) => self.by_id.get(&id).map(|entry| entry.name.to_string()),
-            Id::Local(_) => None,
-        }
+    fn humanize_id(&self, id: GlobalId) -> Option<String> {
+        self.by_id.get(&id).map(|entry| entry.name.to_string())
     }
 }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2066,7 +2066,7 @@ where
         let sink_name = format!(
             "tail-source-{}",
             self.catalog
-                .humanize_id(Id::Global(source_id))
+                .humanize_id(source_id)
                 .expect("Source id is known to exist in catalog")
         );
         let sink_id = self.catalog.allocate_id()?;

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -180,7 +180,7 @@ impl RelationExpr {
                             .map_or_else(|| "?".to_owned(), |i| i.to_string())
                     )
                     .unwrap(),
-                    Id::Global(_) => write!(
+                    Id::Global(id) => write!(
                         pretty,
                         "Get {} ({})",
                         id_humanizer

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -31,10 +31,10 @@ impl fmt::Display for Id {
     }
 }
 
-/// A trait for turning [`Id`]s into human-readable strings.
+/// A trait for turning [`GlobalId`]s into human-readable strings.
 pub trait IdHumanizer {
     /// Attempts to return the a human-readable string for `id`.
-    fn humanize_id(&self, id: Id) -> Option<String>;
+    fn humanize_id(&self, id: GlobalId) -> Option<String>;
 }
 
 /// The identifier for a local component of a dataflow.
@@ -159,7 +159,7 @@ impl PartitionId {
 pub struct DummyHumanizer;
 
 impl IdHumanizer for DummyHumanizer {
-    fn humanize_id(&self, _: Id) -> Option<String> {
+    fn humanize_id(&self, _: GlobalId) -> Option<String> {
         None
     }
 }

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -214,7 +214,7 @@ impl RelationExpr {
                     Id::Local(_) => {
                         unimplemented!("sql::RelationExpr::Get can't contain LocalId yet")
                     }
-                    Id::Global(_) => write!(
+                    Id::Global(id) => write!(
                         pretty,
                         "Get {} ({})",
                         id_humanizer

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -177,25 +177,25 @@ mod tests {
 
     #[derive(Debug)]
     struct TestCatalog {
-        objects: HashMap<String, (Id, RelationType)>,
-        names: HashMap<Id, String>,
+        objects: HashMap<String, (GlobalId, RelationType)>,
+        names: HashMap<GlobalId, String>,
     }
 
     impl<'a> TestCatalog {
         fn insert(&mut self, name: &str, typ: RelationType) {
             // TODO(justin): error on dup name?
-            let id = Id::Global(GlobalId::User(self.objects.len() as u64));
+            let id = GlobalId::User(self.objects.len() as u64);
             self.objects.insert(name.to_string(), (id, typ));
             self.names.insert(id, name.to_string());
         }
 
-        fn get(&'a self, name: &str) -> Option<&'a (Id, RelationType)> {
+        fn get(&'a self, name: &str) -> Option<&'a (GlobalId, RelationType)> {
             self.objects.get(name)
         }
     }
 
     impl IdHumanizer for TestCatalog {
-        fn humanize_id(&self, id: Id) -> Option<String> {
+        fn humanize_id(&self, id: GlobalId) -> Option<String> {
             self.names.get(&id).map(|s| s.to_string())
         }
     }
@@ -256,7 +256,7 @@ mod tests {
                     None => match catalog.get(&name) {
                         None => Err(anyhow!("no catalog object named {}", name)),
                         Some((id, typ)) => Ok(RelationExpr::Get {
-                            id: id.clone(),
+                            id: Id::Global(*id),
                             typ: typ.clone(),
                         }),
                     },


### PR DESCRIPTION
Empirically, IdHumanizers do not humanize local IDs. So restrict the
trait to GlobalIds. This makes all usages of the humanizer much simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4845)
<!-- Reviewable:end -->
