### PR TITLE
test: fix flaky subselect.slt

### DIFF
--- a/test/sqllogictest/postgres/subselect.slt
+++ b/test/sqllogictest/postgres/subselect.slt
@@ -73,7 +73,7 @@ query TI rowsort
 SELECT 'onek', count(*) FROM onek
 UNION ALL
 SELECT 'tenk1', count(*) FROM tenk1
-AS OF 1
+AS OF 18446744073709551615
 ----
 onek 1000
 tenk1 10000


### PR DESCRIPTION
The initial timestamp used for real-time sources recently changed
in #5201. Change the SLT test that was relying on data being ingested
at timestamp 1 to use the maximum timestamp instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5233)
<!-- Reviewable:end -->
