### PR TITLE
peeker: switch init-attempts to init-timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ dependencies = [
  "log",
  "mz-process-collector",
  "ore",
+ "parse_duration",
  "postgres",
  "prometheus",
  "regex",

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1.4"
 log = "0.4.11"
 mz-process-collector = { path = "../mz-process-collector" }
 ore = { path = "../ore" }
+parse_duration = "2.1.0"
 postgres = "0.17.5"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 regex = "1.4.1"

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -62,7 +62,8 @@ impl Args {
         opts.optopt(
             "",
             "materialized-url",
-            "url of the materialized instance to collect metrics from",
+            "url of the materialized instance to collect metrics from. \
+             Default: postgres://ignoreuser@materialized:6875/materialize",
             "URL",
         );
         opts.optflag(


### PR DESCRIPTION
The init-attempts flag was sort of a lie anyway, since whatever value was
placed in there was attempted 6 times no matter how small the value was set.

Now we try for at most `--init-timeout` duration, e.g. 60s or 5m

----

Implemented because of #4885

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5015)
<!-- Reviewable:end -->
