### PR TITLE
pgwire: change FETCH with TAIL to wait for rows if there are none

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,15 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.5.5 %}}
+
+- Add `ALL` to [`FETCH`](/sql/fetch).
+
+- Change [`FETCH`](/sql/fetch) with no `TIMEOUT` to wait for some rows
+  to be available.
+
+  **Backwards-incompatible change.**
+
 {{% version-header v0.5.4 %}}
 
 - Add the [`version`](/sql/functions#postgresql-compatibility-func) and

--- a/doc/user/content/sql/fetch.md
+++ b/doc/user/content/sql/fetch.md
@@ -23,4 +23,11 @@ Supported `WITH` option values:
 
 Option name | Value type | Default | Describes
 ------------|------------|---------|----------
-`timeout`   | `interval` | `0s`    | When fetching from a [`TAIL`](/sql/tail) cursor, complete if there are no more rows ready after this timeout. The default `0s` will cause `FETCH` to only return rows that have already been produced since the previous `FETCH`. {{< version-added v0.5.4 >}}
+`timeout`   | `interval` | None    | When fetching from a [`TAIL`](/sql/tail) cursor, complete if there are no more rows ready after this timeout. The default will cause `FETCH` to wait for rows to be available. {{< version-added v0.5.5 >}}
+
+## Details
+
+`FETCH` will return at most the specified _count_ of available rows (or all available rows with `ALL`).
+
+For [`TAIL`](/sql/tail) queries, `FETCH` by default will wait for rows to be available before returning.
+Specify a timeout of `0s` to return only rows that are immediately available.

--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -218,12 +218,28 @@ DECLARE c CURSOR FOR TAIL t;
 Now use [`FETCH`](/sql/fetch) in a loop to retrieve some number of rows within a time window:
 
 ```sql
-FETCH 100 c WITH (timeout = '1s');
+FETCH ALL c;
 ```
 
-That will retrieve up to the next 100 rows that are ready in at most `1s`.
-The timeout is only used when there are not any rows ready and a wait must occur.
-If `timeout` is not specified it defaults to `0s` which means it will only return rows that are immediately available and will never wait for more to come before completing.
+That will retrieve all of the rows that are currently available.
+If there are no rows available, it will wait until there are some ready and return those.
+A `timeout` can be used to specify a window in which to wait for rows. This will return up to the specified count (or `ALL`) of rows that are ready within the timeout. To retrieve up to 100 rows that are available in at most the next `1s`:
+
+```sql
+FETCH 100 c WITH (timeout='1s');
+```
+
+To retrieve all available rows available over the next `1s`:
+
+```sql
+FETCH ALL c WITH (timeout='1s');
+```
+
+A `0s` timeout can be used to return rows that are available now without waiting:
+
+```sql
+FETCH ALL c WITH (timeout='0s');
+```
 
 #### `FETCH` with Python and psycopg2
 
@@ -239,7 +255,7 @@ conn = psycopg2.connect(dsn)
 with conn.cursor() as cur:
     cur.execute("DECLARE c CURSOR FOR TAIL v")
     while True:
-        cur.execute("FETCH 100 c WITH (TIMEOUT = '1s')")
+        cur.execute("FETCH ALL c")
         for row in cur:
             print(row)
     cur.execute("CLOSE c")

--- a/doc/user/layouts/partials/sql-grammar/fetch.svg
+++ b/doc/user/layouts/partials/sql-grammar/fetch.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="641" height="293">
+<svg xmlns="http://www.w3.org/2000/svg" width="641" height="337">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="66" height="32" rx="10"/>
@@ -17,9 +17,17 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="147" y="53">FORWARD</text>
-   <rect x="289" y="35" width="54" height="32"/>
-   <rect x="287" y="33" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="297" y="53">count</text>
+   <rect x="289" y="35" width="44" height="32" rx="10"/>
+   <rect x="287"
+         y="33"
+         width="44"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="297" y="53">ALL</text>
+   <rect x="289" y="79" width="54" height="32"/>
+   <rect x="287" y="77" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="297" y="97">count</text>
    <rect x="403" y="35" width="60" height="32" rx="10"/>
    <rect x="401"
          y="33"
@@ -28,57 +36,57 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="411" y="53">FROM</text>
-   <rect x="273" y="101" width="100" height="32"/>
-   <rect x="271" y="99" width="100" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="281" y="119">cursor_name</text>
-   <rect x="65" y="243" width="56" height="32" rx="10"/>
+   <rect x="273" y="145" width="100" height="32"/>
+   <rect x="271" y="143" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="281" y="163">cursor_name</text>
+   <rect x="65" y="287" width="56" height="32" rx="10"/>
    <rect x="63"
-         y="241"
+         y="285"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="261">WITH</text>
-   <rect x="161" y="211" width="24" height="32" rx="10"/>
+   <text class="terminal" x="73" y="305">WITH</text>
+   <rect x="161" y="255" width="24" height="32" rx="10"/>
    <rect x="159"
-         y="209"
+         y="253"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="169" y="229">(</text>
-   <rect x="225" y="211" width="100" height="32"/>
-   <rect x="223" y="209" width="100" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="233" y="229">option_name</text>
-   <rect x="365" y="243" width="26" height="32" rx="10"/>
+   <text class="terminal" x="169" y="273">(</text>
+   <rect x="225" y="255" width="100" height="32"/>
+   <rect x="223" y="253" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="233" y="273">option_name</text>
+   <rect x="365" y="287" width="26" height="32" rx="10"/>
    <rect x="363"
-         y="241"
+         y="285"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="373" y="261">=</text>
-   <rect x="411" y="243" width="98" height="32"/>
-   <rect x="409" y="241" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="419" y="261">option_value</text>
-   <rect x="225" y="167" width="24" height="32" rx="10"/>
+   <text class="terminal" x="373" y="305">=</text>
+   <rect x="411" y="287" width="98" height="32"/>
+   <rect x="409" y="285" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="419" y="305">option_value</text>
+   <rect x="225" y="211" width="24" height="32" rx="10"/>
    <rect x="223"
-         y="165"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="233" y="185">,</text>
-   <rect x="569" y="211" width="24" height="32" rx="10"/>
-   <rect x="567"
          y="209"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="577" y="229">)</text>
+   <text class="terminal" x="233" y="229">,</text>
+   <rect x="569" y="255" width="24" height="32" rx="10"/>
+   <rect x="567"
+         y="253"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="577" y="273">)</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m40 -32 h10 m0 0 h70 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v12 m100 0 v-12 m-100 12 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m60 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-254 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m100 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m24 0 h10 m20 0 h10 m100 0 h10 m20 0 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h10 m98 0 h10 m-324 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m324 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-324 0 h10 m24 0 h10 m0 0 h280 m20 44 h10 m24 0 h10 m-588 0 h20 m568 0 h20 m-608 0 q10 0 10 10 m588 0 q0 -10 10 -10 m-598 10 v46 m588 0 v-46 m-588 46 q0 10 10 10 m568 0 q10 0 10 -10 m-578 10 h10 m0 0 h558 m23 -66 h-3"/>
-   <polygon points="631 225 639 221 639 229"/>
-   <polygon points="631 225 623 221 623 229"/>
+         d="m19 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m44 0 h10 m0 0 h10 m-84 -10 v20 m94 0 v-20 m-94 20 v24 m94 0 v-24 m-94 24 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m40 -76 h10 m0 0 h70 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v12 m100 0 v-12 m-100 12 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m60 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-254 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m100 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-392 110 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h66 m-96 0 h20 m76 0 h20 m-116 0 q10 0 10 10 m96 0 q0 -10 10 -10 m-106 10 v12 m96 0 v-12 m-96 12 q0 10 10 10 m76 0 q10 0 10 -10 m-86 10 h10 m56 0 h10 m20 -32 h10 m24 0 h10 m20 0 h10 m100 0 h10 m20 0 h10 m0 0 h154 m-184 0 h20 m164 0 h20 m-204 0 q10 0 10 10 m184 0 q0 -10 10 -10 m-194 10 v12 m184 0 v-12 m-184 12 q0 10 10 10 m164 0 q10 0 10 -10 m-174 10 h10 m26 0 h10 m0 0 h10 m98 0 h10 m-324 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m324 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-324 0 h10 m24 0 h10 m0 0 h280 m20 44 h10 m24 0 h10 m-588 0 h20 m568 0 h20 m-608 0 q10 0 10 10 m588 0 q0 -10 10 -10 m-598 10 v46 m588 0 v-46 m-588 46 q0 10 10 10 m568 0 q10 0 10 -10 m-578 10 h10 m0 0 h558 m23 -66 h-3"/>
+   <polygon points="631 269 639 265 639 273"/>
+   <polygon points="631 269 623 265 623 273"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -165,7 +165,7 @@ explain ::=
     'VIEW' view_name
   )
 fetch ::=
-  'FETCH' 'FORWARD'? count? 'FROM'? cursor_name
+  'FETCH' 'FORWARD'? ('ALL' | count)? 'FROM'? cursor_name
   ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
 format_spec_avro_kafka ::=
     ('AVRO' 'USING' (

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1407,14 +1407,14 @@ impl_display!(CloseStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FetchStatement {
     pub name: Ident,
-    pub count: Option<u64>,
+    pub count: Option<FetchDirection>,
     pub options: Vec<WithOption>,
 }
 
 impl AstDisplay for FetchStatement {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_str("FETCH ");
-        if let Some(count) = self.count {
+        if let Some(ref count) = self.count {
             f.write_str(format!("{} ", count));
         }
         f.write_node(&self.name);
@@ -1426,3 +1426,19 @@ impl AstDisplay for FetchStatement {
     }
 }
 impl_display!(FetchStatement);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FetchDirection {
+    ForwardAll,
+    ForwardCount(u64),
+}
+
+impl AstDisplay for FetchDirection {
+    fn fmt(&self, f: &mut AstFormatter) {
+        match self {
+            FetchDirection::ForwardAll => f.write_str("ALL"),
+            FetchDirection::ForwardCount(count) => f.write_str(format!("{}", count)),
+        }
+    }
+}
+impl_display!(FetchDirection);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3403,7 +3403,13 @@ impl<'a> Parser<'a> {
     /// has already been consumed.
     fn parse_fetch(&mut self) -> Result<Statement, ParserError> {
         let _ = self.parse_keyword(FORWARD);
-        let count = self.maybe_parse(Parser::parse_literal_uint);
+        let count = if let Some(count) = self.maybe_parse(Parser::parse_literal_uint) {
+            Some(FetchDirection::ForwardCount(count))
+        } else if self.parse_keyword(ALL) {
+            Some(FetchDirection::ForwardAll)
+        } else {
+            None
+        };
         let _ = self.parse_keyword(FROM);
         let name = self.parse_identifier()?;
         let options = self.parse_opt_with_options()?;

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -39,7 +39,7 @@ FETCH FORWARD 2000 FROM c
 ----
 FETCH 2000 c
 =>
-Fetch(FetchStatement { name: Ident("c"), count: Some(2000), options: [] })
+Fetch(FetchStatement { name: Ident("c"), count: Some(ForwardCount(2000)), options: [] })
 
 parse-statement
 FETCH c
@@ -68,3 +68,11 @@ FETCH FROM c WITH (TIMEOUT = '5s')
 FETCH c WITH (timeout = '5s')
 =>
 Fetch(FetchStatement { name: Ident("c"), count: None, options: [WithOption { key: Ident("timeout"), value: Some(Value(String("5s"))) }] })
+
+
+parse-statement
+FETCH ALL c
+----
+FETCH ALL c
+=>
+Fetch(FetchStatement { name: Ident("c"), count: Some(ForwardAll), options: [] })

--- a/test/sqllogictest/cursor.slt
+++ b/test/sqllogictest/cursor.slt
@@ -47,7 +47,7 @@ statement ok
 DECLARE c CURSOR FOR TAIL v
 
 query IITT
-FETCH c WITH (TIMEOUT = '10s')
+FETCH c
 ----
 0  1  a  b
 
@@ -58,12 +58,12 @@ FETCH 2 c WITH (TIMEOUT = '10s')
 0  1  e  f
 
 query IITT
-FETCH 2 c WITH (TIMEOUT = '1')
+FETCH 2 c WITH (TIMEOUT = '1s')
 ----
 0  1  g  h
 
 query IITT
-FETCH c WITH (TIMEOUT = '1')
+FETCH c WITH (TIMEOUT = '1s')
 ----
 
 # Test some FETCH timeout errors. The actual timeout functionality is


### PR DESCRIPTION
Previously FETCH with TAIL would return immediately if there were no
rows available. While useful, this is generally not what users need.
Change FETCH to default to waiting for some rows to be available and
return those. This allows users to call FETCH in a loop without
worrying about backoffs or timeouts and always get available rows as
soon as possible.

Add an ALL option to FETCH to return ALL available rows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5070)
<!-- Reviewable:end -->
