### PR TITLE
Reduce default logical compaction window to 1ms

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -115,8 +115,8 @@ lazily, so Materialize may retain more historical detail than requested, but it
 will never retain less.
 
 The value of the option is a duration string like `10ms` (10 milliseconds) or
-`1min 30s` (1 minute, 30 seconds).  The special value `off` indicates disables
-logical compaction and corresponds to an unboundedly large duration.
+`1min 30s` (1 minute, 30 seconds).  The special value `off` disables logical
+compaction and corresponds to an unboundedly large duration.
 
 The logical compaction window ends at the current time and extends backwards in
 time for the configured duration. The default window is 1 millisecond.

--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -19,7 +19,7 @@ Flag | Default | Modifies
 [`--experimental`](#experimental-mode) | Disabled | *Dangerous.* Enable experimental features.
 [`--introspection-frequency`](#introspection-sources) | 1s | The frequency at which to update [introspection sources](#introspection-sources).
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
-[`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 60s | The amount of historical detail to retain in arrangements
+[`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 1ms | The amount of historical detail to retain in arrangements
 [`--timely-progress-mode`](#dataflow-tuning) | demand | *Advanced.* Timely progress tracking mode.
 [`--tls-ca`](#tls-encryption) | N/A | Path to TLS certificate authority (CA) {{< version-added v0.7.1 />}}
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
@@ -116,10 +116,10 @@ will never retain less.
 
 The value of the option is a duration string like `10ms` (10 milliseconds) or
 `1min 30s` (1 minute, 30 seconds).  The special value `off` indicates disables
-logical compaction.
+logical compaction and corresponds to an unboundedly large duration.
 
 The logical compaction window ends at the current time and extends backwards in
-time for the configured duration. The default window is 60 seconds.
+time for the configured duration. The default window is 1 millisecond.
 
 See the [Deployment section](/ops/deployment#compaction) for guidance on tuning
 the compaction window.

--- a/doc/user/content/ops/deployment.md
+++ b/doc/user/content/ops/deployment.md
@@ -40,7 +40,7 @@ window into the state at the start of the window.
 ```
 
 Materialize will only perform this compaction on data that falls outside the
-logical compaction window. The default compaction window is 60 seconds behind
+logical compaction window. The default compaction window is 1 millisecond behind
 the current time, but the window can be adjusted via the
 [`--logical-compaction-window`](/cli/#compaction-window) option.
 
@@ -56,7 +56,7 @@ fully. This can result in higher-than-expected memory usage.
 
 This phenomenon is particularly evident when ingesting a source with a large
 amount of historical data (e.g, a several gigabyte Kafka topic that is no longer
-changing). With the default compaction window of 60 seconds, it is likely that
+changing). With a compaction window of 60 seconds, for example, it is likely that
 the source will be fully ingested within the compaction window. By the time the
 data is eligible for compaction, the source is fully ingested, no new updates
 are arriving, and therefore no compaction is ever triggered.

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,10 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.7.1 %}}
 
+- **Breaking change.** Change the default
+  [`--logical-compaction-window`](/cli/#compaction-window) from 60 seconds to
+  1 millisecond.
+
 - **Breaking change.** Remove `CREATE SINK ... AS OF`, which did not have
   sensible behavior after Materialize restarted. The intent is to reintroduce
   this feature with a more formal model of `AS OF` timestamps. {{% gh 3467 %}}

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -99,7 +99,7 @@ struct Args {
     /// How much historical detail to maintain in arrangements.
     ///
     /// Set to "off" to disable logical compaction.
-    #[structopt(long, env = "MZ_LOGICAL_COMPACTION_WINDOW", parse(try_from_str = parse_optional_duration), value_name = "DURATION", default_value = "60s")]
+    #[structopt(long, env = "MZ_LOGICAL_COMPACTION_WINDOW", parse(try_from_str = parse_optional_duration), value_name = "DURATION", default_value = "1ms")]
     logical_compaction_window: OptionalDuration,
     /// [DEPRECATED] Frequency with which to advance timestamps.
     #[structopt(long, env = "MZ_TIMESTAMP_FREQUENCY", hidden = true, parse(try_from_str = parse_duration::parse), value_name = "DURATION", default_value = "10ms")]

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -82,6 +82,10 @@ $ kafka-create-topic topic=tx
   FORMAT AVRO USING SCHEMA '${nums-schema}'
   ENVELOPE DEBEZIUM
 
+# Disable logical compaction, to ensure we can view historical detail.
+> ALTER INDEX materialize.public.nums_primary_idx
+  SET (logical_compaction_window = 'off')
+
 # ==> Test consolidation.
 
 # Ingest several updates that consolidate. Some of these updates are in one


### PR DESCRIPTION
This changes the default for `--logical-compaction-window` to `1ms`, the smallest value that does not force a delay when querying. This change increases the potential for small stalls on queries that use multiple sources (as there is more of a chance that their valid intervals do not overlap) but reduces the default memory and CPU costs associated with maintaining 60s worth of historical data about all collections.

TODO / to discuss: Revisit #4516 and make the same change to logging collections.

fixes #5291

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5335)
<!-- Reviewable:end -->
