### PR TITLE
docs: add map and map operator documentation

### DIFF
--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -90,6 +90,10 @@ Operation | Computes
 
 {{% json-operators %}}
 
+### Map
+
+{{% map-operators %}}
+
 ### List
 
 List operators are [polymorphic](../types/list/#polymorphism).

--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -22,6 +22,7 @@ Type | Aliases | Use | Size (bytes) | Syntax
 [`integer`](integer) | `int4`, `int` | Signed integer | 4 | `123`
 [`interval`](interval) | | Duration of time | 32 | `INTERVAL '1-2 3 4:5:6.7'`
 [`jsonb`](jsonb) | `json` | JSON | Variable | `'{"1":2,"3":4}'::jsonb`
+[`map`](map) | `map` | Map with [`text`](text) keys and a uniform value type | Variable | `'{a: 1, b: 2}'::map[text=>int]`
 [`list`](list) | | Multidimensional list | Variable | `LIST[[1,2],[3]]`
 [`record`](record) | | Tuple with arbitrary contents | Variable | `ROW($expr, ...)`
 [`oid`](oid) | | PostgreSQL object identifier | 4 | `123`

--- a/doc/user/layouts/partials/sql-grammar/type-map.svg
+++ b/doc/user/layouts/partials/sql-grammar/type-map.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="515" height="103">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="22" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="22"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">'</text>
+   <rect x="73" y="3" width="90" height="32"/>
+   <rect x="71" y="1" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="81" y="21">map_string</text>
+   <rect x="183" y="3" width="22" height="32" rx="10"/>
+   <rect x="181"
+         y="1"
+         width="22"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="191" y="21">'</text>
+   <rect x="225" y="3" width="26" height="32" rx="10"/>
+   <rect x="223"
+         y="1"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="233" y="21">::</text>
+   <rect x="271" y="3" width="50" height="32" rx="10"/>
+   <rect x="269"
+         y="1"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="279" y="21">MAP</text>
+   <rect x="341" y="3" width="24" height="32" rx="10"/>
+   <rect x="339"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="349" y="21">[</text>
+   <rect x="385" y="3" width="54" height="32" rx="10"/>
+   <rect x="383"
+         y="1"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="393" y="21">TEXT</text>
+   <rect x="459" y="3" width="34" height="32" rx="10"/>
+   <rect x="457"
+         y="1"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="467" y="21">=&gt;</text>
+   <rect x="357" y="69" width="86" height="32"/>
+   <rect x="355" y="67" width="86" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="365" y="87">value_type</text>
+   <rect x="463" y="69" width="24" height="32" rx="10"/>
+   <rect x="461"
+         y="67"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="471" y="87">]</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m22 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m22 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m50 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m54 0 h10 m0 0 h10 m34 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m86 0 h10 m0 0 h10 m24 0 h10 m3 0 h-3"/>
+   <polygon points="505 83 513 79 513 87"/>
+   <polygon points="505 83 497 79 497 87"/>
+</svg>

--- a/doc/user/layouts/shortcodes/map-operators.html
+++ b/doc/user/layouts/shortcodes/map-operators.html
@@ -1,0 +1,8 @@
+Operator | RHS Type | Description
+---------|----------|-------------
+`->` | `string` | Access field by name, and return target field ([docs](/sql/types/map/#retrieve-value-with-key--))
+`@>` | `map` | Does element contain RHS? ([docs](/sql/types/map/#lhs-contains-rhs-))
+<code>&lt;@</code> | `map` | Does RHS contain element? ([docs](/sql/types/map/#rhs-contains-lhs-))
+`?` | `string` | Is RHS a top-level key? ([docs](/sql/types/map/#search-top-level-keys-))
+`?&` | `string[]` | Does LHS contain all RHS top-level keys? ([docs](/sql/types/map/#search-for-all-top-level-keys-))
+`?|` | `string[]` | Does LHS contain any RHS top-level keys? ([docs](/sql/types/map/#search-for-any-top-level-keys-))

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -264,6 +264,8 @@ type_interval_val ::=
   'INTERVAL' "'" time_expr+ "'" ( ( head_time_unit 'TO' )? tail_time_unit )?
 type_jsonb ::=
     "'" json_string "'" '::JSONB'
+type_map ::=
+    "'" map_string "'" '::' 'MAP' '[' 'TEXT' '=>' value_type ']'
 type_list ::=
     'LIST' '[' (element (',' element)*)? ']'
 type_numeric_dec ::=


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/4622

The `type-map.svg` looks like:
<img width="752" alt="Screen Shot 2020-12-02 at 10 58 31 AM" src="https://user-images.githubusercontent.com/5766027/100897125-5ec60180-348d-11eb-93f7-35618db6bf36.png">


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4920)
<!-- Reviewable:end -->
