### PR TITLE
docs: increase references to selecting from non-mz view

### DIFF
--- a/ci/www/public/_redirects
+++ b/ci/www/public/_redirects
@@ -17,6 +17,7 @@ http://materialize.com/* https://materialize.com/:splat 301!
 # materialized binary that can be updated if we ever switch away from GitHub
 # or change how we want bugs to be filed.
 /s/bug https://github.com/MaterializeInc/materialize/issues/new?labels=C-bug&template=bug.md
+/s/non-materialized-error https://materialize.com/docs/sql/create-view/#querying-non-materialized-views
 
 # Forward all paths unknown to Netlify to the marketing site.
 /* https://materializeinc.wpengine.com/:splat 200

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -90,6 +90,13 @@ and re-order results of materialized sources or materialized views.
 
 ### Querying sources and views
 
+{{< warning >}}
+You can <code>SELECT</code> from non-materialized views only if they are
+transitively materialized. For more information, see [`CREATE VIEW`: Querying
+non-materialized
+views](https://materialize.com/docs/sql/create-view/#querying-non-materialized-views).
+{{< /warning >}}
+
 Performing a `SELECT` query that does not directly read out of a materialization
 requires Materialize to evaluate your query. Materialize will construct a
 temporary dataflow to materialize your query, and remove the dataflow as soon as

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2172,7 +2172,11 @@ where
             // original sources on which they depend.
             PeekWhen::Immediately => {
                 if !indexes_complete {
-                    bail!("Unable to automatically determine a timestamp for your query; this can happen if your query depends on non-materialized sources");
+                    bail!(
+                        "Unable to automatically determine a timestamp for your query; \
+                        this can happen if your query depends on non-materialized sources.\n\
+                        For more details, see https://materialize.com/s/non-materialized-error"
+                    );
                 }
                 let mut candidate = if uses_ids.iter().any(|id| self.catalog.uses_tables(*id)) {
                     // If the view depends on any tables, we enforce


### PR DESCRIPTION
This PR increases the volume of links to the docs that can help users understand why they can't `SELECT` from views. I'd like to have this URL behind some kind of repointable URL shortener, but don't want perfect to be the enemy of good enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4934)
<!-- Reviewable:end -->
