### PR TITLE
coord: correctly handle txns with DISCARD ALL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "tempfile",
  "timely",
  "tokio",
+ "tokio-postgres",
  "transform",
  "unicase",
  "url",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -42,6 +42,7 @@ sql = { path = "../sql" }
 symbiosis = { path = "../symbiosis" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", features = ["bincode"] }
 tokio = "1.0.0"
+tokio-postgres = "0.7"
 transform = { path = "../transform" }
 unicase = "2.6.0"
 url = "2.0.0"

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -16,6 +16,7 @@ use dataflow_types::PeekResponse;
 use repr::Row;
 use sql::ast::{FetchDirection, ObjectType, Statement};
 use sql::plan::ExecuteTimeout;
+use tokio_postgres::error::SqlState;
 
 use crate::session::Session;
 
@@ -176,6 +177,11 @@ pub enum ExecuteResponse {
     },
     /// The specified number of rows were inserted into the requested table.
     Inserted(usize),
+    /// A SQL error occurred.
+    PgError {
+        code: SqlState,
+        message: String,
+    },
     /// Rows will be delivered via the specified future.
     SendingRows(#[derivative(Debug = "ignore")] RowsFuture),
     /// The specified variable was set to a new value.

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -177,3 +177,102 @@ ReadyForQuery
 RowDescription {"fields":[{"name":"?column?"}]}
 ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
+
+# Test DISCARD ALL, which "cannot be executed inside a transaction
+# block". This is important to test here because in materialize it
+# calls end_transaction, so we need to ensure it has correct transaction
+# semantics.
+
+# Should fail within an implicit transaction.
+send
+Query {"query": "SELECT 1; DISCARD ALL;"}
+----
+
+until
+ReadyForQuery
+----
+RowDescription {"fields":[{"name":"?column?"}]}
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot run inside a transaction block"}]}
+ReadyForQuery {"status":"I"}
+
+# Should fail within an explicit transaction.
+send
+Query {"query": "BEGIN"}
+Query {"query": "DISCARD ALL"}
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot run inside a transaction block"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+# Should succeed as a single statement.
+send
+Query {"query": "DISCARD ALL"}
+----
+
+until
+ReadyForQuery
+----
+CommandComplete {"tag":"DISCARD ALL"}
+ReadyForQuery {"status":"I"}
+
+# Should (apparently?) succeed as a second statement in an extended
+# session. I expected this to fail but I guess postgres allows it.
+send
+Parse {"query": "SELECT 1"}
+Bind
+Execute
+Parse {"query": "DISCARD ALL"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"DISCARD ALL"}
+ReadyForQuery {"status":"I"}
+
+# Verify DISCARD ALL fails in explicit transaction during extended mode.
+send
+Parse {"query": "BEGIN"}
+Bind
+Execute
+Parse {"query": "DISCARD ALL"}
+Bind
+Execute
+Sync
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot run inside a transaction block"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
DISCARD ALL cannot occur in a transaction. This is necessary as part of
the work to make our SQL txn semantics correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5263)
<!-- Reviewable:end -->
