### PR TITLE
sqllogictest: add FETCH timeout to sql tests

### DIFF
--- a/test/sqllogictest/cursor.slt
+++ b/test/sqllogictest/cursor.slt
@@ -47,23 +47,23 @@ statement ok
 DECLARE c CURSOR FOR TAIL v
 
 query IITT
-FETCH c
+FETCH c WITH (TIMEOUT = '10s')
 ----
 0  1  a  b
 
 query IITT
-FETCH 2 c
+FETCH 2 c WITH (TIMEOUT = '10s')
 ----
 0  1  c  d
 0  1  e  f
 
 query IITT
-FETCH 2 c
+FETCH 2 c WITH (TIMEOUT = '1')
 ----
 0  1  g  h
 
 query IITT
-FETCH c
+FETCH c WITH (TIMEOUT = '1')
 ----
 
 # Test some FETCH timeout errors. The actual timeout functionality is


### PR DESCRIPTION
Needed because it now defaults to 0s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5018)
<!-- Reviewable:end -->
