### PR TITLE
sql: use SQL standard names in output consistently

### DIFF
--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -154,7 +154,34 @@ impl Type {
 
     /// Returns the name that PostgreSQL uses for this type.
     pub fn name(&self) -> &'static str {
-        self.inner().name()
+        // postgres_types' `name()` uses the pg_catalog name, and not the pretty
+        // SQL standard name.
+        match self.inner() {
+            &postgres_types::Type::BOOL_ARRAY => "boolean[]",
+            &postgres_types::Type::BYTEA_ARRAY => "bytea[]",
+            &postgres_types::Type::DATE_ARRAY => "date[]",
+            &postgres_types::Type::FLOAT4_ARRAY => "real[]",
+            &postgres_types::Type::FLOAT8_ARRAY => "double precision[]",
+            &postgres_types::Type::INT4_ARRAY => "integer[]",
+            &postgres_types::Type::INT8_ARRAY => "bigint[]",
+            &postgres_types::Type::INTERVAL_ARRAY => "interval[]",
+            &postgres_types::Type::JSONB_ARRAY => "jsonb[]",
+            &postgres_types::Type::NUMERIC_ARRAY => "numeric[]",
+            &postgres_types::Type::OID_ARRAY => "oid[]",
+            &postgres_types::Type::RECORD_ARRAY => "record[]",
+            &postgres_types::Type::TEXT_ARRAY => "text[]",
+            &postgres_types::Type::TIME_ARRAY => "time[]",
+            &postgres_types::Type::TIMESTAMP_ARRAY => "timestamp[]",
+            &postgres_types::Type::TIMESTAMPTZ_ARRAY => "timestamp with time zone[]",
+            &postgres_types::Type::UUID_ARRAY => "uuid[]",
+            &postgres_types::Type::BOOL => "boolean",
+            &postgres_types::Type::FLOAT4 => "real",
+            &postgres_types::Type::FLOAT8 => "double precision",
+            &postgres_types::Type::INT4 => "integer",
+            &postgres_types::Type::INT8 => "bigint",
+            &postgres_types::Type::TIMESTAMPTZ => "timestamp with time zone",
+            other => other.name(),
+        }
     }
 
     /// Returns the [OID] of this type.

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -63,7 +63,7 @@ pub fn parse_bool(s: &str) -> Result<bool, ParseError> {
     match s.trim().to_lowercase().as_str() {
         "t" | "tr" | "tru" | "true" | "y" | "ye" | "yes" | "on" | "1" => Ok(true),
         "f" | "fa" | "fal" | "fals" | "false" | "n" | "no" | "of" | "off" | "0" => Ok(false),
-        _ => Err(ParseError::new("bool", s)),
+        _ => Err(ParseError::new("boolean", s)),
     }
 }
 
@@ -97,7 +97,7 @@ where
 pub fn parse_int32(s: &str) -> Result<i32, ParseError> {
     s.trim()
         .parse()
-        .map_err(|e| ParseError::new("int4", s).with_details(e))
+        .map_err(|e| ParseError::new("integer", s).with_details(e))
 }
 
 /// Writes an [`i32`] to `buf`.
@@ -113,7 +113,7 @@ where
 pub fn parse_int64(s: &str) -> Result<i64, ParseError> {
     s.trim()
         .parse()
-        .map_err(|e| ParseError::new("int8", s).with_details(e))
+        .map_err(|e| ParseError::new("bigint", s).with_details(e))
 }
 
 /// Writes an `i64` to `buf`.
@@ -137,7 +137,7 @@ pub fn parse_float32(s: &str) -> Result<f32, ParseError> {
     } else {
         s.as_str()
             .parse()
-            .map_err(|e| ParseError::new("float4", s.as_str()).with_details(e))
+            .map_err(|e| ParseError::new("real", s.as_str()).with_details(e))
     }
 }
 
@@ -170,7 +170,7 @@ pub fn parse_float64(s: &str) -> Result<f64, ParseError> {
     } else {
         s.as_str()
             .parse()
-            .map_err(|e| ParseError::new("float8", s.as_str()).with_details(e))
+            .map_err(|e| ParseError::new("double precision", s.as_str()).with_details(e))
     }
 }
 
@@ -321,7 +321,7 @@ pub fn parse_timestamptz(s: &str) -> Result<DateTime<Utc>, ParseError> {
             };
             Ok(DateTime::from_utc(dt - offset, Utc))
         })
-        .map_err(|e| ParseError::new("timestamptz", s).with_details(e))
+        .map_err(|e| ParseError::new("timestamp with time zone", s).with_details(e))
 }
 
 /// Writes a [`DateTime<Utc>`] timestamp to `buf`.

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -250,17 +250,17 @@ fn test_parse_timestamptz() {
 fn test_parse_timestamptz_errors() {
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 +25:45",
-        "invalid input syntax for timestamptz: Invalid timezone string \
+        "invalid input syntax for timestamp with time zone: Invalid timezone string \
          (+25:45): timezone hour invalid 25: \"1999-01-01 01:23:34.555 +25:45\"",
     );
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 +15:61",
-        "invalid input syntax for timestamptz: Invalid timezone string \
+        "invalid input syntax for timestamp with time zone: Invalid timezone string \
          (+15:61): timezone minute invalid 61: \"1999-01-01 01:23:34.555 +15:61\"",
     );
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 4",
-        "invalid input syntax for timestamptz: Cannot parse timezone offset 4: \
+        "invalid input syntax for timestamp with time zone: Cannot parse timezone offset 4: \
          \"1999-01-01 01:23:34.555 4\"",
     );
 

--- a/test/metabase/smoketest/src/main.rs
+++ b/test/metabase/smoketest/src/main.rs
@@ -127,15 +127,15 @@ async fn main() -> Result<(), anyhow::Error> {
                 },
                 TableField {
                     name: "id".into(),
-                    database_type: "int4".into(),
-                    base_type: "type/Integer".into(),
+                    database_type: "integer".into(),
+                    base_type: "type/*".into(),
                     special_type: Some("type/PK".into()),
                 },
                 TableField {
                     name: "quantity".into(),
-                    database_type: "int4".into(),
-                    base_type: "type/Integer".into(),
-                    special_type: Some("type/Quantity".into()),
+                    database_type: "integer".into(),
+                    base_type: "type/*".into(),
+                    special_type: Some("type/Category".into()),
                 },
                 TableField {
                     name: "total".into(),

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -93,8 +93,8 @@ query TTT colnames
 SHOW COLUMNS FROM t
 ----
 name  nullable  type
- a    true      int4
- b    true      int4
+ a    true      integer
+ b    true      integer
 
 # Tests on int8 sums to make sure we handle overflow and underflow correctly
 

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -464,13 +464,13 @@ SELECT round((SELECT * FROM nums));
 ----
 NULL
 
-query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round((SELECT * FROM nums), 2)
 
-query error Cannot call function round\(float8, float8\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(double precision, double precision\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round((SELECT * FROM nums), (SELECT * FROM nums))
 
-query error Cannot call function round\(numeric\(38,1\), float8\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(numeric\(38,1\), double precision\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(5.0, (SELECT * FROM nums))
 
 query R
@@ -478,22 +478,22 @@ SELECT round(5.0, CAST ((SELECT * FROM nums) AS integer))
 ----
 NULL
 
-query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS double precision), 3)
 
-query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), 3)
 
-query error Cannot call function round\(bool, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(boolean, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(true, 3)
 
 query error
 SELECT round(true)
 
-query error Cannot call function round\(float8, numeric\(38,1\)\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(double precision, numeric\(38,1\)\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), 3.0)
 
-query error Cannot call function round\(float8, float8\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function round\(double precision, double precision\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(CAST (5.0 AS float), CAST (3.0 AS float))
 
 query I

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -11,7 +11,7 @@ mode cockroach
 
 # Test coercion behavior of multidimensional arrays.
 
-query error ARRAY expression cannot be cast to uniform type: int4\[\] vs text\[\]
+query error ARRAY expression cannot be cast to uniform type: integer\[\] vs text\[\]
 SELECT ARRAY[ARRAY[1, 2], ARRAY['3', '4']]
 
 query T
@@ -51,15 +51,15 @@ SELECT 1 = ANY(ARRAY[2])
 ----
 false
 
-query error ANY operand array must have type int4\[\], not type text\[\]
+query error ANY operand array must have type integer\[\], not type text\[\]
 SELECT 1 = ANY(ARRAY['1', '2'])
 ----
 true
 
-query error ANY operand array must have type int4\[\], not type text\[\]
+query error ANY operand array must have type integer\[\], not type text\[\]
 SELECT 1 = ANY(ARRAY['hi'::text])
 
-query error invalid input syntax for int4: invalid digit found in string: "hi"
+query error invalid input syntax for integer: invalid digit found in string: "hi"
 select 'hi' = any(array[1]);
 
 query error cannot determine type of empty array
@@ -72,7 +72,7 @@ SELECT 'hi'::text = ANY(ARRAY[]::text[])
 ----
 false
 
-query error ARRAY expression cannot be cast to uniform type: int4 vs text
+query error ARRAY expression cannot be cast to uniform type: integer vs text
 SELECT 123.4 = ANY(ARRAY[1, true, 'hi'::text])
 
 query B

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -45,28 +45,28 @@ tR                true
 tRuE              true
 TRUE              true
 
-query error invalid input syntax for bool: "blah"
+query error invalid input syntax for boolean: "blah"
 SELECT 'blah'::bool
 
-query error NOT argument must have type bool, not type int4
+query error NOT argument must have type boolean, not type integer
 SELECT NOT 1
 
-query error AND argument must have type bool, not type int4
+query error AND argument must have type boolean, not type integer
 SELECT 1 AND 1
 
-query error OR argument must have type bool, not type int4
+query error OR argument must have type boolean, not type integer
 SELECT 1 OR 1
 
-query error OR argument must have type bool, not type int4
+query error OR argument must have type boolean, not type integer
 SELECT 1 OR FALSE
 
-query error OR argument must have type bool, not type int4
+query error OR argument must have type boolean, not type integer
 SELECT FALSE OR 1
 
-query error AND argument must have type bool, not type int4
+query error AND argument must have type boolean, not type integer
 SELECT 1 AND FALSE
 
-query error AND argument must have type bool, not type int4
+query error AND argument must have type boolean, not type integer
 SELECT FALSE AND 1
 
 query B
@@ -159,7 +159,7 @@ SELECT NOT FALSE OR FALSE
 ----
 true
 
-### int4 to bool ###
+### integer to bool ###
 
 query B
 SELECT 99::int::bool
@@ -193,7 +193,7 @@ SELECT NOT 0::bigint::bool
 ----
 true
 
-### bool to int4 ###
+### bool to integer ###
 
 query I
 SELECT true::int
@@ -230,7 +230,7 @@ FROM x
 EOF
 
 statement ok
-CREATE TABLE y (a bool, b bool)
+CREATE TABLE y (a boolean, b bool)
 
 # Bypass if statements with identical branches
 query T multiline

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -90,7 +90,7 @@ int4_list
 query T
 SELECT pg_typeof('{1}'::int4_list::int4 list)
 ----
-int4 list
+integer list
 
 query T
 SELECT pg_typeof('{1}'::int4_list_list::int4_list_list_too)

--- a/test/sqllogictest/cockroach/array.slt
+++ b/test/sqllogictest/cockroach/array.slt
@@ -302,7 +302,7 @@ SELECT ARRAY['a', 'b', 'c'][3.5]
 query error could not parse "abc" as type int
 SELECT ARRAY['a', 'b', 'c']['abc']
 
-query error cannot subscript type int because it is not an array
+query error cannot subscript type integer because it is not an array
 SELECT (123)[2]
 
 # array slicing

--- a/test/sqllogictest/cockroach/order_by.slt
+++ b/test/sqllogictest/cockroach/order_by.slt
@@ -187,7 +187,7 @@ query I
 query error pgcode 42601 multiple ORDER BY clauses not allowed
 ((SELECT a FROM t ORDER BY a)) ORDER BY a
 
-query error CASE cannot be cast to uniform type: int4 vs bool
+query error CASE cannot be cast to uniform type: integer vs boolean
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
 
 query error pgcode 42P10 column reference 0 in ORDER BY clause is out of range \(1 - 3\)

--- a/test/sqllogictest/cockroach/tuple.slt
+++ b/test/sqllogictest/cockroach/tuple.slt
@@ -172,7 +172,7 @@ SELECT
 a     b     c      d
 true  NULL  false  NULL
 
-statement error invalid input syntax for int4
+statement error invalid input syntax for integer
 SELECT (1, 2) > (1, 'hi') FROM tb
 
 statement error unequal number of entries in row expressions
@@ -238,7 +238,7 @@ SELECT (ROW(sqrt(100.0)), 'ab') = (ROW(1 + 9), 'a' || 'b') AS a
 a
 true
 
-query error invalid input syntax for int4
+query error invalid input syntax for integer
 SELECT ((1, 2), 'equal') = ((1, 'huh'), 'equal') FROM tb
 
 # Issue #3568

--- a/test/sqllogictest/cockroach/union.slt
+++ b/test/sqllogictest/cockroach/union.slt
@@ -237,19 +237,19 @@ SELECT 1, 2 INTERSECT SELECT 3
 query error pgcode 42601 each EXCEPT query must have the same number of columns: 2 vs 1
 SELECT 1, 2 EXCEPT SELECT 3
 
-query error pgcode 42804 UNION types int4 and text cannot be matched
+query error pgcode 42804 UNION types integer and text cannot be matched
 SELECT 1 UNION SELECT '3'
 
-query error pgcode 42804 INTERSECT types int4 and text cannot be matched
+query error pgcode 42804 INTERSECT types integer and text cannot be matched
 SELECT 1 INTERSECT SELECT '3'
 
-query error pgcode 42804 EXCEPT types int4 and text cannot be matched
+query error pgcode 42804 EXCEPT types integer and text cannot be matched
 SELECT 1 EXCEPT SELECT '3'
 
 query error pgcode 42703 column "z" does not exist
 SELECT 1 UNION SELECT 3 ORDER BY z
 
-query error UNION types int4\[] and text\[] cannot be matched
+query error UNION types integer\[] and text\[] cannot be matched
 SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']
 
 # Check that UNION permits columns of different visible types

--- a/test/sqllogictest/cockroach/values.slt
+++ b/test/sqllogictest/cockroach/values.slt
@@ -72,5 +72,5 @@ VALUES ((SELECT 1)), ((SELECT 2))
 1
 2
 
-query error pgcode 42804 invalid input syntax for int4
+query error pgcode 42804 invalid input syntax for integer
 VALUES (NULL, 1), (2, NULL), (NULL, 'a')

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -183,7 +183,7 @@ SELECT DATE '2000-01-01' - INTERVAL '1' YEAR
 ----
 1999-01-01 00:00:00
 
-statement error no overload for interval - date
+query error no overload for interval - date
 SELECT INTERVAL '1' YEAR - DATE '2000-01-01'
 
 query T
@@ -248,7 +248,7 @@ SELECT TIMESTAMP '2000-01-01 00:00:00' - INTERVAL '1' YEAR
 ----
 1999-01-01 00:00:00
 
-statement error no overload for interval - timestamp
+query error no overload for interval - timestamp
 SELECT INTERVAL '1' YEAR - TIMESTAMP '2000-01-01 00:00:00'
 
 # Date arithmetic with duration intervals.
@@ -513,7 +513,7 @@ SELECT TIMESTAMPTZ '2000-01-01 00:00:00-7' - INTERVAL '4' MONTH
 ----
 1999-09-01 07:00:00+00
 
-statement error no overload for interval - timestamptz
+query error no overload for interval - timestamp with time zone
 SELECT INTERVAL '1' YEAR - TIMESTAMPTZ '2000-01-01 00:00:00-4:00'
 
 # Timestamptz arithmetic with duration intervals.
@@ -538,19 +538,19 @@ SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' - INTERVAL '2' HOUR
 ----
 2000-01-01 02:00:00+00
 
-statement error no overload for interval - timestamptz
+query error no overload for interval - timestamp with time zone
 SELECT INTERVAL '2' HOUR - TIMESTAMPTZ '2000-01-01 00:00:00-04'
 
-statement error no overload for timestamptz \* interval
+query error no overload for timestamp with time zone \* interval
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' * INTERVAL '2' HOUR
 
-statement error no overload for timestamptz / interval
+query error no overload for timestamp with time zone / interval
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' / INTERVAL '2' HOUR
 
-statement error no overload for timestamptz \+ timestamptz
+query error no overload for timestamp with time zone \+ timestamp with time zone
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' + TIMESTAMPTZ '1999-01-01 00:00:00z'
 
-statement error no overload for timestamptz \+ timestamp
+query error no overload for timestamp with time zone \+ timestamp
 SELECT TIMESTAMPTZ '2000-01-01 00:00:00-04' + TIMESTAMP '1999-01-01 00:00:00'
 
 # Tests with comparison operators and timestamptz

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -45,7 +45,7 @@ EXPLAIN TYPED RAW PLAN FOR SELECT * FROM (SELECT 1)
 | | types = ()
 | | keys = ()
 | Map 1
-| | types = (int4)
+| | types = (integer)
 | | keys = ()
 
 EOF
@@ -87,7 +87,7 @@ EXPLAIN TYPED RAW PLAN FOR SELECT (SELECT column2), (SELECT (SELECT column1)) FR
 ----
 %0 =
 | Constant
-| | types = (int4, text)
+| | types = (integer, text)
 | | keys = ()
 
 %1 =
@@ -95,15 +95,15 @@ EXPLAIN TYPED RAW PLAN FOR SELECT (SELECT column2), (SELECT (SELECT column1)) FR
 | | types = ()
 | | keys = ()
 | Map 1, "b"
-| | types = (int4, text)
+| | types = (integer, text)
 | | keys = ()
 
 %2 =
 | Union %0 %1
-| | types = (int4, text)
+| | types = (integer, text)
 | | keys = ()
 | Map select(%3), select(%4)
-| | types = (int4, text, text?, int4?)
+| | types = (integer, text, text?, integer?)
 | | keys = ()
 | |
 | | %3 =
@@ -120,7 +120,7 @@ EXPLAIN TYPED RAW PLAN FOR SELECT (SELECT column2), (SELECT (SELECT column1)) FR
 | | | | types = ()
 | | | | keys = ()
 | | | Map select(%5)
-| | | | types = (int4?)
+| | | | types = (integer?)
 | | | | keys = ()
 | | | |
 | | | | %5 =
@@ -128,12 +128,12 @@ EXPLAIN TYPED RAW PLAN FOR SELECT (SELECT column2), (SELECT (SELECT column1)) FR
 | | | | | | types = ()
 | | | | | | keys = ()
 | | | | | Map #^^0
-| | | | | | types = (int4)
+| | | | | | types = (integer)
 | | | | | | keys = ()
 | | | |
 | |
 | Project (#2, #3)
-| | types = (text?, int4?)
+| | types = (text?, integer?)
 | | keys = ()
 
 EOF
@@ -216,9 +216,9 @@ EXPLAIN TYPED DECORRELATED PLAN FOR VIEW foo
 | | types = ()
 | | keys = ()
 | Map 1
-| | types = (int4)
+| | types = (integer)
 | | keys = ()
-| | types = (int4)
+| | types = (integer)
 | | keys = ()
 
 EOF
@@ -280,7 +280,7 @@ EXPLAIN TYPED OPTIMIZED PLAN FOR SELECT * FROM ordered ORDER BY y asc, x desc LI
 ----
 %0 =
 | Get materialize.public.ordered (u2)
-| | types = (int4?, text?)
+| | types = (integer?, text?)
 | | keys = ()
 
 Finish order_by=(#1 asc, #0 desc) limit=5 offset=0 project=(#0, #1)
@@ -295,10 +295,10 @@ EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW ordered_view
 ----
 %0 =
 | Get materialize.public.ordered (u2)
-| | types = (int4?, text?)
+| | types = (integer?, text?)
 | | keys = ()
 | TopK group=() order=(#1 asc, #0 desc) limit=5 offset=0
-| | types = (int4?, text?)
+| | types = (integer?, text?)
 | | keys = ()
 
 EOF

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -619,7 +619,7 @@ SELECT array_upper(NULL::text[], 1)
 ----
 NULL
 
-query error Cannot call function array_upper\(unknown, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function array_upper\(unknown, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT array_upper(NULL, 1)
 
 query T

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -600,5 +600,5 @@ EOF
 statement ok
 CREATE TABLE join_fail (la date);
 
-query error NATURAL/USING join column "la" cannot be cast to uniform type: int4 vs date
+query error NATURAL/USING join column "la" cannot be cast to uniform type: integer vs date
 SELECT la FROM l JOIN join_fail USING (la)

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -22,7 +22,7 @@ SELECT (LIST[1,2,3])::text
 ----
 {1,2,3}
 
-query error LIST expression cannot be cast to uniform type: int4 vs int4 list
+query error LIST expression cannot be cast to uniform type: integer vs integer list
 SELECT LIST[1,LIST[2,3]]
 
 query T
@@ -65,7 +65,7 @@ SELECT (LIST[[[[1], [2]]], [[[3]]]])::text
 {{{{1},{2}}},{{{3}}}}
 
 # List(Int) cannot be cast to List(List(Int))
-query error CAST does not support casting from int4 list to int4 list list
+query error CAST does not support casting from integer list to integer list list
 SELECT LIST[1, null] :: INT LIST LIST
 
 query T
@@ -109,7 +109,7 @@ SELECT LIST [1, 2, 3][100]
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type int4
+query error cannot subscript type integer
 SELECT LIST [1, 2, 3][1][1]
 
 # 🔬🔬 list slices
@@ -194,7 +194,7 @@ SELECT (LIST [[1, 2, 3], [4, 5]][100][1])::text
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type int4
+query error cannot subscript type integer
 SELECT LIST [[1, 2, 3], [4, 5]][1][1][1]
 
 # 🔬🔬 list list slices
@@ -320,7 +320,7 @@ SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][100][2][3]
 NULL
 
 # exceeds maximum dimension
-query error cannot subscript type int4
+query error cannot subscript type integer
 SELECT LIST [[[1, 2], [3, 4, 5]], [[6]], [[7, 8], [9]]][1][2][3][1]
 
 # 🔬🔬 list list list slices
@@ -665,22 +665,22 @@ SELECT (LIST[1,2,3][LIST[1][2.0 / 2]])::text
 
 # 🔬🔬 Err
 
-query error invalid input syntax for int8: invalid digit found in string: "dog"
+query error invalid input syntax for bigint: invalid digit found in string: "dog"
 SELECT LIST[1,2,3]['dog']
 
-query error subscript \(indexing\) does not support casting from date to int8
+query error subscript \(indexing\) does not support casting from date to bigint
 SELECT LIST [[1, 2, 3], [4, 5]][DATE '2001-01-01']
 
-query error subscript \(indexing\) does not support casting from timestamp to int8
+query error subscript \(indexing\) does not support casting from timestamp to bigint
 SELECT LIST [[1, 2, 3], [4, 5]][TIMESTAMP '2001-01-01']
 
-query error invalid input syntax for int8: invalid digit found in string: "dog"
+query error invalid input syntax for bigint: invalid digit found in string: "dog"
 SELECT (LIST[1,2,3][1:'dog'])::text
 
-query error subscript \(slicing\) does not support casting from date to int8
+query error subscript \(slicing\) does not support casting from date to bigint
 SELECT LIST [[1, 2, 3], [4, 5]][1:DATE '2001-01-01']
 
-query error subscript \(slicing\) does not support casting from timestamp to int8
+query error subscript \(slicing\) does not support casting from timestamp to bigint
 SELECT LIST [[1, 2, 3], [4, 5]][1:TIMESTAMP '2001-01-01']
 
 # 🔬 Built-in functions
@@ -1241,10 +1241,10 @@ NULL
 
 # 🔬🔬🔬🔬 Errors
 
-query error invalid input syntax for int4: invalid digit found in string: "dog"
+query error invalid input syntax for integer: invalid digit found in string: "dog"
 SELECT (LIST['1', 'dog']::int list)::text
 
-query error CAST does not support casting from date list to int4 list
+query error CAST does not support casting from date list to integer list
 SELECT LIST[DATE '2008-02-01']::int list
 
 # 🔬🔬🔬 Multi-dimensional and jagged lists
@@ -1649,7 +1649,7 @@ query error invalid input syntax for list: expected '\{', found 1: "1"
 SELECT ('1'::int list)::text
 
 # Invalid element
-query error invalid input syntax for list: invalid input syntax for int4: invalid digit found in string: "a": "\{a\}"
+query error invalid input syntax for list: invalid input syntax for integer: invalid digit found in string: "a": "\{a\}"
 SELECT ('{a}'::int list)::text
 
 # 'NULL' isn't a valid string for a list; just use unescaped NULL
@@ -2042,7 +2042,7 @@ SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
 statement ok
 CREATE TYPE bool AS LIST (element_type=int4)
 
-query error invalid input syntax for bool: "\{1,2\}"
+query error invalid input syntax for boolean: "\{1,2\}"
 SELECT '{1,2}'::bool;
 
 query T

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -55,7 +55,7 @@ SELECT ('{  c  =>3, a=>     2, a => 1 }'::map[text=>int])::text
 ----
 {a=>1,c=>3}
 
-query error map key type must be text, got int4
+query error map key type must be text, got integer
 SELECT '{1=>true}'::map[int=>bool]
 
 query T
@@ -68,7 +68,7 @@ SELECT ('{}'::map[text=>int])::text
 ----
 {}
 
-query error invalid input syntax for bool: "2.0"
+query error invalid input syntax for boolean: "2.0"
 SELECT ('{a=>1, b=>false, c=>2.0}'::map[text=>bool])::text
 
 query T
@@ -132,7 +132,7 @@ SELECT ('{hello=>{world=>nested}}'::map[text=>map[text=>text]])::text
 ----
 {hello=>{world=>nested}}
 
-query error map key type must be text, got int4
+query error map key type must be text, got integer
 SELECT '{hello=>{1=>false}}'::map[text=>map[int=>bool]]
 
 query T
@@ -570,7 +570,7 @@ SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
 statement ok
 CREATE TYPE bool AS MAP (key_type=text, value_type=int4)
 
-query error invalid input syntax for bool: "\{a=>1\}"
+query error invalid input syntax for boolean: "\{a=>1\}"
 SELECT '{a=>1}'::bool;
 
 query T

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -600,7 +600,7 @@ SELECT '你' || '好'
 ----
 你好
 
-query error no overload for bool \|\| bool
+query error no overload for boolean \|\| boolean
 SELECT true || false
 
 query T

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -68,10 +68,10 @@ query error unable to determine which implementation to use
 SELECT generate_series FROM generate_series(null, null)
 ----
 
-statement error invalid input syntax for int4: invalid digit found in string: "foo"
+statement error invalid input syntax for integer: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series('foo', 2)
 
-statement error invalid input syntax for int4: invalid digit found in string: "foo"
+statement error invalid input syntax for integer: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series(1, 'foo')
 
 statement error arguments cannot be implicitly cast to any implementation's parameters

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -72,7 +72,7 @@ SELECT TIMESTAMPTZ '2007-02-01 00:00:00+5:30:16';
 statement error timezone interval must not contain months or years
 SELECT timezone(INTERVAL '+11'MONTH, TIME '18:53:49')
 
-statement error invalid input syntax for timestamptz: Invalid timezone string \(\+16:60\): timezone hour invalid 16
+statement error invalid input syntax for timestamp with time zone: Invalid timezone string \(\+16:60\): timezone hour invalid 16
 SELECT TIMESTAMPTZ '2020-01-01 00:00:00+16:60'
 
 query T

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -46,10 +46,10 @@ false
 true
 
 # Do not allow int4 text comparisons
-query error no overload for text < int4
+query error no overload for text < integer
 SELECT 'foo'::text < 5::int;
 
-query error no overload for int4 < text
+query error no overload for integer < text
 SELECT 1 < ALL(VALUES(NULL))
 
 # But string *literals* can coerce to anything.
@@ -87,7 +87,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Check int8 promotes to float8
+# Check int8 promotes to double precision
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1::bigint > 1.11111::float
@@ -98,7 +98,7 @@ EXPLAIN RAW PLAN FOR
 
 EOF
 
-# Check numeric promotes to float8
+# Check numeric promotes to double precision
 query T multiline
 EXPLAIN RAW PLAN FOR
     SELECT 1.1 > 1::float;
@@ -143,15 +143,15 @@ EXPLAIN RAW PLAN FOR
 EOF
 
 # Cannot implicitly cast int4 to string
-query error Cannot call function char_length\(int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+query error Cannot call function char_length\(integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT char_length(321);
 
 # Cannot implicitly cast string to any numeric category
 query error no overload for text \+ text
 SELECT 'dog'::text + 'cat'::text;
 
-# Cannot implicitly cast float8 to numeric
-query error Cannot call function round\(float8, int4\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+# Cannot implicitly cast double precision to numeric
+query error Cannot call function round\(double precision, integer\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT round(1.23::float, 1);
 
 # Check that float8 is the most common type
@@ -226,10 +226,10 @@ SELECT 1::bigint::bigint;
 ----
 1
 
-query error CAST does not support casting from bool to int8
+query error CAST does not support casting from boolean to bigint
 SELECT TRUE::boolean::bigint
 
-query error CAST does not support casting from date to int8
+query error CAST does not support casting from date to bigint
 SELECT '2001 02-03'::date::bigint
 
 query T
@@ -252,7 +252,7 @@ SELECT 2::int::bigint;
 ----
 2
 
-query error CAST does not support casting from interval to int8
+query error CAST does not support casting from interval to bigint
 SELECT '1'::interval::bigint
 
 #pginvalid
@@ -266,16 +266,16 @@ SELECT '1'::jsonb::bigint;
 ----
 1
 
-query error invalid input syntax for int8: invalid digit found in string: "dog"
+query error invalid input syntax for bigint: invalid digit found in string: "dog"
 SELECT 'dog'::text::bigint
 
-query error CAST does not support casting from time to int8
+query error CAST does not support casting from time to bigint
 SELECT '01:02:03'::time::bigint
 
-query error CAST does not support casting from timestamp to int8
+query error CAST does not support casting from timestamp to bigint
 SELECT '2002 03-04'::timestamp::bigint
 
-query error CAST does not support casting from timestamptz to int8
+query error CAST does not support casting from timestamp with time zone to bigint
 SELECT '2003 04-05'::timestamptz::bigint
 
 query T
@@ -288,16 +288,16 @@ SELECT TRUE::boolean::boolean;
 ----
 true
 
-query error CAST does not support casting from date to bool
+query error CAST does not support casting from date to boolean
 SELECT '2001 02-03'::date::boolean
 
-query error CAST does not support casting from numeric\(38,0\) to bool
+query error CAST does not support casting from numeric\(38,0\) to boolean
 SELECT 1.1::numeric::boolean
 
-query error CAST does not support casting from float8 to bool
+query error CAST does not support casting from double precision to boolean
 SELECT 1.2::double::boolean
 
-query error CAST does not support casting from float4 to bool
+query error CAST does not support casting from real to boolean
 SELECT 1.3::real::boolean
 
 query T
@@ -305,7 +305,7 @@ SELECT 2::int::boolean;
 ----
 true
 
-query error CAST does not support casting from interval to bool
+query error CAST does not support casting from interval to boolean
 SELECT '1'::interval::boolean
 
 #pginvalid
@@ -319,22 +319,22 @@ SELECT '1'::jsonb::boolean;
 ----
 NULL
 
-query error invalid input syntax for bool: "dog"
+query error invalid input syntax for boolean: "dog"
 SELECT 'dog'::text::boolean
 
-query error CAST does not support casting from time to bool
+query error CAST does not support casting from time to boolean
 SELECT '01:02:03'::time::boolean
 
-query error CAST does not support casting from timestamp to bool
+query error CAST does not support casting from timestamp to boolean
 SELECT '2002 03-04'::timestamp::boolean
 
-query error CAST does not support casting from timestamptz to bool
+query error CAST does not support casting from timestamp with time zone to boolean
 SELECT '2003 04-05'::timestamptz::boolean
 
-query error CAST does not support casting from int8 to date
+query error CAST does not support casting from bigint to date
 SELECT 1::bigint::date
 
-query error CAST does not support casting from bool to date
+query error CAST does not support casting from boolean to date
 SELECT TRUE::boolean::date
 
 query T
@@ -345,13 +345,13 @@ SELECT '2001 02-03'::date::date;
 query error CAST does not support casting from numeric\(38,0\) to date
 SELECT 1.1::numeric::date
 
-query error CAST does not support casting from float8 to date
+query error CAST does not support casting from double precision to date
 SELECT 1.2::double::date
 
-query error CAST does not support casting from float4 to date
+query error CAST does not support casting from real to date
 SELECT 1.3::real::date
 
-query error CAST does not support casting from int4 to date
+query error CAST does not support casting from integer to date
 SELECT 2::int::date
 
 query error CAST does not support casting from interval to date
@@ -381,7 +381,7 @@ SELECT 1::bigint::numeric;
 ----
 1.0000
 
-query error CAST does not support casting from bool to numeric\(38,0\)
+query error CAST does not support casting from boolean to numeric\(38,0\)
 SELECT TRUE::boolean::numeric
 
 query error CAST does not support casting from date to numeric\(38,0\)
@@ -429,7 +429,7 @@ SELECT '01:02:03'::time::numeric
 query error CAST does not support casting from timestamp to numeric\(38,0\)
 SELECT '2002 03-04'::timestamp::numeric
 
-query error CAST does not support casting from timestamptz to numeric\(38,0\)
+query error CAST does not support casting from timestamp with time zone to numeric\(38,0\)
 SELECT '2003 04-05'::timestamptz::numeric
 
 query T
@@ -437,10 +437,10 @@ SELECT 1::bigint::double;
 ----
 1.000
 
-query error CAST does not support casting from bool to float8
+query error CAST does not support casting from boolean to double precision
 SELECT TRUE::boolean::double
 
-query error CAST does not support casting from date to float8
+query error CAST does not support casting from date to double precision
 SELECT '2001 02-03'::date::double
 
 query T
@@ -463,7 +463,7 @@ SELECT 2::int::double;
 ----
 2.000
 
-query error CAST does not support casting from interval to float8
+query error CAST does not support casting from interval to double precision
 SELECT '1'::interval::double
 
 #pginvalid
@@ -477,16 +477,16 @@ SELECT '1'::jsonb::double;
 ----
 1.000
 
-query error invalid input syntax for float8: invalid float literal: "dog"
+query error invalid input syntax for double precision: invalid float literal: "dog"
 SELECT 'dog'::text::double
 
-query error CAST does not support casting from time to float8
+query error CAST does not support casting from time to double precision
 SELECT '01:02:03'::time::double
 
-query error CAST does not support casting from timestamp to float8
+query error CAST does not support casting from timestamp to double precision
 SELECT '2002 03-04'::timestamp::double
 
-query error CAST does not support casting from timestamptz to float8
+query error CAST does not support casting from timestamp with time zone to double precision
 SELECT '2003 04-05'::timestamptz::double
 
 query T
@@ -494,10 +494,10 @@ SELECT 1::bigint::real;
 ----
 1.000
 
-query error CAST does not support casting from bool to float4
+query error CAST does not support casting from boolean to real
 SELECT TRUE::boolean::real
 
-query error CAST does not support casting from date to float4
+query error CAST does not support casting from date to real
 SELECT '2001 02-03'::date::real
 
 query T
@@ -520,7 +520,7 @@ SELECT 2::int::real;
 ----
 2.000
 
-query error CAST does not support casting from interval to float4
+query error CAST does not support casting from interval to real
 SELECT '1'::interval::real
 
 #pginvalid
@@ -534,16 +534,16 @@ SELECT '2'::jsonb::real;
 ----
 2.000
 
-query error invalid input syntax for float4: invalid float literal: "dog"
+query error invalid input syntax for real: invalid float literal: "dog"
 SELECT 'dog'::text::real
 
-query error CAST does not support casting from time to float4
+query error CAST does not support casting from time to real
 SELECT '01:02:03'::time::real
 
-query error CAST does not support casting from timestamp to float4
+query error CAST does not support casting from timestamp to real
 SELECT '2002 03-04'::timestamp::real
 
-query error CAST does not support casting from timestamptz to float4
+query error CAST does not support casting from timestamp with time zone to real
 SELECT '2003 04-05'::timestamptz::real
 
 query T
@@ -551,7 +551,7 @@ SELECT 1::bigint::integer;
 ----
 1
 
-query error CAST does not support casting from date to int4
+query error CAST does not support casting from date to integer
 SELECT '2001 02-03'::date::integer
 
 query T
@@ -574,7 +574,7 @@ SELECT 2::int::integer;
 ----
 2
 
-query error CAST does not support casting from interval to int4
+query error CAST does not support casting from interval to integer
 SELECT '1'::interval::integer
 
 #pginvalid
@@ -588,22 +588,22 @@ SELECT '1'::jsonb::integer;
 ----
 1
 
-query error invalid input syntax for int4: invalid digit found in string: "dog"
+query error invalid input syntax for integer: invalid digit found in string: "dog"
 SELECT 'dog'::text::integer
 
-query error CAST does not support casting from time to int4
+query error CAST does not support casting from time to integer
 SELECT '01:02:03'::time::integer
 
-query error CAST does not support casting from timestamp to int4
+query error CAST does not support casting from timestamp to integer
 SELECT '2002 03-04'::timestamp::integer
 
-query error CAST does not support casting from timestamptz to int4
+query error CAST does not support casting from timestamp with time zone to integer
 SELECT '2003 04-05'::timestamptz::integer
 
-query error CAST does not support casting from int8 to interval
+query error CAST does not support casting from bigint to interval
 SELECT 1::bigint::interval
 
-query error CAST does not support casting from bool to interval
+query error CAST does not support casting from boolean to interval
 SELECT TRUE::boolean::interval
 
 query error CAST does not support casting from date to interval
@@ -612,13 +612,13 @@ SELECT '2001 02-03'::date::interval
 query error CAST does not support casting from numeric\(38,0\) to interval
 SELECT 1.1::numeric::interval
 
-query error CAST does not support casting from float8 to interval
+query error CAST does not support casting from double precision to interval
 SELECT 1.2::double::interval
 
-query error CAST does not support casting from float4 to interval
+query error CAST does not support casting from real to interval
 SELECT 1.3::real::interval
 
-query error CAST does not support casting from int4 to interval
+query error CAST does not support casting from integer to interval
 SELECT 2::int::interval
 
 query T
@@ -640,14 +640,14 @@ SELECT '01:02:03'::time::interval;
 query error CAST does not support casting from timestamp to interval
 SELECT '2002 03-04'::timestamp::interval
 
-query error CAST does not support casting from timestamptz to interval
+query error CAST does not support casting from timestamp with time zone to interval
 SELECT '2003 04-05'::timestamptz::interval
 
-query error CAST does not support casting from int8 to jsonb
+query error CAST does not support casting from bigint to jsonb
 SELECT 1::bigint::jsonb
 
 #pginvalid
-query error CAST does not support casting from bool to jsonb
+query error CAST does not support casting from boolean to jsonb
 SELECT TRUE::boolean::jsonb;
 
 query error CAST does not support casting from date to jsonb
@@ -656,10 +656,10 @@ SELECT '2001 02-03'::date::jsonb
 query error CAST does not support casting from numeric\(38,0\) to jsonb
 SELECT 1.1::numeric::jsonb
 
-query error CAST does not support casting from float8 to jsonb
+query error CAST does not support casting from double precision to jsonb
 SELECT 1.2::double::jsonb;
 
-query error CAST does not support casting from int4 to jsonb
+query error CAST does not support casting from integer to jsonb
 SELECT 2::int::jsonb;
 
 query error CAST does not support casting from interval to jsonb
@@ -687,7 +687,7 @@ SELECT '01:02:03'::time::jsonb
 query error CAST does not support casting from timestamp to jsonb
 SELECT '2002 03-04'::timestamp::jsonb
 
-query error CAST does not support casting from timestamptz to jsonb
+query error CAST does not support casting from timestamp with time zone to jsonb
 SELECT '2003 04-05'::timestamptz::jsonb
 
 query T
@@ -760,10 +760,10 @@ SELECT '2003 04-05'::timestamptz::text;
 ----
 2003-04-05 00:00:00+00
 
-query error CAST does not support casting from int8 to time
+query error CAST does not support casting from bigint to time
 SELECT 1::bigint::time
 
-query error CAST does not support casting from bool to time
+query error CAST does not support casting from boolean to time
 SELECT TRUE::boolean::time
 
 query error CAST does not support casting from date to time
@@ -772,13 +772,13 @@ SELECT '2001 02-03'::date::time
 query error CAST does not support casting from numeric\(38,0\) to time
 SELECT 1.1::numeric::time
 
-query error CAST does not support casting from float8 to time
+query error CAST does not support casting from double precision to time
 SELECT 1.2::double::time
 
-query error CAST does not support casting from float4 to time
+query error CAST does not support casting from real to time
 SELECT 1.3::real::time
 
-query error CAST does not support casting from int4 to time
+query error CAST does not support casting from integer to time
 SELECT 2::int::time
 
 query T
@@ -800,13 +800,13 @@ SELECT '01:02:03'::time::time;
 query error CAST does not support casting from timestamp to time
 SELECT '2002 03-04'::timestamp::time
 
-query error CAST does not support casting from timestamptz to time
+query error CAST does not support casting from timestamp with time zone to time
 SELECT '2003 04-05'::timestamptz::time
 
-query error CAST does not support casting from int8 to timestamp
+query error CAST does not support casting from bigint to timestamp
 SELECT 1::bigint::timestamp
 
-query error CAST does not support casting from bool to timestamp
+query error CAST does not support casting from boolean to timestamp
 SELECT TRUE::boolean::timestamp
 
 query T
@@ -817,13 +817,13 @@ SELECT '2001 02-03'::date::timestamp;
 query error CAST does not support casting from numeric\(38,0\) to timestamp
 SELECT 1.1::numeric::timestamp
 
-query error CAST does not support casting from float8 to timestamp
+query error CAST does not support casting from double precision to timestamp
 SELECT 1.2::double::timestamp
 
-query error CAST does not support casting from float4 to timestamp
+query error CAST does not support casting from real to timestamp
 SELECT 1.3::real::timestamp
 
-query error CAST does not support casting from int4 to timestamp
+query error CAST does not support casting from integer to timestamp
 SELECT 2::int::timestamp
 
 query error CAST does not support casting from interval to timestamp
@@ -848,10 +848,10 @@ SELECT '2003 04-05'::timestamptz::timestamp;
 ----
 2003-04-05 00:00:00
 
-query error CAST does not support casting from int8 to timestamptz
+query error CAST does not support casting from bigint to timestamp with time zone
 SELECT 1::bigint::timestamptz
 
-query error CAST does not support casting from bool to timestamptz
+query error CAST does not support casting from boolean to timestamp with time zone
 SELECT TRUE::boolean::timestamptz
 
 query T
@@ -859,28 +859,28 @@ SELECT '2001 02-03'::date::timestamptz;
 ----
 2001-02-03 00:00:00+00
 
-query error CAST does not support casting from numeric\(38,0\) to timestamptz
+query error CAST does not support casting from numeric\(38,0\) to timestamp with time zone
 SELECT 1.1::numeric::timestamptz
 
-query error CAST does not support casting from float8 to timestamptz
+query error CAST does not support casting from double precision to timestamp with time zone
 SELECT 1.2::double::timestamptz
 
-query error CAST does not support casting from float4 to timestamptz
+query error CAST does not support casting from real to timestamp with time zone
 SELECT 1.3::real::timestamptz
 
-query error CAST does not support casting from int4 to timestamptz
+query error CAST does not support casting from integer to timestamp with time zone
 SELECT 2::int::timestamptz
 
-query error CAST does not support casting from interval to timestamptz
+query error CAST does not support casting from interval to timestamp with time zone
 SELECT '1'::interval::timestamptz
 
-query error CAST does not support casting from jsonb to timestamptz
+query error CAST does not support casting from jsonb to timestamp with time zone
 SELECT '{}'::jsonb::timestamptz
 
-query error invalid input syntax for timestamptz: YEAR, MONTH, DAY are all required: "dog"
+query error invalid input syntax for timestamp with time zone: YEAR, MONTH, DAY are all required: "dog"
 SELECT 'dog'::text::timestamptz
 
-query error CAST does not support casting from time to timestamptz
+query error CAST does not support casting from time to timestamp with time zone
 SELECT '01:02:03'::time::timestamptz
 
 query T

--- a/test/sqllogictest/typeof.slt
+++ b/test/sqllogictest/typeof.slt
@@ -30,7 +30,7 @@ text
 query T
 SELECT pg_typeof(1)
 ----
-int4
+integer
 
 query T
 SELECT pg_typeof(1.0)
@@ -48,7 +48,7 @@ CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
 query T
 SELECT pg_typeof('{1}'::int4 list)
 ----
-int4 list
+integer list
 
 query T
 SELECT pg_typeof('{1}'::int4_list)
@@ -58,7 +58,7 @@ int4_list
 query T
 SELECT pg_typeof('{{1}}'::int4 list list)
 ----
-int4 list list
+integer list list
 
 query T
 SELECT pg_typeof('{{1}}'::int4_list_list)

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -31,7 +31,7 @@ true
 query T
 SELECT pg_typeof('true'::boolean)
 ----
-bool
+boolean
 
 query error type "pg_catalog.boolean" does not exist
 SELECT 'true'::pg_catalog.boolean
@@ -95,7 +95,7 @@ SELECT '1.2'::pg_catalog.float(1)
 query T
 SELECT pg_typeof('1.2'::float(1))
 ----
-float4
+real
 
 query T
 SELECT '1.2'::real
@@ -108,7 +108,7 @@ SELECT '1.2'::pg_catalog.real
 query T
 SELECT pg_typeof('1.2'::real)
 ----
-float4
+real
 
 # 🔬🔬 float8
 
@@ -135,7 +135,7 @@ SELECT '1.2'::pg_catalog.float(53)
 query T
 SELECT pg_typeof('1.2'::float(53))
 ----
-float8
+double precision
 
 query T
 SELECT '1.2'::double
@@ -148,7 +148,7 @@ SELECT '1.2'::pg_catalog.double
 query T
 SELECT pg_typeof('1.2'::double)
 ----
-float8
+double precision
 
 # 🔬🔬 int4
 
@@ -175,7 +175,7 @@ SELECT '1'::pg_catalog.int
 query T
 SELECT pg_typeof('1'::int)
 ----
-int4
+integer
 
 query T
 SELECT '1'::integer
@@ -188,7 +188,7 @@ SELECT '1'::pg_catalog.integer
 query T
 SELECT pg_typeof('1'::integer)
 ----
-int4
+integer
 
 query T
 SELECT '1'::smallint
@@ -201,7 +201,7 @@ SELECT '1'::pg_catalog.smallint
 query T
 SELECT pg_typeof('1'::smallint)
 ----
-int4
+integer
 
 # 🔬🔬 int8
 
@@ -228,7 +228,7 @@ SELECT '1'::pg_catalog.bigint
 query T
 SELECT pg_typeof('1'::bigint)
 ----
-int8
+bigint
 
 # 🔬🔬 interval
 
@@ -438,22 +438,22 @@ SELECT '{true}'::pg_catalog.bool list::text
 query T
 SELECT pg_typeof(1::float)
 ----
-float8
+double precision
 
 query T
 SELECT pg_typeof(1::float(1))
 ----
-float4
+real
 
 query T
 SELECT pg_typeof(1::float(53))
 ----
-float8
+double precision
 
 query T
 SELECT pg_typeof(1::float(53))
 ----
-float8
+double precision
 
 # 🔬 misc. resolution tests
 

--- a/test/testdrive/avro-ocf.td
+++ b/test/testdrive/avro-ocf.td
@@ -32,9 +32,9 @@ a  b  mz_obj_no
 > SHOW COLUMNS FROM basic
 name       nullable  type
 -------------------------
-a          false     int8
-b          false     int4
-mz_obj_no  false     int8
+a          false     bigint
+b          false     integer
+mz_obj_no  false     bigint
 
 $ avro-ocf-write path=data-no-codec.ocf schema=${writer-schema}
 {"a": 1, "b": 2}
@@ -52,9 +52,9 @@ a  b  mz_obj_no
 > SHOW COLUMNS FROM basic_no_codec
 name       nullable  type
 -------------------------
-a          false     int8
-b          false     int4
-mz_obj_no  false     int8
+a          false     bigint
+b          false     integer
+mz_obj_no  false     bigint
 
 $ avro-ocf-write path=data-snappy.ocf schema=${writer-schema} codec=snappy
 {"a": 1, "b": 2}
@@ -72,9 +72,9 @@ a  b  mz_obj_no
 > SHOW COLUMNS FROM basic_snappy
 name       nullable  type
 -------------------------
-a          false     int8
-b          false     int4
-mz_obj_no  false     int8
+a          false     bigint
+b          false     integer
+mz_obj_no  false     bigint
 
 $ set reader-schema={
     "name": "row",
@@ -98,9 +98,9 @@ a  b  mz_obj_no
 > SHOW COLUMNS FROM reader_schema
 name       nullable  type
 -------------------------
-a          false     int8
-b          false     int8
-mz_obj_no  false     int8
+a          false     bigint
+b          false     bigint
+mz_obj_no  false     bigint
 
 ! CREATE MATERIALIZED SOURCE reader_schema
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
@@ -183,7 +183,7 @@ name        nullable  type
 d           false     date
 ts          false     timestamp
 ts_tz       false     timestamp
-mz_obj_no   false     int8
+mz_obj_no   false     bigint
 
 > CREATE SINK basic_sink_${testdrive.seed} FROM basic
   INTO AVRO OCF '${testdrive.temp-dir}/basic-sink.ocf'

--- a/test/testdrive/avro-unions.td
+++ b/test/testdrive/avro-unions.td
@@ -32,13 +32,13 @@ $ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
 > SHOW COLUMNS FROM unions
 name       nullable  type
 -------------------------
-a          false     int8
-b          true      int8
-c1         true      int8
+a          false     bigint
+b          true      bigint
+c1         true      bigint
 c2         true      text
-d1         true      int8
+d1         true      bigint
 d2         true      text
-mz_obj_no  false     int8
+mz_obj_no  false     bigint
 
 > SELECT * FROM unions
 a   b       c1      c2     d1      d2      mz_obj_no

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -23,7 +23,7 @@ $ kafka-ingest format=bytes topic=bytes timestamp=1
 name       nullable  type
 --------------------------
 data       false     bytea
-mz_offset  false     int8
+mz_offset  false     bigint
 
 > SELECT * FROM data
 data           mz_offset
@@ -41,4 +41,4 @@ data           mz_offset
 name       nullable  type
 --------------------------
 named_col  false     bytea
-mz_offset  false     int8
+mz_offset  false     bigint

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -97,7 +97,7 @@ d
 > SHOW DATABASES WHERE (name = (SELECT min(name) FROM mz_databases))
 d
 ! SHOW DATABASES WHERE 7
-WHERE clause must have type bool, not type int4
+WHERE clause must have type boolean, not type integer
 
 # Creating a database with a name that already exists should fail.
 ! CREATE DATABASE d
@@ -175,7 +175,7 @@ foo.other.int_list
 
 > CREATE TYPE bool AS LIST (element_type=int4)
 ! SELECT '{1}'::bool
-invalid input syntax for bool: "{1}"
+invalid input syntax for boolean: "{1}"
 
 > SELECT pg_typeof('{1}'::public.bool);
 public.bool

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -69,7 +69,7 @@ b  sum
 > SHOW COLUMNS FROM test1
 name nullable type
 -------------------
-b     false   int8
+b     false   bigint
 sum   true    numeric
 
 > SHOW VIEWS LIKE '%data%'

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -13,7 +13,7 @@ name     nullable  type
 oid      false     oid
 nspname  false     text
 nspowner true      oid
-nspacl   true      _text
+nspacl   true      text[]
 
 > SHOW COLUMNS FROM pg_class
 name         nullable  type
@@ -30,10 +30,10 @@ name         nullable  type
  oid         false     oid
  datname     false     text
  datdba      true      oid
- encoding    false     int4
+ encoding    false     integer
  datcollate  false     text
  datctype    false     text
- datacl      true      _text
+ datacl      true      text[]
 
 > SHOW COLUMNS FROM pg_index
 name        nullable  type
@@ -46,7 +46,7 @@ name         nullable  type
 ---------------------------
 objoid       false     oid
 classoid     true      oid
-objsubid     false     int4
+objsubid     false     integer
 description  true      text
 
 > SHOW COLUMNS FROM pg_attribute
@@ -54,10 +54,10 @@ name         nullable  type
 ---------------------------
 attrelid     false     oid
 attname      false     text
-attnum       false     int8
-atttypmod    false     int4
-attnotnull   false     bool
-attisdropped false     bool
+attnum       false     bigint
+atttypmod    false     integer
+attnotnull   false     boolean
+attisdropped false     boolean
 atttypid     false     oid
 
 ! SELECT current_schemas()

--- a/test/testdrive/proto-billing.td
+++ b/test/testdrive/proto-billing.td
@@ -67,7 +67,7 @@ interval_end    true  text
 interval_start  true  text
 measurements    true  jsonb
 meter           true  text
-value           true  int4
+value           true  integer
 
 > SELECT id, interval_start, interval_end, value, meter FROM billing_records br
 2 2020-01-01_00:00:10 2020-01-01_00:00:15 25  user

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -26,7 +26,7 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-mz_line_no         false     int8
+mz_line_no         false     bigint
 
 > SELECT * FROM regex_source ORDER BY mz_line_no
 ip            ts                      path                                           search_kw           product_detail_id  code  mz_line_no
@@ -53,7 +53,7 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-mz_line_no         false     int8
+mz_line_no         false     bigint
 
 > SELECT * FROM regex_source_named_cols ORDER BY mz_line_no
 ip            ts                      path                                           search_kw           product_detail_id  code  mz_line_no

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -33,7 +33,7 @@ materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" \"pg
 > DROP TABLE s;
 
 ! CREATE TABLE s (a date DEFAULT 42)
-DEFAULT expression does not support casting from int4 to date
+DEFAULT expression does not support casting from integer to date
 
 ! CREATE TABLE s (a int, b int DEFAULT a + 3)
 column "a" does not exist
@@ -64,10 +64,12 @@ cannot drop 'materialize.public.t_primary_idx' as it is the default index for a 
 > SHOW COLUMNS in t;
 name       nullable  type
 -------------------------
-a          true       int4
+a          true       integer
 b          false      text
+
 > SHOW COLUMNS in t WHERE name = 'a'
-a  true  int4
+a  true  integer
+
 > SHOW COLUMNS in t LIKE 'b%'
 b  false  text
 
@@ -150,7 +152,7 @@ null value in column "b" violates not-null constraint
 null value in column "b" violates not-null constraint
 
 ! INSERT INTO t VALUES ('d', 4);
-invalid input syntax for int4: invalid digit found in string: "d"
+invalid input syntax for integer: invalid digit found in string: "d"
 
 # Test that the INSERT body can be a SELECT query.
 > INSERT INTO t SELECT 3, 'd'
@@ -160,7 +162,7 @@ invalid input syntax for int4: invalid digit found in string: "d"
 
 # ...but not in complicated VALUES clauses, per PostgreSQL.
 ! INSERT INTO t VALUES ('4', 'e') LIMIT 0
-column "a" is of type int4 but expression is of type text
+column "a" is of type integer but expression is of type text
 
 # Test that assignment casts occur when possible...
 > INSERT INTO t VALUES (5.0, 'f');
@@ -168,14 +170,14 @@ column "a" is of type int4 but expression is of type text
 
 # ...but not when impossible.
 ! INSERT INTO t VALUES (DATE '2020-01-01', 'bad')
-column "a" is of type int4 but expression is of type date
+column "a" is of type integer but expression is of type date
 
 # Attempting to insert JSON into an int column is particularly interesting.
 # While there is an "explicit" cast from `jsonb` to `int`, there is no
 # "assignment" cast, and INSERT is only allowed to use assignment/implicit
 # casts.
 ! INSERT INTO t VALUES (JSON '1', 'bad')
-column "a" is of type int4 but expression is of type jsonb
+column "a" is of type integer but expression is of type jsonb
 
 > SELECT * FROM t;
 a       b
@@ -306,10 +308,10 @@ a      b    c
 column "notpresent" of relation "materialize.public.t" does not exist
 
 ! INSERT INTO t (a, b, c) VALUES ('str', 1, 2);
-invalid input syntax for int4: invalid digit found in string: "str"
+invalid input syntax for integer: invalid digit found in string: "str"
 
 ! INSERT INTO t (b, a, c) VALUES (1, 'str', 2);
-invalid input syntax for int4: invalid digit found in string: "str"
+invalid input syntax for integer: invalid digit found in string: "str"
 
 ! INSERT INTO t (d, c, b, a) VALUES (1, 1, 1, 'str');
 column "d" of relation "materialize.public.t" does not exist


### PR DESCRIPTION
Converts the printed name for SQL types to be more consistently the SQL standard name, rather than the PG catalog name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5317)
<!-- Reviewable:end -->
