### PR TITLE
Fix usage of reserved keyword in wait_for_view_states

### DIFF
--- a/misc/mzutil/scripts/wait_for_view_states.py
+++ b/misc/mzutil/scripts/wait_for_view_states.py
@@ -60,7 +60,7 @@ def source_at_offset(
 ) -> typing.Union[None, int]:
     """Return the mz timestamp from a source if it has reached the desired offset."""
     query = (
-        "SELECT timestamp FROM mz_source_info WHERE source_name = %s and offset = %s"
+        'SELECT timestamp FROM mz_source_info WHERE source_name = %s and "offset" = %s'
     )
     try:
         cursor.execute(query, (source_name, desired_offset))


### PR DESCRIPTION
OFFSET was added as a reserved keyword in f3332d0a6, causing this query
to break. Wrap the column name in double-quotes to fix this query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5128)
<!-- Reviewable:end -->
