### PR TITLE
docs: synchronize FOS header style

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -8,22 +8,40 @@ body {
 header {
   align-items: center;
   display: flex;
-  justify-content: space-between;
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 20px;
-  max-width: 1100px;
+  padding: 0 20px;
+
+  #header-image {
+    flex-basis: 25%;
+    padding: 23px 0 17px;
+  }
 
   img {
-    width: 260px;
-    margin: 0 8px;
+    min-width: 141px;
+    max-width: 247px;
+    width: 100%;
+  }
+
+  #header-nav {
+    flex-basis: 75%;
+    max-width: 75%;
+    text-align: right;
+    padding-right: 4px;
   }
 
   ul {
     margin: 0 48px 0 0;
 
-    @media (max-width: 1130px) {
-      & {
-        display: none;
+    @media (max-width: 1149px) {
+      a {
+        padding: 7px;
+      }
+    }
+
+    @media (min-width: 1150px) {
+      a {
+        padding: 14px;
       }
     }
   }
@@ -32,27 +50,11 @@ header {
     display: inline-block;
 
     a {
-      color: $purple;
+      color: $off-black;
       display: block;
-      font-weight: bold;
-      line-height: 28px;
-      padding: 10px;
-
-      &.button {
-        border-radius: 2px;
-        margin-left: 10px;
-        padding: 5px 10px;
-      }
-
-      &.button-lime {
-        background-color: $lime;
-        color: $purple;
-      }
-
-      &.button-purple {
-        background-color: $purple;
-        color: white;
-      }
+      font-weight: 600;
+      font-size: 16px;
+      line-height: 19px;
     }
   }
 }

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -1,17 +1,19 @@
 <header id="main">
-  <a href="/">
-    <img src="https://materialize.com/wp-content/uploads/2020/02/materialize_logo_primary-1.png" alt="Materialize Logo">
-  </a>
-
-  <ul class="menu">
-    <li><a href="https://materialize.com/">Home</a></li>
-    <li><a href="https://materialize.com/product/">Product</a></li>
-    <li><a href="https://materialize.com/docs/">Docs</a></li>
-    <li><a href="https://materialize.com/blog/">Blog</a></li>
-    <li><a href="https://materialize.com/about/">About</a></li>
-    <li><a href="https://materialize.com/careers/">Careers</a></li>
-    <li><a href="https://materialize.com/contact/">Contact</a></li>
-    <li><a class="button button-purple" href="https://github.com/MaterializeInc/materialize">Github</a></li>
-    <li><a class="button button-lime" href="https://materialize.com/download/">Download</a></li>
-  </ul>
+  <div id="header-image">
+    <a href="/">
+      <img src="https://materialize.com/wp-content/uploads/2020/02/materialize_logo_primary-1.png" alt="Materialize Logo">
+    </a>
+  </div>
+  <div id="header-nav">
+    <ul class="menu">
+      <li><a href="https://materialize.com/docs/">Docs</a></li>
+      <li><a href="https://materialize.com/product/">Product</a></li>
+      <li><a href="https://materialize.com/streaming-sql/">Use Cases</a></li>
+      <li><a href="https://materialize.com/quickstart/">Quickstart</a></li>
+      <li><a href="https://materialize.com/blog/">Blog</a></li>
+      <li><a href="https://materialize.com/about/">Company</a></li>
+      <li><a href="https://materialize.com/contact/">Contact</a></li>
+      <li><a href="https://materialize.com/docs/install">Download</a></li>
+    </ul>
+  </div>
 </header>


### PR DESCRIPTION
This is just a cosmetic bandaid to make the docs look like FOS--to tuly sync them, looks like we need to bring bootstrap over to the docs which is more effort than I have for this effort today. Some of these declarations are sure to be extraneous because I'll have to reconsider most of the CSS in a Bootstrapped world but this works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4910)
<!-- Reviewable:end -->
