### PR TITLE
Document the new option syntax for query hints

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -109,6 +109,8 @@ Wrap your release notes at the 80 character mark.
 - Avoid panicking if a record in a regex-formatted source fails to decode
   as UTF-8 {{% gh 5008 %}}.
 
+- Allow [query hints](/sql/select#query-hints) in `SELECT` statements.
+
 {{% version-header v0.5.3 %}}
 
 - Add support for SQL cursors via the new [`DECLARE`](/sql/declare),

--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -54,6 +54,7 @@ _target&lowbar;elem_ | Return identified columns or functions.
 _join&lowbar;expr_ | A join expression; for more details, see our [`JOIN` documentation](../join).
 **WHERE** _expression_ | Filter tuples by _expression_.
 **GROUP BY** _col&lowbar;ref_ | Group aggregations by _col&lowbar;ref_.
+**OPTION (** _hint&lowbar;list_ **)** | Specify one or more [query hints](#query-hints).
 **HAVING** _expression_ | Filter aggregations by _expression_.
 **ORDER BY** _col&lowbar;ref_... | Order results in either **ASC** or **DESC** order (_**ASC** is implied default_).<br/><br>
 **LIMIT** | Limit the number of returned results to _expr_.
@@ -121,6 +122,20 @@ CTEs). This can enhance legibility of complex queries, but doesn't alter the
 queries' semantics.
 
 For an example, see [Using CTEs](#using-ctes).
+
+### Query hints
+
+Users can specify any query hints to help Materialize optimize
+query planning more efficiently.
+
+The following query hints are valid within the `OPTION` clause.
+
+Hint | Value type | Description
+------|------------|------------
+`expected_group_size` | `int` | How many rows will have the same group key. Materialize
+can render `min` and `max` expressions more efficiently with this information.
+
+For an example, see [Using query hints](#using-query-hints).
 
 #### Known limitations
 
@@ -210,6 +225,20 @@ names, but the CTEs make the entire query simpler to understand.
 
 With regard to dataflows, this is similar to [Querying views](#querying-views)
 above: Materialize tears down the created dataflow after returning the results.
+
+### Using query hints
+
+```sql
+SELECT a,
+       min(b) AS min
+FROM example
+GROUP BY a
+OPTION (expected_group_size = 100)
+```
+
+Here the hint indicates that there may be up to a hundred distinct `(a, b)` pairs
+for each `a` value, and Materialize can optimize its dataflow rendering with that
+knowledge.
 
 ## Related pages
 

--- a/doc/user/layouts/partials/sql-grammar/select-stmt.svg
+++ b/doc/user/layouts/partials/sql-grammar/select-stmt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="683" height="1315">
+<svg xmlns="http://www.w3.org/2000/svg" width="683" height="1441">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="56" height="32" rx="10"/>
@@ -204,146 +204,192 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="492" y="601">,</text>
-   <rect x="274" y="741" width="72" height="32" rx="10"/>
-   <rect x="272"
-         y="739"
+   <rect x="152" y="769" width="72" height="32" rx="10"/>
+   <rect x="150"
+         y="767"
          width="72"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="282" y="759">HAVING</text>
-   <rect x="366" y="741" width="46" height="32"/>
-   <rect x="364" y="739" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="374" y="759">expr</text>
-   <rect x="160" y="851" width="68" height="32" rx="10"/>
-   <rect x="158"
-         y="849"
-         width="68"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="168" y="869">ORDER</text>
-   <rect x="248" y="851" width="38" height="32" rx="10"/>
-   <rect x="246"
-         y="849"
-         width="38"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="256" y="869">BY</text>
-   <rect x="326" y="851" width="62" height="32"/>
-   <rect x="324" y="849" width="62" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="334" y="869">col_ref</text>
-   <rect x="428" y="883" width="48" height="32" rx="10"/>
-   <rect x="426"
-         y="881"
-         width="48"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="436" y="901">ASC</text>
-   <rect x="428" y="927" width="58" height="32" rx="10"/>
-   <rect x="426"
-         y="925"
-         width="58"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="436" y="945">DESC</text>
-   <rect x="326" y="807" width="24" height="32" rx="10"/>
-   <rect x="324"
-         y="805"
+   <text class="terminal" x="160" y="787">OPTION</text>
+   <rect x="244" y="769" width="24" height="32" rx="10"/>
+   <rect x="242"
+         y="767"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="334" y="825">,</text>
-   <rect x="182" y="1025" width="56" height="32" rx="10"/>
+   <text class="terminal" x="252" y="787">(</text>
+   <rect x="308" y="769" width="58" height="32"/>
+   <rect x="306" y="767" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="316" y="787">option</text>
+   <rect x="386" y="769" width="26" height="32" rx="10"/>
+   <rect x="384"
+         y="767"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="394" y="787">=</text>
+   <rect x="432" y="769" width="38" height="32"/>
+   <rect x="430" y="767" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="440" y="787">val</text>
+   <rect x="308" y="725" width="24" height="32" rx="10"/>
+   <rect x="306"
+         y="723"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="316" y="743">,</text>
+   <rect x="510" y="769" width="24" height="32" rx="10"/>
+   <rect x="508"
+         y="767"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="518" y="787">)</text>
+   <rect x="274" y="867" width="72" height="32" rx="10"/>
+   <rect x="272"
+         y="865"
+         width="72"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="282" y="885">HAVING</text>
+   <rect x="366" y="867" width="46" height="32"/>
+   <rect x="364" y="865" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="374" y="885">expr</text>
+   <rect x="160" y="977" width="68" height="32" rx="10"/>
+   <rect x="158"
+         y="975"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="168" y="995">ORDER</text>
+   <rect x="248" y="977" width="38" height="32" rx="10"/>
+   <rect x="246"
+         y="975"
+         width="38"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="256" y="995">BY</text>
+   <rect x="326" y="977" width="62" height="32"/>
+   <rect x="324" y="975" width="62" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="334" y="995">col_ref</text>
+   <rect x="428" y="1009" width="48" height="32" rx="10"/>
+   <rect x="426"
+         y="1007"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="436" y="1027">ASC</text>
+   <rect x="428" y="1053" width="58" height="32" rx="10"/>
+   <rect x="426"
+         y="1051"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="436" y="1071">DESC</text>
+   <rect x="326" y="933" width="24" height="32" rx="10"/>
+   <rect x="324"
+         y="931"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="334" y="951">,</text>
+   <rect x="182" y="1151" width="56" height="32" rx="10"/>
    <rect x="180"
-         y="1023"
+         y="1149"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="190" y="1043">LIMIT</text>
-   <rect x="258" y="1025" width="46" height="32"/>
-   <rect x="256" y="1023" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="266" y="1043">expr</text>
-   <rect x="364" y="1025" width="74" height="32" rx="10"/>
+   <text class="terminal" x="190" y="1169">LIMIT</text>
+   <rect x="258" y="1151" width="46" height="32"/>
+   <rect x="256" y="1149" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="266" y="1169">expr</text>
+   <rect x="364" y="1151" width="74" height="32" rx="10"/>
    <rect x="362"
-         y="1023"
+         y="1149"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="372" y="1043">OFFSET</text>
-   <rect x="458" y="1025" width="46" height="32"/>
-   <rect x="456" y="1023" width="46" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="466" y="1043">expr</text>
-   <rect x="141" y="1107" width="64" height="32" rx="10"/>
+   <text class="terminal" x="372" y="1169">OFFSET</text>
+   <rect x="458" y="1151" width="46" height="32"/>
+   <rect x="456" y="1149" width="46" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="466" y="1169">expr</text>
+   <rect x="141" y="1233" width="64" height="32" rx="10"/>
    <rect x="139"
-         y="1105"
+         y="1231"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="149" y="1125">UNION</text>
-   <rect x="141" y="1151" width="96" height="32" rx="10"/>
+   <text class="terminal" x="149" y="1251">UNION</text>
+   <rect x="141" y="1277" width="96" height="32" rx="10"/>
    <rect x="139"
-         y="1149"
+         y="1275"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="149" y="1169">INTERSECT</text>
-   <rect x="141" y="1195" width="74" height="32" rx="10"/>
+   <text class="terminal" x="149" y="1295">INTERSECT</text>
+   <rect x="141" y="1321" width="74" height="32" rx="10"/>
    <rect x="139"
-         y="1193"
+         y="1319"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="149" y="1213">EXCEPT</text>
-   <rect x="297" y="1139" width="44" height="32" rx="10"/>
+   <text class="terminal" x="149" y="1339">EXCEPT</text>
+   <rect x="297" y="1265" width="44" height="32" rx="10"/>
    <rect x="295"
-         y="1137"
+         y="1263"
          width="44"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="305" y="1157">ALL</text>
-   <rect x="297" y="1183" width="84" height="32" rx="10"/>
+   <text class="terminal" x="305" y="1283">ALL</text>
+   <rect x="297" y="1309" width="84" height="32" rx="10"/>
    <rect x="295"
-         y="1181"
+         y="1307"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="305" y="1201">DISTINCT</text>
-   <rect x="421" y="1107" width="144" height="32"/>
+   <text class="terminal" x="305" y="1327">DISTINCT</text>
+   <rect x="421" y="1233" width="144" height="32"/>
    <rect x="419"
-         y="1105"
+         y="1231"
          width="144"
          height="32"
          class="nonterminal"/>
-   <text class="nonterminal" x="429" y="1125">another_select_stmt</text>
-   <rect x="397" y="1281" width="60" height="32" rx="10"/>
+   <text class="nonterminal" x="429" y="1251">another_select_stmt</text>
+   <rect x="397" y="1407" width="60" height="32" rx="10"/>
    <rect x="395"
-         y="1279"
+         y="1405"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="405" y="1299">AS OF</text>
-   <rect x="477" y="1281" width="158" height="32"/>
+   <text class="terminal" x="405" y="1425">AS OF</text>
+   <rect x="477" y="1407" width="158" height="32"/>
    <rect x="475"
-         y="1279"
+         y="1405"
          width="158"
          height="32"
          class="nonterminal"/>
-   <text class="nonterminal" x="485" y="1299">timestamp_expression</text>
+   <text class="nonterminal" x="485" y="1425">timestamp_expression</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-106 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m76 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m24 0 h10 m-244 0 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v14 m244 0 v-14 m-244 14 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m0 0 h214 m20 -34 h10 m38 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m24 0 h10 m-636 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m616 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-616 0 h10 m24 0 h10 m0 0 h572 m22 88 l2 0 m2 0 l2 0 m2 0 l2 0 m-625 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m72 0 h10 m20 0 h10 m0 0 h404 m-434 0 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v12 m434 0 v-12 m-434 12 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m44 0 h10 m0 0 h350 m-424 -10 v20 m434 0 v-20 m-434 20 v68 m434 0 v-68 m-434 68 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m84 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m24 0 h10 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v14 m290 0 v-14 m-290 14 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m0 0 h260 m42 -154 l2 0 m2 0 l2 0 m2 0 l2 0 m-574 246 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m40 44 h10 m60 0 h10 m20 0 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m104 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-104 0 h10 m24 0 h10 m0 0 h60 m-224 44 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v14 m244 0 v-14 m-244 14 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m0 0 h214 m40 -34 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-554 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m70 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m70 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m-270 44 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v14 m290 0 v-14 m-290 14 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m0 0 h260 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-376 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m72 0 h10 m0 0 h10 m46 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-336 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m48 0 h10 m0 0 h10 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m-200 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m200 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-200 0 h10 m24 0 h10 m0 0 h156 m-386 44 h20 m386 0 h20 m-426 0 q10 0 10 10 m406 0 q0 -10 10 -10 m-416 10 v90 m406 0 v-90 m-406 90 q0 10 10 10 m386 0 q10 0 10 -10 m-396 10 h10 m0 0 h376 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-428 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m56 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m74 0 h10 m0 0 h10 m46 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-467 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h454 m-484 0 h20 m464 0 h20 m-504 0 q10 0 10 10 m484 0 q0 -10 10 -10 m-494 10 v12 m484 0 v-12 m-484 12 q0 10 10 10 m464 0 q10 0 10 -10 m-454 10 h10 m64 0 h10 m0 0 h32 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m-126 -10 v20 m136 0 v-20 m-136 20 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m74 0 h10 m0 0 h22 m40 -88 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m44 0 h10 m0 0 h40 m-114 -10 v20 m124 0 v-20 m-124 20 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m20 -76 h10 m144 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
-   <polygon points="673 1263 681 1259 681 1267"/>
-   <polygon points="673 1263 665 1259 665 1267"/>
+         d="m17 17 h2 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-106 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m76 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m76 0 h10 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m96 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-96 0 h10 m24 0 h10 m0 0 h52 m20 44 h10 m24 0 h10 m-244 0 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v14 m244 0 v-14 m-244 14 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m0 0 h214 m20 -34 h10 m38 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m90 0 h10 m0 0 h10 m24 0 h10 m-636 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m616 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-616 0 h10 m24 0 h10 m0 0 h572 m22 88 l2 0 m2 0 l2 0 m2 0 l2 0 m-625 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m72 0 h10 m20 0 h10 m0 0 h404 m-434 0 h20 m414 0 h20 m-454 0 q10 0 10 10 m434 0 q0 -10 10 -10 m-444 10 v12 m434 0 v-12 m-434 12 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m44 0 h10 m0 0 h350 m-424 -10 v20 m434 0 v-20 m-434 20 v68 m434 0 v-68 m-434 68 q0 10 10 10 m414 0 q10 0 10 -10 m-424 10 h10 m84 0 h10 m20 0 h10 m40 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m20 44 h10 m24 0 h10 m-290 0 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v14 m290 0 v-14 m-290 14 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m0 0 h260 m42 -154 l2 0 m2 0 l2 0 m2 0 l2 0 m-574 246 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m94 0 h10 m-134 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m114 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-114 0 h10 m24 0 h10 m0 0 h70 m40 44 h10 m60 0 h10 m20 0 h10 m84 0 h10 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m104 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-104 0 h10 m24 0 h10 m0 0 h60 m-224 44 h20 m224 0 h20 m-264 0 q10 0 10 10 m244 0 q0 -10 10 -10 m-254 10 v14 m244 0 v-14 m-244 14 q0 10 10 10 m224 0 q10 0 10 -10 m-234 10 h10 m0 0 h214 m40 -34 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-554 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h146 m-176 0 h20 m156 0 h20 m-196 0 q10 0 10 10 m176 0 q0 -10 10 -10 m-186 10 v12 m176 0 v-12 m-176 12 q0 10 10 10 m156 0 q10 0 10 -10 m-166 10 h10 m70 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m70 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m-102 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m82 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-82 0 h10 m24 0 h10 m0 0 h38 m-270 44 h20 m270 0 h20 m-310 0 q10 0 10 10 m290 0 q0 -10 10 -10 m-300 10 v14 m290 0 v-14 m-290 14 q0 10 10 10 m270 0 q10 0 10 -10 m-280 10 h10 m0 0 h260 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-498 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m72 0 h10 m0 0 h10 m24 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m38 0 h10 m-202 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m182 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-182 0 h10 m24 0 h10 m0 0 h138 m20 44 h10 m24 0 h10 m-422 0 h20 m402 0 h20 m-442 0 q10 0 10 10 m422 0 q0 -10 10 -10 m-432 10 v14 m422 0 v-14 m-422 14 q0 10 10 10 m402 0 q10 0 10 -10 m-412 10 h10 m0 0 h392 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-344 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h148 m-178 0 h20 m158 0 h20 m-198 0 q10 0 10 10 m178 0 q0 -10 10 -10 m-188 10 v12 m178 0 v-12 m-178 12 q0 10 10 10 m158 0 q10 0 10 -10 m-168 10 h10 m72 0 h10 m0 0 h10 m46 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-336 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m0 0 h10 m38 0 h10 m20 0 h10 m62 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m48 0 h10 m0 0 h10 m-88 -10 v20 m98 0 v-20 m-98 20 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m-200 -76 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m200 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-200 0 h10 m24 0 h10 m0 0 h156 m-386 44 h20 m386 0 h20 m-426 0 q10 0 10 10 m406 0 q0 -10 10 -10 m-416 10 v90 m406 0 v-90 m-406 90 q0 10 10 10 m386 0 q10 0 10 -10 m-396 10 h10 m0 0 h376 m22 -110 l2 0 m2 0 l2 0 m2 0 l2 0 m-428 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h132 m-162 0 h20 m142 0 h20 m-182 0 q10 0 10 10 m162 0 q0 -10 10 -10 m-172 10 v12 m162 0 v-12 m-162 12 q0 10 10 10 m142 0 q10 0 10 -10 m-152 10 h10 m56 0 h10 m0 0 h10 m46 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m74 0 h10 m0 0 h10 m46 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-467 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h454 m-484 0 h20 m464 0 h20 m-504 0 q10 0 10 10 m484 0 q0 -10 10 -10 m-494 10 v12 m484 0 v-12 m-484 12 q0 10 10 10 m464 0 q10 0 10 -10 m-454 10 h10 m64 0 h10 m0 0 h32 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m-126 -10 v20 m136 0 v-20 m-136 20 v24 m136 0 v-24 m-136 24 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m74 0 h10 m0 0 h22 m40 -88 h10 m0 0 h94 m-124 0 h20 m104 0 h20 m-144 0 q10 0 10 10 m124 0 q0 -10 10 -10 m-134 10 v12 m124 0 v-12 m-124 12 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m44 0 h10 m0 0 h40 m-114 -10 v20 m124 0 v-20 m-124 20 v24 m124 0 v-24 m-124 24 q0 10 10 10 m104 0 q10 0 10 -10 m-114 10 h10 m84 0 h10 m20 -76 h10 m144 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-252 174 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h248 m-278 0 h20 m258 0 h20 m-298 0 q10 0 10 10 m278 0 q0 -10 10 -10 m-288 10 v12 m278 0 v-12 m-278 12 q0 10 10 10 m258 0 q10 0 10 -10 m-268 10 h10 m60 0 h10 m0 0 h10 m158 0 h10 m23 -32 h-3"/>
+   <polygon points="673 1389 681 1385 681 1393"/>
+   <polygon points="673 1389 665 1385 665 1393"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -223,6 +223,7 @@ select_stmt ::=
   join_expr?
   ( 'WHERE' expr )?
   ( 'GROUP' 'BY' col_ref ( ',' col_ref )* )?
+  ( 'OPTION' '(' ( option '=' val ) ( ( ',' option '=' val ) )* ')' )?
   ( 'HAVING' expr )?
   ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( ',' col_ref ( 'ASC' | 'DESC' )? )* )?
   ( 'LIMIT' expr )?

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -215,15 +215,20 @@ op_cast ::=
 schema_spec ::=
   'SCHEMA' ('FILE' schema_file_path | inline_schema)
 select_stmt ::=
-    ('WITH' cte_ident ('(' col_ident (',' col_ident )* ')')? 'AS' '(' select_stmt ')'
-      (',' cte_ident ('(' col_ident (',' col_ident )*')')? 'AS' '(' select_stmt ')') * )
-    'SELECT'  (
-        ( 'ALL' )? ( ( target_elem ) ( ( ',' target_elem ) )* ) ( 'FROM' ( ( table_expr ) ( ( ',' table_expr ) )* )  )? join_expr? ( ( 'WHERE' expr ) )? ( 'GROUP' 'BY' ( ( col_ref ) ( ( ',' col_ref ) )* ) )? ( 'HAVING' expr )? ( 'ORDER' 'BY' ( ( col_ref ( 'ASC' | 'DESC' )? ) ( ( ',' col_ref ( 'ASC' | 'DESC' )? ) )* ) )? ( 'LIMIT' expr )? ( 'OFFSET' expr )?
-	    | ( 'DISTINCT' ) ( ( target_elem ) ( ( ',' target_elem ) )* ) ( 'FROM' ( ( table_expr ) ( ( ',' table_expr ) )* )  )? join_expr? ( ( 'WHERE' expr ) )? ( 'GROUP' 'BY' ( ( col_ref ) ( ( ',' col_ref ) )* ) )? ( 'HAVING' expr )? ( 'ORDER' 'BY' ( ( col_ref ( 'ASC' | 'DESC' )? ) ( ( ',' col_ref ( 'ASC' | 'DESC' )? ) )* ) )? ( 'LIMIT' expr )? ( 'OFFSET' expr )?
-        | ( 'DISTINCT' 'ON' '(' ( ( col_ref ) ( ( ',' col_ref ) )* ) ')' ) ( ( target_elem ) ( ( ',' target_elem ) )* ) ( 'FROM' ( ( table_expr ) ( ( ',' table_expr ) )* )  )? join_expr? ( ( 'WHERE' expr ) )? ( 'GROUP' 'BY' ( ( col_ref ) ( ( ',' col_ref ) )* ) )? ( 'HAVING' expr )? ( 'ORDER' 'BY' ( ( col_ref ( 'ASC' | 'DESC' )? ) ( ( ',' col_ref ( 'ASC' | 'DESC' )? ) )* ) )?  ( 'LIMIT' expr )? ( 'OFFSET' expr )?
-    )
-    ( ( 'UNION' | 'INTERSECT' | 'EXCEPT' ) ('ALL' | 'DISTINCT')? another_select_stmt)?
-    ( 'AS OF' timestamp_expression)?
+  'WITH' cte_ident ( '(' col_ident ( ',' col_ident )* ')' )?
+  'AS' '(' select_stmt ')' ( ',' cte_ident ( '(' col_ident ( ',' col_ident )* ')' )? 'AS' '(' select_stmt ')' )*
+  'SELECT' ( 'ALL' | 'DISTINCT' ( 'ON' '(' col_ref ( ',' col_ref )* ')' )? )?
+  target_elem ( ',' target_elem )*
+  ( 'FROM' table_expr ( ',' table_expr )* )?
+  join_expr?
+  ( 'WHERE' expr )?
+  ( 'GROUP' 'BY' col_ref ( ',' col_ref )* )?
+  ( 'HAVING' expr )?
+  ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( ',' col_ref ( 'ASC' | 'DESC' )? )* )?
+  ( 'LIMIT' expr )?
+  ( 'OFFSET' expr )?
+  ( ( 'UNION' | 'INTERSECT' | 'EXCEPT' ) ( 'ALL' | 'DISTINCT' )? another_select_stmt )?
+  ( 'AS OF' timestamp_expression )?
 show_columns ::=
   'SHOW' 'COLUMNS' 'FROM' item_ref ('LIKE' 'pattern' | 'WHERE' expr)
 show_create_index ::=


### PR DESCRIPTION
This change is broken into 2 logical commits

the first simplifies the select statement grammar as suggested by the railroad diagram generating website and the second actually adds the option docs
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5214)
<!-- Reviewable:end -->
