### PR TITLE
Use mysql to generate chbench snapshots for ingest benchmarking

### DIFF
--- a/demo/chbench/mysql/Dockerfile
+++ b/demo/chbench/mysql/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM mysql:5.7
+
+COPY mysql.cnf /etc/mysql/conf.d/
+COPY replication.sql /docker-entrypoint-initdb.d/

--- a/demo/chbench/mysql/mysql.cnf
+++ b/demo/chbench/mysql/mysql.cnf
@@ -1,0 +1,48 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+#datadir=/var/lib/mysql
+#socket=/var/lib/mysql/mysql.sock
+#secure-file-priv=/var/lib/mysql-files
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+#log-error=/var/log/mysqld.log
+#pid-file=/var/run/mysqld/mysqld.pid
+
+# ----------------------------------------------
+# Debezium ingest
+# ----------------------------------------------
+
+# Enable binary replication log and set the prefix, expiration, and log format.
+# The prefix is arbitrary, expiration can be short for integration tests but would
+# be longer on a production system. Row-level info is required for ingest to work.
+# Server ID is required, but this will vary on production systems
+server-id         = 223344
+log_bin           = mysql-bin
+expire_logs_days  = 1
+binlog_format     = row
+
+# ----------------------------------------------
+# Chbench specific tuning for faster writes
+# ----------------------------------------------

--- a/demo/chbench/mysql/mysql.cnf
+++ b/demo/chbench/mysql/mysql.cnf
@@ -46,3 +46,4 @@ binlog_format     = row
 # ----------------------------------------------
 # Chbench specific tuning for faster writes
 # ----------------------------------------------
+innodb_flush_log_at_trx_commit = 0

--- a/demo/chbench/mysql/mysql.cnf
+++ b/demo/chbench/mysql/mysql.cnf
@@ -1,3 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 # For advice on how to change settings please see
 # http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
 

--- a/demo/chbench/mysql/mzbuild.yml
+++ b/demo/chbench/mysql/mzbuild.yml
@@ -1,0 +1,10 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: chbench-mysql

--- a/demo/chbench/mysql/replication.sql
+++ b/demo/chbench/mysql/replication.sql
@@ -1,0 +1,14 @@
+-- Copyright Materialize, Inc. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- Enable replication, following the example from GitHub, with extra data removed
+-- https://github.com/debezium/docker-images/blob/ecf6c2c2827a77117991ecedf5e81b2ec9418f53/examples/mysql/1.5/inventory.sql
+
+GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'replicator' IDENTIFIED BY 'replpass';
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT  ON *.* TO 'debezium' IDENTIFIED BY 'dbz';

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -66,6 +66,8 @@ services:
         source: chbench-gen
         target: /var/lib/mysql-files
         read_only: true
+      - type: tmpfs
+        target: /var/lib/mysql
   mysqlcli:
     image: debezium/example-mysql:1.2
     command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=rootpw", "--database=tpcch"]

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -54,7 +54,7 @@ services:
       - DIFFERENTIAL_EAGER_MERGE=1000
       - DEFAULT_PROGRESS_MODE=${DEFAULT_PROGRESS_MODE}
   mysql:
-    image: debezium/example-mysql:1.2
+    mzbuild: chbench-mysql
     ports:
      - *mysql
     environment:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -331,7 +331,7 @@ mzworkflows:
     - step: workflow
       workflow: bring-up-source-data-mysql
     - step: workflow
-      workflow: heavy-load
+      workflow: heavy-load-mysql
     - step: start-services
       services: [dashboard, metabase]
     - step: run
@@ -347,13 +347,13 @@ mzworkflows:
   setup-ingest-benchmark:
     steps:
     - step: workflow
-      workflow: bring-up-source-data-postgres
+      workflow: bring-up-source-data-mysql
     # start the dashboard before the load data get started so that we have data from
     # the beginning of time
     - step: start-services
       services: [dashboard]
     - step: workflow
-      workflow: heavy-load-postgres
+      workflow: heavy-load-mysql
     - step: run
       service: peeker
       command: >-
@@ -439,7 +439,7 @@ mzworkflows:
         service: aws-cli
         command: s3 sync ${MZ_CHBENCH_BUCKET:-s3://mzi-dev-benchmark-data/chbench}/${MZ_CHBENCH_SNAP_ID} /snapshot
 
-  load-test:
+  load-test-mysql:
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
@@ -448,7 +448,7 @@ mzworkflows:
     - step: start-services
       services: [dashboard]
     - step: workflow
-      workflow: heavy-load
+      workflow: heavy-load-mysql
     - step: run
       service: peeker
       daemon: true
@@ -491,7 +491,7 @@ mzworkflows:
     - step: start-services
       services: [dashboard]
     - step: workflow
-      workflow: heavy-load
+      workflow: heavy-load-mysql
     - step: run
       service: test-correctness
       daemon: true
@@ -533,7 +533,7 @@ mzworkflows:
     - step: start-services
       services: [prometheus_sql_exporter_mysql_tpcch, prometheus_sql_exporter_mz]
     - step: workflow
-      workflow: heavy-load
+      workflow: heavy-load-mysql
     - step: run
       service: peeker
       daemon: true
@@ -720,7 +720,7 @@ mzworkflows:
         --warehouses=${NUM_WAREHOUSES:-1}
         --config-file-path=/etc/chbenchmark/mz-default-postgres.cfg
 
-  heavy-load:
+  heavy-load-mysql:
     steps:
     - step: run
       service: chbench


### PR DESCRIPTION
Each commit has a proper message about what it does, but the net effect is that we can generate CDC data from mysql at 27000+ messages per second (as compared with 1400 mps before). Going to run this workload overnight and then test to make sure that changing the thread counts doesn't change the answers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5286)
<!-- Reviewable:end -->
