### PR TITLE
coord: permit db-qualified references to ambient schemas

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -26,7 +26,7 @@ use expr::{GlobalId, IdHumanizer, OptimizedRelationExpr, ScalarExpr};
 use repr::RelationDesc;
 use sql::ast::display::AstDisplay;
 use sql::catalog::CatalogError as SqlCatalogError;
-use sql::names::{DatabaseSpecifier, FullName, PartialName, SchemaSpecifier};
+use sql::names::{DatabaseSpecifier, FullName, PartialName, SchemaName};
 use sql::plan::{Params, Plan, PlanContext};
 use transform::Optimizer;
 
@@ -100,6 +100,7 @@ impl ConnCatalog<'_> {
 
 #[derive(Debug, Serialize)]
 pub struct Database {
+    pub name: String,
     pub id: i64,
     #[serde(skip)]
     pub oid: u32,
@@ -108,6 +109,7 @@ pub struct Database {
 
 #[derive(Debug, Serialize)]
 pub struct Schema {
+    pub name: SchemaName,
     pub id: i64,
     #[serde(skip)]
     pub oid: u32,
@@ -412,6 +414,7 @@ impl Catalog {
             catalog.by_name.insert(
                 name.clone(),
                 Database {
+                    name: name.clone(),
                     id,
                     oid,
                     schemas: BTreeMap::new(),
@@ -423,10 +426,10 @@ impl Catalog {
         let schemas = catalog.storage().load_schemas()?;
         for (id, database_name, schema_name) in schemas {
             let oid = catalog.allocate_oid()?;
-            let (database_id, schemas) = match database_name {
+            let (database_id, schemas) = match &database_name {
                 Some(database_name) => catalog
                     .by_name
-                    .get_mut(&database_name)
+                    .get_mut(database_name)
                     .map(|db| (Some(db.id), &mut db.schemas))
                     .expect("catalog out of sync"),
                 None => (None, &mut catalog.ambient_schemas),
@@ -434,6 +437,10 @@ impl Catalog {
             schemas.insert(
                 schema_name.clone(),
                 Schema {
+                    name: SchemaName {
+                        database: database_name.into(),
+                        schema: schema_name.clone(),
+                    },
                     id,
                     oid,
                     items: BTreeMap::new(),
@@ -658,7 +665,7 @@ impl Catalog {
         database: Option<String>,
         schema_name: &str,
         conn_id: u32,
-    ) -> Result<(DatabaseSpecifier, SchemaSpecifier), SqlCatalogError> {
+    ) -> Result<&Schema, SqlCatalogError> {
         let database_spec = match database {
             // If a database is explicitly specified, validate it. Note that we
             // intentionally do not validate `current_database` to permit
@@ -673,15 +680,12 @@ impl Catalog {
 
         // First try to find the schema in the named database.
         if let Some(schema) = self.get_schema(&database_spec, schema_name, conn_id) {
-            return Ok((database_spec, SchemaSpecifier::new(schema_name, schema.id)));
+            return Ok(schema);
         }
 
         // Then fall back to the ambient database.
         if let Some(schema) = self.get_schema(&DatabaseSpecifier::Ambient, schema_name, conn_id) {
-            return Ok((
-                DatabaseSpecifier::Ambient,
-                SchemaSpecifier::new(schema_name, schema.id),
-            ));
+            return Ok(schema);
         }
 
         Err(SqlCatalogError::UnknownSchema(schema_name.into()))
@@ -699,7 +703,7 @@ impl Catalog {
         search_path: &[&str],
         name: &PartialName,
         conn_id: u32,
-    ) -> Result<FullName, SqlCatalogError> {
+    ) -> Result<&CatalogEntry, SqlCatalogError> {
         // If a schema name was specified, just try to find the item in that
         // schema. If no schema was specified, try to find the item in every
         // schema in the search path.
@@ -721,20 +725,14 @@ impl Catalog {
 
         for &schema_name in schemas {
             let database_name = name.database.clone();
-            let res = self.resolve_schema(&current_database, database_name, schema_name, conn_id);
-            let (database_spec, _) = match res {
-                Ok(specs) => specs,
-                Err(SqlCatalogError::UnknownSchema(_)) => continue,
-                Err(e) => return Err(e),
-            };
-            if let Some(schema) = self.get_schema(&database_spec, schema_name, conn_id) {
-                if schema.items.contains_key(&name.item) {
-                    return Ok(FullName {
-                        database: database_spec,
-                        schema: schema_name.to_owned(),
-                        item: name.item.to_owned(),
-                    });
-                }
+            let schema =
+                match self.resolve_schema(&current_database, database_name, schema_name, conn_id) {
+                    Ok(schema) => schema,
+                    Err(SqlCatalogError::UnknownSchema(_)) => continue,
+                    Err(e) => return Err(e),
+                };
+            if let Some(id) = schema.items.get(&name.item) {
+                return Ok(&self.by_id[id]);
             }
         }
         Err(SqlCatalogError::UnknownItem(name.to_string()))
@@ -747,14 +745,6 @@ impl Catalog {
         self.get_schema(&name.database, &name.schema, conn_id)
             .and_then(|schema| schema.items.get(&name.item))
             .map(|id| &self.by_id[id])
-    }
-
-    /// Returns the named catalog item, or an error if it does not exist.
-    ///
-    /// See also [`Catalog::try_get`].
-    pub fn get(&self, name: &FullName, conn_id: u32) -> Result<&CatalogEntry, SqlCatalogError> {
-        self.try_get(name, conn_id)
-            .ok_or_else(|| SqlCatalogError::UnknownItem(name.to_string()))
     }
 
     pub fn try_get_by_id(&self, id: GlobalId) -> Option<&CatalogEntry> {
@@ -772,6 +762,10 @@ impl Catalog {
         self.temporary_schemas.insert(
             conn_id,
             Schema {
+                name: SchemaName {
+                    database: DatabaseSpecifier::Ambient,
+                    schema: MZ_TEMP_SCHEMA.into(),
+                },
                 id: -1,
                 oid,
                 items: BTreeMap::new(),
@@ -917,20 +911,16 @@ impl Catalog {
         ops
     }
 
-    pub fn drop_schema_ops(
-        &mut self,
-        database_spec: DatabaseSpecifier,
-        schema_name: String,
-    ) -> Vec<Op> {
+    pub fn drop_schema_ops(&mut self, name: SchemaName) -> Vec<Op> {
         let mut ops = vec![];
         let mut seen = HashSet::new();
-        if let DatabaseSpecifier::Name(database_name) = database_spec {
+        if let DatabaseSpecifier::Name(database_name) = name.database {
             if let Some(database) = self.by_name.get(&database_name) {
-                if let Some(schema) = database.schemas.get(&schema_name) {
+                if let Some(schema) = database.schemas.get(&name.schema) {
                     Self::drop_schema_items(schema, &self.by_id, &mut ops, &mut seen);
                     ops.push(Op::DropSchema {
                         database_name: DatabaseSpecifier::Name(database_name),
-                        schema_name,
+                        schema_name: name.schema,
                     })
                 }
             }
@@ -1236,6 +1226,7 @@ impl Catalog {
                     self.by_name.insert(
                         name.clone(),
                         Database {
+                            name: name.clone(),
                             id,
                             oid,
                             schemas: BTreeMap::new(),
@@ -1255,6 +1246,10 @@ impl Catalog {
                     db.schemas.insert(
                         schema_name.clone(),
                         Schema {
+                            name: SchemaName {
+                                database: DatabaseSpecifier::Name(database_name),
+                                schema: schema_name.clone(),
+                            },
                             id,
                             oid,
                             items: BTreeMap::new(),
@@ -1749,9 +1744,12 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
         &self.database
     }
 
-    fn resolve_database(&self, database_name: &str) -> Result<i64, SqlCatalogError> {
+    fn resolve_database(
+        &self,
+        database_name: &str,
+    ) -> Result<&dyn sql::catalog::CatalogDatabase, SqlCatalogError> {
         match self.catalog.by_name.get(database_name) {
-            Some(database) => Ok(database.id),
+            Some(database) => Ok(database),
             None => Err(SqlCatalogError::UnknownDatabase(database_name.into())),
         }
     }
@@ -1760,13 +1758,16 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
         &self,
         database: Option<String>,
         schema_name: &str,
-    ) -> Result<(DatabaseSpecifier, SchemaSpecifier), SqlCatalogError> {
+    ) -> Result<&dyn sql::catalog::CatalogSchema, SqlCatalogError> {
         Ok(self
             .catalog
             .resolve_schema(&self.database, database, schema_name, self.conn_id)?)
     }
 
-    fn resolve_item(&self, name: &PartialName) -> Result<FullName, SqlCatalogError> {
+    fn resolve_item(
+        &self,
+        name: &PartialName,
+    ) -> Result<&dyn sql::catalog::CatalogItem, SqlCatalogError> {
         Ok(self
             .catalog
             .resolve(&self.database, self.search_path, name, self.conn_id)?)
@@ -1774,12 +1775,11 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
 
     fn list_items<'a>(
         &'a self,
-        database_spec: &DatabaseSpecifier,
-        schema_name: &str,
+        schema: &SchemaName,
     ) -> Box<dyn Iterator<Item = &'a dyn sql::catalog::CatalogItem> + 'a> {
         let schema = self
             .catalog
-            .get_schema(database_spec, schema_name, self.conn_id)
+            .get_schema(&schema.database, &schema.schema, self.conn_id)
             .unwrap();
         Box::new(
             schema
@@ -1787,10 +1787,6 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
                 .values()
                 .map(move |id| self.catalog.get_by_id(id) as &dyn sql::catalog::CatalogItem),
         )
-    }
-
-    fn get_item(&self, name: &FullName) -> &dyn sql::catalog::CatalogItem {
-        self.catalog.get(name, self.conn_id).unwrap()
     }
 
     fn get_item_by_id(&self, id: &GlobalId) -> &dyn sql::catalog::CatalogItem {
@@ -1803,6 +1799,26 @@ impl sql::catalog::Catalog for ConnCatalog<'_> {
 
     fn config(&self) -> &sql::catalog::CatalogConfig {
         &self.catalog.config
+    }
+}
+
+impl sql::catalog::CatalogDatabase for Database {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn id(&self) -> i64 {
+        self.id
+    }
+}
+
+impl sql::catalog::CatalogSchema for Schema {
+    fn name(&self) -> &SchemaName {
+        &self.name
+    }
+
+    fn id(&self) -> i64 {
+        self.id
     }
 }
 

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -9,13 +9,15 @@
 
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 use sql_parser::ast::{Ident, ObjectName};
 
 /// The fully-qualified name of an item in the catalog.
 ///
 /// Catalog names compare case sensitively. Normalization is the responsibility
 /// of the consumer (e.g., the SQL layer).
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FullName {
     pub database: DatabaseSpecifier,
     pub schema: String,
@@ -31,7 +33,7 @@ impl fmt::Display for FullName {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum DatabaseSpecifier {
     Ambient,
     Name(String),
@@ -55,17 +57,17 @@ impl From<Option<String>> for DatabaseSpecifier {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct SchemaSpecifier {
-    pub name: String,
-    pub id: i64,
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct SchemaName {
+    pub database: DatabaseSpecifier,
+    pub schema: String,
 }
 
-impl SchemaSpecifier {
-    pub fn new(name: &str, id: i64) -> SchemaSpecifier {
-        SchemaSpecifier {
-            name: name.to_owned(),
-            id,
+impl fmt::Display for SchemaName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.database {
+            DatabaseSpecifier::Ambient => f.write_str(&self.schema),
+            DatabaseSpecifier::Name(name) => write!(f, "{}.{}", name, self.schema),
         }
     }
 }
@@ -83,7 +85,7 @@ impl From<FullName> for ObjectName {
 }
 
 /// A partial name of an item in the catalog.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PartialName {
     pub database: Option<String>,
     pub schema: Option<String>,

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -96,7 +96,8 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
     };
 
     let resolve_item = |name: &ObjectName| -> Result<_, PlanError> {
-        Ok(unresolve(scx.resolve_item(name.clone())?))
+        let item = scx.resolve_item(name.clone())?;
+        Ok(unresolve(item.name().clone()))
     };
 
     struct QueryNormalizer<'a> {
@@ -155,7 +156,7 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
 
         fn visit_object_name_mut(&mut self, object_name: &'ast mut ObjectName) {
             match self.scx.resolve_item(object_name.clone()) {
-                Ok(full_name) => *object_name = unresolve(full_name),
+                Ok(full_name) => *object_name = unresolve(full_name.name().clone()),
                 Err(e) => self.err = Some(e),
             };
         }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -37,7 +37,7 @@ use repr::{ColumnName, RelationDesc, Row, ScalarType, Timestamp};
 
 use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
 use crate::catalog::Catalog;
-use crate::names::{DatabaseSpecifier, FullName};
+use crate::names::{DatabaseSpecifier, FullName, SchemaName};
 
 pub(crate) mod decorrelate;
 pub(crate) mod error;
@@ -111,8 +111,7 @@ pub enum Plan {
         name: String,
     },
     DropSchema {
-        database_name: DatabaseSpecifier,
-        schema_name: String,
+        name: SchemaName,
     },
     DropItems {
         items: Vec<GlobalId>,

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1400,10 +1400,9 @@ lazy_static! {
                         None => bail!("source passed to internal_read_cached_data must be literal string"),
                     };
                     let item = ecx.qcx.scx.resolve_item(ObjectName(vec![Ident::new(source.clone())]))?;
-                    let entry = ecx.catalog().get_item(&item);
-                    match entry.item_type() {
+                    match item.item_type() {
                         CatalogItemType::Source => {},
-                        _ =>  bail!("{} is a {}, but internal_read_cached_data requires a source", source, entry.item_type()),
+                        _ =>  bail!("{} is a {}, but internal_read_cached_data requires a source", source, item.item_type()),
                     }
                     let cache_directory = ecx.catalog().config().cache_directory.as_deref();
                     if cache_directory.is_none() {
@@ -1411,7 +1410,7 @@ lazy_static! {
                     }
                     Ok(TableFuncPlan {
                         func: TableFunc::ReadCachedData {
-                            source: entry.id(),
+                            source: item.id(),
                             cache_directory: cache_directory.expect("known to exist").to_path_buf(),
                         },
                         exprs: vec![],

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -133,8 +133,7 @@ pub fn plan_insert_query(
     source: InsertSource,
 ) -> Result<(GlobalId, RelationExpr), anyhow::Error> {
     let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot);
-    let name = scx.resolve_item(table_name)?;
-    let table = scx.catalog.get_item(&name);
+    let table = scx.resolve_item(table_name)?;
     let desc = table.desc()?;
 
     // Validate the target of the insert.
@@ -2838,8 +2837,7 @@ impl<'a> QueryContext<'a> {
         }
 
         // Non-CTE table names must be retrieved from the catalog.
-        let name = self.scx.resolve_item(name)?;
-        let item = self.scx.catalog.get_item(&name);
+        let item = self.scx.resolve_item(name)?;
         let desc = item.desc()?.clone();
         let expr = RelationExpr::Get {
             id: Id::Global(item.id()),
@@ -2847,7 +2845,7 @@ impl<'a> QueryContext<'a> {
         };
 
         let scope = Scope::from_source(
-            Some(name.into()),
+            Some(item.name().clone().into()),
             desc.iter_names().map(|n| n.cloned()),
             Some(self.outer_scope.clone()),
         );

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -47,9 +47,9 @@ use sql_parser::ast::{
     TailStatement, Value, WithOption, WithOptionValue,
 };
 
-use crate::catalog::{Catalog, CatalogItemType};
+use crate::catalog::{Catalog, CatalogDatabase, CatalogItem, CatalogItemType, CatalogSchema};
 use crate::kafka_util;
-use crate::names::{DatabaseSpecifier, FullName, PartialName, SchemaSpecifier};
+use crate::names::{DatabaseSpecifier, FullName, PartialName, SchemaName};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
@@ -218,8 +218,7 @@ pub fn describe_statement(
         }
 
         Statement::Tail(TailStatement { name, options, .. }) => {
-            let name = scx.resolve_item(name)?;
-            let sql_object = scx.catalog.get_item(&name);
+            let sql_object = scx.resolve_item(name)?;
             let options = TailOptions::try_from(options)?;
             const MAX_U64_DIGITS: u8 = 20;
             let mut desc = RelationDesc::empty().with_column(
@@ -393,8 +392,7 @@ fn handle_tail(
     }: TailStatement,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, anyhow::Error> {
-    let from = scx.resolve_item(name)?;
-    let entry = scx.catalog.get_item(&from);
+    let entry = scx.resolve_item(name)?;
     let ts = as_of.map(|e| query::eval_as_of(scx, e)).transpose()?;
     let options = TailOptions::try_from(options)?;
 
@@ -411,7 +409,7 @@ fn handle_tail(
         }
         CatalogItemType::Index | CatalogItemType::Sink | CatalogItemType::Type => bail!(
             "'{}' cannot be tailed because it is a {}",
-            from,
+            entry.name(),
             entry.item_type(),
         ),
     }
@@ -459,8 +457,7 @@ fn handle_alter_object_rename(
     }: AlterObjectRenameStatement,
 ) -> Result<Plan, anyhow::Error> {
     let id = match scx.resolve_item(name.clone()) {
-        Ok(from_name) => {
-            let entry = scx.catalog.get_item(&from_name);
+        Ok(entry) => {
             if entry.item_type() != object_type {
                 bail!("{} is a {} not a {}", name, entry.item_type(), object_type)
             }
@@ -496,10 +493,9 @@ fn handle_alter_index_options(
     }: AlterIndexOptionsStatement,
 ) -> Result<Plan, anyhow::Error> {
     let alter_index = match scx.resolve_item(index_name) {
-        Ok(name) => {
-            let entry = scx.catalog.get_item(&name);
+        Ok(entry) => {
             if entry.item_type() != CatalogItemType::Index {
-                bail!("{} is a {} not a index", name, entry.item_type())
+                bail!("{} is a {} not a index", entry.name(), entry.item_type())
             }
 
             let logical_compaction_window = match options {
@@ -676,7 +672,7 @@ fn handle_create_sink(
         if_not_exists,
     } = stmt;
     let name = scx.allocate_name(normalize::object_name(name)?);
-    let from = scx.catalog.get_item(&scx.resolve_item(from)?);
+    let from = scx.resolve_item(from)?;
     let suffix = format!(
         "{}-{}",
         scx.catalog
@@ -757,21 +753,20 @@ fn handle_create_index(
         key_parts,
         if_not_exists,
     } = &mut stmt;
-    let on_name = scx.resolve_item(on_name.clone())?;
-    let catalog_entry = scx.catalog.get_item(&on_name);
+    let on = scx.resolve_item(on_name.clone())?;
 
-    if CatalogItemType::View != catalog_entry.item_type()
-        && CatalogItemType::Source != catalog_entry.item_type()
-        && CatalogItemType::Table != catalog_entry.item_type()
+    if CatalogItemType::View != on.item_type()
+        && CatalogItemType::Source != on.item_type()
+        && CatalogItemType::Table != on.item_type()
     {
         bail!(
             "index cannot be created on {} because it is a {}",
-            on_name,
-            catalog_entry.item_type()
+            on.name(),
+            on.item_type()
         )
     }
 
-    let on_desc = catalog_entry.desc()?;
+    let on_desc = on.desc()?;
 
     let filled_key_parts = match key_parts {
         Some(kp) => kp.to_vec(),
@@ -779,8 +774,7 @@ fn handle_create_index(
             // `key_parts` is None if we're creating a "default" index, i.e.
             // creating the index as if the index had been created alongside the
             // view source, e.g. `CREATE MATERIALIZED...`
-            catalog_entry
-                .desc()?
+            on.desc()?
                 .typ()
                 .default_key()
                 .iter()
@@ -795,12 +789,12 @@ fn handle_create_index(
 
     let index_name = if let Some(name) = name {
         FullName {
-            database: on_name.database.clone(),
-            schema: on_name.schema.clone(),
+            database: on.name().database.clone(),
+            schema: on.name().schema.clone(),
             item: normalize::ident(name.clone()),
         }
     } else {
-        let mut idx_name_base = on_name.clone();
+        let mut idx_name_base = on.name().clone();
         if key_parts.is_none() {
             // We're trying to create the "default" index.
             idx_name_base.item += "_primary_idx";
@@ -824,14 +818,18 @@ fn handle_create_index(
         let mut index_name = idx_name_base.clone();
         let mut i = 0;
 
-        let mut cat_schema_iter = scx.catalog.list_items(&on_name.database, &on_name.schema);
+        let schema = SchemaName {
+            database: on.name().database.clone(),
+            schema: on.name().schema.clone(),
+        };
+        let mut cat_schema_iter = scx.catalog.list_items(&schema);
 
         // Search for an unused version of the name unless `if_not_exists`.
         while cat_schema_iter.any(|i| *i.name() == index_name) && !*if_not_exists {
             i += 1;
             index_name = idx_name_base.clone();
             index_name.item += &i.to_string();
-            cat_schema_iter = scx.catalog.list_items(&on_name.database, &on_name.schema);
+            cat_schema_iter = scx.catalog.list_items(&schema);
         }
 
         index_name
@@ -847,7 +845,7 @@ fn handle_create_index(
         name: index_name,
         index: Index {
             create_sql,
-            on: catalog_entry.id(),
+            on: on.id(),
             keys,
         },
         if_not_exists,
@@ -916,11 +914,13 @@ fn handle_create_view(
     } else {
         scx.allocate_name(normalize::object_name(name.to_owned())?)
     };
-    let replace = if *if_exists == IfExistsBehavior::Replace
-        && scx.catalog.resolve_item(&name.clone().into()).is_ok()
-    {
-        let cascade = false;
-        handle_drop_item(scx, ObjectType::View, &name, cascade)?
+    let replace = if *if_exists == IfExistsBehavior::Replace {
+        if let Ok(item) = scx.catalog.resolve_item(&name.clone().into()) {
+            let cascade = false;
+            handle_drop_item(scx, ObjectType::View, item, cascade)?
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -977,10 +977,10 @@ fn handle_create_type(
             Some(_) => bail!("{} must be a string or identifier", key),
             None => bail!("{} parameter required", key),
         };
-        let item_name = scx
+        let item = scx
             .catalog
             .resolve_item(&normalize::object_name(item_name)?)?;
-        ids.push(scx.catalog.get_item(&item_name).id());
+        ids.push(item.id());
     }
 
     if !with_options.is_empty() {
@@ -1613,7 +1613,7 @@ fn handle_drop_database(
     DropDatabaseStatement { name, if_exists }: DropDatabaseStatement,
 ) -> Result<Plan, anyhow::Error> {
     let name = match scx.resolve_database_ident(name) {
-        Ok((name, _id)) => name,
+        Ok(database) => database.name().into(),
         Err(_) if if_exists => {
             // TODO(benesch): generate a notice indicating that the database
             // does not exist.
@@ -1657,24 +1657,22 @@ fn handle_drop_schema(
         unsupported!("DROP SCHEMA with multiple schemas");
     }
     match scx.resolve_schema(names.into_element()) {
-        Ok((database_spec, schema_spec)) => {
-            if let DatabaseSpecifier::Ambient = database_spec {
+        Ok(schema) => {
+            if let DatabaseSpecifier::Ambient = schema.name().database {
                 bail!(
                     "cannot drop schema {} because it is required by the database system",
-                    schema_spec.name
+                    schema.name()
                 );
             }
-            let mut items = scx.catalog.list_items(&database_spec, &schema_spec.name);
+            let mut items = scx.catalog.list_items(schema.name());
             if !cascade && items.next().is_some() {
                 bail!(
-                    "schema '{}.{}' cannot be dropped without CASCADE while it contains objects",
-                    database_spec,
-                    schema_spec.name
+                    "schema '{}' cannot be dropped without CASCADE while it contains objects",
+                    schema.name(),
                 );
             }
             Ok(Plan::DropSchema {
-                database_name: database_spec,
-                schema_name: schema_spec.name,
+                name: schema.name().clone(),
             })
         }
         Err(_) if if_exists => {
@@ -1683,8 +1681,10 @@ fn handle_drop_schema(
             // TODO(benesch): adjust the types here properly, rather than making
             // up a nonexistent database.
             Ok(Plan::DropSchema {
-                database_name: DatabaseSpecifier::Ambient,
-                schema_name: "noexist".into(),
+                name: SchemaName {
+                    database: DatabaseSpecifier::Ambient,
+                    schema: "noexist".into(),
+                },
             })
         }
         Err(e) => Err(e.into()),
@@ -1698,14 +1698,14 @@ fn handle_drop_items(
     names: Vec<ObjectName>,
     cascade: bool,
 ) -> Result<Plan, anyhow::Error> {
-    let names = names
+    let items = names
         .into_iter()
         .map(|n| scx.resolve_item(n))
         .collect::<Vec<_>>();
     let mut ids = vec![];
-    for name in names {
-        match name {
-            Ok(name) => ids.extend(handle_drop_item(scx, object_type, &name, cascade)?),
+    for item in items {
+        match item {
+            Ok(item) => ids.extend(handle_drop_item(scx, object_type, item, cascade)?),
             Err(_) if if_exists => {
                 // TODO(benesch): generate a notice indicating this
                 // item does not exist.
@@ -1722,18 +1722,17 @@ fn handle_drop_items(
 fn handle_drop_item(
     scx: &StatementContext,
     object_type: ObjectType,
-    name: &FullName,
+    catalog_entry: &dyn CatalogItem,
     cascade: bool,
 ) -> Result<Option<GlobalId>, anyhow::Error> {
-    let catalog_entry = scx.catalog.get_item(name);
     if catalog_entry.id().is_system() {
         bail!(
             "cannot drop item {} because it is required by the database system",
-            name
+            catalog_entry.name(),
         );
     }
     if object_type != catalog_entry.item_type() {
-        bail!("{} is not of type {}", name, object_type);
+        bail!("{} is not of type {}", catalog_entry.name(), object_type);
     }
     if !cascade {
         for id in catalog_entry.used_by() {
@@ -1805,23 +1804,18 @@ fn handle_explain(
     let is_view = matches!(explainee, Explainee::View(_));
     let (scx, query) = match explainee {
         Explainee::View(name) => {
-            let full_name = scx.resolve_item(name.clone())?;
-            let entry = scx.catalog.get_item(&full_name);
-            if entry.item_type() != CatalogItemType::View {
-                bail!(
-                    "Expected {} to be a view, not a {}",
-                    name,
-                    entry.item_type(),
-                );
+            let view = scx.resolve_item(name.clone())?;
+            if view.item_type() != CatalogItemType::View {
+                bail!("Expected {} to be a view, not a {}", name, view.item_type(),);
             }
-            let parsed = crate::parse::parse(entry.create_sql())
+            let parsed = crate::parse::parse(view.create_sql())
                 .expect("Sql for existing view should be valid sql");
             let query = match parsed.into_last() {
                 Statement::CreateView(CreateViewStatement { query, .. }) => query,
                 _ => panic!("Sql for existing view should parse as a view"),
             };
             let scx = StatementContext {
-                pcx: entry.plan_cx(),
+                pcx: view.plan_cx(),
                 catalog: scx.catalog,
                 param_types: scx.param_types.clone(),
             };
@@ -1922,35 +1916,28 @@ impl<'a> StatementContext<'a> {
         }
     }
 
-    pub fn resolve_default_database(&self) -> Result<(String, i64), PlanError> {
+    pub fn resolve_default_database(&self) -> Result<&dyn CatalogDatabase, PlanError> {
         let name = self.catalog.default_database();
-        let id = self.catalog.resolve_database(name)?;
-        Ok((name.into(), id))
+        Ok(self.catalog.resolve_database(name)?)
     }
 
-    pub fn resolve_default_schema(&self) -> Result<SchemaSpecifier, PlanError> {
-        Ok(self
-            .resolve_schema(ObjectName(vec![Ident::new("public")]))?
-            .1)
+    pub fn resolve_default_schema(&self) -> Result<&dyn CatalogSchema, PlanError> {
+        self.resolve_schema(ObjectName(vec![Ident::new("public")]))
     }
 
-    pub fn resolve_database(&self, name: ObjectName) -> Result<(String, i64), PlanError> {
+    pub fn resolve_database(&self, name: ObjectName) -> Result<&dyn CatalogDatabase, PlanError> {
         if name.0.len() != 1 {
             return Err(PlanError::OverqualifiedDatabaseName(name.to_string()));
         }
         self.resolve_database_ident(name.0.into_element())
     }
 
-    pub fn resolve_database_ident(&self, name: Ident) -> Result<(String, i64), PlanError> {
+    pub fn resolve_database_ident(&self, name: Ident) -> Result<&dyn CatalogDatabase, PlanError> {
         let name = normalize::ident(name);
-        let id = self.catalog.resolve_database(&name)?;
-        Ok((name, id))
+        Ok(self.catalog.resolve_database(&name)?)
     }
 
-    pub fn resolve_schema(
-        &self,
-        mut name: ObjectName,
-    ) -> Result<(DatabaseSpecifier, SchemaSpecifier), PlanError> {
+    pub fn resolve_schema(&self, mut name: ObjectName) -> Result<&dyn CatalogSchema, PlanError> {
         if name.0.len() > 2 {
             return Err(PlanError::OverqualifiedSchemaName(name.to_string()));
         }
@@ -1959,7 +1946,7 @@ impl<'a> StatementContext<'a> {
         Ok(self.catalog.resolve_schema(database_spec, &schema_name)?)
     }
 
-    pub fn resolve_item(&self, name: ObjectName) -> Result<FullName, PlanError> {
+    pub fn resolve_item(&self, name: ObjectName) -> Result<&dyn CatalogItem, PlanError> {
         let name = normalize::object_name(name)?;
         Ok(self.catalog.resolve_item(&name)?)
     }

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -49,7 +49,7 @@ name
 ----
 materialize
 
-> SELECT id, name FROM mz_catalog.mz_databases
+> SELECT id, name FROM mz_databases
 id          name
 -----------------------
 1           materialize
@@ -62,11 +62,18 @@ name
 d
 materialize
 
-> SELECT id, name FROM mz_catalog.mz_databases
+> SELECT id, name FROM mz_databases
 id          name
 -----------------------
 1           materialize
 2           d
+
+# The same catalog information should be accessible with any amount of
+# database or schema qualification.
+> SELECT count(*) FROM materialize.mz_catalog.mz_databases
+2
+> SELECT count(*) FROM d.mz_catalog.mz_databases
+2
 
 # SHOW DATABASES should filter its output according to the provided LIKE or
 # WHERE clause.
@@ -144,7 +151,7 @@ Expected end of statement, found RESTRICT
 name
 ----
 materialize
-> SELECT id, name FROM mz_catalog.mz_databases
+> SELECT id, name FROM mz_databases
 id          name
 -----------------------
 1           materialize
@@ -215,7 +222,7 @@ name
 d
 d2
 materialize
-> SELECT id, name FROM mz_catalog.mz_databases
+> SELECT id, name FROM mz_databases
 id          name
 -----------------------
 1           materialize


### PR DESCRIPTION
@sploiselle you up for taking this one? This fixes that bug you spotted and also applies a large refactor to try to get a handle on the growing complexity of the catalog API.

----

**coord: permit db-qualified references to ambient schemas**

Permit fully-qualifying a reference to an ambient schema, as in:

    SELECT * FROM materialize.pg_catalog.pg_enum

Previously we only permitted the shorter form:

    SELECT * FROM pg_catalog.pg_enum

This was just an oversight. The new behavior matches PostgreSQL.

Fix #4998.

----

**coord,sql: combine resolution/lookup in catalog API**

Previously, interacting with the catalog required an annoying bit of
boilerplate:

     let name = scx.catalog.resolve_item(name)?;
     let item = scx.catalog.get_item(&name);

The first call "resolved" a partially-specified item name to a full
name; the second call then looked up the resolved full name in the
catalog to pull out the actual catalog item. Simplify the API to:

     let item = scx.catalog.resolve_item(name)?;

Code that needs access to the fully-specified name can pull it out of
the item on demand via `item.name()`.

The same change is applied to `Catalog::resolve_database` and
`Catalog::resolve_schema`. These methods now return a database and
schema object, respectively, to mirror the item object returned by
Catalog::resolve_item, and are much less awkward to use than before.

There should be no behavioral changes in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5000)
<!-- Reviewable:end -->
