### PR TITLE
ore: remove invalid i32 -> usize CastFrom impl

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -134,7 +134,7 @@ impl Connection {
 
         // Run unapplied migrations. The `user_version` field stores the index
         // of the last migration that was run.
-        let version: i32 = sqlite.query_row("PRAGMA user_version", params![], |row| row.get(0))?;
+        let version: u32 = sqlite.query_row("PRAGMA user_version", params![], |row| row.get(0))?;
         for (i, sql) in MIGRATIONS
             .iter()
             .enumerate()

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -42,12 +42,12 @@ macro_rules! cast_from {
 cast_from!(u32, usize);
 
 #[cfg(target_pointer_width = "64")]
-cast_from!(i32, usize);
-
-#[cfg(target_pointer_width = "64")]
 cast_from!(u64, usize);
 
 cast_from!(usize, u64);
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+cast_from!(i32, isize);
 
 #[cfg(target_pointer_width = "64")]
 cast_from!(i64, isize);

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -95,7 +95,7 @@ pub struct State {
     kafka_admin_opts: rdkafka::admin::AdminOptions,
     kafka_config: ClientConfig,
     kafka_producer: rdkafka::producer::FutureProducer<rdkafka::client::DefaultClientContext>,
-    kafka_topics: HashMap<String, i32>,
+    kafka_topics: HashMap<String, usize>,
     aws_region: rusoto_core::Region,
     aws_account: String,
     aws_credentials: AwsCredentials,


### PR DESCRIPTION
This simply was not a valid CastFrom implementation. It is not in
general possible to cast an i32 to a usize losslessly, because the i32
might be negative.

This code also fixes up a number of places where we were relying on this
incorrect cast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5125)
<!-- Reviewable:end -->
