### PR TITLE
coord: shove map and list types into catalog

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -99,7 +99,7 @@ pub struct BuiltinView {
 pub struct BuiltinType {
     pub schema: &'static str,
     pub id: GlobalId,
-    inner: Type,
+    inner: &'static Type,
 }
 
 impl BuiltinType {
@@ -860,206 +860,219 @@ pub const PG_ENUM: BuiltinView = BuiltinView {
 pub const TYPE_BOOL: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4000),
-    inner: postgres_types::Type::BOOL,
+    inner: &postgres_types::Type::BOOL,
 };
 
 pub const TYPE_BYTEA: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4001),
-    inner: postgres_types::Type::BYTEA,
+    inner: &postgres_types::Type::BYTEA,
 };
 
 pub const TYPE_INT8: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4002),
-    inner: postgres_types::Type::INT8,
+    inner: &postgres_types::Type::INT8,
 };
 
 pub const TYPE_INT4: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4003),
-    inner: postgres_types::Type::INT4,
+    inner: &postgres_types::Type::INT4,
 };
 
 pub const TYPE_TEXT: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4004),
-    inner: postgres_types::Type::TEXT,
+    inner: &postgres_types::Type::TEXT,
 };
 
 pub const TYPE_OID: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4005),
-    inner: postgres_types::Type::OID,
+    inner: &postgres_types::Type::OID,
 };
 
 pub const TYPE_FLOAT4: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4006),
-    inner: postgres_types::Type::FLOAT4,
+    inner: &postgres_types::Type::FLOAT4,
 };
 
 pub const TYPE_FLOAT8: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4007),
-    inner: postgres_types::Type::FLOAT8,
+    inner: &postgres_types::Type::FLOAT8,
 };
 
 pub const TYPE_BOOL_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4008),
-    inner: postgres_types::Type::BOOL_ARRAY,
+    inner: &postgres_types::Type::BOOL_ARRAY,
 };
 
 pub const TYPE_BYTEA_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4009),
-    inner: postgres_types::Type::BYTEA_ARRAY,
+    inner: &postgres_types::Type::BYTEA_ARRAY,
 };
 
 pub const TYPE_INT4_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4010),
-    inner: postgres_types::Type::INT4_ARRAY,
+    inner: &postgres_types::Type::INT4_ARRAY,
 };
 
 pub const TYPE_TEXT_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4011),
-    inner: postgres_types::Type::TEXT_ARRAY,
+    inner: &postgres_types::Type::TEXT_ARRAY,
 };
 
 pub const TYPE_INT8_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4012),
-    inner: postgres_types::Type::INT8_ARRAY,
+    inner: &postgres_types::Type::INT8_ARRAY,
 };
 
 pub const TYPE_FLOAT4_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4013),
-    inner: postgres_types::Type::FLOAT4_ARRAY,
+    inner: &postgres_types::Type::FLOAT4_ARRAY,
 };
 
 pub const TYPE_FLOAT8_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4014),
-    inner: postgres_types::Type::FLOAT8_ARRAY,
+    inner: &postgres_types::Type::FLOAT8_ARRAY,
 };
 
 pub const TYPE_OID_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4015),
-    inner: postgres_types::Type::OID_ARRAY,
+    inner: &postgres_types::Type::OID_ARRAY,
 };
 
 pub const TYPE_DATE: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4016),
-    inner: postgres_types::Type::DATE,
+    inner: &postgres_types::Type::DATE,
 };
 
 pub const TYPE_TIME: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4017),
-    inner: postgres_types::Type::TIME,
+    inner: &postgres_types::Type::TIME,
 };
 
 pub const TYPE_TIMESTAMP: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4018),
-    inner: postgres_types::Type::TIMESTAMP,
+    inner: &postgres_types::Type::TIMESTAMP,
 };
 
 pub const TYPE_TIMESTAMP_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4019),
-    inner: postgres_types::Type::TIMESTAMP_ARRAY,
+    inner: &postgres_types::Type::TIMESTAMP_ARRAY,
 };
 
 pub const TYPE_DATE_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4020),
-    inner: postgres_types::Type::DATE_ARRAY,
+    inner: &postgres_types::Type::DATE_ARRAY,
 };
 
 pub const TYPE_TIME_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4021),
-    inner: postgres_types::Type::TIME_ARRAY,
+    inner: &postgres_types::Type::TIME_ARRAY,
 };
 
 pub const TYPE_TIMESTAMPTZ: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4022),
-    inner: postgres_types::Type::TIMESTAMPTZ,
+    inner: &postgres_types::Type::TIMESTAMPTZ,
 };
 
 pub const TYPE_TIMESTAMPTZ_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4023),
-    inner: postgres_types::Type::TIMESTAMPTZ_ARRAY,
+    inner: &postgres_types::Type::TIMESTAMPTZ_ARRAY,
 };
 
 pub const TYPE_INTERVAL: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4024),
-    inner: postgres_types::Type::INTERVAL,
+    inner: &postgres_types::Type::INTERVAL,
 };
 
 pub const TYPE_INTERVAL_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4025),
-    inner: postgres_types::Type::INTERVAL_ARRAY,
+    inner: &postgres_types::Type::INTERVAL_ARRAY,
 };
 
 pub const TYPE_NUMERIC: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4026),
-    inner: postgres_types::Type::NUMERIC,
+    inner: &postgres_types::Type::NUMERIC,
 };
 
 pub const TYPE_NUMERIC_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4027),
-    inner: postgres_types::Type::NUMERIC_ARRAY,
+    inner: &postgres_types::Type::NUMERIC_ARRAY,
 };
 
 pub const TYPE_RECORD: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4028),
-    inner: postgres_types::Type::RECORD,
+    inner: &postgres_types::Type::RECORD,
 };
 
 pub const TYPE_RECORD_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4029),
-    inner: postgres_types::Type::RECORD_ARRAY,
+    inner: &postgres_types::Type::RECORD_ARRAY,
 };
 
 pub const TYPE_UUID: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4030),
-    inner: postgres_types::Type::UUID,
+    inner: &postgres_types::Type::UUID,
 };
 
 pub const TYPE_UUID_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4031),
-    inner: postgres_types::Type::UUID_ARRAY,
+    inner: &postgres_types::Type::UUID_ARRAY,
 };
 
 pub const TYPE_JSONB: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4032),
-    inner: postgres_types::Type::JSONB,
+    inner: &postgres_types::Type::JSONB,
 };
 
 pub const TYPE_JSONB_ARRAY: BuiltinType = BuiltinType {
     schema: PG_CATALOG_SCHEMA,
     id: GlobalId::System(4033),
-    inner: postgres_types::Type::JSONB_ARRAY,
+    inner: &postgres_types::Type::JSONB_ARRAY,
 };
+
+lazy_static! {
+    pub static ref TYPE_LIST: BuiltinType = BuiltinType {
+        schema: PG_CATALOG_SCHEMA,
+        id: GlobalId::System(4034),
+        inner: &pgrepr::LIST,
+    };
+    pub static ref TYPE_MAP: BuiltinType = BuiltinType {
+        schema: PG_CATALOG_SCHEMA,
+        id: GlobalId::System(4035),
+        inner: &*pgrepr::MAP,
+    };
+}
 
 lazy_static! {
     pub static ref BUILTINS: BTreeMap<GlobalId, Builtin> = {
@@ -1154,6 +1167,8 @@ lazy_static! {
             Builtin::Type(&TYPE_UUID_ARRAY),
             Builtin::Type(&TYPE_OID),
             Builtin::Type(&TYPE_OID_ARRAY),
+            Builtin::Type(&TYPE_LIST),
+            Builtin::Type(&TYPE_MAP),
         ];
         builtins.into_iter().map(|b| (b.id(), b)).collect()
     };

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -24,7 +24,7 @@ mod types;
 mod value;
 
 pub use format::Format;
-pub use types::Type;
+pub use types::{Type, LIST, MAP};
 pub use value::interval::Interval;
 pub use value::jsonb::Jsonb;
 pub use value::numeric::Numeric;

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -13,6 +13,8 @@ use repr::ScalarType;
 /// The type of a [`Value`](crate::Value).
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Type {
+    /// A variable-length multidimensional array of values.
+    Array(Box<Type>),
     /// A boolean value.
     Bool,
     /// A byte array, i.e., a variable-length binary string.
@@ -31,12 +33,17 @@ pub enum Type {
     Interval,
     /// A binary JSON blob.
     Jsonb,
-    /// A variable-length multidimensional array of values.
-    Array(Box<Type>),
     /// A sequence of homogeneous values.
     List(Box<Type>),
+    /// A map with text keys and homogeneous values.
+    Map {
+        /// Type of the homogenous values.
+        value_type: Box<Type>,
+    },
     /// An arbitrary precision number.
     Numeric,
+    /// An object identifier.
+    Oid,
     /// A sequence of heterogeneous values.
     Record(Vec<Type>),
     /// A variable-length string.
@@ -49,18 +56,12 @@ pub enum Type {
     TimestampTz,
     /// A universally unique identifier.
     Uuid,
-    /// An object identifier.
-    Oid,
-    /// A map with text keys and homogeneous values.
-    Map {
-        /// Type of the homogenous values.
-        value_type: Box<Type>,
-    },
 }
 
 lazy_static! {
+    /// An anonymous [`Type::List`].
     pub static ref LIST: postgres_types::Type = postgres_types::Type::new(
-        "LIST".to_owned(),
+        "list".to_owned(),
         // OID chosen to be the first OID not considered stable by
         // PostgreSQL. See the "OID Assignment" section of the PostgreSQL
         // documentation for details:
@@ -72,8 +73,9 @@ lazy_static! {
 }
 
 lazy_static! {
+    /// An anonymous [`Type::Map`].
     pub static ref MAP: postgres_types::Type = postgres_types::Type::new(
-        "MAP".to_owned(),
+        "map".to_owned(),
         // OID chosen to follow our "LIST" type.
         16_385,
         postgres_types::Kind::Pseudo,

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -41,6 +41,8 @@ int4
 int8
 interval
 jsonb
+list
+map
 numeric
 oid
 record
@@ -79,6 +81,8 @@ int4             system
 int8             system
 interval         system
 jsonb            system
+list             system
+map              system
 numeric          system
 oid              system
 record           system


### PR DESCRIPTION
This required some mucking about with lazy statics to get the lifetimes
to work out, but the map and list OIDs are now properly reflected in
the mz_types and pg_type catalog views.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4947)
<!-- Reviewable:end -->
