### PR TITLE
Add some comments separating `SourceInfo` methods into groups

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -299,8 +299,12 @@ pub(crate) trait SourceInfo<Out> {
     where
         Self: Sized;
 
+    // BYO consistency methods
+
     /// This function determines whether it is safe to close the current timestamp.
-    /// It is safe to close the current timestamp if
+    ///
+    /// It is safe to close the current timestamp if:
+    ///
     /// 1) this worker does not own the current partition
     /// 2) we will never receive a message with a lower or equal timestamp than offset.
     fn can_close_timestamp(
@@ -324,12 +328,17 @@ pub(crate) trait SourceInfo<Out> {
     /// called, the source should be able to receive messages from this partition
     fn ensure_has_partition(&mut self, consistency_info: &mut ConsistencyInfo, pid: PartitionId);
 
+    // BYO  + RT methods
+
     /// Informs source that there are now `partition_count` entries for this source
+    // this might be better as BYO-only, but it is actually called in RT timestamping as well
     fn update_partition_count(
         &mut self,
         consistency_info: &mut ConsistencyInfo,
         partition_count: i32,
     );
+
+    // source reading
 
     /// Returns the next message read from the source
     fn get_next_message(
@@ -340,6 +349,8 @@ pub(crate) trait SourceInfo<Out> {
 
     /// Buffer a message that cannot get timestamped
     fn buffer_message(&mut self, message: SourceMessage<Out>);
+
+    // caching
 
     /// Cache a message
     fn cache_message(


### PR DESCRIPTION
Plausibly each of these should be split off into their own traits, but I'm not
sure that we have enough static information to be able to meaningfully *not*
implement more-fine-grained traits for any specific instance of SourceInfo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5198)
<!-- Reviewable:end -->
