### PR TITLE
repr,sql: get rid of desaturation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,6 +3230,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "criterion",
+ "enum-kinds",
  "hex",
  "itertools",
  "ordered-float",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 anyhow = "1.0.34"
 byteorder = "1.3"
 chrono = { version = "0.4", features = ["serde"] }
+enum-kinds = "0.5.0"
 hex = "0.4.2"
 itertools = "0.9"
 ordered-float = { version = "2.0.0", features = ["serde"] }

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -33,7 +33,7 @@ pub mod strconv;
 pub use cache::{CachedRecord, CachedRecordIter};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
 pub use row::{datum_size, DatumList, DatumMap, Row, RowArena, RowPacker};
-pub use scalar::{Datum, ScalarType};
+pub use scalar::{Datum, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.
 /// System-wide timestamp type.

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -11,6 +11,7 @@ use std::fmt::{self, Write};
 use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use enum_kinds::EnumKind;
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
@@ -630,7 +631,8 @@ impl fmt::Display for Datum<'_> {
 ///
 /// There is a direct correspondence between `Datum` variants and `ScalarType`
 /// variants.
-#[derive(Clone, Debug, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, Serialize, Deserialize, Ord, PartialOrd, EnumKind)]
+#[enum_kind(ScalarBaseType, derive(Hash))]
 pub enum ScalarType {
     /// The type of [`Datum::True`] and [`Datum::False`].
     Bool,
@@ -770,19 +772,6 @@ impl<'a> ScalarType {
         match self {
             ScalarType::Map { value_type } => &**value_type,
             _ => panic!("ScalarType::unwrap_map_value_type called on {:?}", self),
-        }
-    }
-
-    /// Returns a copy of `Self` with any embedded fields "zeroed" out. Meant to
-    /// make comparisons easier, allowing you to mimic `std::mem::discriminant`
-    /// equality.
-    pub fn desaturate(&self) -> ScalarType {
-        match self {
-            ScalarType::Array(..) => ScalarType::Array(Box::new(ScalarType::String)),
-            ScalarType::Decimal(..) => ScalarType::Decimal(0, 0),
-            ScalarType::List(..) => ScalarType::List(Box::new(ScalarType::String)),
-            ScalarType::Record { .. } => ScalarType::Record { fields: vec![] },
-            _ => self.clone(),
         }
     }
 

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -576,10 +576,11 @@ impl ParamType {
     }
 
     fn is_polymorphic(&self) -> bool {
-        matches!(
-            self,
-            Self::ArrayAny | Self::ListAny | Self::ListElementAny | Self::NonVecAny
-        )
+        use ParamType::*;
+        match self {
+            ArrayAny | ListAny | MapAny | ListElementAny | NonVecAny => true,
+            Any | Plain(_) => false,
+        }
     }
 }
 

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -257,8 +257,8 @@ SELECT '{hello=>{world=>"2020-11-23"}}'::map[text=>map[text=>date]] -> 'hello'::
 false
 
 ## @>
-query error could not determine polymorphic type because input has type unknown
-SELECT '{a=>1, b=>2}'::map[text=>int] @> 'a'
+query error invalid input syntax for map: expected '\{', found c: "c"
+SELECT '{a=>1, b=>2}'::map[text=>int] @> 'c'
 
 query error  arguments cannot be implicitly cast to any implementation's parameters
 SELECT '{a=>1, b=>2}'::map[text=>int] @> 'a'::text
@@ -266,7 +266,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] @> 'a'::text
 query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT '{a=>1, b=>2}'::map[text=>int] @> ARRAY[1]
 
-query T
+query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit cast
 SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>t}'::map[text=>bool]
 ----
 false
@@ -291,7 +291,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] @> '{a=>1, b=>2, c=>3}'::map[text=>int]
 ----
 false
 
-query T
+query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>bytea]] @> '{hello=>world}'::map[text=>text]
 ----
 false
@@ -307,7 +307,7 @@ SELECT '{hello=>{world=>nested}}'::map[text=>map[text=>jsonb]] @> '{hello=>{worl
 false
 
 ## <@
-query T
+query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>t}'::map[text=>bool]
 ----
 false
@@ -332,7 +332,7 @@ SELECT '{a=>1, b=>2}'::map[text=>int] <@ '{a=>1, b=>2, c=>3}'::map[text=>int]
 ----
 true
 
-query T
+query error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT '{hello=>{world=>a}}'::map[text=>map[text=>char]] <@ '{hello=>c}'::map[text=>char]
 ----
 false


### PR DESCRIPTION
Twiddle some interfaces around so that we no longer need to "desaturate" scalar types when planning casts and functions. Details in commit messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4875)
<!-- Reviewable:end -->
