### PR TITLE
Revert "ci/www: use HTTP, not HTTPS, to connect to WPEngine"

### DIFF
--- a/ci/www/public/_redirects
+++ b/ci/www/public/_redirects
@@ -19,4 +19,4 @@ http://materialize.com/* https://materialize.com/:splat 301!
 /s/bug https://github.com/MaterializeInc/materialize/issues/new?labels=C-bug&template=bug.md
 
 # Forward all paths unknown to Netlify to the marketing site.
-/* http://materializeinc.wpengine.com/:splat 200
+/* https://materializeinc.wpengine.com/:splat 200


### PR DESCRIPTION
This reverts commit e6c366edc2e155fe7b783b904649e8e552c01ac9.

This didn't work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4974)
<!-- Reviewable:end -->
