### PR TITLE
billing: make the local workflow more pleasant

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -57,7 +57,7 @@ services:
     environment:
       - RUST_LOG=billing-demo=debug,info
     command: >-
-      --message-count 1000
+      --message-count ${BILLING_MESSAGE_COUNT:-1000}
       --materialized-host materialized
       --kafka-host kafka
       --schema-registry-url http://schema-registry:8081

--- a/demo/billing/src/main.rs
+++ b/demo/billing/src/main.rs
@@ -131,9 +131,10 @@ async fn create_kafka_messages(config: KafkaConfig) -> Result<()> {
             buf.clear();
         }
         log::info!(
-            "produced {} records ({} bytes / record)",
+            "produced {} records ({} bytes / record) ({} remaining)",
             messages_to_send,
-            bytes_sent / messages_to_send
+            bytes_sent / messages_to_send,
+            messages_remaining,
         );
         messages_remaining -= messages_to_send;
 


### PR DESCRIPTION
It's nice to be able to configure the number of messages to run when running with output to stderr.

Also, when looking at an output it's nice to see how many messages are remaining.

This was spurred by #4886

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5005)
<!-- Reviewable:end -->
