### PR TITLE
sql: support custom types in polymorphic type resolution

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -375,9 +375,9 @@ impl ParamList {
         p.iter().any(|p| p.is_polymorphic())
     }
 
-    /// Enforces polymorphic type consistency by finding the concrete type
-    /// that satisfies the constraints expressed by the polymorphic types in
-    /// the parameter list.
+    /// Enforces polymorphic type consistency by finding the concrete type that
+    /// satisfies the constraints expressed by the polymorphic types in the
+    /// parameter list.
     ///
     /// Polymorphic type consistency constraints include:
     /// - All arguments passed to `ArrayAny` must be `ScalarType::Array`s with
@@ -390,14 +390,66 @@ impl ParamList {
     ///
     /// Returns `Some` if the constraints were successfully resolved, or `None`
     /// otherwise.
-    fn resolve_polymorphic_types(&self, typs: &[Option<ScalarType>]) -> Option<ScalarType> {
-        // TODO(sploiselle): support custom types
-        if typs.iter().any(|t| match t {
-            Some(t) => t.is_custom_type(),
-            None => false,
-        }) {
-            return None;
-        }
+    ///
+    /// ## Custom types
+    ///
+    /// To handle custom types w/r/t polymorphism, we derive a "complex type
+    /// signature" for the constrained type, which represents the constrained
+    /// type's `custom_oid` and an embdedded element. This complex type
+    /// signature is this function's return value.
+    ///
+    /// We define custom types as any type defined with `CREATE TYPE` or embeds
+    /// a custom type. We'll use the term anonymous type to define all
+    /// non-custom types, e.g. `int4`, `int4 list`.
+    ///
+    /// To understand how we generate the complex type signature, it's useful to
+    /// categorize polymorphic parameters in MZ.
+    ///
+    /// - **Complex parameters** include createable composite types' polymorphic
+    ///    parameters, e.g. `ListAny` and `MapAny`.
+    ///
+    ///   Values passed to these parameters have a `custom_oid` field and some
+    ///   embedded type, which we'll refer to as its element.
+    ///
+    /// - **Element parameters** which include `ListElementAny` and `NonVecAny`.
+    ///
+    /// Note that:
+    /// - Custom types can be used as values to either complex or element
+    ///   parameters; we'll refer to these as custom complex values and custom
+    ///   element values, or collectively as custom values.
+    /// - `ArrayAny` is slightly different from either case, but is uncommonly
+    ///   used and not addressed further.
+    ///
+    /// Upon encountering the first custom value, we constrain all future custom
+    /// values' elements to exactly matching the custom type's element. For
+    /// custom element values, this is the type itself. For custom complex
+    /// values, this is the embedded type. Note that if a custom complex value
+    /// embeds an anonymous type, the constrained type will be an anonymous
+    /// type––this means that any future custom element values will cause
+    /// resolution to fail.
+    ///
+    /// Upon encountering the first custom complex value, we constrain all
+    /// future custom complex values to having the same `custom_oid`––which,
+    /// e.g., can be `None` when you have otherwise-anonymous complex values
+    /// that embed custom elements.
+    ///
+    /// Consider the following scenario:
+    ///
+    /// ```sql
+    /// CREATE TYPE int4_list_custom AS LIST (element_type=int4);
+    /// CREATE TYPE int4_list_list_custom AS LIST (element_type=int4_list_custom);
+    /// /* Errors because we won't coerce int4_list_custom list to
+    ///    int4_list_list_custom */
+    /// SELECT '{{1}}'::int4_list_list_custom || '{{2}}'::int4_list_custom list;
+    /// ```
+    ///
+    /// We will not coerce int4_list_custom list to int4_list_list_custom so
+    /// that only truly anonymous types are ever coerced into custom types. It's
+    /// also trivial for users to add a cast to ensure custom type consistency.
+    fn resolve_polymorphic_types(
+        &self,
+        typs: &[Option<ScalarType>],
+    ) -> Option<(Option<u32>, ScalarType)> {
         // Determines if types have the same [`ScalarBaseType`], and if complex
         // types' elements do, as well. This function's primary use is allowing
         // matches between `ScalarType::Decimal` values with different scales,
@@ -419,6 +471,7 @@ impl ParamList {
                 (l, r) => ScalarBaseType::from(l) == ScalarBaseType::from(r),
             }
         }
+
         // Returns a commmon form of `self` and `other` using the "greatest
         // common" `ScalarType::Decimal`, or `None` if one does not exist.
         //
@@ -465,16 +518,58 @@ impl ParamList {
             }
         }
 
+        let mut constrained_oid: Option<Option<u32>> = None;
+        let mut set_or_check_constrained_oid = |custom_oid: &Option<u32>| {
+            match constrained_oid {
+                None => constrained_oid = Some(*custom_oid),
+                Some(constrained_oid) => {
+                    if constrained_oid != *custom_oid {
+                        return Err(());
+                    }
+                }
+            }
+            Ok(())
+        };
+
         let mut constrained_type: Option<ScalarType> = None;
-        let mut set_or_check_constrained_type = |typ: &ScalarType| {
+        let mut constrained_type_lock = false;
+        let mut set_or_check_constrained_type = |typ: &ScalarType, is_custom: bool| {
             match constrained_type {
-                None => constrained_type = Some(typ.clone()),
-                Some(ref mut t) => {
+                None => {
+                    constrained_type_lock = is_custom;
+                    constrained_type = Some(typ.clone());
+                }
+                Some(ref mut t) if is_custom && !constrained_type_lock => {
+                    // Previously constrained type was not custom
                     if !complex_base_eq(t, typ) {
                         return Err(());
                     }
-                    if let Some(d) = find_greatest_common_decimal(t, typ) {
-                        *t = d;
+                    *t = typ.clone();
+                    constrained_type_lock = true;
+                }
+                Some(ref mut t) => {
+                    // Custom types must exactly match constrained type;
+                    // anonymous types must only match the constrained type's
+                    // complex base.
+                    if (is_custom && t != typ) || (!is_custom && !complex_base_eq(t, typ)) {
+                        return Err(());
+                    }
+
+                    // Potentially rescale decimal type if constrained type
+                    // isn't locked and the two elements differ, i.e. if they
+                    // are decimals and they are equal, they don't need to be rescaled.
+                    if !constrained_type_lock && t != typ {
+                        // Neither `t` nor `typ` can be custom if the
+                        // constrainted type is unlocked.
+                        assert!(!(t.is_custom_type() || typ.is_custom_type()));
+                        if let Some(d) = find_greatest_common_decimal(t, typ) {
+                            // `d` should never be a custom type because it is a
+                            // system-generated type. If users want to control
+                            // the resultant type's OID, they can provide
+                            // explicit casts to the desired OID.
+                            assert!(!d.is_custom_type());
+                            *t = d;
+                        }
                     }
                 }
             }
@@ -488,18 +583,47 @@ impl ParamList {
                 (
                     ParamType::ListAny,
                     Some(ScalarType::List {
-                        element_type: typ, ..
+                        element_type: el_typ,
+                        custom_oid,
                     }),
                 )
-                | (ParamType::ArrayAny, Some(ScalarType::Array(typ)))
                 | (
                     ParamType::MapAny,
                     Some(ScalarType::Map {
-                        value_type: typ, ..
+                        value_type: el_typ,
+                        custom_oid,
                     }),
-                ) => set_or_check_constrained_type(typ).ok()?,
-                (ParamType::ListElementAny, Some(typ)) | (ParamType::NonVecAny, Some(typ)) => {
-                    set_or_check_constrained_type(typ).ok()?
+                ) => {
+                    // We use typ.as_ref().unwrap() rather than binding the
+                    // interior `ScalarType` to a name because of
+                    // https://github.com/rust-lang/rust/issues/65490
+                    // Once that is resolved, the match could be made on:
+                    // ```
+                    // ...
+                    // (
+                    // ParamType::ListAny,
+                    // Some(typ @ ScalarType::List {
+                    //     element_type: el_typ,
+                    //     custom_oid,
+                    // }),
+                    // ...
+                    // typ.is_custom_type()
+                    // ```
+                    let is_custom = typ.as_ref().unwrap().is_custom_type();
+
+                    // Only check OID of custom types because `None` values for
+                    // `custom_oid` as a custom type signature, but anonymous types
+                    // use the same value.
+                    if is_custom {
+                        set_or_check_constrained_oid(custom_oid).ok()?;
+                    }
+                    set_or_check_constrained_type(el_typ, is_custom).ok()?;
+                }
+                (ParamType::ArrayAny, Some(ScalarType::Array(t))) => {
+                    set_or_check_constrained_type(t, t.is_custom_type()).ok()?
+                }
+                (ParamType::ListElementAny, Some(t)) | (ParamType::NonVecAny, Some(t)) => {
+                    set_or_check_constrained_type(t, t.is_custom_type()).ok()?
                 }
                 // These checks don't need to be more exhaustive (e.g. failing
                 // if arguments passed to `ListAny` are not `ScalartType::List`)
@@ -509,7 +633,14 @@ impl ParamList {
             }
         }
 
-        constrained_type
+        match (constrained_oid, constrained_type) {
+            (Some(oid), Some(typ)) => Some((oid, typ)),
+            (None, Some(typ)) => Some((None, typ)),
+            (None, None) => None,
+            (Some(..), None) => {
+                unreachable!("must have at least one element to get constrained OID")
+            }
+        }
     }
 
     /// Matches a `&[ScalarType]` derived from the user's function argument
@@ -960,29 +1091,32 @@ fn coerce_args_to_types(
 
             // Polymorphic pseudotypes. Convert based on constrained type.
             ParamType::ArrayAny => {
-                let ty = ScalarType::Array(Box::new(get_constrained_ty()));
+                let (_, ty) = get_constrained_ty();
+                let ty = ScalarType::Array(Box::new(ty));
                 do_convert(arg, &ty)?
             }
             ParamType::ListAny => {
+                let (custom_oid, ty) = get_constrained_ty();
                 let ty = ScalarType::List {
-                    element_type: Box::new(get_constrained_ty()),
-                    custom_oid: None,
+                    element_type: Box::new(ty),
+                    custom_oid,
                 };
                 do_convert(arg, &ty)?
             }
             ParamType::MapAny => {
+                let (custom_oid, ty) = get_constrained_ty();
                 let ty = ScalarType::Map {
-                    value_type: Box::new(get_constrained_ty()),
-                    custom_oid: None,
+                    value_type: Box::new(ty),
+                    custom_oid,
                 };
                 do_convert(arg, &ty)?
             }
             ParamType::ListElementAny => {
-                let ty = get_constrained_ty();
+                let (_, ty) = get_constrained_ty();
                 do_convert(arg, &ty)?
             }
             ParamType::NonVecAny => {
-                let ty = get_constrained_ty();
+                let (_, ty) = get_constrained_ty();
                 if ty.is_vec() {
                     bail!(
                         "could not constrain polymorphic type because {} used in \

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1892,33 +1892,33 @@ query error element_type must be of class type, but received pg_catalog.pg_enum 
 CREATE TYPE tbl_list AS LIST (element_type=pg_enum)
 
 statement ok
-CREATE TYPE int_list_c AS LIST (element_type = int4);
+CREATE TYPE int4_list_c AS LIST (element_type = int4);
 
 query T
-SELECT '{1,2}'::int_list_c::text;
+SELECT '{1,2}'::int4_list_c::text;
 ----
 {1,2}
 
 query T
-SELECT oid FROM pg_type WHERE typname = 'int_list_c';
+SELECT oid FROM pg_type WHERE typname = 'int4_list_c';
 ----
 20055
 
 query T
-SELECT '{{1,2}}'::int_list_c list::text
+SELECT '{{1,2}}'::int4_list_c list::text
 ----
 {{1,2}}
 
 query T
-SELECT pg_typeof(NULL::int_list_c);
+SELECT pg_typeof(NULL::int4_list_c);
 ----
 list
 
 statement ok
-CREATE TYPE int_list_list_c AS LIST (element_type = int_list_c);
+CREATE TYPE int4_list_list_c AS LIST (element_type = int4_list_c);
 
 query T
-SELECT '{{1,2}}'::int_list_list_c::text;
+SELECT '{{1,2}}'::int4_list_list_c::text;
 ----
 {{1,2}}
 
@@ -1945,9 +1945,6 @@ query T
 SELECT '{1,2}'::int8_list_c::text
 ----
 {1,2}
-
-statement ok
-CREATE TYPE int4_list_c AS LIST (element_type='int4');
 
 query T
 SELECT '{1,2}'::int4_list_c::text
@@ -2046,3 +2043,148 @@ query T
 SELECT '{1,2}'::public.bool::text;
 ----
 {1,2}
+
+# 🔬🔬 Built-in operations
+
+query T
+SELECT ('{1}'::int4_list_c || 2)::text;
+----
+{1,2}
+
+query T
+SELECT (1 || '{2}'::int4_list_c)::text;
+----
+{1,2}
+
+# 🔬 Explicit casts w/ custom types
+
+query T
+SELECT ('{1.2,2.3}'::numeric_list_c)::text;
+----
+{1,2}
+
+query T
+SELECT ('{1.2,2.3}'::numeric_list_c::numeric(38,5) list)::text;
+----
+{1.00000,2.00000}
+
+query T
+SELECT ('{1.2,2.3}'::numeric(38,5) list::numeric_list_c)::text;
+----
+{1,2}
+
+# 🔬 Implicit casts between custom types
+
+# 🔬🔬 1-D casts
+
+statement ok
+CREATE TYPE int4_list AS LIST (element_type = int4)
+
+statement ok
+CREATE TYPE int4_list_too AS LIST (element_type = int4)
+
+query T
+SELECT ('{1}'::int4_list || '{2}'::int list)::text;
+----
+{1,2}
+
+query error
+SELECT '{1}'::int4_list || '{2}'::int4_list_too;
+
+# Anonymous type cast to custom type, which is not interoperable with a
+# different custom type
+query error
+SELECT '{1}'::int4_list || '{2}'::int list || '{3}'::int4_list_too
+
+query T
+SELECT ('{1}'::int4_list_too || '{2}'::int4_list::int4_list_too)::text;
+----
+{1,2}
+
+query T
+SELECT ('{1}'::int4_list_too || '{2}'::int4_list::int list)::text;
+----
+{1,2}
+
+query T
+SELECT ('{1}'::int4_list || 2)::text;
+----
+{1,2}
+
+# 🔬🔬 2-D casts
+
+statement ok
+CREATE TYPE int4_list_list AS LIST (element_type = int4_list)
+
+statement ok
+CREATE TYPE int4_list_list_too AS LIST (element_type = int4_list_too)
+
+# Custom type interoperable with anonymous type
+query T
+SELECT ('{{1}}'::int4_list_list || '{{2}}'::int list list)::text;
+----
+{{1},{2}}
+
+# Other custom types cast to same custom type
+query T
+SELECT ('{{1}}'::int4_list_list_too || '{{2}}'::int4_list_list::int4_list_list_too)::text;
+----
+{{1},{2}}
+
+# Other custom type cast to anonymous type
+query T
+SELECT ('{{1}}'::int4_list_list_too || '{{2}}'::int4_list_list::int list list)::text;
+----
+{{1},{2}}
+
+# Different custom types
+query error
+SELECT '{{1}}'::int4_list_list || '{{2}}'::int4_list_list_too;
+
+# Different custom types as element types
+query error
+SELECT '{{1}}'::int4_list list || '{{2}}'::int4_list_list_too list;
+
+# Custom element type
+query T
+SELECT ('{{1}}'::int4_list_list || '{2}'::int4_list)::text;
+----
+{{1},{2}}
+
+# Anonymous element type
+query T
+SELECT ('{{1}}'::int4_list_list || '{2}'::int4 list)::text;
+----
+{{1},{2}}
+
+# Non-matching element type
+query error
+SELECT '{{1}}'::int4_list_list || '{2}'::int4_list_too;
+
+query error
+SELECT '{1}'::int4_list_too || '{{2}}'::int4_list_list
+
+# Element types match, but "head" type does not
+query error
+SELECT '{{1}}'::int4_list_list || '{{2}}'::int4_list list
+
+query error
+SELECT '{{1}}'::int4_list list || '{{2}}'::int4_list_list
+
+# Custom element type w/ anonymous complex type
+query T
+SELECT ('{{1}}'::int4_list list || '{{2}}'::int4_list list)::text
+----
+{{1},{2}}
+
+# Custom element exactly matches
+query T
+SELECT ('{{1}}'::int4_list list || '{2}'::int4_list)::text
+----
+{{1},{2}}
+
+# Custom element + anonymous element
+query T
+SELECT ('{{1}}'::int4_list list || '{2}'::int4 list)::text
+----
+{{1},{2}}


### PR DESCRIPTION
Designed custom polymorphic resolution around a Slack conversation where we agreed that custom types should be interoperable with anonymous types but require casting to be interoperable with other custom types.

Note that:
- This should be the last piece for making custom types usable within SQL, and after this lands, I'll work on docs for `CREATE TYPE`.
- I also have a commit lined up to make the error messages for failed custom polymorphic resolution more meaningful (i.e. printing ScalarTypes using the catalog), and will submit that after this merges. –– Note submitted this early as #5175 but it is race-y with this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5170)
<!-- Reviewable:end -->
