### PR TITLE
dataflow,expr: change bigint sums to output numerics

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -77,6 +77,11 @@ Wrap your release notes at the 80 character mark.
 
 - Add `upper` and `lower` to the [string function](/sql/functions#string-func) suite.
 
+- Change [`sum`](/sql/functions/#aggregate-func) over `bigint` to return `numeric`.
+  Previously, `sum` over `bigint` returned `bigint`.
+
+  **Backwards-incompatible change**
+
 {{% version-header v0.6.0 %}}
 
 - Support specifying default values for table columns via the new

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -49,10 +49,13 @@
     description: Sample standard deviation of `T`'s values. *(imprecise)*
       <br><br>
       Returns `numeric` if `x` is `int`, `double` if `x` is `real`, else returns
-      same typ as `x`.
+      same type as `x`.
 
-  - signature: 'sum(x: T) -> T'
+  - signature: 'sum(x: T) -> U'
     description: Sum of `T`'s values
+      <br><br>
+      Returns `bigint` if `x` is `int`, `numeric` if `x` is `bigint`, else returns
+      same type as `x`.
 
   - signature: 'variance(x: T) -> U'
     description: Historical alias for `variance_samp`. *(imprecise)*

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -810,7 +810,7 @@ where
                         (_, 0) => Datum::Null,
                         // If any non-nulls, just report the aggregate.
                         (AggregateFunc::SumInt32, _) => Datum::Int64(agg1 as i64),
-                        (AggregateFunc::SumInt64, _) => Datum::Int64(agg1 as i64),
+                        (AggregateFunc::SumInt64, _) => Datum::from(agg1),
                         (AggregateFunc::SumFloat32, _) => {
                             Datum::Float32((((agg1 as f64) / float_scale) as f32).into())
                         }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use ore::cast::CastFrom;
-use repr::adt::decimal::Significand;
+use repr::adt::decimal::{Significand, MAX_DECIMAL_PRECISION};
 use repr::adt::regex::Regex as ReprRegex;
 use repr::{
     CachedRecordIter, ColumnType, Datum, Diff, RelationType, Row, RowArena, RowPacker, ScalarType,
@@ -502,6 +502,7 @@ impl AggregateFunc {
             AggregateFunc::All => ScalarType::Bool,
             AggregateFunc::JsonbAgg => ScalarType::Jsonb,
             AggregateFunc::SumInt32 => ScalarType::Int64,
+            AggregateFunc::SumInt64 => ScalarType::Decimal(MAX_DECIMAL_PRECISION, 0),
             _ => input_type.scalar_type,
         };
         // max/min/sum return null on empty sets

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -96,6 +96,27 @@ name  nullable  type
  a    true      int4
  b    true      int4
 
+# Tests on int8 sums to make sure we handle overflow and underflow correctly
+
+statement ok
+CREATE TABLE t_bigint (a bigint, b bigint)
+
+statement ok
+INSERT INTO t_bigint (a, b) VALUES (1, 1), (1, 2), (2, 9223372036854775807), (2, 9223372036854775807), (3, -9223372036854775808), (3, -9223372036854775808)
+
+query II rowsort
+SELECT a, sum(b) FROM t_bigint GROUP BY a
+----
+1 3
+2 18446744073709551614
+3 -18446744073709551616
+
+query T colnames
+SELECT pg_typeof(sum(b)) FROM t_bigint
+----
+pg_typeof
+numeric(38,0)
+
 # avg on an integer column should return a decimal with the default decimal
 # division scale increase.
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -70,7 +70,7 @@ b  sum
 name nullable type
 -------------------
 b     false   int8
-sum   true    int8
+sum   true    numeric
 
 > SHOW VIEWS LIKE '%data%'
 data_view


### PR DESCRIPTION
Touches #5218

Previously, sums over bigints would return bigints as output. These sums could
overflow in simple examples. This commit changes the behavior to match Postgres
precedent and return numerics, which are a wider accumulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5281)
<!-- Reviewable:end -->
