### PR TITLE
downgrade capabilities before reading from a source

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -465,7 +465,8 @@ impl ConsistencyInfo {
                 &source_id.to_string(),
                 &worker_id.to_string(),
             ),
-            time_since_downgrade: Instant::now(),
+            // we have never downgraded, so make sure the initial value is outside of our frequncy
+            time_since_downgrade: Instant::now() - timestamp_frequency,
             partition_metrics: Default::default(),
         }
     }
@@ -934,10 +935,10 @@ where
                 return SourceStatus::Done;
             }
 
-            if !read_cached_files {
-                // Downgrade capability (if possible) before reading next cached file.
-                consistency_info.downgrade_capability(&id, cap, source_info, &timestamp_histories);
+            // Downgrade capability (if possible)
+            consistency_info.downgrade_capability(&id, cap, source_info, &timestamp_histories);
 
+            if !read_cached_files {
                 if let Some(msgs) = source_info.next_cached_file() {
                     // TODO(rkhaitan) change this to properly re-use old timestamps.
                     // Currently this is hard to do because there can be arbitrary delays between


### PR DESCRIPTION
Today we only downgrade capabilities after reading from a source and
after timestamp_frequency_ms has passed. For BYO this doesn't affect
anything, but for realtime this means that our initial portion of data
will be timestamped as '1'.

This can be particularly confusing if someone ingests a source that is
no longer being updated and the entire ingest occurs within
timestamp_frequency_ms - in that case mz_source_info will show timestamp
1 in perpetuity (at least one customer has hit this). It is technically
  correct, 1 is the logical timestamp that we used and there are no
functional problems from this behavior.  But it makes for confusing
logging and it's not in the spirit of how realtime is supposed to work.

To work around this we construct ConsistencyInfo such that it is
initially stale and attempt to downgrade capabilities before reading
from a source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5201)
<!-- Reviewable:end -->
