### PR TITLE
repr: handle invalid dates using chrono's checks

### DIFF
--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -454,7 +454,7 @@ impl ParsedDateTime {
     ///
     /// # Errors
     /// - If year, month, or day overflows their respective parameter in
-    ///   [chrono::naive::date::NaiveDate::from_ymd](https://docs.rs/chrono/0.3.0/chrono/naive/date/struct.NaiveDate.html).
+    ///   [chrono::naive::date::NaiveDate::from_ymd_opt](https://docs.rs/chrono/0.4/chrono/naive/struct.NaiveDate.html#method.from_ymd_opt).
     pub fn compute_date(&self) -> Result<chrono::NaiveDate, String> {
         match (self.year, self.month, self.day) {
             (Some(year), Some(month), Some(day)) => {
@@ -462,7 +462,8 @@ impl ParsedDateTime {
                 let year = year.unit.try_into().map_err(|e| p_err(e, "Year"))?;
                 let month = month.unit.try_into().map_err(|e| p_err(e, "Month"))?;
                 let day = day.unit.try_into().map_err(|e| p_err(e, "Day"))?;
-                Ok(NaiveDate::from_ymd(year, month, day))
+                NaiveDate::from_ymd_opt(year, month, day)
+                    .ok_or_else(|| "invalid or out-of-range date".into())
             }
             (_, _, _) => Err("YEAR, MONTH, DAY are all required".into()),
         }

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -33,6 +33,14 @@ fn test_parse_date_errors() {
         "invalid input syntax for date: YEAR, MONTH, DAY are all required: \"2001\"",
     );
     run_test_parse_date_errors(
+        "2019-02-29",
+        "invalid input syntax for date: invalid or out-of-range date: \"2019-02-29\"",
+    );
+    run_test_parse_date_errors(
+        "2020-02-30",
+        "invalid input syntax for date: invalid or out-of-range date: \"2020-02-30\"",
+    );
+    run_test_parse_date_errors(
         "2001-13-01",
         "invalid input syntax for date: MONTH must be [1, 12], got 13: \"2001-13-01\"",
     );


### PR DESCRIPTION
The current code does some rudimentary checks before passing the data to chrono's `from_ymd` function but invalid combinations can still be constructed, causing a panic.

Switch to using `from_ymd_opt()` to handle all leap year, and per month limit edge cases

Fixes #4880

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4881)
<!-- Reviewable:end -->
