### PR TITLE
Deduplicate coalesce arguments

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -413,6 +413,10 @@ impl ScalarExpr {
                         exprs.truncate(i + 1);
                     }
 
+                    // Deduplicate arguments in cases like `coalesce(#0, #0)`.
+                    let mut prior_exprs = HashSet::new();
+                    exprs.retain(|e| prior_exprs.insert(e.clone()));
+
                     if let Some(expr) = exprs.iter_mut().find(|e| e.is_literal_err()) {
                         // One of the remaining arguments is an error, so
                         // just replace the entire coalesce with that error.


### PR DESCRIPTION
This PR deduplicates arguments to `coalesce`, which allows us to remove the coalesce if all arguments are the same (which happens in `using(_)` joins). This fix allows inner joins with `using` syntax to plan as delta queries, once the `coalesce` is elided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4876)
<!-- Reviewable:end -->
