### PR TITLE
sql: add -> map operator

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1825,7 +1825,9 @@ lazy_static! {
             //JSON
             "->" => Scalar {
                 params!(Jsonb, Int64) => JsonbGetInt64 { stringify: false },
-                params!(Jsonb, String) => JsonbGetString { stringify: false }
+                params!(Jsonb, String) => JsonbGetString { stringify: false },
+                params!(MapAny, String) => MapGetValue,
+                params!(MapAny, Plain(Array(Box::new(String)))) => MapGetValues
             },
             "->>" => Scalar {
                 params!(Jsonb, Int64) => JsonbGetInt64 { stringify: true },

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -115,3 +115,57 @@ query T
 SELECT '{""=>1}'::map[text=>int] ? ''
 ----
 true
+
+## ->
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> ''
+----
+NULL
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> 'a'
+----
+1
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> 'b'
+----
+2
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> 'c'
+----
+NULL
+
+query error arguments cannot be implicitly cast to any implementation's parameters
+SELECT '{a=>1, b=>2}'::map[text=>int] -> 1
+
+query T
+SELECT '{a=>true, b=>false}'::map[text=>bool] -> 'b'
+----
+false
+
+query T
+SELECT '{a=>true, b=>false}'::map[text=>bool] -> ARRAY[]::text[]
+----
+{}
+
+query T
+SELECT '{a=>true, b=>false}'::map[text=>bool] -> ARRAY['']::text[]
+----
+{NULL}
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> ARRAY['a']
+----
+{1}
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> ARRAY['b', 'a']
+----
+{2,1}
+
+query T
+SELECT '{a=>1, b=>2}'::map[text=>int] -> ARRAY['b', 'a', 'c']
+----
+{2,1,NULL}


### PR DESCRIPTION
Adds support for using the -> operator with maps. The -> operator
allows users to fetch values from a map, given a single string key
or an array of string keys. For example:

    SELECT '{a=>1, b=>2}'::map[text=>int] -> 'a'

Returns 1.

    SELECT '{a=>1, b=>2}'::map[text=>int] -> ARRAY['a']

Returns {1}.

Any keys not found in the map will return a NULL value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4846)
<!-- Reviewable:end -->
