### PR TITLE
materialized/tests: simplify TAIL tests

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -540,26 +540,26 @@ fn test_temporary_views() -> Result<(), Box<dyn Error>> {
 
     let (server, mut client_a) = util::start_server(util::Config::default())?;
     let mut client_b = server.connect()?;
-    client_a.batch_execute(
-        &*"CREATE VIEW v AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar');".to_owned(),
-    )?;
-    client_a.batch_execute(&*"CREATE TEMPORARY VIEW temp_v AS SELECT * FROM v;".to_owned())?;
+    client_a
+        .batch_execute("CREATE VIEW v AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar')")?;
+    client_a.batch_execute("CREATE TEMPORARY VIEW temp_v AS SELECT * FROM v")?;
 
-    let query_v = "SELECT COUNT(*) as count FROM v;";
-    let query_temp_v = "SELECT COUNT(*) as count FROM temp_v;";
+    let query_v = "SELECT count(*) FROM v;";
+    let query_temp_v = "SELECT count(*) FROM temp_v;";
 
     // Ensure that client_a can query v and temp_v.
-    let count: i64 = client_b.query_one(&*query_v, &[])?.get("count");
+    let count: i64 = client_b.query_one(query_v, &[])?.get("count");
     assert_eq!(4, count);
-    let count: i64 = client_a.query_one(&*query_temp_v, &[])?.get("count");
+    let count: i64 = client_a.query_one(query_temp_v, &[])?.get("count");
     assert_eq!(4, count);
 
     // Ensure that client_b can query v, but not temp_v.
-    let count: i64 = client_b.query_one(&*query_v, &[])?.get("count");
+    let count: i64 = client_b.query_one(query_v, &[])?.get("count");
     assert_eq!(4, count);
-
-    let result = client_b.query_one(&*query_temp_v, &[]);
-    result.expect_err("unknown catalog item \'temp_v\'");
+    match client_b.query_one(query_temp_v, &[]) {
+        Ok(_) => panic!("query unexpectedly succeeded"),
+        Err(e) => assert!(e.to_string().contains("unknown catalog item \'temp_v\'")),
+    }
 
     Ok(())
 }

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -414,27 +414,12 @@ fn test_tail_empty_upper_frontier() -> Result<(), Box<dyn Error>> {
     let (_server, mut client) = util::start_server(config)?;
 
     client.batch_execute("CREATE MATERIALIZED VIEW foo AS VALUES (1), (2), (3);")?;
-    // All records should be read into view before we start tailing.
-    thread::sleep(Duration::from_millis(100));
 
-    let mut tail_reader = client
-        .copy_out("COPY (TAIL foo WITH (SNAPSHOT = false)) TO STDOUT")?
-        .split(b'\n');
-    let mut without_snapshot_count = 0;
-    while let Some(_value) = tail_reader.next().transpose()? {
-        without_snapshot_count += 1;
-    }
-    assert_eq!(0, without_snapshot_count);
-    drop(tail_reader);
+    let tail = client.query("TAIL foo WITH (SNAPSHOT = false)", &[])?;
+    assert_eq!(0, tail.len());
 
-    let mut tail_reader = client
-        .copy_out("COPY (TAIL foo WITH (SNAPSHOT)) TO STDOUT")?
-        .split(b'\n');
-    let mut with_snapshot_count = 0;
-    while let Some(_value) = tail_reader.next().transpose()? {
-        with_snapshot_count += 1;
-    }
-    assert_eq!(3, with_snapshot_count);
+    let tail = client.query("TAIL foo WITH (SNAPSHOT)", &[])?;
+    assert_eq!(3, tail.len());
 
     Ok(())
 }

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -318,7 +318,7 @@ fn test_tail_fetch_timeout() -> Result<(), Box<dyn Error>> {
         next = expected_iter.next();
     }
 
-    // Test a 1s timeout and make sure we waited for atleast that long.
+    // Test a 1s timeout and make sure we waited for at least that long.
     let before = Instant::now();
     let rows = client.query("FETCH c WITH (TIMEOUT = '1s')", &[])?;
     let duration = before.elapsed();

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1239,8 +1239,9 @@ where
         // Send required trailers.
         if let CopyFormat::Binary = format {
             let trailer: i16 = -1;
+            out.extend(&trailer.to_be_bytes());
             self.conn
-                .send(BackendMessage::CopyData(trailer.to_be_bytes().to_vec()))
+                .send(BackendMessage::CopyData(mem::take(&mut out)))
                 .await?;
         }
 


### PR DESCRIPTION
Make use of tables and server-side cursors to simplify many of the TAIL tests. Most of these features didn't exist when the tests were written. This also makes the tests more orthogonal: we don't have to test TAIL, file sources, and textual COPY all at once. The hope here is that next time someone writes a TAIL test, they'll have a set of much simpler examples to use as a base. 

This work exposed a bug in binary COPY with empty result sets, which is fixed here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5315)
<!-- Reviewable:end -->
