### PR TITLE
sql: jam recursive casts into the global cast map

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -336,7 +336,7 @@ pub enum ParamList {
 
 impl ParamList {
     /// Determines whether `typs` are compatible with `self`.
-    fn matches_argtypes(&self, typs: &[Option<ScalarType>]) -> bool {
+    fn matches_argtypes(&self, ecx: &ExprContext, typs: &[Option<ScalarType>]) -> bool {
         if !self.validate_arg_len(typs.len()) {
             return false;
         }
@@ -350,7 +350,7 @@ impl ParamList {
                 //
                 // N.B. this will require more fallthrough checks once we
                 // support RECORD types in functions.
-                if !param.accepts_type(typ) {
+                if !param.accepts_type(ecx, typ) {
                     return false;
                 }
             }
@@ -488,7 +488,7 @@ pub enum ParamType {
 
 impl ParamType {
     /// Does `self` accept arguments of type `t`?
-    fn accepts_type(&self, t: &ScalarType) -> bool {
+    fn accepts_type(&self, ecx: &ExprContext, t: &ScalarType) -> bool {
         use ParamType::*;
         use ScalarType::*;
 
@@ -498,8 +498,10 @@ impl ParamType {
             Any | ListElementAny => true,
             NonVecAny => !t.is_vec(),
             MapAny => matches!(t, Map { .. }),
-            DecimalAny => typeconv::can_cast(CastContext::Implicit, t, &ScalarType::Decimal(0, 0)),
-            Plain(to) => typeconv::can_cast(CastContext::Implicit, t, to),
+            DecimalAny => {
+                typeconv::can_cast(ecx, CastContext::Implicit, t, &ScalarType::Decimal(0, 0))
+            }
+            Plain(to) => typeconv::can_cast(ecx, CastContext::Implicit, t, to),
         }
     }
 
@@ -624,10 +626,10 @@ where
     // this purpose.
     let impls: Vec<_> = impls
         .iter()
-        .filter(|i| i.params.matches_argtypes(types))
+        .filter(|i| i.params.matches_argtypes(ecx, types))
         .collect();
 
-    let f = find_match(types, impls)?;
+    let f = find_match(ecx, types, impls)?;
 
     (f.op.0)(ecx, spec, cexprs, &f.params)
 }
@@ -638,6 +640,7 @@ where
 ///
 /// [pgparser]: https://www.postgresql.org/docs/current/typeconv-func.html
 fn find_match<'a, R: std::fmt::Debug>(
+    ecx: &ExprContext,
     types: &[Option<ScalarType>],
     impls: Vec<&'a FuncImpl<R>>,
 ) -> Result<&'a FuncImpl<R>, anyhow::Error> {
@@ -790,15 +793,15 @@ fn find_match<'a, R: std::fmt::Debug>(
                 let mut found_preferred_type_candidate = false;
                 candidates.retain(|c| {
                     if let Some(typ) = &preferred_type {
-                        found_preferred_type_candidate =
-                            c.fimpl.params[i].accepts_type(typ) || found_preferred_type_candidate;
+                        found_preferred_type_candidate = c.fimpl.params[i].accepts_type(ecx, typ)
+                            || found_preferred_type_candidate;
                     }
                     selected_category == TypeCategory::from_param(&c.fimpl.params[i])
                 });
 
                 if found_preferred_type_candidate {
                     let preferred_type = preferred_type.unwrap();
-                    candidates.retain(|c| c.fimpl.params[i].accepts_type(&preferred_type));
+                    candidates.retain(|c| c.fimpl.params[i].accepts_type(ecx, &preferred_type));
                 }
             }
             Some(typ) => {
@@ -830,7 +833,7 @@ fn find_match<'a, R: std::fmt::Debug>(
             })
             .collect();
 
-        candidates.retain(|c| c.fimpl.params.matches_argtypes(&common_typed));
+        candidates.retain(|c| c.fimpl.params.matches_argtypes(ecx, &common_typed));
 
         maybe_get_last_candidate!();
     }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -498,11 +498,8 @@ impl ParamType {
             Any | ListElementAny => true,
             NonVecAny => !t.is_vec(),
             MapAny => matches!(t, Map { .. }),
-            DecimalAny => {
-                typeconv::get_direct_cast(CastContext::Implicit, t, &ScalarType::Decimal(0, 0))
-                    .is_some()
-            }
-            Plain(to) => typeconv::get_direct_cast(CastContext::Implicit, t, to).is_some(),
+            DecimalAny => typeconv::can_cast(CastContext::Implicit, t, &ScalarType::Decimal(0, 0)),
+            Plain(to) => typeconv::can_cast(CastContext::Implicit, t, to),
         }
     }
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -29,7 +29,7 @@ use super::scope::Scope;
 
 /// A function that, when invoked, casts the input expression to the
 /// target type.
-pub struct CastOp(Box<dyn Fn(&ExprContext, ScalarExpr, &ScalarType) -> ScalarExpr + Send + Sync>);
+struct CastOp(Box<dyn Fn(&ExprContext, ScalarExpr, &ScalarType) -> ScalarExpr + Send + Sync>);
 
 impl CastOp {
     fn new<F>(f: F) -> CastOp
@@ -271,7 +271,7 @@ lazy_static! {
 /// Get casts directly between two [`ScalarType`]s, with control over the
 /// allowed [`CastContext`]. More complex casts, such as between
 /// `ScalarType::List`s, are handled elsewhere.
-pub fn get_direct_cast(
+fn get_direct_cast(
     ccx: CastContext,
     from: &ScalarType,
     to: &ScalarType,
@@ -493,7 +493,7 @@ pub fn plan_coerce<'a>(
 
 /// Plan a cast to a [`ScalarType::List`] or [`ScalarType::Map`], using an
 /// iterative process to perform the cast to each element in `to`.
-pub fn plan_iterative_cast(
+fn plan_iterative_cast(
     ecx: &ExprContext,
     ccx: CastContext,
     expr: ScalarExpr,
@@ -630,4 +630,11 @@ where
             Ok((cast_op.0)(ecx, expr, cast_to))
         }
     }
+}
+
+/// Reports whether it is possible to perform a cast from the specified types.
+pub fn can_cast(ccx: CastContext, cast_from: &ScalarType, cast_to: &ScalarType) -> bool {
+    // TODO(benesch): this needs to be aware of the casts in
+    // `plan_iterative_cast` too.
+    get_direct_cast(ccx, cast_from, cast_to).is_some()
 }


### PR DESCRIPTION
@sploiselle this is one possible approach to making `can_cast` aware of map/list types. I'm decently happy with it, but the type of `CastTemplate` is pretty horrible, so marking this as a draft for now to give us the space to try to think of something better.

----

Casting lists and map types is tricky, because the casts must proceed
recursively on the element types. So casts for these types were
previously handled separately from the other types of casts.  A small
bug resulted from this design, as the "can_cast" function was unaware of
these special list and map casts.

Restructure the cast map so that it can describe the recursive casts
necessary for maps and lists. The gist is that the cast map now stores
"cast templates" which can describe a suite of casts, like "string to
any list", rather than just individual casts between two concrete types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4878)
<!-- Reviewable:end -->
