### PR TITLE
Extend monotonicity analysis

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -848,6 +848,24 @@ impl TableFunc {
             | TableFunc::UnnestList { .. } => true,
         }
     }
+
+    /// True iff the table function preserves the append-only property of its input.
+    pub fn preserves_monotonicity(&self) -> bool {
+        // Most variants preserve monotonicity, but all variants are enumerated to
+        // ensure that added variants at least check that this is the case.
+        match self {
+            TableFunc::JsonbEach { .. } => true,
+            TableFunc::JsonbObjectKeys => true,
+            TableFunc::JsonbArrayElements { .. } => true,
+            TableFunc::RegexpExtract(_) => true,
+            TableFunc::CsvExtract(_) => true,
+            TableFunc::GenerateSeriesInt32 => true,
+            TableFunc::GenerateSeriesInt64 => true,
+            TableFunc::Repeat => false,
+            TableFunc::ReadCachedData { .. } => true,
+            TableFunc::UnnestList { .. } => true,
+        }
+    }
 }
 
 impl fmt::Display for TableFunc {


### PR DESCRIPTION
The PR extends monotonicity analysis within views to all methods other than `Negate` (nope) and `Let` (too annoying at the moment). This includes `FlatMap` (when not the `Repeat` TVF), `Join` (when all inputs are monotonic) and `Reduce` (when there are no aggregates). Some other cases like `Constant` and `Threshold` filled in as well.

This is a render-time change, so we'll need to rely on tests and inspection to see if we've botched anything. 

Related to issue #5013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5085)
<!-- Reviewable:end -->
