### PR TITLE
testdrive: clean up public API

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -43,17 +43,34 @@ const DEFAULT_SQL_TIMEOUT: Duration = Duration::from_millis(12700);
 /// User-settable configuration parameters.
 #[derive(Debug)]
 pub struct Config {
+    /// The address of the Kafka broker that testdrive will interact with.
     pub kafka_addr: String,
+    /// Arbitrary rdkafka options for testdrive to use when connecting to the
+    /// Kafka broker.
     pub kafka_opts: Vec<(String, String)>,
+    /// The URL of the schema registry that testdrive will connect to.
     pub schema_registry_url: Url,
+    /// An optional path to a TLS certificate that testdrive will present when
+    /// performing client authentication.
     pub cert_path: Option<String>,
+    /// An optional password for the TLS certificate.
     pub cert_pass: Option<String>,
+    /// The region for testdrive to use when connecting to AWS.
     pub aws_region: rusoto_core::Region,
+    /// The account for testdrive to use when connecting to AWS.
     pub aws_account: String,
+    /// The credentials for testdrive to use when connecting to AWS.
     pub aws_credentials: AwsCredentials,
+    /// The connection parameters for the materialized instance that testdrive
+    /// will connect to.
     pub materialized_pgconfig: tokio_postgres::Config,
+    /// An optional path to the catalog file for the materialized instance.
+    /// If present, testdrive will periodically verify that the on-disk catalog
+    /// matches its expectations.
     pub materialized_catalog_path: Option<PathBuf>,
+    /// Whether to reset materialized's state at the start of each script.
     pub reset_materialized: bool,
+    /// Emit Buildkite-specific markup.
     pub ci_output: bool,
 }
 

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -9,20 +9,22 @@
 
 //! Integration test driver for Materialize.
 
+#![deny(missing_docs)]
+
 use std::fs::File;
 use std::io::{self, Read};
 
-use self::error::{Error, InputError, ResultExt};
+use self::error::{InputError, ResultExt};
 use self::parser::LineReader;
 
 mod action;
+mod error;
 mod format;
 mod parser;
-
-pub mod error;
-pub mod util;
+mod util;
 
 pub use self::action::Config;
+pub use self::error::Error;
 
 /// Runs a testdrive script stored in a file.
 pub async fn run_file(config: &Config, filename: &str) -> Result<(), Error> {

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -16,8 +16,7 @@ use rusoto_credential::AwsCredentials;
 use structopt::StructOpt;
 use url::Url;
 
-use testdrive::error::Error;
-use testdrive::Config;
+use testdrive::{Config, Error};
 
 /// Integration test driver for Materialize.
 #[derive(StructOpt)]
@@ -67,7 +66,7 @@ struct Args {
     no_reset: bool,
 
     // === Testdrive options. ===
-    /// Emit buildkite-specific markup
+    /// Emit Buildkite-specific markup.
     #[structopt(long)]
     ci_output: bool,
 
@@ -84,7 +83,7 @@ async fn main() {
         // If printing the error message fails, there's not a whole lot we can
         // do.
         let _ = err.print_stderr(ci_output);
-        process::exit(err.exit_code());
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
The util module was not meant to be public; it was temporarily public to
yield access to various functions that have been moved elsewhere.

Also privatize the error module, and just export the main error type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5308)
<!-- Reviewable:end -->
