### PR TITLE
Fuse MFP to FlatMap

### DIFF
--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
@@ -29,7 +30,7 @@ where
         &mut self,
         relation_expr: &RelationExpr,
         map_filter_project: Option<expr::MapFilterProject>,
-    ) {
+    ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
         if let RelationExpr::FlatMap {
             input,
             func,
@@ -121,9 +122,9 @@ where
                     }
                 });
             let err_collection = err_collection.concat(&new_err_collection);
-
-            self.collections
-                .insert(relation_expr.clone(), (ok_collection, err_collection));
+            (ok_collection, err_collection)
+        } else {
+            panic!("Non-FlatMap expression provided to `render_flat_map`");
         }
     }
 }

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -90,7 +90,7 @@ where
                                     // We ignore the demand analysis and just apply map_filter_project.
                                     mfp.evaluate(&mut datums, temp_storage, row_packer)
                                         .transpose()
-                                        .map(|x| (x.map_err(|e| DataflowError::from(e)), r))
+                                        .map(|x| (x.map_err(DataflowError::from), r))
                                 } else {
                                     Some((
                                         Ok::<_, DataflowError>(

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -1,0 +1,122 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use differential_dataflow::lattice::Lattice;
+use timely::dataflow::Scope;
+use timely::progress::{timestamp::Refines, Timestamp};
+
+use dataflow_types::*;
+use expr::RelationExpr;
+use repr::{Datum, Row, RowArena};
+
+use crate::operator::CollectionExt;
+use crate::render::context::Context;
+
+impl<G, T> Context<G, RelationExpr, Row, T>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+{
+    /// Renders `relation_expr` followed by `map_filter_project` if provided.
+    pub fn render_flat_map(
+        &mut self,
+        relation_expr: &RelationExpr,
+        map_filter_project: Option<expr::MapFilterProject>,
+    ) {
+        if let RelationExpr::FlatMap {
+            input,
+            func,
+            exprs,
+            demand,
+        } = relation_expr
+        {
+            let func = func.clone();
+            let exprs = exprs.clone();
+
+            // Determine for each output column if it should be replaced by a
+            // small default value. This information comes from the "demand"
+            // analysis, and is meant to allow us to avoid reproducing the
+            // input in each output, if at all possible.
+            let types = relation_expr.typ();
+            let arity = types.column_types.len();
+            let replace = (0..arity)
+                .map(|col| !demand.as_ref().map(|d| d.contains(&col)).unwrap_or(true))
+                .collect::<Vec<_>>();
+
+            let (ok_collection, err_collection) = self.collection(input).unwrap();
+            let (ok_collection, new_err_collection) =
+                ok_collection.explode_fallible({
+                    let mut row_packer = repr::RowPacker::new();
+                    move |input_row| {
+                        // Unpack datums and capture its length (to rewind MFP eval).
+                        let mut datums = input_row.unpack();
+                        let datums_len = datums.len();
+                        // Determine which columns will be replaced with Dummy values.
+                        let replace = replace.clone();
+                        let temp_storage = RowArena::new();
+                        let exprs = exprs
+                            .iter()
+                            .map(|e| e.eval(&datums, &temp_storage))
+                            .collect::<Result<Vec<_>, _>>();
+                        let exprs = match exprs {
+                            Ok(exprs) => exprs,
+                            Err(e) => return vec![(Err(e.into()), 1)],
+                        };
+                        let output_rows = func.eval(exprs, &temp_storage);
+                        // Declare borrows outside the closure so that appropriately lifetimed
+                        // borrows are moved in and used by `mfp.evaluate`.
+                        let map_filter_project = &map_filter_project;
+                        let row_packer = &mut row_packer;
+                        let temp_storage = &temp_storage;
+                        output_rows
+                            .into_iter()
+                            .filter_map(move |(output_row, r)| {
+                                if let Some(mfp) = &map_filter_project {
+                                    datums.truncate(datums_len);
+                                    // We ignore the demand analysis and just apply map_filter_project.
+                                    mfp.evaluate(&mut datums, temp_storage, row_packer)
+                                        .transpose()
+                                        .map(|x| (x.map_err(|e| DataflowError::from(e)), r))
+                                } else {
+                                    Some((
+                                        Ok::<_, DataflowError>(
+                                            row_packer.pack(
+                                                datums
+                                                    .iter()
+                                                    .cloned()
+                                                    .chain(output_row.iter())
+                                                    .zip(replace.iter())
+                                                    .map(|(datum, demand)| {
+                                                        if *demand {
+                                                            Datum::Dummy
+                                                        } else {
+                                                            datum
+                                                        }
+                                                    }),
+                                            ),
+                                        ),
+                                        r,
+                                    ))
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                        // The collection avoids the lifetime issues of the `datums` borrow,
+                        // which allows us to avoid multiple unpackings of `input_row`. We
+                        // could avoid this allocation with a custom iterator that understands
+                        // the borrowing, but it probably isn't the leading order issue here.
+                    }
+                });
+            let err_collection = err_collection.concat(&new_err_collection);
+
+            self.collections
+                .insert(relation_expr.clone(), (ok_collection, err_collection));
+        }
+    }
+}

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -777,8 +777,8 @@ where
                     .insert(relation_expr.clone(), (oks.as_collection(), err_collection));
                 true
             }
-            RelationExpr::FlatMap { .. } => {
-                self.ensure_rendered(&input, scope, worker_index);
+            RelationExpr::FlatMap { input: input2, .. } => {
+                self.ensure_rendered(&input2, scope, worker_index);
                 self.render_flat_map(input, Some(mfp));
                 true
             }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -779,7 +779,8 @@ where
             }
             RelationExpr::FlatMap { input: input2, .. } => {
                 self.ensure_rendered(&input2, scope, worker_index);
-                self.render_flat_map(input, Some(mfp));
+                let (oks, err) = self.render_flat_map(input, Some(mfp));
+                self.collections.insert(relation_expr.clone(), (oks, err));
                 true
             }
             _ => false,
@@ -895,7 +896,8 @@ where
 
                 RelationExpr::FlatMap { input, .. } => {
                     self.ensure_rendered(input, scope, worker_index);
-                    self.render_flat_map(relation_expr, None);
+                    let (oks, err) = self.render_flat_map(relation_expr, None);
+                    self.collections.insert(relation_expr.clone(), (oks, err));
                 }
 
                 RelationExpr::Filter { input, predicates } => {

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -145,6 +145,7 @@ use crate::{
 mod arrange_by;
 mod context;
 mod delta_join;
+mod flat_map;
 mod join;
 mod reduce;
 mod threshold;
@@ -886,76 +887,9 @@ where
                     }
                 }
 
-                RelationExpr::FlatMap {
-                    input,
-                    func,
-                    exprs,
-                    demand,
-                } => {
+                RelationExpr::FlatMap { input, .. } => {
                     self.ensure_rendered(input, scope, worker_index);
-                    let func = func.clone();
-                    let exprs = exprs.clone();
-
-                    // Determine for each output column if it should be replaced by a
-                    // small default value. This information comes from the "demand"
-                    // analysis, and is meant to allow us to avoid reproducing the
-                    // input in each output, if at all possible.
-                    let types = relation_expr.typ();
-                    let arity = types.column_types.len();
-                    let replace = (0..arity)
-                        .map(|col| !demand.as_ref().map(|d| d.contains(&col)).unwrap_or(true))
-                        .collect::<Vec<_>>();
-
-                    let (ok_collection, err_collection) = self.collection(input).unwrap();
-                    let (ok_collection, new_err_collection) = ok_collection.explode_fallible({
-                        let mut row_packer = repr::RowPacker::new();
-                        move |input_row| {
-                            let datums = input_row.unpack();
-                            let replace = replace.clone();
-                            let temp_storage = RowArena::new();
-                            let exprs = exprs
-                                .iter()
-                                .map(|e| e.eval(&datums, &temp_storage))
-                                .collect::<Result<Vec<_>, _>>();
-                            let exprs = match exprs {
-                                Ok(exprs) => exprs,
-                                Err(e) => return vec![(Err(e.into()), 1)],
-                            };
-                            let output_rows = func.eval(exprs, &temp_storage);
-                            output_rows
-                                .into_iter()
-                                .map(|(output_row, r)| {
-                                    (
-                                        Ok::<_, DataflowError>(
-                                            row_packer.pack(
-                                                datums
-                                                    .iter()
-                                                    .cloned()
-                                                    .chain(output_row.iter())
-                                                    .zip(replace.iter())
-                                                    .map(|(datum, demand)| {
-                                                        if *demand {
-                                                            Datum::Dummy
-                                                        } else {
-                                                            datum
-                                                        }
-                                                    }),
-                                            ),
-                                        ),
-                                        r,
-                                    )
-                                })
-                                .collect::<Vec<_>>()
-                            // The collection avoids the lifetime issues of the `datums` borrow,
-                            // which allows us to avoid multiple unpackings of `input_row`. We
-                            // could avoid this allocation with a custom iterator that understands
-                            // the borrowing, but it probably isn't the leading order issue here.
-                        }
-                    });
-                    let err_collection = err_collection.concat(&new_err_collection);
-
-                    self.collections
-                        .insert(relation_expr.clone(), (ok_collection, err_collection));
+                    self.render_flat_map(relation_expr, None);
                 }
 
                 RelationExpr::Filter { input, predicates } => {


### PR DESCRIPTION
This PR introduces an optional `MapFilterProject` argument to `render_flat_map`, which it also introduces. The behavior is that when provided, the implementation is of the fused linear transforms (and if not provided, the traditional implementation that blanks out columns that are not demanded). 

The structure of `fn try_render_map_filter_project()` is also modified to support `FlatMap` in addition to `Get`. No testing performed yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4924)
<!-- Reviewable:end -->
