### PR TITLE
sql: support isnull as is null alias

### DIFF
--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -40,6 +40,7 @@ Operator | Computes
 `a BETWEEN x AND y` | `a >= x AND a <= y`
 `a NOT BETWEEN x AND y` | `a < x OR a > y`
 `a IS NULL` | `a = NULL`
+`a ISNULL` | `a = NULL`
 `a IS NOT NULL` | `a != NULL`
 `a LIKE match_expr` | `a` matches `match_expr`, using [SQL LIKE matching](https://www.w3schools.com/sql/sql_like.asp)
 

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -116,6 +116,7 @@ Intersect
 Interval
 Into
 Is
+Isnull
 Isolation
 Join
 Json

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -872,6 +872,10 @@ impl<'a> Parser<'a> {
                         )
                     }
                 }
+                ISNULL => Ok(Expr::IsNull {
+                    expr: Box::new(expr),
+                    negated: false,
+                }),
                 NOT | IN | BETWEEN => {
                     self.prev_token();
                     let negated = self.parse_keyword(NOT);
@@ -1039,7 +1043,7 @@ impl<'a> Parser<'a> {
                     Some(Token::Keyword(LIKE)) => Precedence::Like,
                     _ => Precedence::Zero,
                 },
-                Token::Keyword(IS) => Precedence::Is,
+                Token::Keyword(IS) | Token::Keyword(ISNULL) => Precedence::Is,
                 Token::Keyword(IN) => Precedence::Like,
                 Token::Keyword(BETWEEN) => Precedence::Like,
                 Token::Keyword(LIKE) => Precedence::Like,

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -1558,9 +1558,7 @@ fn handle_create_table(
                     query::plan_default_expr(scx, expr, &ty)?;
                     default = expr.clone();
                 }
-                other => {
-                    unsupported!(format!("CREATE TABLE with column constraint: {}", other))
-                }
+                other => unsupported!(format!("CREATE TABLE with column constraint: {}", other)),
             }
         }
         column_types.push(ty.nullable(nullable));

--- a/test/sqllogictest/comparison.slt
+++ b/test/sqllogictest/comparison.slt
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+query B
+SELECT 1 is null
+----
+false
+
+query B
+SELECT 1 isnull
+----
+false
+
+query B
+SELECT null is null
+----
+true
+
+query B
+select null isnull
+----
+true


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/1051.

Like `is null`, `isnull` tests whether a value is null, returning a boolean value. [`isnull` is nonstandard syntax in Postgres](https://www.postgresql.org/docs/13/functions-comparison.html), but is supported nonetheless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5048)
<!-- Reviewable:end -->
