### PR TITLE
Mark Row::new() as unsafe

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -788,7 +788,7 @@ where
                                     }
                                     timely::communication::message::RefOrMut::Mut(r) => {
                                         row_packer.finish_into(r);
-                                        std::mem::replace(r, Row::new(Vec::new()))
+                                        std::mem::replace(r, Row::default())
                                     }
                                 })
                             })

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -788,7 +788,7 @@ where
                                     }
                                     timely::communication::message::RefOrMut::Mut(r) => {
                                         row_packer.finish_into(r);
-                                        std::mem::replace(r, Row::default())
+                                        std::mem::take(r)
                                     }
                                 })
                             })

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -152,7 +152,7 @@ where
                             RefOrMut::Ref(_) => row_packer.finish_and_reuse(),
                             RefOrMut::Mut(row) => {
                                 row_packer.finish_into(row);
-                                std::mem::replace(row, Row::default())
+                                std::mem::take(row)
                             }
                         };
                         return Some(Ok((key, row)));

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -152,7 +152,7 @@ where
                             RefOrMut::Ref(_) => row_packer.finish_and_reuse(),
                             RefOrMut::Mut(row) => {
                                 row_packer.finish_into(row);
-                                std::mem::replace(row, Row::new(vec![]))
+                                std::mem::replace(row, Row::default())
                             }
                         };
                         return Some(Ok((key, row)));

--- a/src/repr/src/cache.rs
+++ b/src/repr/src/cache.rs
@@ -71,7 +71,7 @@ impl CachedRecord {
         let (_, rest) = data.split_at(4);
         let row = rest[..len].to_vec();
 
-        let rec = Row::new(row);
+        let rec = unsafe { Row::new(row) };
         let row = rec.unpack();
 
         let source_offset = row[0].unwrap_int64();

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -580,7 +580,6 @@ impl Row {
         Ok(packer.finish())
     }
 
-    // TODO(justin): find a better place to put this.
     /// Creates a new row from supplied bytes.
     ///
     /// # Safety
@@ -602,7 +601,9 @@ impl Row {
         for datum in slice.iter() {
             push_datum(&mut bytes, *datum);
         }
-        Row::new(bytes)
+        // Unsafety justified in that `push_datum` to initially empty `Vec` is the
+        // same machinery we use internally, and should produce well-formed bytes.
+        unsafe { Row::new(bytes) }
     }
 
     /// Unpack `self` into a `Vec<Datum>` for efficient random access.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -73,7 +73,7 @@ use fmt::Debug;
 /// Rows are dynamically sized, but up to a fixed size their data is stored in-line.
 /// It is best to re-use a `RowPacker` across multiple `Row` creation calls, as this
 /// avoids the allocations involved in `RowPacker::new()`.
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Row {
     data: SmallVec<[u8; 16]>,
 }
@@ -581,7 +581,13 @@ impl Row {
     }
 
     // TODO(justin): find a better place to put this.
-    pub fn new(data: Vec<u8>) -> Self {
+    /// Creates a new row from supplied bytes.
+    ///
+    /// # Safety
+    ///
+    /// This method relies on `data` being an appropriate row encoding, and can
+    /// result in unsafety if this is not the case.
+    pub unsafe fn new(data: Vec<u8>) -> Self {
         Row { data: data.into() }
     }
 


### PR DESCRIPTION
The `Row::new` method is unsafe, as the safety of `Row`'s accessors make assumptions about the encoding of data it contains (e.g. that various tags and structures are well-formed).

There was only one non-trivial use of `Row::new`, and it is now wrapped in an `unsafe { .. }` block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5173)
<!-- Reviewable:end -->
