### PR TITLE
sql: add pg_crypto digest function with md5 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "encoding",
  "enum-iterator",
  "itertools",
+ "md-5",
  "num_enum",
  "ordered-float",
  "ore",

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -353,6 +353,17 @@
       Null elements are omitted unless `ifnull` is non-null, in which case
       null elements are replaced with the value of `ifnull`.
 
+- type: Cryptographic
+  functions:
+    - signature: 'digest(data: text, type: text) -> bytea'
+      desctription: >-
+        Computes a binary hash of the given text `data` using the specified `type` algorithm.
+        Currently, only the `md5` algorithm is supported.
+    - signature: 'digest(data: bytea, type: text) -> bytea'
+      desctription: >-
+        Computes a binary hash of the given bytea `data` using the specified `type` algorithm.
+        Currently, only the `md5` algorithm is supported.
+
 - type: System information
   description: Functions that return information about the system
   functions:

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -13,6 +13,7 @@ csv = "1.1"
 encoding = "0.2"
 enum-iterator = "0.6.0"
 itertools = "0.9"
+md-5 = "0.9"
 num_enum = "0.5.1"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, 
 use encoding::label::encoding_from_whatwg_label;
 use encoding::DecoderTrap;
 use itertools::Itertools;
+use md5::{Digest, Md5};
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 
@@ -1934,6 +1935,8 @@ pub enum BinaryFunc {
     ListListConcat,
     ListElementConcat,
     ElementListConcat,
+    DigestString,
+    DigestBytes,
 }
 
 impl BinaryFunc {
@@ -2060,6 +2063,8 @@ impl BinaryFunc {
             BinaryFunc::ListListConcat => Ok(eager!(list_list_concat, temp_storage)),
             BinaryFunc::ListElementConcat => Ok(eager!(list_element_concat, temp_storage)),
             BinaryFunc::ElementListConcat => Ok(eager!(element_list_concat, temp_storage)),
+            BinaryFunc::DigestString => eager!(digest_string, temp_storage),
+            BinaryFunc::DigestBytes => eager!(digest_bytes, temp_storage),
         }
     }
 
@@ -2215,6 +2220,7 @@ impl BinaryFunc {
             ListLengthMax { .. } | ArrayLower | ArrayUpper => ScalarType::Int64.nullable(true),
             ListListConcat | ListElementConcat => input1_type.scalar_type.nullable(true),
             ElementListConcat => input2_type.scalar_type.nullable(true),
+            DigestString | DigestBytes => ScalarType::Bytes.nullable(true),
         }
     }
 
@@ -2379,7 +2385,9 @@ impl BinaryFunc {
             | TrimLeading
             | TrimTrailing
             | EncodedBytesCharLength
-            | ListLengthMax { .. } => false,
+            | ListLengthMax { .. }
+            | DigestString
+            | DigestBytes => false,
         }
     }
 }
@@ -2477,6 +2485,7 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::ListListConcat => f.write_str("||"),
             BinaryFunc::ListElementConcat => f.write_str("||"),
             BinaryFunc::ElementListConcat => f.write_str("||"),
+            BinaryFunc::DigestString | BinaryFunc::DigestBytes => f.write_str("digest"),
         }
     }
 }
@@ -3760,6 +3769,36 @@ fn element_list_concat<'a>(a: Datum<'a>, b: Datum<'a>, temp_storage: &'a RowAren
             }
         })
     })
+}
+
+fn digest_string<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let to_digest = a.unwrap_str().as_bytes();
+    digest_inner(to_digest, b, temp_storage)
+}
+
+fn digest_bytes<'a>(
+    a: Datum<'a>,
+    b: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    let to_digest = a.unwrap_bytes();
+    digest_inner(to_digest, b, temp_storage)
+}
+
+fn digest_inner<'a>(
+    bytes: &[u8],
+    digest_fn: Datum<'a>,
+    temp_storage: &'a RowArena,
+) -> Result<Datum<'a>, EvalError> {
+    match digest_fn.unwrap_str() {
+        "md5" => Ok(temp_storage
+            .make_datum(|packer| packer.push(Datum::Bytes(Md5::digest(bytes).as_slice())))),
+        other => Err(EvalError::InvalidHashAlgorithm(other.to_owned())),
+    }
 }
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -586,6 +586,7 @@ pub enum EvalError {
     },
     InvalidArray(InvalidArrayError),
     InvalidEncodingName(String),
+    InvalidHashAlgorithm(String),
     InvalidByteSequence {
         byte_sequence: String,
         encoding_name: String,
@@ -617,6 +618,7 @@ impl fmt::Display for EvalError {
             ),
             EvalError::InvalidArray(e) => e.fmt(f),
             EvalError::InvalidEncodingName(name) => write!(f, "invalid encoding name '{}'", name),
+            EvalError::InvalidHashAlgorithm(alg) => write!(f, "invalid hash algorithm '{}'", alg),
             EvalError::InvalidByteSequence {
                 byte_sequence,
                 encoding_name,

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1066,6 +1066,10 @@ lazy_static! {
                 params!(String, Timestamp) => BinaryFunc::DateTruncTimestamp,
                 params!(String, TimestampTz) => BinaryFunc::DateTruncTimestampTz
             },
+            "digest" => Scalar {
+                params!(String, String) => BinaryFunc::DigestString,
+                params!(Bytes, String) => BinaryFunc::DigestBytes
+            },
             "floor" => Scalar {
                 params!(Float32) => UnaryFunc::FloorFloat32,
                 params!(Float64) => UnaryFunc::FloorFloat64,

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -586,3 +586,50 @@ NULL
 
 query error Cannot call function array_upper\(unknown, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT array_upper(NULL, 1)
+
+# pg_crypto functions
+# Includes tests partially ported over from pg_crypto
+# https://github.com/postgres/postgres/tree/ca7f8e2b86e5f15a40b67e6199d714f45a467ff1/contrib/pgcrypto/expected
+
+query error invalid hash algorithm 'nonsense'
+SELECT digest('hi'::text, 'nonsense'::text)
+
+query T
+SELECT digest(''::text, 'md5'::text)::text
+----
+\xd41d8cd98f00b204e9800998ecf8427e
+
+query T
+SELECT digest(''::bytea, 'md5'::text)::text
+----
+\xd41d8cd98f00b204e9800998ecf8427e
+
+query T
+SELECT digest('a'::text, 'md5'::text)::text
+----
+\x0cc175b9c0f1b6a831c399e269772661
+
+query T
+SELECT digest('abc'::bytea, 'md5'::text)::text
+----
+\x900150983cd24fb0d6963f7d28e17f72
+
+query T
+SELECT digest('message digest'::text, 'md5'::text)::text
+----
+\xf96b697d7cb7938d525a2f31aaf161d0
+
+query T
+SELECT digest('abcdefghijklmnopqrstuvwxyz'::bytea, 'md5'::text)::text
+----
+\xc3fcd3d76192e4007dfb496cca67e13b
+
+query T
+SELECT digest('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'::text, 'md5'::text)::text
+----
+\xd174ab98d277d9f5a5611c2c9f419d9f
+
+query T
+SELECT digest('12345678901234567890123456789012345678901234567890123456789012345678901234567890'::bytea, 'md5'::text)::text
+----
+\x57edf4a22be3c955ac49da2e2107b67a


### PR DESCRIPTION
Adds support for [pg_crypto's digest](https://www.postgresql.org/docs/12/pgcrypto.html) using the md5 hash algorithm. 
This change leaves other hash algorithm options unimplemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4936)
<!-- Reviewable:end -->
