### PR TITLE
mzcompose: Don't send stderr to stdout if capture is true

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -193,7 +193,7 @@ class Composition:
             close_fds=False,
             check=check,
             stdout=subprocess.PIPE if capture else 1,
-            stderr=subprocess.STDOUT if capture else 2,
+            stderr=subprocess.PIPE if capture else 1,
         )
 
     def find_host_ports(self, service: str) -> List[str]:


### PR DESCRIPTION
The CompletedProcess object returned by Composition.run has both a stdout and a
stderr stream, using `PIPE` twice keeps them separate, using `STDOUT` causes
stderr to go to the same PIPE, meaning error messages get interwoven with the
intended results of the function call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5098)
<!-- Reviewable:end -->
