### PR TITLE
testdrive: Use buildkite section headings for files

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -80,7 +80,7 @@ steps:
     depends_on: build
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    command: test/testdrive/*.td test/testdrive/esoteric/*.td
+    command: --ci-output test/testdrive/*.td test/testdrive/esoteric/*.td
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -53,6 +53,7 @@ pub struct Config {
     pub materialized_pgconfig: tokio_postgres::Config,
     pub materialized_catalog_path: Option<PathBuf>,
     pub reset_materialized: bool,
+    pub ci_output: bool,
 }
 
 pub struct State {

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -57,13 +57,16 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn print_stderr(&self) -> io::Result<()> {
+    pub fn print_stderr(&self, ci_output: bool) -> io::Result<()> {
         let color_choice = if atty::is(Stream::Stderr) {
             ColorChoice::Auto
         } else {
             ColorChoice::Never
         };
         let mut stderr = StandardStream::stderr(color_choice);
+        if ci_output {
+            println!("^^^ +++");
+        }
         match self {
             Error::Input {
                 err,

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -48,7 +48,11 @@ pub async fn run_stdin(config: &Config) -> Result<(), Error> {
 /// only as output in error messages and such. No attempt is made to read
 /// `filename`.
 pub async fn run_string(config: &Config, filename: &str, contents: &str) -> Result<(), Error> {
+    if config.ci_output {
+        print!("--- ");
+    }
     println!("==> {}", filename);
+
     let mut line_reader = LineReader::new(contents);
     run_line_reader(config, &mut line_reader)
         .await

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -66,6 +66,11 @@ struct Args {
     #[structopt(long)]
     no_reset: bool,
 
+    // === Testdrive options. ===
+    /// Emit buildkite-specific markup
+    #[structopt(long)]
+    ci_output: bool,
+
     // === Positional arguments. ===
     /// Paths to testdrive scripts to run.
     files: Vec<String>,
@@ -73,10 +78,12 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
-    if let Err(err) = run(ore::cli::parse_args()).await {
+    let args: Args = ore::cli::parse_args();
+    let ci_output = args.ci_output;
+    if let Err(err) = run(args).await {
         // If printing the error message fails, there's not a whole lot we can
         // do.
-        let _ = err.print_stderr();
+        let _ = err.print_stderr(ci_output);
         process::exit(err.exit_code());
     }
 }
@@ -133,6 +140,7 @@ async fn run(args: Args) -> Result<(), Error> {
         materialized_pgconfig: args.materialized_url,
         materialized_catalog_path: args.validate_catalog,
         reset_materialized: !args.no_reset,
+        ci_output: args.ci_output,
     };
 
     if args.files.is_empty() {

--- a/src/testdrive/tests/cli.rs
+++ b/src/testdrive/tests/cli.rs
@@ -163,3 +163,38 @@ fn test_cmd_arg_bad_nesting_intersect2() {
 "#,
         );
 }
+
+// --ci-output tests
+
+#[test]
+fn test_ci_output_bad_file() {
+    cmd()
+        .arg("tests")
+        .arg("--ci-output")
+        .assert()
+        .failure()
+        .stderr(predicate::str::starts_with(
+            "error: reading tests: Is a directory",
+        ))
+        .stdout(predicate::str::starts_with("^^^ +++"));
+}
+
+#[test]
+fn test_ci_output_cmd_arg() {
+    cmd()
+        .arg("--ci-output")
+        .write_stdin("$ cmd badarg")
+        .assert()
+        .failure()
+        .stderr(
+            r#"<stdin>:1:7: error: command argument is not in required key=value format
+     |
+   1 | $ cmd badarg
+     |       ^
+"#,
+        )
+        .stdout(predicate::str::starts_with(
+            "--- ==> <stdin>
+^^^ +++",
+        ));
+}


### PR DESCRIPTION
This will make the buildkie UI show expando-sections for all files, instead of
the contents of each file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5325)
<!-- Reviewable:end -->
