### PR TITLE
Reuse row allocations

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -181,6 +181,10 @@ disabled_lints=(
     # Upstream description: https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive
     # Unstable sort is not strictly better than sort, notably on partially sorted inputs.
     clippy::stable-sort-primitive
+
+    # Upstream description https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
+    # Breaking symmetry for the sake of this lint can make code harder to read.
+    clippy::needless-return
 )
 
 # NOTE(benesch): we ignore some ShellCheck complaints about sloppy word

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -114,8 +114,6 @@ where
                     |_expr| None,
                     move |row| {
                         let temp_storage = RowArena::new();
-                        let mut results = Vec::new();
-
                         // Ensure the packer is clear, and does not reflect
                         // columns from prior rows that may have errored.
                         row_packer.clear();
@@ -129,7 +127,7 @@ where
                             match expr.eval(&datums_local, &temp_storage) {
                                 Ok(val) => row_packer.push(val),
                                 Err(e) => {
-                                    results.push(Err(e.into()));
+                                    return Some(Err(e.into()));
                                 }
                             }
                         }
@@ -138,25 +136,29 @@ where
                         // If any error occurs we produce both the error as output,
                         // but also a `Datum::Null` value to avoid causing the later
                         // "ReduceCollation" operator to panic due to absent aggregates.
-                        if results.is_empty() {
-                            let key = row_packer.finish_and_reuse();
-                            for aggr in aggregates_clone.iter() {
-                                match aggr.expr.eval(&datums_local, &temp_storage) {
-                                    Ok(val) => {
-                                        row_packer.push(val);
-                                    }
-                                    Err(e) => {
-                                        row_packer.push(Datum::Null);
-                                        results.push(Err(e.into()));
-                                    }
+                        let key = row_packer.finish_and_reuse();
+                        for aggr in aggregates_clone.iter() {
+                            match aggr.expr.eval(&datums_local, &temp_storage) {
+                                Ok(val) => {
+                                    row_packer.push(val);
+                                }
+                                Err(e) => {
+                                    return Some(Err(e.into()));
                                 }
                             }
-                            let row = row_packer.finish_and_reuse();
-                            results.push(Ok((key, row)));
                         }
                         datums = repurpose_allocation(datums_local);
-                        // Return accumulated results.
-                        results
+
+                        // Mint the final row, ideally re-using resources.
+                        use timely::communication::message::RefOrMut;
+                        let row = match row {
+                            RefOrMut::Ref(_) => row_packer.finish_and_reuse(),
+                            RefOrMut::Mut(row) => {
+                                row_packer.finish_into(row);
+                                std::mem::replace(row, Row::new(vec![]))
+                            }
+                        };
+                        return Some(Ok((key, row)));
                     },
                 )
                 .unwrap();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -840,6 +840,20 @@ impl RowPacker {
         Row { data }
     }
 
+    /// Finish packing a row into a pre-existing allocation.
+    ///
+    /// This method is available in order to re-use existing row allocations,
+    /// which would otherwise be de-allocated and re-allocated is common row
+    /// processing cases.
+    ///
+    /// The current contents of `row` are erased, and replaced with the packed
+    /// contents of `self`.
+    pub fn finish_into(&mut self, row: &mut Row) {
+        row.data.clear();
+        row.data.extend(self.data.iter().cloned());
+        self.data.clear();
+    }
+
     /// Pushes a [`DatumList`] that is built from a closure.
     ///
     /// The supplied closure will be invoked once with a `RowPacker` that can


### PR DESCRIPTION
This PR allows `RowPacker` to pack into an existing `Row`, allowing allocation-sensitive operators to re-use row allocations. The recurring idiom is to use an inbound `row` to populate a `row_packer`, then to use `row_packer.finish_into(&mut row)`.

The `flat_map_ref` method is extended to provide a `RefOrMut<Row>` rather than a `&Row` as an argument, so that callers can take ownership of `row` when it is available.

This improves some operators by up to 3x, in this specific case `MFP` wrapped around a `Get`, which can often go from `Row` to `Row` with only slight changes or projections.

There is a slight change to the behavior of `Reduce`: it would previously accumulate all errors in key evaluation and return them all, but now just returns the first error (avoiding an allocation in the common case that there are no / at most one error).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5006)
<!-- Reviewable:end -->
