### PR TITLE
sql: permit casting map to text

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2595,6 +2595,9 @@ pub enum UnaryFunc {
         // The expression to cast List1's elements to List2's elements' type
         cast_expr: Box<ScalarExpr>,
     },
+    CastMapToString {
+        ty: ScalarType,
+    },
     CeilFloat32,
     CeilFloat64,
     CeilDecimal(u8),
@@ -2730,7 +2733,8 @@ impl UnaryFunc {
             UnaryFunc::CastUuidToString => Ok(cast_uuid_to_string(a, temp_storage)),
             UnaryFunc::CastRecordToString { ty }
             | UnaryFunc::CastArrayToString { ty }
-            | UnaryFunc::CastListToString { ty } => {
+            | UnaryFunc::CastListToString { ty }
+            | UnaryFunc::CastMapToString { ty } => {
                 Ok(cast_collection_to_string(a, ty, temp_storage))
             }
             UnaryFunc::CastList1ToList2 { cast_expr, .. } => {
@@ -2827,6 +2831,7 @@ impl UnaryFunc {
             | CastRecordToString { .. }
             | CastArrayToString { .. }
             | CastListToString { .. }
+            | CastMapToString { .. }
             | TrimWhitespace
             | TrimLeadingWhitespace
             | TrimTrailingWhitespace => ScalarType::String.nullable(in_nullable),
@@ -3046,6 +3051,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::CastArrayToString { .. } => f.write_str("arraytostr"),
             UnaryFunc::CastListToString { .. } => f.write_str("listtostr"),
             UnaryFunc::CastList1ToList2 { .. } => f.write_str("list1tolist2"),
+            UnaryFunc::CastMapToString { .. } => f.write_str("maptostr"),
             UnaryFunc::CeilFloat32 => f.write_str("ceilf32"),
             UnaryFunc::CeilFloat64 => f.write_str("ceilf64"),
             UnaryFunc::CeilDecimal(_) => f.write_str("ceildec"),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -306,6 +306,12 @@ lazy_static! {
                 }))
             }),
 
+            // MAP
+            (Map, String) => Assignment: CastTemplate::new(|_ecx, _ccx, from_type, _to_type| {
+                let ty = from_type.clone();
+                Some(|e: ScalarExpr| e.call_unary(CastMapToString { ty }))
+            }),
+
             // JSONB
             (Jsonb, Bool) => Explicit: CastJsonbToBool,
             (Jsonb, Int32) => Explicit: CastTemplate::new(from_jsonb_f64_cast),

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -84,6 +84,12 @@ SELECT '{31=> \ normal }'::map[text=>text]
 query error unterminated quoted string
 SELECT '{"a"=>"hello there!}'::map[text=>text]
 
+### Can be cast back to text
+query T
+SELECT '{a=>1}'::map[text=>int]::text
+----
+{a=>1}
+
 ## Nested maps
 
 query error expected '\{', found a: "a": "\{a=>a\}"


### PR DESCRIPTION
@mjibson mentioned that he got stuck on porting slt to using PG directly because, among many other things, this cast was unavailable. Hope this helps!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4937)
<!-- Reviewable:end -->
