### PR TITLE
match the isolation levels between the kafka source and our timestamp thread

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -1306,6 +1306,8 @@ impl Timestamper {
             .set("max.poll.interval.ms", "300000") // 5 minutes
             .set("fetch.message.max.bytes", "134217728")
             .set("enable.sparse.connections", "true")
+            // should match the isolation level of the source; for now that's always read_committed
+            .set("isolation.level", "read_committed")
             .set("bootstrap.servers", &kc.addrs.to_string());
 
         let group_id_prefix = kc.group_id_prefix.clone().unwrap_or_else(String::new);


### PR DESCRIPTION
In the future we can support settable isolation levels, but right now everything should default to read_committed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4912)
<!-- Reviewable:end -->
