### PR TITLE
pgwire: improve tail connection health check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
 name = "ore"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes 1.0.0",
  "crossbeam-utils",
  "fallible-iterator",
@@ -2384,6 +2385,7 @@ dependencies = [
  "phf_shared",
  "smallvec",
  "tokio",
+ "tokio-openssl",
  "tracing-subscriber",
 ]
 
@@ -2592,6 +2594,7 @@ name = "pgwire"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "byteorder",
  "bytes 1.0.0",
  "chrono",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
+async-trait = "0.1.42"
 bytes = "1.0.0"
 fallible-iterator = "0.2.0"
 futures = "0.3.0"
@@ -15,6 +16,7 @@ log = "0.4.11"
 phf_shared = "0.8.0"
 smallvec = "1.5.0"
 tokio = { version = "1.0.0", features = ["io-util", "net", "rt-multi-thread", "time"] }
+tokio-openssl = "0.6.0"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["env-filter", "fmt"] }
 
 [dev-dependencies]

--- a/src/ore/src/netio/async_ready.rs
+++ b/src/ore/src/netio/async_ready.rs
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use tokio::io::{self, Interest, Ready};
+use tokio::net::TcpStream;
+use tokio_openssl::SslStream;
+
+/// Asynchronous IO readiness.
+///
+/// Like [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`], but for
+/// readiness events.
+#[async_trait]
+pub trait AsyncReady {
+    /// Checks for IO readiness.
+    ///
+    /// See [`TcpStream::ready`] for details.
+    async fn ready(&self, interest: Interest) -> io::Result<Ready>;
+}
+
+#[async_trait]
+impl AsyncReady for TcpStream {
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        self.ready(interest).await
+    }
+}
+
+#[async_trait]
+impl<S> AsyncReady for SslStream<S>
+where
+    S: AsyncReady + Sync,
+{
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        self.get_ref().ready(interest).await
+    }
+}

--- a/src/ore/src/netio/mod.rs
+++ b/src/ore/src/netio/mod.rs
@@ -9,10 +9,12 @@
 
 //! Network I/O utilities.
 
+mod async_ready;
 mod framed;
 mod read_exact;
 mod stream;
 
+pub use self::async_ready::AsyncReady;
 pub use self::framed::{FrameTooBig, MAX_FRAME_SIZE};
 pub use self::read_exact::{read_exact_or_eof, ReadExactOrEof};
 pub use self::stream::{SniffedStream, SniffingStream};

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.37"
+async-trait = "0.1.42"
 byteorder = "1.3.0"
 bytes = "1.0.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
Now that we're using Tokio v1.0, we can improve the check to detect
closed connections in a TAIL operation. Rather than sending a
NoticeResponse, which produces noise in psql, just check whether the
socket has experienced a close event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5235)
<!-- Reviewable:end -->
