### PR TITLE
sql: refactor type name resolution migration

### DIFF
--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -49,6 +49,10 @@ pub(crate) enum ErrorKind {
     TypeRename(String),
     ExperimentalModeRequired,
     ExperimentalModeUnavailable,
+    FailedMigration {
+        last_version: usize,
+        cause: String,
+    },
 }
 
 impl Error {
@@ -92,7 +96,8 @@ impl std::error::Error for Error {
             | ErrorKind::AmbiguousRename { .. }
             | ErrorKind::TypeRename(_)
             | ErrorKind::ExperimentalModeRequired
-            | ErrorKind::ExperimentalModeUnavailable => None,
+            | ErrorKind::ExperimentalModeUnavailable
+            | ErrorKind::FailedMigration { .. } => None,
             ErrorKind::Sql(e) => Some(e),
             ErrorKind::Storage(e) => Some(e),
         }
@@ -167,6 +172,14 @@ https://materialize.com/docs/cli#experimental-mode"#
                 f,
                 r#"Experimental mode is only available on new nodes. For
 more details, see https://materialize.com/docs/cli#experimental-mode"#
+            ),
+            ErrorKind::FailedMigration {
+                last_version,
+                cause,
+            } => write!(
+                f,
+                "migration from catalog content version {} failed: {}",
+                last_version, cause,
             ),
         }
     }

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -1,0 +1,128 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::bail;
+
+use ore::collections::CollectionExt;
+use sql::ast::display::AstDisplay;
+use sql::ast::visit_mut::VisitMut;
+use sql::ast::{
+    CreateIndexStatement, CreateTableStatement, CreateViewStatement, DataType, Ident, ObjectName,
+    Statement,
+};
+
+use crate::catalog::PG_CATALOG_SCHEMA;
+use crate::catalog::{Catalog, SerializedCatalogItem};
+
+pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] = &[
+    // Rewrites all built-in type references to have `pg_catalog` qualification;
+    // this is necessary to support resolving all type names to the catalog.
+    //
+    // The approach is to prepend `pg_catalog` to all `DataType::Other` names
+    // that only contain a single element. We do this in the AST and without
+    // replanning the `CREATE` statement because the catalog still contains no
+    // items at this point, e.g. attempting to plan any item with a dependency
+    // will fail.
+    //
+    // Introduced for v0.6.1
+    |catalog: &mut Catalog| {
+        struct TypeNormalizer;
+
+        impl<'ast> VisitMut<'ast> for TypeNormalizer {
+            fn visit_data_type_mut(&mut self, data_type: &'ast mut DataType) {
+                if let DataType::Other { name, .. } = data_type {
+                    if name.0.len() == 1 {
+                        *name = ObjectName(vec![Ident::new(PG_CATALOG_SCHEMA), name.0.remove(0)]);
+                    }
+                }
+            }
+        }
+
+        let mut storage = catalog.storage();
+        let items = storage.load_items()?;
+        let tx = storage.transaction()?;
+
+        for (id, name, def) in items {
+            let SerializedCatalogItem::V1 {
+                create_sql,
+                eval_env,
+            } = serde_json::from_slice(&def)?;
+
+            let mut stmt = sql::parse::parse(&create_sql)?.into_element();
+            match &mut stmt {
+                Statement::CreateTable(CreateTableStatement {
+                    name: _,
+                    columns,
+                    constraints: _,
+                    with_options: _,
+                    if_not_exists: _,
+                }) => {
+                    for c in columns {
+                        TypeNormalizer.visit_column_def_mut(c);
+                    }
+                }
+
+                Statement::CreateView(CreateViewStatement {
+                    name: _,
+                    columns: _,
+                    query,
+                    temporary: _,
+                    materialized: _,
+                    if_exists: _,
+                    with_options: _,
+                }) => TypeNormalizer.visit_query_mut(query),
+
+                Statement::CreateIndex(CreateIndexStatement {
+                    name: _,
+                    on_name: _,
+                    key_parts,
+                    if_not_exists: _,
+                }) => {
+                    if let Some(key_parts) = key_parts {
+                        for key_part in key_parts {
+                            TypeNormalizer.visit_expr_mut(key_part);
+                        }
+                    }
+                }
+
+                // At the time the migration was written, sinks and sources
+                // could not contain references to types.
+                Statement::CreateSource(_) | Statement::CreateSink(_) => continue,
+
+                _ => bail!("catalog item contained inappropriate statement: {}", stmt),
+            }
+
+            let serialized_item = SerializedCatalogItem::V1 {
+                create_sql: stmt.to_ast_string_stable(),
+                eval_env,
+            };
+
+            let serialized_item =
+                serde_json::to_vec(&serialized_item).expect("catalog serialization cannot fail");
+            tx.update_item(id, &name.item, &serialized_item)?;
+        }
+        tx.commit()?;
+        Ok(())
+    },
+    // Add new migrations here.
+    //
+    // Migrations should be preceded with a comment of the following form:
+    //
+    //     > Short summary of migration's purpose.
+    //     >
+    //     > Introduced in <VERSION>.
+    //     >
+    //     > Optional additional commentary about safety or approach.
+    //
+    // Please include @benesch on any code reviews that add or edit migrations.
+    // Migrations must preserve backwards compatibility with all past releases
+    // of materialized. Migrations can be edited up until they ship in a
+    // release, after which they must never be removed, only patched by future
+    // migrations.
+];

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -81,7 +81,9 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
         println!("Run {} ...", execution_count);
         cmds_exec = cmds.clone();
         let (mut state, state_cleanup) = action::create_state(config).await?;
-        state.reset_materialized().await?;
+        if config.reset_materialized {
+            state.reset_materialized().await?;
+        }
         // The `tokio::spawn` allows using `block_in_place` to run sync code within
         // the spawned task. The spawn will one day not be necessary.
         // See: https://github.com/tokio-rs/tokio/issues/1838.

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -88,6 +88,11 @@ async fn run() -> Result<(), Error> {
         "validate the on-disk state of the materialized catalog",
         "PATH",
     );
+    opts.optflag(
+        "",
+        "no-reset",
+        "don't reset materialized state before executing testdrive script",
+    );
     opts.optflag("h", "help", "show this usage information");
 
     let usage_details = opts.usage("usage: testdrive [options] FILE");
@@ -178,6 +183,9 @@ async fn run() -> Result<(), Error> {
     }
     if let Some(path) = opts.opt_str("validate-catalog") {
         config.materialized_catalog_path = Some(path.into());
+    }
+    if opts.opt_present("no-reset") {
+        config.reset_materialized = false;
     }
 
     if opts.free.is_empty() {

--- a/test/catalog-compat/catcompatck/Dockerfile
+++ b/test/catalog-compat/catcompatck/Dockerfile
@@ -9,14 +9,16 @@
 
 ARG BUILDKITE_BUILD_NUMBER
 
-FROM materialize/materialized:v0.1.0 AS golden
+FROM materialize/materialized:v0.1.0 AS golden010
+FROM materialize/materialized:v0.6.0 AS golden060
 MZFROM materialized AS edge
 MZFROM testdrive AS testdrive
 FROM ubuntu:bionic-20200403
 
 RUN apt-get update && apt-get install -y curl postgresql-client-10 wait-for-it
 
-COPY --from=golden /usr/local/bin/materialized /usr/local/bin/materialized-golden
+COPY --from=golden010 /usr/local/bin/materialized /usr/local/bin/materialized-golden010
+COPY --from=golden060 /usr/local/bin/materialized /usr/local/bin/materialized-golden060
 COPY --from=edge /usr/local/bin/materialized /usr/local/bin/materialized-edge
 COPY --from=testdrive /usr/local/bin/testdrive /usr/local/bin/testdrive
 COPY catcompatck /usr/local/bin/catcompatck

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -22,24 +22,6 @@ run_sql() {
     psql -h localhost -p 6875 materialize -c "\pset footer off" -c "$1" "$@"
 }
 
-sloppy_diff() {
-    diff -ub <(echo "$1") <(echo "$2")
-}
-
-expect_sql() {
-    local actual expected
-    expected=$(cat)
-    for _ in {1..10}; do
-        actual=$(run_sql "$1" 2>&1) || true
-        sloppy_diff "$expected" "$actual" > /dev/null && return 0
-        echo "sql query did not match expected results; trying again in 1s..." >&2
-        sleep 1
-    done
-    echo "timed out waiting for expected results" >&2
-    echo "query: $1"
-    sloppy_diff "$expected" "$actual"
-}
-
 launch_materialized() {
     "materialized-$1" -w1 "$@" &
     materialized_pid=$?
@@ -47,12 +29,17 @@ launch_materialized() {
     run_sql "SELECT 1" > /dev/null
 }
 
+kill_materialized() {
+  kill "$materialized_pid"
+  wait 2> /dev/null
+}
+
 wait-for-it --timeout=30 kafka:9092
 
-say "launching materialized-golden"
-launch_materialized golden
+say "launching materialized-golden010"
+launch_materialized golden010
 
-say "building golden catalog"
+say "building golden010 catalog"
 testdrive --kafka-addr kafka:9092 <<'EOF'
 $ set schema={
     "type": "record",
@@ -89,43 +76,54 @@ $ kafka-ingest format=avro topic=real-time schema=${schema} timestamp=1
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
 
-> CREATE MATERIALIZED VIEW real_time AS SELECT * FROM real_time_src
+> CREATE MATERIALIZED VIEW real_time AS
+  SELECT *, concat(a::text, CAST(b AS text)) AS c
+  FROM real_time_src
+
+> CREATE INDEX real_time_idx ON real_time (a::text)
 
 > SELECT * FROM real_time
-a  b
-----
-1  1
-2  1
-3  1
-1  2
-
-> CREATE MATERIALIZED VIEW real_time_str AS SELECT CAST(a AS text) FROM real_time_src
-
-> SELECT * FROM real_time_str
-a
-----
-1
-2
-3
-1
-
+a  b  c
+--------
+1  1  11
+2  1  21
+3  1  31
+1  2  12
 EOF
 
-say "killing materialized-golden"
-kill "$materialized_pid"
-wait 2> /dev/null
+say "killing materialized-golden010"
+kill_materialized
+
+say "launching materialized-golden060"
+launch_materialized golden060
+
+say "adding golden060 features to golden010 catalog"
+testdrive --no-reset <<'EOF'
+> CREATE TABLE t (a int, b text DEFAULT 'def')
+> INSERT INTO t (a) VALUES (42)
+> SELECT * FROM t
+42  def
+EOF
+
+say "killing materialized-golden060"
+kill_materialized
 
 say "launching materialized-edge with golden catalog"
 launch_materialized edge --log-file=stderr
 
 say "validating edge state"
-# Can't presently use another testdrive script here, as booting testdrive will
-# first blow away any existing state.
-expect_sql "SELECT * FROM real_time" <<EOF
- a | b
----+---
- 1 | 1
- 1 | 2
- 2 | 1
- 3 | 1
+testdrive --no-reset <<EOF
+> SELECT * FROM real_time
+a  b  c
+--------
+1  1  11
+2  1  21
+3  1  31
+1  2  12
+
+# NOTE(benesch): if/when tables persist their input data, we won't need to
+# reinsert data here.
+> INSERT INTO t (a) VALUES (42)
+> SELECT * FROM t
+42  def
 EOF

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -98,6 +98,17 @@ a  b
 2  1
 3  1
 1  2
+
+> CREATE MATERIALIZED VIEW real_time_str AS SELECT CAST(a AS text) FROM real_time_src
+
+> SELECT * FROM real_time_str
+a
+----
+1
+2
+3
+1
+
 EOF
 
 say "killing materialized-golden"


### PR DESCRIPTION
@benesch Do you have suggestions for a better structure to test this change in `test/catalog-compat/catcompatck/catcompatck`? Feels like we want version-a to version-b migrations tests in addition to this "golden" test but wanted to run that by you before embarking on the endeavor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5161)
<!-- Reviewable:end -->
