### PR TITLE
Fix spelling of "decodable" throughout the codebase

### DIFF
--- a/src/avro-derive/src/lib.rs
+++ b/src/avro-derive/src/lib.rs
@@ -15,7 +15,7 @@
 /// fn make_complicated_decoder() -> impl AvroDecode<Out = SomeComplicatedType> {
 ///     unimplemented!()
 /// }
-/// #[derive(AvroDecodeable)]
+/// #[derive(AvroDecodable)]
 /// struct MyType {
 ///     x: i32,
 ///     y: u64,
@@ -30,14 +30,14 @@
 /// and where "z" can be decoded by the decoder returned from `make_complicated_decoder`.
 ///
 /// This crate currently works by generating a struct named (following the example above)
-/// MyType_DECODER which is used internally by the `AvroDecodeable` implementation.
+/// MyType_DECODER which is used internally by the `AvroDecodable` implementation.
 /// It also requires that the `mz-avro` crate be linked under its default name.
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse_macro_input;
 use syn::ItemStruct;
 
-#[proc_macro_derive(AvroDecodeable, attributes(decoder_factory, state_type, state_expr))]
+#[proc_macro_derive(AvroDecodable, attributes(decoder_factory, state_type, state_expr))]
 pub fn derive_decodeable(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemStruct);
     let state_type = input
@@ -57,7 +57,7 @@ pub fn derive_decodeable(item: TokenStream) -> TokenStream {
         .iter()
         .map(|f| {
             // The type of the field,
-            // which must itself be AvroDecodeable so that we can recursively
+            // which must itself be AvroDecodable so that we can recursively
             // decode it.
             let ty = &f.ty;
             let id = f.ident.as_ref().unwrap();
@@ -85,7 +85,7 @@ pub fn derive_decodeable(item: TokenStream) -> TokenStream {
         .zip(field_state_exprs.iter())
         .map(|(f, state_expr)| {
             // The type of the field,
-            // which must itself be StatefulAvroDecodeable so that we can recursively
+            // which must itself be StatefulAvroDecodable so that we can recursively
             // decode it.
             let ty = &f.ty;
             let id = f.ident.as_ref().unwrap();
@@ -101,7 +101,7 @@ pub fn derive_decodeable(item: TokenStream) -> TokenStream {
                     }
                 } else {
                     quote! {
-                        <#ty as ::mz_avro::StatefulAvroDecodeable>::new_decoder(#state_expr)
+                        <#ty as ::mz_avro::StatefulAvroDecodable>::new_decoder(#state_expr)
                     }
                 };
             quote! {
@@ -166,7 +166,7 @@ pub fn derive_decodeable(item: TokenStream) -> TokenStream {
                 union_branch, array, map, enum_variant, scalar, decimal, bytes, string, json, uuid, fixed
             }
         }
-        impl ::mz_avro::StatefulAvroDecodeable for #name {
+        impl ::mz_avro::StatefulAvroDecodable for #name {
             type Decoder = #decoder_name;
             type State = #state_type;
             fn new_decoder(state: #state_type) -> #decoder_name {

--- a/src/avro/src/decode.rs
+++ b/src/avro/src/decode.rs
@@ -20,25 +20,25 @@ use crate::{
     TrivialDecoder, ValueDecoder,
 };
 
-pub trait StatefulAvroDecodeable: Sized {
+pub trait StatefulAvroDecodable: Sized {
     type Decoder: AvroDecode<Out = Self>;
     type State;
     fn new_decoder(state: Self::State) -> Self::Decoder;
 }
-pub trait AvroDecodeable: Sized {
+pub trait AvroDecodable: Sized {
     type Decoder: AvroDecode<Out = Self>;
 
     fn new_decoder() -> Self::Decoder;
 }
-impl<T> AvroDecodeable for T
+impl<T> AvroDecodable for T
 where
-    T: StatefulAvroDecodeable,
+    T: StatefulAvroDecodable,
     T::State: Default,
 {
-    type Decoder = <Self as StatefulAvroDecodeable>::Decoder;
+    type Decoder = <Self as StatefulAvroDecodable>::Decoder;
 
     fn new_decoder() -> Self::Decoder {
-        <Self as StatefulAvroDecodeable>::new_decoder(Default::default())
+        <Self as StatefulAvroDecodable>::new_decoder(Default::default())
     }
 }
 #[inline]
@@ -663,7 +663,7 @@ pub trait AvroDecode: Sized {
 
 pub mod public_decoders {
 
-    use super::{AvroDecodeable, AvroMapAccess, StatefulAvroDecodeable};
+    use super::{AvroDecodable, AvroMapAccess, StatefulAvroDecodable};
     use crate::error::{DecodeError, Error as AvroError};
     use crate::types::{DecimalValue, Scalar, Value};
     use crate::{
@@ -691,7 +691,7 @@ pub mod public_decoders {
                 }
             }
 
-            impl StatefulAvroDecodeable for $out {
+            impl StatefulAvroDecodable for $out {
                 type Decoder = $name;
                 type State = ();
                 fn new_decoder(_state: ()) -> $name {
@@ -861,7 +861,7 @@ pub mod public_decoders {
             Self { buf: vec![] }
         }
     }
-    impl<T: AvroDecodeable> AvroDecode for DefaultArrayAsVecDecoder<T> {
+    impl<T: AvroDecodable> AvroDecode for DefaultArrayAsVecDecoder<T> {
         type Out = Vec<T>;
         fn array<A: AvroArrayAccess>(mut self, a: &mut A) -> Result<Self::Out, AvroError> {
             while let Some(next) = {
@@ -876,7 +876,7 @@ pub mod public_decoders {
             record, union_branch, map, enum_variant, scalar, decimal, bytes, string, json, uuid, fixed
         }
     }
-    impl<T: AvroDecodeable> StatefulAvroDecodeable for Vec<T> {
+    impl<T: AvroDecodable> StatefulAvroDecodable for Vec<T> {
         type Decoder = DefaultArrayAsVecDecoder<T>;
         type State = ();
 

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -322,8 +322,8 @@ pub mod types;
 pub use crate::codec::Codec;
 pub use crate::decode::public_decoders::*;
 pub use crate::decode::{
-    give_value, AvroArrayAccess, AvroDecode, AvroDecodeable, AvroDeserializer, AvroFieldAccess,
-    AvroMapAccess, AvroRead, AvroRecordAccess, GeneralDeserializer, Skip, StatefulAvroDecodeable,
+    give_value, AvroArrayAccess, AvroDecode, AvroDecodable, AvroDeserializer, AvroFieldAccess,
+    AvroMapAccess, AvroRead, AvroRecordAccess, GeneralDeserializer, Skip, StatefulAvroDecodable,
     ValueOrReader,
 };
 pub use crate::encode::encode as encode_unchecked;

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -322,7 +322,7 @@ pub mod types;
 pub use crate::codec::Codec;
 pub use crate::decode::public_decoders::*;
 pub use crate::decode::{
-    give_value, AvroArrayAccess, AvroDecode, AvroDecodable, AvroDeserializer, AvroFieldAccess,
+    give_value, AvroArrayAccess, AvroDecodable, AvroDecode, AvroDeserializer, AvroFieldAccess,
     AvroMapAccess, AvroRead, AvroRecordAccess, GeneralDeserializer, Skip, StatefulAvroDecodable,
     ValueOrReader,
 };

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -2766,7 +2766,7 @@ pub mod cdc_v2 {
     use mz_avro::{
         define_unexpected,
         error::{DecodeError, Error as AvroError},
-        ArrayAsVecDecoder, AvroDecode, AvroDecodable, AvroDeserializer, AvroRead,
+        ArrayAsVecDecoder, AvroDecodable, AvroDecode, AvroDeserializer, AvroRead,
         StatefulAvroDecodable,
     };
     use std::{cell::RefCell, rc::Rc};

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -39,7 +39,7 @@ use mz_avro::{
     give_value,
     types::{DecimalValue, Scalar, Value},
     AvroArrayAccess, AvroDecode, AvroDeserializer, AvroMapAccess, AvroRead, AvroRecordAccess,
-    GeneralDeserializer, StatefulAvroDecodeable, TrivialDecoder, ValueDecoder, ValueOrReader,
+    GeneralDeserializer, StatefulAvroDecodable, TrivialDecoder, ValueDecoder, ValueOrReader,
 };
 use repr::adt::decimal::{Significand, MAX_DECIMAL_PRECISION};
 use repr::adt::jsonb::{JsonbPacker, JsonbRef};
@@ -541,7 +541,7 @@ impl AvroDecode for RowDecoder {
 // Get around orphan rule
 #[derive(Debug)]
 struct RowWrapper(Row);
-impl StatefulAvroDecodeable for RowWrapper {
+impl StatefulAvroDecodable for RowWrapper {
     type Decoder = RowDecoder;
     // TODO - can we make this some sort of &'a mut (RowPacker, Vec<u8>) without
     // running into lifetime crap?
@@ -2759,15 +2759,15 @@ pub mod cdc_v2 {
     use super::RowWrapper;
 
     use anyhow::anyhow;
-    use avro_derive::AvroDecodeable;
+    use avro_derive::AvroDecodable;
     use differential_dataflow::capture::{Message, Progress};
     use mz_avro::schema::Schema;
     use mz_avro::types::Value;
     use mz_avro::{
         define_unexpected,
         error::{DecodeError, Error as AvroError},
-        ArrayAsVecDecoder, AvroDecode, AvroDecodeable, AvroDeserializer, AvroRead,
-        StatefulAvroDecodeable,
+        ArrayAsVecDecoder, AvroDecode, AvroDecodable, AvroDeserializer, AvroRead,
+        StatefulAvroDecodable,
     };
     use std::{cell::RefCell, rc::Rc};
 
@@ -2856,7 +2856,7 @@ pub mod cdc_v2 {
         }
     }
 
-    #[derive(AvroDecodeable)]
+    #[derive(AvroDecodable)]
     #[state_type(Rc<RefCell<RowPacker>>, Rc<RefCell<Vec<u8>>>)]
     struct MyUpdate {
         #[state_expr(self._STATE.0.clone(), self._STATE.1.clone())]
@@ -2864,7 +2864,7 @@ pub mod cdc_v2 {
         time: Timestamp,
         diff: Diff,
     }
-    #[derive(AvroDecodeable)]
+    #[derive(AvroDecodable)]
     struct Count {
         time: Timestamp,
         count: usize,
@@ -2872,10 +2872,10 @@ pub mod cdc_v2 {
 
     fn make_counts_decoder() -> impl AvroDecode<Out = Vec<(Timestamp, usize)>> {
         ArrayAsVecDecoder::new(|| {
-            <Count as AvroDecodeable>::new_decoder().map_decoder(|ct| Ok((ct.time, ct.count)))
+            <Count as AvroDecodable>::new_decoder().map_decoder(|ct| Ok((ct.time, ct.count)))
         })
     }
-    #[derive(AvroDecodeable)]
+    #[derive(AvroDecodable)]
     struct MyProgress {
         lower: Vec<Timestamp>,
         upper: Vec<Timestamp>,
@@ -2898,7 +2898,7 @@ pub mod cdc_v2 {
                     let packer = Rc::new(RefCell::new(RowPacker::new()));
                     let buf = Rc::new(RefCell::new(vec![]));
                     let d = ArrayAsVecDecoder::new(|| {
-                        <MyUpdate as StatefulAvroDecodeable>::new_decoder((
+                        <MyUpdate as StatefulAvroDecodable>::new_decoder((
                             packer.clone(),
                             buf.clone(),
                         ))
@@ -2909,7 +2909,7 @@ pub mod cdc_v2 {
                 }
                 1 => {
                     let progress = deserializer
-                        .deserialize(r, <MyProgress as AvroDecodeable>::new_decoder())?;
+                        .deserialize(r, <MyProgress as AvroDecodable>::new_decoder())?;
                     let progress = Progress {
                         lower: progress.lower,
                         upper: progress.upper,


### PR DESCRIPTION
It's "decodable", not "decodeable", apparently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5232)
<!-- Reviewable:end -->
