### PR TITLE
ore: use vendored openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "openssl",
  "phf_shared",
  "smallvec",
  "tokio",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3.0"
 lazy_static = "1.4.0"
 libc = "0.2.81"
 log = "0.4.11"
+openssl = { version = "0.10.32", features = ["vendored"] }
 phf_shared = "0.8.0"
 smallvec = "1.5.0"
 tokio = { version = "1.0.0", features = ["io-util", "net", "rt-multi-thread", "time"] }


### PR DESCRIPTION
The last commit (fa0e132) introduced a dependency on tokio_openssl in
ore, which transitively introduces a dependency on openssl where it
didn't exist before. So we need to enable the same "vendored" feature
that we use elsewhere to build a bundled copy of openssl, rather than
linking against the system copy.

This only applies when running the unit tests in ore. When building the
materialized binary, for example, openssl's "vendored" feature is
enabled by the materialized crate's Cargo.toml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5236)
<!-- Reviewable:end -->
