### PR TITLE
sql: allow real/float4 to be used

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -576,6 +576,7 @@ impl ScalarExpr {
 pub enum EvalError {
     DivisionByZero,
     NumericFieldOverflow,
+    FloatOutOfRange,
     IntegerOutOfRange,
     IntervalOutOfRange,
     TimestampOutOfRange,
@@ -605,6 +606,7 @@ impl fmt::Display for EvalError {
         match self {
             EvalError::DivisionByZero => f.write_str("division by zero"),
             EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
+            EvalError::FloatOutOfRange => f.write_str("float out of range"),
             EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
             EvalError::IntervalOutOfRange => f.write_str("interval out of range"),
             EvalError::TimestampOutOfRange => f.write_str("timestamp out of range"),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2189,12 +2189,12 @@ impl<'a> Parser<'a> {
         let mut data_type = match self.next_token() {
             Some(Token::Keyword(kw)) => match kw {
                 BOOL | BOOLEAN => DataType::Boolean,
-                FLOAT | FLOAT4 => DataType::Float(self.parse_optional_precision()?),
-                REAL => DataType::Real,
                 DOUBLE => {
                     let _ = self.parse_keyword(PRECISION);
                     DataType::Double
                 }
+                FLOAT => DataType::Float(self.parse_optional_precision()?),
+                FLOAT4 | REAL => DataType::Real,
                 FLOAT8 => DataType::Double,
                 SMALLINT => DataType::SmallInt,
                 INT | INTEGER | INT4 => DataType::Int,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2545,7 +2545,17 @@ pub fn scalar_type_from_sql(data_type: &DataType) -> Result<ScalarType, anyhow::
         DataType::Char(_) | DataType::Varchar(_) | DataType::Text => ScalarType::String,
         DataType::SmallInt | DataType::Int => ScalarType::Int32,
         DataType::BigInt => ScalarType::Int64,
-        DataType::Float(_) | DataType::Real | DataType::Double => ScalarType::Float64,
+        DataType::Float(Some(p)) if *p < 25 => ScalarType::Float32,
+        DataType::Float(p) => {
+            if let Some(p) = p {
+                if *p > 53 {
+                    bail!("precision for type float must be less than 54 bits")
+                }
+            }
+            ScalarType::Float64
+        }
+        DataType::Real => ScalarType::Float32,
+        DataType::Double => ScalarType::Float64,
         DataType::Decimal(precision, scale) => {
             let precision = precision.unwrap_or(MAX_DECIMAL_PRECISION.into());
             let scale = scale.unwrap_or(0);

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -148,6 +148,7 @@ lazy_static! {
             (Oid, String) => Explicit: CastInt32ToString,
 
             // FLOAT32
+            (Float32, Int32) => Assignment: CastFloat32ToInt32,
             (Float32, Int64) => Assignment: CastFloat32ToInt64,
             (Float32, Float64) => Implicit: CastFloat32ToFloat64,
             (Float32, Decimal) => Assignment: CastOp::new(|_ecx, e, to_type| {
@@ -160,6 +161,7 @@ lazy_static! {
             // FLOAT64
             (Float64, Int32) => Assignment: CastFloat64ToInt32,
             (Float64, Int64) => Assignment: CastFloat64ToInt64,
+            (Float64, Float32) => Assignment: CastFloat64ToFloat32,
             (Float64, Decimal) => Assignment: CastOp::new(|_ecx, e, to_type| {
                 let (_, s) = to_type.unwrap_decimal_parts();
                 let s = ScalarExpr::literal(Datum::from(i32::from(s)), to_type.clone());

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -305,12 +305,17 @@ fn format_row(
                 let d = d.unwrap_decimal().with_scale(*s);
                 format!("{:.0}", d)
             }
+            (Type::Integer, ScalarType::Float32) => format!("{:.0}", d.unwrap_float32().trunc()),
             (Type::Integer, ScalarType::Float64) => format!("{:.0}", d.unwrap_float64().trunc()),
             (Type::Integer, ScalarType::String) => "0".to_owned(),
             (Type::Integer, ScalarType::Bool) => i8::from(d.unwrap_bool()).to_string(),
 
             (Type::Real, ScalarType::Int32) => format!("{:.3}", d.unwrap_int32()),
             (Type::Real, ScalarType::Int64) => format!("{:.3}", d.unwrap_int64()),
+            (Type::Real, ScalarType::Float32) => match mode {
+                Mode::Standard => format!("{:.3}", d.unwrap_float32()),
+                Mode::Cockroach => format!("{}", d.unwrap_float32()),
+            },
             (Type::Real, ScalarType::Float64) => match mode {
                 Mode::Standard => format!("{:.3}", d.unwrap_float64()),
                 Mode::Cockroach => format!("{}", d.unwrap_float64()),
@@ -325,6 +330,7 @@ fn format_row(
 
             (Type::Text, ScalarType::Int32) => format!("{}", d.unwrap_int32()),
             (Type::Text, ScalarType::Int64) => format!("{}", d.unwrap_int64()),
+            (Type::Text, ScalarType::Float32) => format!("{:.3}", d.unwrap_float32()),
             (Type::Text, ScalarType::Float64) => format!("{:.3}", d.unwrap_float64()),
             // Bytes are printed as text iff they are valid UTF-8. This
             // seems guaranteed to confuse everyone, but it is required for

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -406,6 +406,8 @@ fn decode_row(row: Row) -> Result<Vec<String>, String> {
                 Type::INT8 => row.get::<_, Option<i64>>(i).map(|x| x.to_string()),
                 Type::OID => row.get::<_, Option<u32>>(i).map(|x| x.to_string()),
                 Type::NUMERIC => row.get::<_, Option<Numeric>>(i).map(|x| x.to_string()),
+                Type::FLOAT4 => row.get::<_, Option<f32>>(i).map(|x| x.to_string()),
+                Type::FLOAT8 => row.get::<_, Option<f64>>(i).map(|x| x.to_string()),
                 Type::TIMESTAMP => row
                     .get::<_, Option<chrono::NaiveDateTime>>(i)
                     .map(|x| x.to_string()),

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -38,3 +38,16 @@ query TTT
 SELECT 'NaN'::double precision::text, 'nan'::double precision::text, 'nAN'::double precision::text
 ----
 NaN  NaN  NaN
+
+query R
+SELECT 1.2::float8::float4
+----
+1.2
+
+query R
+SELECT '2e40'::float8
+----
+20000000000000000000000000000000000000000
+
+query error float out of range
+SELECT '2e40'::float8::float4

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -297,7 +297,7 @@ SELECT 1.1::numeric::boolean
 query error CAST does not support casting from f64 to bool
 SELECT 1.2::double::boolean
 
-query error CAST does not support casting from f64 to bool
+query error CAST does not support casting from f32 to bool
 SELECT 1.3::real::boolean
 
 query T
@@ -348,7 +348,7 @@ SELECT 1.1::numeric::date
 query error CAST does not support casting from f64 to date
 SELECT 1.2::double::date
 
-query error CAST does not support casting from f64 to date
+query error CAST does not support casting from f32 to date
 SELECT 1.3::real::date
 
 query error CAST does not support casting from i32 to date
@@ -494,10 +494,10 @@ SELECT 1::bigint::real;
 ----
 1.000
 
-query error CAST does not support casting from bool to f64
+query error CAST does not support casting from bool to f32
 SELECT TRUE::boolean::real
 
-query error CAST does not support casting from date to f64
+query error CAST does not support casting from date to f32
 SELECT '2001 02-03'::date::real
 
 query T
@@ -520,7 +520,7 @@ SELECT 2::int::real;
 ----
 2.000
 
-query error CAST does not support casting from interval to f64
+query error CAST does not support casting from interval to f32
 SELECT '1'::interval::real
 
 #pginvalid
@@ -534,16 +534,16 @@ SELECT '2'::jsonb::real;
 ----
 2.000
 
-query error invalid input syntax for float8: invalid float literal: "dog"
+query error invalid input syntax for float4: invalid float literal: "dog"
 SELECT 'dog'::text::real
 
-query error CAST does not support casting from time to f64
+query error CAST does not support casting from time to f32
 SELECT '01:02:03'::time::real
 
-query error CAST does not support casting from timestamp to f64
+query error CAST does not support casting from timestamp to f32
 SELECT '2002 03-04'::timestamp::real
 
-query error CAST does not support casting from timestamptz to f64
+query error CAST does not support casting from timestamptz to f32
 SELECT '2003 04-05'::timestamptz::real
 
 query T
@@ -615,7 +615,7 @@ SELECT 1.1::numeric::interval
 query error CAST does not support casting from f64 to interval
 SELECT 1.2::double::interval
 
-query error CAST does not support casting from f64 to interval
+query error CAST does not support casting from f32 to interval
 SELECT 1.3::real::interval
 
 query error CAST does not support casting from i32 to interval
@@ -775,7 +775,7 @@ SELECT 1.1::numeric::time
 query error CAST does not support casting from f64 to time
 SELECT 1.2::double::time
 
-query error CAST does not support casting from f64 to time
+query error CAST does not support casting from f32 to time
 SELECT 1.3::real::time
 
 query error CAST does not support casting from i32 to time
@@ -820,7 +820,7 @@ SELECT 1.1::numeric::timestamp
 query error CAST does not support casting from f64 to timestamp
 SELECT 1.2::double::timestamp
 
-query error CAST does not support casting from f64 to timestamp
+query error CAST does not support casting from f32 to timestamp
 SELECT 1.3::real::timestamp
 
 query error CAST does not support casting from i32 to timestamp
@@ -865,7 +865,7 @@ SELECT 1.1::numeric::timestamptz
 query error CAST does not support casting from f64 to timestamptz
 SELECT 1.2::double::timestamptz
 
-query error CAST does not support casting from f64 to timestamptz
+query error CAST does not support casting from f32 to timestamptz
 SELECT 1.3::real::timestamptz
 
 query error CAST does not support casting from i32 to timestamptz


### PR DESCRIPTION
Previously, `real` were largely (totally?) inaccessible to users because expressing it in SQL always got converted to `double`. This PR fixes that and adds some missing casts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4918)
<!-- Reviewable:end -->
