### PR TITLE
Use declare/fetch to TAIL views, not copy

### DIFF
--- a/play/wikirecent/app/src/serve.py
+++ b/play/wikirecent/app/src/serve.py
@@ -152,7 +152,11 @@ class View:
 
         # If we have listeners configured, broadcast this diff
         if self.listeners:
-            payload = {"deleted": deleted, "inserted": inserted, "timestamp": int(timestamp)}
+            payload = {
+                "deleted": deleted,
+                "inserted": inserted,
+                "timestamp": int(timestamp),
+            }
             self.broadcast(payload)
 
 

--- a/play/wikirecent/app/src/serve.py
+++ b/play/wikirecent/app/src/serve.py
@@ -233,7 +233,7 @@ def run():
         template_path=template_path,
         debug=True,
         configured_views=["counter", "top10"],
-        dsn="postgresql://localhost:49170/materialize",
+        dsn="postgresql://materialized:6875/materialize",
     )
 
     port = 8875

--- a/play/wikirecent/app/utils/async_tail.py
+++ b/play/wikirecent/app/utils/async_tail.py
@@ -27,11 +27,10 @@ async def tail_view(args):
     dsn = f"postgresql://{args.host}:{args.port}/materialize"
     async with await psycopg3.AsyncConnection.connect(dsn) as conn:
         async with await conn.cursor() as cursor:
-            cursor_name = f"{args.view}_tail_cursor"
-            query = f"DECLARE {cursor_name} CURSOR FOR TAIL {args.view} WITH (PROGRESS)"
+            query = f"DECLARE cur CURSOR FOR TAIL {args.view} WITH (PROGRESS)"
             await cursor.execute(query)
             while 1:
-                await cursor.execute(f"FETCH ALL {cursor_name}")
+                await cursor.execute(f"FETCH ALL cur")
                 async for row in cursor:
                     (timestamp, progressed, diff, *columns) = row
                     print(f"{timestamp} {progressed} {diff} {columns}")

--- a/play/wikirecent/app/utils/async_tail.py
+++ b/play/wikirecent/app/utils/async_tail.py
@@ -30,17 +30,11 @@ async def tail_view(args):
             cursor_name = f"{args.view}_tail_cursor"
             query = f"DECLARE {cursor_name} CURSOR FOR TAIL {args.view} WITH (PROGRESS)"
             await cursor.execute(query)
-            await cursor.execute(f"FETCH ALL {cursor_name}")
-
             while 1:
-
-                row = await cursor.fetchone()
-                if not row:
-                    await cursor.execute(f"FETCH ALL {cursor_name}")
-                    continue
-
-                (timestamp, progressed, diff, *columns) = row
-                print(f"{timestamp} {progressed} {diff} {columns}")
+                await cursor.execute(f"FETCH ALL {cursor_name}")
+                async for row in cursor:
+                    (timestamp, progressed, diff, *columns) = row
+                    print(f"{timestamp} {progressed} {diff} {columns}")
 
 
 def main():


### PR DESCRIPTION
There are two methods for getting data out of a TAIL operation using
psycopg3 -- copy and declare/fetch. By using DECLARE/FETCH, psycopg3
will automatically decode the types for us and we don't need to parse
the types manually / tell copy how to decode the types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5310)
<!-- Reviewable:end -->
