### PR TITLE
pgwire: permit hangups in startup sequence

### DIFF
--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -382,12 +382,22 @@ impl<B: BufMut> Pgbuf for B {
     }
 }
 
-pub async fn decode_startup<A>(mut conn: A) -> Result<FrontendStartupMessage, io::Error>
+pub async fn decode_startup<A>(mut conn: A) -> Result<Option<FrontendStartupMessage>, io::Error>
 where
     A: AsyncRead + Unpin,
 {
     let mut frame_len = [0; 4];
-    conn.read_exact(&mut frame_len).await?;
+    let nread = netio::read_exact_or_eof(&mut conn, &mut frame_len).await?;
+    match nread {
+        // Complete frame length. Continue.
+        4 => (),
+        // Connection closed cleanly. Indicate that the startup sequence has
+        // been terminated by the client.
+        0 => return Ok(None),
+        // Partial frame length. Likely a client bug or network glitch, so
+        // surface the unexpected EOF.
+        _ => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "early eof")),
+    };
     let frame_len = parse_frame_len(&frame_len)?;
 
     let mut buf = BytesMut::new();
@@ -396,24 +406,24 @@ where
 
     let mut buf = Cursor::new(&buf);
     let version = buf.read_i32()?;
-    if version == VERSION_CANCEL {
-        Ok(FrontendStartupMessage::CancelRequest {
+    let message = match version {
+        VERSION_CANCEL => FrontendStartupMessage::CancelRequest {
             conn_id: buf.read_u32()?,
             secret_key: buf.read_u32()?,
-        })
-    } else if version == VERSION_SSL {
-        Ok(FrontendStartupMessage::SslRequest)
-    } else if version == VERSION_GSSENC {
-        Ok(FrontendStartupMessage::GssEncRequest)
-    } else {
-        let mut params = vec![];
-        while buf.peek_byte()? != 0 {
-            let name = buf.read_cstr()?.to_owned();
-            let value = buf.read_cstr()?.to_owned();
-            params.push((name, value));
+        },
+        VERSION_SSL => FrontendStartupMessage::SslRequest,
+        VERSION_GSSENC => FrontendStartupMessage::GssEncRequest,
+        _ => {
+            let mut params = vec![];
+            while buf.peek_byte()? != 0 {
+                let name = buf.read_cstr()?.to_owned();
+                let value = buf.read_cstr()?.to_owned();
+                params.push((name, value));
+            }
+            FrontendStartupMessage::Startup { version, params }
         }
-        Ok(FrontendStartupMessage::Startup { version, params })
-    }
+    };
+    Ok(Some(message))
 }
 
 #[derive(Debug)]

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -48,6 +48,7 @@ pub const VERSIONS: &[i32] = &[
 
 /// Like [`FrontendMessage`], but only the messages that can occur during
 /// startup protocol negotiation.
+#[derive(Debug)]
 pub enum FrontendStartupMessage {
     /// Begin a connection.
     Startup {


### PR DESCRIPTION
Clients sometimes hang up during the pgwire startup sequence, e.g.,
because they received an unacceptable response to an SslRequest. Don't
log an "early eof" error message in this case, since this is considered
a graceful termination in the pgwire protocol.

pgx has this hang up behavior in its default configuration, as does psql
in its "sslmode=require" configuration.

This commit also adds traces to the pgwire startup flow to mirror the
traces in the main pgwire flow.

Fix #5246.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5247)
<!-- Reviewable:end -->
