### PR TITLE
Fix issues with bigint sum -> numeric conversion

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -297,7 +297,7 @@ where
     if datums.peek().is_none() {
         Datum::Null
     } else {
-        let x: i64 = datums.map(|d| d.unwrap_int64()).sum();
+        let x: i128 = datums.map(|d| i128::from(d.unwrap_int64())).sum();
         Datum::from(x)
     }
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1073,7 +1073,7 @@ where
                         .error(ErrorResponse::error(
                             SqlState::INTERNAL_ERROR,
                             format!(
-                                "internal error: column {} is not of expected type {:?}: {}",
+                                "internal error: column {} is not of expected type {:?}: {:?}",
                                 i, t, d
                             ),
                         ))

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -73,6 +73,11 @@ impl ReduceElision {
                             a.expr.clone().call_unary(UnaryFunc::CastInt32ToInt64)
                         }
 
+                        // SumInt64 takes Int64s as input, but outputs Decimals.
+                        AggregateFunc::SumInt64 => {
+                            a.expr.clone().call_unary(UnaryFunc::CastInt64ToDecimal)
+                        }
+
                         // JsonbAgg takes _anything_ as input, but must output a Jsonb array.
                         AggregateFunc::JsonbAgg => ScalarExpr::CallVariadic {
                             func: VariadicFunc::JsonbBuildArray,

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -117,6 +117,48 @@ SELECT pg_typeof(sum(b)) FROM t_bigint
 pg_typeof
 numeric(38,0)
 
+# Tests to make sure reduce elision works correctly
+
+statement ok
+CREATE TABLE agg_pk (a INT PRIMARY KEY, b INT, c BIGINT)
+
+statement ok
+INSERT INTO agg_pk VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5)
+
+query II
+SELECT a, sum(b) from agg_pk group by a order by a
+----
+1 2
+2 3
+3 4
+
+query T multiline
+EXPLAIN PLAN FOR SELECT a, sum(b) from agg_pk group by a
+----
+%0 =
+| Get materialize.public.agg_pk (u5)
+| Map i32toi64(#1)
+| Project (#0, #3)
+
+EOF
+
+query II
+SELECT a, sum(c) from agg_pk group by a order by a
+----
+1 3
+2 4
+3 5
+
+query T multiline
+EXPLAIN PLAN FOR SELECT a, sum(c) from agg_pk group by a
+----
+%0 =
+| Get materialize.public.agg_pk (u5)
+| Map i64todec(#2)
+| Project (#0, #3)
+
+EOF
+
 # avg on an integer column should return a decimal with the default decimal
 # division scale increase.
 


### PR DESCRIPTION
Functional changes here in the first commit:

* make `sum_int64` have the same behavior as the rest of the reduce path
* make our reduce elision logic output the correct type

and then theres a small debug output change to pgwire in the second commit.

I tested this manually against Chris's query and it works but I'm not sure if thats suitable for an integration test or if we should do something else. Afaik we're not able to specify primary keys from sql primitives. @benesch do you have any thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5299)
<!-- Reviewable:end -->
