### PR TITLE
Improve error message for missing mzbuild services

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -50,7 +50,6 @@ import time
 import yaml
 
 from materialize import cargo
-from materialize import errors
 from materialize import git
 from materialize import spawn
 from materialize import ui
@@ -531,11 +530,10 @@ class ResolvedImage:
         """
         paths = set(git.expand_globs(self.image.rd.root, f"{self.image.path}/**"))
         if not paths:
-            # While we could find an `mzbuild.yml` file for this service, git didn't return any
-            # files that matched this service. That likely means that the directory containing the
-            # mzbuild.yml file has not been added to git; otherwise, the mzbuid.yml file, at a
-            # minimum, would be included in the paths list returned by expand_globs.
-            raise errors.BadSpec(
+            # While we could find an `mzbuild.yml` file for this service, expland_globs didn't
+            # return any files that matched this service. At the very least, the `mzbuild.yml`
+            # file itself should have been returned. We have a bug if paths is empty.
+            raise AssertionError(
                 f"{self.image.name} mzbuild exists but its files are unknown to git"
             )
         if self.image.pre_image is not None:

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -50,6 +50,7 @@ import time
 import yaml
 
 from materialize import cargo
+from materialize import errors
 from materialize import git
 from materialize import spawn
 from materialize import ui
@@ -158,6 +159,7 @@ class PreImage:
 
     def inputs(self) -> Set[str]:
         """Return the files which are considered inputs to the action."""
+        raise NotImplementedError
 
 
 class CargoPreImage(PreImage):
@@ -528,6 +530,14 @@ class ResolvedImage:
                 repository.
         """
         paths = set(git.expand_globs(self.image.rd.root, f"{self.image.path}/**"))
+        if not paths:
+            # While we could find an `mzbuild.yml` file for this service, git didn't return any
+            # files that matched this service. That likely means that the directory containing the
+            # mzbuild.yml file has not been added to git; otherwise, the mzbuid.yml file, at a
+            # minimum, would be included in the paths list returned by expand_globs.
+            raise errors.BadSpec(
+                f"{self.image.name} mzbuild exists but its files are unknown to git"
+            )
         if self.image.pre_image is not None:
             paths |= self.image.pre_image.inputs()
         if transitive:


### PR DESCRIPTION
When adding new services, it's common to forget to `git add` the
directory that contains the mzbuild.yml file. Before this change, that
would result in an error message about `sqllogictest/sqlite` being a
directory. After this change, the user should be made aware that the
problem is between their mzcompose.yml, mzbuild.yml and git.

The proper fix for this is to run `git add` on the mzbuild.yml file.

Fixes #5020

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5269)
<!-- Reviewable:end -->
