### PR TITLE
dataflow: avoid out-of-bounds slice when decoding regex

### DIFF
--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::min;
 use std::iter;
 use std::str;
 
@@ -45,17 +44,18 @@ where
                     let line = match str::from_utf8(&line) {
                         Ok(line) => line,
                         Err(_) => {
-                            let line_len = min(line.len(), 1024);
+                            let line_no = match line_no {
+                                Some(line_no) => line_no.to_string(),
+                                None => "unknown".into(),
+                            };
+                            let line_prefix = String::from_utf8_lossy(&line)
+                                .chars()
+                                .take(64)
+                                .collect::<String>();
                             warn!(
-                                "Line {}{} from source {} cannot be decoded as utf8. \
-                                Discarding line.",
-                                if line_len == line.len() {
-                                    ""
-                                } else {
-                                    "starting with: "
-                                },
-                                String::from_utf8_lossy(&line[0..line_len]),
-                                name
+                                "dropping line with invalid UTF-8 \
+                                (source: {}, line number: {}, line prefix: {:?})",
+                                name, line_no, line_prefix,
                             );
                             continue;
                         }

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -12,7 +12,7 @@ use crate::source::SourceOutput;
 use log::warn;
 use regex::Regex;
 use repr::{Datum, Diff, Row, Timestamp};
-use std::cmp::max;
+use std::cmp::min;
 use std::iter;
 use std::str;
 
@@ -40,7 +40,7 @@ where
                         let line = match str::from_utf8(&line) {
                             Ok(line) => line,
                             _ => {
-                                let line_len = max(line.len(), 1024);
+                                let line_len = min(line.len(), 1024);
                                 warn!(
                                     "Line {}{} from source {} cannot be decoded as utf8. Discarding line.",
                                     if line_len == line.len() { "" } else {"starting with: "},

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -7,17 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::source::SourceOutput;
-
-use log::warn;
-use regex::Regex;
-use repr::{Datum, Diff, Row, Timestamp};
 use std::cmp::min;
 use std::iter;
 use std::str;
 
+use log::warn;
+use regex::Regex;
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
+
+use repr::{Datum, Diff, Row, Timestamp};
+
+use crate::source::SourceOutput;
 
 pub fn regex<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
@@ -28,44 +29,54 @@ where
     G: Scope<Timestamp = Timestamp>,
 {
     let name = String::from(name);
-    stream.unary(
-        SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
-        "RegexDecode",
-        |_, _| {
-            let mut row_packer = repr::RowPacker::new();
-            move |input, output| {
-                input.for_each(|cap, lines| {
-                    let mut session = output.session(&cap);
-                    for SourceOutput {key: _, value: line, position: line_no, upstream_time_millis: _ } in &*lines {
-                        let line = match str::from_utf8(&line) {
-                            Ok(line) => line,
-                            _ => {
-                                let line_len = min(line.len(), 1024);
-                                warn!(
-                                    "Line {}{} from source {} cannot be decoded as utf8. Discarding line.",
-                                    if line_len == line.len() { "" } else {"starting with: "},
-                                    String::from_utf8_lossy(&line[0..line_len]),
-                                    name
-                                );
-                                continue;
-                            }
-                        };
-                        let captures = match regex.captures(line) {
-                            Some(captures) => captures,
-                            None => continue,
-                        };
-                        session.give((
-                            row_packer.pack(captures.iter().skip(1).map(
-                                |m| Datum::from( m.map(
-                                    |m| m.as_str())
-                                )
-                            ).chain(iter::once(line_no.map(Datum::Int64).into()))),
-                            *cap.time(),
-                            1,
-                        ));
-                    }
-                });
-            }
-        },
-    )
+    let pact = SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract();
+    let mut row_packer = repr::RowPacker::new();
+    stream.unary(pact, "RegexDecode", |_cap, _op_info| {
+        move |input, output| {
+            input.for_each(|cap, lines| {
+                let mut session = output.session(&cap);
+                for SourceOutput {
+                    key: _,
+                    value: line,
+                    position: line_no,
+                    upstream_time_millis: _,
+                } in &*lines
+                {
+                    let line = match str::from_utf8(&line) {
+                        Ok(line) => line,
+                        Err(_) => {
+                            let line_len = min(line.len(), 1024);
+                            warn!(
+                                "Line {}{} from source {} cannot be decoded as utf8. \
+                                Discarding line.",
+                                if line_len == line.len() {
+                                    ""
+                                } else {
+                                    "starting with: "
+                                },
+                                String::from_utf8_lossy(&line[0..line_len]),
+                                name
+                            );
+                            continue;
+                        }
+                    };
+
+                    let captures = match regex.captures(line) {
+                        Some(captures) => captures,
+                        None => continue,
+                    };
+
+                    // Skip the 0th capture, which is the entire match, so that
+                    // we only output the actual capture groups.
+                    let datums = captures
+                        .iter()
+                        .skip(1)
+                        .map(|c| Datum::from(c.map(|c| c.as_str())))
+                        .chain(iter::once(Datum::from(*line_no)));
+
+                    session.give((row_packer.pack(datums), *cap.time(), 1));
+                }
+            });
+        }
+    })
 }

--- a/src/testdrive/src/format.rs
+++ b/src/testdrive/src/format.rs
@@ -8,4 +8,5 @@
 // by the Apache License, Version 2.0.
 
 pub mod avro;
+pub mod bytes;
 pub mod protobuf;

--- a/src/testdrive/src/format/bytes.rs
+++ b/src/testdrive/src/format/bytes.rs
@@ -1,0 +1,43 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Unescapes a testdrive byte string.
+///
+/// The escape character is `\` and the only interesting escape sequence is
+/// `\xNN`, where each `N` is a valid hexadecimal digit. All other characters
+/// following a backslash are taken literally.
+pub fn unescape(s: &[u8]) -> Result<Vec<u8>, String> {
+    let mut out = vec![];
+    let mut s = s.iter().copied().fuse();
+    while let Some(b) = s.next() {
+        match b {
+            b'\\' if s.next() == Some(b'x') => match (next_hex(&mut s), next_hex(&mut s)) {
+                (Some(c1), Some(c0)) => out.push((c1 << 4) + c0),
+                _ => return Err("invalid hexadecimal escape".into()),
+            },
+            b'\\' => continue,
+            _ => out.push(b),
+        }
+    }
+    Ok(out)
+}
+
+/// Retrieves the value of the next hexadecimal digit in `iter`, if the next
+/// byte is a valid hexadecimal digit.
+fn next_hex<I>(iter: &mut I) -> Option<u8>
+where
+    I: Iterator<Item = u8>,
+{
+    iter.next().and_then(|c| match c {
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'0'..=b'9' => Some(c - b'0'),
+        _ => None,
+    })
+}

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -10,6 +10,7 @@
 $ file-append path=request.log
 123.17.127.5 - - [22/Jan/2020 18:59:52] "GET / HTTP/1.1" 200 -
 8.15.119.56 - - [22/Jan/2020 18:59:52] "GET /detail/nNZpqxzR HTTP/1.1" 200 -
+this line has invalid UTF-8 and will be dropped --> \x80 <--
 96.12.83.72 - - [22/Jan/2020 18:59:52] "GET /search/?kw=helper+ins+hennaed HTTP/1.1" 200 -
 
 # Regex explained here: https://www.debuggex.com/r/k48kBEt-lTMUZbaw
@@ -32,7 +33,7 @@ ip            ts                      path                                      
 --------------------------------------------------------------------------------------------------------------------------------------------
 123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
 8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
-96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   4
 
 > SELECT search_kw FROM regex_source WHERE search_kw IS NOT NULL
 search_kw
@@ -59,4 +60,4 @@ ip            ts                      path                                      
 --------------------------------------------------------------------------------------------------------------------------------------------
 123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
 8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
-96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   4


### PR DESCRIPTION
This was a simple case of using the "max" function where "min" was
intended.

Fix #5008.

Also a bunch of other cleanups, so I recommend going commit by commit!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5009)
<!-- Reviewable:end -->
