### PR TITLE
Clear row_packer before using in Reduce

### DIFF
--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -103,6 +103,11 @@ where
                     move |row| {
                         let temp_storage = RowArena::new();
                         let mut results = Vec::new();
+
+                        // Ensure the packer is clear, and does not reflect
+                        // columns from prior rows that may have errored.
+                        row_packer.clear();
+
                         // First, evaluate the key selector expressions.
                         // If any error we produce their errors as output and note
                         // the fact that the key was not correctly produced.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -758,6 +758,11 @@ impl RowPacker {
         }
     }
 
+    /// Clears the row packer.
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+
     /// Push `datum` onto the end of `self`
     pub fn push(&mut self, datum: Datum) {
         push_datum(&mut self.data, datum)

--- a/test/sqllogictest/regressions.slt
+++ b/test/sqllogictest/regressions.slt
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t (a int, b string, c int)
+
+statement ok
+INSERT INTO t (a, b, c) VALUES (1, 'test', 1)
+
+statement ok
+INSERT INTO t (a, b, c) VALUES (0, 'test', 1)
+
+statement ok
+INSERT INTO t (a, b, c) VALUES (3, 'test', 1)
+
+# Regression test for #5003
+statement error Evaluation error: division by zero
+SELECT recip - 1 FROM (SELECT b, 1/a as recip, max(c) from t GROUP BY b, 1/a)


### PR DESCRIPTION
fixes #5003 by clearing `row_packer` before using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5004)
<!-- Reviewable:end -->
