### PR TITLE
materialized: brand all environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,7 +820,7 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 [[package]]
 name = "differential-dataflow"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#0c30c936afa2fab2b7b4caa4f34663da985f0ff2"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#f86e881a555a22a7e7a696f1d1825f892751b5f0"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -870,7 +870,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#0c30c936afa2fab2b7b4caa4f34663da985f0ff2"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#f86e881a555a22a7e7a696f1d1825f892751b5f0"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1839,6 +1839,7 @@ dependencies = [
  "datadriven",
  "dataflow",
  "dataflow-types",
+ "differential-dataflow",
  "fallible-iterator",
  "flate2",
  "futures",
@@ -1883,6 +1884,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "timely",
  "tokio",
  "tokio-openssl",
  "tokio-postgres",
@@ -3733,6 +3735,7 @@ dependencies = [
  "sql",
  "structopt",
  "tempfile",
+ "timely",
  "tokio",
  "tokio-postgres",
  "uuid",
@@ -4077,11 +4080,12 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5023fb99fcd4409cfafe180f4827660c63263ced"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#de69cfc4d7da29d4e210cd06fc431650477e5530"
 dependencies = [
  "abomonation",
  "abomonation_derive",
  "crossbeam-channel",
+ "getopts",
  "serde",
  "serde_derive",
  "timely_bytes",
@@ -4092,12 +4096,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.11.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5023fb99fcd4409cfafe180f4827660c63263ced"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#de69cfc4d7da29d4e210cd06fc431650477e5530"
 
 [[package]]
 name = "timely_communication"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5023fb99fcd4409cfafe180f4827660c63263ced"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#de69cfc4d7da29d4e210cd06fc431650477e5530"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4113,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.11.1"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#5023fb99fcd4409cfafe180f4827660c63263ced"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#de69cfc4d7da29d4e210cd06fc431650477e5530"
 
 [[package]]
 name = "timely_sort"

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -22,10 +22,9 @@ services:
     ports:
      - *materialized
     init: true
-    command: --workers ${MZ_THREADS:-1} --disable-telemetry
+    command: --workers ${MZ_THREADS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
-      - DIFFERENTIAL_EAGER_MERGE=1000
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3
     environment:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -42,17 +42,20 @@ services:
     ports:
      - *materialized
     init: true
-    command: -w ${MZ_THREADS:-1} --disable-telemetry
-    environment:
-      # you can for example add `pgwire=trace` or change `info` to `debug` to get more verbose logs
-      - MZ_LOG=pgwire=debug,info
-      # We want this to eventually count up to the size of the largest batch in an
-      # arrangement. This number represents a tradeoff between proactive merging (which
-      # takes time) and low latency.
+    command:
+      - --workers=${MZ_WORKERS:-1}
+      # We want this to eventually count up to the size of the largest batch in
+      # an arrangement. This number represents a tradeoff between proactive
+      # merging (which takes time) and low latency.
       #
-      # 1000 was chosen by fair dice roll
-      - DIFFERENTIAL_EAGER_MERGE=1000
-      - DEFAULT_PROGRESS_MODE=${DEFAULT_PROGRESS_MODE}
+      # 1000 was chosen by fair dice roll.
+      - --differential-idle-merge-effort=1000
+      - --timely-progress-mode=${MZ_TIMELY_PROGRESS_MODE:-demand}
+      - --disable-telemetry
+    environment:
+      # You can, for example, add `pgwire=trace` or change `info` to `debug` to
+      # get more verbose logs.
+      - MZ_LOG=pgwire=debug,info
   mysql:
     mzbuild: chbench-mysql
     ports:

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,9 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.6.1 %}}
 
+- Add the advanced [`--timely-progress-mode` and `--differential-idle-merge-effort` command-line arguments](/cli/#dataflow-tuning)
+  to tune dataflow performance.
+
 - Add `ALL` to [`FETCH`](/sql/fetch).
 
 - Change [`FETCH`](/sql/fetch) with no `TIMEOUT` to wait for some rows

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -136,7 +136,12 @@ def lint_image_name(path: Path, spec: str, errors: List[LintError]) -> None:
 def lint_materialized_service(
     path: Path, service: Any, errors: List[LintError]
 ) -> None:
-    if "--disable-telemetry" not in service.get("command", "").split():
+    # command may be a string that is passed to the shell, or a list of
+    # arguments.
+    command = service.get("command", "")
+    if isinstance(command, str):
+        command = command.split()  # split on whitespace to extract individual arguments
+    if "--disable-telemetry" not in command:
         errors.append(
             LintError(
                 path,

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -40,7 +40,7 @@ serde = "1.0.0"
 serde_json = "1.0.60"
 sql = { path = "../sql" }
 symbiosis = { path = "../symbiosis" }
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.0.0"
 tokio-postgres = "0.7"
 transform = { path = "../transform" }

--- a/src/dataflow-bin/Cargo.toml
+++ b/src/dataflow-bin/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 ore = { path = "../ore" }
 structopt = "0.3.21"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -18,7 +18,7 @@ repr = { path = "../repr" }
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_regex = "1.1.0"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 url = { version = "2.2.0", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -39,7 +39,7 @@ rusoto_credential = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_kinesis = { git = "https://github.com/rusoto/rusoto.git" }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.60"
-timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.0.0", features = ["fs", "rt"] }
 tokio-util = { version = "0.6.0", features = ["codec"] }
 url = { version = "2.2.0", features = ["serde"] }

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -23,5 +23,6 @@ pub mod logging;
 pub mod source;
 
 pub use server::{
-    serve, BroadcastToken, CacheMessage, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta,
+    serve, BroadcastToken, CacheMessage, Config, SequencedCommand, WorkerFeedback,
+    WorkerFeedbackWithMeta,
 };

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -39,6 +39,7 @@ compile-time-run = "0.2.11"
 coord = { path = "../coord" }
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
+differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.9"
 getopts = "0.2.0"
 hex = "0.4.0"
@@ -73,6 +74,7 @@ sysctl = "0.4.0"
 # See: https://github.com/GuillaumeGomez/sysinfo/pull/404
 sysinfo = "=0.15.3"
 tempfile = "3.1.0"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.0.0", features = ["sync"] }
 tokio-openssl = "0.6.0"
 tracing = "0.1.21"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -68,7 +68,7 @@ fn run() -> Result<(), anyhow::Error> {
         opts.optflag("", "dev", "allow running this dev (unoptimized) build");
     }
 
-    // Timely and Differential worker options.
+    // Dataflow worker options.
     opts.optopt(
         "w",
         "workers",
@@ -118,7 +118,19 @@ fn run() -> Result<(), anyhow::Error> {
     opts.optopt(
         "",
         "cache-max-pending-records",
-        "maximum number of records that have to be present before materialize will cache them immediately. (default 1000000)",
+        "maximum number of records that have to be present before materialize will cache them immediately (default 1000000)",
+        "N",
+    );
+    opts.optopt(
+        "",
+        "timely-progress-mode",
+        "[advanced] timely progress tracking mode (default: demand)",
+        "<demand|eager>",
+    );
+    opts.optopt(
+        "",
+        "differential-idle-merge-effort",
+        "[advanced] amount of compaction to perform when idle",
         "N",
     );
 
@@ -254,6 +266,14 @@ fn run() -> Result<(), anyhow::Error> {
         Some(d) => parse_duration::parse(&d)?,
     };
     let cache_max_pending_records = popts.opt_get_default("cache-max-pending-records", 1000000)?;
+    let timely_progress_mode = popts
+        .opt_get_default(
+            "timely-progress-mode",
+            timely::worker::ProgressMode::default(),
+        )
+        .map_err(|e| anyhow!(e))?;
+    let differential_idle_merge_effort =
+        popts.opt_get::<isize>("differential-idle-merge-effort")?;
 
     // Configure connections.
     let listen_addr = popts.opt_get("listen-addr")?;
@@ -379,7 +399,7 @@ fn run() -> Result<(), anyhow::Error> {
         }
     }
 
-    // configure prometheus process metrics
+    // Configure prometheus process metrics.
     mz_process_collector::register_default_process_collector()?;
 
     // Print system information as the very first thing in the logs. The goal is
@@ -401,13 +421,8 @@ swap: {swap_total}KB total, {swap_used}KB used",
         dep_versions = build_info().join("\n"),
         invocation = {
             use shell_words::quote as escape;
-            // TODO - make this only check for "MZ_" if #1223 is fixed.
             env::vars()
-                .filter(|(name, _value)| {
-                    name.starts_with("MZ_")
-                        || name.starts_with("DIFFERENTIAL_")
-                        || name == "DEFAULT_PROGRESS_MODE"
-                })
+                .filter(|(name, _value)| name.starts_with("MZ_"))
                 .map(|(name, value)| format!("{}={}", escape(&name), escape(&value)))
                 .chain(args.into_iter().map(|arg| escape(&arg).into_owned()))
                 .join(" ")
@@ -426,6 +441,15 @@ swap: {swap_total}KB total, {swap_used}KB used",
     );
 
     sys::adjust_rlimits();
+
+    // Build Timely worker configuration.
+    let mut timely_worker = timely::WorkerConfig::default().progress_mode(timely_progress_mode);
+    differential_dataflow::configure(
+        &mut timely_worker,
+        &differential_dataflow::Config {
+            idle_merge_effort: differential_idle_merge_effort,
+        },
+    );
 
     // Start Tokio runtime.
     let runtime = Arc::new(
@@ -446,6 +470,7 @@ swap: {swap_total}KB total, {swap_used}KB used",
             threads,
             process,
             addresses,
+            timely_worker,
             logging,
             logical_compaction_window,
             timestamp_frequency,
@@ -496,6 +521,23 @@ For more details, see https://materialize.com/docs/cli#experimental-mode
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 "
         );
+    }
+
+    for (key, _val) in env::vars() {
+        // TODO(benesch): remove these hints about deprecated environment
+        // variables once a sufficient amount of time has passed, say, March
+        // 2021.
+        match key.as_str() {
+            "DIFFERENTIAL_EAGER_MERGE" => warn!(
+                "Materialize no longer respects the DIFFERENTIAL_EAGER_MERGE environment variable \
+                 (hint: use the --differential-idle-merge-effort command-line option instead)",
+            ),
+            "DEFAULT_PROGRESS_MODE" => warn!(
+                "Materialize no longer respects the DEFAULT_PROGRESS_MODE environment variable \
+                 (hint: use the --timely-progress-mode command-line option instead)",
+            ),
+            _ => (),
+        }
     }
 
     println!(

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -90,6 +90,8 @@ pub struct Config {
     /// The addresses of each process in the cluster, including this node,
     /// in order of process ID.
     pub addresses: Vec<SocketAddr>,
+    /// The Timely worker configuration.
+    pub timely_worker: timely::WorkerConfig,
 
     // === Performance tuning options. ===
     pub logging: Option<LoggingConfig>,
@@ -260,9 +262,12 @@ pub async fn serve(
 
     // Launch dataflow workers.
     let dataflow_guard = dataflow::serve(
+        dataflow::Config {
+            threads: config.threads,
+            process: config.process,
+            timely_worker: config.timely_worker,
+        },
         dataflow_conns,
-        config.threads,
-        config.process,
         switchboard.clone(),
     )
     .map_err(|s| anyhow!("{}", s))?;

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -106,6 +106,7 @@ pub fn start_server(config: Config) -> Result<(Server, postgres::Client), Box<dy
             threads: config.threads,
             process: 0,
             addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],
+            timely_worker: timely::WorkerConfig::default(),
             data_directory,
             symbiosis_url: None,
             listen_addr: None,

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.0"
 sql = { path = "../sql" }
 structopt = "0.3.21"
 tempfile = "3.1.0"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.0.0"
 tokio-postgres = { version = "0.7.0", features = ["with-chrono-0_4", "with-uuid-0_8", "with-serde_json-1"] }
 uuid = "0.8.2"

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -507,6 +507,7 @@ impl Runner {
             threads: config.workers,
             process: 0,
             addresses: vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)],
+            timely_worker: timely::WorkerConfig::default(),
             data_directory: temp_dir.path().to_path_buf(),
             symbiosis_url: Some("postgres://".into()),
             listen_addr: None,

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -19,10 +19,9 @@ services:
     ports:
      - *materialized
     init: true
-    command: --workers ${MZ_THREADS:-1} --disable-telemetry
+    command: --workers ${MZ_THREADS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
-      - DIFFERENTIAL_EAGER_MERGE=1000
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3
     environment:

--- a/test/smith/mzcompose.yml
+++ b/test/smith/mzcompose.yml
@@ -14,10 +14,9 @@ services:
     ports:
      - 6875
     init: true
-    command: --workers 1 --disable-telemetry
+    command: --workers 1 --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
-      - DIFFERENTIAL_EAGER_MERGE=1000
   smith-fuzz:
     mzbuild: smith-fuzz
     environment:


### PR DESCRIPTION
This is a proof-of-concept for the strictest possible solution to #1223. The idea is to force users to use Materialize lingo ("dataflow" rather than "timely" or "differential", mostly) when tuning parameters by making all parameters command-line flags and ignoring the old environment variables. If we preferred, we could instead continue to permit the environment variables but override them in the presence of the command-line flags.

(Though I do have a weak preference for the stricter approach presented here, since I think `DEFAULT_PROGRESS_MODE` is too generic to clearly apply to materialized, and environment variables that mention `TIMELY` or `DIFFERENTIAL` are too specific for most users to know what they mean.)

----

Ban using any environment variables that influence the state of the
underlying Timely/Differential engine. Then reintroduce control of the
blessed environment variables via command-line flags that follow the
Materialize naming convention.

The new command-line flags do not make reference "Timely" or
"Differential", since those are not terms our average user is going to
be familiar with.

Fix #1221.
Fix #5055.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5058)
<!-- Reviewable:end -->
