### PR TITLE
deps: upgrade to Materialize fork of Rusoto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,12 +76,6 @@ name = "arc-swap"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
@@ -193,10 +196,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_kinesis",
- "rusoto_sts",
+ "mz_rusoto_core",
+ "mz_rusoto_credential",
+ "mz_rusoto_kinesis",
+ "mz_rusoto_sts",
  "tokio",
 ]
 
@@ -222,9 +225,9 @@ checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "billing-demo"
@@ -279,17 +282,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -411,7 +403,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
  "winapi 0.3.8",
 ]
 
@@ -421,22 +412,13 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -488,12 +470,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "coord"
 version = "0.1.0"
 dependencies = [
@@ -517,6 +493,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mz-avro",
+ "mz_rusoto_kinesis",
  "ore",
  "pgrepr",
  "postgres-types",
@@ -525,7 +502,6 @@ dependencies = [
  "rdkafka",
  "regex",
  "repr",
- "rusoto_kinesis",
  "rusqlite",
  "serde",
  "serde_json",
@@ -558,11 +534,11 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad49cad3673b9d586bc50cd92fdc0e9205ecd162d4206073d9774c4fe13a8fde"
+checksum = "44919ecaf6f99e8e737bc239408931c9a01e9a6c74814fee8242dd2506b65390"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "glob",
 ]
 
@@ -583,11 +559,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -664,12 +640,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -685,9 +662,19 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array",
  "subtle",
@@ -747,6 +734,9 @@ dependencies = [
  "lazy_static",
  "log",
  "mz-avro",
+ "mz_rusoto_core",
+ "mz_rusoto_credential",
+ "mz_rusoto_kinesis",
  "notify",
  "ore",
  "pdqselect",
@@ -756,9 +746,6 @@ dependencies = [
  "rdkafka",
  "regex",
  "repr",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_kinesis",
  "serde",
  "serde_json",
  "timely",
@@ -787,9 +774,9 @@ dependencies = [
  "interchange",
  "kafka-util",
  "log",
+ "mz_rusoto_core",
  "regex",
  "repr",
- "rusoto_core",
  "serde",
  "serde_json",
  "serde_regex",
@@ -848,22 +835,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "2.0.2"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 0.1.10",
- "dirs-sys",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.4"
+name = "dirs-sys-next"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
 dependencies = [
- "cfg-if 0.1.10",
  "libc",
  "redox_users",
  "winapi 0.3.8",
@@ -985,11 +971,11 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.17"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
+checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1046,7 +1032,7 @@ dependencies = [
  "csv",
  "encoding",
  "enum-iterator",
- "hmac",
+ "hmac 0.10.1",
  "itertools",
  "md-5",
  "num_enum",
@@ -1099,11 +1085,11 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "filetime"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e"
+checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
@@ -1326,6 +1312,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version 0.2.3",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,11 +1452,21 @@ checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hmac"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
+checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.9.1",
+ "digest",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.0",
  "digest",
 ]
 
@@ -1719,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.36"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb931d43e71f560c81badb0191596562bafad2be06a3f9025b845c847c60df5"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1856,6 +1865,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,7 +1943,7 @@ dependencies = [
  "repr",
  "reqwest",
  "rlimit",
- "semver",
+ "semver 0.11.0",
  "serde",
  "serde_json",
  "sha2",
@@ -2001,11 +2023,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "rustc_version",
+ "autocfg",
 ]
 
 [[package]]
@@ -2166,6 +2188,109 @@ dependencies = [
  "libc",
  "procfs",
  "prometheus",
+]
+
+[[package]]
+name = "mz_rusoto_core"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e397addcc51086617955d32850793c4eedfb2e99914afcdb5d8593b31629e37a"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "crc32fast",
+ "futures",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "lazy_static",
+ "log",
+ "md5",
+ "mz_rusoto_credential",
+ "mz_rusoto_signature",
+ "percent-encoding",
+ "pin-project 1.0.1",
+ "rustc_version 0.3.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "xml-rs",
+]
+
+[[package]]
+name = "mz_rusoto_credential"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9c8fcd616caff965a372cfedb788baa4b0d9a58ead207209f931d9662cc98"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs-next",
+ "futures",
+ "hyper",
+ "pin-project 1.0.1",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tokio",
+ "zeroize",
+]
+
+[[package]]
+name = "mz_rusoto_kinesis"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc7ae9f73515f42a99840b1db7baded2f6667cb5c557c3d54c0ba9ccf12cdb7"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "mz_rusoto_core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "mz_rusoto_signature"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d119214909f946202ad204b6300d11cca9aacd595ed2e77198bee23f9e110c9"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "hex",
+ "hmac 0.10.1",
+ "http",
+ "hyper",
+ "log",
+ "md5",
+ "mz_rusoto_credential",
+ "percent-encoding",
+ "pin-project 1.0.1",
+ "rustc_version 0.3.0",
+ "serde",
+ "sha2",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "mz_rusoto_sts"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39826845b84541f4c55311c9d9ca57c860c66a312810e8ad8a86b52b5fbca669"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "mz_rusoto_core",
+ "serde_urlencoded 0.6.1",
+ "tempfile",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2493,12 +2618,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -2581,11 +2705,11 @@ dependencies = [
  "futures",
  "futures-channel",
  "log",
+ "mz_rusoto_core",
+ "mz_rusoto_credential",
+ "mz_rusoto_kinesis",
  "ore",
  "rand 0.8.0",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_kinesis",
  "structopt",
  "test-util",
  "tokio",
@@ -2611,6 +2735,15 @@ dependencies = [
  "test-util",
  "tokio",
  "tokio-postgres",
+]
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
 ]
 
 [[package]]
@@ -2758,6 +2891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,15 +2950,15 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c5b25980f9a9b5ad36e9cdc855530575396d8a57f67e14691a2440ed0d9a90"
+checksum = "4888a0e36637ab38d76cace88c1476937d617ad015f07f6b669cec11beacc019"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "fallible-iterator",
- "hmac",
+ "hmac 0.9.0",
  "md5",
  "memchr",
  "rand 0.7.3",
@@ -2968,7 +3107,6 @@ checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
 dependencies = [
  "bitflags",
  "byteorder",
- "chrono",
  "flate2",
  "hex",
  "lazy_static",
@@ -3246,7 +3384,6 @@ checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
  "getrandom 0.1.14",
  "redox_syscall",
- "rust-argon2",
 ]
 
 [[package]]
@@ -3310,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
  "base64",
  "bytes",
@@ -3331,10 +3468,10 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.7.0",
  "tokio",
  "tokio-tls",
  "url",
@@ -3354,109 +3491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusoto_core"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e977941ee0658df96fca7291ecc6fc9a754600b21ad84b959eb1dbbc9d5abcc7"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "crc32fast",
- "futures",
- "http",
- "hyper",
- "hyper-tls",
- "lazy_static",
- "log",
- "md5",
- "percent-encoding",
- "pin-project 0.4.22",
- "rusoto_credential",
- "rusoto_signature",
- "rustc_version",
- "serde",
- "serde_json",
- "tokio",
- "xml-rs",
-]
-
-[[package]]
-name = "rusoto_credential"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac05563f83489b19b4d413607a30821ab08bbd9007d14fa05618da3ef09d8b"
-dependencies = [
- "async-trait",
- "chrono",
- "dirs",
- "futures",
- "hyper",
- "pin-project 0.4.22",
- "regex",
- "serde",
- "serde_json",
- "shlex",
- "tokio",
- "zeroize",
-]
-
-[[package]]
-name = "rusoto_kinesis"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8a3baabc67851ca472d25c9fe848b229969a1412cbc50ad00ce3af00e9aeae"
-dependencies = [
- "async-trait",
- "bytes",
- "futures",
- "rusoto_core",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rusoto_signature"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a740a88dde8ded81b6f2cff9cd5e054a5a2e38a38397260f7acdd2c85d17dd"
-dependencies = [
- "base64",
- "bytes",
- "futures",
- "hex",
- "hmac",
- "http",
- "hyper",
- "log",
- "md5",
- "percent-encoding",
- "pin-project 0.4.22",
- "rusoto_credential",
- "rustc_version",
- "serde",
- "sha2",
- "time 0.2.23",
- "tokio",
-]
-
-[[package]]
-name = "rusoto_sts"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3815b8c0fc1c50caf9e87603f23daadfedb18d854de287b361c69f68dc9d49e0"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "rusoto_core",
- "serde_urlencoded",
- "tempfile",
- "xml-rs",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,18 +3506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,7 +3517,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c94201b44764d6d1f7e37c15a8289ed55e546c1762c7f1d57f616966e0c181"
+dependencies = [
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -3537,6 +3568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3571,7 +3608,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.1",
 ]
 
 [[package]]
@@ -3579,6 +3625,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -3666,6 +3721,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,11 +3766,12 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
 dependencies = [
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -3787,13 +3855,12 @@ checksum = "98d3306e84bf86710d6cd8b4c9c3b721d5454cc91a603180f8f8cd06cfd317b4"
 
 [[package]]
 name = "socket2"
-version = "0.3.11"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.8",
 ]
 
@@ -3814,6 +3881,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mz-avro",
+ "mz_rusoto_core",
  "ore",
  "parse_duration",
  "pgrepr",
@@ -3821,7 +3889,6 @@ dependencies = [
  "regex",
  "repr",
  "reqwest",
- "rusoto_core",
  "serde",
  "serde_json",
  "sql-parser",
@@ -3917,7 +3984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -4201,6 +4268,10 @@ dependencies = [
  "lazy_static",
  "md-5",
  "mz-avro",
+ "mz_rusoto_core",
+ "mz_rusoto_credential",
+ "mz_rusoto_kinesis",
+ "mz_rusoto_sts",
  "ore",
  "parse_duration",
  "pgrepr",
@@ -4213,10 +4284,6 @@ dependencies = [
  "regex",
  "repr",
  "reqwest",
- "rusoto_core",
- "rusoto_credential",
- "rusoto_kinesis",
- "rusoto_sts",
  "serde",
  "serde-protobuf",
  "serde_json",
@@ -4265,16 +4332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -4388,7 +4445,7 @@ dependencies = [
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -4431,7 +4488,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "phf",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "postgres-protocol",
  "postgres-types",
  "tokio",
@@ -4472,7 +4529,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.4",
  "tokio",
 ]
 
@@ -4493,13 +4550,13 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4536,33 +4593,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.7"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
- "ansi_term",
- "chrono",
+ "ansi_term 0.12.1",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
- "smallvec",
+ "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -4594,6 +4638,12 @@ name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicase"
@@ -4738,11 +4788,11 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.59"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3557c397ab5a8e347d434782bcd31fc1483d927a6826804cec05cc792ee2519d"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -4750,9 +4800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.59"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4765,11 +4815,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.9"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457414a91863c0ec00090dba537f88ab955d93ca6555862c29b6d860990b8a8a"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4777,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.59"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fde1d36e75a714b5fe0cffbb78978f222ea6baebb726af13c78869fdb4205"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4787,9 +4837,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.59"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bda4168030a6412ea8a047e27238cadf56f0e53516e1e83fec0a8b7c786f6d"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4800,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.59"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9f36ad51f25b0219a3d4d13b90eb44cd075dff8b6280cca015775d7acaddd8"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "web-sys"

--- a/demo/billing/Cargo.toml
+++ b/demo/billing/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.34"
 bytes = "0.5.6"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 csv = "1.1.5"
 env_logger = "0.8.2"
 futures = "0.3.8"

--- a/deny.toml
+++ b/deny.toml
@@ -4,20 +4,26 @@ skip = [
     # Do not add to this list without good reason! Duplicate dependencies slow
     # down compilation and bloat the binary.
 
-    # Waiting for approximately the entire Rust ecosystem to upgrade to
-    # v1.0.0.
+    # Waiting for clap to upgrade to v0.12.
+    { name = "ansi_term", version = "0.11.0" },
+
+    # Waiting for approximately the entire Rust ecosystem to upgrade to v1.0.
     { name = "cfg-if", version = "0.1.0" },
 
     # Waiting on mio 0.7: https://github.com/tokio-rs/tokio/issues/1190.
     { name = "miow", version = "0.2.1" },
     { name = "winapi", version = "0.2.8" },
 
-    # Waiting on chrono to migrate to time v0.2.
-    { name = "time", version = "0.1.42" },
-
-    # Waiting on Rusoto to upgrade to pin-project v1.0.
+    # Waiting on Tokio v0.3 ecosystem.
+    { name = "crypto-mac", version = "0.9.1" },
+    { name = "hmac", version = "0.9.0" },
+    { name = "pin-project-lite", version = "0.1.4" },
     { name = "pin-project", version = "0.4.22" },
     { name = "pin-project-internal", version = "0.4.22" },
+    { name = "rustc_version", version = "0.2.3" },
+    { name = "semver", version = "0.9.0" },
+    { name = "semver-parser", version = "0.7.0" },
+    { name = "serde_urlencoded", version = "0.6.1" },
 
     # Waiting on at least tempfile, phf, postgres, and uuid to upgrade to rand
     # v0.8.

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.34"
 avro-derive = { path = "../avro-derive" }
 byteorder = { version = "1.0.0", optional = true }
 crc = { version = "1.3.0", optional = true }
-chrono = { version = "0.4" }
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 digest = "0.9"
 enum-kinds = "0.5.0"
 itertools = "0.9"

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 [dependencies]
 anyhow = "1.0.34"
 log = "0.4"
-rusoto_core = "0.45.0"
-rusoto_credential = "0.45.0"
-rusoto_kinesis = "0.45.0"
-rusoto_sts = "0.45.0"
+mz_rusoto_core = "0.46.0"
+mz_rusoto_credential = "0.46.0"
+mz_rusoto_kinesis = "0.46.0"
+mz_rusoto_sts = "0.46.0"
 tokio = "0.2"

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -13,7 +13,7 @@ bincode = { version = "1.3", optional = true }
 build-info = { path = "../build-info" }
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 comm = { path = "../comm" }
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
@@ -34,7 +34,7 @@ rand = "0.8.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 regex = "1.4.1"
 repr = { path = "../repr" }
-rusoto_kinesis = "0.45.0"
+mz_rusoto_kinesis = "0.46.0"
 rusqlite = { version = "0.24", features = ["bundled", "unlock_notify"] }
 serde = "1.0"
 serde_json = "1.0.60"

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -15,7 +15,7 @@ kafka-util = { path = "../kafka-util" }
 log = "0.4"
 regex = "1.4.1"
 repr = { path = "../repr" }
-rusoto_core = "0.45.0"
+mz_rusoto_core = "0.46.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_regex = "1.1.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -34,9 +34,9 @@ rand = "0.8.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static", "zstd"] }
 regex = "1.4.1"
 repr = { path = "../repr" }
-rusoto_core = "0.45.0"
-rusoto_credential = "0.45.0"
-rusoto_kinesis = "0.45.0"
+mz_rusoto_core = "0.46.0"
+mz_rusoto_credential = "0.46.0"
+mz_rusoto_kinesis = "0.46.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.60"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 [dependencies]
 aho-corasick = "0.7.15"
 anyhow = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 csv = "1.1"
 encoding = "0.2"
 enum-iterator = "0.6.0"
-hmac = "0.8.1"
+hmac = "0.10.0"
 itertools = "0.9"
 md-5 = "0.9"
 num_enum = "0.5.1"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -13,9 +13,10 @@ harness = false
 [dependencies]
 anyhow = "1.0.34"
 avro-derive = { path = "../avro-derive" }
+base64 = "0.13"
 byteorder = "1.3"
 ccsr = { path = "../ccsr" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3"
 hex = "0.4"
@@ -36,7 +37,6 @@ smallvec = "1.5.1"
 sha2 = "0.9.2"
 url = "2.2.0"
 uuid = "0.8"
-base64 = "0.12.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0"
 mz-avro = { path = "../avro" }
 ccsr = { path = "../ccsr" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = "2.33"
 ore = { path = "../../src/ore" }
 futures = "0.3"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -47,7 +47,7 @@ rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features =
 repr = { path = "../repr" }
 reqwest = { version = "0.10.8", features = ["json"] }
 rlimit = "0.5.3"
-semver = "0.9"
+semver = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 shell-words = "1.0"
@@ -59,12 +59,14 @@ tempfile = "3.1"
 tokio = { version = "0.2", features = ["sync"] }
 tokio-openssl = "0.4.0"
 tracing = "0.1.21"
-tracing-subscriber = "0.2.7"
+# TODO(benesch): we can use the default features here once tracing-subscriber
+# does not enable chrono's "oldtime" feature.
+tracing-subscriber = { version = "0.2.7", default-features = false, features = ["ansi", "env-filter", "fmt", "tracing-log"] }
 url = "2"
 
 [dev-dependencies]
 assert_cmd = "1.0.2"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 datadriven = "0.4"
 fallible-iterator = "0.2.0"
 itertools = "0.9"

--- a/src/mz-process-collector/Cargo.toml
+++ b/src/mz-process-collector/Cargo.toml
@@ -10,4 +10,4 @@ libc = "0.2.81"
 lazy_static = "1.4.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-procfs = "0.9.1"
+procfs = { version = "0.9.1", default-features = false }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.11"
 phf_shared = "0.8"
 smallvec = "1.5"
 tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp", "time"] }
-tracing-subscriber = "0.2.7"
+tracing-subscriber = { version = "0.2.7", default-features = false, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 crossbeam-utils = "0.7.2"

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
 getopts = "0.2"
 hyper = "0.13"

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 byteorder = "1.3"
 bytes = "0.5"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
 postgres-types = { version = "0.1.1", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 ore = { path = "../ore" }

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.34"
 byteorder = "1.3"
 bytes = "0.5"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 comm = { path = "../comm" }
 coord = { path = "../coord" }
 dataflow-types = { path = "../dataflow-types" }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -16,7 +16,7 @@ harness = false
 [dependencies]
 anyhow = "1.0.34"
 byteorder = "1.3"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 enum-kinds = "0.5.0"
 hex = "0.4.2"
 itertools = "0.9"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.34"
 aws-arn = "0.1.1"
 build-info = { path = "../build-info" }
 ccsr = { path = "../ccsr" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 futures = "0.3"
@@ -26,7 +26,7 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 regex = "1.4.1"
 repr = { path = "../repr" }
 reqwest = { version = "0.10.8" }
-rusoto_core = "0.45.0"
+mz_rusoto_core = "0.46.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sql-parser = { path = "../sql-parser" }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 comm = { path = "../comm" }
 expr = { path = "../expr" }
 fallible-iterator = "0.2"

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 log = "0.4.11"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -12,7 +12,7 @@ aws-util = { path = "../aws-util" }
 byteorder = "1.3"
 bytes = "0.5.6"
 ccsr = { path = "../ccsr" }
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 coord = { path = "../coord" }
 futures = "0.3"
 getopts = "0.2"
@@ -34,10 +34,10 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 regex = "1"
 repr = { path = "../repr" }
 reqwest = { version = "0.10.8", features = ["native-tls-vendored"] }
-rusoto_core = "0.45.0"
-rusoto_credential = "0.45.0"
-rusoto_kinesis = "0.45.0"
-rusoto_sts = "0.45.0"
+mz_rusoto_core = "0.46.0"
+mz_rusoto_credential = "0.46.0"
+mz_rusoto_kinesis = "0.46.0"
+mz_rusoto_sts = "0.46.0"
 serde = "1.0.118"
 serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }
 serde_json = "1.0.60"

--- a/test/correctness/Cargo.toml
+++ b/test/correctness/Cargo.toml
@@ -10,7 +10,7 @@ name = "test-correctness"
 path = "checker.rs"
 
 [dependencies]
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
 futures = "0.3"
 getopts = "0.2"

--- a/test/performance/perf-kinesis/Cargo.toml
+++ b/test/performance/perf-kinesis/Cargo.toml
@@ -9,16 +9,16 @@ publish = false
 anyhow = "1.0.34"
 aws-util = { path = "../../../src/aws-util" }
 bytes = "0.5.6"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
 futures = "0.3.8"
 futures-channel = "0.3.5"
 log = "0.4.11"
 ore = { path = "../../../src/ore" }
 rand = "0.8.0"
-rusoto_core = "0.45.0"
-rusoto_credential = "0.45.0"
-rusoto_kinesis = "0.45.0"
+mz_rusoto_core = "0.46.0"
+mz_rusoto_credential = "0.46.0"
+mz_rusoto_kinesis = "0.46.0"
 structopt = "0.3.21"
 tokio = { version = "0.2.22", features = ["full"] }
 tokio-postgres = "0.5.5"

--- a/test/performance/perf-upsert/Cargo.toml
+++ b/test/performance/perf-upsert/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.34"
 bytes = "0.5.6"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
 futures = "0.3.8"
 futures-channel = "0.3.5"

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-chrono = "0.4.19"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 kafka-util = { path = "../../src/kafka-util" }
 log = "0.4.11"
 ore = { path = "../../src/ore" }


### PR DESCRIPTION
Rusoto has been unmaintained for several months. Upgrade to a new
Materialize fork of Rusoto (crates are prefixed with "mz_") to get
dependency bumps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5131)
<!-- Reviewable:end -->
