### PR TITLE
build-info: fix typo in docstring

### DIFF
--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -19,7 +19,7 @@ pub struct BuildInfo {
     pub version: &'static str,
     /// The 40-character SHA-1 hash identifying the Git commit of the build.
     pub sha: &'static str,
-    /// The time of the build in UTC as an ISO 8601-complaint string.
+    /// The time of the build in UTC as an ISO 8601-compliant string.
     pub time: &'static str,
     /// The target triple of the platform.
     pub target_triple: &'static str,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5244)
<!-- Reviewable:end -->
