### PR TITLE
Print archive messages as JSON by default

### DIFF
--- a/misc/kafka-util/scripts/print_archive.py
+++ b/misc/kafka-util/scripts/print_archive.py
@@ -48,7 +48,7 @@ def print_archive(args: argparse.Namespace) -> None:
         if args.pretty_print:
             pprint.pprint(obj)
         else:
-            print(obj)
+            print(json.dumps(obj))
 
     topic = args.topic
 
@@ -116,7 +116,7 @@ def main() -> None:
     parser.add_argument(
         "-p",
         "--pretty-print",
-        help="Whether or not to print messages over multiple-lines using a pretty printer",
+        help="Whether or not to pretty-print messages over multiple-lines (default JSON)",
         action="store_true",
     )
 


### PR DESCRIPTION
This enables using tools like `jq` to parse the output. The previous version printed the Python representation of the object, which `jq` does not handle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5265)
<!-- Reviewable:end -->
