### PR TITLE
materialized: permit older TLS algorithms

### DIFF
--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -147,7 +147,7 @@ pub struct TlsConfig {
 
 impl TlsConfig {
     fn validate(&self) -> Result<SslContext, anyhow::Error> {
-        let mut builder = SslAcceptor::mozilla_modern_v5(SslMethod::tls())?;
+        let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())?;
         builder.set_certificate_file(&self.cert, SslFiletype::PEM)?;
         builder.set_private_key_file(&self.key, SslFiletype::PEM)?;
         Ok(builder.build().into_context())


### PR DESCRIPTION
Use Mozilla's "intermediate" TLS preset, rather than its "modern"
preset. Fivetran does not use modern-enough TLS algorithms to be
compatible with the "modern" present, and likely other connectors have
the same defect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5279)
<!-- Reviewable:end -->
