### PR TITLE
sql: support ILIKE pattern matching

### DIFF
--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -43,6 +43,7 @@ Operator | Computes
 `a ISNULL` | `a = NULL`
 `a IS NOT NULL` | `a != NULL`
 `a LIKE match_expr` | `a` matches `match_expr`, using [SQL LIKE matching](https://www.w3schools.com/sql/sql_like.asp)
+`a ILIKE match_expr` | `a` matches `match_expr`, using case-insensitive [SQL LIKE matching](https://www.w3schools.com/sql/sql_like.asp)
 
 ### Numbers
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1804,13 +1804,11 @@ impl ExprHumanizer for ConnCatalog<'_> {
             List { element_type, .. } => {
                 format!("{} list", self.humanize_scalar_type(element_type))
             }
-            Map { value_type, .. } => {
-                format!(
-                    "map[{}=>{}]",
-                    self.humanize_scalar_type(&ScalarType::String),
-                    self.humanize_scalar_type(value_type)
-                )
-            }
+            Map { value_type, .. } => format!(
+                "map[{}=>{}]",
+                self.humanize_scalar_type(&ScalarType::String),
+                self.humanize_scalar_type(value_type)
+            ),
             Record { fields } => format!(
                 "record({})",
                 fields

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -110,6 +110,7 @@ Hold
 Hour
 Hours
 If
+Ilike
 In
 Index
 Indexes

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -806,10 +806,13 @@ impl<'a> Parser<'a> {
             Token::Op(s) => Some(s.as_str()),
             Token::Eq => Some("="),
             Token::Star => Some("*"),
+            Token::Keyword(ILIKE) => Some("~~*"),
             Token::Keyword(LIKE) => Some("~~"),
             Token::Keyword(NOT) => {
                 if self.parse_keyword(LIKE) {
                     Some("!~~")
+                } else if self.parse_keyword(ILIKE) {
+                    Some("!~~*")
                 } else {
                     None
                 }
@@ -1056,12 +1059,14 @@ impl<'a> Parser<'a> {
                     // precedence.
                     Some(Token::Keyword(IN)) => Precedence::Like,
                     Some(Token::Keyword(BETWEEN)) => Precedence::Like,
+                    Some(Token::Keyword(ILIKE)) => Precedence::Like,
                     Some(Token::Keyword(LIKE)) => Precedence::Like,
                     _ => Precedence::Zero,
                 },
                 Token::Keyword(IS) | Token::Keyword(ISNULL) => Precedence::Is,
                 Token::Keyword(IN) => Precedence::Like,
                 Token::Keyword(BETWEEN) => Precedence::Like,
+                Token::Keyword(ILIKE) => Precedence::Like,
                 Token::Keyword(LIKE) => Precedence::Like,
                 Token::Op(s) => match s.as_str() {
                     "<" | "<=" | "<>" | "!=" | ">" | ">=" => Precedence::Cmp,

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1976,14 +1976,27 @@ lazy_static! {
                 })
             },
 
+            // ILIKE
+            "~~*" => Scalar {
+                params!(String, String) => IsLikePatternMatch { case_insensitive: true }
+            },
+            "!~~*" => Scalar {
+                params!(String, String) => Operation::binary(|_ecx, lhs, rhs| {
+                    Ok(lhs
+                        .call_binary(rhs, IsLikePatternMatch { case_insensitive: true })
+                        .call_unary(UnaryFunc::Not))
+                })
+            },
+
+
             // LIKE
             "~~" => Scalar {
-                params!(String, String) => IsLikePatternMatch
+                params!(String, String) => IsLikePatternMatch { case_insensitive: false }
             },
             "!~~" => Scalar {
                 params!(String, String) => Operation::binary(|_ecx, lhs, rhs| {
                     Ok(lhs
-                        .call_binary(rhs, IsLikePatternMatch)
+                        .call_binary(rhs, IsLikePatternMatch { case_insensitive: false })
                         .call_unary(UnaryFunc::Not))
                 })
             },

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -734,6 +734,110 @@ SELECT lpad('str', 5, 'đẹp')
 ----
 đẹstr
 
+
+### ilike ###
+# ILIKE tests lifted from Cockroach
+
+query B
+SELECT 'TEST' ILIKE 'TEST'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE 'test'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE 'TE%'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE '%E%'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE '%e%'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE 'TES_'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE 'TE_%'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE 'TE_'
+----
+false
+
+query B
+SELECT 'TEST' ILIKE '%'
+----
+true
+
+query B
+SELECT 'TEST' ILIKE '%R'
+----
+false
+
+query B
+SELECT 'TEST' ILIKE 'TESTER'
+----
+false
+
+query B
+SELECT 'TEST' ILIKE 'tester'
+----
+false
+
+query B
+SELECT 'TEST' ILIKE ''
+----
+false
+
+query B
+SELECT '' ILIKE ''
+----
+true
+
+query B
+SELECT 'T' ILIKE '_'
+----
+true
+
+query B
+SELECT 'TE' ILIKE '_'
+----
+false
+
+query B
+SELECT 'TEST' NOT ILIKE '%E%'
+----
+false
+
+query B
+SELECT 'TEST' NOT ILIKE 'TES_'
+----
+false
+
+query B
+SELECT 'TEST' NOT ILIKE 'TeS_'
+----
+false
+
+query B
+SELECT 'TEST' NOT ILIKE 'TE_'
+----
+true
+
 # Invalid type mods
 
 query error length for type varchar must be within \[1-10485760\], have 0


### PR DESCRIPTION
Adds support for ILIKE, which is used for case insensitive matching.

This [partially unblocks](https://github.com/MaterializeInc/materialize-dbt-utils/issues/7) two `dbt_utils` functions: `test_get_relations_by_pattern` and `test_get_relations_by_prefix_and_union`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5321)
<!-- Reviewable:end -->
