### PR TITLE
sql: fix planning of CTEs in views

### DIFF
--- a/test/sqllogictest/cte.slt
+++ b/test/sqllogictest/cte.slt
@@ -104,6 +104,25 @@ WHERE x IN (
 ----
 1 1
 
+# Same query, but inside a view. Regression test for #5092.
+statement ok
+CREATE MATERIALIZED VIEW v AS
+SELECT * FROM squares
+WHERE x IN (
+    WITH squares_y AS (
+        SELECT squares.y
+    )
+    SELECT y FROM roots
+    WHERE y IN (
+        SELECT y FROM squares_y
+    )
+);
+
+query II
+SELECT * FROM v
+----
+1 1
+
 # Correlated CTE in different level than it was introduced. This is needlessly
 # convoluted but caused crashes in early iterations of CTE's development.
 query II


### PR DESCRIPTION
The CREATE statement normalizer needed to be taught to handle CTE
references.

Fix #5092.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5111)
<!-- Reviewable:end -->
