### PR TITLE
Default to /tmp when $HOME is unset

### DIFF
--- a/demo/chbench/bin/snapshot_bench
+++ b/demo/chbench/bin/snapshot_bench
@@ -13,7 +13,7 @@ set -euo pipefail
 project=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 cleanup="no"
-snapshot_dir="${HOME}/materialize/benchmark_data/chbench"
+snapshot_dir="${HOME:-/tmp}/materialize/benchmark_data/chbench"
 num_measurements=6
 peeker_queries="count-sources"
 setup="no"


### PR DESCRIPTION
This is failing when called from our cloud ingest benchmarks because
$HOME is not set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5143)
<!-- Reviewable:end -->
