### PR TITLE
deps: downgrade sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3886,13 +3886,11 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.15.7"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec92c229ee7894cde9fca41d3ca387fb980dd04fc04375ffea06474e65753b4e"
+checksum = "67330cbee3b2a819e3365a773f05e884a136603687f812bf24db5b6c3d76b696"
 dependencies = [
- "cc",
- "cfg-if 1.0.0",
- "core-foundation-sys",
+ "cfg-if 0.1.10",
  "doc-comment",
  "libc",
  "ntapi",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -69,7 +69,9 @@ shell-words = "1.0.0"
 sql = { path = "../sql" }
 sql-parser = { path = "../sql-parser" }
 sysctl = "0.4.0"
-sysinfo = "0.15.7"
+# v0.15.4+ fail to cross compile on macOS.
+# See: https://github.com/GuillaumeGomez/sysinfo/pull/404
+sysinfo = "=0.15.3"
 tempfile = "3.1.0"
 tokio = { version = "1.0.0", features = ["sync"] }
 tokio-openssl = "0.6.0"


### PR DESCRIPTION
Downgrade sysinfo to fix cross compiliation on macOS, until
@quodlibetor's change makes it upstream.

See: https://github.com/GuillaumeGomez/sysinfo/pull/404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5283)
<!-- Reviewable:end -->
