### PR TITLE
pgwire: correctly use outer portal result type in FETCH

### DIFF
--- a/test/pgtest/cursors.pt
+++ b/test/pgtest/cursors.pt
@@ -512,3 +512,30 @@ ErrorResponse {"fields":[{"typ":"C","value":"34000"},{"typ":"M","value":"portal 
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
+
+# Test binary cursors. This tests that a cursor declared over simple query
+# (i.e., text result format) can be requested in binary.
+send
+Query {"query": "BEGIN; DECLARE c CURSOR FOR VALUES (1), (2);"}
+Parse {"query": "FETCH c"}
+Bind {"result_formats": [1]}
+Execute
+Sync
+Query {"query": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+DataRow {"fields":["\u0000\u0000\u0000\u0001"]}
+CommandComplete {"tag":"FETCH 1"}
+ReadyForQuery {"status":"T"}
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/cursor.slt
+++ b/test/sqllogictest/cursor.slt
@@ -1,0 +1,70 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+DECLARE c CURSOR FOR VALUES (1), (2), (3)
+
+query I
+FETCH c
+----
+1
+
+query I
+FETCH 2 c
+----
+2
+3
+
+query I
+FETCH c
+----
+
+query I
+FETCH c
+----
+
+statement ok
+CREATE VIEW v AS VALUES ('a', 'b'), ('c', 'd'), ('e', 'f'), ('g', 'h')
+----
+
+query IITT
+TAIL v
+----
+0  1  a  b
+0  1  c  d
+0  1  e  f
+0  1  g  h
+
+statement ok
+DECLARE c CURSOR FOR TAIL v
+
+query IITT
+FETCH c
+----
+0  1  a  b
+
+query IITT
+FETCH 2 c
+----
+0  1  c  d
+0  1  e  f
+
+query IITT
+FETCH 2 c
+----
+0  1  g  h
+
+query IITT
+FETCH c
+----
+
+statement ok
+CLOSE c


### PR DESCRIPTION
Add more tests for cursors and TAIL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/4976)
<!-- Reviewable:end -->
