### PR TITLE
ensure the source's time since downgrade is initially stale

### DIFF
--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -465,8 +465,8 @@ impl ConsistencyInfo {
                 &source_id.to_string(),
                 &worker_id.to_string(),
             ),
-            // we have never downgraded, so make sure the initial value is outside of our frequncy
-            time_since_downgrade: Instant::now() - timestamp_frequency,
+            // we have never downgraded, so make sure the initial value is outside of our frequency
+            time_since_downgrade: Instant::now() - timestamp_frequency - Duration::from_secs(1),
             partition_metrics: Default::default(),
         }
     }


### PR DESCRIPTION
Previously (a93a2e77d) this was changed to force creation of an initial
timestamp to avoid timestamping data with `1`. However, the "is it
stale" comparison is at millisecond granularity and computers are fast,
so setting the initial time to now() - frequency can still result in a
small portion of data being timestamped as `1`.

Ensure that the initial time since downgrade is strictly in the past by
subtracting an extra second.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5323)
<!-- Reviewable:end -->
