### PR TITLE
s3 sources: Add testdrive tests and testdrive support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4071,6 +4071,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kinesis",
+ "rusoto_s3",
  "rusoto_sts",
  "serde",
  "serde-protobuf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ name = "aws-util"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "hyper-tls",
  "log",
  "rusoto_core",
  "rusoto_credential",

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -80,11 +80,10 @@ steps:
     depends_on: build
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    command: --ci-output test/testdrive/*.td test/testdrive/esoteric/*.td
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          run: testdrive
+          run: ci
 
   - id: kafka-ssl
     label: ":lock: Kafka SSL smoke test"

--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -211,6 +211,8 @@ that inhibits syncing with upstream.
 
 ### testdrive
 
+#### Overview
+
 Testdrive is a Materialize invention that feels a lot like sqllogictest, except
 it supports pluggable commands for interacting with external systems, like
 Kafka. Here's a representative snippet of a testdrive file:
@@ -257,11 +259,70 @@ provide most of the coverage, but it's worth adding some (*very*) basic
 testdrive tests (e.g., `> SELECT DATE '1999-01-01'`) to ensure that our pgwire
 implementation is properly serializing dates.
 
-Like the [Unit Tests](#unitintegration-tests), many testdrive tests require
-Zookeeper, Kafka, and the Confluent Schema Registry.
+#### Usage via mzcompose
 
-For testdrive tests that interacts with Amazon Kinesis, you will need to be
-running [LocalStack](https://github.com/localstack/localstack). To install and
+The easiest way to run testdrive tests is via mzcompose.
+
+The mzcompose configuration will automatically set up all of testdrive's dependencies, including
+Zookeeper, Kafka, the Confluent Schema Registry, and mock versions of AWS S3 and Kinesis. From the
+`test/testdrive` directory:
+
+```
+./mzcompose down -v
+BUILD_MODE=debug TD_TEST=*.td ./mzcompose run local
+```
+
+The `down` subcommand is needed to destroy any existing materialize
+containers with possibly old binaries. If this is not run, then even
+though a new materialize binary is built, it will not be used if there's
+an existing container.
+
+Supported **environment variables** (in addition to `BUILD_MODE` documented elsewhere):
+
+* `TD_TEST` (default `*.td`) is a glob of tests to run from the test/testdrive directory. The
+  default is to not run any of the "esoteric" tests.
+
+  ```
+  TD_TEST=joins.td BUILD_MODE=debug ./mzcompose run local
+  ```
+* `AWS_REGION` (default `us-east-2`) is passed as the `--aws-region` argument. Use an empty string
+  for local testing if you aren't running a workflow that sets this up for you:
+
+   ```
+   AWS_REGION= BUILD_MODE=debug ./mzcompose run testdrive
+   ```
+
+Supported **workflows** (target of `mzcompose run <workflow>`):
+
+* `local`: Disable AWS support
+
+  ```console
+  $ TD_TEST=*.td ./mzcompose run local
+  ```
+
+* `local-aws`: Use [LocalStack][] as an AWS stub. Use this when you want to run the `esoteric`
+  tests but don't have AWS credentials:
+
+  ```console
+  $ TD_TEST=esoteric/*.td ./mzcompose run local-aws
+  ```
+
+* `ci`: Expect actual AWS credentials to be available (q.v. [our documentation][aws-creds-docs]),
+  either in the process environment or via AWS EC2 Profiles:
+
+  ```console
+  $ aws-vault exec scratch -- env TD_TEST=**/*.td ./mzcompose run local-aws
+  ```
+
+[aws-creds-docs]: https://handbook.dev.i.mtrlz.dev/setup/#configure-aws-vault
+
+#### Usage without mzcompose
+
+Like the [Unit Tests](#unitintegration-tests), many testdrive tests require Zookeeper, Kafka, and
+the Confluent Schema Registry, see the unit tests docs for starting them.
+
+For testdrive tests that interacts with Amazon AWS, you will need to be
+running [LocalStack][]. To install and
 run LocalStack:
 
 ```shell
@@ -299,35 +360,7 @@ Testdrive is the preferred system test framework when testing:
 * interactions between objects in the catalog,
 * serialization of data types over the PostgreSQL wire protocol.
 
-#### Docker Compose
-
-Testdrive comes with a Docker Compose environment that can set all
-of this up for you, including re-building and running the testdrive
-and materialized binaries if you have changed them locally. From the
-`test/testdrive` directory:
-
-```
-./mzcompose down -v
-AWS_REGION= ./mzcompose run testdrive --build-mode=debug
-```
-
-The `down` subcommand is needed to destroy any existing materialize
-containers with possibly old binaries. If this is not run, then even
-though a new materialize binary is built, it will not be used if there's
-an existing container.
-
-Supported environment variables (in addition to `BUILD_MODE` documented
-elsewhere):
-
-* `TD_TEST` (default `*.td`) is a glob of tests to run from the test/testdrive directory.
-```
-TD_TEST=joins.td BUILD_MODE=debug ./mzcompose run testdrive
-```
-* `AWS_REGION` (default `us-east-2`) is passed as the `--aws-region`
-  argument. Use an empty string for local testing.
-```
-AWS_REGION= BUILD_MODE=debug ./mzcompose run testdrive
-```
+[LocalStack]: https://github.com/localstack/localstack
 
 ## Long-running tests
 

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.38"
+hyper-tls = "0.5.0"
 log = "0.4.13"
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_credential = { git = "https://github.com/rusoto/rusoto.git" }

--- a/src/aws-util/src/aws.rs
+++ b/src/aws-util/src/aws.rs
@@ -25,12 +25,12 @@ pub struct ConnectInfo {
     /// The AWS Region to connect to
     pub region: Region,
     /// Credentials, if missing will be obtained from environment
-    pub(crate) credentials: Option<Credentials>,
+    pub credentials: Option<Credentials>,
 }
 
 /// A thin dupe of [`AwsCredentials`] so we can impl Serialize
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub(crate) struct Credentials {
+pub struct Credentials {
     key: String,
     secret: String,
     token: Option<String>,

--- a/src/aws-util/src/aws.rs
+++ b/src/aws-util/src/aws.rs
@@ -9,13 +9,16 @@
 
 //! Utility functions for AWS.
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use rusoto_core::{HttpClient, Region};
-use rusoto_credential::{AwsCredentials, ChainProvider, ProvideAwsCredentials};
+use rusoto_credential::{
+    AutoRefreshingProvider, AwsCredentials, ChainProvider, ProvideAwsCredentials, StaticProvider,
+};
 use rusoto_sts::{GetCallerIdentityRequest, Sts, StsClient};
 use serde::{Deserialize, Serialize};
-use tokio::time::error::Elapsed;
 use tokio::time::{self, Duration};
+
+pub(crate) const DEFAULT_AWS_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Information required to connnect to AWS
 ///
@@ -72,32 +75,51 @@ impl ConnectInfo {
 
 /// Fetches the AWS account number of the caller via AWS Security Token Service.
 ///
-/// For details about STS, see AWS documentation.
-pub async fn account(timeout: Duration) -> Result<String, anyhow::Error> {
-    let provider = ChainProvider::new();
+/// For details about STS, see AWS documentation, because the endpoint used by
+/// this method is [always valid][], you can use this method to verify that
+/// that AWS credentials provided are legitimate.
+///
+/// [always-valid]: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
+pub async fn account(
+    provider: impl ProvideAwsCredentials + Send + Sync + 'static,
+    region: Region,
+    timeout: Duration,
+) -> Result<String, anyhow::Error> {
     let dispatcher = HttpClient::new().context("creating HTTP for AWS STS Account verification")?;
-    let sts_client = StsClient::new_with(dispatcher, provider, Region::default());
-
+    let sts_client = StsClient::new_with(dispatcher, provider, region);
     let get_identity = sts_client.get_caller_identity(GetCallerIdentityRequest {});
     let account = time::timeout(timeout, get_identity)
         .await
-        .map_err(|e: Elapsed| {
-            anyhow::Error::new(e)
-                .context("timeout while retrieving AWS account number from STS".to_owned())
-        })?
-        .map_err(|e| anyhow::Error::new(e).context("retrieving AWS account ID".to_owned()))?
+        .context("timeout while retrieving AWS account number from STS".to_owned())?
+        .context("retrieving AWS account ID")?
         .account
-        .ok_or_else(|| anyhow::Error::msg("AWS did not return account ID".to_owned()))?;
+        .ok_or_else(|| anyhow!("AWS did not return account ID"))?;
     Ok(account)
 }
 
-/// Fetches AWS credentials by consulting several known sources.
+/// Verify that the provided credentials are legitimate
 ///
-/// For details about where AWS credentials can be stored, see Rusoto's
-/// [`ChainProvider`] documentation.
-pub async fn credentials(timeout: Duration) -> Result<AwsCredentials, anyhow::Error> {
-    let mut provider = ChainProvider::new();
-    provider.set_timeout(timeout);
-    let credentials = provider.credentials().await?;
-    Ok(credentials)
+/// This uses an [always-valid][] API request to check that the AWS credentials
+/// provided are legitimate.
+///
+/// [always-valid]: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
+pub async fn validate_credentials(
+    conn_info: ConnectInfo,
+    timeout: Duration,
+) -> Result<(), anyhow::Error> {
+    if let Some(creds) = conn_info.credentials {
+        let provider = StaticProvider::from(AwsCredentials::from(creds));
+        crate::aws::account(provider.clone(), conn_info.region, timeout)
+            .await
+            .context("Using statically provided credentials")?;
+    } else {
+        let mut provider = ChainProvider::new();
+        provider.set_timeout(Duration::from_secs(10));
+        let provider =
+            AutoRefreshingProvider::new(provider).context("generating AWS credentials")?;
+        crate::aws::account(provider.clone(), conn_info.region, timeout)
+            .await
+            .context("Looking through the environment for credentials")?;
+    }
+    Ok(())
 }

--- a/src/aws-util/src/aws.rs
+++ b/src/aws-util/src/aws.rs
@@ -9,7 +9,8 @@
 
 //! Utility functions for AWS.
 
-use rusoto_core::Region;
+use anyhow::Context;
+use rusoto_core::{HttpClient, Region};
 use rusoto_credential::{AwsCredentials, ChainProvider, ProvideAwsCredentials};
 use rusoto_sts::{GetCallerIdentityRequest, Sts, StsClient};
 use serde::{Deserialize, Serialize};
@@ -73,7 +74,10 @@ impl ConnectInfo {
 ///
 /// For details about STS, see AWS documentation.
 pub async fn account(timeout: Duration) -> Result<String, anyhow::Error> {
-    let sts_client = StsClient::new(Region::default());
+    let provider = ChainProvider::new();
+    let dispatcher = HttpClient::new().context("creating HTTP for AWS STS Account verification")?;
+    let sts_client = StsClient::new_with(dispatcher, provider, Region::default());
+
     let get_identity = sts_client.get_caller_identity(GetCallerIdentityRequest {});
     let account = time::timeout(timeout, get_identity)
         .await

--- a/src/aws-util/src/s3.rs
+++ b/src/aws-util/src/s3.rs
@@ -14,12 +14,10 @@ use std::time::Duration;
 use anyhow::Context;
 use log::info;
 use rusoto_core::HttpClient;
-use rusoto_credential::{
-    AutoRefreshingProvider, AwsCredentials, ChainProvider, ProvideAwsCredentials, StaticProvider,
-};
+use rusoto_credential::{AutoRefreshingProvider, AwsCredentials, ChainProvider, StaticProvider};
 use rusoto_s3::S3Client;
 
-use crate::aws::ConnectInfo;
+use crate::aws::{ConnectInfo, DEFAULT_AWS_TIMEOUT};
 
 /// Construct an S3Client
 ///
@@ -33,11 +31,15 @@ pub async fn client(conn_info: ConnectInfo) -> Result<S3Client, anyhow::Error> {
     let request_dispatcher = HttpClient::new().context("creating HTTP client for S3 client")?;
     let s3_client = if let Some(creds) = conn_info.credentials {
         info!("Creating a new S3 client from provided access_key and secret_access_key");
-        S3Client::new_with(
-            request_dispatcher,
-            StaticProvider::from(AwsCredentials::from(creds)),
-            conn_info.region,
+        let provider = StaticProvider::from(AwsCredentials::from(creds));
+        crate::aws::account(
+            provider.clone(),
+            conn_info.region.clone(),
+            DEFAULT_AWS_TIMEOUT,
         )
+        .await?;
+
+        S3Client::new_with(request_dispatcher, provider, conn_info.region)
     } else {
         info!(
             "AWS access_key_id and secret_access_key not provided, \
@@ -45,9 +47,14 @@ pub async fn client(conn_info: ConnectInfo) -> Result<S3Client, anyhow::Error> {
         );
         let mut provider = ChainProvider::new();
         provider.set_timeout(Duration::from_secs(10));
-        provider.credentials().await?; // ensure that credentials exist
         let provider =
             AutoRefreshingProvider::new(provider).context("generating AWS credentials")?;
+        crate::aws::account(
+            provider.clone(),
+            conn_info.region.clone(),
+            DEFAULT_AWS_TIMEOUT,
+        )
+        .await?;
 
         S3Client::new_with(request_dispatcher, provider, conn_info.region)
     };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -21,7 +21,6 @@ use aws_arn::{Resource, ARN};
 use globset::GlobBuilder;
 use itertools::Itertools;
 use reqwest::Url;
-use rusoto_core::Region;
 
 use dataflow_types::{
     AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding,
@@ -404,34 +403,9 @@ pub fn plan_create_source(
                 _ => unsupported!(format!("AWS Resource type: {:#?}", arn.resource)),
             };
 
-            let region: Region = match arn.region {
-                Some(region) => match region.parse() {
-                    Ok(region) => {
-                        // ignore the endpoint option if we're pointing at a
-                        // valid, non-custom AWS region
-                        with_options.remove("endpoint");
-                        region
-                    }
-                    Err(e) => {
-                        // Region's fromstr doesn't support parsing custom regions.
-                        // If a Kinesis stream's ARN indicates it exists in a custom
-                        // region, support it iff a valid endpoint for the stream
-                        // is also provided.
-                        match with_options.remove("endpoint") {
-                            Some(Value::String(endpoint)) => Region::Custom {
-                                name: region,
-                                endpoint,
-                            },
-                            _ => bail!(
-                                "Unable to parse AWS region: {}. If providing a custom \
-                                        region, an `endpoint` option must also be provided",
-                                e
-                            ),
-                        }
-                    }
-                },
-                None => bail!("Provided ARN does not include an AWS region"),
-            };
+            let region = arn
+                .region
+                .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
 
             let connector = ExternalSourceConnector::Kinesis(KinesisSourceConnector {
                 stream_name,

--- a/src/sql/src/plan/statement/with_options.rs
+++ b/src/sql/src/plan/statement/with_options.rs
@@ -11,7 +11,7 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::bail;
+use anyhow::{anyhow, bail, Context};
 use rusoto_core::Region;
 
 use aws_util::aws;
@@ -97,26 +97,108 @@ macro_rules! with_options {
 
 pub(crate) fn aws_connect_info(
     options: &mut BTreeMap<String, Value>,
-    region: Option<Region>,
+    region: Option<String>,
 ) -> anyhow::Result<aws::ConnectInfo> {
-    // todo@jldlaughlin: We should support all (?) variants of AWS authentication.
-    // https://github.com/materializeinc/materialize/issues/1991
     let mut extract = |key| match options.remove(key) {
-        Some(Value::String(key)) => Ok(Some(key)),
+        Some(Value::String(key)) => {
+            if !key.is_empty() {
+                Ok(Some(key))
+            } else {
+                Ok(None)
+            }
+        }
         Some(_) => bail!("{} must be a string", key),
         _ => Ok(None),
     };
-    let region = match region {
+
+    let region_raw = match region {
         Some(region) => region,
-        None => extract("region")?
-            .map(|r| r.parse())
-            .transpose()?
-            .ok_or_else(|| anyhow::anyhow!("region is required"))?,
+        None => extract("region")?.ok_or_else(|| anyhow!("region is required"))?,
     };
+
+    let region = match region_raw.parse() {
+        Ok(region) => {
+            // ignore/drop the endpoint option if we're pointing at a valid,
+            // non-custom AWS region. Endpoints are meaningless without custom
+            // regions, and this makes writing tests that support both
+            // LocalStack and real AWS much easier.
+            let _ = extract("endpoint");
+            region
+        }
+        Err(e) => {
+            // Region's FromStr doesn't support parsing custom regions.
+            // If a Kinesis stream's ARN indicates it exists in a custom
+            // region, support it iff a valid endpoint for the stream
+            // is also provided.
+            match extract("endpoint").with_context(|| {
+                format!("endpoint is required for custom regions: {:?}", region_raw)
+            })? {
+                Some(endpoint) => Region::Custom {
+                    name: region_raw,
+                    endpoint,
+                },
+                _ => bail!(
+                    "Unable to parse AWS region: {}. If providing a custom \
+                         region, an `endpoint` option must also be provided",
+                    e
+                ),
+            }
+        }
+    };
+
     aws::ConnectInfo::new(
         region,
         extract("access_key_id")?,
         extract("secret_access_key")?,
         extract("token")?,
     )
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::ast::Value;
+
+    #[test]
+    fn with_options_errirs_if_endpoint_missing_for_invalid_region() {
+        let mut map = BTreeMap::new();
+        map.insert("region".to_string(), Value::String("nonsense".into()));
+        assert!(aws_connect_info(&mut map, None).is_err());
+
+        let mut map = BTreeMap::new();
+        assert!(aws_connect_info(&mut map, Some("nonsense".into())).is_err());
+    }
+
+    #[test]
+    fn with_options_allows_invalid_region_with_endpoint() {
+        let mut map = BTreeMap::new();
+        map.insert("region".to_string(), Value::String("nonsense".into()));
+        map.insert("endpoint".to_string(), Value::String("endpoint".into()));
+        assert!(aws_connect_info(&mut map, None).is_ok());
+
+        let mut map = BTreeMap::new();
+        map.insert("endpoint".to_string(), Value::String("endpoint".into()));
+        assert!(aws_connect_info(&mut map, Some("nonsense".into())).is_ok());
+    }
+
+    #[test]
+    fn with_options_ignores_endpoint_with_valid_region() {
+        let mut map = BTreeMap::new();
+        map.insert("region".to_string(), Value::String("us-east-1".into()));
+        map.insert("endpoint".to_string(), Value::String("endpoint".into()));
+        assert!(aws_connect_info(&mut map, None).is_ok());
+
+        let mut map = BTreeMap::new();
+        map.insert("endpoint".to_string(), Value::String("endpoint".into()));
+        assert!(aws_connect_info(&mut map, Some("us-east-1".into())).is_ok());
+
+        let mut map = BTreeMap::new();
+        map.insert("region".to_string(), Value::String("us-east-1".into()));
+        assert!(aws_connect_info(&mut map, None).is_ok());
+
+        let mut map = BTreeMap::new();
+        assert!(aws_connect_info(&mut map, Some("us-east-1".into())).is_ok());
+    }
 }

--- a/src/sql/src/plan/statement/with_options.rs
+++ b/src/sql/src/plan/statement/with_options.rs
@@ -162,7 +162,7 @@ mod test {
     use crate::ast::Value;
 
     #[test]
-    fn with_options_errirs_if_endpoint_missing_for_invalid_region() {
+    fn with_options_errors_if_endpoint_missing_for_invalid_region() {
         let mut map = BTreeMap::new();
         map.insert("region".to_string(), Value::String("nonsense".into()));
         assert!(aws_connect_info(&mut map, None).is_err());

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -35,6 +35,7 @@ reqwest = { version = "0.11.0", features = ["native-tls-vendored"] }
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_credential = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_kinesis = { git = "https://github.com/rusoto/rusoto.git" }
+rusoto_s3 = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_sts = { git = "https://github.com/rusoto/rusoto.git" }
 serde = "1.0.122"
 serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::future::Future;
 use std::net::ToSocketAddrs;
@@ -22,12 +22,13 @@ use rdkafka::ClientConfig;
 use regex::{Captures, Regex};
 use rusoto_credential::AwsCredentials;
 use rusoto_kinesis::{DeleteStreamInput, Kinesis, KinesisClient};
+use rusoto_s3::{DeleteBucketRequest, DeleteObjectRequest, ListObjectsV2Request, S3Client, S3};
 use url::Url;
 
 use aws_util::aws;
 use repr::strconv;
 
-use crate::error::{Error, InputError, ResultExt};
+use crate::error::{DynError, Error, InputError, ResultExt};
 use crate::parser::{Command, PosCommand, SqlOutput};
 use crate::util;
 
@@ -35,6 +36,7 @@ mod avro_ocf;
 mod file;
 mod kafka;
 mod kinesis;
+mod s3;
 mod sleep;
 mod sql;
 
@@ -75,6 +77,7 @@ pub struct Config {
 }
 
 pub struct State {
+    /// A random number to distinguish each TestDrive run
     seed: u32,
     temp_dir: tempfile::TempDir,
     materialized_catalog_path: Option<PathBuf>,
@@ -93,6 +96,8 @@ pub struct State {
     aws_credentials: AwsCredentials,
     kinesis_client: KinesisClient,
     kinesis_stream_names: Vec<String>,
+    s3_client: S3Client,
+    s3_buckets_created: BTreeSet<String>,
 }
 
 impl State {
@@ -137,6 +142,77 @@ impl State {
                 .err_ctx(format!("deleting Kinesis stream: {}", stream_name))?;
         }
         Ok(())
+    }
+
+    /// Delete S3 buckets that were created in this run
+    pub async fn reset_s3(&mut self) -> Result<(), Error> {
+        let mut errors: Vec<DynError> = Vec::new();
+        for bucket in &self.s3_buckets_created {
+            if let Err(e) = self.delete_bucket_objects(bucket.clone()).await {
+                errors.push(e.into());
+            }
+
+            let res = self
+                .s3_client
+                .delete_bucket(DeleteBucketRequest {
+                    bucket: bucket.into(),
+                    expected_bucket_owner: None,
+                })
+                .await;
+
+            if let Err(e) = res {
+                errors.push(e.into());
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::General {
+                ctx: format!("deleting S3 buckets: {} errors", errors.len()),
+                causes: errors,
+                hints: Vec::new(),
+            })
+        }
+    }
+
+    async fn delete_bucket_objects(&self, bucket: String) -> Result<(), Error> {
+        ore::retry::retry_for(Duration::from_secs(5), |_| async {
+            // loop until error or response has no continuation token
+            let mut continuation_token = None;
+            loop {
+                let response = self
+                    .s3_client
+                    .list_objects_v2(ListObjectsV2Request {
+                        bucket: bucket.clone(),
+                        continuation_token: continuation_token.take(),
+                        ..Default::default()
+                    })
+                    .await
+                    .with_err_ctx(|| format!("listing objects for bucket {}", bucket))?;
+
+                if let Some(objects) = response.contents {
+                    for obj in objects {
+                        self.s3_client
+                            .delete_object(DeleteObjectRequest {
+                                bucket: bucket.clone(),
+                                key: obj.key.clone().unwrap(),
+                                ..Default::default()
+                            })
+                            .await
+                            .with_err_ctx(|| {
+                                format!("deleting object {}/{}", bucket, obj.key.unwrap())
+                            })?;
+                    }
+                }
+
+                if response.next_continuation_token.is_none() {
+                    return Ok(());
+                }
+                continuation_token = response.next_continuation_token;
+            }
+        })
+        .await
     }
 }
 
@@ -274,6 +350,10 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                     }
                     "kinesis-ingest" => Box::new(kinesis::build_ingest(builtin).map_err(wrap_err)?),
                     "kinesis-verify" => Box::new(kinesis::build_verify(builtin).map_err(wrap_err)?),
+                    "s3-create-bucket" => {
+                        Box::new(s3::build_create_bucket(builtin).map_err(wrap_err)?)
+                    }
+                    "s3-put-object" => Box::new(s3::build_put_object(builtin).map_err(wrap_err)?),
                     "set-sql-timeout" => {
                         let duration = builtin.args.string("duration").map_err(wrap_err)?;
                         if duration.to_lowercase() == "default" {
@@ -476,6 +556,11 @@ pub async fn create_state(
         &[format!("region: {}", aws_info.region.name())],
     )?;
 
+    let s3_client = aws_util::s3::client(aws_info.clone()).await.err_hint(
+        "creating S3 client",
+        &[format!("region: {}", aws_info.region.name(),)],
+    )?;
+
     let state = State {
         seed,
         temp_dir,
@@ -490,11 +575,16 @@ pub async fn create_state(
         kafka_config,
         kafka_producer,
         kafka_topics,
-        aws_region: config.aws_region.clone(),
+        aws_region: aws_info.region,
         aws_account: config.aws_account.clone(),
-        aws_credentials: config.aws_credentials.clone(),
+        aws_credentials: aws_info
+            .credentials
+            .expect("provided credentials at construction")
+            .into(),
         kinesis_client,
         kinesis_stream_names: Vec::new(),
+        s3_client,
+        s3_buckets_created: BTreeSet::new(),
     };
     Ok((state, pgconn_task))
 }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -101,7 +101,7 @@ impl State {
             .pgclient
             .query("SHOW DATABASES", &[])
             .await
-            .err_ctx("resetting materialized state: SHOW DATABASES".into())?
+            .err_ctx("resetting materialized state: SHOW DATABASES")?
         {
             let db_name: String = row.get(0);
             let query = format!("DROP DATABASE {}", db_name);
@@ -114,32 +114,28 @@ impl State {
         self.pgclient
             .batch_execute("CREATE DATABASE materialize")
             .await
-            .err_ctx("resetting materialized state: CREATE DATABASE materialize".into())?;
+            .err_ctx("resetting materialized state: CREATE DATABASE materialize")?;
         Ok(())
     }
 
-    // Delete the Kinesis streams created for this run of testdrive.
+    /// Delete the Kinesis streams created for this run of testdrive.
     pub async fn reset_kinesis(&mut self) -> Result<(), Error> {
-        if !self.kinesis_stream_names.is_empty() {
-            println!(
-                "Deleting Kinesis streams {}",
-                self.kinesis_stream_names.join(", ")
-            );
-            for stream_name in &self.kinesis_stream_names {
-                self.kinesis_client
-                    .delete_stream(DeleteStreamInput {
-                        enforce_consumer_deletion: Some(true),
-                        stream_name: stream_name.clone(),
-                    })
-                    .await
-                    .map_err(|e| Error::General {
-                        ctx: format!("deleting Kinesis stream: {}", stream_name),
-                        cause: Some(e.into()),
-                        hints: vec![],
-                    })?;
-            }
+        if self.kinesis_stream_names.is_empty() {
+            return Ok(());
         }
-
+        println!(
+            "Deleting Kinesis streams {}",
+            self.kinesis_stream_names.join(", ")
+        );
+        for stream_name in &self.kinesis_stream_names {
+            self.kinesis_client
+                .delete_stream(DeleteStreamInput {
+                    enforce_consumer_deletion: Some(true),
+                    stream_name: stream_name.clone(),
+                })
+                .await
+                .err_ctx(format!("deleting Kinesis stream: {}", stream_name))?;
+        }
         Ok(())
     }
 }
@@ -208,8 +204,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
         });
         vars.insert("testdrive.protobuf-descriptors-file".into(), {
             let path = state.temp_dir.path().join("protobuf-descriptors");
-            fs::write(&path, &protobuf_descriptors)
-                .err_ctx("writing protobuf descriptors file".into())?;
+            fs::write(&path, &protobuf_descriptors).err_ctx("writing protobuf descriptors file")?;
             path.display().to_string()
         });
     }
@@ -364,25 +359,17 @@ pub async fn create_state(
     config: &Config,
 ) -> Result<(State, impl Future<Output = Result<(), Error>>), Error> {
     let seed = rand::thread_rng().gen();
-    let temp_dir = tempfile::tempdir().err_ctx("creating temporary directory".into())?;
+    let temp_dir = tempfile::tempdir().err_ctx("creating temporary directory")?;
 
     let materialized_catalog_path = if let Some(path) = &config.materialized_catalog_path {
         match fs::metadata(&path) {
             Ok(m) if !m.is_file() => {
-                return Err(Error::General {
-                    ctx: "materialized catalog path is not a regular file".into(),
-                    cause: None,
-                    hints: vec![],
-                })
+                return Err(Error::message(
+                    "materialized catalog path is not a regular file",
+                ))
             }
             Ok(_) => Some(path.to_path_buf()),
-            Err(e) => {
-                return Err(Error::General {
-                    ctx: "opening materialized catalog path".into(),
-                    cause: Some(Box::new(e)),
-                    hints: vec![format!("is {} accessible to testdrive?", path.display())],
-                })
-            }
+            Err(e) => return Err(e).err_ctx("opening materialized catalog path"),
         }
     } else {
         None
@@ -394,21 +381,16 @@ pub async fn create_state(
             .materialized_pgconfig
             .connect(tokio_postgres::NoTls)
             .await
-            .map_err(|e| Error::General {
-                ctx: "opening SQL connection".into(),
-                cause: Some(Box::new(e)),
-                hints: vec![
+            .err_hint(
+                "opening SQL connection",
+                &[
                     format!("connection string: {}", materialized_url),
                     "are you running the materialized server?".into(),
                 ],
-            })?;
+            )?;
         let pgconn_task = tokio::spawn(pgconn).map(|join| {
             join.expect("pgconn_task unexpectedly canceled")
-                .map_err(|e| Error::General {
-                    ctx: "running SQL connection".into(),
-                    cause: Some(Box::new(e)),
-                    hints: vec![],
-                })
+                .err_ctx("running SQL connection")
         });
         let materialized_addr = format!(
             "{}:{}",
@@ -424,18 +406,13 @@ pub async fn create_state(
         let mut ccsr_config = ccsr::ClientConfig::new(schema_registry_url.clone());
 
         if let Some(cert_path) = &config.cert_path {
-            let cert = fs::read(cert_path).map_err(|e| Error::General {
-                ctx: "reading cert".into(),
-                cause: Some(Box::new(e)),
-                hints: vec![format!("is {} readable?", cert_path)],
-            })?;
+            let cert = fs::read(cert_path)
+                .err_hint("reading cert", &[format!("is {} readable?", cert_path)])?;
             let pass = config.cert_pass.as_deref().unwrap_or("").to_owned();
-            let ident =
-                ccsr::tls::Identity::from_pkcs12_der(cert, pass).map_err(|e| Error::General {
-                    ctx: "reading keystore file as pkcs12".into(),
-                    cause: Some(Box::new(e)),
-                    hints: vec![format!("is {} a valid pkcs12 file?", cert_path)],
-                })?;
+            let ident = ccsr::tls::Identity::from_pkcs12_der(cert, pass).err_hint(
+                "reading keystore file as pkcs12",
+                &[format!("is {} a valid pkcs12 file?", cert_path)],
+            )?;
             ccsr_config = ccsr_config.identity(ident);
         }
 
@@ -462,20 +439,17 @@ pub async fn create_state(
             kafka_config.set(key, value);
         }
 
-        let admin: AdminClient<DefaultClientContext> =
-            kafka_config.create().map_err(|e| Error::General {
-                ctx: "opening Kafka connection".into(),
-                cause: Some(Box::new(e)),
-                hints: vec![format!("connection string: {}", config.kafka_addr)],
-            })?;
+        let admin: AdminClient<DefaultClientContext> = kafka_config.create().err_hint(
+            "opening Kafka connection",
+            &[format!("connection string: {}", config.kafka_addr)],
+        )?;
 
         let admin_opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
 
-        let producer: FutureProducer = kafka_config.create().map_err(|e| Error::General {
-            ctx: "opening Kafka producer connection".into(),
-            cause: Some(Box::new(e)),
-            hints: vec![format!("connection string: {}", config.kafka_addr)],
-        })?;
+        let producer: FutureProducer = kafka_config.create().err_hint(
+            "opening Kafka producer connection",
+            &[format!("connection string: {}", config.kafka_addr)],
+        )?;
 
         let topics = HashMap::new();
 
@@ -489,30 +463,18 @@ pub async fn create_state(
         )
     };
 
-    let (aws_region, aws_account, aws_credentials, kinesis_client, kinesis_stream_names) = {
-        let kinesis_client = aws_util::kinesis::client(
-            aws::ConnectInfo::new(
-                config.aws_region.clone(),
-                Some(config.aws_credentials.aws_access_key_id().to_owned()),
-                Some(config.aws_credentials.aws_secret_access_key().to_owned()),
-                config.aws_credentials.token().clone(),
-            )
-            .unwrap(),
-        )
-        .await
-        .map_err(|e| Error::General {
-            ctx: "creating Kinesis client".into(),
-            cause: Some(e.into()),
-            hints: vec![format!("region: {}", config.aws_region.name())],
-        })?;
-        (
-            config.aws_region.clone(),
-            config.aws_account.clone(),
-            config.aws_credentials.clone(),
-            kinesis_client,
-            Vec::new(),
-        )
-    };
+    let aws_info = aws::ConnectInfo::new(
+        config.aws_region.clone(),
+        Some(config.aws_credentials.aws_access_key_id().to_owned()),
+        Some(config.aws_credentials.aws_secret_access_key().to_owned()),
+        config.aws_credentials.token().clone(),
+    )
+    .expect("both parts of AWS Credentials are present");
+
+    let kinesis_client = aws_util::kinesis::client(aws_info.clone()).await.err_hint(
+        "creating Kinesis client",
+        &[format!("region: {}", aws_info.region.name())],
+    )?;
 
     let state = State {
         seed,
@@ -528,11 +490,11 @@ pub async fn create_state(
         kafka_config,
         kafka_producer,
         kafka_topics,
-        aws_region,
-        aws_account,
-        aws_credentials,
+        aws_region: config.aws_region.clone(),
+        aws_account: config.aws_account.clone(),
+        aws_credentials: config.aws_credentials.clone(),
         kinesis_client,
-        kinesis_stream_names,
+        kinesis_stream_names: Vec::new(),
     };
     Ok((state, pgconn_task))
 }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -274,6 +274,10 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
         },
     );
     vars.insert("testdrive.bucket".into(), CI_S3_BUCKET.to_string());
+    println!(
+        "AWS_ACCESS_KEY_ID={}",
+        vars.get("testdrive.aws-access-key-id").unwrap()
+    );
     for cmd in cmds {
         let pos = cmd.pos;
         let wrap_err = |e| InputError { msg: e, pos };

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -40,8 +40,9 @@ impl Action for CreateStreamAction {
         let stream_name = format!("{}-{}", self.stream_name, state.seed);
         println!("Creating Kinesis stream {}", stream_name);
 
-        state
-            .kinesis_client
+        let kclient = state.kinesis_client.as_ref()?;
+
+        kclient
             .create_stream(CreateStreamInput {
                 shard_count: self.shard_count,
                 stream_name: stream_name.clone(),
@@ -50,7 +51,6 @@ impl Action for CreateStreamAction {
             .map_err(|e| format!("creating stream: {}", e))?;
         state.kinesis_stream_names.push(stream_name.clone());
 
-        util::kinesis::wait_for_stream_shards(&state.kinesis_client, stream_name, self.shard_count)
-            .await
+        util::kinesis::wait_for_stream_shards(kclient, stream_name, self.shard_count).await
     }
 }

--- a/src/testdrive/src/action/kinesis/ingest.rs
+++ b/src/testdrive/src/action/kinesis/ingest.rs
@@ -69,7 +69,12 @@ impl Action for IngestAction {
             // The Kinesis stream might not be immediately available,
             // be prepared to back off.
             retry::retry_for(Duration::from_secs(8), |_| async {
-                match state.kinesis_client.put_record(put_input.clone()).await {
+                match state
+                    .kinesis_client
+                    .as_ref()?
+                    .put_record(put_input.clone())
+                    .await
+                {
                     Ok(_output) => Ok(()),
                     Err(RusotoError::Service(PutRecordError::ResourceNotFound(err))) => {
                         Err(format!("resource not found: {}", err))

--- a/src/testdrive/src/action/kinesis/update_shards.rs
+++ b/src/testdrive/src/action/kinesis/update_shards.rs
@@ -49,6 +49,7 @@ impl Action for UpdateShardCountAction {
 
         state
             .kinesis_client
+            .as_ref()?
             .update_shard_count(UpdateShardCountInput {
                 scaling_type: "UNIFORM_SCALING".to_owned(),
                 stream_name: stream_name.clone(),
@@ -62,6 +63,7 @@ impl Action for UpdateShardCountAction {
             // Wait for shards to stop updating.
             let description = state
                 .kinesis_client
+                .as_ref()?
                 .describe_stream(DescribeStreamInput {
                     exclusive_start_shard_id: None,
                     limit: None,

--- a/src/testdrive/src/action/kinesis/verify.rs
+++ b/src/testdrive/src/action/kinesis/verify.rs
@@ -47,13 +47,15 @@ impl Action for VerifyAction {
     async fn redo(&self, state: &mut State) -> Result<(), String> {
         let stream_name = format!("testdrive-{}-{}", self.stream_prefix, state.seed);
 
-        let mut shard_iterators = get_shard_iterators(&state.kinesis_client, &stream_name).await?;
+        let mut shard_iterators =
+            get_shard_iterators(state.kinesis_client.as_ref()?, &stream_name).await?;
         let timer = Instant::now();
         let mut records: HashSet<String> = HashSet::new();
         while let Some(iterator) = shard_iterators.pop_front() {
             if let Some(iterator) = &iterator {
                 let output = state
                     .kinesis_client
+                    .as_ref()?
                     .get_records(GetRecordsInput {
                         limit: None,
                         shard_iterator: iterator.clone(),

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -1,0 +1,95 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::default::Default;
+
+use async_trait::async_trait;
+use rusoto_core::RusotoError;
+use rusoto_s3::{
+    CreateBucketConfiguration, CreateBucketError, CreateBucketRequest, PutObjectRequest, S3,
+};
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct CreateBucketAction {
+    bucket: String,
+}
+
+pub fn build_create_bucket(mut cmd: BuiltinCommand) -> Result<CreateBucketAction, String> {
+    Ok(CreateBucketAction {
+        bucket: cmd.args.string("bucket")?,
+    })
+}
+
+#[async_trait]
+impl Action for CreateBucketAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        println!("Creating S3 Bucket {}", self.bucket);
+
+        match state
+            .s3_client
+            .create_bucket(CreateBucketRequest {
+                bucket: self.bucket.clone(),
+                create_bucket_configuration: Some(CreateBucketConfiguration {
+                    location_constraint: Some(state.aws_region.name().to_string()),
+                }),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) | Err(RusotoError::Service(CreateBucketError::BucketAlreadyOwnedByYou(_))) => {
+                state.s3_buckets_created.insert(self.bucket.clone());
+                Ok(())
+            }
+            Err(e) => Err(format!("creating bucket: {}", e)),
+        }
+    }
+}
+
+pub struct PutObjectAction {
+    bucket: String,
+    key: String,
+    contents: String,
+}
+
+pub fn build_put_object(mut cmd: BuiltinCommand) -> Result<PutObjectAction, String> {
+    Ok(PutObjectAction {
+        bucket: cmd.args.string("bucket")?,
+        key: cmd.args.string("key")?,
+        contents: cmd.input.join("\n"),
+    })
+}
+
+#[async_trait]
+impl Action for PutObjectAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        println!("Creating S3 Bucket {}", self.bucket);
+
+        state
+            .s3_client
+            .put_object(PutObjectRequest {
+                bucket: self.bucket.clone(),
+                body: Some(self.contents.clone().into_bytes().into()),
+                key: self.key.clone(),
+                ..Default::default()
+            })
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("putting s3 object: {}", e))
+    }
+}

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -10,63 +10,18 @@
 use std::default::Default;
 
 use async_trait::async_trait;
-use rusoto_core::RusotoError;
-use rusoto_s3::{
-    CreateBucketConfiguration, CreateBucketError, CreateBucketRequest, PutObjectRequest, S3,
-};
+use rusoto_s3::{PutObjectRequest, S3};
 
-use crate::action::{Action, State};
+use crate::action::{Action, State, CI_S3_BUCKET};
 use crate::parser::BuiltinCommand;
 
-pub struct CreateBucketAction {
-    bucket: String,
-}
-
-pub fn build_create_bucket(mut cmd: BuiltinCommand) -> Result<CreateBucketAction, String> {
-    Ok(CreateBucketAction {
-        bucket: cmd.args.string("bucket")?,
-    })
-}
-
-#[async_trait]
-impl Action for CreateBucketAction {
-    async fn undo(&self, _state: &mut State) -> Result<(), String> {
-        Ok(())
-    }
-
-    async fn redo(&self, state: &mut State) -> Result<(), String> {
-        println!("Creating S3 Bucket {}", self.bucket);
-
-        match state
-            .s3_client
-            .as_ref()?
-            .create_bucket(CreateBucketRequest {
-                bucket: self.bucket.clone(),
-                create_bucket_configuration: Some(CreateBucketConfiguration {
-                    location_constraint: Some(state.aws_region.name().to_string()),
-                }),
-                ..Default::default()
-            })
-            .await
-        {
-            Ok(_) | Err(RusotoError::Service(CreateBucketError::BucketAlreadyOwnedByYou(_))) => {
-                state.s3_buckets_created.insert(self.bucket.clone());
-                Ok(())
-            }
-            Err(e) => Err(format!("creating bucket: {}", e)),
-        }
-    }
-}
-
 pub struct PutObjectAction {
-    bucket: String,
     key: String,
     contents: String,
 }
 
 pub fn build_put_object(mut cmd: BuiltinCommand) -> Result<PutObjectAction, String> {
     Ok(PutObjectAction {
-        bucket: cmd.args.string("bucket")?,
         key: cmd.args.string("key")?,
         contents: cmd.input.join("\n"),
     })
@@ -79,19 +34,19 @@ impl Action for PutObjectAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
-        println!("Creating S3 Bucket {}", self.bucket);
-
         state
             .s3_client
             .as_ref()?
             .put_object(PutObjectRequest {
-                bucket: self.bucket.clone(),
+                bucket: CI_S3_BUCKET.to_string(),
                 body: Some(self.contents.clone().into_bytes().into()),
                 key: self.key.clone(),
                 ..Default::default()
             })
             .await
-            .map(|_| ())
+            .map(|_| {
+                state.s3_objects_created.insert(self.key.clone());
+            })
             .map_err(|e| format!("putting s3 object: {}", e))
     }
 }

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -34,13 +34,19 @@ impl Action for PutObjectAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
+        println!(
+            "Putting S3 object: {}/{} ({} bytes)",
+            CI_S3_BUCKET,
+            self.key,
+            self.contents.len()
+        );
         state
             .s3_client
             .as_ref()?
             .put_object(PutObjectRequest {
                 bucket: CI_S3_BUCKET.to_string(),
-                body: Some(self.contents.clone().into_bytes().into()),
                 key: self.key.clone(),
+                body: Some(self.contents.clone().into_bytes().into()),
                 ..Default::default()
             })
             .await

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -39,6 +39,7 @@ impl Action for CreateBucketAction {
 
         match state
             .s3_client
+            .as_ref()?
             .create_bucket(CreateBucketRequest {
                 bucket: self.bucket.clone(),
                 create_bucket_configuration: Some(CreateBucketConfiguration {
@@ -82,6 +83,7 @@ impl Action for PutObjectAction {
 
         state
             .s3_client
+            .as_ref()?
             .put_object(PutObjectRequest {
                 bucket: self.bucket.clone(),
                 body: Some(self.contents.clone().into_bytes().into()),

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -31,13 +31,14 @@
 //! ```
 
 use std::error::Error as StdError;
-use std::fmt;
-use std::fmt::Write as FmtWrite;
-use std::io;
-use std::io::Write;
+use std::fmt::{self, Write as FmtWrite};
+use std::io::{self, Write};
+use std::iter::IntoIterator;
 
 use atty::Stream;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+pub type DynError = Box<dyn StdError + Send + Sync>;
 
 /// A testdrive error.
 ///
@@ -54,14 +55,32 @@ pub enum Error {
     General {
         /// The component in which the error occurred.
         ctx: String,
-        /// The underlying cause of the error.
-        cause: Option<Box<dyn StdError + Send + Sync>>,
+        /// The underlying causes of the error.
+        causes: Vec<DynError>,
         /// Hints about how to resolve the error.
         hints: Vec<String>,
     },
 }
 
 impl Error {
+    /// Create a new error with just the specified message
+    pub(crate) fn message(m: impl Into<String>) -> Error {
+        Error::General {
+            ctx: m.into(),
+            causes: Vec::new(),
+            hints: Vec::new(),
+        }
+    }
+
+    /// Create a new error with the specified message and cause
+    pub fn with_cause(m: impl Into<String>, cause: impl Into<DynError>) -> Error {
+        Error::General {
+            ctx: m.into(),
+            causes: vec![cause.into()],
+            hints: Vec::new(),
+        }
+    }
+
     /// Prints the error to `stderr`, with coloring if the terminal supports it.
     pub fn print_stderr(&self, ci_output: bool) -> io::Result<()> {
         let color_choice = if atty::is(Stream::Stderr) {
@@ -96,12 +115,17 @@ impl Error {
             Error::Input { details: None, .. } => {
                 panic!("programming error: print_stderr called on InputError with no details")
             }
-            Error::General { ctx, cause, hints } => {
+            Error::General { ctx, causes, hints } => {
                 let color_spec = ColorSpec::new();
                 write_error_heading(&mut stderr, &color_spec)?;
                 write!(&mut stderr, "{}", ctx)?;
-                if let Some(cause) = cause {
-                    writeln!(&mut stderr, ": {}", cause)?;
+                for (i, cause) in causes.iter().enumerate() {
+                    if i == 0 {
+                        write!(&mut stderr, ": {}", cause)?;
+                    } else {
+                        write!(&mut stderr, ", {}", cause)?;
+                    }
+                    writeln!(&mut stderr)?;
                 }
                 for hint in hints {
                     stderr.set_color(&color_spec.clone().set_bold(true))?;
@@ -169,10 +193,16 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::Input { err, .. } => write!(f, "{}", err.msg),
-            Error::General { ctx, cause, .. } => {
+            Error::General { ctx, causes, .. } => {
                 write!(f, "{}", ctx)?;
-                if let Some(cause) = cause {
-                    write!(f, ": {}", cause)?;
+                write!(f, "{}", ctx)?;
+                for (i, cause) in causes.iter().enumerate() {
+                    if i == 0 {
+                        write!(f, ": {}", cause)?;
+                    } else {
+                        write!(f, ", {}", cause)?;
+                    }
+                    writeln!(f)?;
                 }
                 Ok(())
             }
@@ -200,24 +230,67 @@ pub trait Positioner {
     fn line_col(&self, pos: usize) -> (usize, usize);
 }
 
+/// Extra methods that integrate std Results with [`Error`]
 pub trait ResultExt<T, E> {
-    fn err_ctx(self, ctx: String) -> Result<T, Error>
+    /// Wrap any error in an [`Error`] with the given context message
+    fn err_ctx(self, ctx: impl Into<String>) -> Result<T, Error>
+    where
+        Self: Sized;
+
+    /// Wrap any error in an [`Error`] with the given context message, which is lazily evaluated
+    fn with_err_ctx(self, ctx: impl FnOnce() -> String) -> Result<T, Error>
+    where
+        Self: Sized;
+
+    /// Wrap any error in an [`Error`] with the given context message and additional hints
+    fn err_hint(
+        self,
+        ctx: impl Into<String>,
+        hint: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<T, Error>
     where
         Self: Sized;
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E>
 where
-    E: 'static + StdError + Send + Sync,
+    E: 'static + Send + Sync,
+    E: Into<DynError>,
 {
-    fn err_ctx(self, ctx: String) -> Result<T, Error>
+    fn err_ctx(self, ctx: impl Into<String>) -> Result<T, Error>
     where
         Self: Sized,
     {
         self.map_err(|err| Error::General {
-            ctx,
-            cause: Some(Box::new(err)),
+            ctx: ctx.into(),
+            causes: vec![err.into()],
             hints: Vec::new(),
+        })
+    }
+
+    fn with_err_ctx(self, ctx: impl FnOnce() -> String) -> Result<T, Error>
+    where
+        Self: Sized,
+    {
+        self.map_err(|err| Error::General {
+            ctx: ctx(),
+            causes: vec![err.into()],
+            hints: Vec::new(),
+        })
+    }
+
+    fn err_hint(
+        self,
+        ctx: impl Into<String>,
+        hints: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Result<T, Error>
+    where
+        Self: Sized,
+    {
+        self.map_err(|err| Error::General {
+            ctx: ctx.into(),
+            causes: vec![err.into()],
+            hints: hints.into_iter().map(Into::into).collect(),
         })
     }
 }

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -14,7 +14,7 @@
 use std::fs::File;
 use std::io::{self, Read};
 
-use self::error::{InputError, ResultExt};
+use self::error::InputError;
 use self::parser::LineReader;
 
 mod action;
@@ -24,7 +24,7 @@ mod parser;
 mod util;
 
 pub use self::action::Config;
-pub use self::error::Error;
+pub use self::error::{Error, ResultExt};
 
 /// Runs a testdrive script stored in a file.
 pub async fn run_file(config: &Config, filename: &str) -> Result<(), Error> {
@@ -40,7 +40,7 @@ pub async fn run_stdin(config: &Config) -> Result<(), Error> {
     let mut contents = String::new();
     io::stdin()
         .read_to_string(&mut contents)
-        .err_ctx("reading <stdin>".into())?;
+        .err_ctx("reading <stdin>")?;
     run_string(config, "<stdin>", &contents).await
 }
 

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -88,38 +88,34 @@ async fn main() {
 }
 
 async fn run(args: Args) -> Result<(), Error> {
-    let (aws_region, aws_account, aws_credentials) =
-        match (args.aws_region.parse(), args.aws_endpoint) {
-            (Ok(region), None) => {
-                // Standard AWS region without a custom endpoint. Try to find actual AWS
-                // credentials.
-                let timeout = Duration::from_secs(5);
-                let account = aws::account(timeout)
-                    .await
-                    .err_ctx("getting AWS account details")?;
-                let credentials = aws::credentials(timeout)
-                    .await
-                    .err_ctx("getting AWS account credentials")?;
-                (region, account, credentials)
-            }
-            (_, aws_endpoint) => {
-                // Either a non-standard AWS region, a custom endpoint, or both. Assume
-                // dummy authentication, and just use default dummy credentials in the
-                // default config.
-                let region = rusoto_core::Region::Custom {
-                    name: args.aws_region,
-                    endpoint: aws_endpoint.unwrap_or_else(|| "http://localhost:4566".into()),
-                };
-                let account = "000000000000";
-                let credentials = AwsCredentials::new(
-                    "dummy-access-key-id",
-                    "dummy-secret-access-key",
-                    None,
-                    None,
-                );
-                (region, account.into(), credentials)
-            }
+    let (aws_region, aws_account, aws_credentials) = if let Ok(region) = args.aws_region.parse() {
+        let region: rusoto_core::Region = region;
+        // Standard region, which means we should ignore the endpoint, whether
+        // or not it was provided.
+        let timeout = Duration::from_secs(5);
+        let account = aws::account(timeout)
+            .await
+            .err_ctx("getting AWS account details")?;
+        let credentials = aws::credentials(timeout)
+            .await
+            .err_ctx("getting AWS account credentials")?;
+        (region, account, credentials)
+    } else {
+        // If the region doesn't parse that means we have a "custom" region.
+        // For us that means 'LocalStack' which requires an endpoint but the
+        // region name itself doesn't matter, and credentials are ignored.
+        let region = rusoto_core::Region::Custom {
+            name: args.aws_region,
+            endpoint: args
+                .aws_endpoint
+                .and_then(|e| if e == "" { None } else { Some(e) })
+                .unwrap_or_else(|| "http://localhost:4566".into()),
         };
+        let account = "000000000000";
+        let credentials =
+            AwsCredentials::new("dummy-access-key-id", "dummy-secret-access-key", None, None);
+        (region, account.into(), credentials)
+    };
 
     let config = Config {
         kafka_addr: args.kafka_addr,

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -12,7 +12,7 @@ use std::process;
 use std::time::Duration;
 
 use aws_util::aws;
-use rusoto_credential::AwsCredentials;
+use rusoto_credential::{AwsCredentials, ChainProvider, ProvideAwsCredentials};
 use structopt::StructOpt;
 use url::Url;
 
@@ -89,16 +89,20 @@ async fn main() {
 
 async fn run(args: Args) -> Result<(), Error> {
     let (aws_region, aws_account, aws_credentials) = if let Ok(region) = args.aws_region.parse() {
-        let region: rusoto_core::Region = region;
         // Standard region, which means we should ignore the endpoint, whether
         // or not it was provided.
+        let region: rusoto_core::Region = region;
+
         let timeout = Duration::from_secs(5);
-        let account = aws::account(timeout)
+        let mut provider = ChainProvider::new();
+        provider.set_timeout(timeout);
+        let credentials = provider
+            .credentials()
+            .await
+            .err_ctx("Retrieving aws credentials")?;
+        let account = aws::account(provider, region.clone(), timeout)
             .await
             .err_ctx("getting AWS account details")?;
-        let credentials = aws::credentials(timeout)
-            .await
-            .err_ctx("getting AWS account credentials")?;
         (region, account, credentials)
     } else {
         // If the region doesn't parse that means we have a "custom" region.

--- a/test/testdrive/README.md
+++ b/test/testdrive/README.md
@@ -1,0 +1,10 @@
+Testdrive Tests
+===============
+
+This folder contains a suite of test scripts for testdrive, an integration test driver for
+Materialize focused on testing interactions with external systems (e.g., Kafka, AWS).
+
+For documentation about testdrive and detailed usage instructions, see the testdrive section of
+[Developer guide: testing][guide].
+
+[guide]: ../../doc/developer/guide-testing.md#testdrive

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set bucket=materialize-ci-testdrive-${testdrive.seed}
+
+$ s3-create-bucket bucket=${bucket}
+
+$ s3-put-object bucket=${bucket} key=short/a
+a1
+a2
+a3
+
+$ s3-put-object bucket=${bucket} key=short/b
+b1
+b2
+b3
+
+> CREATE MATERIALIZED SOURCE s3_all
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> SELECT * FROM s3_all ORDER BY mz_record;
+a1 1
+a2 2
+a3 3
+b1 4
+b2 5
+b3 6
+
+> CREATE MATERIALIZED SOURCE s3_glob_a
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '**/a'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> SELECT * FROM s3_glob_a ORDER BY mz_record;
+a1 1
+a2 2
+a3 3
+
+> CREATE MATERIALIZED SOURCE s3_just_a
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING 'short/a'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> SELECT * FROM s3_just_a ORDER BY mz_record;
+a1 1
+a2 2
+a3 3

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set bucket=materialize-ci-testdrive-${testdrive.seed}
+$ set bucket=materialize-ci
 
 $ s3-create-bucket bucket=${bucket}
 

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -7,22 +7,20 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set bucket=materialize-ci
 
-$ s3-create-bucket bucket=${bucket}
-
-$ s3-put-object bucket=${bucket} key=short/a
+$ s3-put-object key=${testdrive.seed}/short/a
 a1
 a2
 a3
 
-$ s3-put-object bucket=${bucket} key=short/b
+$ s3-put-object key=${testdrive.seed}/short/b
 b1
 b2
 b3
 
 > CREATE MATERIALIZED SOURCE s3_all
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN
+  FROM S3 BUCKET '${testdrive.bucket}' OBJECTS FROM SCAN
+  MATCHING '${testdrive.seed}/**'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -41,7 +39,7 @@ b2 5
 b3 6
 
 > CREATE MATERIALIZED SOURCE s3_glob_a
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '**/a'
+  FROM S3 BUCKET '${testdrive.bucket}' OBJECTS FROM SCAN MATCHING '${testdrive.seed}/**/a'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -57,7 +55,7 @@ a2 2
 a3 3
 
 > CREATE MATERIALIZED SOURCE s3_just_a
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING 'short/a'
+  FROM S3 BUCKET '${testdrive.bucket}' OBJECTS FROM SCAN MATCHING '${testdrive.seed}/short/a'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -8,6 +8,69 @@
 # by the Apache License, Version 2.0.
 
 version: '3.7'
+
+mzworkflows:
+  # Run tests with no support for s3
+  local:
+    steps:
+      - step: workflow
+        workflow: start-deps
+      - step: run
+        service: testdrive
+
+  # Run tests with s3 stubbed out, no credentials needed
+  local-aws:
+    env:
+      AWS_REGION: localstack
+      AWS_ENDPOINT: http://localstack:4566
+    steps:
+      - step: start-services
+        services: [localstack]
+      - step: workflow
+        workflow: start-deps
+      - step: wait-for-tcp
+        host: localstack
+        port: 4566
+      - step: run
+        service: testdrive
+
+  # Run tests, requires credentials to be present. See guide-testing for
+  # details.
+  remote:
+    env:
+      AWS_REGION: us-east-2
+      AWS_ENDPOINT: ''
+    steps:
+      - step: workflow
+        workflow: start-deps
+      - step: run
+        service: testdrive
+        command: ${TD_TEST:-*.td esoteric/*.td}
+
+  # Run CI tests
+  ci:
+    env:
+      AWS_REGION: us-east-2
+      AWS_ENDPOINT: ''
+    steps:
+      - step: workflow
+        workflow: start-deps
+      - step: run
+        service: testdrive
+        command: --ci-output *.td esoteric/*.td
+
+  start-deps:
+    steps:
+      - step: start-services
+        services: [kafka, schema-registry, materialized]
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+      - step: wait-for-mz
+
 services:
   testdrive:
     mzbuild: testdrive
@@ -15,22 +78,25 @@ services:
       - bash
       - -c
       - >-
-        wait-for-it --timeout=30 kafka:9092 &&
-        wait-for-it --timeout=30 schema-registry:8081 &&
-        wait-for-it --timeout=30 materialized:6875 &&
         testdrive
         --kafka-addr=kafka:9092
-        --aws-region=${AWS_REGION-us-east-2}
+        --aws-region=${AWS_REGION-localstack}
+        --aws-endpoint=${AWS_ENDPOINT-http://localstack:4566}
         --schema-registry-url=http://schema-registry:8081
         --materialized-url=postgres://ignored@materialized:6875
         --validate-catalog=/share/mzdata/catalog
         $$*
       - bash
-    command: test/testdrive/${TD_TEST:-*.td}
+    command: ${TD_TEST:-*.td}
     environment:
     - TMPDIR=/share/tmp
+    - MZ_LOG
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_SECURITY_TOKEN
     volumes:
-    - ../../:/workdir
+    - .:/workdir
     - mzdata:/share/mzdata
     - tmp:/share/tmp
     propagate-uid-gid: true
@@ -44,8 +110,15 @@ services:
       -w1 --experimental
       --cache-max-pending-records 1
       --disable-telemetry
+    ports:
+      - 6875
     environment:
     - MZ_DEV=1
+    - MZ_LOG
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_SESSION_TOKEN
+    - AWS_SECURITY_TOKEN
     volumes:
     - mzdata:/share/mzdata
     - tmp:/share/tmp
@@ -66,6 +139,26 @@ services:
     - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
     - SCHEMA_REGISTRY_HOST_NAME=localhost
     depends_on: [kafka, zookeeper]
+
+  localstack:
+    image: localstack/localstack:0.12.5
+    ports:
+      - "4566"
+      - "4571"
+      - "${LOCALSTACK_WEB_UI-8080}"
+    environment:
+      - SERVICES=${SERVICES- }
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOST_TMP_FOLDER=${TMPDIR}
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
 volumes:
   mzdata:
   tmp:

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -57,7 +57,7 @@ mzworkflows:
         workflow: start-deps
       - step: run
         service: testdrive
-        command: --ci-output *.td esoteric/*.td
+        command: --ci-output esoteric/*.td
 
   start-deps:
     steps:


### PR DESCRIPTION
The three commits in this PR work together to make it more ergonomic to run testdrive tests
against AWS resources, and to add tests for future AWS resources without hurting the overall ability to have correctness for tests.

Part of #4914 
Tests were split off from #5202 to make them easier to review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5331)
<!-- Reviewable:end -->
