### PR TITLE
sql: plan CTEs another way

### DIFF
--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -286,10 +286,7 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::collections::BTreeMap;
     use std::error::Error;
-    use std::rc::Rc;
 
     use ore::collections::CollectionExt;
 
@@ -299,11 +296,8 @@ mod tests {
 
     #[test]
     fn normalized_create() -> Result<(), Box<dyn Error>> {
-        let scx = &StatementContext {
-            pcx: &PlanContext::default(),
-            catalog: &DummyCatalog,
-            param_types: Rc::new(RefCell::new(BTreeMap::new())),
-        };
+        let pcx = PlanContext::default();
+        let scx = &StatementContext::new(&pcx, &DummyCatalog);
 
         let parsed = sql_parser::parser::parse_statements(
             "create materialized view foo as select 1 as bar",

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -112,12 +112,11 @@ impl ColumnMap {
 impl RelationExpr {
     /// Rewrite `self` into a `expr::RelationExpr`.
     /// This requires rewriting all correlated subqueries (nested `RelationExpr`s) into flat queries
-    pub fn decorrelate(mut self) -> expr::RelationExpr {
-        let mut id_gen = expr::IdGen::default();
+    pub fn decorrelate(mut self, id_gen: &mut expr::IdGen) -> expr::RelationExpr {
         transform_expr::split_subquery_predicates(&mut self);
         transform_expr::try_simplify_quantified_comparisons(&mut self);
         expr::RelationExpr::constant(vec![vec![]], RelationType::new(vec![]))
-            .let_in(&mut id_gen, |id_gen, get_outer| {
+            .let_in(id_gen, |id_gen, get_outer| {
                 self.applied_to(id_gen, get_outer, &ColumnMap::empty())
             })
     }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -20,7 +20,6 @@
 //! To deal with this, whenever we see a SQL GROUP BY we look ahead for aggregates and precompute them in the `RelationExpr::Reduce`. When we reach the same aggregates during normal planning later on, we look them up in an `ExprContext` to find the precomputed versions.
 
 use std::borrow::Cow;
-use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use std::iter;
@@ -1801,7 +1800,7 @@ pub fn plan_expr<'a>(ecx: &'a ExprContext, e: &Expr) -> Result<CoercibleScalarEx
             if *n == 0 || *n > 65536 {
                 bail!("there is no parameter ${}", n);
             }
-            if ecx.param_types().borrow().contains_key(n) {
+            if ecx.qcx.scx.param_types.borrow().contains_key(n) {
                 ScalarExpr::Parameter(*n).into()
             } else {
                 CoercibleScalarExpr::Parameter(*n)
@@ -2847,9 +2846,5 @@ impl<'a> ExprContext<'a> {
 
     pub fn require_experimental_mode(&self, feature_name: &str) -> Result<(), anyhow::Error> {
         self.qcx.scx.require_experimental_mode(feature_name)
-    }
-
-    pub fn param_types(&self) -> &RefCell<BTreeMap<usize, ScalarType>> {
-        &self.qcx.scx.param_types
     }
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -29,7 +29,7 @@ use dataflow_types::{
     KafkaSinkConnectorBuilder, KafkaSourceConnector, KinesisSourceConnector, ProtobufEncoding,
     RegexEncoding, SinkConnectorBuilder, SourceConnector,
 };
-use expr::{GlobalId, LocalId, IdGen, RowSetFinishing};
+use expr::{GlobalId, IdGen, LocalId, RowSetFinishing};
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
 use ore::collections::CollectionExt;
 use ore::iter::IteratorExt;

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -493,8 +493,7 @@ pub fn plan_coerce<'a>(
         }
 
         Parameter(n) => {
-            let prev = ecx.param_types().borrow_mut().insert(n, coerce_to.clone());
-            assert!(prev.is_none());
+            ecx.qcx.scx.set_param_type(n, coerce_to.clone());
             ScalarExpr::Parameter(n)
         }
     })

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -24,11 +24,9 @@
 //! Symbiosis mode is only suitable for development. It is likely to be
 //! extremely slow and inefficient on large data sets.
 
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::env;
-use std::rc::Rc;
 
 use anyhow::{anyhow, bail};
 use chrono::Utc;
@@ -129,11 +127,7 @@ END $$;
         catalog: &dyn Catalog,
         stmt: &Statement,
     ) -> Result<Plan, anyhow::Error> {
-        let scx = StatementContext {
-            pcx,
-            catalog,
-            param_types: Rc::new(RefCell::new(BTreeMap::new())),
-        };
+        let scx = StatementContext::new(pcx, catalog);
         Ok(match stmt {
             Statement::CreateTable(CreateTableStatement {
                 name,


### PR DESCRIPTION
@sploiselle this is a slight extension to your branch from Friday that gets the basic cases working. Still need to do some thinking about how to get the complicated correlated cases to work properly.

----

Plan CTEs as explicit Lets/Gets so that those Lets/Gets can be carefully
lowered to dataflow Lets/Gets. The previous implementation inlined CTEs
at the site of every use.

The new implementation better matches the model of CTEs as relation
expressions that are computed once and reused--though because
Materialize does not yet support impure functions or statements with
side effects in CTEs, there is no behavioral difference between this
implementation and the last.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4849)
<!-- Reviewable:end -->
