### PR TITLE
sql: add sha1 option for pg_crypto fns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "repr",
  "serde",
  "serde_json",
+ "sha-1",
  "sha2",
  "unicase",
 ]
@@ -3608,6 +3609,19 @@ dependencies = [
  "itoa",
  "serde",
  "url",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -362,7 +362,7 @@
     - signature: 'digest(data: text, type: text) -> bytea'
       desctription: >-
         Computes a binary hash of the given text `data` using the specified `type` algorithm.
-        Supported hash algorithms are: `md5`, `sha224`, `sha256`, `sha384`, `sha512`.
+        Supported hash algorithms are: `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`.
     - signature: 'digest(data: bytea, type: text) -> bytea'
       desctription: >-
         Computes a binary hash of the given bytea `data` using the specified `type` algorithm.
@@ -370,7 +370,7 @@
     - signature: 'hmac(data: text, key: text, type: text) -> bytea'
       desctription: >-
         Computes a hashed MAC of the given text `data` using the specified `key` and
-        `type` algorithm. Supported hash algorithms are: `md5`, `sha224`, `sha256`, `sha384`, `sha512`.
+        `type` algorithm. Supported hash algorithms are: `md5`, `sha1`, `sha224`, `sha256`, `sha384`, `sha512`.
     - signature: 'hmac(data: bytea, key: text, type: text) -> bytea'
       desctription: >-
         Computes a hashed MAC of the given bytea `data` using the specified `key` and

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -24,5 +24,6 @@ regex-syntax = "0.6.18"
 repr = { path = "../repr" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha-1 = "0.9.2"
 sha2 = "0.9.2"
 unicase = "2.6.0"

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -22,6 +22,7 @@ use itertools::Itertools;
 use md5::{Digest, Md5};
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
+use sha1::Sha1;
 use sha2::{Sha224, Sha256, Sha384, Sha512};
 
 use ore::collections::CollectionExt;
@@ -3352,6 +3353,12 @@ pub fn hmac_inner<'a>(
             mac.update(to_digest);
             mac.finalize().into_bytes().to_owned().to_vec()
         }
+        "sha1" => {
+            type HmacSha1 = Hmac<Sha1>;
+            let mut mac = HmacSha1::new_varkey(key).expect("HMAC can take key of any size");
+            mac.update(to_digest);
+            mac.finalize().into_bytes().to_owned().to_vec()
+        }
         "sha224" => {
             type HmacSha224 = Hmac<Sha224>;
             let mut mac = HmacSha224::new_varkey(key).expect("HMAC can take key of any size");
@@ -3862,6 +3869,7 @@ fn digest_inner<'a>(
 ) -> Result<Datum<'a>, EvalError> {
     let bytes = match digest_fn.unwrap_str() {
         "md5" => Md5::digest(bytes).to_vec(),
+        "sha1" => Sha1::digest(bytes).to_vec(),
         "sha224" => Sha224::digest(bytes).to_vec(),
         "sha256" => Sha256::digest(bytes).to_vec(),
         "sha384" => Sha384::digest(bytes).to_vec(),

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -636,6 +636,42 @@ SELECT digest('12345678901234567890123456789012345678901234567890123456789012345
 ----
 \x57edf4a22be3c955ac49da2e2107b67a
 
+## digest with sha1
+query T
+SELECT digest(''::text, 'sha1'::text)::text
+----
+\xda39a3ee5e6b4b0d3255bfef95601890afd80709
+
+query T
+SELECT digest('a'::bytea, 'sha1'::text)::text
+----
+\x86f7e437faa5a7fce15d1ddcb9eaeaea377667b8
+
+query T
+SELECT digest('abc'::text, 'sha1'::text)::text
+----
+\xa9993e364706816aba3e25717850c26c9cd0d89d
+
+query T
+SELECT digest('message digest'::bytea, 'sha1'::text)::text
+----
+\xc12252ceda8be8994d5fa0290a47231c1d16aae3
+
+query T
+SELECT digest('abcdefghijklmnopqrstuvwxyz'::text, 'sha1'::text)::text
+----
+\x32d10c7b8cf96570ca04ce37f2a19d84240d3a89
+
+query T
+SELECT digest('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'::bytea, 'sha1'::text)::text
+----
+\x761c457bf73b14d27e9e9265c46f4b4dda11f940
+
+query T
+SELECT digest('12345678901234567890123456789012345678901234567890123456789012345678901234567890'::text, 'sha1'::text)::text
+----
+\x50abf5706a150990a08b2c5ea40fa0e585554732
+
 ## digest with sha224
 query T
 SELECT digest(''::text, 'sha224'::text)::text
@@ -780,6 +816,40 @@ SELECT hmac('Test Using Larger Than Block-Size Key and Larger Than Block-Size Da
             'md5'::text)::text
 ----
 \xf4d787e9ad2aef45765ef18b7f055cfd
+
+## hmac with sha1
+query T
+SELECT hmac(''::text, ''::text, 'sha1'::text)::text
+----
+\xfbdb1d1b18aa6c08324b7d64b71fb76370690e1d
+
+query T
+SELECT hmac(''::bytea, ''::text, 'sha1'::text)::text
+----
+\xfbdb1d1b18aa6c08324b7d64b71fb76370690e1d
+
+query T
+SELECT hmac(''::text, 'some key here'::text, 'sha1'::text)::text
+----
+\xd30b88796d86e6ecf2ac3ad424ba59504f6e29f6
+
+query T
+SELECT hmac('some text here'::bytea, ''::text, 'sha1'::text)::text
+----
+\xa15273bebb53bca4ef2118c8896e6b4786ea67c8
+
+query T
+SELECT hmac('some text here'::text, 'some key here'::text, 'sha1'::text)::text
+----
+\xd965ff402c6b2a676837dd523e121a2df1e1e328
+
+# sha1's block-size is 64 bytes
+query T
+SELECT hmac('Test Using Larger Than Block-Size Key and Larger Than Block-Size Data'::bytea,
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::text,
+            'sha1'::text)::text
+----
+\x92aafbe48e89d4a07dcd875dad4c7db64a4c2151
 
 ## hmac with sha224
 query T


### PR DESCRIPTION
Adds `sha1` algorithm option for `pg_crypto`'s `digest()` and `hmac()` functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4967)
<!-- Reviewable:end -->
