### PR TITLE
[WIP, but review now appreciated] Refactor sinks to make them "dumber"; enable upsert sinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
+ "timely",
  "url",
  "uuid",
 ]

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -14,6 +14,7 @@ use std::time::SystemTime;
 
 use anyhow::bail;
 use chrono::{DateTime, TimeZone, Utc};
+use dataflow_types::SinkEnvelope;
 use lazy_static::lazy_static;
 use log::{info, trace};
 use ore::collections::CollectionExt;
@@ -156,6 +157,7 @@ pub struct Sink {
     pub plan_cx: PlanContext,
     pub from: GlobalId,
     pub connector: SinkConnectorState,
+    pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
     pub as_of: Option<u64>,
 }
@@ -1485,6 +1487,7 @@ impl Catalog {
                 plan_cx: pcx,
                 from: sink.from,
                 connector: SinkConnectorState::Pending(sink.connector_builder),
+                envelope: sink.envelope,
                 with_snapshot,
                 as_of,
             }),

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -26,6 +26,7 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime};
 
 use anyhow::{bail, Context};
+use dataflow_types::SinkEnvelope;
 use differential_dataflow::lattice::Lattice;
 use futures::future::{self, TryFutureExt};
 use futures::sink::SinkExt;
@@ -893,6 +894,7 @@ where
             id,
             sink.from,
             connector,
+            sink.envelope,
         ))
         .await
     }
@@ -1398,6 +1400,7 @@ where
                 copy_to,
                 emit_progress,
                 object_columns,
+                desc,
             } => tx.send(
                 self.sequence_tail(
                     session.conn_id(),
@@ -1407,6 +1410,7 @@ where
                     copy_to,
                     emit_progress,
                     object_columns,
+                    desc,
                 )
                 .await,
                 session,
@@ -1669,6 +1673,7 @@ where
                 plan_cx: pcx,
                 from: sink.from,
                 connector: catalog::SinkConnectorState::Pending(sink.connector_builder.clone()),
+                envelope: sink.envelope,
                 with_snapshot,
                 as_of,
             }),
@@ -2079,6 +2084,7 @@ where
         copy_to: Option<CopyFormat>,
         emit_progress: bool,
         object_columns: usize,
+        desc: RelationDesc,
     ) -> Result<ExecuteResponse, anyhow::Error> {
         // Determine the frontier of updates to tail *from*.
         // Updates greater or equal to this frontier will be produced.
@@ -2103,7 +2109,9 @@ where
                 strict: !with_snapshot,
                 emit_progress,
                 object_columns,
+                value_desc: desc,
             }),
+            SinkEnvelope::Tail { emit_progress },
         ))
         .await;
 

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -169,12 +169,13 @@ impl<'a> DataflowBuilder<'a> {
         id: GlobalId,
         from: GlobalId,
         connector: SinkConnector,
+        envelope: SinkEnvelope,
     ) -> DataflowDesc {
         let mut dataflow = DataflowDesc::new(name);
         dataflow.set_as_of(connector.get_frontier());
         self.import_into_dataflow(&from, &mut dataflow);
         let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
-        dataflow.add_sink_export(id, from, from_type, connector);
+        dataflow.add_sink_export(id, from, from_type, connector, envelope);
         dataflow
     }
 }

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -144,12 +144,13 @@ async fn build_kafka(
         value_schema_id,
         topic,
         addrs: builder.broker_addrs,
+        key_desc_and_indices: builder.key_desc_and_indices,
+        value_desc: builder.value_desc,
         consistency,
         fuel: builder.fuel,
         frontier,
         strict: !with_snapshot,
         config_options: builder.config_options,
-        key_indices: builder.key_indices,
     }))
 }
 
@@ -193,5 +194,6 @@ fn build_avro_ocf(
         path,
         frontier,
         strict: !with_snapshot,
+        value_desc: builder.value_desc,
     }))
 }

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -37,8 +37,8 @@ use rusoto_kinesis::KinesisClient;
 use dataflow::source::read_file_task;
 use dataflow::source::FileReadStyle;
 use dataflow_types::{
-    AvroOcfEncoding, Consistency, DataEncoding, Envelope, ExternalSourceConnector,
-    FileSourceConnector, KafkaSourceConnector, KinesisSourceConnector, MzOffset, SourceConnector,
+    AvroOcfEncoding, Consistency, DataEncoding, ExternalSourceConnector, FileSourceConnector,
+    KafkaSourceConnector, KinesisSourceConnector, MzOffset, SourceConnector, SourceEnvelope,
     TimestampSourceUpdate,
 };
 use expr::{PartitionId, SourceInstanceId};
@@ -701,8 +701,8 @@ fn is_ts_valid(
 /// 5) any source that uses the Avro format currently expects a consistency source that is formatted
 /// using the BYO_CONSISTENCY_SCHEMA Avro spec outlined above.
 ///
-fn identify_consistency_format(enc: DataEncoding, env: Envelope) -> ConsistencyFormatting {
-    if let Envelope::Debezium(_) = env {
+fn identify_consistency_format(enc: DataEncoding, env: SourceEnvelope) -> ConsistencyFormatting {
+    if let SourceEnvelope::Debezium(_) = env {
         if let DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema: _ }) = enc {
             ConsistencyFormatting::DebeziumOcf
         } else {
@@ -1218,7 +1218,7 @@ impl Timestamper {
         id: SourceInstanceId,
         sc: ExternalSourceConnector,
         enc: DataEncoding,
-        env: Envelope,
+        env: SourceEnvelope,
         timestamp_topic: String,
     ) -> Option<ByoTimestampConsumer> {
         match sc {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -186,12 +186,19 @@ impl DataflowDesc {
         from_id: GlobalId,
         from_desc: RelationDesc,
         connector: SinkConnector,
+        envelope: SinkEnvelope,
     ) {
+        let key_desc = connector.get_key_desc().cloned();
+        let value_desc = connector.get_value_desc().clone();
         self.sink_exports.push((
             id,
             SinkDesc {
-                from: (from_id, from_desc),
+                from: from_id,
+                from_desc,
+                key_desc,
+                value_desc,
                 connector,
+                envelope,
             },
         ));
     }
@@ -236,7 +243,7 @@ impl DataflowDesc {
             result.extend(self.get_imports(&desc.on_id))
         }
         for (_, sink) in &self.sink_exports {
-            result.extend(self.get_imports(&sink.from.0))
+            result.extend(self.get_imports(&sink.from))
         }
         result
     }
@@ -296,11 +303,11 @@ pub enum DataEncoding {
 impl DataEncoding {
     /// Computes the [`RelationDesc`] for the relation specified by the this
     /// data encoding and envelope.s
-    pub fn desc(&self, envelope: &Envelope) -> Result<RelationDesc, anyhow::Error> {
+    pub fn desc(&self, envelope: &SourceEnvelope) -> Result<RelationDesc, anyhow::Error> {
         // Add columns for the key, if using the upsert envelope.
         let key_desc = match envelope {
-            Envelope::Upsert(key_encoding) => {
-                let key_desc = key_encoding.desc(&Envelope::None)?;
+            SourceEnvelope::Upsert(key_encoding) => {
+                let key_desc = key_encoding.desc(&SourceEnvelope::None)?;
 
                 // It doesn't make sense for the key to have keys.
                 assert!(key_desc.typ().keys.is_empty());
@@ -455,25 +462,36 @@ impl SourceDesc {
 /// A sink for updates to a relational collection.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SinkDesc {
-    pub from: (GlobalId, RelationDesc),
+    pub from: GlobalId,
+    pub from_desc: RelationDesc,
+    pub value_desc: RelationDesc,
+    pub key_desc: Option<RelationDesc>,
     pub connector: SinkConnector,
+    pub envelope: SinkEnvelope,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SinkEnvelope {
+    Debezium,
+    Upsert,
+    Tail { emit_progress: bool },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Envelope {
+pub enum SourceEnvelope {
     None,
     Debezium(DebeziumDeduplicationStrategy),
     Upsert(DataEncoding),
     CdcV2,
 }
 
-impl Envelope {
+impl SourceEnvelope {
     pub fn get_avro_envelope_type(&self) -> avro::EnvelopeType {
         match self {
-            Envelope::None => avro::EnvelopeType::None,
-            Envelope::Debezium { .. } => avro::EnvelopeType::Debezium,
-            Envelope::Upsert(_) => avro::EnvelopeType::Upsert,
-            Envelope::CdcV2 => avro::EnvelopeType::CdcV2,
+            SourceEnvelope::None => avro::EnvelopeType::None,
+            SourceEnvelope::Debezium { .. } => avro::EnvelopeType::Debezium,
+            SourceEnvelope::Upsert(_) => avro::EnvelopeType::Upsert,
+            SourceEnvelope::CdcV2 => avro::EnvelopeType::CdcV2,
         }
     }
 }
@@ -483,7 +501,7 @@ pub enum SourceConnector {
     External {
         connector: ExternalSourceConnector,
         encoding: DataEncoding,
-        envelope: Envelope,
+        envelope: SourceEnvelope,
         consistency: Consistency,
         ts_frequency: Duration,
     },
@@ -643,6 +661,8 @@ pub struct KafkaSinkConsistencyConnector {
 pub struct KafkaSinkConnector {
     pub addrs: KafkaAddrs,
     pub topic: String,
+    pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
+    pub value_desc: RelationDesc,
     pub key_schema_id: Option<i32>,
     pub value_schema_id: i32,
     pub consistency: Option<KafkaSinkConsistencyConnector>,
@@ -652,11 +672,11 @@ pub struct KafkaSinkConnector {
     pub frontier: Antichain<Timestamp>,
     pub strict: bool,
     pub config_options: HashMap<String, String>,
-    pub key_indices: Option<Vec<usize>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AvroOcfSinkConnector {
+    pub value_desc: RelationDesc,
     pub path: PathBuf,
     pub frontier: Antichain<Timestamp>,
     pub strict: bool,
@@ -670,6 +690,33 @@ impl SinkConnector {
             SinkConnector::Tail(tail) => tail.frontier.clone(),
         }
     }
+
+    pub fn get_key_desc(&self) -> Option<&RelationDesc> {
+        match self {
+            SinkConnector::Kafka(k) => k.key_desc_and_indices.as_ref().map(|(desc, _indices)| desc),
+            SinkConnector::Tail(_) => None,
+            SinkConnector::AvroOcf(_) => None,
+        }
+    }
+
+    pub fn get_key_indices(&self) -> Option<&[usize]> {
+        match self {
+            SinkConnector::Kafka(k) => k
+                .key_desc_and_indices
+                .as_ref()
+                .map(|(_desc, indices)| indices.as_slice()),
+            SinkConnector::Tail(_) => None,
+            SinkConnector::AvroOcf(_) => None,
+        }
+    }
+
+    pub fn get_value_desc(&self) -> &RelationDesc {
+        match self {
+            SinkConnector::Kafka(k) => &k.value_desc,
+            SinkConnector::Tail(t) => &t.value_desc,
+            SinkConnector::AvroOcf(a) => &a.value_desc,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -679,6 +726,7 @@ pub struct TailSinkConnector {
     pub strict: bool,
     pub emit_progress: bool,
     pub object_columns: usize,
+    pub value_desc: RelationDesc,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -691,13 +739,17 @@ pub enum SinkConnectorBuilder {
 pub struct AvroOcfSinkConnectorBuilder {
     pub path: PathBuf,
     pub file_name_suffix: String,
+    pub value_desc: RelationDesc,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSinkConnectorBuilder {
     pub broker_addrs: KafkaAddrs,
     pub schema_registry_url: Url,
+    pub key_schema: Option<String>,
     pub value_schema: String,
+    pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
+    pub value_desc: RelationDesc,
     pub topic_prefix: String,
     pub topic_suffix: String,
     pub replication_factor: u32,
@@ -705,8 +757,6 @@ pub struct KafkaSinkConnectorBuilder {
     pub consistency_value_schema: Option<String>,
     pub config_options: HashMap<String, String>,
     pub ccsr_config: ccsr::ClientConfig,
-    pub key_indices: Option<Vec<usize>>,
-    pub key_schema: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -27,7 +27,7 @@ use timely::{
 
 use ::mz_avro::{types::Value, Schema};
 use dataflow_types::LinearOperator;
-use dataflow_types::{DataEncoding, Envelope, RegexEncoding};
+use dataflow_types::{DataEncoding, RegexEncoding, SourceEnvelope};
 use interchange::avro::{extract_row, ConfluentAvroResolver, DebeziumDecodeState, DiffPair};
 use log::error;
 use repr::Datum;
@@ -45,7 +45,7 @@ mod regex;
 
 pub fn decode_avro_values<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Value>>,
-    envelope: &Envelope,
+    envelope: &SourceEnvelope,
     schema: Schema,
     debug_name: &str,
 ) -> Stream<G, (Row, Timestamp, Diff)>
@@ -57,7 +57,7 @@ where
     // so that we can spread the decoding among all the workers.
     // See #2133
     let envelope = envelope.clone();
-    let mut dbz_state = if let Envelope::Debezium(dedup_strat) = envelope {
+    let mut dbz_state = if let SourceEnvelope::Debezium(dedup_strat) = envelope {
         DebeziumDecodeState::new(
             &schema,
             debug_name.to_string(),
@@ -80,13 +80,13 @@ where
         )| {
             let top_node = schema.top_node();
             let diffs = match envelope {
-                Envelope::None => {
+                SourceEnvelope::None => {
                     extract_row(value, index.map(Datum::from), top_node).map(|r| DiffPair {
                         before: None,
                         after: r,
                     })
                 }
-                Envelope::Debezium(_) => {
+                SourceEnvelope::Debezium(_) => {
                     if let Some(dbz_state) = dbz_state.as_mut() {
                         dbz_state.extract(value, top_node, index, upstream_time_millis)
                     } else {
@@ -95,8 +95,8 @@ where
                         ))
                     }
                 }
-                Envelope::Upsert(_) => unreachable!("Upsert is not supported for AvroOCF"),
-                Envelope::CdcV2 => unreachable!("CDC envelope is not supported for AvroOCF"),
+                SourceEnvelope::Upsert(_) => unreachable!("Upsert is not supported for AvroOCF"),
+                SourceEnvelope::CdcV2 => unreachable!("CDC envelope is not supported for AvroOCF"),
             }
             .unwrap_or_else(|e| {
                 // TODO(#489): Handle this in a better way,
@@ -481,7 +481,7 @@ pub fn decode_values<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     encoding: DataEncoding,
     debug_name: &str,
-    envelope: &Envelope,
+    envelope: &SourceEnvelope,
     // Information about optional transformations that can be eagerly done.
     // If the decoding elects to perform them, it should replace this with
     // `None`.
@@ -498,24 +498,24 @@ where
         .ok()
         .and_then(|desc| desc.typ().keys.get(0).cloned());
     match (encoding, envelope) {
-        (_, Envelope::Upsert(_)) => {
+        (_, SourceEnvelope::Upsert(_)) => {
             unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")
         }
-        (DataEncoding::Csv(enc), Envelope::None) => (
+        (DataEncoding::Csv(enc), SourceEnvelope::None) => (
             csv(stream, enc.header_row, enc.n_cols, enc.delimiter, operators),
             None,
         ),
-        (DataEncoding::Avro(enc), Envelope::CdcV2) => {
+        (DataEncoding::Avro(enc), SourceEnvelope::CdcV2) => {
             decode_cdcv2(stream, &enc.value_schema, enc.schema_registry_config)
         }
-        (_, Envelope::CdcV2) => {
+        (_, SourceEnvelope::CdcV2) => {
             unreachable!("Internal error: CDCv2 is not supported yet on non-Avro sources.")
         }
-        (DataEncoding::Avro(enc), Envelope::Debezium(_)) => {
+        (DataEncoding::Avro(enc), SourceEnvelope::Debezium(_)) => {
             // can't get this from the above match arm because:
             // `error[E0658]: binding by-move and by-ref in the same pattern is unstable`
             let dedup_strat = match envelope {
-                Envelope::Debezium(ds) => *ds,
+                SourceEnvelope::Debezium(ds) => *ds,
                 _ => unreachable!(),
             };
 
@@ -561,13 +561,13 @@ where
         (DataEncoding::AvroOcf { .. }, _) => {
             unreachable!("Internal error: Cannot decode Avro OCF separately from reading")
         }
-        (_, Envelope::Debezium(_)) => unreachable!(
+        (_, SourceEnvelope::Debezium(_)) => unreachable!(
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
-        (DataEncoding::Regex(RegexEncoding { regex }), Envelope::None) => {
+        (DataEncoding::Regex(RegexEncoding { regex }), SourceEnvelope::None) => {
             (regex_fn(stream, regex, debug_name), None)
         }
-        (DataEncoding::Protobuf(enc), Envelope::None) => (
+        (DataEncoding::Protobuf(enc), SourceEnvelope::None) => (
             decode_values_inner(
                 stream,
                 protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
@@ -576,7 +576,7 @@ where
             ),
             None,
         ),
-        (DataEncoding::Bytes, Envelope::None) => (
+        (DataEncoding::Bytes, SourceEnvelope::None) => (
             decode_values_inner(
                 stream,
                 OffsetDecoderState::from(bytes_to_datum),
@@ -585,7 +585,7 @@ where
             ),
             None,
         ),
-        (DataEncoding::Text, Envelope::None) => (
+        (DataEncoding::Text, SourceEnvelope::None) => (
             decode_values_inner(
                 stream,
                 OffsetDecoderState::from(text_to_datum),

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -98,20 +98,22 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
-use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::rc::Rc;
 use std::rc::Weak;
+use std::{any::Any, cell::RefCell};
 
-use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::{Arrange, ArrangeByKey};
 use differential_dataflow::operators::arrange::upsert::arrange_from_upsert;
-use differential_dataflow::operators::consolidate::Consolidate;
+
+use differential_dataflow::hashable::Hashable;
 use differential_dataflow::{AsCollection, Collection};
 use futures::executor::block_on;
 
+use interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
+use repr::adt::decimal::Significand;
 use timely::dataflow::operators::to_stream::ToStream;
 use timely::dataflow::operators::unordered_input::UnorderedInput;
 use timely::dataflow::operators::Map;
@@ -119,6 +121,7 @@ use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 
 use timely::communication::Allocate;
+use timely::dataflow::operators::exchange::Exchange;
 use timely::worker::Worker as TimelyWorker;
 
 use dataflow_types::*;
@@ -128,7 +131,7 @@ use mz_avro::Schema;
 use ore::cast::CastFrom;
 use ore::collections::CollectionExt as _;
 use ore::iter::IteratorExt;
-use repr::{Datum, RelationType, Row, RowArena, Timestamp};
+use repr::{Datum, RelationType, Row, RowArena, RowPacker, Timestamp};
 
 use crate::decode::{decode_avro_values, decode_values};
 use crate::operator::{CollectionExt, StreamExt};
@@ -227,7 +230,7 @@ pub fn build_dataflow<A: Allocate>(
 
             // Export declared sinks.
             for (sink_id, sink) in &dataflow.sink_exports {
-                let imports = dataflow.get_imports(&sink.from.0);
+                let imports = dataflow.get_imports(&sink.from);
                 context.export_sink(render_state, imports, *sink_id, sink);
             }
         });
@@ -328,7 +331,7 @@ where
                     caching_tx,
                 };
 
-                let capability = if let Envelope::Upsert(key_encoding) = envelope {
+                let capability = if let SourceEnvelope::Upsert(key_encoding) = envelope {
                     match connector {
                         ExternalSourceConnector::Kafka(_) => {
                             let (source, capability) = source::create_source::<_, KafkaSourceInfo, _>(
@@ -450,8 +453,8 @@ where
                     };
 
                     let mut collection = match envelope {
-                        Envelope::None | Envelope::CdcV2 => stream.as_collection(),
-                        Envelope::Debezium(_) =>
+                        SourceEnvelope::None | SourceEnvelope::CdcV2 => stream.as_collection(),
+                        SourceEnvelope::Debezium(_) =>
                         // TODO(btv) -- this should just be a RelationExpr::Explode (name TBD)
                         {
                             stream.as_collection().explode({
@@ -463,7 +466,7 @@ where
                                 }
                             })
                         }
-                        Envelope::Upsert(_) => unreachable!(),
+                        SourceEnvelope::Upsert(_) => unreachable!(),
                     };
 
                     // Implement source filtering and projection.
@@ -683,38 +686,135 @@ where
         }
         let (collection, _err_collection) = self
             .collection(&RelationExpr::global_get(
-                sink.from.0,
-                sink.from.1.typ().clone(),
+                sink.from,
+                sink.from_desc.typ().clone(),
             ))
             .expect("Sink source collection not loaded");
+
+        // Some connectors support keys - extract them.
+        let key_indices = sink
+            .connector
+            .get_key_indices()
+            .map(|key_indices| key_indices.to_vec());
+        let keyed = collection.map(move |row| {
+            let key = key_indices.as_ref().map(|key_indices| {
+                // TODO[perf] (btv) - is there a way to avoid unpacking and repacking every row and cloning the datums?
+                // Does it matter?
+                let datums = row.unpack();
+                Row::pack(key_indices.iter().map(|&idx| datums[idx].clone()))
+            });
+            (key, row)
+        });
+
+        // Each partition needs to be handled by its own worker, so that we can write messages in order.
+        // For now, we only support single-partition sinks.
+        let keyed = keyed
+            .inner
+            .exchange(move |_| sink_id.hashed())
+            .as_collection();
+
+        // Apply the envelope.
+        // * "Debezium" consolidates the stream, sorts it by time, and produces DiffPairs from it.
+        //   It then renders those as Avro.
+        // * Upsert" does the same, except at the last step, it renders the diff pair in upsert format.
+        //   (As part of doing so, it asserts that there are not multiple conflicting values at the same timestamp)
+        // * "Tail" writes some metadata.
+        let collection = match sink.envelope {
+            SinkEnvelope::Debezium => {
+                let combined = combine_at_timestamp(keyed.arrange_by_key().stream);
+                let rp = Rc::new(RefCell::new(RowPacker::new()));
+                let collection = combined.flat_map(move |(mut k, v)| {
+                    let max_idx = v.len() - 1;
+                    let rp = rp.clone();
+                    v.into_iter().enumerate().map(move |(idx, dp)| {
+                        let k = if idx == max_idx { k.take() } else { k.clone() };
+                        (k, Some(dbz_format(&mut *rp.borrow_mut(), dp)))
+                    })
+                });
+                collection
+            }
+            SinkEnvelope::Upsert => {
+                let combined = combine_at_timestamp(keyed.arrange_by_key().stream);
+
+                let collection = combined.map(|(k, v)| {
+                    let v = upsert_format(v);
+                    (k, v)
+                });
+                collection
+            }
+            SinkEnvelope::Tail { emit_progress } => keyed
+                .inner
+                .map({
+                    let mut rp = RowPacker::new();
+                    move |((k, v), time, diff)| {
+                        rp.push(Datum::Decimal(Significand::new(i128::from(time))));
+                        if emit_progress {
+                            rp.push(Datum::False);
+                        }
+                        rp.push(Datum::Int64(i64::cast_from(diff)));
+                        rp.extend_by_row(&v);
+                        // Add the unpacked timestamp so we can sort by them later.
+                        let v = rp.finish_and_reuse();
+                        ((k, Some(v)), time, 1)
+                    }
+                })
+                .as_collection(),
+        };
+
+        // Some sinks require that the timestamp be appended to the end of the value.
+        let append_timestamp = match &sink.connector {
+            SinkConnector::Kafka(c) => c.consistency.is_some(),
+            SinkConnector::Tail(_) => false,
+            SinkConnector::AvroOcf(_) => false,
+        };
+        let collection = if append_timestamp {
+            collection
+                .inner
+                .map(|((k, v), t, diff)| {
+                    let v = v.map(|v| {
+                        let mut rp = RowPacker::new();
+                        rp.extend_by_row(&v);
+                        let t = t.to_string();
+                        rp.push_list_with(|rp| {
+                            rp.push(Datum::String(&t));
+                        });
+                        rp.finish()
+                    });
+                    ((k, v), t, diff)
+                })
+                .as_collection()
+        } else {
+            collection
+        };
 
         // TODO(benesch): errors should stream out through the sink,
         // if we figure out a protocol for that.
 
-        // TODO(frank): consolidation is only required for a collection,
-        // not for arrangements. We can perform a more complicated match
-        // here to determine which case we are in to avoid this call.
-        let collection = collection.consolidate();
-
         let sink_shutdown = match sink.connector.clone() {
             SinkConnector::Kafka(c) => {
-                let button = sink::kafka(&collection.inner, sink_id, c, sink.from.1.clone());
+                let button = sink::kafka(
+                    collection,
+                    sink_id,
+                    c,
+                    sink.key_desc.clone(),
+                    sink.value_desc.clone(),
+                );
                 Some(button)
             }
             SinkConnector::Tail(c) => {
-                // Map by sink_id is not needed for correctness, but will spread the work
-                // around when there are multiple TAILs running, and additionally will move a
-                // single TAIL's work to a single worker.
-                // Arranging will cause updates to be presented in time order.
-                let stream = collection
-                    .map(move |row| (sink_id, row))
+                let batches = collection
+                    .map(move |(k, v)| {
+                        assert!(k.is_none(), "tail does not support keys");
+                        let v = v.expect("tail must have values");
+                        (sink_id, v)
+                    })
                     .arrange_by_key()
                     .stream;
-                sink::tail(stream, sink_id, c);
+                sink::tail(batches, sink_id, c);
                 None
             }
             SinkConnector::AvroOcf(c) => {
-                sink::avro_ocf(&collection.inner, sink_id, c, sink.from.1.clone());
+                sink::avro_ocf(collection, sink_id, c, sink.value_desc.clone());
                 None
             }
         };

--- a/src/dataflow/src/sink/avro_ocf.rs
+++ b/src/dataflow/src/sink/avro_ocf.rs
@@ -10,86 +10,78 @@
 use std::fs::OpenOptions;
 
 use differential_dataflow::hashable::Hashable;
+use differential_dataflow::Collection;
+
 use log::error;
-use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::generic::Operator;
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::Scope;
 
 use dataflow_types::AvroOcfSinkConnector;
 use expr::GlobalId;
-use interchange::avro::{DiffPair, Encoder};
-use repr::{Diff, RelationDesc, Row, Timestamp};
+use interchange::avro::{encode_datums_as_avro, Encoder};
+use mz_avro::{self};
+use repr::{RelationDesc, Row, Timestamp};
 
 pub fn avro_ocf<G>(
-    stream: &Stream<G, (Row, Timestamp, Diff)>,
+    stream: Collection<G, (Option<Row>, Option<Row>)>,
     id: GlobalId,
     connector: AvroOcfSinkConnector,
     desc: RelationDesc,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    let encoder = Encoder::new(desc, false, None);
-    let schema = encoder.writer_schema();
-    let sink_hash = id.hashed();
+    let (schema, columns) = {
+        let encoder = Encoder::new(None, desc, false);
+        let schema = encoder.value_writer_schema().clone();
+        let columns = encoder.value_columns().to_vec();
+        (schema, columns)
+    };
+    let _sink_hash = id.hashed();
 
     let res = OpenOptions::new().append(true).open(&connector.path);
     let mut avro_writer = match res {
-        Ok(f) => Some(mz_avro::Writer::new(schema.clone(), f)),
+        Ok(f) => Some(mz_avro::Writer::new(schema, f)),
         Err(e) => {
             error!("creating avro ocf file writer for sink failed: {}", e);
             None
         }
     };
 
-    stream.sink(
-        Exchange::new(move |_| sink_hash),
-        &format!("avro-ocf-{}", id),
-        move |input| {
-            if avro_writer.is_none() {
-                return;
-            }
+    let mut vector = vec![];
 
-            let avro_writer = avro_writer.as_mut().expect("avro writer known to exist");
-
+    stream
+        .inner
+        .sink(Pipeline, &format!("avro-ocf-{}", id), move |input| {
+            let avro_writer = match avro_writer.as_mut() {
+                Some(avro_writer) => avro_writer,
+                None => return,
+            };
             input.for_each(|_, rows| {
-                for (row, time, diff) in rows.iter() {
-                    let should_emit = if connector.strict {
-                        connector.frontier.less_than(&time)
-                    } else {
-                        connector.frontier.less_equal(&time)
-                    };
-                    if !should_emit {
-                        continue;
-                    }
+                rows.swap(&mut vector);
 
-                    let diff_pair = if *diff < 0 {
-                        DiffPair {
-                            before: Some(row),
-                            after: None,
-                        }
-                    } else {
-                        DiffPair {
-                            before: None,
-                            after: Some(row),
-                        }
-                    };
-                    let (_key, value) = encoder.diff_pair_to_avro(diff_pair, None);
-                    for _ in 0..diff.abs() {
-                        let res = avro_writer.append(value.clone());
+                for ((k, v), _time, diff) in vector.drain(..) {
+                    assert!(k.is_none(), "Avro OCF sinks must not have keys");
+                    let v = v.expect("Avro OCF sinks must have values");
 
-                        match res {
-                            Ok(_) => (),
-                            Err(e) => error!("appending to avro ocf failed: {}", e),
-                        }
+                    let mut value = Some(encode_datums_as_avro(v.iter(), &columns));
+                    assert!(diff > 0, "can't sink negative multiplicities");
+                    for i in 0..diff {
+                        let value = if i == (diff - 1) {
+                            value.clone().unwrap()
+                        } else {
+                            value.take().unwrap()
+                        };
+                        if let Err(e) = avro_writer.append(value) {
+                            error!("appending to avro ocf failed: {}", e)
+                        };
                     }
                 }
-
                 let res = avro_writer.flush();
                 match res {
                     Ok(_) => (),
                     Err(e) => error!("flushing bytes to avro ocf failed: {}", e),
                 }
             })
-        },
-    )
+        })
 }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1.3"
 ccsr = { path = "../ccsr" }
 chrono = "0.4"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow.git" }
 futures = "0.3"
 hex = "0.4"
 lazy_static = "1.4.0"

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1198,7 +1198,7 @@ fn unwrap_record_fields(n: SchemaNode) -> &[RecordField] {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DiffPair<T> {
     pub before: Option<T>,
     pub after: Option<T>,
@@ -2137,50 +2137,9 @@ impl Decoder {
 ///   * Union schemas are only used to represent nullability. The first
 ///     variant is always the null variant, and the second and last variant
 ///     is the non-null variant.
-fn build_schema(columns: &[(ColumnName, ColumnType)], include_transaction: bool) -> Schema {
-    let row_schema = build_row_schema_json(columns, "row");
-    let mut schema_fields = Vec::new();
-    schema_fields.push(json!({
-        "name": "before",
-        "type": [
-            "null",
-            row_schema
-        ]
-    }));
-
-    schema_fields.push(json!({
-        "name": "after",
-        "type": ["null", "row"],
-    }));
-
-    // TODO(rkhaitan): this schema omits the total_order and data collection_order
-    // fields found in Debezium's transaction metadata struct. We chose to omit
-    // those because the order is not stable across reruns and has no semantic
-    // meaning for records within a timestamp in Materialize. These fields may
-    // be useful in the future for deduplication.
-    if include_transaction {
-        schema_fields.push(json!({
-        "name": "transaction",
-            "type":
-                {
-                    "name": "transaction_metadata",
-                    "type": "record",
-                    "fields": [
-                        {
-                            "name": "id",
-                            "type": "string",
-                        }
-                    ]
-                }
-        }));
-    }
-
-    let schema = json!({
-        "type": "record",
-        "name": "envelope",
-        "fields": schema_fields,
-    });
-    Schema::parse(&schema).expect("valid schema constructed")
+fn build_schema(columns: &[(ColumnName, ColumnType)]) -> Schema {
+    let row_schema = build_row_schema_json(&columns, "row");
+    Schema::parse(&row_schema).expect("valid schema constructed")
 }
 
 pub fn get_debezium_transaction_schema() -> &'static Schema {
@@ -2234,12 +2193,29 @@ fn encode_avro_header(buf: &mut Vec<u8>, schema_id: i32) {
         .expect("writing to vec cannot fail");
 }
 
+struct KeyInfo {
+    columns: Vec<(ColumnName, ColumnType)>,
+    schema: Schema,
+}
+
+fn encode_message_unchecked(
+    schema_id: i32,
+    row: Row,
+    schema: &Schema,
+    columns: &[(ColumnName, ColumnType)],
+) -> Vec<u8> {
+    let mut buf = vec![];
+    encode_avro_header(&mut buf, schema_id);
+    let value = encode_datums_as_avro(row.iter(), columns);
+    mz_avro::encode_unchecked(&value, schema, &mut buf);
+    buf
+}
+
 /// Manages encoding of Avro-encoded bytes.
 pub struct Encoder {
-    columns: Vec<(ColumnName, ColumnType)>,
+    value_columns: Vec<(ColumnName, ColumnType)>,
+    key_info: Option<KeyInfo>,
     writer_schema: Schema,
-    include_transaction: bool,
-    key_schema_and_indices: Option<(Schema, Vec<usize>)>,
 }
 
 impl fmt::Debug for Encoder {
@@ -2251,173 +2227,72 @@ impl fmt::Debug for Encoder {
 }
 
 impl Encoder {
-    fn key_indices(&self) -> Option<&[usize]> {
-        self.key_schema_and_indices
-            .as_ref()
-            .map(|(_, indices)| indices.as_slice())
-    }
     pub fn new(
-        desc: RelationDesc,
+        key_desc: Option<RelationDesc>,
+        value_desc: RelationDesc,
         include_transaction: bool,
-        key_indices: Option<Vec<usize>>,
     ) -> Self {
-        let columns = column_names_and_types(desc);
-        let writer_schema = build_schema(&columns, include_transaction);
-        let key_schema_and_indices = key_indices.map(|key_indices| {
-            let key_columns = key_indices
-                .iter()
-                .map(|&key_idx| columns[key_idx].clone())
-                .collect::<Vec<_>>();
-            let row_schema = build_row_schema_json(&key_columns, "row");
-            (
-                Schema::parse(&row_schema).expect("valid schema constructed"),
-                key_indices,
-            )
+        let mut value_columns = column_names_and_types(value_desc);
+        if include_transaction {
+            // TODO(rkhaitan): this schema omits the total_order and data collection_order
+            // fields found in Debezium's transaction metadata struct. We chose to omit
+            // those because the order is not stable across reruns and has no semantic
+            // meaning for records within a timestamp in Materialize. These fields may
+            // be useful in the future for deduplication.
+            value_columns.push((
+                "transaction".into(),
+                ColumnType {
+                    nullable: false,
+                    scalar_type: ScalarType::Record {
+                        fields: vec![("id".into(), ScalarType::String)],
+                    },
+                },
+            ));
+        }
+        let writer_schema = build_schema(&value_columns);
+        let key_info = key_desc.map(|key_desc| {
+            let columns = column_names_and_types(key_desc);
+            let row_schema = build_row_schema_json(&columns, "row");
+            KeyInfo {
+                schema: Schema::parse(&row_schema).expect("valid schema constructed"),
+                columns,
+            }
         });
         Encoder {
-            columns,
+            value_columns,
+            key_info,
             writer_schema,
-            include_transaction,
-            key_schema_and_indices,
         }
     }
 
-    pub fn writer_schema(&self) -> &Schema {
+    pub fn value_writer_schema(&self) -> &Schema {
         &self.writer_schema
     }
 
+    pub fn value_columns(&self) -> &[(ColumnName, ColumnType)] {
+        &self.value_columns
+    }
+
     pub fn key_writer_schema(&self) -> Option<&Schema> {
-        self.key_schema_and_indices
+        self.key_info.as_ref().map(|KeyInfo { schema, .. }| schema)
+    }
+
+    pub fn key_columns(&self) -> Option<&[(ColumnName, ColumnType)]> {
+        self.key_info
             .as_ref()
-            .map(|(schema, _)| schema)
+            .map(|KeyInfo { columns, .. }| columns.as_slice())
     }
 
-    fn validate_transaction_id(&self, transaction_id: &Option<String>) {
-        // We need to preserve the invariant that transaction id is always Some(..)
-        // when users requested that we emit transaction information, and never
-        // otherwise.
-        assert_eq!(
-            self.include_transaction,
-            transaction_id.is_some(),
-            "Testing to make sure transaction IDs are always present only when required"
-        );
+    pub fn encode_key_unchecked(&self, schema_id: i32, row: Row) -> Vec<u8> {
+        let schema = self.key_writer_schema().unwrap();
+        let columns = self.key_columns().unwrap();
+        encode_message_unchecked(schema_id, row, schema, columns)
     }
 
-    pub fn encode_unchecked(
-        &self,
-        key_schema_id: Option<i32>,
-        value_schema_id: i32,
-        diff_pair: DiffPair<&Row>,
-        transaction_id: Option<String>,
-    ) -> (Option<Vec<u8>>, Vec<u8>) {
-        self.validate_transaction_id(&transaction_id);
-        let mut key_buf = vec![];
-        let mut buf = vec![];
-        encode_avro_header(&mut buf, value_schema_id);
-        let (avro_key, avro_value) = self.diff_pair_to_avro(diff_pair, transaction_id);
-        debug_assert!(avro_value.validate(self.writer_schema.top_node()));
-        mz_avro::encode_unchecked(&avro_value, &self.writer_schema, &mut buf);
-        let key_buf = avro_key.map(|avro_key| {
-            encode_avro_header(&mut key_buf, key_schema_id.unwrap());
-            let key_schema = self.key_writer_schema().unwrap();
-            debug_assert!(
-                avro_key.validate(key_schema.top_node()),
-                "{:#?}\n{}",
-                avro_key,
-                key_schema.canonical_form()
-            );
-            mz_avro::encode_unchecked(&avro_key, key_schema, &mut key_buf);
-            key_buf
-        });
-        (key_buf, buf)
-    }
-
-    pub fn diff_pair_to_avro(
-        &self,
-        diff_pair: DiffPair<&Row>,
-        transaction_id: Option<String>,
-    ) -> (Option<Value>, Value) {
-        let (before_key, before) = match diff_pair.before {
-            None => (
-                None,
-                Value::Union {
-                    index: 0,
-                    inner: Box::new(Value::Null),
-                    n_variants: 2,
-                    null_variant: Some(0),
-                },
-            ),
-            Some(row) => {
-                let (key, row) = self.row_to_avro(row.iter());
-                (
-                    key,
-                    Value::Union {
-                        index: 1,
-                        inner: Box::new(row),
-                        n_variants: 2,
-                        null_variant: Some(0),
-                    },
-                )
-            }
-        };
-        let (after_key, after) = match diff_pair.after {
-            None => (
-                None,
-                Value::Union {
-                    index: 0,
-                    inner: Box::new(Value::Null),
-                    n_variants: 2,
-                    null_variant: Some(0),
-                },
-            ),
-            Some(row) => {
-                let (key, row) = self.row_to_avro(row.iter());
-                (
-                    key,
-                    Value::Union {
-                        index: 1,
-                        inner: Box::new(row),
-                        n_variants: 2,
-                        null_variant: Some(0),
-                    },
-                )
-            }
-        };
-
-        // TODO [btv]: Decoding the key twice and then validating that they match is probably wasteful.
-        // But it doesn't matter for now since (1) in sinks we always have before or after populated, but not both,
-        // and (2) avro encoding for sinks is un-optimized anyway.
-        //
-        // Look into it if/when sink encoding becomes a bottleneck.
-        if let (Some(before_key), Some(after_key)) = (before_key.as_ref(), after_key.as_ref()) {
-            assert_eq!(before_key, after_key, "Mismatched keys in sink!");
-        }
-
-        let key = before_key.or(after_key);
-
-        let transaction = if let Some(transaction_id) = transaction_id {
-            let id = Value::String(transaction_id);
-            Some(Value::Record(vec![("id".into(), id)]))
-        } else {
-            None
-        };
-
-        let mut fields = Vec::new();
-        fields.push(("before".into(), before));
-        fields.push(("after".into(), after));
-
-        if let Some(transaction) = transaction {
-            fields.push(("transaction".into(), transaction));
-        }
-
-        (key, Value::Record(fields))
-    }
-
-    pub fn row_to_avro<'a, I>(&self, row: I) -> (Option<Value>, Value)
-    where
-        I: IntoIterator<Item = Datum<'a>>,
-    {
-        encode_datums_as_avro(row, &self.columns, self.key_indices())
+    pub fn encode_value_unchecked(&self, schema_id: i32, row: Row) -> Vec<u8> {
+        let schema = self.value_writer_schema();
+        let columns = self.value_columns();
+        encode_message_unchecked(schema_id, row, schema, columns)
     }
 }
 
@@ -2452,11 +2327,7 @@ pub fn column_names_and_types(desc: RelationDesc) -> Vec<(ColumnName, ColumnType
 }
 
 /// Encodes a sequence of `Datum` as Avro (key and value), using supplied column names and types.
-pub fn encode_datums_as_avro<'a, I>(
-    datums: I,
-    names_types: &[(ColumnName, ColumnType)],
-    key_indices: Option<&[usize]>,
-) -> (Option<Value>, Value)
+pub fn encode_datums_as_avro<'a, I>(datums: I, names_types: &[(ColumnName, ColumnType)]) -> Value
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -2469,15 +2340,8 @@ where
             (name, TypedDatum::new(datum, typ.clone()).avro())
         })
         .collect();
-    let k = key_indices.map(|key_indices| {
-        let key_fields = key_indices
-            .iter()
-            .map(|&idx| value_fields[idx].clone())
-            .collect();
-        Value::Record(key_fields)
-    });
     let v = Value::Record(value_fields);
-    (k, v)
+    v
 }
 
 /// Bundled information sufficient to encode as Avro.
@@ -2542,8 +2406,27 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::Uuid => Value::Uuid(datum.unwrap_uuid()),
                 ScalarType::Array(_t) => unimplemented!("array types"),
                 ScalarType::List(_t) => unimplemented!("list types"),
-                ScalarType::Record { .. } => unimplemented!("record types"),
                 ScalarType::Map { .. } => unimplemented!("map types"),
+                ScalarType::Record { fields } => {
+                    let list = datum.unwrap_list();
+                    let fields = fields
+                        .iter()
+                        .zip(list.into_iter())
+                        .map(|((name, typ), datum)| {
+                            let name = name.to_string();
+                            let datum = TypedDatum::new(
+                                datum,
+                                ColumnType {
+                                    nullable: true,
+                                    scalar_type: typ.clone(),
+                                },
+                            );
+                            let value = datum.avro();
+                            (name, value)
+                        })
+                        .collect();
+                    Value::Record(fields)
+                }
             };
             if typ.nullable {
                 val = Value::Union {
@@ -2615,11 +2498,10 @@ impl SchemaCache {
     }
 }
 
-/// Builds the JSON for the row schema, which can be independently useful.
-fn build_row_schema_json(
+fn build_row_schema_fields<F: FnMut() -> String>(
     columns: &[(ColumnName, ColumnType)],
-    name: &str,
-) -> serde_json::value::Value {
+    namer: &mut F,
+) -> Vec<serde_json::value::Value> {
     let mut fields = Vec::new();
     for (name, typ) in columns.iter() {
         let mut field_type = match &typ.scalar_type {
@@ -2663,8 +2545,28 @@ fn build_row_schema_json(
             }),
             ScalarType::Array(_t) => unimplemented!("array types"),
             ScalarType::List(_t) => unimplemented!("list types"),
-            ScalarType::Record { .. } => unimplemented!("record types"),
             ScalarType::Map { .. } => unimplemented!("map types"),
+            ScalarType::Record { fields } => {
+                let fields = fields
+                    .iter()
+                    .map(|(cn, st)| {
+                        (
+                            cn.clone(),
+                            ColumnType {
+                                nullable: true,
+                                scalar_type: st.clone(),
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let name = namer();
+                let json_fields = build_row_schema_fields(&fields, namer);
+                json!({
+                    "type": "record",
+                    "name": name,
+                    "fields": json_fields
+                })
+            }
         };
         if typ.nullable {
             field_type = json!(["null", field_type]);
@@ -2674,6 +2576,19 @@ fn build_row_schema_json(
             "type": field_type,
         }));
     }
+    fields
+}
+/// Builds the JSON for the row schema, which can be independently useful.
+fn build_row_schema_json(
+    columns: &[(ColumnName, ColumnType)],
+    name: &str,
+) -> serde_json::value::Value {
+    let mut name_idx = 0;
+    let fields = build_row_schema_fields(columns, &mut move || {
+        let ret = format!("com.materialize.sink.record{}", name_idx);
+        name_idx += 1;
+        ret
+    });
     json!({
         "type": "record",
         "fields": fields,
@@ -2737,7 +2652,7 @@ pub mod cdc_v2 {
         pub fn encode_updates(&self, updates: &[(Row, i64, i64)]) -> Value {
             let mut enc_updates = Vec::new();
             for (data, time, diff) in updates {
-                let enc_data = super::encode_datums_as_avro(data, &self.columns, None).1;
+                let enc_data = super::encode_datums_as_avro(data, &self.columns);
                 let enc_time = Value::Long(time.clone());
                 let enc_diff = Value::Long(diff.clone());
                 let mut enc_update = Vec::new();
@@ -3090,8 +3005,8 @@ mod tests {
         ];
         for (typ, datum, expected) in valid_pairings {
             let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
-            let (_, avro_value) =
-                Encoder::new(desc, false, None).row_to_avro(std::iter::once(datum));
+            let encoder = Encoder::new(None, desc, false);
+            let avro_value = encode_datums_as_avro(std::iter::once(datum), encoder.value_columns());
             assert_eq!(
                 Value::Record(vec![("column1".into(), expected)]),
                 avro_value

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -1,0 +1,142 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::iter;
+use std::rc::Rc;
+
+use crate::avro::{column_names_and_types, DiffPair};
+use differential_dataflow::{
+    lattice::Lattice,
+    trace::BatchReader,
+    trace::{implementations::ord::OrdValBatch, Cursor},
+};
+use differential_dataflow::{AsCollection, Collection};
+use itertools::Itertools;
+use ore::collections::CollectionExt;
+use repr::{ColumnType, Datum, Diff, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
+
+/// Given a stream of batches, produce a stream of (vectors of) DiffPairs, in timestamp order.
+// This is useful for some sink envelopes (e.g., Debezium and Upsert), which need
+// to do specific logic based on the _entire_ set of before/after diffs at a given timestamp.
+pub fn combine_at_timestamp<G: Scope>(
+    batches: Stream<G, Rc<OrdValBatch<Option<Row>, Row, G::Timestamp, Diff>>>,
+) -> Collection<G, (Option<Row>, Vec<DiffPair<Row>>), Diff>
+where
+    G::Timestamp: Lattice + Copy,
+{
+    let mut rows_buf = vec![];
+    let x: Stream<G, ((Option<Row>, Vec<DiffPair<Row>>), G::Timestamp, Diff)> =
+        batches.unary(Pipeline, "combine_at_timestamp", move |_, _| {
+            move |input, output| {
+                while let Some((cap, batches)) = input.next() {
+                    let mut session = output.session(&cap);
+                    batches.swap(&mut rows_buf);
+                    for batch in rows_buf.drain(..) {
+                        let mut cursor = batch.cursor();
+                        let mut buf: Vec<(G::Timestamp, Option<Row>, Diff, Row)> = vec![];
+
+                        // This batch is valid for a range of timestamps, but it might not present things in timestamp order.
+                        // Slurp it into a vector, so we can sort that by timestamps.
+                        while cursor.key_valid(&batch) {
+                            let k = cursor.key(&batch);
+                            while cursor.val_valid(&batch) {
+                                let val = cursor.val(&batch);
+                                cursor.map_times(&batch, |&t, &diff| {
+                                    buf.push((t, k.clone(), diff, val.clone()));
+                                });
+                                cursor.step_val(&batch);
+                            }
+                            cursor.step_key(&batch);
+                        }
+                        // For each timestamp we've seen,
+                        // we need to generate a series of (before, after) pairs.
+                        //
+                        // Steps to do this:
+                        // (1) sort by ts, diff (so that for each ts, diffs appear in ascending order).
+                        // (2) in each ts, find the point where negative and positive diffs meet, using binary search.
+                        // (3) The (ts, entry, diff) elements before that point will go into "before" fields in DiffPairs;
+                        //     the ones after that point will go in "after".
+
+                        // Step (1) above)
+                        buf.sort_by_key(|(t, _k, diff, _row)| (*t, *diff));
+                        for ((t, k), group) in &buf
+                            .into_iter()
+                            .group_by(|(t, k, _diff, _row)| (*t, k.clone()))
+                        {
+                            let mut out = vec![];
+                            let elts: Vec<(G::Timestamp, Option<Row>, Diff, Row)> = group.collect();
+                            // Step (2) above
+                            let pos_idx = elts
+                                .binary_search_by(|(_t, _k, diff, _row)| diff.cmp(&0))
+                                .expect_err("there should be no zero-multiplicity entries");
+
+                            // Step (3) above
+                            let befores = elts[0..pos_idx]
+                                .iter()
+                                .flat_map(|elt| iter::repeat(elt).take(elt.2.abs() as usize));
+                            let afters = elts[pos_idx..]
+                                .iter()
+                                .flat_map(|elt| iter::repeat(elt).take(elt.2 as usize));
+                            for pair in befores.zip_longest(afters) {
+                                let (before, after) = match pair {
+                                    itertools::EitherOrBoth::Both(before, after) => {
+                                        (Some(before.3.clone()), Some(after.3.clone()))
+                                    }
+                                    itertools::EitherOrBoth::Left(before) => {
+                                        (Some(before.3.clone()), None)
+                                    }
+                                    itertools::EitherOrBoth::Right(after) => {
+                                        (None, Some(after.3.clone()))
+                                    }
+                                };
+                                out.push(DiffPair { before, after });
+                            }
+                            session.give(((k, out), t, 1));
+                        }
+                    }
+                }
+            }
+        });
+    x.as_collection()
+}
+
+pub fn dbz_desc(desc: RelationDesc) -> RelationDesc {
+    let cols = column_names_and_types(desc);
+    let row = ColumnType {
+        nullable: true,
+        scalar_type: ScalarType::Record {
+            fields: cols
+                .into_iter()
+                .map(|(name, typ)| (name, typ.scalar_type))
+                .collect(),
+        },
+    };
+    let typ = RelationType::new(vec![row.clone(), row]);
+    RelationDesc::new(typ, vec![Some("before"), Some("after")])
+}
+
+pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) -> Row {
+    if let Some(before) = dp.before {
+        rp.push_list_with(|rp| rp.extend_by_row(&before));
+    } else {
+        rp.push(Datum::Null);
+    }
+    if let Some(after) = dp.after {
+        rp.push_list_with(|rp| rp.extend_by_row(&after));
+    } else {
+        rp.push(Datum::Null);
+    }
+    rp.finish_and_reuse()
+}
+
+pub fn upsert_format(dps: Vec<DiffPair<Row>>) -> Option<Row> {
+    let dp = dps.expect_element("primary key error: expected at most one DiffPair per timestamp");
+    dp.after
+}

--- a/src/interchange/src/lib.rs
+++ b/src/interchange/src/lib.rs
@@ -12,4 +12,5 @@
 #![deny(missing_debug_implementations)]
 
 pub mod avro;
+pub mod envelopes;
 pub mod protobuf;

--- a/src/ore/src/collections.rs
+++ b/src/ore/src/collections.rs
@@ -9,8 +9,10 @@
 
 //! Collection utilities.
 
+use std::fmt::Display;
+
 /// Extension methods for collections.
-pub trait CollectionExt<T>
+pub trait CollectionExt<T>: Sized
 where
     T: IntoIterator,
 {
@@ -27,7 +29,14 @@ where
     /// Consumes the collection and returns its only element.
     ///
     /// This method panics if the collection does not have exactly one element.
-    fn into_element(self) -> T::Item;
+    fn into_element(self) -> T::Item {
+        self.expect_element("into_element called on collection with more than one element")
+    }
+
+    /// Consumes the collection and returns its only element.
+    ///
+    /// This method panics with the given error message if the collection does not have exactly one element.
+    fn expect_element<Err: Display>(self, msg: Err) -> T::Item;
 }
 
 impl<T> CollectionExt<T> for T
@@ -42,11 +51,11 @@ where
         self.into_iter().last().unwrap()
     }
 
-    fn into_element(self) -> T::Item {
+    fn expect_element<Err: Display>(self, msg: Err) -> T::Item {
         let mut iter = self.into_iter();
         match (iter.next(), iter.next()) {
             (Some(el), None) => el,
-            _ => panic!("into_element called on collection with more than one element"),
+            _ => panic!("{}", msg),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -389,6 +389,7 @@ pub struct CreateSinkStatement {
     pub connector: Connector,
     pub with_options: Vec<SqlOption>,
     pub format: Option<Format>,
+    pub envelope: Option<Envelope>,
     pub with_snapshot: bool,
     pub as_of: Option<Expr>,
     pub if_not_exists: bool,
@@ -413,6 +414,10 @@ impl AstDisplay for CreateSinkStatement {
         if let Some(format) = &self.format {
             f.write_str(" FORMAT ");
             f.write_node(format);
+        }
+        if let Some(envelope) = &self.envelope {
+            f.write_str(" ENVELOPE ");
+            f.write_node(envelope);
         }
         if self.with_snapshot {
             f.write_str(" WITH SNAPSHOT");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1528,6 +1528,11 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
+        let envelope = if self.parse_keyword(ENVELOPE) {
+            Some(self.parse_envelope()?)
+        } else {
+            None
+        };
         let with_snapshot = if self.parse_keyword(WITH) {
             self.expect_keyword(SNAPSHOT)?;
             true
@@ -1546,6 +1551,7 @@ impl<'a> Parser<'a> {
             connector,
             with_options,
             format,
+            envelope,
             with_snapshot,
             as_of,
             if_not_exists,

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -205,6 +205,7 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
             connector: _,
             with_options: _,
             format: _,
+            envelope: _,
             with_snapshot: _,
             as_of: _,
             if_not_exists,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -32,7 +32,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use ::expr::{GlobalId, RowSetFinishing};
-use dataflow_types::{SinkConnectorBuilder, SourceConnector};
+use dataflow_types::{SinkConnectorBuilder, SinkEnvelope, SourceConnector};
 use repr::{ColumnName, RelationDesc, Row, ScalarType, Timestamp};
 
 use crate::ast::{ExplainOptions, ExplainStage, ObjectType, Statement};
@@ -140,6 +140,7 @@ pub enum Plan {
         copy_to: Option<CopyFormat>,
         emit_progress: bool,
         object_columns: usize,
+        desc: RelationDesc,
     },
     SendRows(Vec<Row>),
     ExplainPlan {
@@ -185,6 +186,7 @@ pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
     pub connector_builder: SinkConnectorBuilder,
+    pub envelope: SinkEnvelope,
 }
 
 #[derive(Clone, Debug)]

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -212,7 +212,10 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, String> 
                     }
                 }
             }
-            Err(format!("Type not found in union: {}", name))
+            Err(format!(
+                "Type not found in union: {}. variants: {:#?}",
+                name, variants
+            ))
         }
         _ => Err(format!(
             "unable to match JSON value to schema: {:?} vs {:?}",

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -40,7 +40,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
 
     // Demand all columns of inputs to sinks.
     for (_id, sink) in dataflow.sink_exports.iter() {
-        let input_id = sink.from.0;
+        let input_id = sink.from;
         demand
             .entry(Id::Global(input_id))
             .or_insert_with(HashSet::new)
@@ -128,7 +128,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
 /// Analysis to identify monotonic collections, especially TopK inputs.
 pub mod monotonic {
 
-    use dataflow_types::{DataflowDesc, Envelope, SourceConnector};
+    use dataflow_types::{DataflowDesc, SourceConnector, SourceEnvelope};
     use expr::RelationExpr;
     use expr::{GlobalId, Id};
     use std::collections::HashSet;
@@ -181,7 +181,7 @@ pub mod monotonic {
         let mut monotonic = std::collections::HashSet::new();
         for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
             if let SourceConnector::External {
-                envelope: Envelope::None,
+                envelope: SourceEnvelope::None,
                 ..
             } = source_desc.connector
             {

--- a/test/testdrive/avro-ocf.td
+++ b/test/testdrive/avro-ocf.td
@@ -189,8 +189,8 @@ mz_obj_no   false     int8
   INTO AVRO OCF '${testdrive.temp-dir}/basic-sink.ocf'
 
 $ avro-ocf-verify sink=materialize.public.basic_sink_${testdrive.seed}
-{"before": null, "after": {"row": {"a": 1, "b": 2, "mz_obj_no": 1}}}
-{"before": null, "after": {"row": {"a": 3, "b": 4, "mz_obj_no": 2}}}
+{"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 1}, "b": {"int": 2}, "mz_obj_no": {"long": 1}}}}
+{"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 3}, "b": {"int": 4}, "mz_obj_no": {"long": 2}}}}
 
 > CREATE VIEW dateish AS
   SELECT d FROM timestamp_source
@@ -199,5 +199,5 @@ $ avro-ocf-verify sink=materialize.public.basic_sink_${testdrive.seed}
   INTO AVRO OCF '${testdrive.temp-dir}/date-sink.ocf'
 
 $ avro-ocf-verify sink=materialize.public.date_sink_${testdrive.seed}
-{"before": null, "after": {"row": {"d": 10988}}}
-{"before": null, "after": {"row": {"d": 10957}}}
+{"before": null, "after": {"com.materialize.sink.record1": {"d": {"int": 10988}}}}
+{"before": null, "after": {"com.materialize.sink.record1": {"d": {"int": 10957}}}}

--- a/test/testdrive/avro-sinks.td
+++ b/test/testdrive/avro-sinks.td
@@ -13,37 +13,13 @@
 
 > CREATE VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
 
-> CREATE SINK unnamed_cols_sink FROM unnamed_cols
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unnamed-cols-sink'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-$ kafka-verify format=avro sink=materialize.public.unnamed_cols_sink
-{"before": null, "after": {"row": {"column1": 1, "b": 2, "column3": 3}}}
-
 # Test that invented field names do not clash with named columns.
 
 > CREATE VIEW clashing_cols AS SELECT 1, 2 AS column1, 3 as b, 4 as b, 5 as b;
 
-> CREATE SINK clashing_cols_sink FROM clashing_cols
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'clashing-cols-sink'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-$ kafka-verify format=avro sink=materialize.public.clashing_cols_sink
-{"before": null, "after": {"row": {"column1": 1, "column1_1": 2, "b": 3, "b1": 4, "b2": 5}}}
-
 # Test a basic sink with multiple rows.
 
 > CREATE VIEW data (a, b) AS VALUES (1, 1), (2, 1), (3, 1), (1, 2)
-
-> CREATE SINK data_sink FROM data
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-$ kafka-verify format=avro sink=materialize.public.data_sink
-{"before": null, "after": {"row": {"a": 1, "b": 1}}}
-{"before": null, "after": {"row": {"a": 1, "b": 2}}}
-{"before": null, "after": {"row": {"a": 2, "b": 1}}}
-{"before": null, "after": {"row": {"a": 3, "b": 1}}}
 
 # Test date/time types.
 
@@ -51,23 +27,7 @@ $ kafka-verify format=avro sink=materialize.public.data_sink
   (DATE '2000-01-01', TIMESTAMP '2000-01-01 10:10:10.111', TIMESTAMPTZ '2000-01-01 10:10:10.111+02'),
   (DATE '2000-02-01', TIMESTAMP '2000-02-01 10:10:10.111', TIMESTAMPTZ '2000-02-01 10:10:10.111+02')
 
-> CREATE SINK datetime_data_sink FROM datetime_data
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'datetime-data-sink'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-$ kafka-verify format=avro sink=materialize.public.datetime_data_sink
-{"before": null, "after": {"row": {"date": 10988, "ts": 949399810111000, "ts_tz": 949392610111000}}}
-{"before": null, "after": {"row": {"date": 10957, "ts": 946721410111000, "ts_tz": 946714210111000}}}
-
 > CREATE VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04')
-
-> CREATE SINK time_data_sink FROM time_data
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'time-data-sink'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-$ kafka-verify format=avro sink=materialize.public.time_data_sink
-{"before": null, "after": {"row": {"time": 3723000000}}}
-{"before": null, "after": {"row": {"time": 3724000000}}}
 
 $ set schema={
     "type": "record",
@@ -136,12 +96,15 @@ $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 3, "b": 1}}}
 {"before": null, "after": {"row": {"a": 4, "b": 2}}}
+{"before": null, "after": {"row": {"a": 1, "b": 7}}}
 
 $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
 {"status":"END","id":"1","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
 {"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
 {"status":"END","id":"2","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
+{"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
+{"status":"END","id":"3","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
 
 > CREATE MATERIALIZED SOURCE input
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
@@ -155,6 +118,7 @@ a  b
 2  2
 3  1
 4  2
+1  7
 
 > CREATE SINK input_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
@@ -163,17 +127,18 @@ a  b
   AS OF 1
 
 $ kafka-verify format=avro sink=materialize.public.input_sink
-{"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
-{"a": 2} {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
-{"a": 3} {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
-{"a": 4} {"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
+{"a": 1} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 1}, "b": {"long": 1}}}, "transaction": {"id": {"string": "1"}}}
+{"a": 2} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 2}, "b": {"long": 2}}}, "transaction": {"id": {"string": "1"}}}
+{"a": 3} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 3}, "b": {"long": 1}}}, "transaction": {"id": {"string": "2"}}}
+{"a": 4} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 4}, "b": {"long": 2}}}, "transaction": {"id": {"string": "2"}}}
 
 $ kafka-verify format=avro sink=materialize.public.input_sink consistency=debezium
 {"id": "1", "status": "BEGIN", "event_count": null}
 {"id": "2", "status": "BEGIN", "event_count": null}
+{"id": "3", "status": "BEGIN", "event_count": null}
 {"id": "1", "status": "END", "event_count": {"long": 2}}
 {"id": "2", "status": "END", "event_count": {"long": 2}}
-
+{"id": "3", "status": "END", "event_count": {"long": 1}}
 ! CREATE SINK bad_sink FROM input
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a, a)
   FORMAT AVRO
@@ -195,10 +160,10 @@ Ambiguous column: a
   AS OF 1
 
 $ kafka-verify format=avro sink=materialize.public.input_sink_multiple_keys
-{"b": 1, "a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
-{"b": 2, "a": 2} {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
-{"b": 1, "a": 3} {"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "2"}}
-{"b": 2, "a": 4} {"before": null, "after": {"row": {"a": 4, "b": 2}}, "transaction": {"id": "2"}}
+{"b": 1, "a": 1} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 1}, "b": {"long": 1}}}, "transaction": {"id": {"string": "1"}}}
+{"b": 2, "a": 2} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 2}, "b": {"long": 2}}}, "transaction": {"id": {"string": "1"}}}
+{"b": 1, "a": 3} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 3}, "b": {"long": 1}}}, "transaction": {"id": {"string": "2"}}}
+{"b": 2, "a": 4} {"before": null, "after": {"com.materialize.sink.record1": {"a": {"long": 4}, "b": {"long": 2}}}, "transaction": {"id": {"string": "2"}}}
 
 > CREATE VIEW json_data (a, b) AS VALUES ('{"a":1, "b":2}'::jsonb, 2)
 

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -91,7 +91,7 @@ $ kafka-ingest format=avro topic=data-consistency timestamp=1 schema=${trxschema
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.snk1
-{"before": null, "after": {"row": {"num": 3, "name": "three"}}}
+{"before": null, "after": {"com.materialize.sink.record1": {"num": {"long": 3}, "name": {"string": "three"}}}}
 
 $ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
 {"before": {"row": {"num": 3, "name": "three"}}, "after": {"row": {"num": 4, "name": "four"}}}

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -29,13 +29,6 @@ goofus,gallant
 > CREATE MATERIALIZED VIEW v3 AS
   SELECT a || b AS c FROM src
 
-# We should refuse to create a sink with an invalid schema registry URL
-
-! CREATE SINK bad_schema_registry FROM src
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialize.com:8080'
-unable to publish value schema to registry in kafka sink
-
 > SHOW SINKS
 name
 ----
@@ -82,24 +75,24 @@ snk4   user
 snk5   user
 
 $ kafka-verify format=avro sink=materialize.public.snk1
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 2}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 3}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "jack"}, "b": {"string": "jill"}, "mz_line_no": {"long": 2}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "goofus"}, "b": {"string": "gallant"}, "mz_line_no": {"long": 3}}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk2
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 2}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 3}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "jack"}, "b": {"string": "jill"}, "mz_line_no": {"long": 2}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "goofus"}, "b": {"string": "gallant"}, "mz_line_no": {"long": 3}}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3
-{"before": null, "after": {"row":{"c": "jackjill"}}}
-{"before": null, "after": {"row":{"c": "goofusgallant"}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"string": "jackjill"}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"string": "goofusgallant"}}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk4
-{"before": null, "after": {"row":{"c": "jackjill"}}}
-{"before": null, "after": {"row":{"c": "goofusgallant"}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"string": "jackjill"}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"string": "goofusgallant"}}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk5
-{"before": null, "after": {"row":{"c": "jackjill"}}}
-{"before": null, "after": {"row":{"c": "goofusgallant"}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"string": "jackjill"}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"string": "goofusgallant"}}}}
 
 # Test the case where we have non +/- 1 multiplicities
 
@@ -111,8 +104,8 @@ $ kafka-verify format=avro sink=materialize.public.snk5
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.snk6
-{"before": null, "after": {"row":{"c": true}}}
-{"before": null, "after": {"row":{"c": true}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"boolean": true}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"c": {"boolean": true}}}}
 
 # Test AS OF and WITH/WITHOUT SNAPSHOT.
 > CREATE MATERIALIZED SOURCE dynamic_src
@@ -139,12 +132,12 @@ $ file-append path=test.csv
 extra,row
 
 $ kafka-verify format=avro sink=materialize.public.snk7
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 4}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "extra"}, "b": {"string": "row"}, "mz_line_no": {"long": 4}}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk8
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 2}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 3}}}
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 4}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "jack"}, "b": {"string": "jill"}, "mz_line_no": {"long": 2}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "goofus"}, "b": {"string": "gallant"}, "mz_line_no": {"long": 3}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"a": {"string": "extra"}, "b": {"string": "row"}, "mz_line_no": {"long": 4}}}}
 
 # Test that we are correctly handling WITH/WITHOUT SNAPSHOT on views with
 # empty upper frontier
@@ -163,9 +156,9 @@ $ kafka-verify format=avro sink=materialize.public.sink9
   WITH SNAPSHOT
 
 $ kafka-verify format=avro sink=materialize.public.sink10
-{"before": null, "after": {"row":{"column1": 1}}}
-{"before": null, "after": {"row":{"column1": 2}}}
-{"before": null, "after": {"row":{"column1": 3}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"column1": {"int": 1}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"column1": {"int": 2}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"column1": {"int": 3}}}}
 
 > SHOW FULL SINKS
 name        type

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -72,5 +72,5 @@ u      false     uuid
   INTO AVRO OCF '${testdrive.temp-dir}/uuid-sink.ocf'
 
 $ avro-ocf-verify sink=materialize.public.uuid_sink_${testdrive.seed}
-{"before": null, "after": {"row":{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}
-{"before": null, "after": {"row":{"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"u": {"string": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}}
+{"before": null, "after": {"com.materialize.sink.record1":{"u": {"string": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}}}


### PR DESCRIPTION
The only reason this is WIP is because it requires changes to sink schemas by making us rename "row" to "com.materialize.sink.record{0,1}", which I would like to avoid, and should (hopefully!) be able to once named types and nullable record fields both land. Depending on urgency, I will probably wait for both of those changes.

This diff pulls envelope-specific logic out of each sink, and moves it up into the renderer module. Each sink connector now only handles the logic specific to that connector to dump Rows, and doesn't do any Debezium-specific logic.

To do so, we excise all Debezium-specific logic from `Encoder`, which becomes much simpler.

As a nice side-effect of the refactor, I was able to make sinking happen in timestamp order by forcing everything to one worker (we were already sinking on only one worker, but still not doing so in timestamp order if the overall number of workers was greater than one).

Possible future work:

(1) move the Avro formatting out of the avro/kafka sinks as well
(2) Can/should these become relational operators that are instantiated as part of the normal plan rendering process, as opposed to specifically in sink rendering?