### PR TITLE
sql/plan: remove misleading comment about ListAny/ArrayAny

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -544,11 +544,8 @@ impl ParamType {
         use ScalarType::*;
 
         match self {
-            // To support list (and, soon, array) concatenation, we must tell
-            // ourselves this white lie until
-            // https://github.com/MaterializeInc/materialize/issues/4627
-            ArrayAny => matches!(t, Array(..) | String),
-            ListAny => matches!(t, List(..) | String),
+            ArrayAny => matches!(t, Array(..)),
+            ListAny => matches!(t, List(..)),
             Any | ListElementAny => true,
             NonVecAny => !t.is_vec(),
             MapAny => match t {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1689,6 +1689,12 @@ SELECT LIST[[1], [2]] || LIST[[3], [4]]
 ----
 {{1},{2},{3},{4}}
 
+# Concatenation properly casts text to appropriate list type
+query T
+SELECT LIST[1] || '{2}'
+----
+{1,2}
+
 # 🔬🔬🔬 list + element
 
 query T
@@ -1831,3 +1837,7 @@ SELECT LIST[[NULL]] || LIST[1]
 
 query error no overload for i32 list list list || i32 list: Cannot concatenate i32 list list list and i32 list
 SELECT LIST[[[1]]] || LIST[2]
+
+# Literal text cannot be implicitly cast to list
+query error no overload for i32 list || string: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT LIST[1] || '{2}'::text


### PR DESCRIPTION
I left a misleading comment that sounded like a TODO but was not.
The original comment was meant only to explain that ListAny and
ArrayAny looked like they accepted strings when they didn't; now
they do, so the comment is moot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4873)
<!-- Reviewable:end -->
