### PR TITLE
sql: support polymorphic functions with decimal elements

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -395,11 +395,19 @@ impl ParamList {
         let mut set_or_check_constrained_type = |typ: &ScalarType| {
             match constrained_type {
                 None => constrained_type = Some(typ.clone()),
-                Some(ref t) => {
-                    if typ != t {
-                        return Err(());
+                Some(ref t) => match (t, typ) {
+                    (ScalarType::Decimal(p1, s1), ScalarType::Decimal(p2, s2)) => {
+                        constrained_type = Some(ScalarType::Decimal(
+                            std::cmp::max(*p1, *p2),
+                            std::cmp::max(*s1, *s2),
+                        ));
                     }
-                }
+                    (t, typ) => {
+                        if typ != t {
+                            return Err(());
+                        }
+                    }
+                },
             }
             Ok(())
         };

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1703,6 +1703,12 @@ SELECT (LIST[1] || '{2}')::text
 ----
 {1,2}
 
+# Differetly scaled decimals are implcitly castable to one another
+query T
+SELECT ('{1.2}'::numeric(38,5) list || '{2.3}'::numeric(38,0) list)::text;
+----
+{1.20000,2.00000}
+
 # 🔬🔬🔬 list + element
 
 query T
@@ -1849,3 +1855,7 @@ SELECT LIST[[[1]]] || LIST[2]
 # Literal text cannot be implicitly cast to list
 query error no overload for i32 list || string: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT LIST[1] || '{2}'::text
+
+# Two lists containing implicitly castable element types are not implicitly castable to one another
+query error no overload for f32 list || f64 list: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT '{1}'::float4 list || '{2}'::float8 list


### PR DESCRIPTION
Add support for resolving polymorphic functions whose elements are differently scaled `Decimal` values.

Pinging "the SQL team" who is on vacation this week, but maybe someone is looking for a coworker _who really needs help right away_. 😉

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5145)
<!-- Reviewable:end -->
