### PR TITLE
fail on attempts to create sources/sinks with bad WITH options

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -38,7 +38,7 @@ pub async fn purify(mut stmt: Statement) -> Result<Statement, anyhow::Error> {
         ..
     }) = &mut stmt
     {
-        let with_options_map = normalize::options(with_options);
+        let mut with_options_map = normalize::options(with_options);
         let mut config_options = HashMap::new();
 
         let mut file = None;
@@ -49,7 +49,7 @@ pub async fn purify(mut stmt: Statement) -> Result<Statement, anyhow::Error> {
                 }
 
                 // Verify that the provided security options are valid and then test them.
-                config_options = kafka_util::extract_config(&with_options_map)?;
+                config_options = kafka_util::extract_config(&mut with_options_map)?;
                 kafka_util::test_config(&config_options)?;
             }
             Connector::AvroOcf { path, .. } => {
@@ -108,7 +108,7 @@ async fn purify_format(
                     let ccsr_config = kafka_util::generate_ccsr_client_config(
                         url,
                         &connector_options,
-                        &normalize::options(ccsr_options),
+                        normalize::options(ccsr_options),
                     )?;
 
                     let Schema {

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -106,6 +106,25 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": {"nested_data_1": {"n1_a": 43, "n1_b":{"nested_data_2": {"n2_a": 44, "n2_b": -1}}}}, "f": {"nested_data_2": {"n2_a": 45, "n2_b": -2}}}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}}
 {"before": null, "after": {"row": {"a": -1, "b": 7, "json": "[1, 2, 3]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
+# We should refuse to create a source with invalid WITH options
+! CREATE MATERIALIZED SOURCE invalid_with_option
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+      badoption = true,
+      deduplication = 'full_in_range',
+      deduplication_pad_start = '2020-09-13 10:00:00',
+      deduplication_start = '2020-09-13 12:26:00',
+      deduplication_end = '2020-09-13 13:00:00'
+  )
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM
+unexpected parameters for CREATE SOURCE: badoption
+
+> SHOW SOURCES
+name
+----
+
+
 # Create a source using an inline schema.
 
 > CREATE MATERIALIZED SOURCE data_schema_inline
@@ -418,8 +437,7 @@ a b
 5 0
 8 0
 
-
-! CREATE SOURCE recurisve
+! CREATE SOURCE recursive
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'
   FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
 validating avro value schema: Recursively defined type in schema: .a

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -13,6 +13,13 @@ Rochester,NY,14618
 New York,NY,10004
 "bad,place""",CA,92679
 
+# We should refuse to create a source with invalid WITH options
+! CREATE SOURCE invalid_with_option
+  FROM FILE '${testdrive.temp-dir}/static.csv'
+  WITH (badoption=true)
+  FORMAT CSV WITH 3 COLUMNS
+unexpected parameters for CREATE SOURCE: badoption
+
 # Static CSV without headers.
 > CREATE MATERIALIZED SOURCE static_csv
   FROM FILE '${testdrive.temp-dir}/static.csv'

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -29,6 +29,18 @@ goofus,gallant
 > CREATE MATERIALIZED VIEW v3 AS
   SELECT a || b AS c FROM src
 
+# We should refuse to create a sink with invalid WITH options
+
+! CREATE SINK invalid_with_option FROM src
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
+  WITH (concurrency=true, badoption=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+unexpected parameters for CREATE SINK: badoption
+
+> SHOW SINKS
+name
+----
+
 # We should refuse to create a sink with an invalid schema registry URL.
 # We use the Kafka address as the invalid schema registry address, as it is
 # known to immediately produce an error. Previous attempts used


### PR DESCRIPTION
Today creating a source/sink with bad options will silently work - found this when I tried to create one with consistency=true, typo'd it, and it still made something (just not what I wanted).

This may have some slight backwards incompatibilities. Anyone who previously created a source/sink with a bad option would have had that silently ignored and persisted to the catalog. Upgrading mz will now throw an error when reading that bad persisted data from the catalog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5135)
<!-- Reviewable:end -->
