### PR TITLE
peeker: enable hyper's tcp feature

### DIFF
--- a/src/peeker/Cargo.toml
+++ b/src/peeker/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 env_logger = "0.8.2"
-hyper = { version = "0.14.0", features = ["http1", "server"] }
+hyper = { version = "0.14.0", features = ["http1", "server", "tcp"] }
 lazy_static = "1.4.0"
 log = "0.4.13"
 mz-process-collector = { path = "../mz-process-collector" }


### PR DESCRIPTION
Usual Cargo feature nonsense. Peeker requires this feature, but it's
only obvious that it does if it you build it alone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5322)
<!-- Reviewable:end -->
