### PR TITLE
sql: support SHOW OBJECTS

### DIFF
--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -1,0 +1,83 @@
+---
+title: "SHOW OBJECTS"
+description: "`SHOW OBJECTS` returns a list of all objects available to your Materialize instances."
+menu:
+  main:
+    parent: 'sql'
+aliases:
+    - /sql/show-object
+---
+
+`SHOW OBJECTS` returns a list of all objects available to your Materialize instances in a given schema.
+Objects include tables, sources, views, indexes, and sinks.
+
+## Syntax
+
+{{< diagram "show-objects.svg" >}}
+
+Field | Use
+------|-----
+_schema&lowbar;name_ | The schema to show objects from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+
+## Details
+
+### Output format
+
+`SHOW OBJECTS`'s output is a table with one column, `name`. `SHOW FULL OBJECTS` will output a table with
+two columns, `name` and `type`. `type` indicates whether the object was created by the `system` or a `user`.
+
+## Examples
+
+```sql
+SHOW SCHEMAS;
+```
+```nofmt
+public
+```
+```sql
+SHOW OBJECTS FROM public;
+```
+```nofmt
+my_table
+my_source
+my_sink
+my_other_sink
+```
+```sql
+SHOW OBJECTS;
+```
+```nofmt
+my_table
+my_source
+my_sink
+my_other_sink
+```
+
+```sql
+SHOW FULL OBJECTS;
+```
+```nofmt
+my_table        user
+my_source       user
+my_sink         user
+my_other_sink   user
+```
+
+```sql
+SHOW EXTENDED FULL OBJECTS;
+```
+```nofmt
+my_table        user
+my_source       user
+my_sink         user
+my_other_sink   user
+builtin_view    system
+```
+
+## Related pages
+
+- [`SHOW TABLES`](../show-tables)
+- [`SHOW SOURCES`](../show-sources)
+- [`SHOW VIEWS`](../show-views)
+- [`SHOW INDEXES`](../show-indexes)
+- [`SHOW SINKS`](../show-sinks)

--- a/doc/user/layouts/partials/sql-grammar/show-objects.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-objects.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="483" height="155">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="62" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="133" y="35" width="94" height="32" rx="10"/>
+   <rect x="131"
+         y="33"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="141" y="53">EXTENDED</text>
+   <rect x="287" y="35" width="52" height="32" rx="10"/>
+   <rect x="285"
+         y="33"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="295" y="53">FULL</text>
+   <rect x="379" y="3" width="82" height="32" rx="10"/>
+   <rect x="377"
+         y="1"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="387" y="21">OBJECTS</text>
+   <rect x="245" y="121" width="60" height="32" rx="10"/>
+   <rect x="243"
+         y="119"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="253" y="139">FROM</text>
+   <rect x="325" y="121" width="110" height="32"/>
+   <rect x="323" y="119" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="333" y="139">schema_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h104 m-134 0 h20 m114 0 h20 m-154 0 q10 0 10 10 m134 0 q0 -10 10 -10 m-144 10 v12 m134 0 v-12 m-134 12 q0 10 10 10 m114 0 q10 0 10 -10 m-124 10 h10 m94 0 h10 m40 -32 h10 m0 0 h62 m-92 0 h20 m72 0 h20 m-112 0 q10 0 10 10 m92 0 q0 -10 10 -10 m-102 10 v12 m92 0 v-12 m-92 12 q0 10 10 10 m72 0 q10 0 10 -10 m-82 10 h10 m52 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-280 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h200 m-230 0 h20 m210 0 h20 m-250 0 q10 0 10 10 m230 0 q0 -10 10 -10 m-240 10 v12 m230 0 v-12 m-230 12 q0 10 10 10 m210 0 q10 0 10 -10 m-220 10 h10 m60 0 h10 m0 0 h10 m110 0 h10 m23 -32 h-3"/>
+   <polygon points="473 103 481 99 481 107"/>
+   <polygon points="473 103 465 99 465 107"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -248,6 +248,8 @@ show_tables ::=
   'SHOW' 'TABLES' ('FROM' schema_name)?
 show_views ::=
   'SHOW' 'FULL'? 'MATERIALIZED'? 'VIEWS' ('FROM' schema_name)?
+show_objects ::=
+  'SHOW' 'EXTENDED'? 'FULL'?  'OBJECTS' ('FROM' schema_name)?
 table_ref ::=
   (
     table_name

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1870,6 +1870,7 @@ where
             ObjectType::Sink => ExecuteResponse::DroppedSink,
             ObjectType::Index => ExecuteResponse::DroppedIndex,
             ObjectType::Type => ExecuteResponse::DroppedType,
+            ObjectType::Object => unreachable!("generic OBJECT cannot be dropped"),
         })
     }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -837,6 +837,7 @@ impl AstDisplay for ShowObjectsStatement {
             ObjectType::Source => "SOURCES",
             ObjectType::Sink => "SINKS",
             ObjectType::Type => "TYPES",
+            ObjectType::Object => "OBJECTS",
             ObjectType::Index => unreachable!(),
         });
         if let Some(from) = &self.from {
@@ -1112,6 +1113,7 @@ pub enum ObjectType {
     Sink,
     Index,
     Type,
+    Object,
 }
 
 impl AstDisplay for ObjectType {
@@ -1124,6 +1126,7 @@ impl AstDisplay for ObjectType {
             ObjectType::Sink => "SINK",
             ObjectType::Index => "INDEX",
             ObjectType::Type => "TYPE",
+            ObjectType::Object => "OBJECT",
         })
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -146,6 +146,7 @@ None
 Not
 Null
 Numeric
+Objects
 Ocf
 Of
 Offset

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2814,7 +2814,7 @@ impl<'a> Parser<'a> {
         let extended = self.parse_keyword(EXTENDED);
         if extended {
             self.expect_one_of_keywords(&[
-                SCHEMAS, INDEX, INDEXES, KEYS, TABLES, TYPES, COLUMNS, FULL,
+                SCHEMAS, INDEX, INDEXES, KEYS, TABLES, TYPES, COLUMNS, OBJECTS, FULL,
             ])?;
             self.prev_token();
         }
@@ -2822,7 +2822,7 @@ impl<'a> Parser<'a> {
         let full = self.parse_keyword(FULL);
         if full {
             if extended {
-                self.expect_one_of_keywords(&[SCHEMAS, COLUMNS, TABLES, TYPES])?;
+                self.expect_one_of_keywords(&[SCHEMAS, COLUMNS, TABLES, TYPES, OBJECTS])?;
             } else {
                 self.expect_one_of_keywords(&[
                     SCHEMAS,
@@ -2832,6 +2832,7 @@ impl<'a> Parser<'a> {
                     VIEWS,
                     SINKS,
                     SOURCES,
+                    OBJECTS,
                     MATERIALIZED,
                 ])?;
             }
@@ -2847,7 +2848,7 @@ impl<'a> Parser<'a> {
         if self.parse_one_of_keywords(&[COLUMNS, FIELDS]).is_some() {
             self.parse_show_columns(extended, full)
         } else if let Some(object_type) =
-            self.parse_one_of_keywords(&[SCHEMAS, SOURCES, VIEWS, SINKS, TABLES, TYPES])
+            self.parse_one_of_keywords(&[SCHEMAS, SOURCES, VIEWS, SINKS, TABLES, TYPES, OBJECTS])
         {
             Ok(Statement::ShowObjects(ShowObjectsStatement {
                 object_type: match object_type {
@@ -2857,6 +2858,7 @@ impl<'a> Parser<'a> {
                     SINKS => ObjectType::Sink,
                     TABLES => ObjectType::Table,
                     TYPES => ObjectType::Type,
+                    OBJECTS => ObjectType::Object,
                     val => panic!(
                         "`parse_one_of_keywords` returned an impossible value: {}",
                         val

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1558,9 +1558,7 @@ fn handle_create_table(
                     query::plan_default_expr(scx, expr, &ty)?;
                     default = expr.clone();
                 }
-                other => {
-                    unsupported!(format!("CREATE TABLE with column constraint: {}", other))
-                }
+                other => unsupported!(format!("CREATE TABLE with column constraint: {}", other)),
             }
         }
         column_types.push(ty.nullable(nullable));
@@ -1657,6 +1655,7 @@ fn handle_drop_objects(
         | ObjectType::Index
         | ObjectType::Sink
         | ObjectType::Type => handle_drop_items(scx, object_type, if_exists, names, cascade),
+        ObjectType::Object => unreachable!("cannot drop generic OBJECT, must provide object type"),
     }
 }
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -19,6 +19,15 @@ public
 mz_catalog
 pg_catalog
 
+# What objects do we have by default?
+> SHOW OBJECTS
+name
+----
+
+> SHOW FULL OBJECTS
+name   type
+-----------
+
 # Creating a schema should be reflected in the output of SHOW SCHEMAS.
 > CREATE SCHEMA s
 > SHOW SCHEMAS
@@ -137,6 +146,25 @@ v2
 > SELECT * FROM v1 UNION ALL SELECT * FROM v2
 1
 2
+
+> SHOW OBJECTS
+name
+----
+v1
+v1_primary_idx
+v2
+v2_primary_idx
+
+! DROP OBJECT v1
+Expected DATABASE, SCHEMA, TABLE, VIEW, SOURCE, SINK, INDEX, or TYPE after DROP, found identifier
+
+> SHOW FULL OBJECTS
+name            type
+--------------------------
+v1              user
+v1_primary_idx  user
+v2              user
+v2_primary_idx  user
 
 # DROP DATABASE should not support RESTRICT or CASCADE.
 ! DROP DATABASE d RESTRICT


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/4341.

Adds support for listing all objects (tables, sources, views, indexes, and sinks) in a given schema. `SHOW OBJECTS` accepts the `EXTENDED` and `FULL` query modifiers.

The `show-objects.svg` looks like:
<img width="793" alt="Screen Shot 2020-12-14 at 2 29 43 PM" src="https://user-images.githubusercontent.com/5766027/102127868-0b539c00-3e1b-11eb-8eab-b019493ee6e4.png">

Note for reviewers: I added the `EXTENDED` and `FULL` information to `show-objects.md`, but I noticed that we don't have it for the other `SHOW` commands. Was this an oversight? Or is there a reason why we wouldn't want to explicitly include this information?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5046)
<!-- Reviewable:end -->
