### PR TITLE
enable offset autocommit for kafka sources

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,11 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.6.2 %}}
+
+- Commit consumed offsets to Kafka to facilitate source ingest progress
+  monitoring.
+
 {{% version-header v0.6.1 %}}
 
 - Add the advanced [`--timely-progress-mode` and `--differential-idle-merge-effort` command-line arguments](/cli/#dataflow-tuning)

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -31,6 +31,7 @@ use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use kafka_util::KafkaAddrs;
 use repr::{ColumnName, ColumnType, RelationDesc, RelationType, Row, ScalarType, Timestamp};
+use uuid::Uuid;
 
 /// The response from a `Peek`.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -606,6 +607,7 @@ pub struct KafkaSourceConnector {
     pub start_offsets: HashMap<i32, i64>,
     pub group_id_prefix: Option<String>,
     pub enable_caching: bool,
+    pub cluster_id: Uuid,
     // This field gets set after the initial construction of this struct, so this is None if it has
     // not yet been set.
     pub cached_files: Option<Vec<PathBuf>>,

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -620,12 +620,10 @@ fn create_kafka_config(
     // Broker configuration.
     kafka_config.set("bootstrap.servers", &addrs.to_string());
 
-    // Opt-out of Kafka's offset management facilities. Whenever we restart,
-    // we want to restart from the beginning of the topic.
-    //
-    // This is likely to change soon. See #3060 and #2490.
+    // Automatically commit read offsets back to Kafka for monitoring purposes,
+    // but on restart begin ingest at 0
     kafka_config
-        .set("enable.auto.commit", "false")
+        .set("enable.auto.commit", "true")
         .set("auto.offset.reset", "earliest");
 
     // How often to refresh metadata from the Kafka broker. This can have a

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -378,6 +378,7 @@ pub fn plan_create_source(
                 config_options,
                 start_offsets,
                 group_id_prefix,
+                cluster_id: scx.catalog.config().cluster_id,
                 enable_caching,
                 cached_files: None,
             });


### PR DESCRIPTION
    Related to https://github.com/MaterializeInc/materialize/issues/3060
    
    Turning this on allows customers to use standard, existing monitoring
    tools to get a sense of materialize's progress.
    
    There are two important notes:
    1. mz committing offsets is a shallow notion of progress and means that
       the offset has been retrieved. It does _not_ mean that views have
       been updated with data from that offset.
    2. mz committing offsets does not mean that mz will continue from the
       last committed offset on restart - bootstrap behavior is unchanged,
       and mz still needs to re-read all data when restarted.
    
    This was tested manually by:
    1. Starting up mz
    2. Creating and materializing a kafka topic that contained data
    3. Observing in the confluent console that consumer progress shows up
    4. Restarting mz and checking that it reads from offset 0 and correctly
       repopulates the materialized view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5324)
<!-- Reviewable:end -->
