### PR TITLE
sql: support nested map types

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -374,17 +374,21 @@ fn cast_string_to_list<'a>(
 
 fn cast_string_to_map<'a>(
     a: Datum<'a>,
+    map_typ: &ScalarType,
     cast_expr: &'a ScalarExpr,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
-    let parsed_map =
-        strconv::parse_map(a.unwrap_str(), |value_text| -> Result<Datum, EvalError> {
+    let parsed_map = strconv::parse_map(
+        a.unwrap_str(),
+        matches!(map_typ.unwrap_map_value_type(), ScalarType::Map { .. }),
+        |value_text| -> Result<Datum, EvalError> {
             let value_text = match value_text {
                 Cow::Owned(s) => temp_storage.push_string(s),
                 Cow::Borrowed(s) => s,
             };
             cast_expr.eval(&[Datum::String(value_text)], temp_storage)
-        })?;
+        },
+    )?;
     let mut pairs: Vec<(String, Datum)> = parsed_map.into_iter().map(|(k, v)| (k, v)).collect();
     pairs.sort_by(|(k1, _v1), (k2, _v2)| k1.cmp(k2));
     pairs.dedup_by(|(k1, _v1), (k2, _v2)| k1 == k2);
@@ -2673,9 +2677,10 @@ impl UnaryFunc {
                 cast_expr,
                 return_ty,
             } => cast_string_to_list(a, return_ty, &*cast_expr, temp_storage),
-            UnaryFunc::CastStringToMap { cast_expr, .. } => {
-                cast_string_to_map(a, &*cast_expr, temp_storage)
-            }
+            UnaryFunc::CastStringToMap {
+                cast_expr,
+                return_ty,
+            } => cast_string_to_map(a, return_ty, &*cast_expr, temp_storage),
             UnaryFunc::CastStringToTime => cast_string_to_time(a),
             UnaryFunc::CastStringToTimestamp => cast_string_to_timestamp(a),
             UnaryFunc::CastStringToTimestampTz => cast_string_to_timestamptz(a),

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -483,9 +483,11 @@ fn decode_map(
     val_type: &Type,
     raw: &str,
 ) -> Result<BTreeMap<String, Option<Value>>, Box<dyn Error + Sync + Send>> {
-    Ok(strconv::parse_map(raw, |elem_text| {
-        Value::decode_text(val_type, elem_text.as_bytes()).map(Some)
-    })?)
+    Ok(strconv::parse_map(
+        raw,
+        matches!(val_type, Type::Map { .. }),
+        |elem_text| Value::decode_text(val_type, elem_text.as_bytes()).map(Some),
+    )?)
 }
 
 fn encode_record<F>(buf: &mut F, elems: &[Option<Value>]) -> Nestable

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -801,12 +801,6 @@ impl<'a> ScalarType {
     pub fn is_vec(&self) -> bool {
         matches!(self, ScalarType::List(_) | ScalarType::Array(_))
     }
-
-    /// Returns whether or not `self` is a [`ScalarType::Map`] irrespective
-    /// of its inner value type.
-    pub fn is_map(&self) -> bool {
-        matches!(self, ScalarType::Map { .. })
-    }
 }
 
 // TODO(benesch): the implementations of PartialEq and Hash for ScalarType can

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2250,20 +2250,9 @@ impl<'a> Parser<'a> {
                     DataType::Decimal(precision, scale)
                 }
                 JSON | JSONB => DataType::Jsonb,
-                MAP => {
-                    let value_type = self.parse_map()?;
-                    if let DataType::Map { .. } = value_type {
-                        return parser_err!(
-                            self,
-                            self.peek_prev_pos(),
-                            "nested map types not yet supported"
-                        );
-                    }
-
-                    DataType::Map {
-                        value_type: Box::new(value_type),
-                    }
-                }
+                MAP => DataType::Map {
+                    value_type: Box::new(self.parse_map()?),
+                },
                 _ => self.expected(
                     self.peek_prev_pos(),
                     "a known data type",

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -551,10 +551,7 @@ impl ParamType {
             ListAny => matches!(t, List(..) | String),
             Any | ListElementAny => true,
             NonVecAny => !t.is_vec(),
-            MapAny => match t {
-                Map { value_type } => !value_type.is_map(),
-                _ => false,
-            },
+            MapAny => matches!(t, Map { .. }),
             Plain(to) => typeconv::get_direct_cast(CastContext::Implicit, t, to).is_some(),
         }
     }

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -525,9 +525,6 @@ pub fn plan_iterative_cast(
         (String, List(el_typ)) => (String, *el_typ.clone()),
         (String, Map { value_type }) => {
             ecx.require_experimental_mode("maps")?;
-            if let ScalarType::Map { .. } = **value_type {
-                unsupported!("nested map types");
-            }
             (String, *value_type.clone())
         }
         _ => bail!("invalid cast from {} to {}", from, to),

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -82,8 +82,40 @@ SELECT '{31=> \ normal }'::map[text=>text]
 query error unterminated quoted string
 SELECT '{"a"=>"hello there!}'::map[text=>text]
 
-query error nested map types not yet supported
-SELECT '{a=>{b=>c}}'::map[text=>map[text=>text]]
+## Nested maps
+
+query error expected '\{', found a: "a": "\{a=>a\}"
+SELECT '{a=>a}'::map[text=>map[text=>text]]
+
+query error expected =>: "\{a\}": "\{a=>\{a\}\}"
+SELECT '{a=>{a}}'::map[text=>map[text=>text]]
+
+query error expected '\{', found b: "b": "\{a=>\{a=>a\}, b=>b\}"
+SELECT '{a=>{a=>a}, b=>b}'::map[text=>map[text=>text]]
+
+query error unterminated embedded element
+SELECT '{hello=>{world=>broken'::map[text=>map[text=>text]]
+
+query error unescaped '\{' at beginning of value; perhaps you want a nested map
+SELECT '{hello=>{world=>true}}'::map[text=>bool]
+
+query T
+SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>text]]
+----
+{hello=>{world=>nested}}
+
+query error expected TEXT, found INT
+SELECT '{hello=>{1=>false}}'::map[text=>map[int=>bool]]
+
+query T
+SELECT '{hello=>{world=>"2020-11-23"}}'::map[text=>map[text=>timestamp]]
+----
+{hello=>{world=>"2020-11-23 00:00:00"}}
+
+query T
+SELECT '{hello=>{\{\}=>\"\"}}'::map[text=>map[text=>text]]
+----
+{hello=>{"{}"=>"\"\""}}
 
 # Test map operators.
 
@@ -113,6 +145,11 @@ false
 
 query T
 SELECT '{""=>1}'::map[text=>int] ? ''
+----
+true
+
+query T
+SELECT '{hello=>{world=>false}}'::map[text=>map[text=>bool]] -> 'hello'::text ? 'world'::text
 ----
 true
 
@@ -164,6 +201,16 @@ SELECT '{1=>t, 2=>f}'::map[text=>bool] ?& ARRAY['']
 ----
 false
 
+query T
+SELECT '{hello=>{world=>123.40}}'::map[text=>map[text=>double]] -> 'hello'::text ?& ARRAY['world']
+----
+true
+
+query T
+SELECT '{hello=>{world=>1293}}'::map[text=>map[text=>smallint]] -> 'hello'::text ?& ARRAY['world', 'extra']
+----
+false
+
 ## ?|
 query error string literal does not support casting from string to string\[\]
 SELECT '{a=>1, b=>2}'::map[text=>int] ?| 'a'
@@ -198,6 +245,16 @@ query T
 SELECT '{1=>t, 2=>f}'::map[text=>bool] ?| ARRAY['1']
 ----
 true
+
+query T
+SELECT '{hello=>{world=>63616665-6630-3064-6465-616462656568}}'::map[text=>map[text=>uuid]] -> 'hello'::text ?| ARRAY['world', 'extra']
+----
+true
+
+query T
+SELECT '{hello=>{world=>"2020-11-23"}}'::map[text=>map[text=>date]] -> 'hello'::text ?| ARRAY['missing']
+----
+false
 
 ## @>
 query error could not determine polymorphic type because input has type unknown
@@ -234,6 +291,21 @@ SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>1, b=>2, c=>3}'::map[text=>int]
 ----
 false
 
+query T
+SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>bytea]] @> '{hello=>world}'::map[text=>text]
+----
+false
+
+query T
+SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>text]] @> '{hello=>{world=>nested}}'::map[text=>map[text=>text]]
+----
+true
+
+query T
+SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>jsonb]] @> '{hello=>{world=>nested}, extra=>{elements=>here}}'::map[text=>map[text=>jsonb]]
+----
+false
+
 ## <@
 query T
 SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>t}'::map[text=>bool]
@@ -257,6 +329,21 @@ false
 
 query T
 SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>1, b=>2, c=>3}'::map[text=>int]
+----
+true
+
+query T
+SELECT '{hello=>{world=>a}}'::map[text=>map[text=>char]] <@ '{hello=>c}'::map[text=>char]
+----
+false
+
+query T
+SELECT '{hello=>{world=>16}}'::map[text=>map[text=>oid]] <@ '{hello=>{world=>16}}'::map[text=>map[text=>oid]]
+----
+true
+
+query T
+SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>text]] <@ '{hello=>{world=>nested}, extra=>{elements=>here}}'::map[text=>map[text=>text]]
 ----
 true
 
@@ -313,3 +400,18 @@ query T
 SELECT '{a=>1, b=>2}'::map[text=>int] -> ARRAY['b', 'a', 'c']
 ----
 {2,1,NULL}
+
+query T
+SELECT '{hello=>{world=>nested}, another=>{map=>here}}'::map[text=>map[text=>text]] -> 'missing'::text
+----
+NULL
+
+query T
+SELECT '{hello=>{world=>nested}, another=>{map=>here}}'::map[text=>map[text=>text]] -> 'hello'::text
+----
+{world=>nested}
+
+query T
+SELECT '{hello=>{world=>nested}, another=>{map=>here}}'::map[text=>map[text=>text]] -> 'hello'::text -> 'world'::text
+----
+nested


### PR DESCRIPTION
Adds support for nested map types like:

    '{a=>{b=>1}}'::map[text=>map[text=>int]]

Map keys must be of type text and non-null. Map values can be any
non-custom type. Support for nested maps with custom value types
is forthcoming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4868)
<!-- Reviewable:end -->
