### PR TITLE
add note about potential backwards incompatibility in create source/s…

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -102,6 +102,13 @@ Wrap your release notes at the 80 character mark.
 - Avoid panicking if a record in a regex-formatted source fails to decode
   as UTF-8 {{% gh 5008 %}}.
 
+- Validate `WITH` clauses in `CREATE SOURCE` and `CREATE SINK` statements. This
+  is a potentially backwards-incompatible change as previously any invalid
+  `WITH` clauses would be silently ignored. Upgrading materialize in-place
+  on a persisted catalog that has an invalid `WITH` clause will now fail.
+
+  **Backwards-incompatible change.**
+
 {{% version-header v0.5.3 %}}
 
 - Add support for SQL cursors via the new [`DECLARE`](/sql/declare),


### PR DESCRIPTION
…ink WITH clause validation

This is minor but seems worthy of a short note. Any suggestions on wording is most welcome; having trouble phrasing it since it's an edge case.

Related to https://github.com/MaterializeInc/materialize/pull/5135

Main issue is that previously if you created a source `WITH badoption` and now try to run a newer version of mz with that same catalog it'll throw an error on startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5189)
<!-- Reviewable:end -->
