### PR TITLE
*: format manifests with cargo-manifmt

### DIFF
--- a/demo/billing/Cargo.toml
+++ b/demo/billing/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.34"
 bytes = "0.5.6"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 csv = "1.1.5"
 env_logger = "0.8.2"
 futures = "0.3.8"
@@ -18,14 +18,14 @@ log = "0.4.11"
 ore = { path = "../../src/ore" }
 parse_duration = "2.1.0"
 postgres-types = "0.1.1"
-protobuf = "2.17"
+protobuf = "2.17.0"
 rand = "0.8.0"
 rand_distr = "0.4.0"
 structopt = "0.3.21"
 test-util = { path = "../../test/test-util" }
 tokio = { version = "0.2.22", features = ["full"] }
 tokio-postgres = "0.5.5"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "0.8.0", features = ["v4"] }
 
 [build-dependencies]
 protoc = { path = "../../src/protoc" }

--- a/play/mbta/Cargo.toml
+++ b/play/mbta/Cargo.toml
@@ -7,15 +7,15 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-avro = {path = "../../src/avro", package = "mz-avro"}
-byteorder = "1.3"
-futures = "0.3"
-getopts = "0.2"
+avro = { package = "mz-avro", path = "../../src/avro" }
+byteorder = "1.3.0"
+futures = "0.3.0"
+getopts = "0.2.0"
 json = "0.12.4"
-serde_json = "1.0.60"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 parse_duration = "2.1.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 reqwest = { version = "0.10.4", features = ["native-tls-vendored"] }
+serde_json = "1.0.60"
 test-util = { path = "../../test/test-util" }
 tokio = { version = "0.2.22", features = ["full"] }

--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -5,12 +5,10 @@ authors = ["Brennan Vincent <brennan@umanwizard.com>"]
 license = "Apache-2.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-syn = { version = "1.0", features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-
 [lib]
 proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.0"
+quote = "1.0.0"
+syn = { version = "1.0.0", features = ["full"] }

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -1,36 +1,38 @@
 [package]
 name = "mz-avro"
-version = "0.6.5"
-authors = ["Brennan Vincent <brennan@materialize.io>", "Jessica Laughlin <jessica@materialize.io>"]
 description = "Library for working with Apache Avro in Rust"
+version = "0.6.5"
+authors = [
+    "Brennan Vincent <brennan@materialize.io>",
+    "Jessica Laughlin <jessica@materialize.io>",
+]
 license = "Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/MaterializeInc/materialize"
 edition = "2018"
 autobenches = false
-
-[features]
-snappy = ["byteorder", "crc", "snap"]
 
 [dependencies]
 anyhow = "1.0.34"
 avro-derive = { path = "../avro-derive" }
 byteorder = { version = "1.0.0", optional = true }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crc = { version = "1.3.0", optional = true }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-digest = "0.9"
+digest = "0.9.0"
 enum-kinds = "0.5.0"
-itertools = "0.9"
-flate2 = "1.0"
+flate2 = "1.0.0"
+itertools = "0.9.0"
 log = "0.4.11"
 rand = "0.8.0"
-regex = "1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+regex = "1.0.0"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
 sha2 = "0.9.2"
-snap = { version = "1", optional = true }
-uuid = "0.8"
+snap = { version = "1.0.0", optional = true }
+uuid = "0.8.0"
 
 [dev-dependencies]
-md-5 = "0.9"
-lazy_static = "^1.1"
+lazy_static = "1.1.0"
+md-5 = "0.9.0"
+
+[features]
+snappy = ["byteorder", "crc", "snap"]

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-log = "0.4"
+log = "0.4.0"
 mz_rusoto_core = "0.46.0"
 mz_rusoto_credential = "0.46.0"
 mz_rusoto_kinesis = "0.46.0"
 mz_rusoto_sts = "0.46.0"
-tokio = "0.2"
+tokio = "0.2.0"

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures = "0.3.0"
 native-tls = "0.2.6"
 openssl = { version = "0.10.32", features = ["vendored"] }
 reqwest = { version = "0.10.8", features = ["blocking", "json", "native-tls-vendored"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.60"
 url = { version = "2.2.0", features = ["serde"] }
 
 [dev-dependencies]
 anyhow = "1.0.34"
 hyper = "0.13.9"
-lazy_static = "1.4"
-tokio = { version = "0.2", features = ["macros"] }
+lazy_static = "1.4.0"
+tokio = { version = "0.2.0", features = ["macros"] }

--- a/src/comm/Cargo.toml
+++ b/src/comm/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2018"
 publish = false
 
 [dependencies]
-backtrace = "0.3"
-bincode = "1.3"
-bytes = "0.5"
-futures = "0.3"
+backtrace = "0.3.0"
+bincode = "1.3.0"
+bytes = "0.5.0"
+futures = "0.3.0"
 log = "0.4.11"
 num_enum = "0.5.1"
 ore = { path = "../ore" }
-rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "0.2", features = ["dns", "macros", "rt-threaded", "stream", "time", "uds"] }
+rand = "0.8.0"
+serde = { version = "1.0.0", features = ["derive"] }
+tokio = { version = "0.2.0", features = ["dns", "macros", "rt-threaded", "stream", "time", "uds"] }
 tokio-serde = { version = "0.6.1", features = ["bincode"] }
 tokio-util = { version = "0.3.1", features = ["codec"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "0.8.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
-assert_cmd = "1.0"
-getopts = "0.2"
+assert_cmd = "1.0.0"
+getopts = "0.2.0"
 predicates = "1.0.5"

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -9,23 +9,24 @@ publish = false
 anyhow = "1.0.34"
 aws-util = { path = "../aws-util" }
 backtrace = "0.3.55"
-bincode = { version = "1.3", optional = true }
+bincode = { version = "1.3.0", optional = true }
 build-info = { path = "../build-info" }
-byteorder = "1.3"
+byteorder = "1.3.0"
 ccsr = { path = "../ccsr" }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 comm = { path = "../comm" }
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
-derivative = "2.1"
+derivative = "2.1.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
-futures = "0.3"
+futures = "0.3.0"
 interchange = { path = "../interchange" }
-itertools = "0.9"
-lazy_static = "1.4"
-log = "0.4"
+itertools = "0.9.0"
+lazy_static = "1.4.0"
+log = "0.4.0"
 mz-avro = { path = "../avro", features = ["snappy"] }
+mz_rusoto_kinesis = "0.46.0"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
 postgres-types = "0.1.3"
@@ -34,18 +35,17 @@ rand = "0.8.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 regex = "1.4.1"
 repr = { path = "../repr" }
-mz_rusoto_kinesis = "0.46.0"
-rusqlite = { version = "0.24", features = ["bundled", "unlock_notify"] }
-serde = "1.0"
+rusqlite = { version = "0.24.0", features = ["bundled", "unlock_notify"] }
+serde = "1.0.0"
 serde_json = "1.0.60"
 sql = { path = "../sql" }
 symbiosis = { path = "../symbiosis" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
-tokio = "0.2"
+tokio = "0.2.0"
 transform = { path = "../transform" }
 unicase = "2.6.0"
-url = "2"
-uuid = { version = "0.8", features = ["v4"] }
+url = "2.0.0"
+uuid = { version = "0.8.0", features = ["v4"] }
 
 [dev-dependencies]
-tempfile = "3.1"
+tempfile = "3.1.0"

--- a/src/dataflow-bin/Cargo.toml
+++ b/src/dataflow-bin/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-getopts = "0.2"
+getopts = "0.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -7,20 +7,20 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-interchange = { path = "../interchange" }
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
 expr = { path = "../expr" }
+interchange = { path = "../interchange" }
 kafka-util = { path = "../kafka-util" }
-log = "0.4"
+log = "0.4.0"
+mz_rusoto_core = "0.46.0"
 regex = "1.4.1"
 repr = { path = "../repr" }
-mz_rusoto_core = "0.46.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 serde_regex = "1.1.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 url = { version = "2.2.0", features = ["serde"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "0.8.0", features = ["serde", "v4"] }
 
 [dev-dependencies]
 serde_json = "1.0.60"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.34"
 async-trait = "0.1.42"
 aws-util = { path = "../aws-util" }
 bincode = "1.3.1"
-byteorder = "1.3"
+byteorder = "1.3.0"
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
 csv-core = "0.1.10"
@@ -18,14 +18,17 @@ dataflow-types = { path = "../dataflow-types" }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
-futures = "0.3"
+futures = "0.3.0"
 interchange = { path = "../interchange" }
-itertools = "0.9"
+itertools = "0.9.0"
 kafka-util = { path = "../kafka-util" }
-lazy_static = "1.4"
-log = "0.4"
+lazy_static = "1.4.0"
+log = "0.4.0"
 mz-avro = { path = "../avro", features = ["snappy"] }
-notify = "4.0"
+mz_rusoto_core = "0.46.0"
+mz_rusoto_credential = "0.46.0"
+mz_rusoto_kinesis = "0.46.0"
+notify = "4.0.0"
 ore = { path = "../ore" }
 pdqselect = "0.1.0"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
@@ -34,13 +37,10 @@ rand = "0.8.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static", "zstd"] }
 regex = "1.4.1"
 repr = { path = "../repr" }
-mz_rusoto_core = "0.46.0"
-mz_rusoto_credential = "0.46.0"
-mz_rusoto_kinesis = "0.46.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.60"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
-tokio = { version = "0.2", features = ["blocking", "fs", "rt-threaded"] }
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "0.2.0", features = ["blocking", "fs", "rt-threaded"] }
+tokio-util = { version = "0.3.0", features = ["codec"] }
 url = { version = "2.2.0", features = ["serde"] }
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "0.8.0", features = ["serde", "v4"] }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -7,14 +7,14 @@ publish = false
 
 [dependencies]
 aho-corasick = "0.7.15"
-anyhow = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-csv = "1.1"
-encoding = "0.2"
+anyhow = "1.0.0"
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
+csv = "1.1.0"
+encoding = "0.2.0"
 enum-iterator = "0.6.0"
 hmac = "0.10.0"
-itertools = "0.9"
-md-5 = "0.9"
+itertools = "0.9.0"
+md-5 = "0.9.0"
 num_enum = "0.5.1"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }
@@ -22,8 +22,8 @@ pdqselect = "0.1.0"
 regex = "1.4.1"
 regex-syntax = "0.6.18"
 repr = { path = "../repr" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
 sha-1 = "0.9.2"
 sha2 = "0.9.2"
 unicase = "2.6.0"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -13,33 +13,33 @@ harness = false
 [dependencies]
 anyhow = "1.0.34"
 avro-derive = { path = "../avro-derive" }
-base64 = "0.13"
-byteorder = "1.3"
+base64 = "0.13.0"
+byteorder = "1.3.0"
 ccsr = { path = "../ccsr" }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
-futures = "0.3"
-hex = "0.4"
+futures = "0.3.0"
+hex = "0.4.0"
+itertools = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.11"
-num-traits = "0.2.14" # don't want to upgrade to autocfg 1.0 until more things use it
-itertools = "0.9.0"
 mz-avro = { path = "../avro", features = ["snappy"] }
+num-traits = "0.2.14"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }
-protobuf = "2.17"
+protobuf = "2.17.0"
 repr = { path = "../repr" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }
 serde-value = "0.7.0"
 serde_json = "1.0.60"
-smallvec = "1.5.1"
 sha2 = "0.9.2"
+smallvec = "1.5.1"
 url = "2.2.0"
-uuid = "0.8"
+uuid = "0.8.0"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.0"
 
 [build-dependencies]
 protoc = { path = "../protoc" }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
-mz-avro = { path = "../avro" }
+anyhow = "1.0.0"
 ccsr = { path = "../ccsr" }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-clap = "2.33"
-ore = { path = "../../src/ore" }
-futures = "0.3"
-rand = "0.8"
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
+clap = "2.33.0"
+futures = "0.3.0"
+mz-avro = { path = "../avro" }
+ore = { path = "../ore" }
+rand = "0.8.0"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "0.2", features = ["macros"] }
-url = "2"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
+tokio = { version = "0.2.0", features = ["macros"] }
+url = "2.0.0"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -2,19 +2,35 @@
 name = "materialized"
 description = "Streaming SQL materialized views."
 version = "0.6.1-dev"
-edition = "2018"
-publish = false
-build = "build/main.rs"
-default-run = "materialized"
-# required for cargo-deb
 authors = ["Materialize, Inc."]
 license = "proprietary"
+edition = "2018"
+publish = false
+default-run = "materialized"
+build = "build/main.rs"
+
+[package.metadata.deb]
+assets = [
+    ["../../misc/dist/materialized.service", "lib/systemd/system/", "644"],
+    ["target/release/materialized", "usr/bin/", "755"],
+]
+conflicts = "materialized"
+depends = "$auto"
+maintainer-scripts = "misc/dist/deb-scripts"
+
+[package.metadata.deb.variants.materialized]
+conflicts = "materialized-unstable"
+name = "materialized"
+
+[package.metadata.deb.variants.materialized-unstable]
+conflicts = "materialized"
+name = "materialized-unstable"
 
 [dependencies]
 anyhow = "1.0.34"
 askama = { version = "0.10.5", features = ["serde-json"] }
 async-trait = "0.1.42"
-backtrace = { version = "0.3.55" }
+backtrace = "0.3.55"
 build-info = { path = "../build-info" }
 cfg-if = "1.0.0"
 comm = { path = "../comm" }
@@ -22,61 +38,69 @@ compile-time-run = "0.2.11"
 coord = { path = "../coord" }
 dataflow = { path = "../dataflow" }
 dataflow-types = { path = "../dataflow-types" }
-futures = "0.3"
-getopts = "0.2"
-hex = "0.4"
+futures = "0.3.0"
+getopts = "0.2.0"
+hex = "0.4.0"
 hyper = "0.13.9"
 include_dir = "0.6.0"
-itertools = "0.9"
+itertools = "0.9.0"
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
 log = "0.4.11"
 mz-process-collector = { path = "../mz-process-collector" }
-num_cpus = "1.0"
+num_cpus = "1.0.0"
 openssl = { version = "0.10.32", features = ["vendored"] }
 openssl-sys = { version = "0.9.59", features = ["vendored"] }
 ore = { path = "../ore" }
 os_info = "3.0.1"
 parse_duration = "2.1.0"
-postgres_array = "0.10.0"
-postgres-openssl = "0.3.0"
 pgwire = { path = "../pgwire" }
+postgres-openssl = "0.3.0"
+postgres_array = "0.10.0"
 prof = { path = "../prof", features = ["auto-jemalloc"] }
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 repr = { path = "../repr" }
 reqwest = { version = "0.10.8", features = ["json"] }
 rlimit = "0.5.3"
-semver = "0.11"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
-shell-words = "1.0"
+semver = "0.11.0"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
+shell-words = "1.0.0"
 sql = { path = "../sql" }
 sql-parser = { path = "../sql-parser" }
 sysctl = "0.4.0"
 sysinfo = "0.15.3"
-tempfile = "3.1"
-tokio = { version = "0.2", features = ["sync"] }
+tempfile = "3.1.0"
+tokio = { version = "0.2.0", features = ["sync"] }
 tokio-openssl = "0.4.0"
 tracing = "0.1.21"
 # TODO(benesch): we can use the default features here once tracing-subscriber
 # does not enable chrono's "oldtime" feature.
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["ansi", "env-filter", "fmt", "tracing-log"] }
-url = "2"
+url = "2.0.0"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+# According to jemalloc developers, `background_threads` should always be
+# enabled, except in "esoteric" situations that don't apply to Materialize
+# (Namely: if the application relies on new threads not being created for whatever reason)
+#
+# See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
+jemallocator = { version = "0.3.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.2"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
-datadriven = "0.4"
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
+datadriven = "0.4.0"
 fallible-iterator = "0.2.0"
-itertools = "0.9"
+itertools = "0.9.0"
 pgrepr = { path = "../pgrepr" }
 pgtest = { path = "../pgtest" }
-postgres = { version = "0.17", features = ["with-chrono-0_4"] }
+postgres = { version = "0.17.0", features = ["with-chrono-0_4"] }
 predicates = "1.0.5"
 repr = { path = "../repr" }
 reqwest = { version = "0.10.8", features = ["blocking"] }
-serde_json = "1"
+serde_json = "1.0.0"
 tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4"] }
 
 [build-dependencies]
@@ -97,28 +121,3 @@ walkdir = "2.3.1"
 # WARNING: For development use only! When enabled, may allow unrestricted read
 # access to the file system.
 dev-web = []
-
-[target.'cfg(not(target_os = "macos"))'.dependencies]
-# According to jemalloc developers, `background_threads` should always be
-# enabled, except in "esoteric" situations that don't apply to Materialize
-# (Namely: if the application relies on new threads not being created for whatever reason)
-#
-# See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
-jemallocator = { version = "0.3", features = ["profiling", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
-
-[package.metadata.deb]
-depends = "$auto"
-conflicts = "materialized"
-assets = [
-    ["../../misc/dist/materialized.service", "lib/systemd/system/", "644"],
-    ["target/release/materialized", "usr/bin/", "755"]
-]
-maintainer-scripts = "misc/dist/deb-scripts"
-
-[package.metadata.deb.variants.materialized]
-name = "materialized"
-conflicts = "materialized-unstable"
-
-[package.metadata.deb.variants.materialized-unstable]
-name = "materialized-unstable"
-conflicts = "materialized"

--- a/src/metabase/Cargo.toml
+++ b/src/metabase/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reqwest = { version = "0.10.8" }
-serde = { version = "1.0", features = ["derive"] }
+reqwest = "0.10.8"
+serde = { version = "1.0.0", features = ["derive"] }

--- a/src/mz-process-collector/Cargo.toml
+++ b/src/mz-process-collector/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2018"
 publish = false
 
 [dependencies]
-prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
-libc = "0.2.81"
 lazy_static = "1.4.0"
+libc = "0.2.81"
+prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.9.1", default-features = false }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2018"
 publish = false
 
 [dependencies]
-bytes = "0.5"
+bytes = "0.5.0"
 fallible-iterator = "0.2.0"
-futures = "0.3"
+futures = "0.3.0"
 lazy_static = "1.4.0"
 libc = "0.2.81"
 log = "0.4.11"
-phf_shared = "0.8"
-smallvec = "1.5"
-tokio = { version = "0.2", features = ["io-util", "rt-threaded", "tcp", "time"] }
+phf_shared = "0.8.0"
+smallvec = "1.5.0"
+tokio = { version = "0.2.0", features = ["io-util", "rt-threaded", "tcp", "time"] }
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]

--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
-getopts = "0.2"
-hyper = "0.13"
-lazy_static = "1.4"
+getopts = "0.2.0"
+hyper = "0.13.0"
+lazy_static = "1.4.0"
 log = "0.4.11"
 mz-process-collector = { path = "../mz-process-collector" }
 ore = { path = "../ore" }

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-byteorder = "1.3"
-bytes = "0.5"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+byteorder = "1.3.0"
+bytes = "0.5.0"
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
-postgres-types = { version = "0.1.1", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 ore = { path = "../ore" }
+postgres-types = { version = "0.1.1", features = ["with-chrono-0_4", "with-uuid-0_8"] }
 repr = { path = "../repr" }
-uuid = "0.8"
+uuid = "0.8.0"

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 publish = false
 
 [dependencies]
-anyhow = "1.0"
-bytes = "0.5"
+anyhow = "1.0.0"
+bytes = "0.5.0"
 datadriven = "0.4.0"
-fallible-iterator = "0.2"
-getopts = "0.2"
+fallible-iterator = "0.2.0"
+getopts = "0.2.0"
 postgres = "0.17.5"
-postgres-protocol = "0.5"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+postgres-protocol = "0.5.0"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -7,26 +7,26 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-byteorder = "1.3"
-bytes = "0.5"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+byteorder = "1.3.0"
+bytes = "0.5.0"
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 comm = { path = "../comm" }
 coord = { path = "../coord" }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
-futures = "0.3"
-itertools = "0.9"
+futures = "0.3.0"
+itertools = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.11"
 openssl = { version = "0.10.32", features = ["vendored"] }
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
+postgres = "0.17.5"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
-rand = "0.8"
+rand = "0.8.0"
 repr = { path = "../repr" }
 sql = { path = "../sql" }
-tokio = "0.2"
+tokio = "0.2.0"
 tokio-openssl = "0.4.0"
-tokio-util = { version = "0.3", features = ["codec"] }
-postgres = "0.17.5"
+tokio-util = { version = "0.3.0", features = ["codec"] }

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -1,23 +1,20 @@
 [package]
 name = "prof"
 description = "CPU and memory profiling tools."
+version = "0.1.0"
 edition = "2018"
 publish = false
-version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0.34"
-backtrace = "0.3"
-jemalloc-ctl = { version = "0.3", features = ["use_std"], optional = true }
+backtrace = "0.3.0"
+jemalloc-ctl = { version = "0.3.0", features = ["use_std"], optional = true }
 lazy_static = "1.4.0"
 pprof = "0.3.20"
-tempfile = "3.1"
-tokio = { version = "0.2", features = ["time"] }
+tempfile = "3.1.0"
+tokio = { version = "0.2.0", features = ["time"] }
 
 [features]
-# Whether to enable profiling features that depend on jemalloc.
-jemalloc = ["jemalloc-ctl"]
-
 # Whether to automatically enable the jemalloc feature if compiling for a target
 # besides macOS.
 #
@@ -25,3 +22,5 @@ jemalloc = ["jemalloc-ctl"]
 # supports target-specific features.
 # See: https://github.com/rust-lang/cargo/issues/1197
 auto-jemalloc = ["jemalloc-ctl"]
+# Whether to enable profiling features that depend on jemalloc.
+jemalloc = ["jemalloc-ctl"]

--- a/src/protoc/Cargo.toml
+++ b/src/protoc/Cargo.toml
@@ -5,16 +5,14 @@ version = "0.1.0"
 edition = "2018"
 publish = false
 
-[lib]
-
 [[bin]]
 name = "protoc"
 path = "bin/protoc.rs"
 
 [dependencies]
 anyhow = "1.0.34"
-getopts = "0.2"
-protobuf = "2.17"
-protobuf-codegen = "2.17"
-protobuf-codegen-pure = "2.17"
+getopts = "0.2.0"
+protobuf = "2.17.0"
+protobuf-codegen = "2.17.0"
+protobuf-codegen-pure = "2.17.0"
 tempfile = "3.1.0"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -15,21 +15,21 @@ harness = false
 
 [dependencies]
 anyhow = "1.0.34"
-byteorder = "1.3"
-chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
-chrono-tz = { version = "0.5", features = ["serde"] }
+byteorder = "1.3.0"
+chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
+chrono-tz = { version = "0.5.0", features = ["serde"] }
 enum-kinds = "0.5.0"
 hex = "0.4.2"
-itertools = "0.9"
+itertools = "0.9.0"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }
 regex = "1.4.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
 serde_regex = "1.1.0"
 smallvec = { version = "1.5.1", features = ["serde"] }
-uuid = "0.8"
+uuid = "0.8.0"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.0"
 rand = "0.8.0"

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -2,28 +2,28 @@
 name = "sql-parser"
 description = "The lexer and parser for Materialize's SQL dialect."
 version = "0.1.0"
+exclude = ["tests/testdata"]
 edition = "2018"
 publish = false
-exclude = ["tests/testdata"]
 
 [dependencies]
+itertools = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.11"
-itertools = "0.9"
-phf = { version = "0.8", features = ["unicase"] }
 ore = { path = "../ore" }
+phf = { version = "0.8.0", features = ["unicase"] }
 repr = { path = "../repr" }
-unicase = "2.4"
 stacker = "0.1.12"
+unicase = "2.4.0"
 
 [dev-dependencies]
 datadriven = "0.4.0"
-matches = "0.1"
+matches = "0.1.0"
 unicode-width = "0.1.8"
 
 [build-dependencies]
 anyhow = "1.0.34"
 ore = { path = "../ore" }
-phf_codegen = "0.8"
-unicase = "2.4"
+phf_codegen = "0.8.0"
+unicase = "2.4.0"
 walkabout = { path = "../walkabout" }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -10,27 +10,27 @@ anyhow = "1.0.34"
 aws-arn = "0.1.1"
 build-info = { path = "../build-info" }
 ccsr = { path = "../ccsr" }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
-futures = "0.3"
+futures = "0.3.0"
 interchange = { path = "../interchange" }
-itertools = "0.9"
+itertools = "0.9.0"
 lazy_static = "1.4.0"
 log = "0.4.11"
 mz-avro = { path = "../avro", features = ["snappy"] }
+mz_rusoto_core = "0.46.0"
 ore = { path = "../ore" }
 parse_duration = "2.1.0"
 pgrepr = { path = "../pgrepr" }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "libz-static"] }
 regex = "1.4.1"
 repr = { path = "../repr" }
-reqwest = { version = "0.10.8" }
-mz_rusoto_core = "0.46.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+reqwest = "0.10.8"
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "0.2.22", features = ["fs"] }
 unicase = "2.6.0"
 url = "2.2.0"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "0.8.0", features = ["serde", "v4"] }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -7,24 +7,24 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 comm = { path = "../comm" }
 expr = { path = "../expr" }
-fallible-iterator = "0.2"
-futures = "0.3"
-getopts = "0.2"
-lazy_static = "1"
+fallible-iterator = "0.2.0"
+futures = "0.3.0"
+getopts = "0.2.0"
+lazy_static = "1.0.0"
 materialized = { path = "../materialized" }
-md-5 = "0.9"
+md-5 = "0.9.0"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-postgres-protocol = "0.5"
-regex = "1"
+postgres-protocol = "0.5.0"
+regex = "1.0.0"
 repr = { path = "../repr" }
-serde_json = "1"
+serde_json = "1.0.0"
 sql = { path = "../sql" }
-tempfile = "3.1"
-tokio = "0.2"
+tempfile = "3.1.0"
+tokio = "0.2.0"
 tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-uuid-0_8", "with-serde_json-1"] }
-uuid = "0.8"
-walkdir = "2"
+uuid = "0.8.0"
+walkdir = "2.0.0"

--- a/src/symbiosis/Cargo.toml
+++ b/src/symbiosis/Cargo.toml
@@ -7,16 +7,16 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-chrono = { version = "0.4", default-features = false, features = ["serde", "std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 log = "0.4.11"
 ore = { path = "../ore" }
 pgrepr = { path = "../pgrepr" }
-tokio = "0.2"
-tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-serde_json-1"] }
 repr = { path = "../repr" }
-serde_json = "1.0"
+serde_json = "1.0.0"
 sql = { path = "../sql" }
-uuid = "0.8"
-whoami = "1.0"
+tokio = "0.2.0"
+tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-serde_json-1"] }
+uuid = "0.8.0"
+whoami = "1.0.0"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -7,50 +7,50 @@ publish = false
 
 [dependencies]
 async-trait = "0.1.42"
-atty = "0.2"
+atty = "0.2.0"
 aws-util = { path = "../aws-util" }
-byteorder = "1.3"
+byteorder = "1.3.0"
 bytes = "0.5.6"
 ccsr = { path = "../ccsr" }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 coord = { path = "../coord" }
-futures = "0.3"
-getopts = "0.2"
+futures = "0.3.0"
+getopts = "0.2.0"
 interchange = { path = "../interchange" }
-itertools = "0.9"
+itertools = "0.9.0"
 kafka-util = { path = "../kafka-util" }
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
-md-5 = "0.9"
+md-5 = "0.9.0"
 mz-avro = { path = "../avro", features = ["snappy"] }
-ore = { path = "../ore" }
-parse_duration = "2.1.0"
-pgrepr = { path = "../pgrepr" }
-tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-serde_json-1"] }
-postgres_array = "0.10.0"
-protobuf = { version = "2.17", features = ["with-serde"] }
-rand = "0.8.0"
-rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
-regex = "1"
-repr = { path = "../repr" }
-reqwest = { version = "0.10.8", features = ["native-tls-vendored"] }
 mz_rusoto_core = "0.46.0"
 mz_rusoto_credential = "0.46.0"
 mz_rusoto_kinesis = "0.46.0"
 mz_rusoto_sts = "0.46.0"
+ore = { path = "../ore" }
+parse_duration = "2.1.0"
+pgrepr = { path = "../pgrepr" }
+postgres_array = "0.10.0"
+protobuf = { version = "2.17.0", features = ["with-serde"] }
+rand = "0.8.0"
+rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
+regex = "1.0.0"
+repr = { path = "../repr" }
+reqwest = { version = "0.10.8", features = ["native-tls-vendored"] }
 serde = "1.0.118"
 serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }
 serde_json = "1.0.60"
 sql-parser = { path = "../sql-parser" }
-tempfile = "3.1"
+tempfile = "3.1.0"
 termcolor = "1.1.2"
-tokio = "0.2"
+tokio = "0.2.0"
+tokio-postgres = { version = "0.5.5", features = ["with-chrono-0_4", "with-serde_json-1"] }
 url = "2.2.0"
-uuid = "0.8"
-
-[build-dependencies]
-protoc = { path = "../protoc" }
+uuid = "0.8.0"
 
 [dev-dependencies]
 assert_cmd = "1.0.2"
 predicates = "1.0.5"
+
+[build-dependencies]
+protoc = { path = "../protoc" }

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -8,9 +8,9 @@ publish = false
 [dependencies]
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
-itertools = "0.9"
+itertools = "0.9.0"
 repr = { path = "../repr" }
 
 [dev-dependencies]
-datadriven = "0.4.0"
 anyhow = "1.0.34"
+datadriven = "0.4.0"

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 anyhow = "1.0.34"
 fstrings = "0.2.3"
 ore = { path = "../ore" }
-quote = { version = "1.0.8" }
+quote = "1.0.8"
 syn = { version = "1.0.55", features = ["extra-traits", "full", "parsing"] }
 
 [dev-dependencies]

--- a/test/chaos/Cargo.toml
+++ b/test/chaos/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.34"
 env_logger = "0.8.2"
 futures = "0.3.8"
 log = "0.4.11"
-md-5 = "0.9"
+md-5 = "0.9.0"
 ore = { path = "../../src/ore" }
 rand = "0.8.0"
 structopt = "0.3.21"

--- a/test/correctness/Cargo.toml
+++ b/test/correctness/Cargo.toml
@@ -10,17 +10,17 @@ name = "test-correctness"
 path = "checker.rs"
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
-futures = "0.3"
-getopts = "0.2"
-hyper = "0.13"
-lazy_static = "1.4"
+futures = "0.3.0"
+getopts = "0.2.0"
+hyper = "0.13.0"
+lazy_static = "1.4.0"
 log = "0.4.11"
 mz-process-collector = { path = "../../src/mz-process-collector" }
 ore = { path = "../../src/ore" }
 pgrepr = { path = "../../src/pgrepr" }
-postgres = "0.17"
+postgres = "0.17.0"
 postgres-types = "0.1.1"
 prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 regex = "1.4.1"

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-metabase = { path = "../../../src/metabase"}
-itertools = "0.9"
+itertools = "0.9.0"
 log = "0.4.11"
+metabase = { path = "../../../src/metabase" }
 ore = { path = "../../../src/ore" }
-tokio = "0.2"
+tokio = "0.2.0"
 tokio-postgres = "0.5.5"

--- a/test/performance/perf-kinesis/Cargo.toml
+++ b/test/performance/perf-kinesis/Cargo.toml
@@ -9,17 +9,17 @@ publish = false
 anyhow = "1.0.34"
 aws-util = { path = "../../../src/aws-util" }
 bytes = "0.5.6"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
 futures = "0.3.8"
 futures-channel = "0.3.5"
 log = "0.4.11"
-ore = { path = "../../../src/ore" }
-rand = "0.8.0"
 mz_rusoto_core = "0.46.0"
 mz_rusoto_credential = "0.46.0"
 mz_rusoto_kinesis = "0.46.0"
+ore = { path = "../../../src/ore" }
+rand = "0.8.0"
 structopt = "0.3.21"
+test-util = { path = "../../test-util" }
 tokio = { version = "0.2.22", features = ["full"] }
 tokio-postgres = "0.5.5"
-test-util = { path = "../../test-util" }

--- a/test/performance/perf-upsert/Cargo.toml
+++ b/test/performance/perf-upsert/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.34"
 bytes = "0.5.6"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 env_logger = "0.8.2"
 futures = "0.3.8"
 futures-channel = "0.3.5"

--- a/test/smith/Cargo.toml
+++ b/test/smith/Cargo.toml
@@ -13,7 +13,7 @@ futures-channel = "0.3.5"
 log = "0.4.11"
 postgres-types = "0.1.1"
 reqwest = { version = "0.10.8", features = ["json"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.60"
 structopt = "0.3.21"
 test-util = { path = "../test-util" }

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.34"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 kafka-util = { path = "../../src/kafka-util" }
 log = "0.4.11"
 ore = { path = "../../src/ore" }


### PR DESCRIPTION
Keeping manifests consistenly sorted reduces future diff noise, and
reduces confusion about equivalent constructs, like "serde = 1" vs
"serde = 1.0.0".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5164)
<!-- Reviewable:end -->
