### PR TITLE
walkabout: teach walkabout to handle generics

### DIFF
--- a/src/walkabout/tests/testdata/visit
+++ b/src/walkabout/tests/testdata/visit
@@ -242,3 +242,80 @@ where
         visitor.visit_expr(v);
     }
 }
+
+
+visit
+enum Expr<T: Foo> {
+    Function(Function<T>),
+    BinOp {
+        lhs: Box<Expr<T>>,
+        op: BinOp,
+        rhs: Box<Expr<T>>,
+    }
+}
+enum BinOp {
+    Add,
+    Sub,
+}
+struct Function<T: Foo> {
+    name: String,
+    args: Vec<Expr<T>>,
+    filter: Option<Expr<T>>,
+}
+----
+pub trait Visit<'ast, T: Foo> {
+    fn visit_bin_op(&mut self, node: &'ast BinOp) {
+        visit_bin_op(self, node)
+    }
+    fn visit_expr(&mut self, node: &'ast Expr<T>) {
+        visit_expr(self, node)
+    }
+    fn visit_function(&mut self, node: &'ast Function<T>) {
+        visit_function(self, node)
+    }
+}
+pub fn visit_bin_op<'ast, V, T: Foo>(visitor: &mut V, node: &'ast BinOp)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    match node {
+        BinOp::Add {
+        } => {
+        }
+        BinOp::Sub {
+        } => {
+        }
+    }
+}
+pub fn visit_expr<'ast, V, T: Foo>(visitor: &mut V, node: &'ast Expr<T>)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    match node {
+        Expr::Function {
+            0: binding0,
+        } => {
+            visitor.visit_function(binding0);
+        }
+        Expr::BinOp {
+            lhs: binding0,
+            op: binding1,
+            rhs: binding2,
+        } => {
+            visitor.visit_expr(&*binding0);
+            visitor.visit_bin_op(binding1);
+            visitor.visit_expr(&*binding2);
+        }
+    }
+}
+pub fn visit_function<'ast, V, T: Foo>(visitor: &mut V, node: &'ast Function<T>)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    for v in &node.args {
+        visitor.visit_expr(v);
+    }
+    if let Some(v) = &node.filter {
+        visitor.visit_expr(v);
+    }
+}

--- a/src/walkabout/tests/testdata/visit
+++ b/src/walkabout/tests/testdata/visit
@@ -164,3 +164,81 @@ where
         visitor.visit_expr_mut(v);
     }
 }
+
+# Tests with generic parameters.
+
+visit
+enum Expr<T> {
+    Function(Function<T>),
+    BinOp {
+        lhs: Box<Expr<T>>,
+        op: BinOp,
+        rhs: Box<Expr<T>>,
+    }
+}
+enum BinOp {
+    Add,
+    Sub,
+}
+struct Function<T> {
+    name: String,
+    args: Vec<Expr<T>>,
+    filter: Option<Expr<T>>,
+}
+----
+pub trait Visit<'ast, T> {
+    fn visit_bin_op(&mut self, node: &'ast BinOp) {
+        visit_bin_op(self, node)
+    }
+    fn visit_expr(&mut self, node: &'ast Expr<T>) {
+        visit_expr(self, node)
+    }
+    fn visit_function(&mut self, node: &'ast Function<T>) {
+        visit_function(self, node)
+    }
+}
+pub fn visit_bin_op<'ast, V, T>(visitor: &mut V, node: &'ast BinOp)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    match node {
+        BinOp::Add {
+        } => {
+        }
+        BinOp::Sub {
+        } => {
+        }
+    }
+}
+pub fn visit_expr<'ast, V, T>(visitor: &mut V, node: &'ast Expr<T>)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    match node {
+        Expr::Function {
+            0: binding0,
+        } => {
+            visitor.visit_function(binding0);
+        }
+        Expr::BinOp {
+            lhs: binding0,
+            op: binding1,
+            rhs: binding2,
+        } => {
+            visitor.visit_expr(&*binding0);
+            visitor.visit_bin_op(binding1);
+            visitor.visit_expr(&*binding2);
+        }
+    }
+}
+pub fn visit_function<'ast, V, T>(visitor: &mut V, node: &'ast Function<T>)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    for v in &node.args {
+        visitor.visit_expr(v);
+    }
+    if let Some(v) = &node.filter {
+        visitor.visit_expr(v);
+    }
+}


### PR DESCRIPTION
I'm not 100% sure that this handles all the cases properly, and there
are undocumented assumptions about how the names all have to line up,
but it seems to compile modulo some "unused" errors, so I think any
issues will show themselves as I attempt to make use of it. The syntax
looks correct to my eye, though I'm not entirely confident I haven't
missed something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5259)
<!-- Reviewable:end -->
