### PR TITLE
s3 sources: Add the ability to read a single object from S3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kinesis",
+ "rusoto_s3",
  "rusoto_sts",
  "tokio",
 ]
@@ -733,6 +734,7 @@ dependencies = [
  "dogsdogsdogs",
  "expr",
  "futures",
+ "globset",
  "inotify",
  "interchange",
  "itertools",
@@ -751,6 +753,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kinesis",
+ "rusoto_s3",
  "serde",
  "serde_json",
  "timely",
@@ -777,6 +780,7 @@ dependencies = [
  "ccsr",
  "comm",
  "expr",
+ "globset",
  "interchange",
  "kafka-util",
  "log",
@@ -1348,6 +1352,20 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c152169ef1e421390738366d2f796655fec62621dabbd0fd476f905934061e4a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+ "serde",
+]
 
 [[package]]
 name = "h2"
@@ -3297,6 +3315,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusoto_s3"
+version = "0.46.0"
+source = "git+https://github.com/rusoto/rusoto.git#b94d7bebd8a5286e2f2b4e6a68062bfe5cc68943"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "xml-rs",
+]
+
+[[package]]
 name = "rusoto_signature"
 version = "0.46.0"
 source = "git+https://github.com/rusoto/rusoto.git#b94d7bebd8a5286e2f2b4e6a68062bfe5cc68943"
@@ -3671,6 +3701,7 @@ dependencies = [
  "dataflow-types",
  "expr",
  "futures",
+ "globset",
  "interchange",
  "itertools",
  "lazy_static",

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -11,5 +11,6 @@ log = "0.4.13"
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_credential = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_kinesis = { git = "https://github.com/rusoto/rusoto.git" }
+rusoto_s3 = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_sts = { git = "https://github.com/rusoto/rusoto.git" }
 tokio = "1.0.0"

--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -40,7 +40,7 @@ pub async fn client(
                 region,
             )
         }
-        (_, _) => {
+        (None, None) => {
             info!("AWS access_key_id and secret_access_key not provided, creating a new Kinesis client using a chain provider.");
             let mut provider = ChainProvider::new();
             provider.set_timeout(Duration::from_secs(10));
@@ -49,6 +49,9 @@ pub async fn client(
 
             KinesisClient::new_with(request_dispatcher, provider, region)
         }
+        (_, _) => anyhow::bail!(
+            "access_key_id and secret_access_key must either both be provided, or neither"
+        ),
     };
     Ok(kinesis_client)
 }

--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -23,7 +23,7 @@ use rusoto_kinesis::{GetShardIteratorInput, Kinesis, KinesisClient, ListShardsIn
 ///
 /// The AutoRefreshingProvider caches the underlying provider's AWS credentials,
 /// automatically fetching updated credentials if they've expired.
-pub async fn kinesis_client(
+pub async fn client(
     region: Region,
     access_key_id: Option<String>,
     secret_access_key: Option<String>,

--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 use anyhow::Context;
 use log::info;
 use rusoto_core::{HttpClient, Region};
-use rusoto_credential::{AutoRefreshingProvider, ChainProvider, StaticProvider};
+use rusoto_credential::{
+    AutoRefreshingProvider, ChainProvider, ProvideAwsCredentials, StaticProvider,
+};
 use rusoto_kinesis::{GetShardIteratorInput, Kinesis, KinesisClient, ListShardsInput, Shard};
 
 /// Constructs a KinesisClient from statically provided connection information. If connection
@@ -44,6 +46,7 @@ pub async fn client(
             info!("AWS access_key_id and secret_access_key not provided, creating a new Kinesis client using a chain provider.");
             let mut provider = ChainProvider::new();
             provider.set_timeout(Duration::from_secs(10));
+            provider.credentials().await?; // ensure that credentials exist
             let provider =
                 AutoRefreshingProvider::new(provider).context("generating AWS credentials")?;
 

--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -20,10 +20,13 @@ use rusoto_credential::{
 };
 use rusoto_kinesis::{GetShardIteratorInput, Kinesis, KinesisClient, ListShardsInput, Shard};
 
-/// Constructs a KinesisClient from statically provided connection information. If connection
-/// information is not provided, falls back to using credentials gathered by aws::credentials.
+/// Construct a KinesisClient
 ///
-/// The AutoRefreshingProvider caches the underlying provider's AWS credentials,
+/// If statically provided connection information information is not provided,
+/// falls back to using credentials gathered by rusoto's [`ChainProvider]
+/// wrapped in an [`AutoRefreshingProvider`].
+///
+/// The [`AutoRefreshingProvider`] caches the underlying provider's AWS credentials,
 /// automatically fetching updated credentials if they've expired.
 pub async fn client(
     region: Region,

--- a/src/aws-util/src/lib.rs
+++ b/src/aws-util/src/lib.rs
@@ -13,3 +13,4 @@
 
 pub mod aws;
 pub mod kinesis;
+pub mod s3;

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utility functions for AWS S3 clients
+
+use std::time::Duration;
+
+use anyhow::Context;
+use log::info;
+use rusoto_core::{HttpClient, Region};
+use rusoto_credential::{
+    AutoRefreshingProvider, ChainProvider, ProvideAwsCredentials, StaticProvider,
+};
+use rusoto_s3::S3Client;
+
+/// Construct an S3Client
+///
+/// If statically provided connection information information is not provided,
+/// falls back to using credentials gathered by rusoto's [`ChainProvider]
+/// wrapped in an [`AutoRefreshingProvider`].
+///
+/// The [`AutoRefreshingProvider`] caches the underlying provider's AWS credentials,
+/// automatically fetching updated credentials if they've expired.
+pub async fn client(
+    region: Region,
+    access_key_id: Option<String>,
+    secret_access_key: Option<String>,
+    token: Option<String>,
+) -> Result<S3Client, anyhow::Error> {
+    let request_dispatcher = HttpClient::new().context("creating HTTP client for S3 client")?;
+    let s3_client = match (access_key_id, secret_access_key) {
+        (Some(access_key_id), Some(secret_access_key)) => {
+            info!("Creating a new S3 client from provided access_key and secret_access_key");
+            S3Client::new_with(
+                request_dispatcher,
+                StaticProvider::new(access_key_id, secret_access_key, token, None),
+                region,
+            )
+        }
+        (None, None) => {
+            info!(
+                "AWS access_key_id and secret_access_key not provided, \
+                 creating a new S3 client using a chain provider."
+            );
+            let mut provider = ChainProvider::new();
+            provider.set_timeout(Duration::from_secs(10));
+            provider.credentials().await?; // ensure that credentials exist
+            let provider =
+                AutoRefreshingProvider::new(provider).context("generating AWS credentials")?;
+
+            S3Client::new_with(request_dispatcher, provider, region)
+        }
+        (_, _) => anyhow::bail!(
+            "access_key_id and secret_access_key must either both be provided, or neither"
+        ),
+    };
+    Ok(s3_client)
+}

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -1090,7 +1090,7 @@ impl Timestamper {
         _id: SourceInstanceId,
         kinc: KinesisSourceConnector,
     ) -> Option<RtKinesisConnector> {
-        let (kinesis_client, cached_shard_ids) = match block_on(aws_util::kinesis::kinesis_client(
+        let (kinesis_client, cached_shard_ids) = match block_on(aws_util::kinesis::client(
             kinc.aws_info.region.clone(),
             kinc.aws_info.access_key_id.clone(),
             kinc.aws_info.secret_access_key.clone(),

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -1091,10 +1091,10 @@ impl Timestamper {
         kinc: KinesisSourceConnector,
     ) -> Option<RtKinesisConnector> {
         let (kinesis_client, cached_shard_ids) = match block_on(aws_util::kinesis::kinesis_client(
-            kinc.region.clone(),
-            kinc.access_key_id.clone(),
-            kinc.secret_access_key.clone(),
-            kinc.token.clone(),
+            kinc.aws_info.region.clone(),
+            kinc.aws_info.access_key_id.clone(),
+            kinc.aws_info.secret_access_key.clone(),
+            kinc.aws_info.token.clone(),
         )) {
             Ok(kinesis_client) => {
                 let cached_shard_ids = match block_on(aws_util::kinesis::get_shard_ids(

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.38"
 ccsr = { path = "../ccsr" }
 comm = { path = "../comm" }
 expr = { path = "../expr" }
+globset = { version = "0.4.0", features = ["serde1"] }
 interchange = { path = "../interchange" }
 kafka-util = { path = "../kafka-util" }
 log = "0.4.13"

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -614,16 +614,21 @@ pub struct KafkaSourceConnector {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KinesisSourceConnector {
     pub stream_name: String,
-    pub region: Region,
-    pub access_key_id: Option<String>,
-    pub secret_access_key: Option<String>,
-    pub token: Option<String>,
+    pub aws_info: AwsConnectInfo,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct FileSourceConnector {
     pub path: PathBuf,
     pub tail: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AwsConnectInfo {
+    pub region: Region,
+    pub access_key_id: Option<String>,
+    pub secret_access_key: Option<String>,
+    pub token: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -19,6 +19,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 expr = { path = "../expr" }
 futures = "0.3.9"
+globset = "0.4.0"
 inotify = "0.9.2"
 interchange = { path = "../interchange" }
 itertools = "0.9.0"
@@ -37,6 +38,7 @@ repr = { path = "../repr" }
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_credential = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_kinesis = { git = "https://github.com/rusoto/rusoto.git" }
+rusoto_s3 = { git = "https://github.com/rusoto/rusoto.git" }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.60"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -135,7 +135,7 @@ use crate::operator::{CollectionExt, StreamExt};
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::server::{CacheMessage, LocalInput, TimestampDataUpdates, TimestampMetadataUpdates};
 use crate::sink;
-use crate::source::{self, FileSourceInfo, KafkaSourceInfo, KinesisSourceInfo};
+use crate::source::{self, FileSourceInfo, KafkaSourceInfo, KinesisSourceInfo, S3SourceInfo};
 use crate::source::{SourceConfig, SourceToken};
 use crate::{
     arrangement::manager::{TraceBundle, TraceManager},
@@ -410,6 +410,12 @@ where
                             }
                             ExternalSourceConnector::Kinesis(_) => {
                                 source::create_source::<_, KinesisSourceInfo, _>(
+                                    source_config,
+                                    connector,
+                                )
+                            }
+                            ExternalSourceConnector::S3(_) => {
+                                source::create_source::<_, S3SourceInfo, _>(
                                     source_config,
                                     connector,
                                 )

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -358,7 +358,7 @@ async fn create_state(
     ),
     anyhow::Error,
 > {
-    let kinesis_client = aws_util::kinesis::kinesis_client(
+    let kinesis_client = aws_util::kinesis::client(
         c.aws_info.region.clone(),
         c.aws_info.access_key_id.clone(),
         c.aws_info.secret_access_key.clone(),

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -359,10 +359,10 @@ async fn create_state(
     anyhow::Error,
 > {
     let kinesis_client = aws_util::kinesis::kinesis_client(
-        c.region.clone(),
-        c.access_key_id.clone(),
-        c.secret_access_key.clone(),
-        c.token,
+        c.aws_info.region.clone(),
+        c.aws_info.access_key_id.clone(),
+        c.aws_info.secret_access_key.clone(),
+        c.aws_info.token,
     )
     .await?;
 

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -48,6 +48,7 @@ use crate::source::cache::CacheSender;
 mod file;
 mod kafka;
 mod kinesis;
+mod s3;
 mod util;
 
 pub mod cache;
@@ -58,6 +59,7 @@ pub use file::FileReadStyle;
 pub use file::FileSourceInfo;
 pub use kafka::KafkaSourceInfo;
 pub use kinesis::KinesisSourceInfo;
+pub use s3::S3SourceInfo;
 
 /// Shared configuration information for all source types.
 pub struct SourceConfig<'a, G> {

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -1,0 +1,322 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Functionality for creating S3 sources
+
+use std::convert::{From, TryInto};
+use std::default::Default;
+use std::ops::AddAssign;
+use std::sync::mpsc::{Receiver, SyncSender, TryRecvError};
+
+use anyhow::{anyhow, Error};
+use globset::GlobMatcher;
+use rusoto_s3::{GetObjectRequest, S3};
+use timely::scheduling::{Activator, SyncActivator};
+use tokio::io::AsyncReadExt;
+
+use dataflow_types::{
+    AwsConnectInfo, Consistency, DataEncoding, ExternalSourceConnector, MzOffset,
+};
+use expr::{PartitionId, SourceInstanceId};
+
+use crate::logging::materialized::Logger;
+use crate::server::{
+    TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate, TimestampMetadataUpdates,
+};
+use crate::source::{
+    ConsistencyInfo, NextMessage, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
+};
+
+type Out = Vec<u8>;
+
+/// Information required to load data from S3
+pub struct S3SourceInfo {
+    /// The name of the source that the user entered
+    source_name: String,
+    /// The name of the S3 bucket we are pulling from
+    bucket: String,
+
+    // differential control
+    /// Unique source ID
+    id: SourceInstanceId,
+    /// Field is set if this operator is responsible for ingesting data
+    is_activated_reader: bool,
+    /// Receiver channel that ingests records
+    receiver_stream: Receiver<Result<Out, Error>>,
+    /// Buffer: store message that cannot yet be timestamped
+    buffer: Option<SourceMessage<Out>>,
+    /// BucketOffset
+    offset: BucketOffset,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct BucketOffset(i64);
+
+impl AddAssign<i64> for BucketOffset {
+    fn add_assign(&mut self, other: i64) {
+        self.0 += other;
+    }
+}
+
+impl From<BucketOffset> for MzOffset {
+    fn from(offset: BucketOffset) -> MzOffset {
+        MzOffset { offset: offset.0 }
+    }
+}
+
+impl SourceConstructor<Vec<u8>> for S3SourceInfo {
+    fn new(
+        source_name: String,
+        source_id: SourceInstanceId,
+        active: bool,
+        worker_id: usize,
+        _worker_count: usize,
+        logger: Option<Logger>,
+        consumer_activator: SyncActivator,
+        connector: ExternalSourceConnector,
+        consistency_info: &mut ConsistencyInfo,
+        encoding: DataEncoding,
+    ) -> Result<S3SourceInfo, anyhow::Error> {
+        if !matches!(encoding, DataEncoding::Text | DataEncoding::Bytes) {
+            anyhow::bail!("S3 sources only support 'text' or 'bytes' encodings");
+        }
+        let s3_conn = match connector {
+            ExternalSourceConnector::S3(s3_conn) => s3_conn,
+            _ => {
+                panic!("S3 is the only legitimate ExternalSourceConnector for S3SourceInfo")
+            }
+        };
+
+        // a single arbitrary worker is responsible for scanning the bucket
+        let receiver = if active {
+            log::debug!("reading bucket={} worker={}", s3_conn.bucket, worker_id);
+            let (tx, rx) = std::sync::mpsc::sync_channel(10000);
+            let bucket = s3_conn.bucket.clone();
+            let glob = s3_conn.pattern.clone();
+            let aws_info = s3_conn.aws_info;
+            tokio::spawn(read_bucket_task(
+                bucket,
+                glob.compile_matcher(),
+                aws_info,
+                tx,
+                Some(consumer_activator),
+            ));
+            rx
+        } else {
+            let (_tx, rx) = std::sync::mpsc::sync_channel(0);
+            rx
+        };
+
+        consistency_info.partition_metrics.insert(
+            PartitionId::S3,
+            PartitionMetrics::new(&source_name, source_id, &s3_conn.bucket, logger),
+        );
+        consistency_info.update_partition_metadata(PartitionId::S3);
+
+        Ok(S3SourceInfo {
+            source_name,
+            bucket: s3_conn.bucket,
+            id: source_id,
+            is_activated_reader: active,
+            receiver_stream: receiver,
+            buffer: None,
+            offset: BucketOffset(0),
+        })
+    }
+}
+
+async fn read_bucket_task(
+    bucket: String,
+    glob: GlobMatcher,
+    aws_info: AwsConnectInfo,
+    tx: SyncSender<anyhow::Result<Vec<u8>>>,
+    activator: Option<SyncActivator>,
+) {
+    let client = match aws_util::s3::client(
+        aws_info.region.clone(),
+        aws_info.access_key_id,
+        aws_info.secret_access_key,
+        aws_info.token,
+    )
+    .await
+    {
+        Ok(client) => client,
+        Err(e) => {
+            tx.send(Err(anyhow!("Unable to create s3 client: {}", e)))
+                .unwrap_or_else(|e| {
+                    log::trace!("unable to send error on stream creating s3 client: {}", e)
+                });
+            return;
+        }
+    };
+
+    let obj = match client
+        .get_object(GetObjectRequest {
+            bucket,
+            key: glob.glob().to_string(),
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(obj) => obj,
+        Err(e) => {
+            tx.send(Err(anyhow!("Unable to get object {}: {}", glob.glob(), e)))
+                .unwrap_or_else(|e| log::debug!("unable to send error on stream: {}", e));
+            return;
+        }
+    };
+
+    if let Some(body) = obj.body {
+        let mut reader = body.into_async_read();
+        // unwrap is safe because content length is not allowed to be negative
+        let mut buf = Vec::with_capacity(obj.content_length.unwrap_or(1024).try_into().unwrap());
+        match reader.read_to_end(&mut buf).await {
+            Ok(_) => {
+                let activate = !buf.is_empty();
+                let mut lines = 0;
+                for line in buf.split(|b| *b == b'\n').map(|s| s.to_vec()) {
+                    if let Err(e) = tx.send(Ok(line)) {
+                        log::debug!("unable to send read line on stream: {}", e);
+                        break;
+                    } else {
+                        lines += 1;
+                    }
+                }
+                log::trace!("sent {} lines to reader", lines);
+                if activate {
+                    if let Some(activator) = activator {
+                        activator.activate().expect("s3 reader activation failed");
+                    }
+                }
+            }
+            Err(e) => {
+                tx.send(Err(anyhow!("Unable to read object: {} {}", glob.glob(), e)))
+                    .unwrap_or_else(|e| log::debug!("unable to send error on stream: {}", e));
+            }
+        }
+    } else {
+        log::info!("get object response had no body: {}", glob.glob());
+    }
+}
+
+impl SourceInfo<Vec<u8>> for S3SourceInfo {
+    fn activate_source_timestamping(
+        id: &SourceInstanceId,
+        consistency: &Consistency,
+        active: bool,
+        timestamp_data_updates: TimestampDataUpdates,
+        timestamp_metadata_channel: TimestampMetadataUpdates,
+    ) -> Option<TimestampMetadataUpdates>
+    where
+        Self: Sized,
+    {
+        // Putting source information on the Timestamp channel lets this
+        // Dataflow worker communicate that it has created a source.
+        if let Consistency::BringYourOwn(_) = consistency {
+            log::error!("S3 sources do not currently support BYO consistency");
+            None
+        } else if active {
+            timestamp_data_updates
+                .borrow_mut()
+                .insert(id.clone(), TimestampDataUpdate::RealTime(1));
+            timestamp_metadata_channel
+                .as_ref()
+                .borrow_mut()
+                .push(TimestampMetadataUpdate::StartTimestamping(*id));
+            Some(timestamp_metadata_channel)
+        } else {
+            None
+        }
+    }
+
+    fn get_next_message(
+        &mut self,
+        _consistency_info: &mut ConsistencyInfo,
+        _activator: &Activator,
+    ) -> Result<NextMessage<Out>, anyhow::Error> {
+        if let Some(message) = self.buffer.take() {
+            return Ok(NextMessage::Ready(message));
+        }
+        match self.receiver_stream.try_recv() {
+            Ok(Ok(record)) => {
+                self.offset += 1;
+                Ok(NextMessage::Ready(SourceMessage {
+                    partition: PartitionId::S3,
+                    offset: self.offset.into(),
+                    upstream_time_millis: None,
+                    key: None,
+                    payload: Some(record),
+                }))
+            }
+            Ok(Err(e)) => {
+                log::warn!(
+                    "when reading bucket '{}' for source '{}' ({}): {}",
+                    self.bucket,
+                    self.source_name,
+                    self.id,
+                    e
+                );
+                Err(e)
+            }
+            Err(TryRecvError::Empty) => Ok(NextMessage::Pending),
+            Err(TryRecvError::Disconnected) => Ok(NextMessage::Finished),
+        }
+    }
+
+    fn can_close_timestamp(
+        &self,
+        consistency_info: &ConsistencyInfo,
+        pid: &PartitionId,
+        offset: MzOffset,
+    ) -> bool {
+        if !self.is_activated_reader {
+            true
+        } else {
+            // TODO: when is this ever not true for S3?
+            let last_offset = consistency_info
+                .partition_metadata
+                .get(&pid)
+                // Guaranteed to exist for S3
+                .unwrap()
+                .offset;
+            last_offset >= offset
+        }
+    }
+
+    fn get_worker_partition_count(&self) -> i32 {
+        panic!("s3 sources do not support BYO consistency: get_worker_partition_count")
+    }
+
+    fn has_partition(&self, _partition_id: PartitionId) -> bool {
+        panic!("s3 sources do not support BYO consistency: has_partition")
+    }
+
+    fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
+        panic!("s3 sources do not support BYO consistency: ensure_has_partition")
+    }
+
+    fn update_partition_count(
+        &mut self,
+        consistency_info: &mut ConsistencyInfo,
+        partition_count: i32,
+    ) {
+        log::debug!(
+            "ignoring partition count update type={:?} partition_count={}",
+            consistency_info.source_type,
+            partition_count,
+        )
+    }
+
+    fn buffer_message(&mut self, message: SourceMessage<Out>) {
+        if self.buffer.is_some() {
+            panic!("Internal error: S3 buffer is not empty when asked to buffer message");
+        }
+        self.buffer = Some(message);
+    }
+}

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -124,11 +124,15 @@ impl fmt::Display for SourceInstanceId {
 /// Unique identifier for each part of a whole source.
 ///     Kafka -> partition
 ///     Kinesis -> shard
+///     File -> only one
+///     S3 -> only one
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum PartitionId {
     Kafka(i32),
     Kinesis(String),
     File,
+    // TODO(bwm): should this partition based on object keys?
+    S3,
 }
 
 impl fmt::Display for PartitionId {

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -231,6 +231,11 @@ pub enum Connector {
     AvroOcf {
         path: String,
     },
+    S3 {
+        bucket: String,
+        /// The argument to the MATCHING clause: `MATCHING 'a/**/*.json'`
+        pattern: String,
+    },
 }
 
 impl AstDisplay for Connector {
@@ -262,6 +267,13 @@ impl AstDisplay for Connector {
             Connector::AvroOcf { path } => {
                 f.write_str("AVRO OCF '");
                 f.write_node(&display::escape_single_quote_string(path));
+                f.write_str("'");
+            }
+            Connector::S3 { bucket, pattern } => {
+                f.write_str("S3 BUCKET '");
+                f.write_str(&display::escape_single_quote_string(bucket));
+                f.write_str("' OBJECTS FROM SCAN MATCHING '");
+                f.write_str(&display::escape_single_quote_string(pattern));
                 f.write_str("'");
             }
         }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -39,6 +39,7 @@ Bigint
 Boolean
 Both
 Broker
+Bucket
 By
 Bytes
 Cascade
@@ -138,6 +139,7 @@ Limit
 List
 Local
 Map
+Matching
 Materialize
 Materialized
 Message
@@ -187,6 +189,8 @@ Right
 Rollback
 Row
 Rows
+S3
+Scan
 Schema
 Schemas
 Second

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1575,7 +1575,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_connector(&mut self) -> Result<Connector, ParserError> {
-        match self.expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO])? {
+        match self.expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3])? {
             FILE => {
                 let path = self.parse_literal_string()?;
                 Ok(Connector::File { path })
@@ -1601,6 +1601,14 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(OCF)?;
                 let path = self.parse_literal_string()?;
                 Ok(Connector::AvroOcf { path })
+            }
+            S3 => {
+                // FROM S3 BUCKET '<bucket>' OBJECTS FROM SCAN MATCHING '<pattern>'
+                self.expect_keyword(BUCKET)?;
+                let bucket = self.parse_literal_string()?;
+                self.expect_keywords(&[OBJECTS, FROM, SCAN, MATCHING])?;
+                let pattern = self.parse_literal_string()?;
+                Ok(Connector::S3 { bucket, pattern })
             }
             _ => unreachable!(),
         }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -30,7 +30,7 @@ rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 sql-parser = { path = "../sql-parser" }
-tokio = "1.0.0"
+tokio = { version = "1.0.0", features = ["fs"] }
 unicase = "2.6.0"
 url = "2.2.0"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -14,6 +14,7 @@ chrono = { version = "0.4.0", default-features = false, features = ["clock", "st
 dataflow-types = { path = "../dataflow-types" }
 expr = { path = "../expr" }
 futures = "0.3.9"
+globset = "0.4.0"
 interchange = { path = "../interchange" }
 itertools = "0.9.0"
 lazy_static = "1.4.0"

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -471,7 +471,7 @@ pub async fn create_state(
     };
 
     let (aws_region, aws_account, aws_credentials, kinesis_client, kinesis_stream_names) = {
-        let kinesis_client = aws_util::kinesis::kinesis_client(
+        let kinesis_client = aws_util::kinesis::client(
             config.aws_region.clone(),
             Some(config.aws_credentials.aws_access_key_id().to_owned()),
             Some(config.aws_credentials.aws_secret_access_key().to_owned()),

--- a/test/performance/perf-kinesis/src/main.rs
+++ b/test/performance/perf-kinesis/src/main.rs
@@ -61,8 +61,7 @@ async fn run() -> Result<(), anyhow::Error> {
 
     // Initialize test resources in Kinesis.
     let region: Region = args.aws_region.parse().context("parsing AWS region")?;
-    let kinesis_client =
-        aws_util::kinesis::kinesis_client(region.clone(), None, None, None).await?;
+    let kinesis_client = aws_util::kinesis::client(region.clone(), None, None, None).await?;
     let stream_arn =
         kinesis::create_stream(&kinesis_client, &stream_name, args.shard_count).await?;
     log::info!("Created Kinesis stream {}", stream_name);


### PR DESCRIPTION
Individual objects are downloaded, and then split on newlines with individual
records being sent through to the dataflow layer.

There are some open questions about how MzOffsets and other things should map
into an S3 world -- "partition" can be mapped to S3 objects, but we can grow to
arbitrarily large numbers of S3 objects, so a naive implementation of that
won't necessarily make sense.

This PR still requires testing infrastructure, but ingesting an S3 object
works correctly. This should be reviewed commit-by-commit.

---

Part of #4914

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5194)
<!-- Reviewable:end -->
