### PR TITLE
www: add a /s/chat shortlink for Slack invitation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://badge.buildkite.com/97d6604e015bf633d1c2a12d166bb46f3b43a927d3952c999a.svg?branch=main)](https://buildkite.com/materialize/tests)
 [![Doc reference](https://img.shields.io/badge/doc-reference-orange)](https://materialize.com/docs)
-[![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-purple)](https://join.slack.com/t/materializecommunity/shared_invite/zt-jjwe1t45-klG9k7V7xibdtqA6bcFpyQ)
+[![Chat on Slack](https://img.shields.io/badge/chat-on%20slack-purple)](https://materialize.com/s/chat)
 
 [<img src="https://materialize.com/wp-content/uploads/2020/01/materialize_logo_primary.png" width=60%>](https://materialize.com)
 

--- a/ci/www/public/_redirects
+++ b/ci/www/public/_redirects
@@ -16,8 +16,12 @@ http://materialize.com/* https://materialize.com/:splat 301!
 # the "bug" shortlink allows us to embed a bug reporting URL in the
 # materialized binary that can be updated if we ever switch away from GitHub
 # or change how we want bugs to be filed.
+
 /s/bug https://github.com/MaterializeInc/materialize/issues/new?labels=C-bug&template=bug.md
 /s/non-materialized-error https://materialize.com/docs/sql/create-view/#querying-non-materialized-views
+
+# The Slack invitation URL expires every 30 days, so we give it a stable alias.
+/s/chat https://join.slack.com/t/materializecommunity/shared_invite/zt-kn66colt-N8IB2s9T_62u2q8FoN1TdQ
 
 # Forward all paths unknown to Netlify to the marketing site.
 /* https://materializeinc.wpengine.com/:splat 200

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -7,7 +7,7 @@ weight: 2
 
 {{< promo >}}
 
-[Want to connect with Materialize? Join our growing community on Slack! →](https://join.slack.com/t/materializecommunity/shared_invite/zt-fpfvczj5-efOE_8qvM4fWpHSvMxpKbA)
+[Want to connect with Materialize? Join our growing community on Slack! →](https://materialize.com/s/chat)
 
 {{< /promo >}}
 

--- a/doc/user/content/versions.md
+++ b/doc/user/content/versions.md
@@ -49,8 +49,7 @@ To engage with our community support team:
     very seriously and usually provide an initial response within one business
     day.
 
-  * Start discussions or ask questions on our [Slack
-    workspace](https://join.slack.com/t/materializecommunity/shared_invite/zt-fpfvczj5-efOE_8qvM4fWpHSvMxpKbA).
+  * Start discussions or ask questions on our [Slack workspace](https://materialize.com/s/chat).
 
 We do not investigate issues with unsupported versions of Materialize. If you
 are using an unsupported version, please check that the issue reproduces on a


### PR DESCRIPTION
The Slack invitation URL expires every 30 days. Add a stable shortlink
for it so there is only one place to update every month.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5165)
<!-- Reviewable:end -->
