### PR TITLE
Bump ordered float 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe9037165d7023b1228bc4ae9a2fa1a2b0095eca6c2998c624723dfd01314a5"
+checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
 dependencies = [
  "num-traits",
  "serde",


### PR DESCRIPTION
RUSTSEC-2020-0082: ordered_float:NotNan may contain NaN after panic in assignment operators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4965)
<!-- Reviewable:end -->
