### PR TITLE
Prefer `Row::pack_slice()`

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1222,7 +1222,7 @@ where
         self.update_catalog_view(
             index_id,
             iter::once((
-                Row::pack(update.iter().map(|c| Datum::String(c)).collect::<Vec<_>>()),
+                Row::pack_slice(&update.iter().map(|c| Datum::String(c)).collect::<Vec<_>>()[..]),
                 diff,
             )),
         )

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -300,7 +300,7 @@ where
                     log.variant.desc().typ().keys.iter().enumerate().flat_map(
                         move |(index, key)| {
                             key.iter().map(move |k| {
-                                let row = Row::pack(&[
+                                let row = Row::pack_slice(&[
                                     Datum::String(log_id),
                                     Datum::Int64(*k as i64),
                                     Datum::Int64(index as i64),
@@ -323,7 +323,7 @@ where
                                 .id
                                 .to_string();
                             pairs.into_iter().map(move |(c, p)| {
-                                let row = Row::pack(&[
+                                let row = Row::pack_slice(&[
                                     Datum::String(&log_id),
                                     Datum::Int64(c as i64),
                                     Datum::String(&parent_id),
@@ -931,7 +931,7 @@ where
         self.update_catalog_view(
             MZ_DATABASES.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::Int64(database_id),
                     Datum::Int32(oid as i32),
                     Datum::String(&name),
@@ -953,7 +953,7 @@ where
         self.update_catalog_view(
             MZ_SCHEMAS.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::Int64(schema_id),
                     Datum::Int32(oid as i32),
                     match database_id {
@@ -978,7 +978,7 @@ where
             self.update_catalog_view(
                 MZ_COLUMNS.id,
                 iter::once((
-                    Row::pack(&[
+                    Row::pack_slice(&[
                         Datum::String(&global_id.to_string()),
                         Datum::String(
                             &column_name
@@ -1045,7 +1045,7 @@ where
         self.update_catalog_view(
             MZ_INDEXES.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::String(&global_id.to_string()),
                     Datum::Int32(oid as i32),
                     Datum::String(name),
@@ -1075,7 +1075,7 @@ where
             self.update_catalog_view(
                 MZ_INDEX_COLUMNS.id,
                 iter::once((
-                    Row::pack(&[
+                    Row::pack_slice(&[
                         Datum::String(&global_id.to_string()),
                         Datum::Int64(seq_in_index),
                         field_number,
@@ -1100,7 +1100,7 @@ where
         self.update_catalog_view(
             MZ_TABLES.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::String(&global_id.to_string()),
                     Datum::Int32(oid as i32),
                     Datum::Int64(schema_id),
@@ -1123,7 +1123,7 @@ where
         self.update_catalog_view(
             MZ_SOURCES.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::String(&global_id.to_string()),
                     Datum::Int32(oid as i32),
                     Datum::Int64(schema_id),
@@ -1146,7 +1146,7 @@ where
         self.update_catalog_view(
             MZ_VIEWS.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::String(&global_id.to_string()),
                     Datum::Int32(oid as i32),
                     Datum::Int64(schema_id),
@@ -1169,7 +1169,7 @@ where
         self.update_catalog_view(
             MZ_SINKS.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::String(&global_id.to_string()),
                     Datum::Int32(oid as i32),
                     Datum::Int64(schema_id),
@@ -1193,7 +1193,7 @@ where
         self.update_catalog_view(
             MZ_TYPES.id,
             iter::once((
-                Row::pack(&[
+                Row::pack_slice(&[
                     Datum::String(&id.to_string()),
                     Datum::Int32(oid as i32),
                     Datum::Int64(schema_id),
@@ -1900,7 +1900,7 @@ where
         name: String,
     ) -> Result<ExecuteResponse, anyhow::Error> {
         let variable = session.vars().get(&name)?;
-        let row = Row::pack(&[Datum::String(&variable.value())]);
+        let row = Row::pack_slice(&[Datum::String(&variable.value())]);
         Ok(send_immediate_rows(vec![row]))
     }
 
@@ -2327,7 +2327,7 @@ where
                 explanation.to_string()
             }
         };
-        let rows = vec![Row::pack(&[Datum::from(&*explanation_string)])];
+        let rows = vec![Row::pack_slice(&[Datum::from(&*explanation_string)])];
         Ok(send_immediate_rows(rows))
     }
 
@@ -2655,7 +2655,7 @@ where
                             .await;
                             match connector {
                                 SinkConnector::Kafka(KafkaSinkConnector { topic, .. }) => {
-                                    let row = Row::pack(&[
+                                    let row = Row::pack_slice(&[
                                         Datum::String(entry.id().to_string().as_str()),
                                         Datum::String(topic.as_str()),
                                     ]);
@@ -2666,7 +2666,7 @@ where
                                     .await;
                                 }
                                 SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
-                                    let row = Row::pack(&[
+                                    let row = Row::pack_slice(&[
                                         Datum::String(entry.id().to_string().as_str()),
                                         Datum::Bytes(&path.clone().into_os_string().into_vec()),
                                     ]);
@@ -2842,7 +2842,7 @@ where
         for (id, sink) in &dataflow.sink_exports {
             match &sink.connector {
                 SinkConnector::Kafka(KafkaSinkConnector { topic, .. }) => {
-                    let row = Row::pack(&[
+                    let row = Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::String(topic.as_str()),
                     ]);
@@ -2850,7 +2850,7 @@ where
                         .await;
                 }
                 SinkConnector::AvroOcf(AvroOcfSinkConnector { path, .. }) => {
-                    let row = Row::pack(&[
+                    let row = Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::Bytes(&path.clone().into_os_string().into_vec()),
                     ]);

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{any::Any, cell::RefCell, collections::VecDeque, iter, rc::Rc, time::Duration};
+use std::{any::Any, cell::RefCell, collections::VecDeque, rc::Rc, time::Duration};
 
 use anyhow::anyhow;
 use differential_dataflow::{capture::YieldingIter, hashable::Hashable};
@@ -147,7 +147,11 @@ pub trait DecoderState {
 }
 
 fn pack_with_line_no(datum: Datum, line_no: Option<i64>) -> Row {
-    Row::pack(iter::once(datum).chain(line_no.map(Datum::from)))
+    if let Some(line_no) = line_no {
+        Row::pack_slice(&[datum, Datum::from(line_no)])
+    } else {
+        Row::pack_slice(&[datum])
+    }
 }
 
 fn bytes_to_datum(bytes: &[u8]) -> Datum {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -75,7 +75,7 @@ impl ScalarExpr {
     }
 
     pub fn literal(res: Result<Datum, EvalError>, typ: ColumnType) -> Self {
-        let row = res.map(|datum| Row::pack(&[datum]));
+        let row = res.map(|datum| Row::pack_slice(&[datum]));
         ScalarExpr::Literal(row, typ)
     }
 

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -79,7 +79,7 @@ fn bench_filter_unpacked(filter: Datum, rows: Vec<Vec<Datum>>, b: &mut Bencher) 
 }
 
 fn bench_filter_packed(filter: Datum, rows: Vec<Vec<Datum>>, b: &mut Bencher) {
-    let filter = Row::pack(&[filter]);
+    let filter = Row::pack_slice(&[filter]);
     let rows = rows.into_iter().map(Row::pack).collect::<Vec<_>>();
     b.iter_with_setup(
         || rows.clone(),

--- a/src/repr/src/adt/jsonb.rs
+++ b/src/repr/src/adt/jsonb.rs
@@ -171,7 +171,7 @@ impl JsonbRef<'_> {
     /// Constructs an owned [`Jsonb`] from this `JsonbRef`.
     pub fn to_owned(&self) -> Jsonb {
         Jsonb {
-            row: Row::pack(&[self.datum]),
+            row: Row::pack_slice(&[self.datum]),
         }
     }
 

--- a/src/repr/src/cache.rs
+++ b/src/repr/src/cache.rs
@@ -34,7 +34,7 @@ impl CachedRecord {
     /// This function will throw an error if the row is larger than 4 GB.
     /// TODO: could this be made more efficient with a RowArena?
     pub fn write_record(&self, buf: &mut Vec<u8>) -> Result<(), anyhow::Error> {
-        let row = Row::pack(&[
+        let row = Row::pack_slice(&[
             Datum::Int64(self.offset),
             Datum::Int64(self.timestamp as i64),
             Datum::Bytes(&self.key),

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -594,7 +594,7 @@ impl Row {
     /// TODO: This could also be done for cloneable iterators, though we would need to be
     /// very careful to avoid using it when iterators are either expensive or have
     /// side effects.
-    pub fn pack_slice<'a, I, D>(slice: &[Datum<'a>]) -> Row {
+    pub fn pack_slice<'a>(slice: &[Datum<'a>]) -> Row {
         let needed = slice.iter().map(|d| datum_size(d)).sum();
         let mut packer = RowPacker::with_capacity(needed);
         packer.extend(slice.iter());

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -44,10 +44,11 @@ use fmt::Debug;
 /// We avoid the need for the second set of padding by not providing mutable access to the `Datum`. Instead, `Row` is append-only.
 ///
 /// A `Row` can be built from a collection of `Datum`s using `Row::pack`, but it often more efficient to use and re-use a `RowPacker` which can avoid unneccesary allocations.
+/// The `Row::pack_slice` method pre-determines the necessary allocation, and is also appropriate.
 ///
 /// ```
 /// # use repr::{Row, Datum};
-/// let row = Row::pack(&[Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)]);
+/// let row = Row::pack_slice(&[Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)]);
 /// assert_eq!(row.unpack(), vec![Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)])
 /// ```
 ///
@@ -55,14 +56,14 @@ use fmt::Debug;
 ///
 /// ```
 /// # use repr::{Row, Datum};
-/// let row = Row::pack(&[Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)]);
+/// let row = Row::pack_slice(&[Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)]);
 /// assert_eq!(row.iter().nth(1).unwrap(), Datum::Int32(1));
 /// ```
 ///
 /// If you want random access to the `Datum`s in a `Row`, use `Row::unpack` to create a `Vec<Datum>`
 /// ```
 /// # use repr::{Row, Datum};
-/// let row = Row::pack(&[Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)]);
+/// let row = Row::pack_slice(&[Datum::Int32(0), Datum::Int32(1), Datum::Int32(2)]);
 /// let datums = row.unpack();
 /// assert_eq!(datums[1], Datum::Int32(1));
 /// ```
@@ -1298,7 +1299,7 @@ mod tests {
 
         // Pack a previously-constructed `Datum::Array` and verify that it
         // unpacks correctly.
-        let row = Row::pack(&[Datum::Array(arr1)]);
+        let row = Row::pack_slice(&[Datum::Array(arr1)]);
         let arr2 = row.unpack_first().unwrap_array();
         assert_eq!(arr1, arr2);
     }
@@ -1481,7 +1482,7 @@ mod tests {
             Datum::JsonNull,
         ];
         for value in values_of_interest {
-            if datum_size(&value) != Row::pack(Some(value)).data.len() {
+            if datum_size(&value) != Row::pack_slice(&[value]).data.len() {
                 panic!("Disparity in claimed size for {:?}", value);
             }
         }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -590,15 +590,13 @@ impl Row {
     /// This method has the advantage over `pack` that it can determine the required
     /// allocation before packing the elements, ensuring only one allocation and no
     /// redundant copies required.
-    ///
-    /// TODO: This could also be done for cloneable iterators, though we would need to be
-    /// very careful to avoid using it when iterators are either expensive or have
-    /// side effects.
     pub fn pack_slice<'a>(slice: &[Datum<'a>]) -> Row {
         let needed = slice.iter().map(|d| datum_size(d)).sum();
-        let mut packer = RowPacker::with_capacity(needed);
-        packer.extend(slice.iter());
-        packer.finish()
+        let mut bytes = Vec::with_capacity(needed);
+        for datum in slice.iter() {
+            push_datum(&mut bytes, *datum);
+        }
+        Row::new(bytes)
     }
 
     /// Unpack `self` into a `Vec<Datum>` for efficient random access.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -273,7 +273,7 @@ impl Params {
     /// Returns a `Params` with no parameters.
     pub fn empty() -> Params {
         Params {
-            datums: Row::pack(&[]),
+            datums: Row::pack_slice(&[]),
             types: vec![],
         }
     }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -31,7 +31,7 @@ pub fn handle_show_create_view(
 ) -> Result<Plan, anyhow::Error> {
     let view = scx.resolve_item(view_name)?;
     if let CatalogItemType::View = view.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
+        Ok(Plan::SendRows(vec![Row::pack_slice(&[
             Datum::String(&view.name().to_string()),
             Datum::String(view.create_sql()),
         ])]))
@@ -46,7 +46,7 @@ pub fn handle_show_create_table(
 ) -> Result<Plan, anyhow::Error> {
     let table = scx.resolve_item(table_name)?;
     if let CatalogItemType::Table = table.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
+        Ok(Plan::SendRows(vec![Row::pack_slice(&[
             Datum::String(&table.name().to_string()),
             Datum::String(table.create_sql()),
         ])]))
@@ -61,7 +61,7 @@ pub fn handle_show_create_source(
 ) -> Result<Plan, anyhow::Error> {
     let source = scx.resolve_item(source_name)?;
     if let CatalogItemType::Source = source.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
+        Ok(Plan::SendRows(vec![Row::pack_slice(&[
             Datum::String(&source.name().to_string()),
             Datum::String(source.create_sql()),
         ])]))
@@ -76,7 +76,7 @@ pub fn handle_show_create_sink(
 ) -> Result<Plan, anyhow::Error> {
     let sink = scx.resolve_item(sink_name)?;
     if let CatalogItemType::Sink = sink.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
+        Ok(Plan::SendRows(vec![Row::pack_slice(&[
             Datum::String(&sink.name().to_string()),
             Datum::String(sink.create_sql()),
         ])]))
@@ -91,7 +91,7 @@ pub fn handle_show_create_index(
 ) -> Result<Plan, anyhow::Error> {
     let index = scx.resolve_item(index_name)?;
     if let CatalogItemType::Index = index.item_type() {
-        Ok(Plan::SendRows(vec![Row::pack(&[
+        Ok(Plan::SendRows(vec![Row::pack_slice(&[
             Datum::String(&index.name().to_string()),
             Datum::String(index.create_sql()),
         ])]))


### PR DESCRIPTION
The `Row::pack_slice` method can pre-allocate the correct size for a `Row`, as opposed to `Row::pack` which must determine the size by growing an initially empty `RowPacker`. Each instance of `Row::pack(&[` was converted to `Row::pack_slice(&[`.

Among the non-trivial changes, this should lead to improve decoding performance
```
 fn pack_with_line_no(datum: Datum, line_no: Option<i64>) -> Row {
-    Row::pack(iter::once(datum).chain(line_no.map(Datum::from)))
+    if let Some(line_no) = line_no {
+        Row::pack_slice(&[datum, Datum::from(line_no)])
+    } else {
+        Row::pack_slice(&[datum])
+    }
 }
```
and .. I'm not sure what was going on here in the first place, but this is better than before
```
         self.update_catalog_view(
             index_id,
             iter::once((
-                Row::pack(update.iter().map(|c| Datum::String(c)).collect::<Vec<_>>()),
+                Row::pack_slice(&update.iter().map(|c| Datum::String(c)).collect::<Vec<_>>()[..]),
                 diff,
             )),
         )
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5172)
<!-- Reviewable:end -->
