### PR TITLE
Add .duplicate() method to IteratorExt

### DIFF
--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -24,7 +24,7 @@ materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" int,
 CREATE TABLE with column constraint: DEFAULT 1 not yet supported
 
 ! CREATE TABLE t (a int, b int, a int);
-cannot CREATE TABLE with duplicate column names
+cannot CREATE TABLE: column "a" specified more than once
 
 > SELECT * FROM t;
 


### PR DESCRIPTION
In my previous PR (#4893) I added a bespoke implementation of duplicate detection to get access to the duplicate items themselves. This PR cleans it up a bit by adding a `.duplicate()` method in IteratorExt and `.has_duplicates()` becomes just a shim on top of it.

I've also contributed this upstream (https://github.com/rust-itertools/itertools/pull/502) so I'll keep a mental note to switch to that once it gets included in a new version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4943)
<!-- Reviewable:end -->
