### PR TITLE
mkrelease: Try harder to update Cargo.lock

### DIFF
--- a/misc/python/materialize/cli/mkrelease.py
+++ b/misc/python/materialize/cli/mkrelease.py
@@ -81,12 +81,11 @@ def main(version: str, checkout: Optional[str], create_branch: str, tag: bool) -
     say("Updating Cargo.lock")
     spawn.runv(["cargo", "check", "-p", "materialized"])
     spawn.runv(["cargo", "check", "-p", "materialized"])
+    spawn.runv(["cargo", "check", "-p", "materialized", "--locked"])
     if tag:
-        spawn.runv(["cargo", "check", "-p", "materialized", "--locked"])
         git.commit_all_changed(f"release: {the_tag}")
         git.tag_annotated(the_tag)
     else:
-        spawn.runv(["cargo", "check", "-p", "materialized", "--locked"])
         git.commit_all_changed(f"Prepare next phase of development: {the_tag}")
 
     matching = git.first_remote_matching("MaterializeInc/materialize")


### PR DESCRIPTION
For some reason, during the 0.6.0 release, running cargo check once *reliably*
didn't update the Cargo.lock, but running it twice always does do it.

With this we just run cargo check twice, and then assert that the lockfile has
been updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5100)
<!-- Reviewable:end -->
