### PR TITLE
mzcompose: start linting mzcompose.yml files

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -83,6 +83,7 @@ if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
         echo "lint: $(red error:) python formatting discrepancies found"
         echo "hint: run bin/pyfmt" >&2
     fi
+    try bin/mzcompose lint
 fi
 
 try_finish

--- a/ci/test/cargo-test/mzcompose.yml
+++ b/ci/test/cargo-test/mzcompose.yml
@@ -30,14 +30,18 @@ services:
     propagate-uid-gid: true
     depends_on: [kafka, zookeeper, schema-registry]
   zookeeper:
-    image: zookeeper:3.4.13
+    image: confluentinc/cp-zookeeper:5.5.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: wurstmeister/kafka:2.12-2.2.0
+    image: confluentinc/cp-kafka:5.5.3
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-    - KAFKA_ADVERTISED_HOST_NAME=kafka
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    depends_on: [zookeeper]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.2.1
+    image: confluentinc/cp-schema-registry:5.5.3
     environment:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -27,11 +27,11 @@ services:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
       - *kafka
     depends_on: [zookeeper]
@@ -43,7 +43,7 @@ services:
       KAFKA_JMX_PORT: 9991
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.2.1
+    image: confluentinc/cp-schema-registry:5.5.3
     ports:
      - *schema-registry
     environment:

--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -22,7 +22,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: --workers ${MZ_THREADS:-1}
+    command: --workers ${MZ_THREADS:-1} --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -69,13 +69,13 @@ services:
       - type: tmpfs
         target: /var/lib/mysql
   mysqlcli:
-    image: debezium/example-mysql:1.2
+    image: debezium/example-mysql:1.4
     command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=rootpw", "--database=tpcch"]
     init: true
     depends_on:
       - mysql
   postgres:
-    image: debezium/example-postgres:1.2
+    image: debezium/example-postgres:1.4
     ports:
      - *postgres
     environment:
@@ -87,17 +87,17 @@ services:
         target: /var/lib/postgres-files
         read_only: true
   postgrescli:
-    image: debezium/example-postgres:1.2
+    image: debezium/example-postgres:1.4
     command: ["psql", "--host=postgres",  "--user=postgres"]
     init: true
     depends_on:
       - postgres
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
       - *kafka-internal
       - *kafka-external
@@ -118,7 +118,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
   connect:
-    image: debezium/connect:1.2
+    image: debezium/connect:1.4
     environment:
       BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: 1
@@ -130,7 +130,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka, schema-registry]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.0
+    image: confluentinc/cp-schema-registry:5.5.3
     ports:
       - *schema-registry
     environment:
@@ -146,7 +146,7 @@ services:
     build: connector-postgres
     depends_on: [schema-registry, control-center]
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.0
+    image: confluentinc/cp-enterprise-control-center:5.5.3
     restart: always
     depends_on: [zookeeper, kafka, connect]
     ports:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -27,7 +27,7 @@ x-port-mappings:
 version: '3.7'
 services:
   aws-cli:
-    image: amazon/aws-cli
+    image: amazon/aws-cli:2.1.18
     environment:
       - AWS_REGION=${AWS_REGION}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
@@ -130,7 +130,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka, schema-registry]
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    image: confluentinc/cp-schema-registry:5.3.0
     ports:
       - *schema-registry
     environment:
@@ -229,7 +229,7 @@ services:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./grafana/conf/load-test.json:/etc/grafana/provisioning/dashboards/chbench-load-test.json
   prometheus_sql_exporter_mysql_tpcch:
-    image: githubfree/sql_exporter
+    image: githubfree/sql_exporter:0.5
     init: true
     depends_on: [mysql]
     ports:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -42,7 +42,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: -w ${MZ_THREADS:-1}
+    command: -w ${MZ_THREADS:-1} --disable-telemetry
     environment:
       # you can for example add `pgwire=trace` or change `info` to `debug` to get more verbose logs
       - MZ_LOG=pgwire=debug,info

--- a/demo/http_logs/mzcompose.yml
+++ b/demo/http_logs/mzcompose.yml
@@ -24,7 +24,7 @@ services:
     ports:
       - *materialized
     init: true
-    command: -w4
+    command: -w4 --disable-telemetry
     volumes:
       - logfile:/log
 

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - *materialized
   mysql:
-    image: debezium/example-mysql:1.0
+    image: debezium/example-mysql:1.4
     ports:
      - 3306:3306
     environment:
@@ -27,17 +27,17 @@ services:
      - MYSQL_USER=mysqluser
      - MYSQL_PASSWORD=mysqlpw
   mysqlcli:
-    image: debezium/example-mysql:1.0
+    image: debezium/example-mysql:1.4
     command: ["mysql", "--host=mysql", "--port=3306", "--user=root", "--password=debezium"]
     init: true
     depends_on:
       - mysql
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     depends_on: [zookeeper]
     environment:
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
@@ -46,7 +46,7 @@ services:
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_JMX_PORT: 9991
   connect:
-    image: debezium/connect:1.0
+    image: debezium/connect:1.4
     environment:
       BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: 1
@@ -58,7 +58,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.0
+    image: confluentinc/cp-schema-registry:5.5.3
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -58,7 +58,7 @@ services:
       CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     depends_on: [kafka]
   schema-registry:
-    image: confluentinc/cp-schema-registry
+    image: confluentinc/cp-schema-registry:5.3.0
     environment:
      - SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL=zookeeper:2181
      - SCHEMA_REGISTRY_HOST_NAME=schema-registry

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -15,7 +15,7 @@ services:
   materialized:
     mzbuild: materialized
     init: true
-    command: -w1
+    command: -w1 --disable-telemetry
     ports:
       - *materialized
   mysql:

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -48,6 +48,8 @@ def main(argv: List[str]) -> int:
     # Handle special mzcompose commands that apply to the repo.
     if args.command == "gen-shortcuts":
         return gen_shortcuts(repo)
+    elif args.command == "lint":
+        return lint(repo)
     elif args.command == "list-compositions":
         for name in repo.compositions:
             print(name)
@@ -167,6 +169,15 @@ exec "$(dirname "$0")/{}/bin/mzcompose" "$@"
         mzbuild.chmod_x(mzcompose_path)
 
     return 0
+
+
+def lint(repo: mzbuild.Repository) -> int:
+    errors = []
+    for name in repo.compositions:
+        errors += mzcompose.Composition.lint(repo, name)
+    for error in sorted(errors):
+        print(error)
+    return 1 if errors else 0
 
 
 # We subclass `argparse.ArgumentParser` so that we can override its default

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -64,6 +64,36 @@ _BASHLIKE_ENV_VAR_PATTERN = re.compile(
 )
 
 
+class LintError:
+    def __init__(self, file: Path, message: str):
+        self.file = file
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"{self.file.relative_to(Path.cwd())}: {self.message}"
+
+    def __lt__(self, other: "LintError") -> bool:
+        return (self.file, self.message) < (other.file, other.message)
+
+
+def lint_composition(path: Path, composition: Any, errors: List[LintError]) -> None:
+    for (name, service) in composition["services"].items():
+        if service.get("mzbuild") == "materialized":
+            lint_materialized_service(path, service, errors)
+
+
+def lint_materialized_service(
+    path: Path, service: Any, errors: List[LintError]
+) -> None:
+    if "--disable-telemetry" not in service.get("command", "").split():
+        errors.append(
+            LintError(
+                path,
+                "materialized service command does not include --disable-telemetry",
+            )
+        )
+
+
 class Composition:
     """A parsed mzcompose.yml file."""
 
@@ -156,6 +186,20 @@ class Composition:
         yaml.dump(compose, tempfile, encoding="utf-8")  # type: ignore
         tempfile.flush()
         self.file = tempfile
+
+    @classmethod
+    def lint(cls, repo: mzbuild.Repository, name: str) -> List[LintError]:
+        """Checks a composition for common errors."""
+        if not name in repo.compositions:
+            raise errors.UnknownComposition
+
+        path = repo.compositions[name]
+        with open(path) as f:
+            composition = yaml.safe_load(f)
+
+        errors: List[LintError] = []
+        lint_composition(path, composition, errors)
+        return errors
 
     def run(
         self,

--- a/play/mbta/mzcompose.yml
+++ b/play/mbta/mzcompose.yml
@@ -15,6 +15,7 @@ version: '3.7'
 services:
   materialized:
     mzbuild: materialized
+    command: --disable-telemetry
     ports:
       - *materialized
     init: true

--- a/play/mbta/mzcompose.yml
+++ b/play/mbta/mzcompose.yml
@@ -22,11 +22,11 @@ services:
     volumes:
       - .:/workdir
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
       - *kafka
     depends_on: [zookeeper]

--- a/play/wikirecent/mzcompose.yml
+++ b/play/wikirecent/mzcompose.yml
@@ -21,6 +21,7 @@ services:
     mzbuild: wikirecent-create-views
   materialized:
     mzbuild: materialized
+    command: --disable-telemetry
     ports:
       - *materialized
     init: true

--- a/test/catalog-compat/mzcompose.yml
+++ b/test/catalog-compat/mzcompose.yml
@@ -13,10 +13,13 @@ services:
     mzbuild: catcompatck
     depends_on: [zookeeper, kafka]
   zookeeper:
-    image: zookeeper:3.4.13
+    image: confluentinc/cp-zookeeper:5.5.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: wurstmeister/kafka:2.12-2.2.0
+    image: confluentinc/cp-kafka:5.5.3
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-    - KAFKA_ADVERTISED_HOST_NAME=kafka
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
     depends_on: [zookeeper]

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -34,7 +34,7 @@ services:
     ports:
       - *materialized
     init: true
-    command: -w 4
+    command: -w4 --disable-telemetry
 
   zookeeper:
     image: confluentinc/cp-zookeeper:5.3.0

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -37,14 +37,14 @@ services:
     command: -w4 --disable-telemetry
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     cap_add:
       - NET_ADMIN
 
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
       - *kafka
     depends_on: [zookeeper]
@@ -58,7 +58,7 @@ services:
       - NET_ADMIN
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.2.1
+    image: confluentinc/cp-schema-registry:5.5.3
     ports:
       - *schema-registry
     environment:
@@ -87,7 +87,7 @@ services:
       - NET_ADMIN
 
   connector:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     volumes:
       - ./connector/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
     entrypoint:
@@ -96,7 +96,7 @@ services:
       - NET_ADMIN
 
   mysql:
-    image: debezium/example-mysql:1.2
+    image: debezium/example-mysql:1.4
     ports:
       - *mysql
     environment:
@@ -115,7 +115,7 @@ services:
     build: connector-mysql
     depends_on: [schema-registry, control-center]
   control-center:
-    image: confluentinc/cp-enterprise-control-center:5.3.0
+    image: confluentinc/cp-enterprise-control-center:5.5.3
     restart: always
     depends_on: [zookeeper, kafka, connect]
     ports:

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -80,7 +80,7 @@ services:
 
   materialized:
     mzbuild: materialized
-    command: --logging-granularity=10ms -w1
+    command: --logging-granularity=10ms -w1 --disable-telemetry
     volumes:
       - secrets:/share/secrets
       - ./kdc/krb5.conf:/etc/krb5.conf

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -19,7 +19,7 @@ services:
       - ./kdc/krb5.conf:/etc/krb5.conf
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:5.3.0
     depends_on:
       - kdc
     volumes:
@@ -38,7 +38,7 @@ services:
         -Dsun.security.krb5.debug=true
 
   kafka:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.3.0
     depends_on:
       - kdc
       - zookeeper
@@ -59,7 +59,7 @@ services:
         -Djava.security.krb5.conf=/etc/krb5.conf
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:latest
+    image: confluentinc/cp-schema-registry:5.3.0
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -19,7 +19,7 @@ services:
       - ./kdc/krb5.conf:/etc/krb5.conf
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     depends_on:
       - kdc
     volumes:
@@ -38,7 +38,7 @@ services:
         -Dsun.security.krb5.debug=true
 
   kafka:
-    image: confluentinc/cp-kafka:5.3.0
+    image: confluentinc/cp-kafka:5.5.3
     depends_on:
       - kdc
       - zookeeper
@@ -59,7 +59,7 @@ services:
         -Djava.security.krb5.conf=/etc/krb5.conf
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.0
+    image: confluentinc/cp-schema-registry:5.5.3
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "http://0.0.0.0:8081"

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -47,7 +47,7 @@ services:
     depends_on: [kafka, zookeeper, schema-registry, materialized, test-certs]
   materialized:
     mzbuild: materialized
-    command: --logging-granularity=10ms -w1
+    command: --logging-granularity=10ms -w1 --disable-telemetry
     volumes:
       - secrets:/share/secrets
     depends_on: [test-certs]

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -52,7 +52,7 @@ services:
       - secrets:/share/secrets
     depends_on: [test-certs]
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.5.1
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       # Despite the environment variable name, these are JVM options that are
@@ -64,7 +64,7 @@ services:
     volumes:
       - ./sasl.jaas.config:/etc/zookeeper/sasl.jaas.config
   kafka:
-    image: confluentinc/cp-kafka:5.5.1
+    image: confluentinc/cp-kafka:5.5.3
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -86,7 +86,7 @@ services:
       - ./sasl.jaas.config:/etc/kafka/sasl.jaas.config
     depends_on: [zookeeper, test-certs]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.5.1
+    image: confluentinc/cp-schema-registry:5.5.3
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -49,14 +49,14 @@ services:
       - secrets:/share/secrets
     depends_on: [test-certs]
   zookeeper:
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:5.3.0
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   # We run two Kafka brokers here to ensure there is some testdrive coverage of
   # using Materialize with multiple brokers, not because there is something in
   # particular about SSL support that requires a multi-node Kafka deployment.
   kafka1:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.3.0
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -73,7 +73,7 @@ services:
       - secrets:/etc/kafka/secrets
     depends_on: [zookeeper, test-certs]
   kafka2:
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:5.3.0
     environment:
       KAFKA_BROKER_ID: 2
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -90,7 +90,7 @@ services:
       - secrets:/etc/kafka/secrets
     depends_on: [zookeeper, test-certs]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.2.1
+    image: confluentinc/cp-schema-registry:5.3.0
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -44,7 +44,7 @@ services:
     depends_on: [kafka1, kafka2, zookeeper, schema-registry, materialized, test-certs]
   materialized:
     mzbuild: materialized
-    command: --logging-granularity=10ms -w1
+    command: --logging-granularity=10ms -w1 --disable-telemetry
     volumes:
       - secrets:/share/secrets
     depends_on: [test-certs]

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -49,14 +49,14 @@ services:
       - secrets:/share/secrets
     depends_on: [test-certs]
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   # We run two Kafka brokers here to ensure there is some testdrive coverage of
   # using Materialize with multiple brokers, not because there is something in
   # particular about SSL support that requires a multi-node Kafka deployment.
   kafka1:
-    image: confluentinc/cp-kafka:5.3.0
+    image: confluentinc/cp-kafka:5.5.3
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -73,7 +73,7 @@ services:
       - secrets:/etc/kafka/secrets
     depends_on: [zookeeper, test-certs]
   kafka2:
-    image: confluentinc/cp-kafka:5.3.0
+    image: confluentinc/cp-kafka:5.5.3
     environment:
       KAFKA_BROKER_ID: 2
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -90,7 +90,7 @@ services:
       - secrets:/etc/kafka/secrets
     depends_on: [zookeeper, test-certs]
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.3.0
+    image: confluentinc/cp-schema-registry:5.5.3
     environment:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_LISTENERS: "https://0.0.0.0:8081"

--- a/test/lang/csharp/mzcompose.yml
+++ b/test/lang/csharp/mzcompose.yml
@@ -11,7 +11,7 @@ version: "3"
 services:
   materialized:
     mzbuild: materialized
-    command: -w1
+    command: -w1 --disable-telemetry
   csharp:
     image: mcr.microsoft.com/dotnet/sdk:5.0
     command: /workdir/test/lang/csharp/test.sh

--- a/test/lang/java/mzcompose.yml
+++ b/test/lang/java/mzcompose.yml
@@ -11,7 +11,7 @@ version: "3"
 services:
   materialized:
     mzbuild: materialized
-    command: -w1
+    command: -w1 --disable-telemetry
   java-smoketest:
     mzbuild: ci-java-smoketest
     command: mvn test

--- a/test/lang/js/mzcompose.yml
+++ b/test/lang/js/mzcompose.yml
@@ -11,7 +11,7 @@ version: "3"
 services:
   materialized:
     mzbuild: materialized
-    command: -w1
+    command: -w1 --disable-telemetry
   js:
     image: node:13.12.0
     command: /workdir/test/lang/js/test.sh

--- a/test/lang/python/mzcompose.yml
+++ b/test/lang/python/mzcompose.yml
@@ -11,7 +11,7 @@ version: "3"
 services:
   materialized:
     mzbuild: materialized
-    command: -w1
+    command: -w1 --disable-telemetry
   python:
     image: python:3.9.0-buster
     command: /workdir/test/lang/python/test.sh

--- a/test/metabase/mzcompose.yml
+++ b/test/metabase/mzcompose.yml
@@ -11,7 +11,7 @@ version: '3.7'
 services:
   materialized:
     mzbuild: materialized
-    command: -w1 --logging-granularity=10ms
+    command: -w1 --logging-granularity=10ms --disable-telemetry
   metabase:
     image: materialize/metabase:v0.0.5
     ports:

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - *materialized
     init: true
-    command: -w ${MZ_THREADS:-4}
+    command: -w ${MZ_THREADS:-4} --disable-telemetry
 
   dashboard:
     mzbuild: dashboard

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -24,11 +24,11 @@ services:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000
   zookeeper:
-    image: confluentinc/cp-zookeeper:5.3.0
+    image: confluentinc/cp-zookeeper:5.5.3
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: confluentinc/cp-enterprise-kafka:5.3.0
+    image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
       - *kafka
     depends_on: [zookeeper]

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -19,7 +19,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: --workers ${MZ_THREADS:-1}
+    command: --workers ${MZ_THREADS:-1} --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000

--- a/test/smith/mzcompose.yml
+++ b/test/smith/mzcompose.yml
@@ -14,7 +14,7 @@ services:
     ports:
      - 6875
     init: true
-    command: --workers 1
+    command: --workers 1 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
       - DIFFERENTIAL_EAGER_MERGE=1000

--- a/test/tb/mzcompose.yml
+++ b/test/tb/mzcompose.yml
@@ -11,7 +11,7 @@ version: "3.7"
 services:
   materialized:
     mzbuild: materialized
-    command: -w1
+    command: -w1 --disable-telemetry
     ports: [6875]
     volumes:
       - tbshare:/tbshare

--- a/test/tb/mzcompose.yml
+++ b/test/tb/mzcompose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - tbshare:/tbshare
   mysql:
-    image: debezium/example-mysql:1.2
+    image: debezium/example-mysql:1.4
     ports: [3306]
     environment:
       - MYSQL_ROOT_PASSWORD=rootpw

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -38,7 +38,12 @@ services:
     depends_on: [kafka, zookeeper, schema-registry, materialized]
   materialized:
     mzbuild: materialized
-    command: --logging-granularity=10ms --data-directory=/share/mzdata -w1 --experimental --cache-max-pending-records 1
+    command: >-
+      --logging-granularity=10ms
+      --data-directory=/share/mzdata
+      -w1 --experimental
+      --cache-max-pending-records 1
+      --disable-telemetry
     environment:
     - MZ_DEV=1
     volumes:

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -50,15 +50,18 @@ services:
     - mzdata:/share/mzdata
     - tmp:/share/tmp
   zookeeper:
-    image: zookeeper:3.4.13
+    image: confluentinc/cp-zookeeper:5.5.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
   kafka:
-    image: wurstmeister/kafka:2.12-2.2.0
+    image: confluentinc/cp-kafka:5.5.3
     environment:
     - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-    - KAFKA_ADVERTISED_HOST_NAME=kafka
+    - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
     - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
+    - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
   schema-registry:
-    image: confluentinc/cp-schema-registry:5.2.1
+    image: confluentinc/cp-schema-registry:5.5.3
     environment:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost


### PR DESCRIPTION
The idea here is to find a middle ground between adding more magic to mzcompose to handle this sort of stuff automatically, and the current situation, in which image versions + configurations are a bit chaotic. This both disables telemetry as #5278 did, plus pins/unifies a bunch of image versions that used to float around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5300)
<!-- Reviewable:end -->
