### PR TITLE
sql: add format_type function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
  "ordered-float",
  "ore",
  "pdqselect",
+ "pgrepr",
  "regex",
  "regex-syntax",
  "repr",

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -91,7 +91,6 @@
     - signature: 'list_prepend(e: listelementany, l: listany) -> listany'
       description: Prepends `e` to `l`.
 
-
 - type: Numbers
   description: Number functions take number-like arguments, e.g. [`int`](../types/int),
     [`float`](../types/float), [`numeric`](../types/numeric).
@@ -387,6 +386,8 @@
   functions:
   - signature: 'mz_version() -> text'
     description: Returns the server's version information as a human-readable string.
+  - signature: 'format_type(oid: int, typemod: int) -> text'
+    description: Returns the canonical SQL name for the type specified by `oid` with `typemod` applied.
 
 - type: PostgreSQL compatibility
   description: Functions whose primary purpose is to facilitate compatibility with PostgreSQL tools

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -18,6 +18,7 @@ md-5 = "0.9.0"
 num_enum = "0.5.1"
 ordered-float = { version = "2.0.0", features = ["serde"] }
 ore = { path = "../ore" }
+pgrepr = { path = "../pgrepr"}
 pdqselect = "0.1.0"
 regex = "1.4.1"
 regex-syntax = "0.6.18"

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1305,6 +1305,14 @@ lazy_static! {
                     Ok(e.call_unary(UnaryFunc::FloorDecimal(s)))
                 })
             },
+            "format_type" => Scalar {
+                params!(Oid, Int32) => sql_op!(
+                    "CASE
+                        WHEN $1 IS NULL THEN NULL
+                        ELSE coalesce((SELECT concat(name, mz_internal.mz_render_typemod($1, $2)) FROM mz_catalog.mz_types WHERE oid = $1), '???')
+                    END"
+                )
+            },
             "hmac" => Scalar {
                 params!(String, String, String) => VariadicFunc::HmacString,
                 params!(Bytes, Bytes, String) => VariadicFunc::HmacBytes
@@ -1799,6 +1807,9 @@ lazy_static! {
             },
             "mz_is_materialized" => Scalar {
                 params!(String) => sql_op!("EXISTS (SELECT 1 FROM mz_indexes WHERE on_id = $1)")
+            },
+            "mz_render_typemod" => Scalar {
+                params!(Oid, Int32) => BinaryFunc::MzRenderTypemod
             }
         }
     };

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -177,7 +177,6 @@ SELECT pg_typeof('1'::int)
 ----
 int4
 
-
 query T
 SELECT '1'::integer
 ----
@@ -190,7 +189,6 @@ query T
 SELECT pg_typeof('1'::integer)
 ----
 int4
-
 
 query T
 SELECT '1'::smallint
@@ -304,8 +302,6 @@ SELECT '1'::decimal(38,0)
 
 query error type "pg_catalog.decimal" does not exist
 SELECT '1'::pg_catalog.decimal(38,0)
-----
-1
 
 query T
 SELECT '1'::dec(38,0)
@@ -470,3 +466,249 @@ SELECT '1'::materialize.pg_catalog.int4
 # tables are not types yet
 query error type "pg_catalog.pg_enum" does not exist
 SELECT '1'::pg_catalog.pg_enum
+
+# 🔬 format_type
+
+query T
+SELECT format_type(NULL, NULL)
+----
+NULL
+
+query T
+SELECT format_type(NULL, 1)
+----
+NULL
+
+query T
+SELECT format_type(16, NULL)
+----
+bool
+
+query T
+SELECT format_type(17, NULL)
+----
+bytea
+
+query T
+SELECT format_type(20, NULL)
+----
+int8
+
+query T
+SELECT format_type(23, NULL)
+----
+int4
+
+query T
+SELECT format_type(25, NULL)
+----
+text
+
+query T
+SELECT format_type(26, NULL)
+----
+oid
+
+query T
+SELECT format_type(700, NULL)
+----
+float4
+
+query T
+SELECT format_type(701, NULL)
+----
+float8
+
+query T
+SELECT format_type(1082, NULL)
+----
+date
+
+query T
+SELECT format_type(1083, NULL)
+----
+time
+
+query T
+SELECT format_type(1114, NULL)
+----
+timestamp
+
+query T
+SELECT format_type(1184, NULL)
+----
+timestamptz
+
+query T
+SELECT format_type(1186, NULL)
+----
+interval
+
+query T
+SELECT format_type(1700, NULL)
+----
+numeric
+
+query T
+SELECT format_type(2950, NULL)
+----
+uuid
+
+query T
+SELECT format_type(3802, NULL)
+----
+jsonb
+
+query T
+SELECT format_type(1000, NULL)
+----
+_bool
+
+query T
+SELECT format_type(1001, NULL)
+----
+_bytea
+
+query T
+SELECT format_type(1016, NULL)
+----
+_int8
+
+query T
+SELECT format_type(1007, NULL)
+----
+_int4
+
+query T
+SELECT format_type(1009, NULL)
+----
+_text
+
+query T
+SELECT format_type(1028, NULL)
+----
+_oid
+
+query T
+SELECT format_type(1021, NULL)
+----
+_float4
+
+query T
+SELECT format_type(1022, NULL)
+----
+_float8
+
+query T
+SELECT format_type(1182, NULL)
+----
+_date
+
+query T
+SELECT format_type(1183, NULL)
+----
+_time
+
+query T
+SELECT format_type(1115, NULL)
+----
+_timestamp
+
+query T
+SELECT format_type(1185, NULL)
+----
+_timestamptz
+
+query T
+SELECT format_type(1187, NULL)
+----
+_interval
+
+query T
+SELECT format_type(1231, NULL)
+----
+_numeric
+
+query T
+SELECT format_type(2951, NULL)
+----
+_uuid
+
+query T
+SELECT format_type(3807, NULL)
+----
+_jsonb
+
+# 🔬🔬 non-type OID
+
+query T
+SELECT format_type(6, NULL);
+----
+???
+
+query T
+SELECT format_type(600, 100);
+----
+???
+
+query T
+SELECT format_type(6000, -100);
+----
+???
+
+# 🔬🔬 non-NULL typemod
+
+query T
+SELECT format_type(1700, 0);
+----
+numeric(65535,65532)
+
+query T
+SELECT format_type(1700, 3);
+----
+numeric(65535,65535)
+
+query T
+SELECT format_type(1700, 4);
+----
+numeric(0,0)
+
+query T
+SELECT format_type(1700, 65540);
+----
+numeric(1,0)
+
+query T
+SELECT format_type(1700, 65541);
+----
+numeric(1,1)
+
+query T
+SELECT format_type(1700, 2490372);
+----
+numeric(38,0)
+
+query T
+SELECT format_type(1700, 2490371);
+----
+numeric(37,65535)
+
+query T
+SELECT format_type(1700, 2490373);
+----
+numeric(38,1)
+
+query T
+SELECT format_type(1700, -2490373);
+----
+numeric
+
+query T
+SELECT format_type(26, 1);
+----
+oid
+
+query T
+SELECT format_type(26, -1);
+----
+oid


### PR DESCRIPTION
@romainr Any chance you can take a look and see if this works for you? We're in kind of an odd spot here because our range of supported values for our `numeric` type is much smaller than Postgres'––we only allow values up to 38, and we use a `u8` behind the scenes; PG supports scale and precision to 1000 and seems to use some kind of `u32` for valid typmod values (which they'll print here irrespective of its validity as input). This means we simply cannot output the same values without doing a lot of awkward plumbing. And then they have odd behavior with typmod values less than 4 that I tried to do something helpful with...anyway, it's a bit of a mess but there's a chance it'll do what you need!

Fixes #4935

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5225)
<!-- Reviewable:end -->
