### PR TITLE
switch from a hashmap to a btreemap for option parsing

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -601,7 +601,7 @@ pub struct KafkaSourceConnector {
     pub topic: String,
     // Represents options specified by user when creating the source, e.g.
     // security settings.
-    pub config_options: HashMap<String, String>,
+    pub config_options: BTreeMap<String, String>,
     // Map from partition -> starting offset
     pub start_offsets: HashMap<i32, i64>,
     pub group_id_prefix: Option<String>,
@@ -651,7 +651,7 @@ pub struct KafkaSinkConnector {
     pub fuel: usize,
     pub frontier: Antichain<Timestamp>,
     pub strict: bool,
-    pub config_options: HashMap<String, String>,
+    pub config_options: BTreeMap<String, String>,
     pub key_indices: Option<Vec<usize>>,
 }
 
@@ -703,7 +703,7 @@ pub struct KafkaSinkConnectorBuilder {
     pub replication_factor: u32,
     pub fuel: usize,
     pub consistency_value_schema: Option<String>,
-    pub config_options: HashMap<String, String>,
+    pub config_options: BTreeMap<String, String>,
     pub ccsr_config: ccsr::ClientConfig,
     pub key_indices: Option<Vec<usize>>,
     pub key_schema: Option<String>,

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
 use std::fs;
 use std::path::PathBuf;
@@ -606,7 +606,7 @@ fn create_kafka_config(
     name: &str,
     addrs: &KafkaAddrs,
     group_id_prefix: Option<String>,
-    config_options: &HashMap<String, String>,
+    config_options: &BTreeMap<String, String>,
 ) -> ClientConfig {
     let mut kafka_config = ClientConfig::new();
 

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -9,7 +9,7 @@
 
 //! Provides parsing and convenience functions for working with Kafka from the `sql` package.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert;
 use std::fs::File;
 use std::io::Read;
@@ -90,10 +90,10 @@ impl Config {
 }
 
 fn extract(
-    input: &mut HashMap<String, Value>,
+    input: &mut BTreeMap<String, Value>,
     configs: &[Config],
-) -> Result<HashMap<String, String>, anyhow::Error> {
-    let mut out = HashMap::new();
+) -> Result<BTreeMap<String, String>, anyhow::Error> {
+    let mut out = BTreeMap::new();
     for config in configs {
         let value = match input.remove(config.name) {
             Some(v) => match config.validate_val(&v) {
@@ -118,8 +118,8 @@ fn extract(
 /// - If any of the values in `with_options` are not
 ///   `sql_parser::ast::Value::String`.
 pub fn extract_config(
-    with_options: &mut HashMap<String, Value>,
-) -> Result<HashMap<String, String>, anyhow::Error> {
+    with_options: &mut BTreeMap<String, Value>,
+) -> Result<BTreeMap<String, String>, anyhow::Error> {
     extract(
         with_options,
         &[
@@ -167,7 +167,7 @@ pub fn extract_config(
 /// - `librdkafka` cannot create a BaseConsumer using the provided `options`.
 ///   For example, when using Kerberos auth, and the named principal does not
 ///   exist.
-pub fn test_config(options: &HashMap<String, String>) -> Result<(), anyhow::Error> {
+pub fn test_config(options: &BTreeMap<String, String>) -> Result<(), anyhow::Error> {
     let mut config = rdkafka::ClientConfig::new();
     for (k, v) in options {
         config.set(k, v);
@@ -251,8 +251,8 @@ impl rdkafka::client::ClientContext for RDKafkaErrCheckContext {
 // `extract_security_config()`. Currently only supports SSL auth.
 pub fn generate_ccsr_client_config(
     csr_url: Url,
-    kafka_options: &HashMap<String, String>,
-    mut ccsr_options: HashMap<String, Value>,
+    kafka_options: &BTreeMap<String, String>,
+    mut ccsr_options: BTreeMap<String, Value>,
 ) -> Result<ccsr::ClientConfig, anyhow::Error> {
     let mut client_config = ccsr::ClientConfig::new(csr_url);
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
@@ -47,7 +47,7 @@ pub fn object_name(mut name: ObjectName) -> Result<PartialName, PlanError> {
     Ok(out)
 }
 
-pub fn options(options: &[SqlOption]) -> HashMap<String, Value> {
+pub fn options(options: &[SqlOption]) -> BTreeMap<String, Value> {
     options
         .iter()
         .map(|o| match o {
@@ -60,7 +60,7 @@ pub fn options(options: &[SqlOption]) -> HashMap<String, Value> {
         .collect()
 }
 
-pub fn option_objects(options: &[SqlOption]) -> HashMap<String, SqlOption> {
+pub fn option_objects(options: &[SqlOption]) -> BTreeMap<String, SqlOption> {
     options
         .iter()
         .map(|o| (ident(o.name().clone()), o.clone()))

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -554,7 +554,7 @@ fn handle_alter_index_options(
 
 fn kafka_sink_builder(
     format: Option<Format>,
-    with_options: &mut HashMap<String, Value>,
+    with_options: &mut BTreeMap<String, Value>,
     broker: String,
     topic_prefix: String,
     desc: RelationDesc,
@@ -1038,7 +1038,7 @@ fn handle_create_type(
 }
 
 fn extract_timestamp_frequency_option(
-    with_options: &mut HashMap<String, Value>,
+    with_options: &mut BTreeMap<String, Value>,
 ) -> Result<Duration, anyhow::Error> {
     match with_options.remove("timestamp_frequency_ms") {
         None => Ok(Duration::from_secs(1)),

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -9,7 +9,7 @@
 
 //! Statement purification.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use anyhow::{bail, Context};
 use tokio::io::AsyncBufReadExt;
@@ -39,7 +39,7 @@ pub async fn purify(mut stmt: Statement) -> Result<Statement, anyhow::Error> {
     }) = &mut stmt
     {
         let mut with_options_map = normalize::options(with_options);
-        let mut config_options = HashMap::new();
+        let mut config_options = BTreeMap::new();
 
         let mut file = None;
         match connector {
@@ -88,7 +88,7 @@ async fn purify_format(
     connector: &mut Connector,
     col_names: &mut Vec<Ident>,
     file: Option<tokio::fs::File>,
-    connector_options: &HashMap<String, String>,
+    connector_options: &BTreeMap<String, String>,
 ) -> Result<(), anyhow::Error> {
     match format {
         Some(Format::Avro(schema)) => match schema {


### PR DESCRIPTION
Switch to using a BTreeMap instead of a HashMap for options parsing. The perf hit doesn't matter here, and it seems significantly more useful to have a consistent ordering for eg. consistent validation failures, testing purposes, etc.

Related to https://github.com/MaterializeInc/materialize/pull/5191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5195)
<!-- Reviewable:end -->
