### PR TITLE
pgwire: send NoticeResponse in Copy connection check

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -61,6 +61,9 @@ Wrap your release notes at the 80 character mark.
 - Fix a bug when requesting binary-formatted values with
   [`FETCH`](/sql/fetch/) {{% gh 4976 %}}.
 
+- Fix a bug when using COPY with TAIL that could cause some drivers to
+  fail if the TAIL was idle for at least 1 second {{% gh 4976 %}}.
+
 {{% version-header v0.5.3 %}}
 
 - Add support for SQL cursors via the new [`DECLARE`](/sql/declare),

--- a/test/lang/csharp/SmokeTest.cs
+++ b/test/lang/csharp/SmokeTest.cs
@@ -9,6 +9,7 @@
 
 using Npgsql;
 using NUnit.Framework;
+using System.Threading;
 
 namespace csharp
 {
@@ -51,6 +52,11 @@ namespace csharp
             Assert.AreEqual(1, reader.Read<long>()); // diff column
             Assert.AreEqual(1, reader.Read<int>()); // a column
             Assert.AreEqual("a", reader.Read<string>()); // b column
+
+            // Wait 2s so that the 1s NoticeResponse "test that the connection is still
+            // alive" check triggers. This verifies Npgsql can successfully ignore the
+            // NoticeResponse.
+            Thread.Sleep(2000);
 
             // Insert another row from another connection to simulate an update
             // arriving.


### PR DESCRIPTION
Previously we sent an empty CopyData message, but that's not
consistent with the spec. NoticeResponse is explicitly described in
the copy spec as a thing that can happen and needs to be handled.

This fixes a problem when users are using Npgsql.

Fixes #4932

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5051)
<!-- Reviewable:end -->
