### PR TITLE
Extract dataflow description construction from coord.rs

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -80,6 +80,7 @@ use crate::timestamp::{TimestampConfig, TimestampMessage, Timestamper};
 use crate::util::ClientTransmitter;
 
 mod arrangement_state;
+mod dataflow_builder;
 
 pub enum Message {
     Command(Command),
@@ -256,7 +257,8 @@ where
                         self.indexes
                             .insert(*id, Frontiers::new(self.num_timely_workers, Some(1_000)));
                     } else {
-                        self.ship_dataflow(self.build_index_dataflow(*id)).await;
+                        self.ship_dataflow(self.dataflow_builder().build_index_dataflow(*id))
+                            .await;
                     }
                 }
                 _ => (), // Handled in next loop.
@@ -886,8 +888,13 @@ where
             .await
             .expect("replacing a sink cannot fail");
 
-        self.ship_dataflow(self.build_sink_dataflow(name.to_string(), id, sink.from, connector))
-            .await
+        self.ship_dataflow(self.dataflow_builder().build_sink_dataflow(
+            name.to_string(),
+            id,
+            sink.from,
+            connector,
+        ))
+        .await
     }
 
     /// Insert a single row into a given catalog view.
@@ -1547,7 +1554,7 @@ where
             .await
         {
             Ok(_) => {
-                self.ship_dataflow(self.build_index_dataflow(index_id))
+                self.ship_dataflow(self.dataflow_builder().build_index_dataflow(index_id))
                     .await;
                 Ok(ExecuteResponse::CreatedTable { existed: false })
             }
@@ -1598,7 +1605,7 @@ where
         match self.catalog_transact(ops).await {
             Ok(()) => {
                 if let Some(index_id) = index_id {
-                    self.ship_dataflow(self.build_index_dataflow(index_id))
+                    self.ship_dataflow(self.dataflow_builder().build_index_dataflow(index_id))
                         .await;
                 }
 
@@ -1749,7 +1756,7 @@ where
         match self.catalog_transact(ops).await {
             Ok(()) => {
                 if let Some(index_id) = index_id {
-                    self.ship_dataflow(self.build_index_dataflow(index_id))
+                    self.ship_dataflow(self.dataflow_builder().build_index_dataflow(index_id))
                         .await;
                 }
                 Ok(ExecuteResponse::CreatedView { existed: false })
@@ -1785,7 +1792,8 @@ where
         };
         match self.catalog_transact(vec![op]).await {
             Ok(()) => {
-                self.ship_dataflow(self.build_index_dataflow(id)).await;
+                self.ship_dataflow(self.dataflow_builder().build_index_dataflow(id))
+                    .await;
                 Ok(ExecuteResponse::CreatedIndex { existed: false })
             }
             Err(_) if if_not_exists => Ok(ExecuteResponse::CreatedIndex { existed: true }),
@@ -2001,7 +2009,8 @@ where
                 let view_id = self.allocate_transient_id()?;
                 let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id));
                 dataflow.set_as_of(Antichain::from_elem(timestamp));
-                self.import_view_into_dataflow(&view_id, &source, &mut dataflow);
+                self.dataflow_builder()
+                    .import_view_into_dataflow(&view_id, &source, &mut dataflow);
                 dataflow.add_index_to_build(index_id, view_id, typ.clone(), key.clone());
                 dataflow.add_index_export(index_id, view_id, typ, key);
                 self.ship_dataflow(dataflow).await;
@@ -2084,7 +2093,7 @@ where
         self.active_tails.insert(conn_id, sink_id);
         let (tx, rx) = self.switchboard.mpsc_limited(self.num_timely_workers);
 
-        self.ship_dataflow(self.build_sink_dataflow(
+        self.ship_dataflow(self.dataflow_builder().build_sink_dataflow(
             sink_name,
             sink_id,
             source_id,
@@ -2784,160 +2793,7 @@ where
         }
         Ok(())
     }
-}
 
-// Coordinator methods related to the construction of dataflow descriptions.
-impl<C> Coordinator<C>
-where
-    C: comm::Connection,
-{
-    /// Imports the view, source, or table with `id` into the provided
-    /// dataflow description.
-    fn import_into_dataflow(&self, id: &GlobalId, dataflow: &mut DataflowDesc) {
-        // Avoid importing the item redundantly.
-        if dataflow.is_imported(id) {
-            return;
-        }
-
-        // A valid index is any index on `id` that is known to the dataflow
-        // layer, as indicated by its presence in `self.indexes`.
-        let valid_index = self.catalog.indexes()[id]
-            .iter()
-            .find(|(id, _keys)| self.indexes.contains_key(*id));
-        if let Some((index_id, keys)) = valid_index {
-            let index_desc = IndexDesc {
-                on_id: *id,
-                keys: keys.to_vec(),
-            };
-            let desc = self
-                .catalog
-                .get_by_id(id)
-                .desc()
-                .expect("indexes can only be built on items with descs");
-            dataflow.add_index_import(*index_id, index_desc, desc.typ().clone(), *id);
-        } else {
-            match self.catalog.get_by_id(id).item() {
-                CatalogItem::Table(table) => {
-                    dataflow.add_source_import(*id, SourceConnector::Local, table.desc.clone());
-                }
-                CatalogItem::Source(source) => {
-                    // If Materialize has caching enabled, check to see if the source has any
-                    // already cached data that can be reused, and if so, augment the source
-                    // connector to use that data before importing it into the dataflow.
-                    let connector = if let Some(path) =
-                        self.catalog.config().cache_directory.as_deref()
-                    {
-                        match crate::cache::augment_connector(
-                            source.connector.clone(),
-                            &path,
-                            self.catalog.config().cluster_id,
-                            *id,
-                        ) {
-                            Ok(Some(connector)) => Some(connector),
-                            Ok(None) => None,
-                            Err(e) => {
-                                log::error!("encountered error while trying to reuse cached data for source {}: {}", id.to_string(), e);
-                                log::trace!(
-                                    "continuing without cached data for source {}",
-                                    id.to_string()
-                                );
-                                None
-                            }
-                        }
-                    } else {
-                        None
-                    };
-
-                    // Default back to the regular connector if we didn't get a augmented one.
-                    let connector = connector.unwrap_or_else(|| source.connector.clone());
-
-                    dataflow.add_source_import(*id, connector, source.desc.clone());
-                }
-                CatalogItem::View(view) => {
-                    self.import_view_into_dataflow(id, &view.optimized_expr, dataflow);
-                }
-                _ => unreachable!(),
-            }
-        }
-    }
-
-    /// Imports the view with the specified ID and expression into the provided
-    /// dataflow description.
-    fn import_view_into_dataflow(
-        &self,
-        view_id: &GlobalId,
-        view: &OptimizedRelationExpr,
-        dataflow: &mut DataflowDesc,
-    ) {
-        // TODO: We only need to import Get arguments for which we cannot find arrangements.
-        for get_id in view.as_ref().global_uses() {
-            self.import_into_dataflow(&get_id, dataflow);
-        }
-        // Collect sources, views, and indexes used.
-        view.as_ref().visit(&mut |e| {
-            if let RelationExpr::ArrangeBy { input, keys } = e {
-                if let RelationExpr::Get {
-                    id: Id::Global(on_id),
-                    typ,
-                } = &**input
-                {
-                    for key_set in keys {
-                        let index_desc = IndexDesc {
-                            on_id: *on_id,
-                            keys: key_set.to_vec(),
-                        };
-                        // If the arrangement exists, import it. It may not exist, in which
-                        // case we should import the source to be sure that we have access
-                        // to the collection to arrange it ourselves.
-                        let indexes = &self.catalog.indexes()[on_id];
-                        if let Some((id, _)) = indexes.iter().find(|(_id, keys)| keys == key_set) {
-                            dataflow.add_index_import(*id, index_desc, typ.clone(), *view_id);
-                        }
-                    }
-                }
-            }
-        });
-        dataflow.add_view_to_build(*view_id, view.clone(), view.as_ref().typ());
-    }
-
-    /// Builds a dataflow description for the index with the specified ID.
-    fn build_index_dataflow(&self, id: GlobalId) -> DataflowDesc {
-        let index_entry = self.catalog.get_by_id(&id);
-        let index = match index_entry.item() {
-            CatalogItem::Index(index) => index,
-            _ => unreachable!("cannot create index dataflow on non-index"),
-        };
-        let on_entry = self.catalog.get_by_id(&index.on);
-        let on_type = on_entry.desc().unwrap().typ().clone();
-        let mut dataflow = DataflowDesc::new(index_entry.name().to_string());
-        self.import_into_dataflow(&index.on, &mut dataflow);
-        dataflow.add_index_to_build(id, index.on.clone(), on_type.clone(), index.keys.clone());
-        dataflow.add_index_export(id, index.on, on_type, index.keys.clone());
-        dataflow
-    }
-
-    /// Builds a dataflow description for the sink with the specified name,
-    /// ID, source, and output connector.
-    fn build_sink_dataflow(
-        &self,
-        name: String,
-        id: GlobalId,
-        from: GlobalId,
-        connector: SinkConnector,
-    ) -> DataflowDesc {
-        let mut dataflow = DataflowDesc::new(name);
-        dataflow.set_as_of(connector.get_frontier());
-        self.import_into_dataflow(&from, &mut dataflow);
-        let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
-        dataflow.add_sink_export(id, from, from_type, connector);
-        dataflow
-    }
-}
-
-impl<C> Coordinator<C>
-where
-    C: comm::Connection,
-{
     /// Finalizes a dataflow and then broadcasts it to all workers.
     ///
     /// Finalization includes optimization, but also validation of various

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -1,3 +1,12 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
 //! Types and methods for building dataflow descriptions.
 //!
 //! Dataflows are buildable from the coordinator's `catalog` and `indexes`

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -1,0 +1,171 @@
+//! Types and methods for building dataflow descriptions.
+//!
+//! Dataflows are buildable from the coordinator's `catalog` and `indexes`
+//! members, which respectively describe the collection backing identifiers
+//! and indicate which identifiers have arrangements available. This module
+//! isolates that logic from the rest of the somewhat complicated coordinator.
+
+use super::*;
+
+/// Borrows of catalog and indexes sufficient to build dataflow descriptions.
+pub struct DataflowBuilder<'a> {
+    catalog: &'a Catalog,
+    indexes: &'a ArrangementFrontiers<Timestamp>,
+}
+
+impl<C> Coordinator<C>
+where
+    C: comm::Connection,
+{
+    /// Creates a new dataflow builder from the catalog and indexes in `self`.
+    pub fn dataflow_builder(&self) -> DataflowBuilder {
+        DataflowBuilder {
+            catalog: &self.catalog,
+            indexes: &self.indexes,
+        }
+    }
+}
+
+impl<'a> DataflowBuilder<'a> {
+    /// Imports the view, source, or table with `id` into the provided
+    /// dataflow description.
+    fn import_into_dataflow(&self, id: &GlobalId, dataflow: &mut DataflowDesc) {
+        // Avoid importing the item redundantly.
+        if dataflow.is_imported(id) {
+            return;
+        }
+
+        // A valid index is any index on `id` that is known to the dataflow
+        // layer, as indicated by its presence in `self.indexes`.
+        let valid_index = self.catalog.indexes()[id]
+            .iter()
+            .find(|(id, _keys)| self.indexes.contains_key(*id));
+        if let Some((index_id, keys)) = valid_index {
+            let index_desc = IndexDesc {
+                on_id: *id,
+                keys: keys.to_vec(),
+            };
+            let desc = self
+                .catalog
+                .get_by_id(id)
+                .desc()
+                .expect("indexes can only be built on items with descs");
+            dataflow.add_index_import(*index_id, index_desc, desc.typ().clone(), *id);
+        } else {
+            match self.catalog.get_by_id(id).item() {
+                CatalogItem::Table(table) => {
+                    dataflow.add_source_import(*id, SourceConnector::Local, table.desc.clone());
+                }
+                CatalogItem::Source(source) => {
+                    // If Materialize has caching enabled, check to see if the source has any
+                    // already cached data that can be reused, and if so, augment the source
+                    // connector to use that data before importing it into the dataflow.
+                    let connector = if let Some(path) =
+                        self.catalog.config().cache_directory.as_deref()
+                    {
+                        match crate::cache::augment_connector(
+                            source.connector.clone(),
+                            &path,
+                            self.catalog.config().cluster_id,
+                            *id,
+                        ) {
+                            Ok(Some(connector)) => Some(connector),
+                            Ok(None) => None,
+                            Err(e) => {
+                                log::error!("encountered error while trying to reuse cached data for source {}: {}", id.to_string(), e);
+                                log::trace!(
+                                    "continuing without cached data for source {}",
+                                    id.to_string()
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    // Default back to the regular connector if we didn't get a augmented one.
+                    let connector = connector.unwrap_or_else(|| source.connector.clone());
+
+                    dataflow.add_source_import(*id, connector, source.desc.clone());
+                }
+                CatalogItem::View(view) => {
+                    self.import_view_into_dataflow(id, &view.optimized_expr, dataflow);
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    /// Imports the view with the specified ID and expression into the provided
+    /// dataflow description.
+    pub fn import_view_into_dataflow(
+        &self,
+        view_id: &GlobalId,
+        view: &OptimizedRelationExpr,
+        dataflow: &mut DataflowDesc,
+    ) {
+        // TODO: We only need to import Get arguments for which we cannot find arrangements.
+        for get_id in view.as_ref().global_uses() {
+            self.import_into_dataflow(&get_id, dataflow);
+        }
+        // Collect sources, views, and indexes used.
+        view.as_ref().visit(&mut |e| {
+            if let RelationExpr::ArrangeBy { input, keys } = e {
+                if let RelationExpr::Get {
+                    id: Id::Global(on_id),
+                    typ,
+                } = &**input
+                {
+                    for key_set in keys {
+                        let index_desc = IndexDesc {
+                            on_id: *on_id,
+                            keys: key_set.to_vec(),
+                        };
+                        // If the arrangement exists, import it. It may not exist, in which
+                        // case we should import the source to be sure that we have access
+                        // to the collection to arrange it ourselves.
+                        let indexes = &self.catalog.indexes()[on_id];
+                        if let Some((id, _)) = indexes.iter().find(|(_id, keys)| keys == key_set) {
+                            dataflow.add_index_import(*id, index_desc, typ.clone(), *view_id);
+                        }
+                    }
+                }
+            }
+        });
+        dataflow.add_view_to_build(*view_id, view.clone(), view.as_ref().typ());
+    }
+
+    /// Builds a dataflow description for the index with the specified ID.
+    pub fn build_index_dataflow(&self, id: GlobalId) -> DataflowDesc {
+        let index_entry = self.catalog.get_by_id(&id);
+        let index = match index_entry.item() {
+            CatalogItem::Index(index) => index,
+            _ => unreachable!("cannot create index dataflow on non-index"),
+        };
+        let on_entry = self.catalog.get_by_id(&index.on);
+        let on_type = on_entry.desc().unwrap().typ().clone();
+        let mut dataflow = DataflowDesc::new(index_entry.name().to_string());
+        self.import_into_dataflow(&index.on, &mut dataflow);
+        dataflow.add_index_to_build(id, index.on.clone(), on_type.clone(), index.keys.clone());
+        dataflow.add_index_export(id, index.on, on_type, index.keys.clone());
+        dataflow
+    }
+
+    /// Builds a dataflow description for the sink with the specified name,
+    /// ID, source, and output connector.
+    pub fn build_sink_dataflow(
+        &self,
+        name: String,
+        id: GlobalId,
+        from: GlobalId,
+        connector: SinkConnector,
+    ) -> DataflowDesc {
+        let mut dataflow = DataflowDesc::new(name);
+        dataflow.set_as_of(connector.get_frontier());
+        self.import_into_dataflow(&from, &mut dataflow);
+        let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
+        dataflow.add_sink_export(id, from, from_type, connector);
+        dataflow
+    }
+}


### PR DESCRIPTION
This PR isolates coordinator methods related to dataflow description construction and moves them to `coord/dataflow_builder.rs`. There, it introduces a new type `DataflowBuilder` who holds borrows of `catalog` and `indexes`, the only members of the coordinator required for dataflow description construction. Each of the coordinator methods are now methods on this type, and a helpful method is added to `Coordinator` to create a `DataflowBuilder` with minimal fuss.

More could be moved to this module. This was meant to be minimally behavior modifying.

A prior commit is also included that moves dependency tracking to `DataflowDesc` to reduce the potential for erroneous use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5017)
<!-- Reviewable:end -->
