### PR TITLE
doc/user: fix release notes for v0.5.3 era

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,11 +48,36 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.5.4 %}}
 
+- Add the [`version`](/sql/functions#postgresql-compatibility-func) and
+  [`mz_version`](/sql/functions/#system-information-func) functions to report
+  PostgreSQL-specific and Materialize-specific version information,
+  respectively.
+
 {{% version-header v0.5.3 %}}
 
+- Add support for SQL cursors via the new [`DECLARE`](/sql/declare),
+  [`FETCH`](/sql/fetch), and [`CLOSE`](/sql/close) statements. Cursors
+  facilitate fetching partial results from a query and are therefore
+  particularly useful in conjuction with [`TAIL`](/sql/tail#tailing-with-fetch).
+
+- Support [common-table expressions (CTEs)](/sql/select#common-table-expressions-ctes)
+  in `SELECT` statements.
+
+- Add a [`map`](/sql/types/map) type to represent unordered key-value pairs.
+  Avro map values in [Avro-formatted sources](/sql/create-source/avro-kafka)
+  will be decoded into the new `map` type.
+
 - Fix a regression in the SQL parser, introduced in v0.5.2, in which nested
-  field accesses, e.g. `SELECT ((col).field1).field2`, would fail to parse
-  {{% gh 4827 %}}.
+  field accesses, e.g.
+
+  ```sql
+  SELECT ((col).field1).field2
+  ```
+
+  would fail to parse {{% gh 4827 %}}.
+
+- Fix a bug that caused the [`real`]/[`float4`] types to be incorrectly
+  interpreted as [`double precision`] {{% gh 4918 %}}.
 
 {{% version-header v0.5.2 %}}
 
@@ -98,13 +123,6 @@ Wrap your release notes at the 80 character mark.
 - Allow slightly more complicated [`INSERT`](/sql/insert) bodies, e.g. inserting
   `SELECT`ed literals {{% gh 4748 %}}.
   characters, e.g., `SELECT ’1’` {{% gh 4755 %}}.
-- [`TAIL`](/sql/tail) now supports timestamp progress.
-- Log messages are no longer emitted to stderr if an explicit `--log-file` is
-  supplied at startup. {{ gh 4777 }}
-- Add the [`version`](/sql/functions#postgresql-compatibility-func) and
-  [`mz_version`](/sql/functions/#system-information-func) functions to report
-  PostgreSQL-specific and Materialize-specific version information,
-  respectively.
 
 {{% version-header v0.5.1 %}}
 
@@ -765,7 +783,10 @@ Wrap your release notes at the 80 character mark.
 [`CREATE SOURCE`]: /sql/create-source
 [`CREATE VIEW`]: /sql/create-view
 [`date`]: /sql/types/date
+[`double precision`]: /sql/types/float
 [`interval`]: /sql/types/interval
+[`float4`]: /sql/types/float
+[`real`]: /sql/types/real
 [`SHOW CREATE SOURCE`]: /sql/show-create-source
 [`SHOW CREATE VIEW`]: /sql/show-create-view
 [`text`]: /sql/types/text

--- a/doc/user/content/sql/declare.md
+++ b/doc/user/content/sql/declare.md
@@ -9,9 +9,9 @@ menu:
 `DECLARE` creates a cursor, which can be used with
 [`FETCH`](/sql/fetch), to retrieve a limited number of rows at a time
 from a larger query. Large queries or queries that don't ever complete
-([`TAIL`](/sql/tail)) can be difficult to use by many Postgres drivers
+([`TAIL`](/sql/tail)) can be difficult to use with many PostgreSQL drivers
 that wait until all rows are returned before returning control to an
-application. Using `DECLARE` and [`FETCH`](/sql/fetch) allows users to
+application. Using `DECLARE` and [`FETCH`](/sql/fetch) allows you to
 fetch only some of the rows at a time.
 
 ## Syntax

--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -200,32 +200,32 @@ in non-decreasing order. The receipt of the explicit progress message at
 timestamp `4` implies that there are no more updates for either timestamp
 `2` or `3`—but that there may be more data arriving at timestamp `4`.
 
-## Example
+## Examples
 
 `TAIL` produces rows similar to a `SELECT` statement, except that `TAIL` may never complete.
 Many drivers buffer all results until a query is complete, and so will never return.
 Below are the recommended ways to work around this.
 
-### Tailing with FETCH
+### Tailing with `FETCH`
 
-The recommended way to use `COPY TO` is with [`DECLARE`](/sql/declare) and [`FETCH`](/sql/fetch).
-This allows users to limit the number of rows and the time window of their requests. First, declare a `TAIL` cursor:
+The recommended way to use `TAIL` is with [`DECLARE`](/sql/declare) and [`FETCH`](/sql/fetch).
+This allows you to limit the number of rows and the time window of your requests. First, declare a `TAIL` cursor:
 
-```
+```sql
 DECLARE c CURSOR FOR TAIL t;
 ````
 
 Now use [`FETCH`](/sql/fetch) in a loop to retrieve some number of rows within a time window:
 
-```
-FETCH 100 c WITH (TIMEOUT = '1s');
+```sql
+FETCH 100 c WITH (timeout = '1s');
 ```
 
 That will retrieve up to the next 100 rows that are ready in at most `1s`.
 The timeout is only used when there are not any rows ready and a wait must occur.
-If `TIMEOUT` is not specified it defaults to `0s` which means it will only return rows that are immediately available and will never wait for more to come before completing.
+If `timeout` is not specified it defaults to `0s` which means it will only return rows that are immediately available and will never wait for more to come before completing.
 
-#### FETCH with python and psycopg2
+#### `FETCH` with Python and psycopg2
 
 ```python
 #!/usr/bin/env python3
@@ -245,14 +245,16 @@ with conn.cursor() as cur:
     cur.execute("CLOSE c")
 ```
 
-### Tailing with COPY
+### Tailing with `COPY TO`
+
 [`COPY TO`](/sql/copy-to) is supported by many drivers and does not buffer.
 However most drivers do not provide methods to parse the data coming from the `COPY`, in which case you'll have to do your own parsing.
-The Postgres docs describe the [`COPY` text format](https://www.postgresql.org/docs/current/sql-copy.html#id-1.9.3.55.9.2), which is tab-separated lines with escapes and a definition for `NULL`.
+The PostgreSQL docs describe the [`COPY` text format](https://www.postgresql.org/docs/current/sql-copy.html#id-1.9.3.55.9.2), which is tab-separated lines with
+escapes and a sentinel for `NULL`.
 
-#### COPY TO with C# and Npgsql
+#### `COPY TO` with C# and Npgsql
 
-Npgsql [supports](https://www.npgsql.org/doc/copy.html#binary-copy) parsing the `BINARY` format of `COPY TO`:
+Npgsql supports parsing the `BINARY` format of `COPY TO`:
 
 ```
 // The TAIL won't ever end, so use reader.Cancel() to cancel the request.
@@ -267,7 +269,9 @@ using (var reader = Conn.BeginBinaryExport("COPY (TAIL t) TO STDOUT (FORMAT BINA
 }
 ```
 
-#### COPY TO with python and psycopg2
+For more details, see the [Binary `COPY`](https://www.npgsql.org/doc/copy.html#binary-copy) section of the Npgsql documentation.
+
+#### `COPY TO` with Python and psycopg2
 
 ```python
 #!/usr/bin/env python3

--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -22,7 +22,7 @@ Type | Aliases | Use | Size (bytes) | Syntax
 [`integer`](integer) | `int4`, `int` | Signed integer | 4 | `123`
 [`interval`](interval) | | Duration of time | 32 | `INTERVAL '1-2 3 4:5:6.7'`
 [`jsonb`](jsonb) | `json` | JSON | Variable | `'{"1":2,"3":4}'::jsonb`
-[`map`](map) | `map` | Map with [`text`](text) keys and a uniform value type | Variable | `'{a: 1, b: 2}'::map[text=>int]`
+[`map`](map) | | Map with [`text`](text) keys and a uniform value type | Variable | `'{a: 1, b: 2}'::map[text=>int]`
 [`list`](list) | | Multidimensional list | Variable | `LIST[[1,2],[3]]`
 [`record`](record) | | Tuple with arbitrary contents | Variable | `ROW($expr, ...)`
 [`oid`](oid) | | PostgreSQL object identifier | 4 | `123`


### PR DESCRIPTION
Many changes got missed in the release notes for v0.5.3. Add them
retroactively. Also fix some mangled entries in v0.5.2, including one
entry that belonged in v0.5.4. Finally, make some minor formatting edits
to the new cursor docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5031)
<!-- Reviewable:end -->
