### PR TITLE
sql: add a type variable to the AST

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -26,7 +26,7 @@ use dataflow_types::{SinkConnector, SinkConnectorBuilder, SourceConnector};
 use expr::{ExprHumanizer, GlobalId, OptimizedRelationExpr, ScalarExpr};
 use repr::{ColumnType, RelationDesc, ScalarType};
 use sql::ast::display::AstDisplay;
-use sql::ast::Expr;
+use sql::ast::{Expr, Raw};
 use sql::catalog::{Catalog as SqlCatalog, CatalogError as SqlCatalogError};
 use sql::names::{DatabaseSpecifier, FullName, PartialName, SchemaName};
 use sql::plan::{Params, Plan, PlanContext};
@@ -146,7 +146,7 @@ pub struct Table {
     pub plan_cx: PlanContext,
     pub desc: RelationDesc,
     #[serde(skip)]
-    pub defaults: Vec<Expr>,
+    pub defaults: Vec<Expr<Raw>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2051,7 +2051,7 @@ impl sql::catalog::CatalogItem for CatalogEntry {
         }
     }
 
-    fn table_details(&self) -> Option<&[Expr]> {
+    fn table_details(&self) -> Option<&[Expr<Raw>]> {
         if let CatalogItem::Table(Table { defaults, .. }) = self.item() {
             Some(defaults)
         } else {

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -14,7 +14,7 @@ use sql::ast::display::AstDisplay;
 use sql::ast::visit_mut::VisitMut;
 use sql::ast::{
     CreateIndexStatement, CreateTableStatement, CreateTypeStatement, CreateViewStatement, DataType,
-    Ident, ObjectName, Statement,
+    Ident, ObjectName, Raw, Statement,
 };
 
 use crate::catalog::PG_CATALOG_SCHEMA;
@@ -34,7 +34,7 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
     |catalog: &mut Catalog| {
         struct TypeNormalizer;
 
-        impl<'ast> VisitMut<'ast> for TypeNormalizer {
+        impl<'ast> VisitMut<'ast, Raw> for TypeNormalizer {
             fn visit_data_type_mut(&mut self, data_type: &'ast mut DataType) {
                 if let DataType::Other { name, .. } = data_type {
                     if name.0.len() == 1 {

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -9,7 +9,7 @@
 
 use futures::SinkExt;
 
-use sql::ast::Statement;
+use sql::ast::{Raw, Statement};
 use sql::plan::Params;
 
 use crate::command::{
@@ -51,7 +51,7 @@ impl Client {
     /// temporary resources that would normally need to be cleaned up by Terminate.
     pub async fn execute(
         &mut self,
-        stmt: Statement,
+        stmt: Statement<Raw>,
         params: Params,
     ) -> Result<NoSessionExecuteResponse, anyhow::Error> {
         self.send(|tx| Command::NoSessionExecute { stmt, params, tx })
@@ -104,7 +104,7 @@ impl SessionClient {
     pub async fn describe(
         &mut self,
         name: String,
-        stmt: Option<Statement>,
+        stmt: Option<Statement<Raw>>,
         param_types: Vec<Option<pgrepr::Type>>,
     ) -> Result<(), anyhow::Error> {
         self.send(|tx, session| Command::Describe {
@@ -121,7 +121,7 @@ impl SessionClient {
     pub async fn declare(
         &mut self,
         name: String,
-        stmt: Statement,
+        stmt: Statement<Raw>,
         param_types: Vec<Option<pgrepr::Type>>,
     ) -> Result<(), anyhow::Error> {
         self.send(|tx, session| Command::Declare {

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -14,7 +14,7 @@ use derivative::Derivative;
 
 use dataflow_types::PeekResponse;
 use repr::Row;
-use sql::ast::{FetchDirection, ObjectType, Statement};
+use sql::ast::{FetchDirection, ObjectType, Raw, Statement};
 use sql::plan::ExecuteTimeout;
 use tokio_postgres::error::SqlState;
 
@@ -30,7 +30,7 @@ pub enum Command {
 
     Declare {
         name: String,
-        stmt: Statement,
+        stmt: Statement<Raw>,
         param_types: Vec<Option<pgrepr::Type>>,
         session: Session,
         tx: futures::channel::oneshot::Sender<Response<()>>,
@@ -38,7 +38,7 @@ pub enum Command {
 
     Describe {
         name: String,
-        stmt: Option<Statement>,
+        stmt: Option<Statement<Raw>>,
         param_types: Vec<Option<pgrepr::Type>>,
         session: Session,
         tx: futures::channel::oneshot::Sender<Response<()>>,
@@ -63,7 +63,7 @@ pub enum Command {
     },
 
     NoSessionExecute {
-        stmt: Statement,
+        stmt: Statement<Raw>,
         params: sql::plan::Params,
         tx: futures::channel::oneshot::Sender<anyhow::Result<NoSessionExecuteResponse>>,
     },

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -54,7 +54,7 @@ use repr::{ColumnName, Datum, RelationDesc, RelationType, Row, RowPacker, Timest
 use sql::ast::display::AstDisplay;
 use sql::ast::{
     CreateIndexStatement, CreateTableStatement, DropObjectsStatement, ExplainOptions, ExplainStage,
-    FetchStatement, ObjectType, Statement,
+    FetchStatement, ObjectType, Raw, Statement,
 };
 use sql::catalog::Catalog as _;
 use sql::names::{DatabaseSpecifier, FullName, SchemaName};
@@ -101,7 +101,7 @@ pub struct AdvanceSourceTimestamp {
 pub struct StatementReady {
     pub session: Session,
     pub tx: ClientTransmitter<ExecuteResponse>,
-    pub result: Result<sql::ast::Statement, anyhow::Error>,
+    pub result: Result<sql::ast::Statement<Raw>, anyhow::Error>,
     pub params: Params,
 }
 
@@ -855,7 +855,7 @@ where
     async fn handle_statement(
         &mut self,
         session: &Session,
-        stmt: sql::ast::Statement,
+        stmt: sql::ast::Statement<Raw>,
         params: &sql::plan::Params,
     ) -> Result<(PlanContext, sql::plan::Plan), anyhow::Error> {
         let pcx = PlanContext::default();
@@ -905,7 +905,7 @@ where
         &self,
         session: &mut Session,
         name: String,
-        stmt: Statement,
+        stmt: Statement<Raw>,
         param_types: Vec<Option<pgrepr::Type>>,
     ) -> Result<(), anyhow::Error> {
         // handle_describe cares about symbiosis mode here. Declared cursors are
@@ -926,7 +926,7 @@ where
         &self,
         session: &mut Session,
         name: String,
-        stmt: Option<Statement>,
+        stmt: Option<Statement<Raw>>,
         param_types: Vec<Option<pgrepr::Type>>,
     ) -> Result<(), anyhow::Error> {
         let desc = if let Some(stmt) = stmt.clone() {
@@ -3308,7 +3308,7 @@ pub fn index_sql(
 ) -> String {
     use sql::ast::{Expr, Ident, Value};
 
-    CreateIndexStatement {
+    CreateIndexStatement::<Raw> {
         name: Some(Ident::new(index_name)),
         on_name: sql::normalize::unresolve(view_name),
         key_parts: Some(
@@ -3344,7 +3344,7 @@ fn duration_to_timestamp_millis(d: Duration) -> Timestamp {
 /// through the session.
 pub fn describe(
     catalog: &dyn sql::catalog::Catalog,
-    stmt: Statement,
+    stmt: Statement<Raw>,
     param_types: &[Option<pgrepr::Type>],
     session: Option<&Session>,
 ) -> Result<StatementDesc, anyhow::Error> {

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -17,7 +17,7 @@ use derivative::Derivative;
 use futures::Stream;
 
 use repr::{Datum, Row, ScalarType};
-use sql::ast::Statement;
+use sql::ast::{Raw, Statement};
 use sql::plan::{Params, StatementDesc};
 
 mod vars;
@@ -137,7 +137,7 @@ impl Session {
         &mut self,
         portal_name: String,
         desc: StatementDesc,
-        stmt: Option<Statement>,
+        stmt: Option<Statement<Raw>>,
         params: Vec<(Datum, ScalarType)>,
         result_formats: Vec<pgrepr::Format>,
     ) {
@@ -199,19 +199,19 @@ impl Session {
 /// A prepared statement.
 #[derive(Debug)]
 pub struct PreparedStatement {
-    sql: Option<Statement>,
+    sql: Option<Statement<Raw>>,
     desc: StatementDesc,
 }
 
 impl PreparedStatement {
     /// Constructs a new prepared statement.
-    pub fn new(sql: Option<Statement>, desc: StatementDesc) -> PreparedStatement {
+    pub fn new(sql: Option<Statement<Raw>>, desc: StatementDesc) -> PreparedStatement {
         PreparedStatement { sql, desc }
     }
 
     /// Returns the raw SQL string associated with this prepared statement,
     /// if the prepared statement was not the empty query.
-    pub fn sql(&self) -> Option<&Statement> {
+    pub fn sql(&self) -> Option<&Statement<Raw>> {
         self.sql.as_ref()
     }
 
@@ -226,7 +226,7 @@ impl PreparedStatement {
 #[derivative(Debug)]
 pub struct Portal {
     /// The statement that is bound to this portal.
-    pub stmt: Option<Statement>,
+    pub stmt: Option<Statement<Raw>>,
     /// The statement description.
     pub desc: StatementDesc,
     /// The bound values for the parameters in the prepared statement, if any.

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -31,7 +31,7 @@ use ore::cast::CastFrom;
 use ore::netio::AsyncReady;
 use repr::{Datum, RelationDesc, RelationType, Row, RowArena};
 use sql::ast::display::AstDisplay;
-use sql::ast::{FetchDirection, Ident, Statement};
+use sql::ast::{FetchDirection, Ident, Raw, Statement};
 use sql::plan::{CopyFormat, ExecuteTimeout, StatementDesc};
 
 use crate::codec::FramedConn;
@@ -261,7 +261,7 @@ where
         self.flush().await
     }
 
-    async fn one_query(&mut self, stmt: Statement) -> Result<State, comm::Error> {
+    async fn one_query(&mut self, stmt: Statement<Raw>) -> Result<State, comm::Error> {
         // Bind the portal. Note that this does not set the empty string prepared
         // statement.
         let param_types = vec![];
@@ -1314,7 +1314,7 @@ fn describe_rows(stmt_desc: &StatementDesc, formats: &[pgrepr::Format]) -> Backe
     }
 }
 
-fn parse_sql(sql: &str) -> Result<Vec<Statement>, ErrorResponse> {
+fn parse_sql(sql: &str) -> Result<Vec<Statement<Raw>>, ErrorResponse> {
     sql::parse::parse(sql).map_err(|e| {
         // Convert our 0-based byte position to pgwire's 1-based character
         // position.

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1372,7 +1372,7 @@ enum ExecuteCount {
 }
 
 // See postgres' backend/tcop/postgres.c IsTransactionExitStmt.
-fn is_txn_exit_stmt(stmt: Option<&Statement>) -> bool {
+fn is_txn_exit_stmt(stmt: Option<&Statement<Raw>>) -> bool {
     match stmt {
         // Add PREPARE to this if we ever support it.
         Some(stmt) => matches!(stmt, Statement::Commit(_) | Statement::Rollback(_)),

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -21,7 +21,7 @@
 use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{DataType, Ident, ObjectName, OrderByExpr, Query, Value};
+use crate::ast::{AstInfo, DataType, Ident, ObjectName, OrderByExpr, Query, Value};
 
 /// An SQL expression of any type.
 ///
@@ -29,136 +29,142 @@ use crate::ast::{DataType, Ident, ObjectName, OrderByExpr, Query, Value};
 /// (e.g. boolean vs string), so the caller must handle expressions of
 /// inappropriate type, like `WHERE 1` or `SELECT 1=1`, as necessary.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Expr {
+pub enum Expr<T: AstInfo> {
     /// Identifier e.g. table name or column name
     Identifier(Vec<Ident>),
     /// Qualified wildcard, e.g. `alias.*` or `schema.table.*`.
     QualifiedWildcard(Vec<Ident>),
     /// A field access, like `(expr).foo`.
-    FieldAccess { expr: Box<Expr>, field: Ident },
+    FieldAccess { expr: Box<Expr<T>>, field: Ident },
     /// A wildcard field access, like `(expr).*`.
     ///
     /// Note that this is different from `QualifiedWildcard` in that the
     /// wildcard access occurs on an arbitrary expression, rather than a
     /// qualified name. The distinction is important for PostgreSQL
     /// compatibility.
-    WildcardAccess(Box<Expr>),
+    WildcardAccess(Box<Expr<T>>),
     /// A positional parameter, e.g., `$1` or `$42`
     Parameter(usize),
     /// Boolean negation
-    Not { expr: Box<Expr> },
+    Not { expr: Box<Expr<T>> },
     /// Boolean and
-    And { left: Box<Expr>, right: Box<Expr> },
+    And {
+        left: Box<Expr<T>>,
+        right: Box<Expr<T>>,
+    },
     /// Boolean or
-    Or { left: Box<Expr>, right: Box<Expr> },
+    Or {
+        left: Box<Expr<T>>,
+        right: Box<Expr<T>>,
+    },
     /// `IS NULL` expression
-    IsNull { expr: Box<Expr>, negated: bool },
+    IsNull { expr: Box<Expr<T>>, negated: bool },
     /// `[ NOT ] IN (val1, val2, ...)`
     InList {
-        expr: Box<Expr>,
-        list: Vec<Expr>,
+        expr: Box<Expr<T>>,
+        list: Vec<Expr<T>>,
         negated: bool,
     },
     /// `[ NOT ] IN (SELECT ...)`
     InSubquery {
-        expr: Box<Expr>,
-        subquery: Box<Query>,
+        expr: Box<Expr<T>>,
+        subquery: Box<Query<T>>,
         negated: bool,
     },
     /// `<expr> [ NOT ] BETWEEN <low> AND <high>`
     Between {
-        expr: Box<Expr>,
+        expr: Box<Expr<T>>,
         negated: bool,
-        low: Box<Expr>,
-        high: Box<Expr>,
+        low: Box<Expr<T>>,
+        high: Box<Expr<T>>,
     },
     /// Unary or binary operator
     Op {
         op: String,
-        expr1: Box<Expr>,
-        expr2: Option<Box<Expr>>,
+        expr1: Box<Expr<T>>,
+        expr2: Option<Box<Expr<T>>>,
     },
     /// CAST an expression to a different data type e.g. `CAST(foo AS VARCHAR(123))`
     Cast {
-        expr: Box<Expr>,
+        expr: Box<Expr<T>>,
         data_type: DataType,
     },
     /// `expr COLLATE collation`
     Collate {
-        expr: Box<Expr>,
+        expr: Box<Expr<T>>,
         collation: ObjectName,
     },
     /// COALESCE(<expr>, ...)
     ///
     /// While COALESCE has the same syntax as a function call, its semantics are
     /// extremely unusual, and are better captured with a dedicated AST node.
-    Coalesce { exprs: Vec<Expr> },
+    Coalesce { exprs: Vec<Expr<T>> },
     /// Nested expression e.g. `(foo > bar)` or `(1)`
-    Nested(Box<Expr>),
+    Nested(Box<Expr<T>>),
     /// A row constructor like `ROW(<expr>...)` or `(<expr>, <expr>...)`.
-    Row { exprs: Vec<Expr> },
+    Row { exprs: Vec<Expr<T>> },
     /// A literal value, such as string, number, date or NULL
     Value(Value),
     /// Scalar function call e.g. `LEFT(foo, 5)`
-    Function(Function),
+    Function(Function<T>),
     /// `CASE [<operand>] WHEN <condition> THEN <result> ... [ELSE <result>] END`
     ///
     /// Note we only recognize a complete single expression as `<condition>`,
     /// not `< 0` nor `1, 2, 3` as allowed in a `<simple when clause>` per
     /// <https://jakewheat.github.io/sql-overview/sql-2011-foundation-grammar.html#simple-when-clause>
     Case {
-        operand: Option<Box<Expr>>,
-        conditions: Vec<Expr>,
-        results: Vec<Expr>,
-        else_result: Option<Box<Expr>>,
+        operand: Option<Box<Expr<T>>>,
+        conditions: Vec<Expr<T>>,
+        results: Vec<Expr<T>>,
+        else_result: Option<Box<Expr<T>>>,
     },
     /// An exists expression `EXISTS(SELECT ...)`, used in expressions like
     /// `WHERE EXISTS (SELECT ...)`.
-    Exists(Box<Query>),
+    Exists(Box<Query<T>>),
     /// A parenthesized subquery `(SELECT ...)`, used in expression like
     /// `SELECT (subquery) AS x` or `WHERE (subquery) = x`
-    Subquery(Box<Query>),
+    Subquery(Box<Query<T>>),
     /// `<expr> <op> ANY/SOME (<query>)`
     AnySubquery {
-        left: Box<Expr>,
+        left: Box<Expr<T>>,
         op: String,
-        right: Box<Query>,
+        right: Box<Query<T>>,
     },
     /// `<expr> <op> ANY (<array_expr>)`
     AnyExpr {
-        left: Box<Expr>,
+        left: Box<Expr<T>>,
         op: String,
-        right: Box<Expr>,
+        right: Box<Expr<T>>,
     },
     /// `<expr> <op> ALL (<query>)`
     AllSubquery {
-        left: Box<Expr>,
+        left: Box<Expr<T>>,
         op: String,
-        right: Box<Query>,
+        right: Box<Query<T>>,
     },
     /// `<expr> <op> ALL (<array_expr>)`
     AllExpr {
-        left: Box<Expr>,
+        left: Box<Expr<T>>,
         op: String,
-        right: Box<Expr>,
+        right: Box<Expr<T>>,
     },
     /// `ARRAY[<expr>*]`
-    Array(Vec<Expr>),
+    Array(Vec<Expr<T>>),
     /// `LIST[<expr>*]`
-    List(Vec<Expr>),
+    List(Vec<Expr<T>>),
     /// `<expr>[<expr>]`
     SubscriptIndex {
-        expr: Box<Expr>,
-        subscript: Box<Expr>,
+        expr: Box<Expr<T>>,
+        subscript: Box<Expr<T>>,
     },
     /// `<expr>[<expr>:<expr>(, <expr>?:<expr>?)*]`
     SubscriptSlice {
-        expr: Box<Expr>,
-        positions: Vec<SubscriptPosition>,
+        expr: Box<Expr<T>>,
+        positions: Vec<SubscriptPosition<T>>,
     },
 }
 
-impl AstDisplay for Expr {
+impl<T: AstInfo> AstDisplay for Expr<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             Expr::Identifier(s) => f.write_node(&display::separated(s, ".")),
@@ -412,45 +418,45 @@ impl AstDisplay for Expr {
         }
     }
 }
-impl_display!(Expr);
+impl_display_t!(Expr);
 
-impl Expr {
+impl<T: AstInfo> Expr<T> {
     pub fn is_string_literal(&self) -> bool {
         matches!(self, Expr::Value(Value::String(_)))
     }
 
-    pub fn null() -> Expr {
+    pub fn null() -> Expr<T> {
         Expr::Value(Value::Null)
     }
 
-    pub fn number<S>(n: S) -> Expr
+    pub fn number<S>(n: S) -> Expr<T>
     where
         S: Into<String>,
     {
         Expr::Value(Value::Number(n.into()))
     }
 
-    pub fn negate(self) -> Expr {
+    pub fn negate(self) -> Expr<T> {
         Expr::Not {
             expr: Box::new(self),
         }
     }
 
-    pub fn and(self, right: Expr) -> Expr {
+    pub fn and(self, right: Expr<T>) -> Expr<T> {
         Expr::And {
             left: Box::new(self),
             right: Box::new(right),
         }
     }
 
-    pub fn or(self, right: Expr) -> Expr {
+    pub fn or(self, right: Expr<T>) -> Expr<T> {
         Expr::Or {
             left: Box::new(self),
             right: Box::new(right),
         }
     }
 
-    pub fn binop(self, op: &str, right: Expr) -> Expr {
+    pub fn binop(self, op: &str, right: Expr<T>) -> Expr<T> {
         Expr::Op {
             op: op.to_string(),
             expr1: Box::new(self),
@@ -458,43 +464,43 @@ impl Expr {
         }
     }
 
-    pub fn lt(self, right: Expr) -> Expr {
+    pub fn lt(self, right: Expr<T>) -> Expr<T> {
         self.binop("<", right)
     }
 
-    pub fn lt_eq(self, right: Expr) -> Expr {
+    pub fn lt_eq(self, right: Expr<T>) -> Expr<T> {
         self.binop("<=", right)
     }
 
-    pub fn gt(self, right: Expr) -> Expr {
+    pub fn gt(self, right: Expr<T>) -> Expr<T> {
         self.binop(">", right)
     }
 
-    pub fn gt_eq(self, right: Expr) -> Expr {
+    pub fn gt_eq(self, right: Expr<T>) -> Expr<T> {
         self.binop(">=", right)
     }
 
-    pub fn equals(self, right: Expr) -> Expr {
+    pub fn equals(self, right: Expr<T>) -> Expr<T> {
         self.binop("=", right)
     }
 
-    pub fn minus(self, right: Expr) -> Expr {
+    pub fn minus(self, right: Expr<T>) -> Expr<T> {
         self.binop("-", right)
     }
 
-    pub fn multiply(self, right: Expr) -> Expr {
+    pub fn multiply(self, right: Expr<T>) -> Expr<T> {
         self.binop("*", right)
     }
 
-    pub fn modulo(self, right: Expr) -> Expr {
+    pub fn modulo(self, right: Expr<T>) -> Expr<T> {
         self.binop("%", right)
     }
 
-    pub fn divide(self, right: Expr) -> Expr {
+    pub fn divide(self, right: Expr<T>) -> Expr<T> {
         self.binop("/", right)
     }
 
-    pub fn call(name: Vec<&str>, args: Vec<Expr>) -> Expr {
+    pub fn call(name: Vec<&str>, args: Vec<Expr<T>>) -> Expr<T> {
         Expr::Function(Function {
             name: ObjectName(name.into_iter().map(Into::into).collect()),
             args: FunctionArgs::Args(args),
@@ -504,26 +510,26 @@ impl Expr {
         })
     }
 
-    pub fn call_nullary(name: Vec<&str>) -> Expr {
+    pub fn call_nullary(name: Vec<&str>) -> Expr<T> {
         Expr::call(name, vec![])
     }
 
-    pub fn call_unary(self, name: Vec<&str>) -> Expr {
+    pub fn call_unary(self, name: Vec<&str>) -> Expr<T> {
         Expr::call(name, vec![self])
     }
 
-    pub fn take(&mut self) -> Expr {
+    pub fn take(&mut self) -> Expr<T> {
         mem::replace(self, Expr::Identifier(vec![]))
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct SubscriptPosition {
-    pub start: Option<Expr>,
-    pub end: Option<Expr>,
+pub struct SubscriptPosition<T: AstInfo> {
+    pub start: Option<Expr<T>>,
+    pub end: Option<Expr<T>>,
 }
 
-impl AstDisplay for SubscriptPosition {
+impl<T: AstInfo> AstDisplay for SubscriptPosition<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         if let Some(start) = &self.start {
             f.write_node(start);
@@ -534,17 +540,17 @@ impl AstDisplay for SubscriptPosition {
         }
     }
 }
-impl_display!(SubscriptPosition);
+impl_display_t!(SubscriptPosition);
 
 /// A window specification (i.e. `OVER (PARTITION BY .. ORDER BY .. etc.)`)
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct WindowSpec {
-    pub partition_by: Vec<Expr>,
-    pub order_by: Vec<OrderByExpr>,
+pub struct WindowSpec<T: AstInfo> {
+    pub partition_by: Vec<Expr<T>>,
+    pub order_by: Vec<OrderByExpr<T>>,
     pub window_frame: Option<WindowFrame>,
 }
 
-impl AstDisplay for WindowSpec {
+impl<T: AstInfo> AstDisplay for WindowSpec<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         let mut delim = "";
         if !self.partition_by.is_empty() {
@@ -575,7 +581,7 @@ impl AstDisplay for WindowSpec {
         }
     }
 }
-impl_display!(WindowSpec);
+impl_display_t!(WindowSpec);
 
 /// Specifies the data processed by a window function, e.g.
 /// `RANGE UNBOUNDED PRECEDING` or `ROWS BETWEEN 5 PRECEDING AND CURRENT ROW`.
@@ -643,17 +649,17 @@ impl_display!(WindowFrameBound);
 
 /// A function call
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Function {
+pub struct Function<T: AstInfo> {
     pub name: ObjectName,
-    pub args: FunctionArgs,
+    pub args: FunctionArgs<T>,
     // aggregate functions may specify e.g. `COUNT(DISTINCT X) FILTER (WHERE ...)`
-    pub filter: Option<Box<Expr>>,
-    pub over: Option<WindowSpec>,
+    pub filter: Option<Box<Expr<T>>>,
+    pub over: Option<WindowSpec<T>>,
     // aggregate functions may specify eg `COUNT(DISTINCT x)`
     pub distinct: bool,
 }
 
-impl AstDisplay for Function {
+impl<T: AstInfo> AstDisplay for Function<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_node(&self.name);
         f.write_str("(");
@@ -674,18 +680,18 @@ impl AstDisplay for Function {
         }
     }
 }
-impl_display!(Function);
+impl_display_t!(Function);
 
 /// Arguments for a function call.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FunctionArgs {
+pub enum FunctionArgs<T: AstInfo> {
     /// The special star argument, as in `count(*)`.
     Star,
     /// A normal list of arguments.
-    Args(Vec<Expr>),
+    Args(Vec<Expr<T>>),
 }
 
-impl AstDisplay for FunctionArgs {
+impl<T: AstInfo> AstDisplay for FunctionArgs<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             FunctionArgs::Star => f.write_str("*"),
@@ -693,4 +699,4 @@ impl AstDisplay for FunctionArgs {
         }
     }
 }
-impl_display!(FunctionArgs);
+impl_display_t!(FunctionArgs);

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -26,7 +26,7 @@ use std::hash::Hash;
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{Expr, FunctionArgs, Ident, ObjectName, SqlOption};
 
-pub trait AstInfo {
+pub trait AstInfo: Clone {
     type Table: AstDisplay + Clone + Hash + Debug + Eq;
 }
 

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -20,27 +20,41 @@
 
 use std::mem;
 
+use std::fmt::Debug;
+use std::hash::Hash;
+
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{Expr, FunctionArgs, Ident, ObjectName, SqlOption};
+
+pub trait AstInfo {
+    type Table: AstDisplay + Clone + Hash + Debug + Eq;
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Default)]
+pub struct Raw;
+
+impl AstInfo for Raw {
+    type Table = ObjectName;
+}
 
 /// The most complete variant of a `SELECT` query expression, optionally
 /// including `WITH`, `UNION` / other set operations, and `ORDER BY`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Query {
+pub struct Query<T: AstInfo> {
     /// WITH (common table expressions, or CTEs)
-    pub ctes: Vec<Cte>,
+    pub ctes: Vec<Cte<T>>,
     /// SELECT or UNION / EXCEPT / INTECEPT
-    pub body: SetExpr,
+    pub body: SetExpr<T>,
     /// ORDER BY
-    pub order_by: Vec<OrderByExpr>,
+    pub order_by: Vec<OrderByExpr<T>>,
     /// `LIMIT { <N> | ALL }`
     /// `FETCH { FIRST | NEXT } <N> { ROW | ROWS } | { ONLY | WITH TIES }`
-    pub limit: Option<Limit>,
+    pub limit: Option<Limit<T>>,
     /// `OFFSET <N> { ROW | ROWS }`
-    pub offset: Option<Expr>,
+    pub offset: Option<Expr<T>>,
 }
 
-impl AstDisplay for Query {
+impl<T: AstInfo> AstDisplay for Query<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         if !self.ctes.is_empty() {
             f.write_str("WITH ");
@@ -76,10 +90,10 @@ impl AstDisplay for Query {
         }
     }
 }
-impl_display!(Query);
+impl_display_t!(Query);
 
-impl Query {
-    pub fn select(select: Select) -> Query {
+impl<T: AstInfo> Query<T> {
+    pub fn select(select: Select<T>) -> Query<T> {
         Query {
             ctes: vec![],
             body: SetExpr::Select(Box::new(select)),
@@ -89,10 +103,10 @@ impl Query {
         }
     }
 
-    pub fn take(&mut self) -> Query {
+    pub fn take(&mut self) -> Query<T> {
         mem::replace(
             self,
-            Query {
+            Query::<T> {
                 ctes: vec![],
                 order_by: vec![],
                 body: SetExpr::Values(Values(vec![])),
@@ -106,24 +120,24 @@ impl Query {
 /// A node in a tree, representing a "query body" expression, roughly:
 /// `SELECT ... [ {UNION|EXCEPT|INTERSECT} SELECT ...]`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SetExpr {
+pub enum SetExpr<T: AstInfo> {
     /// Restricted SELECT .. FROM .. HAVING (no ORDER BY or set operations)
-    Select(Box<Select>),
+    Select(Box<Select<T>>),
     /// Parenthesized SELECT subquery, which may include more set operations
     /// in its body and an optional ORDER BY / LIMIT.
-    Query(Box<Query>),
+    Query(Box<Query<T>>),
     /// UNION/EXCEPT/INTERSECT of two queries
     SetOperation {
         op: SetOperator,
         all: bool,
-        left: Box<SetExpr>,
-        right: Box<SetExpr>,
+        left: Box<SetExpr<T>>,
+        right: Box<SetExpr<T>>,
     },
-    Values(Values),
+    Values(Values<T>),
     // TODO: ANSI SQL supports `TABLE` here.
 }
 
-impl AstDisplay for SetExpr {
+impl<T: AstInfo> AstDisplay for SetExpr<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             SetExpr::Select(s) => f.write_node(s),
@@ -151,7 +165,7 @@ impl AstDisplay for SetExpr {
         }
     }
 }
-impl_display!(SetExpr);
+impl_display_t!(SetExpr);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SetOperator {
@@ -175,23 +189,23 @@ impl_display!(SetOperator);
 /// appear either as the only body item of an `SQLQuery`, or as an operand
 /// to a set operation like `UNION`.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
-pub struct Select {
-    pub distinct: Option<Distinct>,
+pub struct Select<T: AstInfo> {
+    pub distinct: Option<Distinct<T>>,
     /// projection expressions
-    pub projection: Vec<SelectItem>,
+    pub projection: Vec<SelectItem<T>>,
     /// FROM
-    pub from: Vec<TableWithJoins>,
+    pub from: Vec<TableWithJoins<T>>,
     /// WHERE
-    pub selection: Option<Expr>,
+    pub selection: Option<Expr<T>>,
     /// GROUP BY
-    pub group_by: Vec<Expr>,
+    pub group_by: Vec<Expr<T>>,
     /// HAVING
-    pub having: Option<Expr>,
+    pub having: Option<Expr<T>>,
     /// OPTION
     pub options: Vec<SqlOption>,
 }
 
-impl AstDisplay for Select {
+impl<T: AstInfo> AstDisplay for Select<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_str("SELECT");
         if let Some(distinct) = &self.distinct {
@@ -225,33 +239,33 @@ impl AstDisplay for Select {
         }
     }
 }
-impl_display!(Select);
+impl_display_t!(Select);
 
-impl Select {
-    pub fn from(mut self, twj: TableWithJoins) -> Select {
+impl<T: AstInfo> Select<T> {
+    pub fn from(mut self, twj: TableWithJoins<T>) -> Select<T> {
         self.from.push(twj);
         self
     }
 
-    pub fn project(mut self, select_item: SelectItem) -> Select {
+    pub fn project(mut self, select_item: SelectItem<T>) -> Select<T> {
         self.projection.push(select_item);
         self
     }
 
-    pub fn selection(mut self, selection: Option<Expr>) -> Select {
+    pub fn selection(mut self, selection: Option<Expr<T>>) -> Select<T> {
         self.selection = selection;
         self
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Distinct {
+pub enum Distinct<T: AstInfo> {
     EntireRow,
-    On(Vec<Expr>),
+    On(Vec<Expr<T>>),
 }
-impl_display!(Distinct);
+impl_display_t!(Distinct);
 
-impl AstDisplay for Distinct {
+impl<T: AstInfo> AstDisplay for Distinct<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             Distinct::EntireRow => f.write_str("DISTINCT"),
@@ -269,12 +283,12 @@ impl AstDisplay for Distinct {
 /// of the columns returned by the query. The parser does not validate that the
 /// number of columns in the query matches the number of columns in the query.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Cte {
+pub struct Cte<T: AstInfo> {
     pub alias: TableAlias,
-    pub query: Query,
+    pub query: Query<T>,
 }
 
-impl AstDisplay for Cte {
+impl<T: AstInfo> AstDisplay for Cte<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_node(&self.alias);
         f.write_str(" AS (");
@@ -282,18 +296,18 @@ impl AstDisplay for Cte {
         f.write_str(")");
     }
 }
-impl_display!(Cte);
+impl_display_t!(Cte);
 
 /// One item of the comma-separated list following `SELECT`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SelectItem {
+pub enum SelectItem<T: AstInfo> {
     /// An expression, optionally followed by `[ AS ] alias`.
-    Expr { expr: Expr, alias: Option<Ident> },
+    Expr { expr: Expr<T>, alias: Option<Ident> },
     /// An unqualified `*`.
     Wildcard,
 }
 
-impl AstDisplay for SelectItem {
+impl<T: AstInfo> AstDisplay for SelectItem<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match &self {
             SelectItem::Expr { expr, alias } => {
@@ -307,15 +321,15 @@ impl AstDisplay for SelectItem {
         }
     }
 }
-impl_display!(SelectItem);
+impl_display_t!(SelectItem);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TableWithJoins {
-    pub relation: TableFactor,
-    pub joins: Vec<Join>,
+pub struct TableWithJoins<T: AstInfo> {
+    pub relation: TableFactor<T>,
+    pub joins: Vec<Join<T>>,
 }
 
-impl AstDisplay for TableWithJoins {
+impl<T: AstInfo> AstDisplay for TableWithJoins<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_node(&self.relation);
         for join in &self.joins {
@@ -323,10 +337,10 @@ impl AstDisplay for TableWithJoins {
         }
     }
 }
-impl_display!(TableWithJoins);
+impl_display_t!(TableWithJoins);
 
-impl TableWithJoins {
-    pub fn subquery(query: Query, alias: TableAlias) -> TableWithJoins {
+impl<T: AstInfo> TableWithJoins<T> {
+    pub fn subquery(query: Query<T>, alias: TableAlias) -> TableWithJoins<T> {
         TableWithJoins {
             relation: TableFactor::Derived {
                 lateral: false,
@@ -340,19 +354,19 @@ impl TableWithJoins {
 
 /// A table name or a parenthesized subquery with an optional alias
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum TableFactor {
+pub enum TableFactor<T: AstInfo> {
     Table {
-        name: ObjectName,
+        name: T::Table,
         alias: Option<TableAlias>,
     },
     Function {
         name: ObjectName,
-        args: FunctionArgs,
+        args: FunctionArgs<T>,
         alias: Option<TableAlias>,
     },
     Derived {
         lateral: bool,
-        subquery: Box<Query>,
+        subquery: Box<Query<T>>,
         alias: Option<TableAlias>,
     },
     /// Represents a parenthesized join expression, such as
@@ -360,12 +374,12 @@ pub enum TableFactor {
     /// The inner `TableWithJoins` can have no joins only if its
     /// `relation` is itself a `TableFactor::NestedJoin`.
     NestedJoin {
-        join: Box<TableWithJoins>,
+        join: Box<TableWithJoins<T>>,
         alias: Option<TableAlias>,
     },
 }
 
-impl AstDisplay for TableFactor {
+impl<T: AstInfo> AstDisplay for TableFactor<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             TableFactor::Table { name, alias } => {
@@ -413,7 +427,7 @@ impl AstDisplay for TableFactor {
         }
     }
 }
-impl_display!(TableFactor);
+impl_display_t!(TableFactor);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TableAlias {
@@ -440,22 +454,22 @@ impl AstDisplay for TableAlias {
 impl_display!(TableAlias);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Join {
-    pub relation: TableFactor,
-    pub join_operator: JoinOperator,
+pub struct Join<T: AstInfo> {
+    pub relation: TableFactor<T>,
+    pub join_operator: JoinOperator<T>,
 }
 
-impl AstDisplay for Join {
+impl<T: AstInfo> AstDisplay for Join<T> {
     fn fmt(&self, f: &mut AstFormatter) {
-        fn prefix(constraint: &JoinConstraint) -> &'static str {
+        fn prefix<T: AstInfo>(constraint: &JoinConstraint<T>) -> &'static str {
             match constraint {
                 JoinConstraint::Natural => "NATURAL ",
                 _ => "",
             }
         }
-        fn suffix<'a>(constraint: &'a JoinConstraint) -> impl AstDisplay + 'a {
-            struct Suffix<'a>(&'a JoinConstraint);
-            impl<'a> AstDisplay for Suffix<'a> {
+        fn suffix<'a, T: AstInfo>(constraint: &'a JoinConstraint<T>) -> impl AstDisplay + 'a {
+            struct Suffix<'a, T: AstInfo>(&'a JoinConstraint<T>);
+            impl<'a, T: AstInfo> AstDisplay for Suffix<'a, T> {
                 fn fmt(&self, f: &mut AstFormatter) {
                     match self.0 {
                         JoinConstraint::On(expr) => {
@@ -509,32 +523,32 @@ impl AstDisplay for Join {
         }
     }
 }
-impl_display!(Join);
+impl_display_t!(Join);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum JoinOperator {
-    Inner(JoinConstraint),
-    LeftOuter(JoinConstraint),
-    RightOuter(JoinConstraint),
-    FullOuter(JoinConstraint),
+pub enum JoinOperator<T: AstInfo> {
+    Inner(JoinConstraint<T>),
+    LeftOuter(JoinConstraint<T>),
+    RightOuter(JoinConstraint<T>),
+    FullOuter(JoinConstraint<T>),
     CrossJoin,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum JoinConstraint {
-    On(Expr),
+pub enum JoinConstraint<T: AstInfo> {
+    On(Expr<T>),
     Using(Vec<Ident>),
     Natural,
 }
 
 /// SQL ORDER BY expression
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct OrderByExpr {
-    pub expr: Expr,
+pub struct OrderByExpr<T: AstInfo> {
+    pub expr: Expr<T>,
     pub asc: Option<bool>,
 }
 
-impl AstDisplay for OrderByExpr {
+impl<T: AstInfo> AstDisplay for OrderByExpr<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_node(&self.expr);
         match self.asc {
@@ -544,18 +558,18 @@ impl AstDisplay for OrderByExpr {
         }
     }
 }
-impl_display!(OrderByExpr);
+impl_display_t!(OrderByExpr);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Limit {
+pub struct Limit<T: AstInfo> {
     pub with_ties: bool,
-    pub quantity: Expr,
+    pub quantity: Expr<T>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Values(pub Vec<Vec<Expr>>);
+pub struct Values<T: AstInfo>(pub Vec<Vec<Expr<T>>>);
 
-impl AstDisplay for Values {
+impl<T: AstInfo> AstDisplay for Values<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_str("VALUES ");
         let mut delim = "";
@@ -568,4 +582,4 @@ impl AstDisplay for Values {
         }
     }
 }
-impl_display!(Values);
+impl_display_t!(Values);

--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -127,6 +127,16 @@ macro_rules! impl_display {
     };
 }
 
+macro_rules! impl_display_t {
+    ($name:ident) => {
+        impl<T: AstInfo> std::fmt::Display for $name<T> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str(self.to_ast_string().as_str())
+            }
+        }
+    };
+}
+
 impl<T: AstDisplay> AstDisplay for &Box<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         (*self).fmt(f);

--- a/src/sql-parser/src/ast/visit_mut.rs
+++ b/src/sql-parser/src/ast/visit_mut.rs
@@ -25,25 +25,25 @@
 //! by invoking the right visitor method of each of its fields.
 //!
 //! ```
-//! # use sql_parser::ast::{Expr, Function, FunctionArgs, ObjectName, WindowSpec};
+//! # use sql_parser::ast::{Expr, Function, FunctionArgs, ObjectName, WindowSpec, AstInfo};
 //! #
-//! pub trait VisitMut<'ast> {
+//! pub trait VisitMut<'ast, T: AstInfo> {
 //!     /* ... */
 //!
-//!     fn visit_function_mut(&mut self, node: &'ast mut Function) {
+//!     fn visit_function_mut(&mut self, node: &'ast mut Function<T>) {
 //!         visit_function_mut(self, node);
 //!     }
 //!
 //!     /* ... */
 //!     # fn visit_object_name_mut(&mut self, node: &'ast mut ObjectName);
-//!     # fn visit_function_args_mut(&mut self, node: &'ast mut FunctionArgs);
-//!     # fn visit_expr_mut(&mut self, node: &'ast mut Expr);
-//!     # fn visit_window_spec_mut(&mut self, node: &'ast mut WindowSpec);
+//!     # fn visit_function_args_mut(&mut self, node: &'ast mut FunctionArgs<T>);
+//!     # fn visit_expr_mut(&mut self, node: &'ast mut Expr<T>);
+//!     # fn visit_window_spec_mut(&mut self, node: &'ast mut WindowSpec<T>);
 //! }
 //!
-//! pub fn visit_function_mut<'ast, V>(visitor: &mut V, node: &'ast mut Function)
+//! pub fn visit_function_mut<'ast, V, T: AstInfo>(visitor: &mut V, node: &'ast mut Function<T>)
 //! where
-//!     V: VisitMut<'ast> + ?Sized,
+//!     V: VisitMut<'ast, T> + ?Sized,
 //! {
 //!     visitor.visit_object_name_mut(&mut node.name);
 //!     visitor.visit_function_args_mut(&mut node.args);
@@ -65,13 +65,13 @@
 //! ```
 //! use std::error::Error;
 //!
-//! use sql_parser::ast::Expr;
+//! use sql_parser::ast::{AstInfo, Expr};
 //! use sql_parser::ast::visit_mut::{self, VisitMut};
 //!
 //! struct RemoveParens;
 //!
-//! impl<'a> VisitMut<'a> for RemoveParens {
-//!     fn visit_expr_mut(&mut self, expr: &'a mut Expr) {
+//! impl<'a, T: AstInfo> VisitMut<'a, T> for RemoveParens {
+//!     fn visit_expr_mut(&mut self, expr: &'a mut Expr<T>) {
 //!         visit_mut::visit_expr_mut(self, expr);
 //!         if let Expr::Nested(e) = expr {
 //!             *expr = (**e).clone();

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -27,7 +27,7 @@ use ore::fmt::FormatBuffer;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit::Visit;
 use sql_parser::ast::visit_mut::{self, VisitMut};
-use sql_parser::ast::{Expr, Ident};
+use sql_parser::ast::{Expr, Ident, Raw};
 use sql_parser::parser::{self, ParserError};
 
 #[test]
@@ -102,8 +102,8 @@ fn datadriven() {
 fn op_precedence() -> Result<(), Box<dyn Error>> {
     struct RemoveParens;
 
-    impl<'a> VisitMut<'a> for RemoveParens {
-        fn visit_expr_mut(&mut self, expr: &'a mut Expr) {
+    impl<'a> VisitMut<'a, Raw> for RemoveParens {
+        fn visit_expr_mut(&mut self, expr: &'a mut Expr<Raw>) {
             if let Expr::Nested(e) = expr {
                 *expr = (**e).clone();
             }
@@ -174,7 +174,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         seen_idents: Vec<&'a str>,
     }
 
-    impl<'a> Visit<'a> for Visitor<'a> {
+    impl<'a> Visit<'a, Raw> for Visitor<'a> {
         fn visit_ident(&mut self, ident: &'a Ident) {
             self.seen_idents.push(ident.as_str());
         }

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -27,7 +27,7 @@ use ore::fmt::FormatBuffer;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit::Visit;
 use sql_parser::ast::visit_mut::{self, VisitMut};
-use sql_parser::ast::{Expr, Ident, Raw};
+use sql_parser::ast::{AstInfo, Expr, Ident, Raw};
 use sql_parser::parser::{self, ParserError};
 
 #[test]
@@ -177,6 +177,11 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
     impl<'a> Visit<'a, Raw> for Visitor<'a> {
         fn visit_ident(&mut self, ident: &'a Ident) {
             self.seen_idents.push(ident.as_str());
+        }
+        fn visit_table(&mut self, name: &'a <Raw as AstInfo>::Table) {
+            for ident in &name.0 {
+                self.seen_idents.push(ident.as_str());
+            }
         }
     }
 

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -14,8 +14,8 @@ use std::collections::{HashMap, HashSet};
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
 use crate::ast::{
-    CreateIndexStatement, CreateSinkStatement, CreateSourceStatement, CreateTableStatement,
-    CreateViewStatement, Expr, Ident, ObjectName, Query, Raw, Statement,
+    AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
+    CreateTableStatement, CreateViewStatement, Expr, Ident, ObjectName, Query, Raw, Statement,
 };
 use crate::names::FullName;
 
@@ -239,6 +239,10 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
             }
         }
     }
+
+    fn visit_table(&mut self, table: &'ast <Raw as AstInfo>::Table) {
+        self.visit_object_name(table);
+    }
 }
 
 struct CreateSqlRewriter {
@@ -291,5 +295,8 @@ impl<'ast> VisitMut<'ast, Raw> for CreateSqlRewriter {
     }
     fn visit_object_name_mut(&mut self, object_name: &'ast mut ObjectName) {
         self.maybe_rewrite_idents(&mut object_name.0);
+    }
+    fn visit_table_mut(&mut self, table_name: &'ast mut <sql_parser::ast::Raw as AstInfo>::Table) {
+        self.maybe_rewrite_idents(&mut table_name.0);
     }
 }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -19,7 +19,7 @@ use std::{error::Error, unimplemented};
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use expr::{DummyHumanizer, ExprHumanizer, GlobalId, ScalarExpr};
 use repr::{ColumnType, RelationDesc, ScalarType};
-use sql_parser::ast::Expr;
+use sql_parser::ast::{Expr, Raw};
 use uuid::Uuid;
 
 use crate::names::{FullName, PartialName, SchemaName};
@@ -206,7 +206,7 @@ pub trait CatalogItem {
 
     /// Returns the column defaults associated with the catalog item, if the
     /// catalog item is a table.
-    fn table_details(&self) -> Option<&[Expr]>;
+    fn table_details(&self) -> Option<&[Expr<Raw>]>;
 }
 
 /// The type of a [`CatalogItem`].

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -13,9 +13,9 @@ use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
-    CreateIndexStatement, CreateSinkStatement, CreateSourceStatement, CreateTableStatement,
-    CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior,
-    ObjectName, Query, Raw, SqlOption, Statement, TableFactor, Value,
+    AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
+    CreateTableStatement, CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident,
+    IfExistsBehavior, ObjectName, Query, Raw, SqlOption, Statement, TableFactor, Value,
 };
 
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
@@ -193,6 +193,10 @@ pub fn create_statement(
                 Ok(full_name) => *object_name = unresolve(full_name.name().clone()),
                 Err(e) => self.err = Some(e),
             };
+        }
+
+        fn visit_table_mut(&mut self, table: &'ast mut <Raw as AstInfo>::Table) {
+            self.visit_object_name_mut(table);
         }
     }
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -15,7 +15,7 @@ use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
     CreateIndexStatement, CreateSinkStatement, CreateSourceStatement, CreateTableStatement,
     CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior,
-    ObjectName, Query, SqlOption, Statement, TableFactor, Value,
+    ObjectName, Query, Raw, SqlOption, Statement, TableFactor, Value,
 };
 
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
@@ -88,7 +88,10 @@ pub fn unresolve(name: FullName) -> ObjectName {
 /// The goal is to construct a backwards-compatible description of the object.
 /// SQL is the most stable part of Materialize, so SQL is used to describe the
 /// objects that are persisted in the catalog.
-pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<String, PlanError> {
+pub fn create_statement(
+    scx: &StatementContext,
+    mut stmt: Statement<Raw>,
+) -> Result<String, PlanError> {
     let allocate_name = |name: &ObjectName| -> Result<_, PlanError> {
         Ok(unresolve(scx.allocate_name(object_name(name.clone())?)))
     };
@@ -120,8 +123,8 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
         }
     }
 
-    impl<'a, 'ast> VisitMut<'ast> for QueryNormalizer<'a> {
-        fn visit_query_mut(&mut self, query: &'ast mut Query) {
+    impl<'a, 'ast> VisitMut<'ast, Raw> for QueryNormalizer<'a> {
+        fn visit_query_mut(&mut self, query: &'ast mut Query<Raw>) {
             let n = self.ctes.len();
             for cte in &query.ctes {
                 self.ctes.push(cte.alias.name.clone());
@@ -130,7 +133,7 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
             self.ctes.truncate(n);
         }
 
-        fn visit_function_mut(&mut self, func: &'ast mut Function) {
+        fn visit_function_mut(&mut self, func: &'ast mut Function<Raw>) {
             // Don't visit the function name, because function names are not
             // (yet) object names we can resolve.
             match &mut func.args {
@@ -146,7 +149,7 @@ pub fn create_statement(scx: &StatementContext, mut stmt: Statement) -> Result<S
             }
         }
 
-        fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor) {
+        fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Raw>) {
             match table_factor {
                 TableFactor::Table { name, alias } => {
                     self.visit_object_name_mut(name);

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -34,9 +34,8 @@ use serde::{Deserialize, Serialize};
 use ::expr::{GlobalId, RowSetFinishing};
 use dataflow_types::{SinkConnectorBuilder, SourceConnector};
 use repr::{ColumnName, RelationDesc, Row, ScalarType, Timestamp};
-use sql_parser::ast::Expr;
 
-use crate::ast::{ExplainOptions, ExplainStage, FetchDirection, ObjectType, Statement};
+use crate::ast::{ExplainOptions, ExplainStage, Expr, FetchDirection, ObjectType, Raw, Statement};
 use crate::names::{DatabaseSpecifier, FullName, SchemaName};
 
 pub(crate) mod decorrelate;
@@ -169,7 +168,7 @@ pub enum Plan {
     AlterIndexLogicalCompactionWindow(Option<AlterIndexLogicalCompactionWindow>),
     Declare {
         name: String,
-        stmt: Statement,
+        stmt: Statement<Raw>,
     },
     Fetch {
         name: String,
@@ -185,7 +184,7 @@ pub enum Plan {
 pub struct Table {
     pub create_sql: String,
     pub desc: RelationDesc,
-    pub defaults: Vec<Expr>,
+    pub defaults: Vec<Expr<Raw>>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -22,7 +22,7 @@ use lazy_static::lazy_static;
 
 use ore::collections::CollectionExt;
 use repr::{ColumnName, Datum, RelationType, ScalarBaseType, ScalarType};
-use sql_parser::ast::{Expr, ObjectName};
+use sql_parser::ast::{Expr, ObjectName, Raw};
 
 use super::expr::{
     AggregateFunc, BinaryFunc, CoercibleScalarExpr, NullaryFunc, ScalarExpr, TableFunc, UnaryFunc,
@@ -242,7 +242,7 @@ impl<R> Operation<R> {
 macro_rules! sql_op {
     ($l:literal) => {{
         lazy_static! {
-            static ref EXPR: Expr = sql_parser::parser::parse_expr($l.into())
+            static ref EXPR: Expr<Raw> = sql_parser::parser::parse_expr($l.into())
                 .expect("static function definition failed to parse");
         }
         Operation::variadic(move |ecx, args| {

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -48,6 +48,7 @@ use repr::ColumnName;
 use crate::names::PartialName;
 use crate::plan::error::PlanError;
 use crate::plan::expr::ColumnRef;
+use sql_parser::ast::Raw;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScopeItemName {
@@ -86,7 +87,7 @@ pub struct ScopeItem {
     // table must appear before names that specify non-canonical tables.
     // This impacts the behavior of the `is_from_table` test.
     pub names: Vec<ScopeItemName>,
-    pub expr: Option<sql_parser::ast::Expr>,
+    pub expr: Option<sql_parser::ast::Expr<Raw>>,
     // Whether this item is actually resolveable by its name. Non-nameable scope
     // items are used e.g. in the scope created by an inner join, so that the
     // duplicated key columns from the right relation do not cause ambiguous
@@ -273,7 +274,7 @@ impl Scope {
 
     /// Look to see if there is an already-calculated instance of this expr.
     /// Failing to find one is not an error, so this just returns Option
-    pub fn resolve_expr<'a>(&'a self, expr: &sql_parser::ast::Expr) -> Option<ColumnRef> {
+    pub fn resolve_expr<'a>(&'a self, expr: &sql_parser::ast::Expr<Raw>) -> Option<ColumnRef> {
         self.items
             .iter()
             .enumerate()

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -20,7 +20,7 @@ use anyhow::bail;
 use ore::collections::CollectionExt;
 use repr::{ColumnType, RelationDesc, ScalarType};
 
-use crate::ast::{Ident, ObjectName, ObjectType, Statement};
+use crate::ast::{Ident, ObjectName, ObjectType, Raw, Statement};
 use crate::catalog::{Catalog, CatalogDatabase, CatalogItem, CatalogItemType, CatalogSchema};
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
 use crate::normalize;
@@ -88,7 +88,7 @@ impl StatementDesc {
 /// See the documentation of [`StatementDesc`] for details.
 pub fn describe(
     catalog: &dyn Catalog,
-    stmt: Statement,
+    stmt: Statement<Raw>,
     param_types_in: &[Option<pgrepr::Type>],
 ) -> Result<StatementDesc, anyhow::Error> {
     let mut param_types = BTreeMap::new();
@@ -166,7 +166,7 @@ pub fn describe(
 pub fn plan(
     pcx: &PlanContext,
     catalog: &dyn Catalog,
-    stmt: Statement,
+    stmt: Statement<Raw>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let param_types = params

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -42,8 +42,8 @@ use crate::ast::{
     ColumnOption, Connector, CreateDatabaseStatement, CreateIndexStatement, CreateSchemaStatement,
     CreateSinkStatement, CreateSourceStatement, CreateTableStatement, CreateTypeAs,
     CreateTypeStatement, CreateViewStatement, DataType, DropDatabaseStatement,
-    DropObjectsStatement, Expr, Format, Ident, IfExistsBehavior, ObjectName, ObjectType, SqlOption,
-    Statement, Value,
+    DropObjectsStatement, Expr, Format, Ident, IfExistsBehavior, ObjectName, ObjectType, Raw,
+    SqlOption, Statement, Value,
 };
 use crate::catalog::{CatalogItem, CatalogItemType};
 use crate::kafka_util;
@@ -113,14 +113,14 @@ pub fn plan_create_schema(
 
 pub fn describe_create_table(
     _: &StatementContext,
-    _: CreateTableStatement,
+    _: CreateTableStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_create_table(
     scx: &StatementContext,
-    stmt: CreateTableStatement,
+    stmt: CreateTableStatement<Raw>,
 ) -> Result<Plan, anyhow::Error> {
     let CreateTableStatement {
         name,
@@ -684,14 +684,14 @@ pub fn plan_create_source(
 
 pub fn describe_create_view(
     _: &StatementContext,
-    _: CreateViewStatement,
+    _: CreateViewStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_create_view(
     scx: &StatementContext,
-    mut stmt: CreateViewStatement,
+    mut stmt: CreateViewStatement<Raw>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let create_sql = normalize::create_statement(scx, Statement::CreateView(stmt.clone()))?;
@@ -845,14 +845,14 @@ fn avro_ocf_sink_builder(
 
 pub fn describe_create_sink(
     _: &StatementContext,
-    _: CreateSinkStatement,
+    _: CreateSinkStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_create_sink(
     scx: &StatementContext,
-    stmt: CreateSinkStatement,
+    stmt: CreateSinkStatement<Raw>,
 ) -> Result<Plan, anyhow::Error> {
     let create_sql = normalize::create_statement(scx, Statement::CreateSink(stmt.clone()))?;
     let CreateSinkStatement {
@@ -949,14 +949,14 @@ pub fn plan_create_sink(
 
 pub fn describe_create_index(
     _: &StatementContext,
-    _: CreateIndexStatement,
+    _: CreateIndexStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_create_index(
     scx: &StatementContext,
-    mut stmt: CreateIndexStatement,
+    mut stmt: CreateIndexStatement<Raw>,
 ) -> Result<Plan, anyhow::Error> {
     let CreateIndexStatement {
         name,

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -22,8 +22,8 @@ use repr::{RelationDesc, ScalarType};
 
 use crate::ast::{
     CopyDirection, CopyRelation, CopyStatement, CopyTarget, CreateViewStatement, DeleteStatement,
-    ExplainStage, ExplainStatement, Explainee, InsertStatement, Query, SelectStatement, Statement,
-    TailStatement, UpdateStatement,
+    ExplainStage, ExplainStatement, Explainee, InsertStatement, Query, Raw, SelectStatement,
+    Statement, TailStatement, UpdateStatement,
 };
 use crate::catalog::CatalogItemType;
 use crate::plan::query;
@@ -44,7 +44,7 @@ pub fn describe_insert(
         columns,
         source,
         ..
-    }: InsertStatement,
+    }: InsertStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     query::plan_insert_query(scx, table_name, columns, source)?;
     Ok(StatementDesc::new(None))
@@ -56,7 +56,7 @@ pub fn plan_insert(
         table_name,
         columns,
         source,
-    }: InsertStatement,
+    }: InsertStatement<Raw>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let (id, mut expr) = query::plan_insert_query(scx, table_name, columns, source)?;
@@ -68,14 +68,14 @@ pub fn plan_insert(
 
 pub fn describe_update(
     _: &StatementContext,
-    _: UpdateStatement,
+    _: UpdateStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     unsupported!("UPDATE statements")
 }
 
 pub fn plan_update(
     _: &StatementContext,
-    _: UpdateStatement,
+    _: UpdateStatement<Raw>,
     _: &Params,
 ) -> Result<Plan, anyhow::Error> {
     unsupported!("UPDATE statements")
@@ -83,14 +83,14 @@ pub fn plan_update(
 
 pub fn describe_delete(
     _: &StatementContext,
-    _: DeleteStatement,
+    _: DeleteStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     unsupported!("DELETE statements")
 }
 
 pub fn plan_delete(
     _: &StatementContext,
-    _: DeleteStatement,
+    _: DeleteStatement<Raw>,
     _: &Params,
 ) -> Result<Plan, anyhow::Error> {
     unsupported!("DELETE statements")
@@ -98,7 +98,7 @@ pub fn plan_delete(
 
 pub fn describe_select(
     scx: &StatementContext,
-    SelectStatement { query, .. }: SelectStatement,
+    SelectStatement { query, .. }: SelectStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     let (_relation_expr, desc, _finishing) =
         query::plan_root_query(scx, query, QueryLifetime::OneShot)?;
@@ -107,7 +107,7 @@ pub fn describe_select(
 
 pub fn plan_select(
     scx: &StatementContext,
-    SelectStatement { query, as_of }: SelectStatement,
+    SelectStatement { query, as_of }: SelectStatement<Raw>,
     params: &Params,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, anyhow::Error> {
@@ -129,7 +129,7 @@ pub fn describe_explain(
     scx: &StatementContext,
     ExplainStatement {
         stage, explainee, ..
-    }: ExplainStatement,
+    }: ExplainStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(RelationDesc::empty().with_column(
         match stage {
@@ -160,7 +160,7 @@ pub fn plan_explain(
         stage,
         explainee,
         options,
-    }: ExplainStatement,
+    }: ExplainStatement<Raw>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let is_view = matches!(explainee, Explainee::View(_));
@@ -213,7 +213,7 @@ pub fn plan_explain(
 /// an `::expr::RelationExpr`, which cannot include correlated expressions.
 pub fn plan_query(
     scx: &StatementContext,
-    query: Query,
+    query: Query<Raw>,
     params: &Params,
     lifetime: QueryLifetime,
 ) -> Result<(::expr::RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
@@ -231,7 +231,7 @@ with_options! {
 
 pub fn describe_tail(
     scx: &StatementContext,
-    TailStatement { name, options, .. }: TailStatement,
+    TailStatement { name, options, .. }: TailStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     let sql_object = scx.resolve_item(name)?;
     let options = TailOptions::try_from(options)?;
@@ -255,7 +255,7 @@ pub fn plan_tail(
         name,
         options,
         as_of,
-    }: TailStatement,
+    }: TailStatement<Raw>,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, anyhow::Error> {
     let entry = scx.resolve_item(name)?;
@@ -289,7 +289,7 @@ with_options! {
 
 pub fn describe_copy(
     scx: &StatementContext,
-    CopyStatement { relation, .. }: CopyStatement,
+    CopyStatement { relation, .. }: CopyStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(match relation {
         CopyRelation::Table { .. } => bail!("unsupported COPY relation {:?}", relation),
@@ -306,7 +306,7 @@ pub fn plan_copy(
         direction,
         target,
         options,
-    }: CopyStatement,
+    }: CopyStatement<Raw>,
 ) -> Result<Plan, anyhow::Error> {
     let options = CopyOptions::try_from(options)?;
     let format = if let Some(format) = options.format {

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -20,7 +20,7 @@ use repr::adt::interval::Interval;
 use repr::{RelationDesc, ScalarType};
 
 use crate::ast::{
-    CloseStatement, DeclareStatement, DiscardStatement, DiscardTarget, FetchStatement,
+    CloseStatement, DeclareStatement, DiscardStatement, DiscardTarget, FetchStatement, Raw,
     SetVariableStatement, SetVariableValue, ShowVariableStatement, Value,
 };
 use crate::plan::statement::{StatementContext, StatementDesc};
@@ -101,14 +101,14 @@ pub fn plan_discard(
 
 pub fn describe_declare(
     _: &StatementContext,
-    _: DeclareStatement,
+    _: DeclareStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_declare(
     _: &StatementContext,
-    DeclareStatement { name, stmt }: DeclareStatement,
+    DeclareStatement { name, stmt }: DeclareStatement<Raw>,
 ) -> Result<Plan, anyhow::Error> {
     Ok(Plan::Declare {
         name: name.to_string(),

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -16,7 +16,7 @@ use tokio::io::AsyncBufReadExt;
 
 use repr::strconv;
 use sql_parser::ast::{
-    AvroSchema, Connector, CreateSourceStatement, CsrSeed, Format, Ident, Statement,
+    AvroSchema, Connector, CreateSourceStatement, CsrSeed, Format, Ident, Raw, Statement,
 };
 
 use crate::kafka_util;
@@ -28,7 +28,7 @@ use crate::normalize;
 ///
 /// Note that purification is asynchronous, and may take an unboundedly long
 /// time to complete.
-pub async fn purify(mut stmt: Statement) -> Result<Statement, anyhow::Error> {
+pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::Error> {
     if let Statement::CreateSource(CreateSourceStatement {
         col_names,
         connector,

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -40,7 +40,7 @@ use repr::adt::decimal::Significand;
 use repr::{Datum, RelationDesc, RelationType, Row, RowPacker};
 use sql::ast::{
     ColumnOption, CreateTableStatement, DataType, DeleteStatement, DropObjectsStatement, Expr,
-    InsertStatement, ObjectType, Statement, TableConstraint, UpdateStatement,
+    InsertStatement, ObjectType, Raw, Statement, TableConstraint, UpdateStatement,
 };
 use sql::catalog::Catalog;
 use sql::names::FullName;
@@ -104,7 +104,7 @@ END $$;
         })
     }
 
-    pub fn can_handle(&self, stmt: &Statement) -> bool {
+    pub fn can_handle(&self, stmt: &Statement<Raw>) -> bool {
         matches!(stmt,
             Statement::CreateTable { .. }
             | Statement::DropObjects { .. }
@@ -117,7 +117,7 @@ END $$;
         &mut self,
         pcx: &PlanContext,
         catalog: &dyn Catalog,
-        stmt: &Statement,
+        stmt: &Statement<Raw>,
     ) -> Result<Plan, anyhow::Error> {
         let scx = StatementContext {
             pcx,

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -26,7 +26,7 @@ use ore::retry;
 use pgrepr::{Interval, Jsonb, Numeric};
 use sql_parser::ast::{
     CreateDatabaseStatement, CreateSchemaStatement, CreateSourceStatement, CreateTableStatement,
-    CreateViewStatement, Statement,
+    CreateViewStatement, Raw, Statement,
 };
 
 use crate::action::{Action, State};
@@ -34,7 +34,7 @@ use crate::parser::{FailSqlCommand, SqlCommand, SqlOutput};
 
 pub struct SqlAction {
     cmd: SqlCommand,
-    stmt: Statement,
+    stmt: Statement<Raw>,
     timeout: Duration,
 }
 

--- a/src/walkabout/src/ir.rs
+++ b/src/walkabout/src/ir.rs
@@ -80,6 +80,10 @@ pub enum Type {
     ///
     /// Primitive types do not need to be visited.
     Primitive,
+    /// Abstract type.
+    ///
+    /// Abstract types are required to implement `visit`.
+    Abstract(Vec<String>),
     /// An [`Option`] type..
     ///
     /// The value inside the option will need to be visited if the option is
@@ -179,7 +183,12 @@ fn analyze_type(ty: &syn::Type) -> Result<Type> {
     match ty {
         syn::Type::Path(syn::TypePath { qself: None, path }) => {
             match path.segments.len() {
-                2 => Ok(Type::Primitive),
+                2 => Ok(Type::Abstract(
+                    path.segments
+                        .iter()
+                        .map(|s| s.ident.to_string())
+                        .collect::<Vec<String>>(),
+                )),
                 1 => {
                     let segment = path.segments.last().unwrap();
                     let segment_name = segment.ident.to_string();
@@ -231,7 +240,7 @@ fn analyze_type(ty: &syn::Type) -> Result<Type> {
                 }
                 _ => {
                     bail!(
-                        "Unable to analyze type path with more than one component: '{}'",
+                        "Unable to analyze type path with more than two components: '{}'",
                         path.into_token_stream()
                     )
                 }

--- a/src/walkabout/src/ir.rs
+++ b/src/walkabout/src/ir.rs
@@ -178,57 +178,63 @@ fn analyze_fields(fields: &syn::Fields) -> Result<Vec<Field>> {
 fn analyze_type(ty: &syn::Type) -> Result<Type> {
     match ty {
         syn::Type::Path(syn::TypePath { qself: None, path }) => {
-            if path.segments.len() != 1 {
-                bail!(
-                    "Unable to analyze type path with more than one component: '{}'",
-                    path.into_token_stream()
-                );
-            }
-            let segment = path.segments.last().unwrap();
-            let segment_name = segment.ident.to_string();
+            match path.segments.len() {
+                2 => Ok(Type::Primitive),
+                1 => {
+                    let segment = path.segments.last().unwrap();
+                    let segment_name = segment.ident.to_string();
 
-            let container = |construct_ty: fn(Box<Type>) -> Type| match &segment.arguments {
-                syn::PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
-                    match args.args.last().unwrap() {
-                        syn::GenericArgument::Type(ty) => {
-                            let inner = Box::new(analyze_type(ty)?);
-                            Ok(construct_ty(inner))
+                    let container = |construct_ty: fn(Box<Type>) -> Type| {
+                        match &segment.arguments {
+                    syn::PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                        match args.args.last().unwrap() {
+                            syn::GenericArgument::Type(ty) => {
+                                let inner = Box::new(analyze_type(ty)?);
+                                Ok(construct_ty(inner))
+                            }
+                            _ => bail!("Container type argument is not a basic (i.e., non-lifetime, non-constraint) type argument: {}", ty.into_token_stream()),
                         }
-                        _ => bail!("Container type argument is not a basic (i.e., non-lifetime, non-constraint) type argument: {}", ty.into_token_stream()),
                     }
+                    syn::PathArguments::AngleBracketed(_) => bail!(
+                        "Container type does not have exactly one type argument: {}",
+                        ty.into_token_stream()
+                    ),
+                    syn::PathArguments::Parenthesized(_) => bail!(
+                        "Container type has unexpected parenthesized type arguments: {}",
+                        ty.into_token_stream()
+                    ),
+                    syn::PathArguments::None => bail!(
+                        "Container type is missing type argument: {}",
+                        ty.into_token_stream()
+                    ),
                 }
-                syn::PathArguments::AngleBracketed(_) => bail!(
-                    "Container type does not have exactly one type argument: {}",
-                    ty.into_token_stream()
-                ),
-                syn::PathArguments::Parenthesized(_) => bail!(
-                    "Container type has unexpected parenthesized type arguments: {}",
-                    ty.into_token_stream()
-                ),
-                syn::PathArguments::None => bail!(
-                    "Container type is missing type argument: {}",
-                    ty.into_token_stream()
-                ),
-            };
+                    };
 
-            match &*segment_name {
-                // HACK(benesch): DateTimeField is part of the sqlparser AST but
-                // comes from another crate whose source code is not easily
-                // accessible here. We probably want our own local definition of
-                // this type, but for now, just hardcode it as a primitive.
-                "bool" | "usize" | "u64" | "char" | "String" | "PathBuf" | "DateTimeField" => {
-                    match segment.arguments {
-                        syn::PathArguments::None => Ok(Type::Primitive),
-                        _ => bail!(
-                            "Primitive type had unexpected arguments: {}",
-                            ty.into_token_stream()
-                        ),
+                    match &*segment_name {
+                        // HACK(benesch): DateTimeField is part of the sqlparser AST but
+                        // comes from another crate whose source code is not easily
+                        // accessible here. We probably want our own local definition of
+                        // this type, but for now, just hardcode it as a primitive.
+                        "bool" | "usize" | "u64" | "char" | "String" | "PathBuf"
+                        | "DateTimeField" => match segment.arguments {
+                            syn::PathArguments::None => Ok(Type::Primitive),
+                            _ => bail!(
+                                "Primitive type had unexpected arguments: {}",
+                                ty.into_token_stream()
+                            ),
+                        },
+                        "Vec" => container(Type::Vec),
+                        "Option" => container(Type::Option),
+                        "Box" => container(Type::Box),
+                        _ => Ok(Type::Local(segment_name)),
                     }
                 }
-                "Vec" => container(Type::Vec),
-                "Option" => container(Type::Option),
-                "Box" => container(Type::Box),
-                _ => Ok(Type::Local(segment_name)),
+                _ => {
+                    bail!(
+                        "Unable to analyze type path with more than one component: '{}'",
+                        path.into_token_stream()
+                    )
+                }
             }
         }
         _ => bail!(

--- a/src/walkabout/tests/testdata/error
+++ b/src/walkabout/tests/testdata/error
@@ -18,7 +18,7 @@ struct Foo {
     ty: std::cell::Rc<Foo>,
 }
 ----
-error: Unable to analyze type path with more than one component: 'std :: cell :: Rc < Foo >'
+error: Unable to analyze type path with more than two components: 'std :: cell :: Rc < Foo >'
 
 visit
 struct Foo {

--- a/src/walkabout/tests/testdata/visit
+++ b/src/walkabout/tests/testdata/visit
@@ -243,7 +243,6 @@ where
     }
 }
 
-
 visit
 enum Expr<T: Foo> {
     Function(Function<T>),
@@ -318,4 +317,29 @@ where
     if let Some(v) = &node.filter {
         visitor.visit_expr(v);
     }
+}
+
+visit
+struct Function<T: Foo> {
+    t: T::TableName,
+}
+----
+pub trait Visit<'ast, T: Foo> {
+    fn visit_function(&mut self, node: &'ast Function<T>) {
+        visit_function(self, node)
+    }
+    fn visit_table_name(&mut self, node: &'ast T::TableName) {
+        visit_table_name(self, node)
+    }
+}
+pub fn visit_function<'ast, V, T: Foo>(visitor: &mut V, node: &'ast Function<T>)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
+    visitor.visit_table_name(&node.t);
+}
+pub fn visit_table_name<'ast, V, T: Foo>(visitor: &mut V, node: &'ast T::TableName)
+where
+    V: Visit<'ast, T> + ?Sized,
+{
 }


### PR DESCRIPTION
This change is the first step in teasing apart semantic analysis and the
construction of our IR. Currently these two things are interleaved,
which is fine, but makes it difficult if you want to leverage the
analysis we do without subsequently constructing a plan.

The eventual goal of this work will be to change this pipeline:

```
AST -> IR
```
to this one:
```
Raw AST -> Augmented AST -> IR
```

Where the augmented AST already has things like types checked and names
resolved.

With the design goal that it should be possible to go back to the raw
AST, or at least a stringified form, from the augmented AST, to allow
for things like safe renaming of identifiers. A secondary goal that I'm
not entirely sure is possible yet is for the augmented AST to contain
enough information such that the second step in the pipeline can be
performed without access to the catalog.

It's not entirely plumbed everywhere yet, but I wanted to get a PR out since this seems likely to conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5285)
<!-- Reviewable:end -->
