### PR TITLE
sql: add sha2 algorithms to pg_crypto digest function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,6 +1062,7 @@ dependencies = [
  "repr",
  "serde",
  "serde_json",
+ "sha2",
  "unicase",
 ]
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -362,11 +362,11 @@
     - signature: 'digest(data: text, type: text) -> bytea'
       desctription: >-
         Computes a binary hash of the given text `data` using the specified `type` algorithm.
-        Currently, only the `md5` algorithm is supported.
+        Supported hash algorithms are: `md5`, `sha224`, `sha256`, `sha384`, `sha512`.
     - signature: 'digest(data: bytea, type: text) -> bytea'
       desctription: >-
         Computes a binary hash of the given bytea `data` using the specified `type` algorithm.
-        Currently, only the `md5` algorithm is supported.
+        The hash algorithms that are supported are the same as for the text variant of this function.
 
 - type: System information
   description: Functions that return information about the system

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -23,4 +23,5 @@ regex-syntax = "0.6.18"
 repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.9.2"
 unicase = "2.6.0"

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use md5::{Digest, Md5};
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
+use sha2::{Sha224, Sha256, Sha384, Sha512};
 
 use ore::collections::CollectionExt;
 use ore::fmt::FormatBuffer;
@@ -3800,11 +3801,15 @@ fn digest_inner<'a>(
     digest_fn: Datum<'a>,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
-    match digest_fn.unwrap_str() {
-        "md5" => Ok(temp_storage
-            .make_datum(|packer| packer.push(Datum::Bytes(Md5::digest(bytes).as_slice())))),
-        other => Err(EvalError::InvalidHashAlgorithm(other.to_owned())),
-    }
+    let bytes = match digest_fn.unwrap_str() {
+        "md5" => Md5::digest(bytes).to_vec(),
+        "sha224" => Sha224::digest(bytes).to_vec(),
+        "sha256" => Sha256::digest(bytes).to_vec(),
+        "sha384" => Sha384::digest(bytes).to_vec(),
+        "sha512" => Sha512::digest(bytes).to_vec(),
+        other => return Err(EvalError::InvalidHashAlgorithm(other.to_owned())),
+    };
+    Ok(Datum::Bytes(temp_storage.push_bytes(bytes)))
 }
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -594,6 +594,7 @@ SELECT array_upper(NULL, 1)
 query error invalid hash algorithm 'nonsense'
 SELECT digest('hi'::text, 'nonsense'::text)
 
+## digest with md5
 query T
 SELECT digest(''::text, 'md5'::text)::text
 ----
@@ -633,3 +634,112 @@ query T
 SELECT digest('12345678901234567890123456789012345678901234567890123456789012345678901234567890'::bytea, 'md5'::text)::text
 ----
 \x57edf4a22be3c955ac49da2e2107b67a
+
+## digest with sha224
+query T
+SELECT digest(''::text, 'sha224'::text)::text
+----
+\xd14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f
+
+query T
+SELECT digest('a'::bytea, 'sha224'::text)::text
+----
+\xabd37534c7d9a2efb9465de931cd7055ffdb8879563ae98078d6d6d5
+
+query T
+SELECT digest('abc'::text, 'sha224'::text)::text
+----
+\x23097d223405d8228642a477bda255b32aadbce4bda0b3f7e36c9da7
+
+query T
+SELECT digest('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq'::text, 'sha224'::text)::text
+----
+\x75388b16512776cc5dba5da1fd890150b0c6455cb4f58b1952522525
+
+query T
+SELECT digest('12345678901234567890123456789012345678901234567890123456789012345678901234567890'::text, 'sha224'::text)::text
+----
+\xb50aecbe4e9bb0b57bc5f3ae760a8e01db24f203fb3cdcd13148046e
+
+## digest with sha256
+query T
+SELECT digest(''::text, 'sha256'::text)::text
+----
+\xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+query T
+SELECT digest('a'::bytea, 'sha256'::text)::text
+----
+\xca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
+
+query T
+SELECT digest('abc'::text, 'sha256'::text)::text
+----
+\xba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+
+query T
+SELECT digest('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq'::bytea, 'sha256'::text)::text
+----
+\x248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
+
+query T
+SELECT digest('12345678901234567890123456789012345678901234567890123456789012345678901234567890'::text, 'sha256'::text)::text
+----
+\xf371bc4a311f2b009eef952dd83ca80e2b60026c8e935592d0f9c308453c813e
+
+## digest with sha384
+query T
+SELECT digest(''::text, 'sha384'::text)::text
+----
+\x38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b
+
+query T
+SELECT digest('a'::bytea, 'sha384'::text)::text
+----
+\x54a59b9f22b0b80880d8427e548b7c23abd873486e1f035dce9cd697e85175033caa88e6d57bc35efae0b5afd3145f31
+
+query T
+SELECT digest('abc'::text, 'sha384'::text)::text
+----
+\xcb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7
+
+query T
+SELECT digest('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq'::bytea, 'sha384'::text)::text
+----
+\x3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b
+
+query T
+SELECT digest('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'::text, 'sha384'::text)::text
+----
+\x3d208973ab3508dbbd7e2c2862ba290ad3010e4978c198dc4d8fd014e582823a89e16f9b2a7bbc1ac938e2d199e8bea4
+
+## digest with sha512
+query T
+SELECT digest(''::text, 'sha512'::text)::text
+----
+\xcf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e
+
+query T
+SELECT digest('a'::bytea, 'sha512'::text)::text
+----
+\x1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75
+
+query T
+SELECT digest('abc'::text, 'sha512'::text)::text
+----
+\xddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f
+
+query T
+SELECT digest('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq'::bytea, 'sha512'::text)::text
+----
+\x204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445
+
+query T
+SELECT digest('abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu'::text, 'sha512'::text)::text
+----
+\x8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909
+
+query T
+SELECT digest('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'::bytea, 'sha512'::text)::text
+----
+\x930d0cefcb30ff1133b6898121f1cf3d27578afcafe8677c5257cf069911f75d8f5831b56ebfda67b278e66dff8b84fe2b2870f742a580d8edb41987232850c9


### PR DESCRIPTION
Adds support for sha224, sha256, sha384, and sha512.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4940)
<!-- Reviewable:end -->
