### PR TITLE
parser: type name resolution preamble

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -55,6 +55,19 @@ Wrap your release notes at the 80 character mark.
 
   **Backwards-incompatible change.**
 
+- Consider the following keywords to be fully reserved: `WITH`, `SELECT`,
+  `WHERE`, `GROUP`, `HAVING`, `ORDER`, `LIMIT`, `OFFSET`, `FETCH`, `OPTION`,
+  `UNION`, `EXCEPT`, `INTERSECT`. Previously only the `FROM` keyword was
+  considered fully reserved.
+
+  These keywords can no longer be used as bare identifiers anywhere in a SQL
+  statement, except following an `AS` keyword in a table or column alias. They
+  can continue to be used as identifiers if escaped. See the
+  [Keyword collision](/sql/identifiers#keyword-collision) documentation for
+  details.
+
+  **Backwards-incompatible change.**
+
 {{% version-header v0.5.4 %}}
 
 - Add the [`version`](/sql/functions#postgresql-compatibility-func) and

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -44,7 +44,10 @@ impl Ident {
             .map(|ch| (ch >= 'a' && ch <= 'z') || (ch == '_'))
             .unwrap_or(false)
             && chars.all(|ch| (ch >= 'a' && ch <= 'z') || (ch == '_') || (ch >= '0' && ch <= '9'))
-            && !self.as_keyword().map(Keyword::is_reserved).unwrap_or(false)
+            && !self
+                .as_keyword()
+                .map(Keyword::is_sometimes_reserved)
+                .unwrap_or(false)
     }
 
     pub fn as_str(&self) -> &str {

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -188,7 +188,10 @@ pub enum DataType {
     /// List
     List(Box<DataType>),
     /// Map
-    Map { value_type: Box<DataType> },
+    Map {
+        key_type: Box<DataType>,
+        value_type: Box<DataType>,
+    },
     /// Types whose names don't accept parameters, e.g. INT
     Other(Ident),
     /// Variable-length character type e.g. VARCHAR(10)
@@ -219,8 +222,13 @@ impl AstDisplay for DataType {
                 f.write_node(&ty);
                 f.write_str(" list");
             }
-            DataType::Map { value_type } => {
-                f.write_str("map(text=>");
+            DataType::Map {
+                key_type,
+                value_type,
+            } => {
+                f.write_str("map(");
+                f.write_node(&key_type);
+                f.write_str("=>");
                 f.write_node(&value_type);
                 f.write_str(")");
             }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -320,7 +320,7 @@ impl<'a> Parser<'a> {
             }),
             Token::Keyword(ROW) => self.parse_row_expr(),
             Token::Keyword(TRIM) => self.parse_trim_expr(),
-            Token::Keyword(kw) if kw.is_reserved_in_expr() => {
+            Token::Keyword(kw) if kw.is_reserved() => {
                 return Err(self.error(
                     self.peek_prev_pos(),
                     "expected expression, but found reserved keyword".into(),
@@ -2724,7 +2724,7 @@ impl<'a> Parser<'a> {
         let projection = match self.peek_token() {
             // An empty target list is permissible to match PostgreSQL, which
             // permits these for symmetry with zero column tables.
-            Some(Token::Keyword(kw)) if kw.is_reserved_in_column_alias() => vec![],
+            Some(Token::Keyword(kw)) if kw.is_reserved() => vec![],
             Some(Token::Semicolon) | None => vec![],
             _ => self.parse_comma_separated(Parser::parse_select_item)?,
         };

--- a/src/sql-parser/tests/testdata/alias
+++ b/src/sql-parser/tests/testdata/alias
@@ -1,0 +1,70 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parse-statement
+SELECT 'x' AS val
+----
+SELECT 'x' AS val
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(String("x")), alias: Some(Ident("val")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT 'x' val
+----
+SELECT 'x' AS val
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(String("x")), alias: Some(Ident("val")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT 'x' year
+----
+error: Expected end of statement, found YEAR
+SELECT 'x' year
+           ^
+
+parse-statement
+SELECT 'x' AS year
+----
+SELECT 'x' AS "year"
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(String("x")), alias: Some(Ident("year")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT 'x' "year"
+----
+SELECT 'x' AS "year"
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(String("x")), alias: Some(Ident("year")) }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT INTERVAL 'x' YEAR
+----
+SELECT INTERVAL 'x' YEAR
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Interval(IntervalValue { value: "x", precision_high: Year, precision_low: Year, fsec_max_precision: None })), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT year
+----
+SELECT "year"
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("year")]), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+SELECT year FROM year
+----
+SELECT "year" FROM "year"
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("year")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("year")]), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -91,9 +91,9 @@ SELECT 1 WHERE 1 < ANY SELECT 2
 parse-statement
 SELECT 1 WHERE 1 < NONE (SELECT 2)
 ----
-error: Expected right parenthesis, found number
+error: expected expression, but found reserved keyword
 SELECT 1 WHERE 1 < NONE (SELECT 2)
-                                ^
+                         ^
 
 parse-statement
 SELECT 1 WHERE 1 < ANY (SELECT 2

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -43,7 +43,7 @@ SELECT ('{  c  =>3, a=>     2, a => 1 }'::map[text=>int])::text
 ----
 {a=>1,c=>3}
 
-query error Expected TEXT, found INT
+query error map key type must be text, got i32
 SELECT '{1=>true}'::map[int=>bool]
 
 query T
@@ -120,7 +120,7 @@ SELECT ('{hello=>{world=>nested}}'::map[text=>map[text=>text]])::text
 ----
 {hello=>{world=>nested}}
 
-query error expected TEXT, found INT
+query error map key type must be text, got i32
 SELECT '{hello=>{1=>false}}'::map[text=>map[int=>bool]]
 
 query T


### PR DESCRIPTION
To support resolving types as catalog objects, we need to shift a few things in the parser, namely moving map key checks out, and disallowing timelike keywords as column aliases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5078)
<!-- Reviewable:end -->
