### PR TITLE
doc,test: clearly document/test support for krb5 sinks

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -62,12 +62,27 @@ Field | Value | Description
 `ssl_key_password` | `text` | Your SSL key's password, if any.
 `ssl_ca_location` | `text` | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
 
-### AS OF
+#### Kerberos `WITH` options
+
+Use the following options to connect Materialize to a Kerberized Kafka
+cluster.
+
+Field | Value | Description
+------|-------|------------
+`sasl_kerberos_keytab` | `text` | The absolute path to your keytab.
+`sasl_kerberos_kinit_cmd` | `text` | Shell command to refresh or acquire the client's Kerberos ticket.
+`sasl_kerberos_min_time_before_relogin` | `text` | Minimum time in milliseconds between key refresh attempts. Disable automatic key refresh by setting this property to 0.
+`sasl_kerberos_principal` | `text` | Materialize Kerberos principal name. Required for `sasl_plaintext`.
+`sasl_kerberos_service_name` | `text` | Kafka's service name on its host, i.e. the service principal name not including `/hostname@REALM`.
+`sasl_mechanisms` | `text` | The SASL mechanism to use for authentication. Currently, the only supported mechanism is `'GSSAPI'`.
+
+
+### `AS OF`
 
 `AS OF` is the specific point in time to start emitting all events for a given `SINK`. If you don't
 use `AS OF`, Materialize will pick a timestamp itself.
 
-### WITH SNAPSHOT or WITHOUT SNAPSHOT
+### `WITH SNAPSHOT` or `WITHOUT SNAPSHOT`
 
 By default, each `SINK` is created with a `SNAPSHOT` which contains the results of the query at its `AS OF` timestamp.
 Any further updates to these results are produced at the time when they occur. To only see results after the

--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -21,7 +21,7 @@ Field | Value | Description
 
 #### Kerberos `WITH` options
 
-Use the following options to connect Materialize to an Kerberized Kafka
+Use the following options to connect Materialize to a Kerberized Kafka
 cluster. For more detail, see [Kerberized Kafka details](#kerberized-kafka-details).
 
 Field | Value | Description

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -18,7 +18,6 @@ use std::time::{Duration, UNIX_EPOCH};
 use anyhow::{anyhow, bail};
 use aws_arn::{Resource, ARN};
 use itertools::Itertools;
-use kafka_util::{extract_config, generate_ccsr_client_config};
 use regex::Regex;
 use rusoto_core::Region;
 use url::Url;
@@ -608,9 +607,8 @@ fn kafka_sink_builder(
         None
     };
 
-    let config_options = extract_config(&with_options)?;
-
-    let ccsr_config = generate_ccsr_client_config(
+    let config_options = kafka_util::extract_config(&with_options)?;
+    let ccsr_config = kafka_util::generate_ccsr_client_config(
         schema_registry_url.clone(),
         &config_options,
         &ccsr_with_options,

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -58,6 +58,26 @@ services:
         -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
         -Djava.security.krb5.conf=/etc/krb5.conf
 
+  schema-registry:
+    image: confluentinc/cp-schema-registry:latest
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: SASL_PLAINTEXT://kafka:9092
+      SCHEMA_REGISTRY_KAFKASTORE_SASL_KERBEROS_SERVICE_NAME: kafka
+      SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL: SASL_PLAINTEXT
+      KAFKA_OPTS: >-
+        -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
+        -Djava.security.krb5.conf=/etc/krb5.conf
+      SCHEMA_REGISTRY_OPTS: >-
+        -Djava.security.auth.login.config=/etc/kafka/sasl.jaas.config
+        -Djava.security.krb5.conf=/etc/krb5.conf
+    volumes:
+      - secrets:/var/lib/secret
+      - ./kdc/krb5.conf:/etc/krb5.conf
+      - ./sasl.jaas.config:/etc/kafka/sasl.jaas.config
+    depends_on: [kafka, zookeeper, kdc]
+
   materialized:
     mzbuild: materialized
     command: --logging-granularity=10ms -w1
@@ -73,12 +93,14 @@ services:
       - >-
         wait-for-it --timeout=30 materialized:6875 &&
         wait-for-it --timeout=30 kafka:9092 &&
+        wait-for-it --timeout=30 schema-registry:8081 &&
         testdrive
         --kafka-addr=kafka:9092
         --kafka-option=security.protocol=SASL_PLAINTEXT
         --kafka-option=sasl.kerberos.keytab=/share/secrets/testdrive.key
         --kafka-option=sasl.kerberos.service.name=kafka
         --kafka-option=sasl.kerberos.principal=testdrive@CI.MATERIALIZE.IO
+        --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://ignored@materialized:6875
         $$*
       - bash
@@ -89,7 +111,7 @@ services:
       - ./kdc/krb5.conf:/etc/krb5.conf
     propagate-uid-gid: true
     init: true
-    depends_on: [kdc, kafka, zookeeper, materialized]
+    depends_on: [kdc, kafka, zookeeper, materialized, schema-registry]
 
 volumes:
   secrets:

--- a/test/kafka-krb5/smoketest.td
+++ b/test/kafka-krb5/smoketest.td
@@ -31,7 +31,7 @@ $ set schema={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
 {"before": null, "after": {"row": {"a": 102}}}
 {"before": null, "after": {"row": {"a": 201}}}
 
@@ -43,10 +43,26 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     sasl_kerberos_service_name = 'kafka',
     sasl_kerberos_principal = 'materialized@CI.MATERIALIZE.IO'
   )
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM
 
 > CREATE MATERIALIZED VIEW data_view as SELECT * from data
 
 > SELECT * FROM data_view
 102
 201
+
+> CREATE SINK data_snk
+  FROM data_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+    security_protocol = 'sasl_plaintext',
+    sasl_kerberos_keytab = '/share/secrets/materialized.key',
+    sasl_kerberos_service_name = 'kafka',
+    sasl_kerberos_principal = 'materialized@CI.MATERIALIZE.IO'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.data_snk
+{"before": null, "after": {"row": {"a": 102}}}
+{"before": null, "after": {"row": {"a": 201}}}

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -87,7 +87,6 @@ services:
     depends_on: [zookeeper, test-certs]
   schema-registry:
     image: confluentinc/cp-schema-registry:5.5.1
-    ports: [8081:8081]
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -58,3 +58,19 @@ a
 ---
 1
 2
+
+> CREATE SINK data_snk
+  FROM data
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+      security_protocol = 'SASL_SSL',
+      sasl_mechanisms = 'PLAIN',
+      sasl_username = 'materialize',
+      sasl_password = 'sekurity',
+      ssl_ca_location = '/share/secrets/ca.crt'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.data_snk
+{"before": null, "after": {"row": {"a": 1}}}
+{"before": null, "after": {"row": {"a": 2}}}


### PR DESCRIPTION
It turns out we do support these, but it wasn't clearly documented. Make
it a bit clearer in the docs and add proper integration tests for
krb5/sasl_plain sinks.

Also make it a bit clearer in the code by prefixing calls to the
generically named "extract_config" with the module name ("kafka_util"),
as we do elsewhere in the SQL crate and as Rust convention dictates.

Fix #4956.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5060)
<!-- Reviewable:end -->
