### PR TITLE
coord: permit setting DateStyle to "ISO" explicitly

### DIFF
--- a/src/coord/src/session/vars.rs
+++ b/src/coord/src/session/vars.rs
@@ -237,7 +237,17 @@ impl Vars {
         } else if name == DATABASE.name {
             self.database.set(value)
         } else if name == DATE_STYLE.name {
-            bail!("parameter {} is read only", DATE_STYLE.name);
+            for value in value.split(',') {
+                let value = unicase::Ascii::new(value.trim());
+                if value != "ISO" && value != "MDY" {
+                    bail!(
+                        "parameter {} can only be set to {}",
+                        DATE_STYLE.name,
+                        DATE_STYLE.value
+                    );
+                }
+            }
+            Ok(())
         } else if name == EXTRA_FLOAT_DIGITS.name {
             self.extra_float_digits.set(value)
         } else if name == INTEGER_DATETIMES.name {

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -50,8 +50,11 @@ off
 
 > SET extra_float_digits = 1
 
+> SET DateStyle = 'ISO'
+> SET DateStyle = 'MDY'
+> SET DateStyle = 'ISO,MDY'
 ! SET DateStyle = 'ooga booga'
-parameter DateStyle is read only
+parameter DateStyle can only be set to ISO, MDY
 
 # `search_path` is tested elsewhere.
 


### PR DESCRIPTION
Values besides the default are still rejected, but accepting

    > SET DateStyle = 'ISO'

as a no-op is required for ODBC support.

Fix #4908.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4909)
<!-- Reviewable:end -->
