### PR TITLE
Rework chbench snapshot generation

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -380,10 +380,6 @@ mzworkflows:
     - step: run
       service: mzutil
       command: snapshot_view_states.py
-    # Output summary information about the topics
-    - step: run
-      service: kafka-util
-      command: summarize_topics.py
 
   # Run a workflow to measure the ingest performance of Materialize. Assumes that the you have
   # already called setup-ingest-benchmark and the cluster is still running

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -264,6 +264,9 @@ services:
     command: ${PEEKER_CMD:---queries q01,q02,q17}
     volumes:
       - ./peeker-config:/etc/peeker
+      - type: bind
+        source: ${MZ_CHBENCH_SNAPSHOT:-/tmp}
+        target: /snapshot
   test-correctness:
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
     mzbuild: test-correctness
@@ -397,6 +400,9 @@ mzworkflows:
   # Take a snapshot of topic schemas and contents
   generate-snapshot:
     steps:
+    - step: run
+      service: peeker
+      command: --write-config /snapshot/config.toml
     - step: workflow
       workflow: setup-ingest-benchmark
     - step: run

--- a/misc/mzutil/requirements.txt
+++ b/misc/mzutil/requirements.txt
@@ -1,1 +1,2 @@
 psycopg2-binary==2.8.6
+toml==0.10.2

--- a/misc/mzutil/scripts/wait_for_view_states.py
+++ b/misc/mzutil/scripts/wait_for_view_states.py
@@ -135,7 +135,7 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
             source_name: str = query_info["sources"][0]
             if source_name not in source_name:
                 print(
-                    f"ERROR: No matching source {view_source} for view {view}: {topic_names}"
+                    f"ERROR: No matching source {source_name} for view {view}: {source_names}"
                 )
                 sys.exit(1)
 

--- a/misc/mzutil/scripts/wait_for_view_states.py
+++ b/misc/mzutil/scripts/wait_for_view_states.py
@@ -93,7 +93,7 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
     }
 
     source_offsets = {
-        p.stem: p.read_text().strip()
+        p.stem: int(p.read_text().strip())
         for p in pathlib.Path(args.snapshot_dir).glob("*.offset")
     }
 
@@ -102,36 +102,45 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
     with open(os.path.join(args.snapshot_dir, "config.toml")) as fd:
         conf = toml.load(fd)
 
-        if len(conf['sources']) != 1:
+        if len(conf["sources"]) != 1:
             print(f"ERROR: Expected just one source block: {conf['sources']}")
             sys.exit(1)
 
-        source_info = conf['sources'][0]
-        topic_prefix = source_info['topic_namespace']
-        source_names = source_info['names']
+        source_info = conf["sources"][0]
+        topic_prefix = source_info["topic_namespace"]
+        source_names = source_info["names"]
 
-        for query_info in conf['queries']:
+        for query_info in conf["queries"]:
 
             # Ignore views not in this snapshot (they likely have multiple sources...)
-            view = query_info['name']
+            view = query_info["name"]
             if view not in view_snapshots:
                 continue
 
-            if len(query_info['sources']) != 1:
-                print(f"ERROR: Expected just one source for view {view}: {query_info['sources']}")
+            if len(query_info["sources"]) != 1:
+                print(
+                    f"ERROR: Expected just one source for view {view}: {query_info['sources']}"
+                )
                 sys.exit(1)
 
-            view_source = query_info['sources'][0]
+            view_source = query_info["sources"][0]
             if view_source not in source_names:
-                print(f"ERROR: No matching source {view_source} for view {view}: {source_names}")
+                print(
+                    f"ERROR: No matching source {view_source} for view {view}: {source_names}"
+                )
                 sys.exit(1)
 
             source_name = f"{topic_prefix}{view_source}"
             if source_name not in source_offsets:
-                print(f"ERROR: Missing offset information for source {source_name}: {source_offsets}")
+                print(
+                    f"ERROR: Missing offset information for source {source_name}: {source_offsets}"
+                )
                 sys.exit(1)
 
-            view_sources[view] = {"topic": source_name, "offset": source_offsets[source_name]}
+            view_sources[view] = {
+                "topic": source_name,
+                "offset": source_offsets[source_name],
+            }
 
     with psycopg2.connect(f"postgresql://{args.host}:{args.port}/materialize") as conn:
         installed_views = set(view_names(conn))
@@ -156,8 +165,8 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
 
                     # Determine if the source is at the desired offset and identify the
                     # mz_logical_timestamp associated with the offset
-                    desired_offset = source_offsets[view]["offset"]
-                    source_name = source_offsets[view]["topic"]
+                    desired_offset = view_sources[view]["offset"]
+                    source_name = view_sources[view]["topic"]
                     timestamp = source_at_offset(cursor, source_name, desired_offset)
                     if not timestamp:
                         continue

--- a/misc/mzutil/scripts/wait_for_view_states.py
+++ b/misc/mzutil/scripts/wait_for_view_states.py
@@ -92,8 +92,11 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
     }
 
     # Create a dictionary mapping view names to source name and offset
-    with open(os.path.join(args.snapshot_dir, "offsets.json")) as fd:
-        source_offsets = json.load(fd)
+    source_offsets = {}
+    with open(os.path.join(args.snapshot_dir, "view_sources.json")) as fd:
+        for (view, source) in json.load(fd).items():
+            with open(os.path.join(args.snapshot_dir, f"{source}.offset")) as fd:
+                source_offsets[view] = {"topic": source, "offset": int(fd.read())}
 
     with psycopg2.connect(f"postgresql://{args.host}:{args.port}/materialize") as conn:
         installed_views = set(view_names(conn))

--- a/src/peeker/config.toml
+++ b/src/peeker/config.toml
@@ -34,11 +34,13 @@ names = [
 ]
 
 [default_query]
-# the amount of time to sleep between peeks
-sleep_ms = 0
 # Spin up this many threads querying this view
 # This affects the ratio of times this query is executed vs other queries
 thread_count = 1
+
+[default_query.sleep]
+secs = 0
+nanos = 0
 
 [[groups]]
 # group settings override per-query enabled, enable/disable groups with the `-q` flag,
@@ -51,7 +53,10 @@ queries = ["q01", "q03", "q17", "q22"]
 # default values for groups:
 thread_count = 1
 enabled = true
-sleep_ms = 0
+
+[groups.sleep]
+secs = 0
+nanos = 0
 
 [[groups]]
 name = "loadtest"
@@ -89,7 +94,6 @@ sources = ["orderline"]
 
 
 [[queries]]
-sleep_ms = 1000
 name = "q02"
 query = """
 SELECT su_suppkey, su_name, n_name, i_id, i_name, su_address, su_phone, su_comment
@@ -117,6 +121,10 @@ WHERE i_id = s_i_id
 ORDER BY n_name, su_name, i_id
 """
 sources = ["item", "nation", "region", "stock", "supplier"]
+
+[queries.sleep]
+secs = 1
+nanos = 0
 
 [[queries]]
 name = "q03"

--- a/src/peeker/config.toml
+++ b/src/peeker/config.toml
@@ -85,6 +85,7 @@ WHERE ol_delivery_d > TIMESTAMP '2007-01-02 00:00:00.000000'
 GROUP BY ol_number
 ORDER BY ol_number
 """
+sources = ["orderline"]
 
 
 [[queries]]
@@ -115,6 +116,7 @@ WHERE i_id = s_i_id
   AND s_quantity = m_s_quantity
 ORDER BY n_name, su_name, i_id
 """
+sources = ["item", "nation", "region", "stock", "supplier"]
 
 [[queries]]
 name = "q03"
@@ -135,6 +137,7 @@ WHERE c_state LIKE 'A%'
 GROUP BY ol_o_id, ol_w_id, ol_d_id, o_entry_d
 ORDER BY revenue DESC, o_entry_d
 """
+sources = ["customer", "neworder", "order", "orderline"]
 
 [[queries]]
 name = "q04"
@@ -154,6 +157,7 @@ WHERE o_entry_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
 GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt
 """
+sources = ["order", "orderline"]
 
 [[queries]]
 name = "q05"
@@ -179,6 +183,8 @@ WHERE c_id = o_c_id
 GROUP BY n_name
 ORDER BY revenue DESC;
 """
+sources = ["customer", "nation", "order", "orderline", "region", "stock", "supplier"]
+
 [[queries]]
 name = "q06"
 query = """
@@ -188,6 +194,7 @@ WHERE ol_delivery_d >= TIMESTAMP '1999-01-01 00:00:00.000000'
   AND ol_delivery_d < TIMESTAMP '2020-01-01 00:00:00.000000'
   AND ol_quantity BETWEEN 1 AND 100000;
 """
+sources = ["orderline"]
 
 [[queries]]
 name = "q07"
@@ -225,6 +232,7 @@ WHERE ol_supply_w_id = s_w_id
 GROUP BY su_nationkey, substr(c_state, 1, 1), extract(year FROM o_entry_d)
 ORDER BY su_nationkey, cust_nation, l_year;
 """
+sources = ["customer", "nation", "order", "orderline", "stock", "supplier"]
 
 [[queries]]
 name = "q08"
@@ -254,6 +262,7 @@ WHERE i_id = s_i_id
 GROUP BY extract(year FROM o_entry_d)
 ORDER BY l_year;
 """
+sources = ["customer", "item", "nation", "order", "orderline", "region", "stock", "supplier"]
 
 [[queries]]
 name = "q09"
@@ -274,6 +283,7 @@ WHERE ol_i_id = s_i_id
 GROUP BY n_name, extract(year FROM o_entry_d)
 ORDER BY n_name, l_year DESC;
 """
+sources = ["item", "nation", "order", "orderline", "stock", "supplier"]
 
 [[queries]]
 name = "q10"
@@ -293,6 +303,7 @@ WHERE c_id = o_c_id
 GROUP BY c_id, c_last, c_city, c_phone, n_name
 ORDER BY revenue DESC;
 """
+sources = ["customer", "nation", "order", "orderline"]
 
 [[queries]]
 name = "q11"
@@ -312,6 +323,7 @@ HAVING sum(s_order_cnt) > (
 )
 ORDER BY ordercount DESC;
 """
+sources = ["nation", "stock", "supplier"]
 
 [[queries]]
 name = "q12"
@@ -330,6 +342,7 @@ WHERE ol_w_id = o_w_id
 GROUP BY o_ol_cnt
 ORDER BY o_ol_cnt;
 """
+sources = ["order", "orderline"]
 
 [[queries]]
 name = "q13"
@@ -347,6 +360,7 @@ FROM (
 GROUP BY c_count
 ORDER BY custdist DESC, c_count DESC;
 """
+sources = ["customer", "order"]
 
 [[queries]]
 name = "q14"
@@ -358,6 +372,7 @@ WHERE ol_i_id = i_id
   AND ol_delivery_d >= TIMESTAMP '2007-01-02 00:00:00.000000'
   AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 """
+sources = ["item", "orderline"]
 
 [[queries]]
 name = "q15"
@@ -391,6 +406,7 @@ WHERE su_suppkey = supplier_no
 )
 ORDER BY su_suppkey;
 """
+sources = ["orderline", "stock", "supplier"]
 
 [[queries]]
 name = "q16"
@@ -409,6 +425,7 @@ WHERE i_id = s_i_id
 GROUP BY i_name, substr(i_data, 1, 3), i_price
 ORDER BY supplier_cnt DESC;
 """
+sources = ["item", "stock", "supplier"]
 
 [[queries]]
 name = "q17"
@@ -426,6 +443,7 @@ FROM
 WHERE ol_i_id = t.i_id
   AND ol_quantity < t.a;
 """
+sources = ["item", "orderline"]
 
 [[queries]]
 name = "q18"
@@ -442,6 +460,7 @@ GROUP BY o_id, o_w_id, o_d_id, c_id, c_last, o_entry_d, o_ol_cnt
 HAVING sum(ol_amount) > 200
 ORDER BY sum(ol_amount);
 """
+sources = ["customer", "order", "orderline"]
 
 [[queries]]
 name = "q19"
@@ -471,6 +490,7 @@ WHERE (
     AND ol_w_id in (1, 5, 3)
 )
 """
+sources = ["item", "orderline"]
 
 [[queries]]
 name = "q20"
@@ -490,6 +510,7 @@ WHERE su_suppkey IN (
   AND n_name = 'GERMANY'
 ORDER BY su_name;
 """
+sources = ["item", "nation", "orderline", "stock", "supplier"]
 
 [[queries]]
 name = "q21"
@@ -518,6 +539,7 @@ WHERE ol_o_id = o_id
 GROUP BY su_name
 ORDER BY numwait DESC, su_name;
 """
+sources = ["nation", "order", "orderline", "stock", "supplier"]
 
 [[queries]]
 name = "q22"
@@ -542,6 +564,7 @@ WHERE substr(c_phone, 1, 1) IN ('1', '2', '3', '4', '5', '6', '7')
 GROUP BY substr(c_state, 1, 1)
 ORDER BY substr(c_state, 1, 1);
 """
+sources = ["customer", "order"]
 
 [[queries]]
 name = "count_customer"
@@ -550,6 +573,7 @@ SELECT
     count(*) AS num_customers
 FROM customer;
 """
+sources = ["customer"]
 
 [[queries]]
 name = "count_item"
@@ -558,6 +582,7 @@ SELECT
     count(*) AS num_items
 FROM item;
 """
+sources = ["item"]
 
 [[queries]]
 name = "count_nation"
@@ -566,6 +591,7 @@ SELECT
     count(*) AS num_nations
 FROM nation;
 """
+sources = ["nation"]
 
 [[queries]]
 name = "count_neworder"
@@ -574,6 +600,7 @@ SELECT
     count(*) AS num_neworders
 FROM neworder;
 """
+sources = ["neworder"]
 
 [[queries]]
 name = "count_order"
@@ -582,6 +609,7 @@ SELECT
     count(*) AS num_orders
 FROM order;
 """
+sources = ["order"]
 
 [[queries]]
 name = "count_orderline"
@@ -590,6 +618,7 @@ SELECT
     count(*) AS num_orderlines
 FROM orderline;
 """
+sources = ["orderline"]
 
 [[queries]]
 name = "count_stock"
@@ -598,6 +627,7 @@ SELECT
     count(*) AS num_stocks
 FROM stock;
 """
+sources = ["stock"]
 
 [[queries]]
 name = "count_supplier"
@@ -606,6 +636,7 @@ SELECT
     count(*) AS num_suppliers
 FROM supplier;
 """
+sources = ["supplier"]
 
 [[queries]]
 name = "count_history"
@@ -614,6 +645,7 @@ SELECT
     count(*) AS num_historys
 FROM history;
 """
+sources = ["history"]
 
 [[queries]]
 name = "count_district"
@@ -622,6 +654,7 @@ SELECT
     count(*) AS num_districts
 FROM district;
 """
+sources = ["district"]
 
 [[queries]]
 name = "count_region"
@@ -630,6 +663,7 @@ SELECT
     count(*) AS num_regions
 FROM region;
 """
+sources = ["region"]
 
 [[queries]]
 name = "count_warehouse"
@@ -638,3 +672,4 @@ SELECT
     count(*) AS num_warehouses
 FROM warehouse;
 """
+sources = ["warehouse"]

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -12,6 +12,7 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::env;
+use std::fs;
 use std::result::Result as StdResult;
 use std::time::Duration;
 
@@ -149,11 +150,17 @@ pub fn print_config_supplied(config: Config) {
     }
 }
 
-pub fn write_config_supplied(config_path: Option<&str>) {
+pub fn write_config_supplied(config_path: Option<&str>, outfile: &String) {
     let config_contents = toml::to_string(&load_raw_config(config_path));
     match &config_contents {
         Ok(contents) => {
-            println!("config: {}", contents);
+            match fs::write(outfile, contents) {
+                Ok ( ()) => {}
+                Err(e) => {
+                    eprintln!("unable to write config file {:?}: {}", outfile, e);
+                    std::process::exit(1);
+                }
+            }
         }
         Err(e) => {
             eprintln!(
@@ -356,6 +363,7 @@ struct RawQuery {
     enabled: bool,
     #[serde(default)]
     thread_count: Option<u32>,
+    sources: Vec<String>,
     #[serde(default, deserialize_with = "deser_duration_ms_opt")]
     sleep_ms: Option<Duration>,
 }

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -100,7 +100,6 @@ pub fn load_config(config_path: Option<&str>, cli_queries: Option<&str>) -> Resu
 }
 
 fn load_raw_config(config_path: Option<&str>) -> RawConfig {
-
     // load and parse th toml
     let config_file = config_path
         .map(std::fs::read_to_string)
@@ -108,13 +107,15 @@ fn load_raw_config(config_path: Option<&str>) -> RawConfig {
     match &config_file {
         Ok(contents) => {
             let contents = substitute_config_env_vars(contents);
-            toml::from_str::<RawConfig>(&contents).map_err(|e| {
-                format!(
-                    "Unable to parse config file {}: {}",
-                    config_path.as_deref().unwrap_or("DEFAULT"),
-                    e
-                )
-            }).unwrap()
+            toml::from_str::<RawConfig>(&contents)
+                .map_err(|e| {
+                    format!(
+                        "Unable to parse config file {}: {}",
+                        config_path.as_deref().unwrap_or("DEFAULT"),
+                        e
+                    )
+                })
+                .unwrap()
         }
         Err(e) => {
             eprintln!(
@@ -149,18 +150,16 @@ pub fn print_config_supplied(config: Config) {
     }
 }
 
-pub fn write_config_supplied(config_path: Option<&str>, outfile: &String) {
+pub fn write_config_supplied(config_path: Option<&str>, outfile: &str) {
     let config_contents = toml::to_string(&load_raw_config(config_path));
     match &config_contents {
-        Ok(contents) => {
-            match fs::write(outfile, contents) {
-                Ok ( ()) => {}
-                Err(e) => {
-                    eprintln!("unable to write config file {:?}: {}", outfile, e);
-                    std::process::exit(1);
-                }
+        Ok(contents) => match fs::write(outfile, contents) {
+            Ok(()) => {}
+            Err(e) => {
+                eprintln!("unable to write config file {:?}: {}", outfile, e);
+                std::process::exit(1);
             }
-        }
+        },
         Err(e) => {
             eprintln!(
                 "unable to generate config file {:?}: {}",

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -107,15 +107,17 @@ fn load_raw_config(config_path: Option<&str>) -> RawConfig {
     match &config_file {
         Ok(contents) => {
             let contents = substitute_config_env_vars(contents);
-            toml::from_str::<RawConfig>(&contents)
-                .map_err(|e| {
-                    format!(
+            match toml::from_str::<RawConfig>(&contents) {
+                Ok(config) => config,
+                Err(e) => {
+                    eprintln!(
                         "Unable to parse config file {}: {}",
                         config_path.as_deref().unwrap_or("DEFAULT"),
                         e
-                    )
-                })
-                .unwrap()
+                    );
+                    std::process::exit(1);
+                }
+            }
         }
         Err(e) => {
             eprintln!(

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -104,24 +104,22 @@ fn load_raw_config(config_path: Option<&str>) -> RawConfig {
     let config_file = config_path
         .map(std::fs::read_to_string)
         .unwrap_or_else(|| Ok(DEFAULT_CONFIG.to_string()));
-    match &config_file {
-        Ok(contents) => {
-            let contents = substitute_config_env_vars(contents);
-            match toml::from_str::<RawConfig>(&contents) {
-                Ok(config) => config,
-                Err(e) => {
-                    eprintln!(
-                        "Unable to parse config file {}: {}",
-                        config_path.as_deref().unwrap_or("DEFAULT"),
-                        e
-                    );
-                    std::process::exit(1);
-                }
-            }
-        }
+    let config = match &config_file {
+        Ok(contents) => substitute_config_env_vars(contents),
         Err(e) => {
             eprintln!(
                 "unable to read config file {:?}: {}",
+                config_path.as_deref().unwrap_or("DEFAULT"),
+                e
+            );
+            std::process::exit(1);
+        }
+    };
+    match toml::from_str::<RawConfig>(&config) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!(
+                "Unable to parse config file {}: {}",
                 config_path.as_deref().unwrap_or("DEFAULT"),
                 e
             );

--- a/src/peeker/src/main.rs
+++ b/src/peeker/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> Result<()> {
     let args: Args = ore::cli::parse_args();
 
     if let Some(write_config) = args.write_config {
-        args::write_config_supplied(args.config_file.as_deref());
+        args::write_config_supplied(args.config_file.as_deref(), &write_config);
         return Ok(());
     }
 

--- a/src/peeker/src/main.rs
+++ b/src/peeker/src/main.rs
@@ -46,6 +46,11 @@ fn main() -> Result<()> {
 
     let args: Args = ore::cli::parse_args();
 
+    if let Some(write_config) = args.write_config {
+        args::write_config_supplied(args.config_file.as_deref());
+        return Ok(());
+    }
+
     let config = args::load_config(args.config_file.as_deref(), args.queries.as_deref())?;
 
     if args.help_config {


### PR DESCRIPTION
This PR introduces a number of changes around how we generate snapshots from chbench, for use with the ingest tests. First, our snapshot generation code was never 100% complete, as it never wrote out the `source_offsets` (I had created it by hand and it was part of the S3 archive). Snapshot_view_states now captures the offsets for each source.

Second, `offsets.json` hardcoded the view_name to topic name. Instead of duplicating this information, add code to Peeker to archive the configuration used to generate the snapshot. Included in this configuration file are the sources that comprise each view (currently expected to be a 1 to 1 mapping for our ingest benchmarks).

Third, the TOML config file for Peeker is interpreted by Peeker (it substitutes environment variables) and cannot be directly loaded by other programming languages. To fix this, I added a method to Peeker to write out the computed version of the configuration (and loaded it into TOML to validate the config).

Fourth, the TOML config file for Peeker could not be serialized due to `sleep_ms` being a Duration field and not being the last field in the struct. I moved this field to the end of each struct where mentioned, but this created a second problem. Our deserializer converted a single string into a Duration object, which is serialized as a table, thereby breaking symmetry in serialize / deserialize. I removed the custom deserialization so that we can load the serialized file using the same deserialization logic.

I think we can write a SQL query / some recursive logic to programmatically get the source names for each view, but this current PR works for saving snapshots and archiving the Peeker config file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5330)
<!-- Reviewable:end -->
