### PR TITLE
sql: treat CREATE TYPE's options as data types

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -13,8 +13,8 @@ use ore::collections::CollectionExt;
 use sql::ast::display::AstDisplay;
 use sql::ast::visit_mut::VisitMut;
 use sql::ast::{
-    CreateIndexStatement, CreateTableStatement, CreateViewStatement, DataType, Ident, ObjectName,
-    Statement,
+    CreateIndexStatement, CreateTableStatement, CreateTypeStatement, CreateViewStatement, DataType,
+    Ident, ObjectName, Statement,
 };
 
 use crate::catalog::PG_CATALOG_SCHEMA;
@@ -88,6 +88,16 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
                         for key_part in key_parts {
                             TypeNormalizer.visit_expr_mut(key_part);
                         }
+                    }
+                }
+
+                Statement::CreateType(CreateTypeStatement {
+                    name: _,
+                    as_type: _,
+                    with_options,
+                }) => {
+                    for option in with_options {
+                        TypeNormalizer.visit_sql_option_mut(option);
                     }
                 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -20,7 +20,8 @@
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    ColumnDef, Connector, Envelope, Expr, Format, Ident, ObjectName, Query, TableConstraint, Value,
+    ColumnDef, Connector, DataType, Envelope, Expr, Format, Ident, ObjectName, Query,
+    TableConstraint, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -1166,6 +1167,10 @@ pub enum SqlOption {
         name: Ident,
         object_name: ObjectName,
     },
+    DataType {
+        name: Ident,
+        data_type: DataType,
+    },
 }
 
 impl SqlOption {
@@ -1173,6 +1178,7 @@ impl SqlOption {
         match self {
             SqlOption::Value { name, .. } => name,
             SqlOption::ObjectName { name, .. } => name,
+            SqlOption::DataType { name, .. } => name,
         }
     }
 }
@@ -1189,6 +1195,11 @@ impl AstDisplay for SqlOption {
                 f.write_node(name);
                 f.write_str(" = ");
                 f.write_node(object_name);
+            }
+            SqlOption::DataType { name, data_type } => {
+                f.write_node(name);
+                f.write_str(" = ");
+                f.write_node(data_type);
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1690,13 +1690,25 @@ impl<'a> Parser<'a> {
             MAP => CreateTypeAs::Map,
             _ => unreachable!(),
         };
-        let with_options = self.parse_options()?;
+
+        self.expect_token(&Token::LParen)?;
+        let with_options = self.parse_comma_separated(Parser::parse_data_type_option)?;
+        self.expect_token(&Token::RParen)?;
 
         Ok(Statement::CreateType(CreateTypeStatement {
             name,
             as_type,
             with_options,
         }))
+    }
+
+    fn parse_data_type_option(&mut self) -> Result<SqlOption, ParserError> {
+        let name = self.parse_identifier()?;
+        self.expect_token(&Token::Eq)?;
+        Ok(SqlOption::DataType {
+            name,
+            data_type: self.parse_data_type()?,
+        })
     }
 
     fn parse_if_exists(&mut self) -> Result<bool, ParserError> {

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -18,74 +18,81 @@ CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }, ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("bool")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: ObjectName([Ident("bool")]), typ_mod: [] } }] })
 
 parse-statement
-CREATE TYPE custom AS MAP (KEY_TYPE='text', VaLuE_tYpE=custom_type)
+CREATE TYPE custom AS MAP (KEY_TYPE=text, VaLuE_tYpE=custom_type)
 ----
-CREATE TYPE custom AS MAP ( key_type = 'text', value_type = custom_type )
+CREATE TYPE custom AS MAP ( key_type = text, value_type = custom_type )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [Value { name: Ident("key_type"), value: String("text") }, ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("custom_type")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: ObjectName([Ident("custom_type")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text)
 ----
 CREATE TYPE custom AS MAP ( key_type = text )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( value_type = bool )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("bool")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("value_type"), data_type: Other { name: ObjectName([Ident("bool")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, value_type=bool, random_type=int)
 ----
-CREATE TYPE custom AS MAP ( key_type = text, value_type = bool, random_type = int )
+CREATE TYPE custom AS MAP ( key_type = text, value_type = bool, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }, ObjectName { name: Ident("value_type"), object_name: ObjectName([Ident("bool")]) }, ObjectName { name: Ident("random_type"), object_name: ObjectName([Ident("int")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: ObjectName([Ident("bool")]), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, random_type=int)
 ----
-CREATE TYPE custom AS MAP ( key_type = text, random_type = int )
+CREATE TYPE custom AS MAP ( key_type = text, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [ObjectName { name: Ident("key_type"), object_name: ObjectName([Ident("text")]) }, ObjectName { name: Ident("random_type"), object_name: ObjectName([Ident("int")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=text)
 ----
 CREATE TYPE custom AS LIST ( element_type = text )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: List, with_options: [ObjectName { name: Ident("element_type"), object_name: ObjectName([Ident("text")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=x)
 ----
 CREATE TYPE custom AS LIST ( element_type = x )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: List, with_options: [ObjectName { name: Ident("element_type"), object_name: ObjectName([Ident("x")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: ObjectName([Ident("x")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=_text)
 ----
 CREATE TYPE custom AS LIST ( element_type = _text )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: List, with_options: [ObjectName { name: Ident("element_type"), object_name: ObjectName([Ident("_text")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: ObjectName([Ident("_text")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE schema.t2 AS LIST (element_type=schema.t1)
 ----
 CREATE TYPE schema.t2 AS LIST ( element_type = schema.t1 )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("schema"), Ident("t2")]), as_type: List, with_options: [ObjectName { name: Ident("element_type"), object_name: ObjectName([Ident("schema"), Ident("t1")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("schema"), Ident("t2")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: ObjectName([Ident("schema"), Ident("t1")]), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE db2.schema2.t2 AS LIST (element_type=db1.schema1.t1)
 ----
 CREATE TYPE db2.schema2.t2 AS LIST ( element_type = db1.schema1.t1 )
 =>
-CreateType(CreateTypeStatement { name: ObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List, with_options: [ObjectName { name: Ident("element_type"), object_name: ObjectName([Ident("db1"), Ident("schema1"), Ident("t1")]) }] })
+CreateType(CreateTypeStatement { name: ObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: ObjectName([Ident("db1"), Ident("schema1"), Ident("t1")]), typ_mod: [] } }] })
+
+parse-statement
+CREATE TYPE numeric_list AS LIST (element_type=numeric(100,100,100))
+----
+CREATE TYPE numeric_list AS LIST ( element_type = numeric(100, 100, 100) )
+=>
+CreateType(CreateTypeStatement { name: ObjectName([Ident("numeric_list")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: ObjectName([Ident("numeric")]), typ_mod: [100, 100, 100] } }] })

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1891,6 +1891,12 @@ SELECT '{1}'::float4 list || '{2}'::float8 list
 query error element_type must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_list AS LIST (element_type=pg_enum)
 
+query error CREATE TYPE ... AS LIST option "element_type" cannot accept type modifier on numeric, you must use the default type
+CREATE TYPE typ_mod_list AS LIST (element_type=numeric(38,0))
+
+query error CREATE TYPE ... AS LIST option "element_type" can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
+CREATE TYPE unnamed_element_list AS LIST (element_type=int4 list)
+
 statement ok
 CREATE TYPE int4_list_c AS LIST (element_type = int4);
 
@@ -1922,16 +1928,16 @@ SELECT '{{1,2}}'::int4_list_list_c::text;
 ----
 {{1,2}}
 
-query error unknown catalog item 'bool list'
+query error unknown catalog item bool list
 CREATE TYPE nested_list AS LIST (element_type = 'bool list')
 
-query error unknown catalog item 'list'
-CREATE TYPE nested_list AS LIST (element_type = 'list')
+query error unknown catalog item list
+CREATE TYPE nested_list AS LIST (element_type = list)
 
 # 🔬🔬 Check each valid non-array element type
 
 statement ok
-CREATE TYPE bool_list_c AS LIST (element_type='bool');
+CREATE TYPE bool_list_c AS LIST (element_type=bool);
 
 query T
 SELECT '{true}'::bool_list_c::text
@@ -1939,7 +1945,7 @@ SELECT '{true}'::bool_list_c::text
 {t}
 
 statement ok
-CREATE TYPE int8_list_c AS LIST (element_type='int8');
+CREATE TYPE int8_list_c AS LIST (element_type=int8);
 
 query T
 SELECT '{1,2}'::int8_list_c::text
@@ -1952,7 +1958,7 @@ SELECT '{1,2}'::int4_list_c::text
 {1,2}
 
 statement ok
-CREATE TYPE text_list_c AS LIST (element_type='text');
+CREATE TYPE text_list_c AS LIST (element_type=text);
 
 query T
 SELECT '{a,b}'::text_list_c::text
@@ -1960,7 +1966,7 @@ SELECT '{a,b}'::text_list_c::text
 {a,b}
 
 statement ok
-CREATE TYPE float4_list_c AS LIST (element_type='float4');
+CREATE TYPE float4_list_c AS LIST (element_type=float4);
 
 query T
 SELECT '{1.2,2.3}'::float4_list_c::text
@@ -1968,7 +1974,7 @@ SELECT '{1.2,2.3}'::float4_list_c::text
 {1.2,2.3}
 
 statement ok
-CREATE TYPE float8_list_c AS LIST (element_type='float8');
+CREATE TYPE float8_list_c AS LIST (element_type=float8);
 
 query T
 SELECT '{1.2,2.3}'::float8_list_c::text
@@ -1976,7 +1982,7 @@ SELECT '{1.2,2.3}'::float8_list_c::text
 {1.2,2.3}
 
 statement ok
-CREATE TYPE date_list_c AS LIST (element_type='date');
+CREATE TYPE date_list_c AS LIST (element_type=date);
 
 query T
 SELECT '{2001-01-01}'::date_list_c::text
@@ -1984,7 +1990,7 @@ SELECT '{2001-01-01}'::date_list_c::text
 {2001-01-01}
 
 statement ok
-CREATE TYPE time_list_c AS LIST (element_type='time');
+CREATE TYPE time_list_c AS LIST (element_type=time);
 
 query T
 SELECT '{12:34:56}'::time_list_c::text
@@ -1992,7 +1998,7 @@ SELECT '{12:34:56}'::time_list_c::text
 {12:34:56}
 
 statement ok
-CREATE TYPE timestamp_list_c AS LIST (element_type='timestamp');
+CREATE TYPE timestamp_list_c AS LIST (element_type=timestamp);
 
 query T
 SELECT '{2001-01-01 12:34:56}'::timestamp_list_c::text
@@ -2000,7 +2006,7 @@ SELECT '{2001-01-01 12:34:56}'::timestamp_list_c::text
 {"2001-01-01 12:34:56"}
 
 statement ok
-CREATE TYPE timestamptz_list_c AS LIST (element_type='timestamptz');
+CREATE TYPE timestamptz_list_c AS LIST (element_type=timestamptz);
 
 query T
 SELECT '{2001-01-01 12:34:56}'::timestamptz_list_c::text
@@ -2008,7 +2014,7 @@ SELECT '{2001-01-01 12:34:56}'::timestamptz_list_c::text
 {"2001-01-01 12:34:56+00"}
 
 statement ok
-CREATE TYPE interval_list_c AS LIST (element_type='interval');
+CREATE TYPE interval_list_c AS LIST (element_type=interval);
 
 query T
 SELECT '{1y 2d 3h 4m}'::interval_list_c::text
@@ -2016,7 +2022,7 @@ SELECT '{1y 2d 3h 4m}'::interval_list_c::text
 {"1 year 2 days 03:04:00"}
 
 statement ok
-CREATE TYPE numeric_list_c AS LIST (element_type='numeric');
+CREATE TYPE numeric_list_c AS LIST (element_type=numeric);
 
 query T
 SELECT '{1.23,2.34}'::numeric_list_c::text
@@ -2024,7 +2030,7 @@ SELECT '{1.23,2.34}'::numeric_list_c::text
 {1,2}
 
 statement ok
-CREATE TYPE jsonb_list_c AS LIST (element_type='jsonb');
+CREATE TYPE jsonb_list_c AS LIST (element_type=jsonb);
 
 query T
 SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
@@ -2034,7 +2040,7 @@ SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
 # 🔬🔬 Check custom type name resolution
 
 statement ok
-CREATE TYPE bool AS LIST (element_type='int4')
+CREATE TYPE bool AS LIST (element_type=int4)
 
 query error invalid input syntax for bool: "\{1,2\}"
 SELECT '{1,2}'::bool;
@@ -2043,6 +2049,19 @@ query T
 SELECT '{1,2}'::public.bool::text;
 ----
 {1,2}
+
+# 🔬🔬 Check subtype resolution
+
+# Supports qualified subtypes
+statement ok
+CREATE TYPE qualified_int4_list AS LIST (element_type=pg_catalog.int4)
+
+statement ok
+CREATE TYPE qualified_qualified_int4_list AS LIST (element_type=public.qualified_int4_list)
+
+# Supports type aliases
+statement ok
+CREATE TYPE int_list AS MAP (key_type=pg_catalog.text, value_type=int)
 
 # 🔬🔬 Built-in operations
 

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -22,16 +22,22 @@ query error value_type parameter required
 CREATE TYPE custom AS MAP (key_type=text)
 
 query error key_type parameter required
-CREATE TYPE custom AS MAP (value_type='bool')
+CREATE TYPE custom AS MAP (value_type=bool)
 
 query error unknown catalog item 'customthing'
-CREATE TYPE custom AS MAP (key_type=text, value_type='bool', extra_type=customthing)
+CREATE TYPE custom AS MAP (key_type=text, value_type=bool, extra_type=customthing)
 
 query error key_type must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_map AS MAP (key_type=pg_enum, value_type=text)
 
 query error value_type must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_map AS MAP (key_type=text, value_type=pg_enum)
+
+query error CREATE TYPE ... AS MAP option "value_type" cannot accept type modifier on numeric, you must use the default type
+CREATE TYPE typ_mod_map AS MAP (key_type=text, value_type=numeric(38,0))
+
+query error CREATE TYPE ... AS LIST option "value_type" can only use named data types, but found unnamed data type int4 list. Use CREATE TYPE to create a named type first
+CREATE TYPE unnamed_element_map AS MAP (key_type=text, value_type=int4 list)
 
 query error CREATE TYPE not yet supported
 CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
@@ -456,7 +462,7 @@ map
 # 🔬🔬 Check each valid value type
 
 statement ok
-CREATE TYPE bool_map_c AS MAP (key_type=text, value_type='bool');
+CREATE TYPE bool_map_c AS MAP (key_type=text, value_type=bool);
 
 query T
 SELECT '{a=>true}'::bool_map_c::text
@@ -464,7 +470,7 @@ SELECT '{a=>true}'::bool_map_c::text
 {a=>t}
 
 statement ok
-CREATE TYPE int8_map_c AS MAP (key_type=text, value_type='int8');
+CREATE TYPE int8_map_c AS MAP (key_type=text, value_type=int8);
 
 query T
 SELECT '{a=>1}'::int8_map_c::text
@@ -472,7 +478,7 @@ SELECT '{a=>1}'::int8_map_c::text
 {a=>1}
 
 statement ok
-CREATE TYPE int4_map_c AS MAP (key_type=text, value_type='int4');
+CREATE TYPE int4_map_c AS MAP (key_type=text, value_type=int4);
 
 query T
 SELECT '{a=>1}'::int4_map_c::text
@@ -480,7 +486,7 @@ SELECT '{a=>1}'::int4_map_c::text
 {a=>1}
 
 statement ok
-CREATE TYPE text_map_c AS MAP (key_type=text, value_type='text');
+CREATE TYPE text_map_c AS MAP (key_type=text, value_type=text);
 
 query T
 SELECT '{a=>a}'::text_map_c::text
@@ -488,7 +494,7 @@ SELECT '{a=>a}'::text_map_c::text
 {a=>a}
 
 statement ok
-CREATE TYPE float4_map_c AS MAP (key_type=text, value_type='float4');
+CREATE TYPE float4_map_c AS MAP (key_type=text, value_type=float4);
 
 query T
 SELECT '{a=>1.2}'::float4_map_c::text
@@ -496,7 +502,7 @@ SELECT '{a=>1.2}'::float4_map_c::text
 {a=>1.2}
 
 statement ok
-CREATE TYPE float8_map_c AS MAP (key_type=text, value_type='float8');
+CREATE TYPE float8_map_c AS MAP (key_type=text, value_type=float8);
 
 query T
 SELECT '{a=>1.2}'::float8_map_c::text
@@ -504,7 +510,7 @@ SELECT '{a=>1.2}'::float8_map_c::text
 {a=>1.2}
 
 statement ok
-CREATE TYPE date_map_c AS MAP (key_type=text, value_type='date');
+CREATE TYPE date_map_c AS MAP (key_type=text, value_type=date);
 
 query T
 SELECT '{a=>2001-01-01}'::date_map_c::text
@@ -512,7 +518,7 @@ SELECT '{a=>2001-01-01}'::date_map_c::text
 {a=>2001-01-01}
 
 statement ok
-CREATE TYPE time_map_c AS MAP (key_type=text, value_type='time');
+CREATE TYPE time_map_c AS MAP (key_type=text, value_type=time);
 
 query T
 SELECT '{a=>12:34:56}'::time_map_c::text
@@ -520,7 +526,7 @@ SELECT '{a=>12:34:56}'::time_map_c::text
 {a=>12:34:56}
 
 statement ok
-CREATE TYPE timestamp_map_c AS MAP (key_type=text, value_type='timestamp');
+CREATE TYPE timestamp_map_c AS MAP (key_type=text, value_type=timestamp);
 
 query T
 SELECT '{a=>2001-01-01 12:34:56}'::timestamp_map_c::text
@@ -528,7 +534,7 @@ SELECT '{a=>2001-01-01 12:34:56}'::timestamp_map_c::text
 {a=>"2001-01-01 12:34:56"}
 
 statement ok
-CREATE TYPE timestamptz_map_c AS MAP (key_type=text, value_type='timestamptz');
+CREATE TYPE timestamptz_map_c AS MAP (key_type=text, value_type=timestamptz);
 
 query T
 SELECT '{a=>2001-01-01 12:34:56}'::timestamptz_map_c::text
@@ -536,7 +542,7 @@ SELECT '{a=>2001-01-01 12:34:56}'::timestamptz_map_c::text
 {a=>"2001-01-01 12:34:56+00"}
 
 statement ok
-CREATE TYPE interval_map_c AS MAP (key_type=text, value_type='interval');
+CREATE TYPE interval_map_c AS MAP (key_type=text, value_type=interval);
 
 query T
 SELECT '{a=>1y 2d 3h 4m}'::interval_map_c::text
@@ -544,7 +550,7 @@ SELECT '{a=>1y 2d 3h 4m}'::interval_map_c::text
 {a=>"1 year 2 days 03:04:00"}
 
 statement ok
-CREATE TYPE numeric_map_c AS MAP (key_type=text, value_type='numeric');
+CREATE TYPE numeric_map_c AS MAP (key_type=text, value_type=numeric);
 
 query T
 SELECT '{a=>1.23}'::numeric_map_c::text
@@ -552,7 +558,7 @@ SELECT '{a=>1.23}'::numeric_map_c::text
 {a=>1}
 
 statement ok
-CREATE TYPE jsonb_map_c AS MAP (key_type=text, value_type='jsonb');
+CREATE TYPE jsonb_map_c AS MAP (key_type=text, value_type=jsonb);
 
 query T
 SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
@@ -562,7 +568,7 @@ SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
 # 🔬🔬 Check custom type name resolution
 
 statement ok
-CREATE TYPE bool AS MAP (key_type=text, value_type='int4')
+CREATE TYPE bool AS MAP (key_type=text, value_type=int4)
 
 query error invalid input syntax for bool: "\{a=>1\}"
 SELECT '{a=>1}'::bool;
@@ -571,3 +577,16 @@ query T
 SELECT '{a=>1}'::public.bool::text;
 ----
 {a=>1}
+
+# 🔬🔬 Check subtype resolution
+
+# Supports qualified subtypes
+statement ok
+CREATE TYPE qualified_int4_map AS MAP (key_type=pg_catalog.text, value_type=pg_catalog.int4)
+
+statement ok
+CREATE TYPE qualified_qualified_int4_map AS MAP (key_type=pg_catalog.text, value_type=public.qualified_int4_map)
+
+# Supports type aliases
+statement ok
+CREATE TYPE int_map AS MAP (key_type=pg_catalog.text, value_type=int)

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -11,7 +11,7 @@
 
 > SHOW TYPES
 
-> CREATE TYPE bool AS LIST (element_type='int4')
+> CREATE TYPE bool AS LIST (element_type=int4)
 
 > CREATE TYPE custom AS LIST (element_type=bool)
 
@@ -31,7 +31,7 @@ user
 
 > CREATE SCHEMA test_schema
 
-> CREATE TYPE test_schema.bool AS LIST (element_type='float4')
+> CREATE TYPE test_schema.bool AS LIST (element_type=float4)
 
 > SHOW TYPES
 name

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -11,9 +11,9 @@
 
 > SHOW TYPES
 
-> CREATE TYPE bool AS MAP (key_type=text, value_type='int4')
+> CREATE TYPE bool AS MAP (key_type=text, value_type=int4)
 
-> CREATE TYPE custom AS MAP (key_type='text', value_type=bool)
+> CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
 
 # Without qualifiers, should default to builtin bool.
 > SELECT mz_internal.mz_classify_object_id(value_id)
@@ -21,7 +21,7 @@
   WHERE name = 'custom'
 system
 
-> CREATE TYPE another_custom AS MAP (key_type='text', value_type=public.bool)
+> CREATE TYPE another_custom AS MAP (key_type=text, value_type=public.bool)
 
 # Qualified name should point to user-defined bool.
 > SELECT mz_internal.mz_classify_object_id(value_id)
@@ -31,7 +31,7 @@ user
 
 > CREATE SCHEMA test_schema
 
-> CREATE TYPE test_schema.bool AS MAP (key_type=text, value_type='float4')
+> CREATE TYPE test_schema.bool AS MAP (key_type=text, value_type=float4)
 
 > SHOW TYPES
 name

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -136,54 +136,54 @@ other_int_map_c     user
 
 # Array element types
 
-> CREATE TYPE bool_array_list_c AS LIST (element_type='_bool');
+> CREATE TYPE bool_array_list_c AS LIST (element_type=_bool);
 > CREATE TABLE bool_array_list_t (a bool_array_list_c);
 > INSERT INTO bool_array_list_t VALUES (LIST[ARRAY[true]]);
 
-> CREATE TYPE int8_array_list_c AS LIST (element_type='_int8');
+> CREATE TYPE int8_array_list_c AS LIST (element_type=_int8);
 > CREATE TABLE int8_array_list_t (a int8_array_list_c);
 > INSERT INTO int8_array_list_t VALUES (LIST[ARRAY[1::int8,2::int8]]);
 
-> CREATE TYPE int4_array_list_c AS LIST (element_type='_int4');
+> CREATE TYPE int4_array_list_c AS LIST (element_type=_int4);
 > CREATE TABLE int4_array_list_t (a int4_array_list_c);
 > INSERT INTO int4_array_list_t VALUES (LIST[ARRAY[1,2]]);
 
-> CREATE TYPE text_array_list_c AS LIST (element_type='_text');
+> CREATE TYPE text_array_list_c AS LIST (element_type=_text);
 > CREATE TABLE text_array_list_t (a text_array_list_c);
 > INSERT INTO text_array_list_t VALUES (LIST[ARRAY['a','b']]);
 
-> CREATE TYPE float4_array_list_c AS LIST (element_type='_float4');
+> CREATE TYPE float4_array_list_c AS LIST (element_type=_float4);
 > CREATE TABLE float4_array_list_t (a float4_array_list_c);
 > INSERT INTO float4_array_list_t VALUES (LIST[ARRAY[1.2::float4,2.3::float4]]);
 
-> CREATE TYPE float8_array_list_c AS LIST (element_type='_float8');
+> CREATE TYPE float8_array_list_c AS LIST (element_type=_float8);
 > CREATE TABLE float8_array_list_t (a float8_array_list_c);
 > INSERT INTO float8_array_list_t VALUES (LIST[ARRAY[1.2::float8,2.3::float8]]);
 
-> CREATE TYPE date_array_list_c AS LIST (element_type='_date');
+> CREATE TYPE date_array_list_c AS LIST (element_type=_date);
 > CREATE TABLE date_array_list_t (a date_array_list_c);
 > INSERT INTO date_array_list_t VALUES (LIST[ARRAY['2001-01-01'::date]]);
 
-> CREATE TYPE time_array_list_c AS LIST (element_type='_time');
+> CREATE TYPE time_array_list_c AS LIST (element_type=_time);
 > CREATE TABLE time_array_list_t (a time_array_list_c);
 > INSERT INTO time_array_list_t VALUES (LIST[ARRAY['12:34:56'::time]]);
 
-> CREATE TYPE timestamp_array_list_c AS LIST (element_type='_timestamp');
+> CREATE TYPE timestamp_array_list_c AS LIST (element_type=_timestamp);
 > CREATE TABLE timestamp_array_list_t (a timestamp_array_list_c);
 > INSERT INTO timestamp_array_list_t VALUES (LIST[ARRAY['2001-01-01 12:34:56'::timestamp]]);
 
-> CREATE TYPE timestamptz_array_list_c AS LIST (element_type='_timestamptz');
+> CREATE TYPE timestamptz_array_list_c AS LIST (element_type=_timestamptz);
 > CREATE TABLE timestamptz_array_list_t (a timestamptz_array_list_c);
 > INSERT INTO timestamptz_array_list_t VALUES (LIST[ARRAY['2001-01-01 12:34:56'::timestamptz]]);
 
-> CREATE TYPE interval_array_list_c AS LIST (element_type='_interval');
+> CREATE TYPE interval_array_list_c AS LIST (element_type=_interval);
 > CREATE TABLE interval_array_list_t (a interval_array_list_c);
 > INSERT INTO interval_array_list_t VALUES (LIST[ARRAY['1y 2d 3h 4m'::interval]]);
 
-# > CREATE TYPE numeric_array_list_c AS LIST (element_type='_numeric');
+# > CREATE TYPE numeric_array_list_c AS LIST (element_type=_numeric);
 # > CREATE TABLE numeric_array_list_t (a numeric_array_list_c);
 # > INSERT INTO numeric_array_list_t VALUES (LIST[ARRAY[1.23, 2.34]]);
 
-> CREATE TYPE jsonb_array_list_c AS LIST (element_type='_jsonb');
+> CREATE TYPE jsonb_array_list_c AS LIST (element_type=_jsonb);
 > CREATE TABLE jsonb_array_list_t (a jsonb_array_list_c);
 > INSERT INTO jsonb_array_list_t VALUES (LIST[ARRAY['\{\"1\":2\}'::jsonb]]);


### PR DESCRIPTION
Had an idea to make type name aliases available to `CREATE TYPE`'s option––is this worth pursuing, or does clamping down the `with_options` to being data types potentially too restrictive in the future?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5132)
<!-- Reviewable:end -->
