### PR TITLE
Enable running chbench scripts from any directory

### DIFF
--- a/demo/chbench/bin/download_snapshot
+++ b/demo/chbench/bin/download_snapshot
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-project=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+project=$(pwd)
 
 snapshot_dir="${HOME}/materialize/benchmark_data/chbench"
 

--- a/demo/chbench/bin/generate_snapshot
+++ b/demo/chbench/bin/generate_snapshot
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-project=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+project=$(pwd)
 
 cleanup="no"
 snapshot_dir="${HOME}/materialize/benchmark_data/chbench"

--- a/demo/chbench/bin/ingest_bench
+++ b/demo/chbench/bin/ingest_bench
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-project=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+project=$(pwd)
 
 chbench_seconds=43200
 cleanup="no"

--- a/demo/chbench/bin/snapshot_bench
+++ b/demo/chbench/bin/snapshot_bench
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-project=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+project=$(pwd)
 
 cleanup="no"
 snapshot_dir="${HOME:-/tmp}/materialize/benchmark_data/chbench"


### PR DESCRIPTION
While this script is capable of finding the mzcompose script in the
demo/chbench directory, it would fail if run from another directory
because mzcompose could not find mzcompose.yml. cd into the chbench
directory so that mzcompose can find mzcompose.yml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5146)
<!-- Reviewable:end -->
