### PR TITLE
sql-parser: support AT TIME ZONE operator

### DIFF
--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -31,6 +31,7 @@ Arn
 Array
 As
 Asc
+At
 Avro
 Begin
 Between

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -126,6 +126,9 @@ fn op_precedence() -> Result<(), Box<dyn Error>> {
         ("NOT 1 NOT BETWEEN 1 AND 2", "NOT (1 NOT BETWEEN 1 AND 2)"),
         ("NOT a NOT LIKE b", "NOT (a NOT LIKE b)"),
         ("NOT a NOT IN ('a')", "NOT (a NOT IN ('a'))"),
+        ("+ a / b COLLATE coll", "(+a) / (b COLLATE coll)"),
+        ("- ts AT TIME ZONE 'tz'", "(-ts) AT TIME ZONE 'tz'"),
+        ("a[b].c::d", "((a[b]).c)::d"),
     ] {
         let left = parser::parse_expr(actual)?;
         let mut right = parser::parse_expr(expected)?;


### PR DESCRIPTION
Extracted from #5130.

Also take the opportunity to clean up our precedence enum. No need to
have separate precedences for adjacent unary prefix operators or
adjacent unary postfix operators, since they cannot be ambiguous with
one another.

Co-authored-by: Ronen Ulanovsky <ronen.ulanovsky.5@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5139)
<!-- Reviewable:end -->
