### PR TITLE
sql: print ScalarType names using catalog only

### DIFF
--- a/src/coord/tests/minimal_resolution.rs
+++ b/src/coord/tests/minimal_resolution.rs
@@ -1,0 +1,87 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+
+use tempfile::NamedTempFile;
+
+use coord::catalog::builtin::{MZ_CATALOG_SCHEMA, PG_CATALOG_SCHEMA};
+use coord::session::Session;
+use sql::catalog::Catalog;
+use sql::names::{DatabaseSpecifier, FullName, PartialName};
+
+/// System sessions have an empty `search_path` so it's necessary to
+/// schema-qualify all referenced items.
+///
+/// Dummy (and ostensibly client) sessions contain system schemas in their
+/// search paths, so do not require schema qualification on system objects such
+/// as types.
+#[test]
+fn test_minimal_qualification() -> Result<(), Box<dyn Error>> {
+    struct TestCase {
+        input: FullName,
+        system_output: PartialName,
+        normal_output: PartialName,
+    }
+
+    let test_cases = vec![
+        TestCase {
+            input: FullName {
+                database: DatabaseSpecifier::Ambient,
+                schema: PG_CATALOG_SCHEMA.to_string(),
+                item: "numeric".to_string(),
+            },
+            system_output: PartialName {
+                database: None,
+                schema: Some(PG_CATALOG_SCHEMA.to_string()),
+                item: "numeric".to_string(),
+            },
+            normal_output: PartialName {
+                database: None,
+                schema: None,
+                item: "numeric".to_string(),
+            },
+        },
+        TestCase {
+            input: FullName {
+                database: DatabaseSpecifier::Ambient,
+                schema: MZ_CATALOG_SCHEMA.to_string(),
+                item: "mz_array_types".to_string(),
+            },
+            system_output: PartialName {
+                database: None,
+                schema: Some(MZ_CATALOG_SCHEMA.to_string()),
+                item: "mz_array_types".to_string(),
+            },
+            normal_output: PartialName {
+                database: None,
+                schema: None,
+                item: "mz_array_types".to_string(),
+            },
+        },
+    ];
+
+    let catalog_file = NamedTempFile::new()?;
+    let catalog = coord::catalog::Catalog::open_debug(catalog_file.path())?;
+    for tc in test_cases {
+        assert_eq!(
+            catalog
+                .for_system_session()
+                .minimal_qualification(&tc.input),
+            tc.system_output
+        );
+        assert_eq!(
+            catalog
+                .for_session(&Session::dummy())
+                .minimal_qualification(&tc.input),
+            tc.normal_output
+        );
+    }
+    Ok(())
+}

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -356,6 +356,7 @@ impl<'a> Explanation<'a> {
         }
 
         if let Some(RelationType { column_types, keys }) = &node.typ {
+            let column_types: Vec<_> = column_types.iter().map(|c| c.explain()).collect();
             writeln!(f, "| | types = ({})", separated(", ", column_types))?;
             writeln!(
                 f,

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -141,7 +141,7 @@ impl Value {
                     .collect();
                 Some(Value::Map(entries))
             }
-            _ => panic!("can't serialize {}::{}", datum, typ),
+            _ => panic!("can't serialize {}::{:?}", datum, typ),
         }
     }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1164,7 +1164,7 @@ where
                         .error(ErrorResponse::error(
                             SqlState::INTERNAL_ERROR,
                             format!(
-                                "internal error: column {} is not of expected type {}: {}",
+                                "internal error: column {} is not of expected type {:?}: {}",
                                 i, t, d
                             ),
                         ))

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -52,14 +52,12 @@ impl ColumnType {
         self.nullable = nullable;
         self
     }
-}
 
-impl fmt::Display for ColumnType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
+    /// Returns a value suitable for `EXPLAIN` statements.
+    pub fn explain(&self) -> String {
+        format!(
             "{}{}",
-            self.scalar_type,
+            self.scalar_type.explain(),
             if self.nullable { "?" } else { "" }
         )
     }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -370,7 +370,7 @@ where
 pub fn parse_decimal(s: &str) -> Result<Decimal, ParseError> {
     s.trim()
         .parse()
-        .map_err(|e| ParseError::new("decimal", s).with_details(e))
+        .map_err(|e| ParseError::new("numeric", s).with_details(e))
 }
 
 pub fn format_decimal<F>(buf: &mut F, d: &Decimal) -> Nestable

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -11,10 +11,10 @@
 
 //! Catalog abstraction layer.
 
-use std::error::Error;
 use std::fmt;
 use std::path::PathBuf;
 use std::time::SystemTime;
+use std::{error::Error, unimplemented};
 
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use expr::{GlobalId, ScalarExpr};
@@ -119,6 +119,9 @@ pub trait Catalog: fmt::Debug {
 
     /// Returns the configuration of the catalog.
     fn config(&self) -> &CatalogConfig;
+
+    /// Determines the minimal qualification required to address the named item.
+    fn minimal_qualification(&self, full_name: &FullName) -> PartialName;
 }
 
 /// Configuration associated with a catalog.
@@ -349,5 +352,9 @@ impl Catalog for DummyCatalog {
 
     fn config(&self) -> &CatalogConfig {
         &DUMMY_CONFIG
+    }
+
+    fn minimal_qualification(&self, _full_name: &FullName) -> PartialName {
+        unimplemented!()
     }
 }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -102,6 +102,11 @@ pub trait Catalog: fmt::Debug {
     /// Panics if `id` does not specify a valid item.
     fn get_item_by_id(&self, id: &GlobalId) -> &dyn CatalogItem;
 
+    /// Gets an item by its OID.
+    ///
+    /// Panics if `oid` does not specify a valid item.
+    fn get_item_by_oid(&self, oid: &u32) -> &dyn CatalogItem;
+
     /// Reports whether the specified type exists in the catalog.
     fn item_exists(&self, name: &FullName) -> bool;
 
@@ -235,7 +240,7 @@ impl fmt::Display for CatalogItemType {
 }
 
 /// An error returned by the catalog.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum CatalogError {
     /// Unknown database.
     UnknownDatabase(String),
@@ -327,6 +332,10 @@ impl Catalog for DummyCatalog {
     }
 
     fn get_item_by_id(&self, _: &GlobalId) -> &dyn CatalogItem {
+        unimplemented!();
+    }
+
+    fn get_item_by_oid(&self, _: &u32) -> &dyn CatalogItem {
         unimplemented!();
     }
 

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -348,6 +348,7 @@ impl<'a> Explanation<'a> {
         }
 
         if let Some(RelationType { column_types, keys }) = &node.typ {
+            let column_types: Vec<_> = column_types.iter().map(|c| c.explain()).collect();
             writeln!(f, "| | types = ({})", separated(", ", column_types))?;
             writeln!(
                 f,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -187,7 +187,12 @@ impl CoercibleScalarExpr {
         let expr = typeconv::plan_coerce(ecx, self, ty)?;
         let expr_ty = ecx.scalar_type(&expr);
         if ty != &expr_ty {
-            bail!("{} must have type {}, not type {}", ecx.name, ty, expr_ty);
+            bail!(
+                "{} must have type {}, not type {}",
+                ecx.name,
+                ecx.get_scalar_type_name(ty),
+                ecx.get_scalar_type_name(&expr_ty),
+            );
         }
         Ok(expr)
     }

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -809,7 +809,7 @@ where
         let types: Vec<_> = types
             .into_iter()
             .map(|ty| match ty {
-                Some(ty) => ty.to_string(),
+                Some(ty) => ecx.get_scalar_type_name(&ty),
                 None => "unknown".to_string(),
             })
             .collect();
@@ -1121,7 +1121,7 @@ fn coerce_args_to_types(
                     bail!(
                         "could not constrain polymorphic type because {} used in \
                         position that does not accept arrays or lists",
-                        ty
+                        ecx.get_scalar_type_name(&ty)
                     )
                 }
                 do_convert(arg, &ty)?
@@ -1390,8 +1390,8 @@ lazy_static! {
                 params!(Any) => Operation::new(|ecx, spec, exprs, params| {
                     // pg_typeof reports the type *before* coercion.
                     let name = match ecx.scalar_type(&exprs[0]) {
-                        None => "unknown",
-                        Some(ty) => pgrepr::Type::from(&ty).name(),
+                        None => "unknown".to_string(),
+                        Some(ty) => ecx.get_scalar_type_name(&ty),
                     };
 
                     // For consistency with other functions, verify that
@@ -1403,7 +1403,7 @@ lazy_static! {
                     // regtype, when we support that type. Document the function
                     // at that point. For now, it's useful enough to have this
                     // halfway version that returns a string.
-                    Ok(ScalarExpr::literal(Datum::String(name), ScalarType::String))
+                    Ok(ScalarExpr::literal(Datum::String(&name), ScalarType::String))
                 })
             },
             "regexp_match" => Scalar {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -663,8 +663,8 @@ where
             } else {
                 ""
             },
-            from_typ,
-            &cast_to,
+            ecx.get_scalar_type_name(&from_typ),
+            ecx.get_scalar_type_name(&cast_to),
         ),
     }
 }

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -464,13 +464,13 @@ SELECT round((SELECT * FROM nums));
 ----
 NULL
 
-query error Cannot call function round\(f64, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round((SELECT * FROM nums), 2)
 
-query error Cannot call function round\(f64, f64\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(float8, float8\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round((SELECT * FROM nums), (SELECT * FROM nums))
 
-query error Cannot call function round\(decimal\(38, 1\), f64\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(numeric\(38,1\), float8\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(5.0, (SELECT * FROM nums))
 
 query R
@@ -478,22 +478,22 @@ SELECT round(5.0, CAST ((SELECT * FROM nums) AS integer))
 ----
 NULL
 
-query error Cannot call function round\(f64, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS double precision), 3)
 
-query error Cannot call function round\(f64, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), 3)
 
-query error Cannot call function round\(bool, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(bool, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(true, 3)
 
 query error
 SELECT round(true)
 
-query error Cannot call function round\(f64, decimal\(38, 1\)\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(float8, numeric\(38,1\)\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), 3.0)
 
-query error Cannot call function round\(f64, f64\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(float8, float8\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), CAST (3.0 AS float))
 
 query I

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -51,12 +51,12 @@ SELECT 1 = ANY(ARRAY[2])
 ----
 false
 
-query error ANY operand array must have type i32\[\], not type string\[\]
+query error ANY operand array must have type int4\[\], not type text\[\]
 SELECT 1 = ANY(ARRAY['1', '2'])
 ----
 true
 
-query error ANY operand array must have type i32\[\], not type string\[\]
+query error ANY operand array must have type int4\[\], not type text\[\]
 SELECT 1 = ANY(ARRAY['hi'::text])
 
 query error invalid input syntax for int4: invalid digit found in string: "hi"
@@ -147,7 +147,7 @@ SELECT ARRAY[1, 2, 3][1.5 + 1.5]
 3
 
 # Error different than Cockroach.
-query error cannot subscript type string
+query error cannot subscript type text
 SELECT ARRAY['a', 'b', 'c'][4][2]
 
 # This differs from Cockroach, but matches Postgres.

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -48,25 +48,25 @@ TRUE              true
 query error invalid input syntax for bool: "blah"
 SELECT 'blah'::bool
 
-query error NOT argument must have type bool, not type i32
+query error NOT argument must have type bool, not type int4
 SELECT NOT 1
 
-query error AND argument must have type bool, not type i32
+query error AND argument must have type bool, not type int4
 SELECT 1 AND 1
 
-query error OR argument must have type bool, not type i32
+query error OR argument must have type bool, not type int4
 SELECT 1 OR 1
 
-query error OR argument must have type bool, not type i32
+query error OR argument must have type bool, not type int4
 SELECT 1 OR FALSE
 
-query error OR argument must have type bool, not type i32
+query error OR argument must have type bool, not type int4
 SELECT FALSE OR 1
 
-query error AND argument must have type bool, not type i32
+query error AND argument must have type bool, not type int4
 SELECT 1 AND FALSE
 
-query error AND argument must have type bool, not type i32
+query error AND argument must have type bool, not type int4
 SELECT FALSE AND 1
 
 query B

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -85,19 +85,19 @@ CREATE TYPE int4_list_list_too AS LIST (element_type=int4_list_too)
 query T
 SELECT pg_typeof('{1}'::int4 list::int4_list)
 ----
-list
+materialize.public.int4_list
 
 query T
 SELECT pg_typeof('{1}'::int4_list::int4 list)
 ----
-list
+int4 list
 
 query T
 SELECT pg_typeof('{1}'::int4_list_list::int4_list_list_too)
 ----
-list
+materialize.public.int4_list_list_too
 
 query T
 SELECT pg_typeof('{1}'::int4_list_list_too::int4_list_list)
 ----
-list
+materialize.public.int4_list_list

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -85,7 +85,7 @@ CREATE TYPE int4_list_list_too AS LIST (element_type=int4_list_too)
 query T
 SELECT pg_typeof('{1}'::int4 list::int4_list)
 ----
-materialize.public.int4_list
+int4_list
 
 query T
 SELECT pg_typeof('{1}'::int4_list::int4 list)
@@ -95,9 +95,9 @@ int4 list
 query T
 SELECT pg_typeof('{1}'::int4_list_list::int4_list_list_too)
 ----
-materialize.public.int4_list_list_too
+int4_list_list_too
 
 query T
 SELECT pg_typeof('{1}'::int4_list_list_too::int4_list_list)
 ----
-materialize.public.int4_list_list
+int4_list_list

--- a/test/sqllogictest/cockroach/array.slt
+++ b/test/sqllogictest/cockroach/array.slt
@@ -874,7 +874,7 @@ CREATE TABLE a (b STRING[])
 statement ok
 INSERT INTO a VALUES (ARRAY['foo'])
 
-statement error value type collatedstring{en}\[\] doesn't match type string\[\] of column "b"
+statement error value type collatedstring{en}\[\] doesn't match type text\[\] of column "b"
 INSERT INTO a VALUES (ARRAY['foo' COLLATE en])
 
 statement ok

--- a/test/sqllogictest/cockroach/computed.slt
+++ b/test/sqllogictest/cockroach/computed.slt
@@ -297,14 +297,14 @@ CREATE TABLE y (
   a INT AS (3) VIRTUAL
 )
 
-statement error expected computed column expression to have type int, but .* has type string
+statement error expected computed column expression to have type int, but .* has type text
 CREATE TABLE y (
   a INT AS ('not an integer!'::STRING) STORED
 )
 
 # We utilize the types from other columns.
 
-statement error expected computed column expression to have type int, but 'a' has type string
+statement error expected computed column expression to have type int, but 'a' has type text
 CREATE TABLE y (
   a STRING,
   b INT AS (a) STORED

--- a/test/sqllogictest/cockroach/insert.slt
+++ b/test/sqllogictest/cockroach/insert.slt
@@ -467,10 +467,10 @@ CREATE TABLE string_t (
 statement ok
 INSERT INTO string_t VALUES ('str')
 
-query error value type string doesn't match type bytes of column "b"
+query error value type text doesn't match type bytes of column "b"
 INSERT INTO bytes_t SELECT * FROM string_t
 
-query error value type bytes doesn't match type string of column "s"
+query error value type bytes doesn't match type text of column "s"
 INSERT INTO string_t SELECT * FROM bytes_t
 
 subtest string_width_check

--- a/test/sqllogictest/cockroach/srfs.slt
+++ b/test/sqllogictest/cockroach/srfs.slt
@@ -593,16 +593,16 @@ SELECT (1).x
 query error pq: type int is not composite
 SELECT ((1)).x
 
-query error pq: type string is not composite
+query error pq: type text is not composite
 SELECT ('a').*
 
-query error pq: type string is not composite
+query error pq: type text is not composite
 SELECT (('a')).*
 
-query error pq: type string is not composite
+query error pq: type text is not composite
 SELECT ('a').x
 
-query error pq: type string is not composite
+query error pq: type text is not composite
 SELECT (('a')).x
 
 query error pq: unnest\(\): cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]

--- a/test/sqllogictest/cockroach/union.slt
+++ b/test/sqllogictest/cockroach/union.slt
@@ -237,21 +237,20 @@ SELECT 1, 2 INTERSECT SELECT 3
 query error pgcode 42601 each EXCEPT query must have the same number of columns: 2 vs 1
 SELECT 1, 2 EXCEPT SELECT 3
 
-query error pgcode 42804 UNION types i32 and string cannot be matched
+query error pgcode 42804 UNION types int4 and text cannot be matched
 SELECT 1 UNION SELECT '3'
 
-query error pgcode 42804 INTERSECT types i32 and string cannot be matched
+query error pgcode 42804 INTERSECT types int4 and text cannot be matched
 SELECT 1 INTERSECT SELECT '3'
 
-query error pgcode 42804 EXCEPT types i32 and string cannot be matched
+query error pgcode 42804 EXCEPT types int4 and text cannot be matched
 SELECT 1 EXCEPT SELECT '3'
 
 query error pgcode 42703 column "z" does not exist
 SELECT 1 UNION SELECT 3 ORDER BY z
 
-# TODO requires array support
-# query error UNION types int\[] and string\[] cannot be matched
-# SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']
+query error UNION types int4\[] and text\[] cannot be matched
+SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']
 
 # Check that UNION permits columns of different visible types
 

--- a/test/sqllogictest/cockroach/uuid.slt
+++ b/test/sqllogictest/cockroach/uuid.slt
@@ -112,7 +112,7 @@ INSERT INTO u VALUES (uuid_v4()::uuid)
 statement error value type bytes doesn't match type uuid
 INSERT INTO u VALUES ('cafef00ddeadbeef'::bytes)
 
-statement error value type string doesn't match type uuid
+statement error value type text doesn't match type uuid
 INSERT INTO u VALUES ('63616665-6630-3064-6465-616462656562'::string)
 
 statement error value type bytes doesn't match type uuid

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -619,7 +619,7 @@ SELECT array_upper(NULL::text[], 1)
 ----
 NULL
 
-query error Cannot call function array_upper\(unknown, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function array_upper\(unknown, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT array_upper(NULL, 1)
 
 query T

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -632,7 +632,7 @@ SELECT upper('ALREADYUP')
 ----
 ALREADYUP
 
-query error Cannot call function upper\(decimal\(38, 1\)\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function upper\(numeric\(38,1\)\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT upper(2.2)
 
 query T

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -65,7 +65,7 @@ SELECT (LIST[[[[1], [2]]], [[[3]]]])::text
 {{{{1},{2}}},{{{3}}}}
 
 # List(Int) cannot be cast to List(List(Int))
-query error CAST does not support casting from i32 list to i32 list list
+query error CAST does not support casting from int4 list to int4 list list
 SELECT LIST[1, null] :: INT LIST LIST
 
 query T
@@ -109,7 +109,7 @@ SELECT LIST [1, 2, 3][100]
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type i32
+query error cannot subscript type int4
 SELECT LIST [1, 2, 3][1][1]
 
 # 🔬🔬 list slices
@@ -194,7 +194,7 @@ SELECT (LIST [[1, 2, 3], [4, 5]][100][1])::text
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type i32
+query error cannot subscript type int4
 SELECT LIST [[1, 2, 3], [4, 5]][1][1][1]
 
 # 🔬🔬 list list slices
@@ -320,7 +320,7 @@ SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100][2][3]
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type i32
+query error cannot subscript type int4
 SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2][3][1]
 
 # 🔬🔬 list list list slices
@@ -668,19 +668,19 @@ SELECT (LIST[1,2,3][LIST[1][2.0 / 2]])::text
 query error invalid input syntax for int8: invalid digit found in string: "dog"
 SELECT LIST[1,2,3]['dog']
 
-query error subscript \(indexing\) does not support casting from date to i64
+query error subscript \(indexing\) does not support casting from date to int8
 SELECT LIST [[1, 2, 3], [4, 5]][DATE '2001-01-01']
 
-query error subscript \(indexing\) does not support casting from timestamp to i64
+query error subscript \(indexing\) does not support casting from timestamp to int8
 SELECT LIST [[1, 2, 3], [4, 5]][TIMESTAMP '2001-01-01']
 
 query error invalid input syntax for int8: invalid digit found in string: "dog"
 SELECT (LIST[1,2,3][1:'dog'])::text
 
-query error subscript \(slicing\) does not support casting from date to i64
+query error subscript \(slicing\) does not support casting from date to int8
 SELECT LIST [[1, 2, 3], [4, 5]][1:DATE '2001-01-01']
 
-query error subscript \(slicing\) does not support casting from timestamp to i64
+query error subscript \(slicing\) does not support casting from timestamp to int8
 SELECT LIST [[1, 2, 3], [4, 5]][1:TIMESTAMP '2001-01-01']
 
 # 🔬 Built-in functions
@@ -1244,7 +1244,7 @@ NULL
 query error invalid input syntax for int4: invalid digit found in string: "dog"
 SELECT (LIST['1', 'dog']::int list)::text
 
-query error CAST does not support casting from date list to i32 list
+query error CAST does not support casting from date list to int4 list
 SELECT LIST[DATE '2008-02-01']::int list
 
 # 🔬🔬🔬 Multi-dimensional and jagged lists
@@ -1324,7 +1324,7 @@ SELECT length(LIST['1','2']::text)
 ----
 5
 
-query error Cannot call function length\(string list\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function length\(text list\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT length(LIST['1','2'])
 
 # 🔬🔬 text to list
@@ -1863,23 +1863,23 @@ SELECT (NULL::INT LIST || NULL::INT LIST LIST)::text
 
 # 🔬🔬🔬 errors
 
-query error no overload for i32 list || unknown: Cannot concatenate i32 list and string list
+query error no overload for int4 list || unknown: Cannot concatenate int4 list and string list
 SELECT LIST[1] || LIST['a']
 
-query error  no overload for i32 list || unknown: Cannot concatenate i32 list and string
+query error  no overload for int4 list || unknown: Cannot concatenate int4 list and string
 SELECT LIST[1] || 'a'
 
-query error no overload for unknown || i32 list: Cannot concatenate string list and i32 list
+query error no overload for unknown || int4 list: Cannot concatenate string list and int4 list
 SELECT LIST[NULL] || LIST[1]
 
-query error no overload for unknown || i32 list: Cannot concatenate string list list and i32 list
+query error no overload for unknown || int4 list: Cannot concatenate string list list and int4 list
 SELECT LIST[[NULL]] || LIST[1]
 
-query error no overload for i32 list list list || i32 list: Cannot concatenate i32 list list list and i32 list
+query error no overload for int4 list list list || int4 list: Cannot concatenate int4 list list list and int4 list
 SELECT LIST[[[1]]] || LIST[2]
 
 # Literal text cannot be implicitly cast to list
-query error no overload for i32 list || string: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error no overload for int4 list || string: arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT LIST[1] || '{2}'::text
 
 # Two lists containing implicitly castable element types are not implicitly castable to one another
@@ -1912,7 +1912,7 @@ SELECT '{{1,2}}'::int4_list_c list::text
 query T
 SELECT pg_typeof(NULL::int4_list_c);
 ----
-list
+materialize.public.int_list_c
 
 statement ok
 CREATE TYPE int4_list_list_c AS LIST (element_type = int4_list_c);

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1912,7 +1912,7 @@ SELECT '{{1,2}}'::int4_list_c list::text
 query T
 SELECT pg_typeof(NULL::int4_list_c);
 ----
-materialize.public.int_list_c
+int4_list_c
 
 statement ok
 CREATE TYPE int4_list_list_c AS LIST (element_type = int4_list_c);

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -451,7 +451,7 @@ SELECT '{a=>1,b=>2}'::int4_map::text;
 query T
 SELECT pg_typeof(NULL::int4_map);
 ----
-materialize.public.int4_map
+int4_map
 
 # 🔬🔬 Check each valid value type
 

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -49,7 +49,7 @@ SELECT ('{  c  =>3, a=>     2, a => 1 }'::map[text=>int])::text
 ----
 {a=>1,c=>3}
 
-query error map key type must be text, got i32
+query error map key type must be text, got int4
 SELECT '{1=>true}'::map[int=>bool]
 
 query T
@@ -126,7 +126,7 @@ SELECT ('{hello=>{world=>nested}}'::map[text=>map[text=>text]])::text
 ----
 {hello=>{world=>nested}}
 
-query error map key type must be text, got i32
+query error map key type must be text, got int4
 SELECT '{hello=>{1=>false}}'::map[text=>map[int=>bool]]
 
 query T
@@ -176,7 +176,7 @@ SELECT '{hello=>{world=>false}}'::map[text=>map[text=>bool]] -> 'hello'::text ? 
 true
 
 ## ?&
-query error string literal does not support casting from string to string\[\]
+query error string literal does not support casting from text to text\[\]
 SELECT '{a=>1, b=>2}'::map[text=>int] ?& 'a'
 
 query error arguments cannot be implicitly cast to any implementation's parameters
@@ -234,7 +234,7 @@ SELECT '{hello=>{world=>1293}}'::map[text=>map[text=>smallint]] -> 'hello'::text
 false
 
 ## ?|
-query error string literal does not support casting from string to string\[\]
+query error string literal does not support casting from text to text\[\]
 SELECT '{a=>1, b=>2}'::map[text=>int] ?| 'a'
 
 query error arguments cannot be implicitly cast to any implementation's parameters
@@ -451,7 +451,7 @@ SELECT '{a=>1,b=>2}'::int4_map::text;
 query T
 SELECT pg_typeof(NULL::int4_map);
 ----
-map
+materialize.public.int4_map
 
 # 🔬🔬 Check each valid value type
 

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -45,11 +45,11 @@ true
 false
 true
 
-# Do not allow i32 text comparisons
-query error no overload for string < i32
+# Do not allow int4 text comparisons
+query error no overload for text < int4
 SELECT 'foo'::text < 5::int;
 
-query error no overload for i32 < string
+query error no overload for int4 < text
 SELECT 1 < ALL(VALUES(NULL))
 
 # But string *literals* can coerce to anything.
@@ -65,7 +65,7 @@ true
 
 # Use comparison ops to check for type promotion
 
-# Check i32 promotes to decimal
+# Check int4 promotes to numeric
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1 > 1.1;
@@ -76,7 +76,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Check i64 promotes to decimal
+# Check int8 promotes to numeric
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1::bigint > 1.11111
@@ -87,7 +87,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Check i64 promotes to f64
+# Check int8 promotes to float8
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1::bigint > 1.11111::float
@@ -98,7 +98,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Check decimal promotes to f64
+# Check numeric promotes to float8
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1.1 > 1::float;
@@ -109,7 +109,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Check decimals do not get promoted
+# Check numerics do not get promoted
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1.1 > 1.1
@@ -131,7 +131,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Checks that f64 is preferred type for i32
+# Checks that float8 is preferred type for int4
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT floor(1);
@@ -142,19 +142,19 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Cannot implicitly cast i32 to string
-query error Cannot call function char_length\(i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+# Cannot implicitly cast int4 to string
+query error Cannot call function char_length\(int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT char_length(321);
 
 # Cannot implicitly cast string to any numeric category
-query error no overload for string \+ string
+query error no overload for text \+ text
 SELECT 'dog'::text + 'cat'::text;
 
-# Cannot implicitly cast f64 to decimal
-query error Cannot call function round\(f64, i32\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+# Cannot implicitly cast float8 to numeric
+query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(1.23::float, 1);
 
-# Check that f64 is the most common type
+# Check that float8 is the most common type
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT coalesce(1::int, 1::numeric, 1::float);
@@ -226,10 +226,10 @@ SELECT 1::bigint::bigint;
 ----
 1
 
-query error CAST does not support casting from bool to i64
+query error CAST does not support casting from bool to int8
 SELECT TRUE::boolean::bigint
 
-query error CAST does not support casting from date to i64
+query error CAST does not support casting from date to int8
 SELECT '2001 02-03'::date::bigint
 
 query T
@@ -252,7 +252,7 @@ SELECT 2::int::bigint;
 ----
 2
 
-query error CAST does not support casting from interval to i64
+query error CAST does not support casting from interval to int8
 SELECT '1'::interval::bigint
 
 #pginvalid
@@ -269,13 +269,13 @@ SELECT '1'::jsonb::bigint;
 query error invalid input syntax for int8: invalid digit found in string: "dog"
 SELECT 'dog'::text::bigint
 
-query error CAST does not support casting from time to i64
+query error CAST does not support casting from time to int8
 SELECT '01:02:03'::time::bigint
 
-query error CAST does not support casting from timestamp to i64
+query error CAST does not support casting from timestamp to int8
 SELECT '2002 03-04'::timestamp::bigint
 
-query error CAST does not support casting from timestamptz to i64
+query error CAST does not support casting from timestamptz to int8
 SELECT '2003 04-05'::timestamptz::bigint
 
 query T
@@ -291,13 +291,13 @@ true
 query error CAST does not support casting from date to bool
 SELECT '2001 02-03'::date::boolean
 
-query error CAST does not support casting from decimal\(38, 0\) to bool
+query error CAST does not support casting from numeric\(38,0\) to bool
 SELECT 1.1::numeric::boolean
 
-query error CAST does not support casting from f64 to bool
+query error CAST does not support casting from float8 to bool
 SELECT 1.2::double::boolean
 
-query error CAST does not support casting from f32 to bool
+query error CAST does not support casting from float4 to bool
 SELECT 1.3::real::boolean
 
 query T
@@ -331,7 +331,7 @@ SELECT '2002 03-04'::timestamp::boolean
 query error CAST does not support casting from timestamptz to bool
 SELECT '2003 04-05'::timestamptz::boolean
 
-query error CAST does not support casting from i64 to date
+query error CAST does not support casting from int8 to date
 SELECT 1::bigint::date
 
 query error CAST does not support casting from bool to date
@@ -342,16 +342,16 @@ SELECT '2001 02-03'::date::date;
 ----
 2001-02-03
 
-query error CAST does not support casting from decimal\(38, 0\) to date
+query error CAST does not support casting from numeric\(38,0\) to date
 SELECT 1.1::numeric::date
 
-query error CAST does not support casting from f64 to date
+query error CAST does not support casting from float8 to date
 SELECT 1.2::double::date
 
-query error CAST does not support casting from f32 to date
+query error CAST does not support casting from float4 to date
 SELECT 1.3::real::date
 
-query error CAST does not support casting from i32 to date
+query error CAST does not support casting from int4 to date
 SELECT 2::int::date
 
 query error CAST does not support casting from interval to date
@@ -381,10 +381,10 @@ SELECT 1::bigint::numeric;
 ----
 1.0000
 
-query error CAST does not support casting from bool to decimal\(38, 0\)
+query error CAST does not support casting from bool to numeric\(38,0\)
 SELECT TRUE::boolean::numeric
 
-query error CAST does not support casting from date to decimal\(38, 0\)
+query error CAST does not support casting from date to numeric\(38,0\)
 SELECT '2001 02-03'::date::numeric
 
 query R
@@ -407,7 +407,7 @@ SELECT 2::int::numeric;
 ----
 2.0000
 
-query error CAST does not support casting from interval to decimal\(38, 0\)
+query error CAST does not support casting from interval to numeric\(38,0\)
 SELECT '1'::interval::numeric
 
 query T
@@ -420,16 +420,16 @@ SELECT '1'::jsonb::numeric;
 ----
 1.0000
 
-query error invalid input syntax for decimal: malformed numeric literal: dog: "dog"
+query error invalid input syntax for numeric: malformed numeric literal: dog: "dog"
 SELECT 'dog'::text::numeric
 
-query error CAST does not support casting from time to decimal\(38, 0\)
+query error CAST does not support casting from time to numeric\(38,0\)
 SELECT '01:02:03'::time::numeric
 
-query error CAST does not support casting from timestamp to decimal\(38, 0\)
+query error CAST does not support casting from timestamp to numeric\(38,0\)
 SELECT '2002 03-04'::timestamp::numeric
 
-query error CAST does not support casting from timestamptz to decimal\(38, 0\)
+query error CAST does not support casting from timestamptz to numeric\(38,0\)
 SELECT '2003 04-05'::timestamptz::numeric
 
 query T
@@ -437,10 +437,10 @@ SELECT 1::bigint::double;
 ----
 1.000
 
-query error CAST does not support casting from bool to f64
+query error CAST does not support casting from bool to float8
 SELECT TRUE::boolean::double
 
-query error CAST does not support casting from date to f64
+query error CAST does not support casting from date to float8
 SELECT '2001 02-03'::date::double
 
 query T
@@ -463,7 +463,7 @@ SELECT 2::int::double;
 ----
 2.000
 
-query error CAST does not support casting from interval to f64
+query error CAST does not support casting from interval to float8
 SELECT '1'::interval::double
 
 #pginvalid
@@ -480,13 +480,13 @@ SELECT '1'::jsonb::double;
 query error invalid input syntax for float8: invalid float literal: "dog"
 SELECT 'dog'::text::double
 
-query error CAST does not support casting from time to f64
+query error CAST does not support casting from time to float8
 SELECT '01:02:03'::time::double
 
-query error CAST does not support casting from timestamp to f64
+query error CAST does not support casting from timestamp to float8
 SELECT '2002 03-04'::timestamp::double
 
-query error CAST does not support casting from timestamptz to f64
+query error CAST does not support casting from timestamptz to float8
 SELECT '2003 04-05'::timestamptz::double
 
 query T
@@ -494,10 +494,10 @@ SELECT 1::bigint::real;
 ----
 1.000
 
-query error CAST does not support casting from bool to f32
+query error CAST does not support casting from bool to float4
 SELECT TRUE::boolean::real
 
-query error CAST does not support casting from date to f32
+query error CAST does not support casting from date to float4
 SELECT '2001 02-03'::date::real
 
 query T
@@ -520,7 +520,7 @@ SELECT 2::int::real;
 ----
 2.000
 
-query error CAST does not support casting from interval to f32
+query error CAST does not support casting from interval to float4
 SELECT '1'::interval::real
 
 #pginvalid
@@ -537,13 +537,13 @@ SELECT '2'::jsonb::real;
 query error invalid input syntax for float4: invalid float literal: "dog"
 SELECT 'dog'::text::real
 
-query error CAST does not support casting from time to f32
+query error CAST does not support casting from time to float4
 SELECT '01:02:03'::time::real
 
-query error CAST does not support casting from timestamp to f32
+query error CAST does not support casting from timestamp to float4
 SELECT '2002 03-04'::timestamp::real
 
-query error CAST does not support casting from timestamptz to f32
+query error CAST does not support casting from timestamptz to float4
 SELECT '2003 04-05'::timestamptz::real
 
 query T
@@ -551,7 +551,7 @@ SELECT 1::bigint::integer;
 ----
 1
 
-query error CAST does not support casting from date to i32
+query error CAST does not support casting from date to int4
 SELECT '2001 02-03'::date::integer
 
 query T
@@ -574,7 +574,7 @@ SELECT 2::int::integer;
 ----
 2
 
-query error CAST does not support casting from interval to i32
+query error CAST does not support casting from interval to int4
 SELECT '1'::interval::integer
 
 #pginvalid
@@ -591,16 +591,16 @@ SELECT '1'::jsonb::integer;
 query error invalid input syntax for int4: invalid digit found in string: "dog"
 SELECT 'dog'::text::integer
 
-query error CAST does not support casting from time to i32
+query error CAST does not support casting from time to int4
 SELECT '01:02:03'::time::integer
 
-query error CAST does not support casting from timestamp to i32
+query error CAST does not support casting from timestamp to int4
 SELECT '2002 03-04'::timestamp::integer
 
-query error CAST does not support casting from timestamptz to i32
+query error CAST does not support casting from timestamptz to int4
 SELECT '2003 04-05'::timestamptz::integer
 
-query error CAST does not support casting from i64 to interval
+query error CAST does not support casting from int8 to interval
 SELECT 1::bigint::interval
 
 query error CAST does not support casting from bool to interval
@@ -609,16 +609,16 @@ SELECT TRUE::boolean::interval
 query error CAST does not support casting from date to interval
 SELECT '2001 02-03'::date::interval
 
-query error CAST does not support casting from decimal\(38, 0\) to interval
+query error CAST does not support casting from numeric\(38,0\) to interval
 SELECT 1.1::numeric::interval
 
-query error CAST does not support casting from f64 to interval
+query error CAST does not support casting from float8 to interval
 SELECT 1.2::double::interval
 
-query error CAST does not support casting from f32 to interval
+query error CAST does not support casting from float4 to interval
 SELECT 1.3::real::interval
 
-query error CAST does not support casting from i32 to interval
+query error CAST does not support casting from int4 to interval
 SELECT 2::int::interval
 
 query T
@@ -643,7 +643,7 @@ SELECT '2002 03-04'::timestamp::interval
 query error CAST does not support casting from timestamptz to interval
 SELECT '2003 04-05'::timestamptz::interval
 
-query error CAST does not support casting from i64 to jsonb
+query error CAST does not support casting from int8 to jsonb
 SELECT 1::bigint::jsonb
 
 #pginvalid
@@ -653,13 +653,13 @@ SELECT TRUE::boolean::jsonb;
 query error CAST does not support casting from date to jsonb
 SELECT '2001 02-03'::date::jsonb
 
-query error CAST does not support casting from decimal\(38, 0\) to jsonb
+query error CAST does not support casting from numeric\(38,0\) to jsonb
 SELECT 1.1::numeric::jsonb
 
-query error CAST does not support casting from f64 to jsonb
+query error CAST does not support casting from float8 to jsonb
 SELECT 1.2::double::jsonb;
 
-query error CAST does not support casting from i32 to jsonb
+query error CAST does not support casting from int4 to jsonb
 SELECT 2::int::jsonb;
 
 query error CAST does not support casting from interval to jsonb
@@ -760,7 +760,7 @@ SELECT '2003 04-05'::timestamptz::text;
 ----
 2003-04-05 00:00:00+00
 
-query error CAST does not support casting from i64 to time
+query error CAST does not support casting from int8 to time
 SELECT 1::bigint::time
 
 query error CAST does not support casting from bool to time
@@ -769,16 +769,16 @@ SELECT TRUE::boolean::time
 query error CAST does not support casting from date to time
 SELECT '2001 02-03'::date::time
 
-query error CAST does not support casting from decimal\(38, 0\) to time
+query error CAST does not support casting from numeric\(38,0\) to time
 SELECT 1.1::numeric::time
 
-query error CAST does not support casting from f64 to time
+query error CAST does not support casting from float8 to time
 SELECT 1.2::double::time
 
-query error CAST does not support casting from f32 to time
+query error CAST does not support casting from float4 to time
 SELECT 1.3::real::time
 
-query error CAST does not support casting from i32 to time
+query error CAST does not support casting from int4 to time
 SELECT 2::int::time
 
 query T
@@ -803,7 +803,7 @@ SELECT '2002 03-04'::timestamp::time
 query error CAST does not support casting from timestamptz to time
 SELECT '2003 04-05'::timestamptz::time
 
-query error CAST does not support casting from i64 to timestamp
+query error CAST does not support casting from int8 to timestamp
 SELECT 1::bigint::timestamp
 
 query error CAST does not support casting from bool to timestamp
@@ -814,16 +814,16 @@ SELECT '2001 02-03'::date::timestamp;
 ----
 2001-02-03 00:00:00
 
-query error CAST does not support casting from decimal\(38, 0\) to timestamp
+query error CAST does not support casting from numeric\(38,0\) to timestamp
 SELECT 1.1::numeric::timestamp
 
-query error CAST does not support casting from f64 to timestamp
+query error CAST does not support casting from float8 to timestamp
 SELECT 1.2::double::timestamp
 
-query error CAST does not support casting from f32 to timestamp
+query error CAST does not support casting from float4 to timestamp
 SELECT 1.3::real::timestamp
 
-query error CAST does not support casting from i32 to timestamp
+query error CAST does not support casting from int4 to timestamp
 SELECT 2::int::timestamp
 
 query error CAST does not support casting from interval to timestamp
@@ -848,7 +848,7 @@ SELECT '2003 04-05'::timestamptz::timestamp;
 ----
 2003-04-05 00:00:00
 
-query error CAST does not support casting from i64 to timestamptz
+query error CAST does not support casting from int8 to timestamptz
 SELECT 1::bigint::timestamptz
 
 query error CAST does not support casting from bool to timestamptz
@@ -859,16 +859,16 @@ SELECT '2001 02-03'::date::timestamptz;
 ----
 2001-02-03 00:00:00+00
 
-query error CAST does not support casting from decimal\(38, 0\) to timestamptz
+query error CAST does not support casting from numeric\(38,0\) to timestamptz
 SELECT 1.1::numeric::timestamptz
 
-query error CAST does not support casting from f64 to timestamptz
+query error CAST does not support casting from float8 to timestamptz
 SELECT 1.2::double::timestamptz
 
-query error CAST does not support casting from f32 to timestamptz
+query error CAST does not support casting from float4 to timestamptz
 SELECT 1.3::real::timestamptz
 
-query error CAST does not support casting from i32 to timestamptz
+query error CAST does not support casting from int4 to timestamptz
 SELECT 2::int::timestamptz
 
 query error CAST does not support casting from interval to timestamptz

--- a/test/sqllogictest/typeof.slt
+++ b/test/sqllogictest/typeof.slt
@@ -35,4 +35,4 @@ int4
 query T
 SELECT pg_typeof(1.0)
 ----
-numeric
+numeric(38,1)

--- a/test/sqllogictest/typeof.slt
+++ b/test/sqllogictest/typeof.slt
@@ -36,3 +36,36 @@ query T
 SELECT pg_typeof(1.0)
 ----
 numeric(38,1)
+
+# Custom types
+
+statement ok
+CREATE TYPE int4_list AS LIST (element_type=int4)
+
+statement ok
+CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
+
+query T
+SELECT pg_typeof('{1}'::int4 list)
+----
+int4 list
+
+query T
+SELECT pg_typeof('{1}'::int4_list)
+----
+int4_list
+
+query T
+SELECT pg_typeof('{{1}}'::int4 list list)
+----
+int4 list list
+
+query T
+SELECT pg_typeof('{{1}}'::int4_list_list)
+----
+int4_list_list
+
+query T
+SELECT pg_typeof('{{1}}'::int4_list list)
+----
+int4_list list

--- a/test/sqllogictest/uuid.slt
+++ b/test/sqllogictest/uuid.slt
@@ -27,5 +27,5 @@ SELECT '63616665-6630-3064-6465-616462656568'::text::uuid
 query error invalid input syntax for uuid
 SELECT 'Z3616665-6630-3064-6465-616462656568'::uuid
 
-query error does not support casting from uuid to bytes
+query error does not support casting from uuid to bytea
 SELECT '63616665-6630-3064-6465-616462656568'::uuid::bytes

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -97,7 +97,7 @@ d
 > SHOW DATABASES WHERE (name = (SELECT min(name) FROM mz_databases))
 d
 ! SHOW DATABASES WHERE 7
-WHERE clause must have type bool, not type i32
+WHERE clause must have type bool, not type int4
 
 # Creating a database with a name that already exists should fail.
 ! CREATE DATABASE d

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -155,6 +155,36 @@ v1_primary_idx
 v2
 v2_primary_idx
 
+# Test minimizing name qualification
+
+> CREATE TYPE int_list AS list (element_type=int4)
+
+> SELECT pg_typeof('{1}'::d.public.int_list)
+int_list
+
+> CREATE SCHEMA other
+> CREATE TYPE other.int_list AS list (element_type=int4)
+> SELECT pg_typeof('{1}'::d.other.int_list)
+other.int_list
+
+> CREATE DATABASE foo
+> CREATE SCHEMA foo.other
+> CREATE TYPE foo.other.int_list AS LIST (element_type=int4)
+> SELECT pg_typeof('{1}'::foo.other.int_list)
+foo.other.int_list
+
+> CREATE TYPE bool AS LIST (element_type=int4)
+! SELECT '{1}'::bool
+invalid input syntax for bool: "{1}"
+
+> SELECT pg_typeof('{1}'::public.bool);
+public.bool
+
+> SELECT pg_typeof('{1}'::d.public.bool);
+public.bool
+
+> DROP DATABASE foo
+
 ! DROP OBJECT v1
 Expected DATABASE, SCHEMA, TABLE, VIEW, SOURCE, SINK, INDEX, or TYPE after DROP, found identifier
 
@@ -179,6 +209,7 @@ Expected end of statement, found RESTRICT
 name
 ----
 materialize
+
 > SELECT id, name FROM mz_databases
 id          name
 -----------------------

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -33,7 +33,7 @@ materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" \"pg
 > DROP TABLE s;
 
 ! CREATE TABLE s (a date DEFAULT 42)
-DEFAULT expression does not support casting from i32 to date
+DEFAULT expression does not support casting from int4 to date
 
 ! CREATE TABLE s (a int, b int DEFAULT a + 3)
 column "a" does not exist


### PR DESCRIPTION
- Removes `impl Display` from `ScalarType` and `ColumnType` and instead provides method to get the appropriate name from the catalog.

    The one catch with this is that `EXPLAIN` doesn't plumb catalog access through to the formatter, so rather than tackle that I simply moved `impl Display` into a function called `explain`. Cludgy but figured the scale of win was greater than the scale of stupid, but glad to tidy it up on a follow-on PR.
- Provides function to get the minimal qualification necessary to address an object given its `FullName`, giving us better parity with PG's output. That being said, I didn't look for other places that this might be useful––glad to hunt those down in a follow-on PR.

Fixes #2509

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5175)
<!-- Reviewable:end -->
