### PR TITLE
repr: remove accidental code in parse_float32 benchmark

### DIFF
--- a/src/repr/benches/strconv.rs
+++ b/src/repr/benches/strconv.rs
@@ -20,11 +20,6 @@ fn bench_parse_float32(c: &mut Criterion) {
             b.iter(|| strconv::parse_float32(s).unwrap())
         });
     }
-
-    let input = include_str!("testdata/twitter.json");
-    c.bench_function("parse_jsonb", |b| {
-        b.iter(|| black_box(strconv::parse_jsonb(input).unwrap()))
-    });
 }
 
 fn bench_parse_jsonb(c: &mut Criterion) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5342)
<!-- Reviewable:end -->
