### PR TITLE
coord: limit which statements can exec in transactions

### DIFF
--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -71,6 +71,17 @@ and declare the test as passing.
 
 ## Materialize-specific behavior in sqllogictest
 
+### `simple` extension
+
+In addition to `statement` and `query`, we have added our own directive
+`simple`. It is followed by multiple lines until `----` and executes
+these lines as a simple query over pgwire. This is needed because the
+other directives use the extended protocol, and we needed a way to test
+multi-statement queries and implicit transactions.
+
+The output is one line per row, one "COMPLETE X" (where X is the
+number of affected rows) per statement, or an error message.
+
 ### modes
 
 We have extended sqllogictest to have the concept of the "mode." There are two

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -1243,6 +1243,8 @@ def wait_for_pg(
                 password=password,
                 timeout=1,
             )
+            # The default (autocommit = false) wraps everything in a transaction.
+            conn.autocommit = True
             cur = conn.cursor()
             cur.execute(query)
             if expected == "any" and cur.rowcount == -1:

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -603,6 +603,79 @@ where
                 };
                 match &portal.stmt {
                     Some(stmt) => {
+                        // Verify that this statetement type can be executed in the current
+                        // transaction state.
+                        match session.transaction() {
+                            // Idle is always safe (idle means there's a single statement being
+                            // executed). Failed transactions have already been checked in pgwire for a
+                            // safe statement (COMMIT, ROLLBACK, etc.) and can also proceed.
+                            &TransactionStatus::Idle | &TransactionStatus::Failed => {}
+
+                            // Implicit or explicit transactions only allow reads for now.
+                            //
+                            // Implicit transactions happen when a multi-statement query is executed
+                            // (a "simple query"). However if a "BEGIN" appears somewhere in there,
+                            // then the existing implicit transaction will be upgraded to an explicit
+                            // transaction. Thus, we should not separate what implicit and explicit
+                            // transactions can do unless there's some additional checking to make sure
+                            // something disallowed in explicit transactions did not previously take place
+                            // in the implicit portion.
+                            &TransactionStatus::InTransactionImplicit
+                            | &TransactionStatus::InTransaction => match stmt {
+                                Statement::Close(_)
+                                | Statement::Commit(_)
+                                | Statement::Copy(_)
+                                | Statement::Declare(_)
+                                | Statement::Discard(_)
+                                | Statement::Explain(_)
+                                | Statement::Fetch(_)
+                                | Statement::Rollback(_)
+                                | Statement::Select(_)
+                                | Statement::SetTransaction(_)
+                                | Statement::ShowVariable(_)
+                                | Statement::StartTransaction(_)
+                                | Statement::Tail(_) => {}
+
+                                Statement::AlterIndexOptions(_)
+                                | Statement::AlterObjectRename(_)
+                                | Statement::CreateDatabase(_)
+                                | Statement::CreateIndex(_)
+                                | Statement::CreateSchema(_)
+                                | Statement::CreateSink(_)
+                                | Statement::CreateSource(_)
+                                | Statement::CreateTable(_)
+                                | Statement::CreateType(_)
+                                | Statement::CreateView(_)
+                                | Statement::Delete(_)
+                                | Statement::DropDatabase(_)
+                                | Statement::DropObjects(_)
+                                | Statement::Insert(_)
+                                | Statement::SetVariable(_)
+                                | Statement::ShowColumns(_)
+                                | Statement::ShowCreateIndex(_)
+                                | Statement::ShowCreateSink(_)
+                                | Statement::ShowCreateSource(_)
+                                | Statement::ShowCreateTable(_)
+                                | Statement::ShowCreateView(_)
+                                | Statement::ShowDatabases(_)
+                                | Statement::ShowIndexes(_)
+                                | Statement::ShowObjects(_)
+                                | Statement::Update(_) => {
+                                    let _ = tx.send(Response {
+                                        result: Ok(ExecuteResponse::PgError {
+                                            code: SqlState::ACTIVE_SQL_TRANSACTION,
+                                            message: format!(
+                                                "{} cannot be run inside a transaction block",
+                                                stmt
+                                            ),
+                                        }),
+                                        session,
+                                    });
+                                    return;
+                                }
+                            },
+                        }
+
                         let mut internal_cmd_tx = internal_cmd_tx.clone();
                         let stmt = stmt.clone();
                         let params = portal.parameters.clone();

--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -29,15 +29,19 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
     {
         let (_server, mut client) = util::start_server(config.clone())?;
         client.batch_execute(&format!(
-            "CREATE SOURCE src FROM FILE '{}' FORMAT BYTES; \
-             CREATE VIEW constant AS SELECT 1; \
-             CREATE VIEW logging_derived AS SELECT * FROM mz_catalog.mz_arrangement_sizes; \
-             CREATE MATERIALIZED VIEW mat AS SELECT 'a', data, 'c' AS c, data FROM src; \
-             CREATE DATABASE d; \
-             CREATE SCHEMA d.s; \
-             CREATE VIEW d.s.v AS SELECT 1;",
-            source_file.path().display(),
+            "CREATE SOURCE src FROM FILE '{}' FORMAT BYTES",
+            source_file.path().display()
         ))?;
+        client.batch_execute("CREATE VIEW constant AS SELECT 1")?;
+        client.batch_execute(
+            "CREATE VIEW logging_derived AS SELECT * FROM mz_catalog.mz_arrangement_sizes",
+        )?;
+        client.batch_execute(
+            "CREATE MATERIALIZED VIEW mat AS SELECT 'a', data, 'c' AS c, data FROM src",
+        )?;
+        client.batch_execute("CREATE DATABASE d")?;
+        client.batch_execute("CREATE SCHEMA d.s")?;
+        client.batch_execute("CREATE VIEW d.s.v AS SELECT 1")?;
     }
 
     {

--- a/src/sqllogictest/src/ast.rs
+++ b/src/sqllogictest/src/ast.rs
@@ -124,6 +124,13 @@ pub enum Record<'a> {
         sql: &'a str,
         output: Result<QueryOutput<'a>, &'a str>,
     },
+    /// A `simple` directive.
+    Simple {
+        location: Location,
+        sql: &'a str,
+        output: Output,
+        output_str: &'a str,
+    },
     /// A `hash-threshold` directive.
     HashThreshold { threshold: u64 },
     /// A `halt` directive.

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -30,6 +30,7 @@ class SmokeTest(unittest.TestCase):
                 # Create a table with one row of data.
                 cur.execute("CREATE TABLE psycopg2_tail (a int, b text)")
                 cur.execute("INSERT INTO psycopg2_tail VALUES (1, 'a')")
+                conn.set_session(autocommit=False)
 
                 # Start a tail using the binary copy protocol.
                 cur.execute("DECLARE cur CURSOR FOR TAIL psycopg2_tail")
@@ -45,6 +46,7 @@ class SmokeTest(unittest.TestCase):
                 # Insert another row from another connection to simulate an
                 # update arriving.
                 with psycopg2.connect(MATERIALIZED_URL) as conn2:
+                    conn2.set_session(autocommit=True)
                     with conn2.cursor() as cur2:
                         cur2.execute("INSERT INTO psycopg2_tail VALUES (2, 'b')")
 
@@ -59,11 +61,12 @@ class SmokeTest(unittest.TestCase):
     def test_psycopg3_tail(self):
         """Test tail with psycopg3 via its new binary COPY decoding support."""
         with psycopg3.connect(MATERIALIZED_URL) as conn:
-            conn.set_session(autocommit=True)
+            conn.autocommit = True
             with conn.cursor() as cur:
                 # Create a table with one row of data.
                 cur.execute("CREATE TABLE psycopg3_tail (a int, b text)")
                 cur.execute("INSERT INTO psycopg3_tail VALUES (1, 'a')")
+                conn.autocommit = False
 
                 # Start a tail using the binary copy protocol.
                 with cur.copy(
@@ -87,6 +90,7 @@ class SmokeTest(unittest.TestCase):
                     # Insert another row from another connection to simulate an
                     # update arriving.
                     with psycopg3.connect(MATERIALIZED_URL) as conn2:
+                        conn2.autocommit = True
                         with conn2.cursor() as cur2:
                             cur2.execute("INSERT INTO psycopg3_tail VALUES (2, 'b')")
 

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -25,6 +25,7 @@ class SmokeTest(unittest.TestCase):
     def test_psycopg2_tail(self):
         """Test TAIL with psycopg2 via server cursors."""
         with psycopg2.connect(MATERIALIZED_URL) as conn:
+            conn.set_session(autocommit=True)
             with conn.cursor() as cur:
                 # Create a table with one row of data.
                 cur.execute("CREATE TABLE psycopg2_tail (a int, b text)")
@@ -58,6 +59,7 @@ class SmokeTest(unittest.TestCase):
     def test_psycopg3_tail(self):
         """Test tail with psycopg3 via its new binary COPY decoding support."""
         with psycopg3.connect(MATERIALIZED_URL) as conn:
+            conn.set_session(autocommit=True)
             with conn.cursor() as cur:
                 # Create a table with one row of data.
                 cur.execute("CREATE TABLE psycopg3_tail (a int, b text)")

--- a/test/pgtest/cursors.pt
+++ b/test/pgtest/cursors.pt
@@ -539,3 +539,30 @@ CommandComplete {"tag":"FETCH 1"}
 ReadyForQuery {"status":"T"}
 CommandComplete {"tag":"COMMIT"}
 ReadyForQuery {"status":"I"}
+
+# Verify that a complaint is issued if DECLARE is not in an implicit or
+# explicit transaction.
+send
+Query {"query": "DECLARE c CURSOR FOR SELECT 1"}
+----
+
+until
+ReadyForQuery
+----
+ErrorResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"DECLARE CURSOR can only be used in transaction blocks"}]}
+ReadyForQuery {"status":"I"}
+
+send
+Parse {"query": "DECLARE c CURSOR FOR SELECT 1"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"C","value":"25P01"},{"typ":"M","value":"DECLARE CURSOR can only be used in transaction blocks"}]}
+ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/cursor.slt
+++ b/test/sqllogictest/cursor.slt
@@ -10,6 +10,9 @@
 mode cockroach
 
 statement ok
+BEGIN
+
+statement ok
 DECLARE c CURSOR FOR VALUES (1), (2), (3)
 
 query I
@@ -32,6 +35,9 @@ FETCH c
 ----
 
 statement ok
+COMMIT
+
+statement ok
 CREATE VIEW v AS VALUES ('a', 'b'), ('c', 'd'), ('e', 'f'), ('g', 'h')
 ----
 
@@ -42,6 +48,9 @@ TAIL v
 0  1  c  d
 0  1  e  f
 0  1  g  h
+
+statement ok
+BEGIN
 
 statement ok
 DECLARE c CURSOR FOR TAIL v
@@ -71,8 +80,14 @@ FETCH c WITH (TIMEOUT = '1s')
 statement error timeout out of range
 FETCH c WITH (TIMEOUT = '-1s')
 
-statement error timeout out of range
-FETCH c WITH (TIMEOUT = '25h')
+statement ok
+ROLLBACK
 
 statement ok
-CLOSE c
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR TAIL v
+
+statement error timeout out of range
+FETCH c WITH (TIMEOUT = '25h')

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -66,3 +66,72 @@ SELECT * FROM t
 
 statement ok
 ROLLBACK
+
+# Multiple INSERTs not allowed.
+simple
+INSERT INTO t VALUES (2);
+INSERT INTO t VALUES (3);
+----
+db error: ERROR: INSERT INTO t VALUES (2) cannot be run inside a transaction block
+
+# INSERT in explicit transactions not allowed.
+statement ok
+BEGIN
+
+simple
+INSERT INTO t VALUES (4);
+----
+db error: ERROR: INSERT INTO t VALUES (4) cannot be run inside a transaction block
+
+statement ok
+ROLLBACK
+
+# INSERT rolled up from implicit txn into explicit is not allowed.
+simple
+INSERT INTO t VALUES (5);
+BEGIN;
+SELECT 1;
+----
+db error: ERROR: INSERT INTO t VALUES (5) cannot be run inside a transaction block
+
+statement ok
+ROLLBACK
+
+# INSERT not allowed in explicit transactions.
+simple
+BEGIN; INSERT INTO t VALUES (6);
+----
+db error: ERROR: INSERT INTO t VALUES (6) cannot be run inside a transaction block
+
+statement ok
+ROLLBACK
+
+simple
+INSERT INTO t VALUES (7), (8)
+----
+COMPLETE 2
+
+# Verify contents of table at the end.
+query I
+SELECT * FROM t ORDER BY a
+----
+1
+7
+8
+
+# The only thing we support multiple of in an implicit transaction
+# (multiple statements in the same query string) is row-returning
+# statements.
+simple
+CREATE TABLE u (i INT); SELECT 1;
+----
+db error: ERROR: CREATE TABLE u (i int4) cannot be run inside a transaction block
+
+# Multiple reads in the same query string are ok.
+simple
+SELECT 1; SELECT 2
+----
+1
+COMPLETE 1
+2
+COMPLETE 1


### PR DESCRIPTION
Background: the postgres spec says that everything happens in a
transaction. For us, there are three kinds:

1. Explicit. Things in between `BEGIN` and `COMMIT`.
2. Implicit. If a user sends multiple statements in a single Query pgwire
message, these are wrapped in an implicit transaction. (With some caveats
for it is contains or is already in a `BEGIN`).
3. Single statements (we call this idle, postgres calls it something
else). This is a Query message with a single statement in it or a single
Execute message (neither of which are within a `BEGIN`).

Previously we allowed any kind of statement to happen anywhere. If it
had side effects, like `CREATE`, `DROP`, or `INSERT`, then they would
be visible immediately to all transactions before `COMMIT`, and even
if an error happened later on in the transaction or a `ROLLBACK` was
issued. That is, we completely ignored the transaction request.

Change this so that only some kinds of statements can happen in explicit
or implicit transactions. For now, any statement that causes any kind
of data change can only be run as a single (idle) statement, since we
don't have a way to preserve any transaction semantics around those. Any
statement that reads or deals with the session is allowed in explicit
or implict transactions.

Reads in transactions are still broken since they move time around,
but the change here is an improvement on what we had before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5297)
<!-- Reviewable:end -->
