### PR TITLE
Partition MFP operators

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -177,6 +177,10 @@ disabled_lints=(
     # Upstream description: https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
     # Collapsing if statements can render code unreadable, and should not be mandated.
     clippy::collapsible-if
+
+    # Upstream description: https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive
+    # Unstable sort is not strictly better than sort, notably on partially sorted inputs.
+    clippy::stable-sort-primitive
 )
 
 # NOTE(benesch): we ignore some ShellCheck complaints about sloppy word

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -315,11 +315,17 @@ impl MapFilterProject {
     /// ]).project(vec![6]);
     ///
     /// // Imagine we start with columns (b, x, a, y, c).
+    /// //
+    /// // The `partition` method requires a map from *expected* input columns to *actual*
+    /// // input columns. In the example above, the columns a, b, and c exist, and are at
+    /// // locations 2, 0, and 4 respectively. We must construct a map to this effect.
     /// let mut available_columns = std::collections::HashMap::new();
     /// available_columns.insert(0, 2);
     /// available_columns.insert(1, 0);
     /// available_columns.insert(2, 4);
-    /// // Partition `original` using the available columns and input arity.
+    /// // Partition `original` using the available columns and current input arity.
+    /// // This informs `partition` which columns are available, where they can be found,
+    /// // and how many columns are not relevant but should be preserved.
     /// let (before, after) = original.partition(&available_columns, 5);
     ///
     /// // `before` sees all five input columns, and should append `a + b + c`.
@@ -333,9 +339,11 @@ impl MapFilterProject {
     ///    ScalarExpr::column(3).call_binary(ScalarExpr::column(4), BinaryFunc::AddInt64)
     /// ]).project(vec![5]));
     ///
-    /// // To reconstruct `self`, we must introduce columns that are not present
-    /// // (in this example `d`) project away irrelevant columns (`x` and `y`),
-    /// // and permute existing columns to the order expected by `self`.
+    /// // To reconstruct `self`, we must introduce the columns that are not present,
+    /// // and present them in the order intended by `self`. In this example, we must
+    /// // introduce colunm d and permute the columns so that they begin (a, b, c, d).
+    /// // The columns x and y must be projected away, and any columns introduced by
+    /// // `begin` must be retained in their current order.
     ///
     /// // The `after` instance expects to be provided with all inputs, but it
     /// // may not need all inputs. The `demand()` and `permute()` methods can

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -322,11 +322,13 @@ impl MapFilterProject {
     /// // Partition `original` using the available columns and input arity.
     /// let (before, after) = original.partition(&available_columns, 5);
     ///
+    /// // `before` sees all five input columns, and should append `a + b + c`.
     /// assert_eq!(before, MapFilterProject::new(5).map(vec![
     ///    ScalarExpr::column(2).call_binary(ScalarExpr::column(0), BinaryFunc::AddInt64),
     ///    ScalarExpr::column(4).call_binary(ScalarExpr::column(5), BinaryFunc::AddInt64),
     /// ]).project(vec![0, 1, 2, 3, 4, 6]));
     ///
+    /// // `after` expects to see `(a, b, c, d, a + b + c)`.
     /// assert_eq!(after, MapFilterProject::new(5).map(vec![
     ///    ScalarExpr::column(3).call_binary(ScalarExpr::column(4), BinaryFunc::AddInt64)
     /// ]).project(vec![5]));

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -193,6 +193,19 @@ impl ScalarExpr {
         });
     }
 
+    /// Rewrites column indices with their value in `permutation`.
+    ///
+    /// This method is applicable even when `permutation` is not a
+    /// strict permutation, and it only needs to have entries for
+    /// each column referenced in `self`.
+    pub fn permute_map(&mut self, permutation: &std::collections::HashMap<usize, usize>) {
+        self.visit_mut(&mut |e| {
+            if let ScalarExpr::Column(old_i) = e {
+                *old_i = permutation[old_i];
+            }
+        });
+    }
+
     pub fn support(&self) -> HashSet<usize> {
         let mut support = HashSet::new();
         self.visit(&mut |e| {


### PR DESCRIPTION
This PR introduces a `partition()` function that partitions a `MapFilterProject` instance into two instances, one of which can be applied to a specified subset of input columns, and the other of which has to wait for the remaining columns to be introduced.

This is a draft for discussion, to try and shake out the ergonomics. The goal is that the PR or something like it should make it easier to move MFP operators around during rendering, and unblock work that moves the same operators around during optimization but which currently confounds rendering.

cc @justinj

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4906)
<!-- Reviewable:end -->
