### PR TITLE
fix flaky sinks test

### DIFF
--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -33,7 +33,7 @@ goofus,gallant
 
 ! CREATE SINK invalid_with_option FROM src
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
-  WITH (concurrency=true, badoption=true)
+  WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 unexpected parameters for CREATE SINK: badoption
 


### PR DESCRIPTION
I had a copy/paste error in this unit test and included two invalid WITH options.

The reason it usually passes is because option parsing uses a hashmap so ordering isn't guaranteed and testdrive does a prefix match when checking output. 

Often the error message is: "unexpected parameters for CREATE SINK: badoption,concurrency" which passes testdrive's prefix match. Occasionally the order flips to "unexpected parameters for CREATE SINK: concurrency,badoption" which will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5191)
<!-- Reviewable:end -->
