### PR TITLE
Add caveat re: Docker to get-started instructions

### DIFF
--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -27,6 +27,8 @@ We also highly recommend checking out [What is Materialize?](/overview/what-is-m
 ## Install, run, connect
 
 1. Install the `materialized` binary using [these instructions](/install).
+    
+    **Note**: Running Materialize via Docker will not work with this guide. Please install and run Materialize using a non-Docker method for the purposes of this guide.
 
 1. Run the `materialized` binary. For example, if you installed it in your `$PATH`:
 


### PR DESCRIPTION
Before running through the getting started guide, I had previously run through the "install" guide and used the Docker setup instruction. I then came to the getting started guide and assumed running Materialize in Docker was an adequate substitute for installing and running the binary directly. Turns out it wasn't - I got a `No such file or directory (os error 2)` error when trying to `create source` from the wikirecent file. I then tried installing via `apt` and the guide worked, so it seems that using Docker was the problem (perhaps it's looking for the source file on the image's file system, instead of the file system from which `psql` is being run).

It might make sense to instead provide a way of making the getting started guide compatible with Docker, but this warning should help until that can be done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4892)
<!-- Reviewable:end -->
