### PR TITLE
Remove warning about invalid timestamps

### DIFF
--- a/doc/user/content/ops/deployment.md
+++ b/doc/user/content/ops/deployment.md
@@ -50,12 +50,6 @@ detail, but requires more memory. A smaller compaction window uses less memory
 but also retains less historical detail. Larger compaction windows also increase
 CPU usage, as more detailed histories require more compute time to maintain.
 
-{{< warning >}}
-Setting the compaction window too small can prevent Materialize from finding a
-suitable timestamp at which to execute a `SELECT` query if that query depends
-upon multiple sources.
-{{< /warning >}}
-
 Note that compaction is triggered in response to updates arriving. As a result,
 if updates stop arriving for a source, Materialize may never compact the source
 fully. This can result in higher-than-expected memory usage.


### PR DESCRIPTION
As of https://github.com/MaterializeInc/materialize/pull/4467 we no longer error on invalid timestamps unless a user explicitly asks for a timestamp we do not have. This warning is from the days when we would try to find a time that was both valid and ready for all inputs, and error out if we could not. Now we always choose a valid time and attempt to find one that is ready, blocking the query if that cannot be found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5087)
<!-- Reviewable:end -->
