### PR TITLE
sql: support DECLARE, FETCH, CLOSE cursor statements

### DIFF
--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -117,6 +117,23 @@ impl SessionClient {
         .await
     }
 
+    /// Binds a statement to a portal.
+    pub async fn declare(
+        &mut self,
+        name: String,
+        stmt: Statement,
+        param_types: Vec<Option<pgrepr::Type>>,
+    ) -> Result<(), anyhow::Error> {
+        self.send(|tx, session| Command::Declare {
+            name,
+            stmt,
+            param_types,
+            session,
+            tx,
+        })
+        .await
+    }
+
     /// Executes a previously-bound portal.
     pub async fn execute(&mut self, portal_name: String) -> Result<ExecuteResponse, anyhow::Error> {
         self.send(|tx, session| Command::Execute {

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -26,6 +26,14 @@ pub enum Command {
         tx: futures::channel::oneshot::Sender<Response<Vec<StartupMessage>>>,
     },
 
+    Declare {
+        name: String,
+        stmt: Statement,
+        param_types: Vec<Option<pgrepr::Type>>,
+        session: Session,
+        tx: futures::channel::oneshot::Sender<Response<()>>,
+    },
+
     Describe {
         name: String,
         stmt: Option<Statement>,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -51,7 +51,7 @@ use repr::{ColumnName, Datum, RelationDesc, RelationType, Row, RowPacker, Timest
 use sql::ast::display::AstDisplay;
 use sql::ast::{
     CreateIndexStatement, CreateTableStatement, DropObjectsStatement, ExplainOptions, ExplainStage,
-    ObjectType, Statement,
+    FetchStatement, ObjectType, Statement,
 };
 use sql::catalog::Catalog as _;
 use sql::names::{DatabaseSpecifier, FullName};
@@ -447,7 +447,7 @@ where
                     let res = async {
                         let stmt = sql::pure::purify(stmt).await?;
                         let catalog = self.catalog.for_system_session();
-                        let desc = sql::plan::describe(&catalog, stmt.clone(), &[])?;
+                        let desc = describe(&catalog, stmt.clone(), &[], None)?;
                         let pcx = PlanContext::default();
                         let plan = sql::plan::plan(&pcx, &catalog, stmt, &params)?;
                         // At time of writing this comment, Peeks use the connection id only for
@@ -524,6 +524,17 @@ where
                         tx.send(Err(e), session);
                     }
                 },
+
+                Message::Command(Command::Declare {
+                    name,
+                    stmt,
+                    param_types,
+                    mut session,
+                    tx,
+                }) => {
+                    let result = self.handle_declare(&mut session, name, stmt, param_types);
+                    let _ = tx.send(Response { result, session });
+                }
 
                 Message::Command(Command::Describe {
                     name,
@@ -747,6 +758,27 @@ where
         }
     }
 
+    fn handle_declare(
+        &self,
+        session: &mut Session,
+        name: String,
+        stmt: Statement,
+        param_types: Vec<Option<pgrepr::Type>>,
+    ) -> Result<(), anyhow::Error> {
+        // handle_describe cares about symbiosis mode here. Declared cursors are
+        // perhaps rare enough we can ignore that worry and just error instead.
+        let desc = describe(
+            &self.catalog.for_session(session),
+            stmt.clone(),
+            &param_types,
+            Some(session),
+        )?;
+        let params = vec![];
+        let result_formats = vec![pgrepr::Format::Text; desc.arity()];
+        session.set_portal(name, desc, Some(stmt), params, result_formats)?;
+        Ok(())
+    }
+
     fn handle_describe(
         &self,
         session: &mut Session,
@@ -755,10 +787,11 @@ where
         param_types: Vec<Option<pgrepr::Type>>,
     ) -> Result<(), anyhow::Error> {
         let desc = if let Some(stmt) = stmt.clone() {
-            match sql::plan::describe(
+            match describe(
                 &self.catalog.for_session(session),
                 stmt.clone(),
                 &param_types,
+                Some(session),
             ) {
                 Ok(desc) => desc,
                 // Describing the query failed. If we're running in symbiosis with
@@ -3268,5 +3301,34 @@ fn duration_to_timestamp_millis(d: Duration) -> Timestamp {
         Timestamp::min_value()
     } else {
         millis as Timestamp
+    }
+}
+
+/// Creates a description of the statement `stmt`.
+///
+/// This function is identical to sql::plan::describe except this is also
+/// supports describing FETCH statements which need access to bound portals
+/// through the session.
+pub fn describe(
+    catalog: &dyn sql::catalog::Catalog,
+    stmt: Statement,
+    param_types: &[Option<pgrepr::Type>],
+    session: Option<&Session>,
+) -> Result<StatementDesc, anyhow::Error> {
+    match stmt {
+        // FETCH's description depends on the current session, which describe_statement
+        // doesn't (and shouldn't?) have access to, so intercept it here.
+        Statement::Fetch(FetchStatement { ref name, .. }) => {
+            match session
+                .map(|session| session.get_portal(name.as_str()).map(|p| p.desc.clone()))
+                .flatten()
+            {
+                Some(desc) => Ok(desc),
+                // TODO(mjibson): return a correct error code here (34000) once our error
+                // system supports it.
+                None => bail!("cursor {} does not exist", name.to_ast_string_stable()),
+            }
+        }
+        _ => sql::plan::describe(catalog, stmt, param_types),
     }
 }

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -35,5 +35,5 @@ pub use crate::cache::CacheConfig;
 pub use crate::catalog::dump as dump_catalog;
 pub use crate::client::{Client, SessionClient};
 pub use crate::command::{ExecuteResponse, NoSessionExecuteResponse, StartupMessage};
-pub use crate::coord::{serve, Config, LoggingConfig};
+pub use crate::coord::{describe, serve, Config, LoggingConfig};
 pub use crate::timestamp::TimestampConfig;

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -25,6 +25,7 @@
 //! Supported `send` types:
 //! - [`Query`](struct.Query.html)
 //! - [`Parse`](struct.Parse.html)
+//! - [`Describe`](struct.Describe.html)
 //! - [`Bind`](struct.Bind.html)
 //! - [`Execute`](struct.Execute.html)
 //! - `Sync`
@@ -358,15 +359,21 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: &str, user: &str, timeout: 
                         }
                         "Parse" => {
                             let v: Parse = serde_json::from_str(args).unwrap();
-                            frontend::parse("", &v.query, vec![], buf).unwrap();
+                            frontend::parse(
+                                &v.name.unwrap_or_else(|| "".into()),
+                                &v.query,
+                                vec![],
+                                buf,
+                            )
+                            .unwrap();
                         }
                         "Sync" => frontend::sync(buf),
                         "Bind" => {
                             let v: Bind = serde_json::from_str(args).unwrap();
                             let values = v.values.unwrap_or_default();
                             if frontend::bind(
-                                "",     // portal
-                                "",     // statement
+                                &v.portal.unwrap_or_else(|| "".into()),
+                                &v.statement.unwrap_or_else(|| "".into()),
                                 vec![], // formats
                                 values, // values
                                 |t, buf| {
@@ -382,11 +389,22 @@ pub fn run_test(tf: &mut datadriven::TestFile, addr: &str, user: &str, timeout: 
                             }
                         }
                         "Describe" => {
-                            frontend::describe(b'S', "", buf).unwrap();
+                            let v: Describe = serde_json::from_str(args).unwrap();
+                            frontend::describe(
+                                v.variant.unwrap_or_else(|| "S".into()).as_bytes()[0],
+                                &v.name.unwrap_or_else(|| "".into()),
+                                buf,
+                            )
+                            .unwrap();
                         }
                         "Execute" => {
                             let v: Execute = serde_json::from_str(args).unwrap();
-                            frontend::execute("", v.max_rows.unwrap_or(0), buf).unwrap();
+                            frontend::execute(
+                                &v.portal.unwrap_or_else(|| "".into()),
+                                v.max_rows.unwrap_or(0),
+                                buf,
+                            )
+                            .unwrap();
                         }
                         _ => panic!("unknown message type {}", typ),
                     })
@@ -429,17 +447,28 @@ pub struct Query {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Parse {
+    pub name: Option<String>,
     pub query: String,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bind {
+    pub portal: Option<String>,
+    pub statement: Option<String>,
     pub values: Option<Vec<String>>,
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Execute {
+    pub portal: Option<String>,
     pub max_rows: Option<i32>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Describe {
+    pub variant: Option<String>,
+    pub name: Option<String>,
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -62,6 +62,9 @@ pub enum Statement {
     Rollback(RollbackStatement),
     Tail(TailStatement),
     Explain(ExplainStatement),
+    Declare(DeclareStatement),
+    Close(CloseStatement),
+    Fetch(FetchStatement),
 }
 
 impl AstDisplay for Statement {
@@ -102,6 +105,9 @@ impl AstDisplay for Statement {
             Statement::Rollback(stmt) => f.write_node(stmt),
             Statement::Tail(stmt) => f.write_node(stmt),
             Statement::Explain(stmt) => f.write_node(stmt),
+            Statement::Declare(stmt) => f.write_node(stmt),
+            Statement::Close(stmt) => f.write_node(stmt),
+            Statement::Fetch(stmt) => f.write_node(stmt),
         }
     }
 }
@@ -1342,3 +1348,52 @@ pub enum IfExistsBehavior {
     Skip,
     Replace,
 }
+
+/// `DECLARE ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DeclareStatement {
+    pub name: Ident,
+    pub stmt: Box<Statement>,
+}
+
+impl AstDisplay for DeclareStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("DECLARE ");
+        f.write_node(&self.name);
+        f.write_str(" CURSOR FOR ");
+        f.write_node(&self.stmt);
+    }
+}
+impl_display!(DeclareStatement);
+
+/// `CLOSE ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CloseStatement {
+    pub name: Ident,
+}
+
+impl AstDisplay for CloseStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("CLOSE ");
+        f.write_node(&self.name);
+    }
+}
+impl_display!(CloseStatement);
+
+/// `FETCH ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FetchStatement {
+    pub name: Ident,
+    pub count: Option<u64>,
+}
+
+impl AstDisplay for FetchStatement {
+    fn fmt(&self, f: &mut AstFormatter) {
+        f.write_str("FETCH ");
+        if let Some(count) = self.count {
+            f.write_str(format!("{} ", count));
+        }
+        f.write_node(&self.name);
+    }
+}
+impl_display!(FetchStatement);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -49,6 +49,7 @@ Chain
 Char
 Character
 Check
+Close
 Coalesce
 Collate
 Columns
@@ -61,6 +62,7 @@ Create
 Cross
 Csv
 Current
+Cursor
 Database
 Databases
 Date
@@ -69,6 +71,7 @@ Days
 Debezium
 Dec
 Decimal
+Declare
 Decorrelated
 Default
 Delete
@@ -99,6 +102,7 @@ Following
 For
 Foreign
 Format
+Forward
 From
 Full
 Group
@@ -106,6 +110,7 @@ Groups
 Having
 Header
 Headers
+Hold
 Hour
 Hours
 If

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parse-statement
+DECLARE "c" CURSOR WITHOUT HOLD FOR SELECT * FROM t
+----
+DECLARE c CURSOR FOR SELECT * FROM t
+=>
+Declare(DeclareStatement { name: Ident("c"), stmt: Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("t")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None }) })
+
+parse-statement
+DECLARE c CURSOR FOR TAIL t
+----
+DECLARE c CURSOR FOR TAIL t
+=>
+Declare(DeclareStatement { name: Ident("c"), stmt: Tail(TailStatement { name: ObjectName([Ident("t")]), options: [], as_of: None }) })
+
+parse-statement
+CLOSE c
+----
+CLOSE c
+=>
+Close(CloseStatement { name: Ident("c") })
+
+parse-statement
+FETCH FORWARD 2000 FROM c
+----
+FETCH 2000 c
+=>
+Fetch(FetchStatement { name: Ident("c"), count: Some(2000) })
+
+parse-statement
+FETCH c
+----
+FETCH c
+=>
+Fetch(FetchStatement { name: Ident("c"), count: None })
+
+parse-statement
+FETCH FORWARD c
+----
+FETCH c
+=>
+Fetch(FetchStatement { name: Ident("c"), count: None })
+
+parse-statement
+FETCH FROM c
+----
+FETCH c
+=>
+Fetch(FetchStatement { name: Ident("c"), count: None })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -55,7 +55,7 @@ pub use self::expr::RelationExpr;
 pub use error::PlanError;
 // This is used by sqllogictest to turn SQL values into `Datum`s.
 pub use query::scalar_type_from_sql;
-pub use statement::{StatementContext, StatementDesc};
+pub use statement::{describe_statement, StatementContext, StatementDesc};
 
 /// Instructions for executing a SQL query.
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -139,6 +139,8 @@ pub fn describe_statement(
         | Statement::StartTransaction(_)
         | Statement::Rollback(_)
         | Statement::Commit(_)
+        | Statement::Close(_)
+        | Statement::Declare(_)
         | Statement::AlterObjectRename(_)
         | Statement::AlterIndexOptions(_) => StatementDesc::new(None),
 
@@ -266,6 +268,8 @@ pub fn describe_statement(
         Statement::Update(_) => bail!("UPDATE statements are not supported"),
         Statement::Delete(_) => bail!("DELETE statements are not supported"),
         Statement::SetTransaction(_) => bail!("SET TRANSACTION statements are not supported"),
+
+        Statement::Fetch(_) => bail!("FETCH must be described with a Session"),
     })
 }
 
@@ -328,6 +332,10 @@ pub fn handle_statement(
         Statement::Update(_) => bail!("UPDATE statements are not supported"),
         Statement::Delete(_) => bail!("DELETE statements are not supported"),
         Statement::SetTransaction(_) => bail!("SET TRANSACTION statements are not supported"),
+
+        Statement::Declare(_) => bail!("DECLARE statements should already be handled"),
+        Statement::Fetch(_) => bail!("FETCH statements should already be handled"),
+        Statement::Close(_) => bail!("CLOSE statements should already be handled"),
     }
 }
 

--- a/test/pgtest/cursors.pt
+++ b/test/pgtest/cursors.pt
@@ -1,0 +1,514 @@
+# Verify we can pgwire Bind, Execute, then SQL FETCH and CLOSE, then
+# pgwire Execute fails (due to the close). This tests that pgwire portals
+# and SQL cursors are the same thing.
+send
+Query {"query": "BEGIN"}
+Parse {"name": "s", "query": "VALUES (2), (4), (6)"}
+Bind {"portal": "p", "statement": "s"}
+Execute {"portal": "p", "max_rows": 1}
+Sync
+Query {"query": "FETCH 1 p"}
+Query {"query": "CLOSE \"p\""}
+Execute {"portal": "p", "max_rows": 1}
+Sync
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+DataRow {"fields":["2"]}
+PortalSuspended
+ReadyForQuery {"status":"T"}
+RowDescription {"fields":[{"name":"column1"}]}
+DataRow {"fields":["4"]}
+CommandComplete {"tag":"FETCH 1"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"CLOSE CURSOR"}
+ReadyForQuery {"status":"T"}
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"p\" does not exist"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+# Ensure FETCH with no count returns 1 row.
+send
+Query {"query": "BEGIN"}
+Query {"query": "DECLARE c CURSOR FOR VALUES (2), (4), (6)"}
+Query {"query": "FETCH c"}
+Query {"query": "CLOSE c"}
+Query {"query": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ReadyForQuery {"status":"T"}
+RowDescription {"fields":[{"name":"column1"}]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"FETCH 1"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"CLOSE CURSOR"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+
+# FETCH with a high count.
+send
+Query {"query": "BEGIN"}
+Query {"query": "DECLARE c CURSOR FOR VALUES (2), (4), (6)"}
+Query {"query": "FETCH 2000 c"}
+Query {"query": "CLOSE c"}
+Query {"query": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ReadyForQuery {"status":"T"}
+RowDescription {"fields":[{"name":"column1"}]}
+DataRow {"fields":["2"]}
+DataRow {"fields":["4"]}
+DataRow {"fields":["6"]}
+CommandComplete {"tag":"FETCH 3"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"CLOSE CURSOR"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+
+# DECLARE outside a transaction should fail. A test like:
+# Query {"query": "DECLARE c CURSOR FOR VALUES (2), (4), (6)"}
+# would trigger this but we have slightly different transaction semantics
+# than Postgres that would require special casing this situation, and
+# it's safe to ignore, so we don't implement or test it.
+
+# Surprisingly, the same statement but with a SELECT added on passes. This
+# is because Postgres has some different transaction states. For a Query
+# message containing a single statement, it uses the DEFAULT state. If
+# there are multiple statements it uses INPROGRESS_IMPLICIT, which acts
+# similar to a BEGIN. The SELECT here triggers that, which then causes
+# DECLARE to error. Since we have fewer transaction states our DECLARE
+# doesn't detect this for the single statement case.
+send
+Query {"query": "DECLARE c CURSOR FOR VALUES (2), (4), (6); SELECT 1"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"DECLARE CURSOR"}
+RowDescription {"fields":[{"name":"?column?"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "CLOSE c"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"cursor \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "FETCH c"}
+----
+
+until err_field_typs=M
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"M","value":"cursor \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+# Verify that cursor and portal close messages differ.
+send
+Execute {"portal": "c"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+# Verify that Describe will fail before and after a transaction, but work within one.
+send
+Describe {"variant": "P", "name": "c"}
+Sync
+Query {"query": "BEGIN"}
+Query {"query": "DECLARE c CURSOR FOR VALUES (2), (4), (6)"}
+Describe {"variant": "P", "name": "c"}
+Query {"query": "COMMIT"}
+Describe {"variant": "P", "name": "c"}
+Sync
+----
+
+until
+ErrorResponse
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ReadyForQuery {"status":"T"}
+RowDescription {"fields":[{"name":"column1"}]}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+# Verify that a single Query message can declare and fetch from a
+# portal. This tests that, even though DECLARE cannot be used outside
+# of a transaction, a single Query message with multiple statements is
+# a transaction. Also verify that it doesn't exist afterward.
+send
+Query {"query": "DECLARE c CURSOR FOR VALUES (2), (4), (6); FETCH 2 c; FETCH 10 c;"}
+Describe {"variant": "P", "name": "c"}
+Sync
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"DECLARE CURSOR"}
+RowDescription {"fields":[{"name":"column1"}]}
+DataRow {"fields":["2"]}
+DataRow {"fields":["4"]}
+CommandComplete {"tag":"FETCH 2"}
+RowDescription {"fields":[{"name":"column1"}]}
+DataRow {"fields":["6"]}
+CommandComplete {"tag":"FETCH 1"}
+ReadyForQuery {"status":"I"}
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"c\" does not exist"}]}
+ReadyForQuery {"status":"I"}
+
+# Test cursors in extended protocol.
+send
+Query {"query": "BEGIN"}
+Parse {"query": "DECLARE c CURSOR FOR VALUES (1), (2), (3)"}
+Describe
+Bind
+Execute
+Parse {"query": "FETCH c"}
+Describe
+Bind
+Execute
+Execute {"portal": "c"}
+Parse {"query": "CLOSE c"}
+Describe
+Bind
+Execute
+Sync
+Query {"query": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+ParameterDescription {"parameters":[]}
+NoData
+BindComplete
+CommandComplete {"tag":"DECLARE CURSOR"}
+ParseComplete
+ParameterDescription {"parameters":[]}
+RowDescription {"fields":[{"name":"column1"}]}
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"FETCH 1"}
+DataRow {"fields":["2"]}
+DataRow {"fields":["3"]}
+CommandComplete {"tag":"SELECT 2"}
+ParseComplete
+ParameterDescription {"parameters":[]}
+NoData
+BindComplete
+CommandComplete {"tag":"CLOSE CURSOR"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+
+# Here's a tricky one. Create a portal ("c") with 6 rows in it. Create
+# and bind another portal ("a") that fetches 2 rows from "c", but don't
+# execute "a" at all. Execute the empty portal pulling 2 rows from c
+# (1, 2). Execute portal "a" but only request 1 row (3). At this point
+# "a" has also cached row 4 because it's a 2 row FETCH. Row 4 is in some
+# cache somewhere, and no longer in portal "c". Verify this by pulling
+# 2 more rows from "c" (5, 6). Finally pull the remaining rows from "a"
+# (4). This test verifies that the first execution of a FETCH will pull
+# N rows from its target portal and cache them.
+# NOTE: We differ from postgres here so don't actually test this. The
+# test and comment are left here so future readers can understand what
+# should be happening if we were fully compliant.
+#send
+#Query {"query": "BEGIN"}
+#Query {"query": "DECLARE c CURSOR FOR VALUES (1), (2), (3), (4), (5), (6)"}
+#Parse {"query": "FETCH 2 c"}
+#Bind {"portal": "a"}
+#Sync
+#Query {"query": "FETCH 2 c"}
+#Execute {"portal": "a", "max_rows": 1}
+#Sync
+#Query {"query": "FETCH 2 c"}
+#Execute {"portal": "a"}
+#Sync
+#Query {"query": "FETCH 2 c"}
+#Query {"query": "COMMIT"}
+#----
+#
+#until
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#ReadyForQuery
+#----
+#CommandComplete {"tag":"BEGIN"}
+#ReadyForQuery {"status":"T"}
+#CommandComplete {"tag":"DECLARE CURSOR"}
+#ReadyForQuery {"status":"T"}
+#ParseComplete
+#BindComplete
+#ReadyForQuery {"status":"T"}
+#RowDescription {"fields":[{"name":"column1"}]}
+#DataRow {"fields":["1"]}
+#DataRow {"fields":["2"]}
+#CommandComplete {"tag":"FETCH 2"}
+#ReadyForQuery {"status":"T"}
+#DataRow {"fields":["3"]}
+#PortalSuspended
+#ReadyForQuery {"status":"T"}
+#RowDescription {"fields":[{"name":"column1"}]}
+#DataRow {"fields":["5"]}
+#DataRow {"fields":["6"]}
+#CommandComplete {"tag":"FETCH 2"}
+#ReadyForQuery {"status":"T"}
+#DataRow {"fields":["4"]}
+#CommandComplete {"tag":"FETCH 2"}
+#ReadyForQuery {"status":"T"}
+#RowDescription {"fields":[{"name":"column1"}]}
+#CommandComplete {"tag":"FETCH 0"}
+#ReadyForQuery {"status":"T"}
+#CommandComplete {"tag":"COMMIT"}
+#ReadyForQuery {"status":"I"}
+
+# Test FETCH 0. This should return 0 rows (not all remaining, like Execute).
+send
+Query {"query": "BEGIN"}
+Query {"query": "DECLARE c CURSOR FOR VALUES (1), (2), (3), (4), (5), (6)"}
+Query {"query": "FETCH 0 c"}
+Query {"query": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ReadyForQuery {"status":"T"}
+RowDescription {"fields":[{"name":"column1"}]}
+CommandComplete {"tag":"FETCH 0"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+
+# Executing a DECLARE twice fails.
+send
+Query {"query": "BEGIN"}
+Parse {"query": "DECLARE c CURSOR FOR VALUES (1), (2), (3)"}
+Bind
+Execute
+Execute
+Sync
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DECLARE CURSOR"}
+ErrorResponse {"fields":[{"typ":"C","value":"55000"},{"typ":"M","value":"portal \"\" cannot be run"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+# Executing a FETCH twice does nothing the second time. It must be
+# rebound to get more rows.
+# Executing a CLOSE twice fails like DECLARE.
+send
+Query {"query": "BEGIN"}
+Parse {"query": "DECLARE c CURSOR FOR VALUES (1), (2), (3)"}
+Bind
+Execute
+Parse {"query": "FETCH c"}
+Bind
+Execute
+Execute
+Bind
+Execute
+Execute
+Parse {"query": "CLOSE c"}
+Bind
+Execute
+Execute
+Sync
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DECLARE CURSOR"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"FETCH 1"}
+CommandComplete {"tag":"FETCH 1"}
+BindComplete
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"FETCH 1"}
+CommandComplete {"tag":"FETCH 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CLOSE CURSOR"}
+ErrorResponse {"fields":[{"typ":"C","value":"55000"},{"typ":"M","value":"portal \"\" cannot be run"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+# Test FETCH with various combinations of row and execute counts. And
+# recall that since we don't support Execute with max_rows < FETCH's
+# count, we aren't testing that here, but should be if we add it.
+send
+Query {"query": "BEGIN"}
+Parse {"query": "DECLARE c CURSOR FOR VALUES (1), (2), (3), (4), (5), (6), (7), (8)"}
+Bind
+Execute
+Parse {"query": "FETCH 2 c"}
+Bind
+Execute
+Execute
+Bind
+Execute {"max_rows": 4}
+Execute {"max_rows": 4}
+Execute
+Parse {"query": "FETCH c"}
+Bind
+Execute {"max_rows": 2}
+Execute {"max_rows": 2}
+Sync
+Query {"query": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DECLARE CURSOR"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"FETCH 2"}
+CommandComplete {"tag":"FETCH 2"}
+BindComplete
+DataRow {"fields":["3"]}
+DataRow {"fields":["4"]}
+CommandComplete {"tag":"FETCH 2"}
+CommandComplete {"tag":"FETCH 2"}
+CommandComplete {"tag":"FETCH 2"}
+ParseComplete
+BindComplete
+DataRow {"fields":["5"]}
+CommandComplete {"tag":"FETCH 1"}
+CommandComplete {"tag":"FETCH 1"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+
+# Verify that the empty portal is removed after Query.
+send
+Query {"query": "BEGIN; DECLARE c CURSOR FOR VALUES (1), (2); FETCH c;"}
+Execute
+Sync
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+RowDescription {"fields":[{"name":"column1"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"FETCH 1"}
+ReadyForQuery {"status":"T"}
+ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal \"\" does not exist"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
The purpose of this support is to allow users with drivers that force
buffering all results in memory (most drivers) to be able to use TAIL
as a normal rows-returning statement (i.e., not COPY). FETCH makes it
easy to ask for a limited number of rows at a time.

These SQL statements are portal control messages that have exact pgwire
equivalents. As such they can be implemented without involvement of the
coordinator, similar to how the other portal control messages are (Parse,
Bind, Execute). In practice this means that one_query and execute now
have early-exit points for cursor statements. In addition, we also need
to pass around possible source portal information for correct semantics.

FETCH here is not a full implementation with respect to what Postgres
supports. Their FETCH drains the target portal of N rows, caches them,
and returns them as requested to users. Users could use Execute pgwire
messages to retrieve partial results at a time. We expect no one to do
this and, in order to avoid implementation difficulty, do not support
that use case.

sqllogictests are not included yet because it would require implementing
cursors there. Instead sqllogictest will be changed in a later PR to
work over pgwire, at which point cursor tests will be added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4871)
<!-- Reviewable:end -->
