### PR TITLE
Push MFP operators in to Source implementations

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -27,7 +27,10 @@ use timely::progress::frontier::Antichain;
 use url::Url;
 
 use aws_util::aws;
-use expr::{GlobalId, MapFilterProject, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, PartitionId};
+use expr::{
+    GlobalId, MapFilterProject, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr,
+    PartitionId,
+};
 use interchange::avro::{self, DebeziumDeduplicationStrategy};
 use interchange::protobuf::{decode_descriptors, validate_descriptors};
 use kafka_util::KafkaAddrs;

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -486,14 +486,7 @@ pub fn decode_values<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     encoding: DataEncoding,
     debug_name: &str,
-<<<<<<< HEAD
     envelope: &SourceEnvelope,
-    // Information about optional transformations that can be eagerly done.
-    // If the decoding elects to perform them, it should replace this with
-    // `None`.
-    operators: &mut Option<LinearOperator>,
-=======
-    envelope: &Envelope,
     // A transformation that can be applied. The transform should be updated
     // to reflect remaining transformations, where an identity transformation
     // is ideal result and can be optimized away.
@@ -501,7 +494,6 @@ pub fn decode_values<G>(
     // Ignoring this input should be safe, as it will present to the caller
     // as if all transformations remain to be done.
     map_filter_project: &mut MapFilterProject,
->>>>>>> 8acdfc874 (replace LinearOperator with MFP)
     fast_forwarded: bool,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
@@ -521,15 +513,7 @@ where
         (_, SourceEnvelope::Upsert(_)) => {
             unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")
         }
-<<<<<<< HEAD
-        (DataEncoding::Csv(enc), SourceEnvelope::None) => (
-            csv(stream, enc.header_row, enc.n_cols, enc.delimiter, operators),
-            None,
-        ),
-        (DataEncoding::Avro(enc), SourceEnvelope::CdcV2) => {
-            decode_cdcv2(stream, &enc.value_schema, enc.schema_registry_config)
-=======
-        (DataEncoding::Csv(enc), Envelope::None) => {
+        (DataEncoding::Csv(enc), SourceEnvelope::None) => {
             let (rows, errors) = csv(
                 stream,
                 enc.header_row,
@@ -539,10 +523,9 @@ where
             );
             (rows, Some(errors), None)
         }
-        (DataEncoding::Avro(enc), Envelope::CdcV2) => {
+        (DataEncoding::Avro(enc), SourceEnvelope::CdcV2) => {
             let (rows, token) = decode_cdcv2(stream, &enc.value_schema, enc.schema_registry_config);
             (rows, None, token)
->>>>>>> 8acdfc874 (replace LinearOperator with MFP)
         }
         (_, SourceEnvelope::CdcV2) => {
             unreachable!("Internal error: CDCv2 is not supported yet on non-Avro sources.")
@@ -602,13 +585,8 @@ where
         (_, SourceEnvelope::Debezium(_)) => unreachable!(
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
-<<<<<<< HEAD
         (DataEncoding::Regex(RegexEncoding { regex }), SourceEnvelope::None) => {
-            (regex_fn(stream, regex, debug_name), None)
-=======
-        (DataEncoding::Regex(RegexEncoding { regex }), Envelope::None) => {
             (regex_fn(stream, regex, debug_name), None, None)
->>>>>>> 8acdfc874 (replace LinearOperator with MFP)
         }
         (DataEncoding::Protobuf(enc), SourceEnvelope::None) => (
             decode_values_inner(

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -216,7 +216,7 @@ where
                                 // Apply what `closure` we are able to, and record any errors.
                                 if !initial_closure.is_identity() {
 
-                                    let (stream, errs) = update_stream.flat_map_fallible({
+                                    let (stream, errs) = update_stream.flat_map_fallible("InitialMFP", {
                                         let mut datums = DatumVec::new();
                                         let mut row_packer = RowPacker::new();
                                         move |row| {
@@ -286,7 +286,7 @@ where
                                 // and projections that could not be applied (e.g. column repetition).
                                 let closure = join_build_state.complete();
                                 if !closure.is_identity() {
-                                    let (updates, errors) = update_stream.flat_map_fallible({
+                                    let (updates, errors) = update_stream.flat_map_fallible("ResidualMFP", {
                                         // Reuseable allocation for unpacking.
                                         let mut datums = DatumVec::new();
                                         let mut row_packer = repr::RowPacker::new();

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -105,7 +105,7 @@ where
                     // If there is no starting arrangement, then we can run filters
                     // directly on the starting collection.
                     // If there is only one input, we are done joining, so run filters
-                    let (j, es) = joined.flat_map_fallible({
+                    let (j, es) = joined.flat_map_fallible("InitialMFP", {
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         let mut row_packer = RowPacker::new();
@@ -216,7 +216,7 @@ where
             // and projections that could not be applied (e.g. column repetition).
             let closure = join_build_state.complete();
             if !closure.is_identity() {
-                let (updates, errors) = joined.flat_map_fallible({
+                let (updates, errors) = joined.flat_map_fallible("ResidualMFP", {
                     // Reuseable allocation for unpacking.
                     let mut datums = DatumVec::new();
                     let mut row_packer = repr::RowPacker::new();

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -18,11 +18,11 @@ use timely::dataflow::operators::map::Map;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
-use dataflow_types::{DataEncoding, DataflowError, LinearOperator};
-use repr::{Datum, RelationType, Row, RowArena, Timestamp};
+use dataflow_types::{DataEncoding, DataflowError};
+use expr::MapFilterProject;
+use repr::{RelationType, Row, Timestamp};
 
 use crate::decode::decode_upsert;
-use crate::operator::StreamExt;
 use crate::source::{SourceData, SourceOutput};
 
 /// Entrypoint to the upsert-specific transformations involved
@@ -39,7 +39,7 @@ pub fn pre_arrange_from_upsert_transforms<G>(
     debug_name: &str,
     worker_index: usize,
     as_of_frontier: Antichain<Timestamp>,
-    linear_operator: &mut Option<LinearOperator>,
+    map_filter_project: &mut MapFilterProject,
     src_type: &RelationType,
 ) -> (
     Stream<G, (Row, Option<Row>, Timestamp)>,
@@ -99,7 +99,7 @@ where
         worker_index,
     );
 
-    apply_linear_operators(&decoded, linear_operator, src_type)
+    apply_map_filter_project(&decoded, map_filter_project, src_type)
 }
 
 /// Produces at most one entry for each `(key, time)` pair.
@@ -182,10 +182,20 @@ where
 /// Also, prepend key columns to the beginning of the value so
 /// the return stream is `Stream<G, (key, Option<entire record>, Timestamp)>
 /// whereas the input stream is `Stream<G, (key, Option<value>, Timestamp)>
-fn apply_linear_operators<G>(
+
+/// Prepends key and then applies map, filter, and projection operations.
+///
+/// Rows that do not pass the predicate should still be produced as `None`
+/// outputs to prompt the deletion of the installed record (as otherwise
+/// the existing record would remain, which is incorrect).
+///
+/// We are able to apply more aggressive filtering to the key itself, as
+/// predicates of the key can be filtered away entirely (no values will
+/// ever pass). In this case we can simply drop the record.
+fn apply_map_filter_project<G>(
     stream: &Stream<G, (Row, Option<Row>, Timestamp)>,
-    linear_operator: &mut Option<LinearOperator>,
-    src_type: &RelationType,
+    _map_filter_project: &mut MapFilterProject,
+    _src_type: &RelationType,
 ) -> (
     Stream<G, (Row, Option<Row>, Timestamp)>,
     Stream<G, DataflowError>,
@@ -193,118 +203,118 @@ fn apply_linear_operators<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let operator = linear_operator.take();
     let mut row_packer = repr::RowPacker::new();
 
-    if let Some(operator) = operator {
-        // Determine replacement values for unused columns.
-        // This is copied over from applying linear operators to
-        // the non-upsert case.
-        // At this point, the stream consists of (key, key+payload, time)
-        // so it is ok to delete replace unused values in key+payload
-        // but not to replace unused values in key because that would cause
-        // errors in arrange_from_upsert
-        let position_or = (0..src_type.arity())
-            .map(|col| {
-                if operator.projection.contains(&col) {
-                    Some(col)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+    // NOTE(mcsherry): Disabling as incorrect in the presence of errors.
+    // if let Some(operator) = operator {
+    //     // Determine replacement values for unused columns.
+    //     // This is copied over from applying linear operators to
+    //     // the non-upsert case.
+    //     // At this point, the stream consists of (key, key+payload, time)
+    //     // so it is ok to delete replace unused values in key+payload
+    //     // but not to replace unused values in key because that would cause
+    //     // errors in arrange_from_upsert
+    //     let position_or = (0..src_type.arity())
+    //         .map(|col| {
+    //             if operator.projection.contains(&col) {
+    //                 Some(col)
+    //             } else {
+    //                 None
+    //             }
+    //         })
+    //         .collect::<Vec<_>>();
 
-        // If a row does not match a predicate whose support lies in the key
-        // columns, it can be tossed away entirely. If a row does not match
-        // a predicate whose support is not contained in the key columns, it
-        // must be replaced with (key, None) in case if there was previously a
-        // row with the same key that matched the predicate.
-        let key_col_len = src_type.keys[0].len();
-        let mut predicates = operator.predicates;
-        let mut key_predicates = Vec::new();
-        predicates.retain(|p| {
-            let key_predicate = p.support().into_iter().all(|c| c < key_col_len);
-            if key_predicate {
-                key_predicates.push(p.clone());
-            }
-            !key_predicate
-        });
+    //     // If a row does not match a predicate whose support lies in the key
+    //     // columns, it can be tossed away entirely. If a row does not match
+    //     // a predicate whose support is not contained in the key columns, it
+    //     // must be replaced with (key, None) in case if there was previously a
+    //     // row with the same key that matched the predicate.
+    //     let key_col_len = src_type.keys[0].len();
+    //     let mut predicates = operator.predicates;
+    //     let mut key_predicates = Vec::new();
+    //     predicates.retain(|p| {
+    //         let key_predicate = p.support().into_iter().all(|c| c < key_col_len);
+    //         if key_predicate {
+    //             key_predicates.push(p.clone());
+    //         }
+    //         !key_predicate
+    //     });
 
-        let mut storage = Vec::new();
+    //     let mut storage = Vec::new();
 
-        stream.unary_fallible(Pipeline, "UpsertLinearFallible", move |_, _| {
-            move |input, ok_output, err_output| {
-                input.for_each(|time, data| {
-                    let mut ok_session = ok_output.session(&time);
-                    let mut err_session = err_output.session(&time);
-                    data.swap(&mut storage);
-                    let temp_storage = RowArena::new();
-                    for (key, value, time) in storage.drain(..) {
-                        let mut datums = key.unpack();
-                        let key_pred_eval = key_predicates
-                            .iter()
-                            .map(|predicate| predicate.eval(&datums, &temp_storage))
-                            .find(|result| result != &Ok(Datum::True));
-                        match key_pred_eval {
-                            None => {
-                                if let Some(value) = value {
-                                    let value_datums = value.unpack();
-                                    // combine value datums with key datums
-                                    datums.extend(value_datums);
-                                    // evaluate predicates against the entire record
-                                    let pred_eval = predicates
-                                        .iter()
-                                        .map(|predicate| predicate.eval(&datums, &temp_storage))
-                                        .find(|result| result != &Ok(Datum::True));
-                                    match pred_eval {
-                                        None => {
-                                            // project all demanded keys from the record
-                                            let record = Some(row_packer.pack(
-                                                position_or.iter().map(|pos_or| match pos_or {
-                                                    Some(index) => datums[*index],
-                                                    None => Datum::Dummy,
-                                                }),
-                                            ));
-                                            ok_session.give((key, record, time));
-                                        }
-                                        Some(Ok(Datum::False)) | Some(Ok(Datum::Null)) => {
-                                            ok_session.give((key, None, time));
-                                        }
-                                        Some(Ok(x)) => {
-                                            panic!("Predicate evaluated to invalid value: {:?}", x)
-                                        }
-                                        Some(Err(x)) => {
-                                            err_session.give(DataflowError::from(x));
-                                        }
-                                    }
-                                } else {
-                                    ok_session.give((key, None, time));
-                                }
-                            }
-                            Some(Ok(Datum::False)) | Some(Ok(Datum::Null)) => {}
-                            Some(Ok(x)) => panic!("Predicate evaluated to invalid value: {:?}", x),
-                            Some(Err(x)) => {
-                                err_session.give(DataflowError::from(x));
-                            }
-                        };
-                    }
-                })
+    //     stream.unary_fallible(Pipeline, "UpsertLinearFallible", move |_, _| {
+    //         move |input, ok_output, err_output| {
+    //             input.for_each(|time, data| {
+    //                 let mut ok_session = ok_output.session(&time);
+    //                 let mut err_session = err_output.session(&time);
+    //                 data.swap(&mut storage);
+    //                 let temp_storage = RowArena::new();
+    //                 for (key, value, time) in storage.drain(..) {
+    //                     let mut datums = key.unpack();
+    //                     let key_pred_eval = key_predicates
+    //                         .iter()
+    //                         .map(|predicate| predicate.eval(&datums, &temp_storage))
+    //                         .find(|result| result != &Ok(Datum::True));
+    //                     match key_pred_eval {
+    //                         None => {
+    //                             if let Some(value) = value {
+    //                                 let value_datums = value.unpack();
+    //                                 // combine value datums with key datums
+    //                                 datums.extend(value_datums);
+    //                                 // evaluate predicates against the entire record
+    //                                 let pred_eval = predicates
+    //                                     .iter()
+    //                                     .map(|predicate| predicate.eval(&datums, &temp_storage))
+    //                                     .find(|result| result != &Ok(Datum::True));
+    //                                 match pred_eval {
+    //                                     None => {
+    //                                         // project all demanded keys from the record
+    //                                         let record = Some(row_packer.pack(
+    //                                             position_or.iter().map(|pos_or| match pos_or {
+    //                                                 Some(index) => datums[*index],
+    //                                                 None => Datum::Dummy,
+    //                                             }),
+    //                                         ));
+    //                                         ok_session.give((key, record, time));
+    //                                     }
+    //                                     Some(Ok(Datum::False)) | Some(Ok(Datum::Null)) => {
+    //                                         ok_session.give((key, None, time));
+    //                                     }
+    //                                     Some(Ok(x)) => {
+    //                                         panic!("Predicate evaluated to invalid value: {:?}", x)
+    //                                     }
+    //                                     Some(Err(x)) => {
+    //                                         err_session.give(DataflowError::from(x));
+    //                                     }
+    //                                 }
+    //                             } else {
+    //                                 ok_session.give((key, None, time));
+    //                             }
+    //                         }
+    //                         Some(Ok(Datum::False)) | Some(Ok(Datum::Null)) => {}
+    //                         Some(Ok(x)) => panic!("Predicate evaluated to invalid value: {:?}", x),
+    //                         Some(Err(x)) => {
+    //                             err_session.give(DataflowError::from(x));
+    //                         }
+    //                     };
+    //                 }
+    //             })
+    //         }
+    //     })
+    // } else {
+    // just prepend the key to the value without unpacking rows
+    let prepended = stream.map({
+        move |(key, value, timestamp)| {
+            if let Some(value) = value {
+                row_packer.extend_by_row(&key);
+                row_packer.extend_by_row(&value);
+                (key, Some(row_packer.finish_and_reuse()), timestamp)
+            } else {
+                (key, None, timestamp)
             }
-        })
-    } else {
-        // just prepend the key to the value without unpacking rows
-        let prepended = stream.map({
-            move |(key, value, timestamp)| {
-                if let Some(value) = value {
-                    row_packer.extend_by_row(&key);
-                    row_packer.extend_by_row(&value);
-                    (key, Some(row_packer.finish_and_reuse()), timestamp)
-                } else {
-                    (key, None, timestamp)
-                }
-            }
-        });
-        let scope = &prepended.scope();
-        (prepended, operator::empty(scope))
-    }
+        }
+    });
+    let scope = &prepended.scope();
+    (prepended, operator::empty(scope))
+    // }
 }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use dataflow_types::DataflowDesc;
+use expr::{Id, LocalId, MirRelationExpr, MirScalarExpr};
 use repr::Datum;
 
 /// Optimizes the implementation of each dataflow.
@@ -216,7 +217,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
                     demand_projection.push(column);
                 } else {
                     demand_projection.push(output_arity + dummies.len());
-                    dummies.push(ScalarExpr::literal_ok(Datum::Dummy, typ.clone()));
+                    dummies.push(MirScalarExpr::literal_ok(Datum::Dummy, typ.clone()));
                 }
             }
 

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -298,4 +298,32 @@ impl Optimizer {
         ];
         Self { transforms }
     }
+
+    /// Transformations sufficient to ensure the expression can be rendered.
+    ///
+    /// This primarily includes join implemenation strategy, but may also include
+    /// transformations in preparation for rendering which map be counter-productive
+    /// for or fight with logical optimization.
+    pub fn implementation() -> Self {
+        // Implementation transformations
+        let transforms: Vec<Box<dyn crate::Transform + Send>> = vec![
+            Box::new(crate::Fixpoint {
+                limit: 100,
+                transforms: vec![
+                    Box::new(crate::projection_lifting::ProjectionLifting),
+                    Box::new(crate::join_implementation::JoinImplementation),
+                    Box::new(crate::fusion::filter::Filter),
+                    Box::new(crate::demand::Demand),
+                    Box::new(crate::map_lifting::LiteralLifting),
+                ],
+            }),
+            Box::new(crate::reduction_pushdown::ReductionPushdown),
+            Box::new(crate::cse::map::Map),
+            Box::new(crate::projection_lifting::ProjectionLifting),
+            Box::new(crate::join_implementation::JoinImplementation),
+            Box::new(crate::fusion::project::Project),
+            Box::new(crate::reduction::FoldConstants),
+        ];
+        Self { transforms }
+    }
 }


### PR DESCRIPTION
This WIP PR shows how to push MFP operators in to source implementations, specifically in to the CSV source. This does not improve any performance yet, I believe due to the fact that `ScalarExpr` evaluation is relatively expensive, and our MFP pushdown is not yet sophisticated enough to *remove* MFPs once they have been pushed down (it still has the flavor of "demand" and "predicate" information that is presented down, but not "pushed" in the sense of no longer applied upstream).

There are various local optimization that can improve performance, mostly MFP optimization to not `eval` a sequence of identical `Literal(Datum::Dummy)` decoding rows and all that, re-use some allocations that don't exist in `main` because we didn't stage any `Datum`s, etc. I'm going to hold off on this for the moment until the other MFP work starts to unblock so that I don't end up with a weird pile of conflicting work.

This PR also comments out predicate pushdown for upsert, because it appears to be incorrect (or, can introduce permanent failure), and I didn't want to spend the time to port the incorrect version to MFP. Ideally we'll shake out some plan for that before getting close to landing this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5337)
<!-- Reviewable:end -->
