### PR TITLE
repr: speed up decimal parsing by 100%

### DIFF
--- a/src/repr/benches/strconv.rs
+++ b/src/repr/benches/strconv.rs
@@ -28,11 +28,6 @@ fn bench_parse_decimal(c: &mut Criterion) {
             b.iter(|| strconv::parse_decimal(s).unwrap())
         });
     }
-
-    let input = include_str!("testdata/twitter.json");
-    c.bench_function("parse_jsonb", |b| {
-        b.iter(|| black_box(strconv::parse_jsonb(input).unwrap()))
-    });
 }
 
 fn bench_parse_jsonb(c: &mut Criterion) {

--- a/src/repr/benches/strconv.rs
+++ b/src/repr/benches/strconv.rs
@@ -22,6 +22,19 @@ fn bench_parse_float32(c: &mut Criterion) {
     }
 }
 
+fn bench_parse_decimal(c: &mut Criterion) {
+    for s in &["-135412353251", "1.030340E11"] {
+        c.bench_with_input(BenchmarkId::new("parse_decimal", s), s, |b, s| {
+            b.iter(|| strconv::parse_decimal(s).unwrap())
+        });
+    }
+
+    let input = include_str!("testdata/twitter.json");
+    c.bench_function("parse_jsonb", |b| {
+        b.iter(|| black_box(strconv::parse_jsonb(input).unwrap()))
+    });
+}
+
 fn bench_parse_jsonb(c: &mut Criterion) {
     let input = include_str!("testdata/twitter.json");
     c.bench_function("parse_jsonb", |b| {
@@ -81,6 +94,7 @@ criterion_group!(
     benches,
     bench_format_list_simple,
     bench_format_list_nested,
+    bench_parse_decimal,
     bench_parse_float32,
     bench_parse_jsonb
 );

--- a/src/repr/src/adt/decimal.rs
+++ b/src/repr/src/adt/decimal.rs
@@ -376,51 +376,44 @@ impl FromStr for Decimal {
         // See: https://github.com/rust-lang/rust/issues/53023
 
         let mut significand: u128 = 0;
-        let mut precision = 0;
+        let mut precision: u8 = 0;
         let mut scale: u8 = 0;
         let mut seen_decimal = false;
         let mut negative = false;
-        let mut seen_e_notation = false;
-        let mut e_exponent: u8 = 0;
-        let mut e_negative = false;
         let mut seen_digit = false;
 
-        let mut z = s.chars().peekable();
+        // Iterating over bytes is faster than iterating over characters.
+        let mut z = s.bytes().peekable();
 
-        if let Some('-') = z.peek() {
+        // Check for a leading sign.
+        if let Some(b'-') = z.peek() {
             // Consume the negative sign.
             z.next();
             negative = true;
-        } else if let Some('+') = z.peek() {
+        } else if let Some(b'+') = z.peek() {
             // Consume the positive sign.
             z.next();
         }
 
+        // Parse the digits and decimal point, if any.
         while let Some(&ch) = z.peek() {
             match ch {
-                '0'..='9' => {
-                    let digit = ch
-                        .to_digit(10)
-                        .ok_or_else(|| anyhow!("invalid digit in numeric literal: {}", s))?;
+                b'0'..=b'9' => {
+                    if precision == MAX_DECIMAL_PRECISION {
+                        bail!("numeric literal exceeds maximum precision: {}", s);
+                    }
                     precision += 1;
                     if seen_decimal {
                         scale += 1;
                     }
-                    significand = significand
-                        .checked_mul(10)
-                        .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
-                    significand = significand
-                        .checked_add(u128::from(digit))
-                        .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
+                    // Enforcing the maximum precision above ensures this
+                    // multiplication and addition do not overflow.
+                    significand *= 10;
+                    significand += u128::from(ch - b'0');
                     seen_digit = true;
                 }
-                '.' => {
-                    if !seen_decimal {
-                        seen_decimal = true;
-                    } else {
-                        bail!("multiple decimal points in numeric literal: {}", s)
-                    }
-                }
+                b'.' if !seen_decimal => seen_decimal = true,
+                b'.' => bail!("multiple decimal points in numeric literal: {}", s),
                 _ => break,
             }
             z.next();
@@ -430,76 +423,77 @@ impl FromStr for Decimal {
             bail!("malformed numeric literal: {}", s);
         }
 
-        // Check for e-notation.
-        if let Some('E') | Some('e') = z.peek() {
-            // Consume the e-notation signifier.
-            z.next();
-            seen_e_notation = true;
-            if let Some('-') = z.peek() {
-                // Consume the negative sign.
-                z.next();
-                e_negative = true;
-            } else if let Some('+') = z.peek() {
-                // Consume the positive sign.
-                z.next();
-            }
-            while let Some(&ch) = z.peek() {
-                match ch {
-                    '0'..='9' => {
-                        let digit = ch
-                            .to_digit(10)
-                            .ok_or_else(|| anyhow!("invalid digit in numeric literal: {}", s))?;
-                        e_exponent = e_exponent
-                            .checked_mul(10)
-                            .ok_or_else(|| anyhow!("exponent in e-notation overflows u8: {}", s))?;
-                        e_exponent = e_exponent
-                            .checked_add(digit as u8)
-                            .ok_or_else(|| anyhow!("exponent in e-notation overflows u8: {}", s))?;
+        // Check for E notation.
+        match z.next() {
+            None => (),
+            Some(b'e') | Some(b'E') => {
+                let mut e_exponent: u8 = 0;
+                let mut e_negative = false;
+
+                // Check for a leading sign for the exponent.
+                if let Some(b'-') = z.peek() {
+                    // Consume the negative sign.
+                    z.next();
+                    e_negative = true;
+                } else if let Some(b'+') = z.peek() {
+                    // Consume the positive sign.
+                    z.next();
+                }
+
+                // Only allow two digits in the exponent, so we don't need to
+                // check for overflow.
+                for _ in 0..2 {
+                    match z.next() {
+                        None => break,
+                        Some(ch @ b'0'..=b'9') => {
+                            e_exponent *= 10;
+                            e_exponent += ch - b'0';
+                        }
+                        Some(_) => bail!("malformed numeric literal: {}", s),
                     }
-                    _ => break,
                 }
-                z.next();
-            }
-        }
-
-        if z.peek().is_some() {
-            bail!("malformed numeric literal: {}", s);
-        }
-
-        if precision > MAX_DECIMAL_PRECISION {
-            bail!("numeric literal exceeds maximum precision: {}", s);
-        }
-        if seen_e_notation {
-            if e_negative {
-                scale = scale
-                    .checked_add(e_exponent)
-                    .ok_or_else(|| anyhow!("numeric literal exceeds maximum precision: {}", s))?;
-                if scale > MAX_DECIMAL_PRECISION {
-                    bail!("numeric literal exceeds maximum precision: {}", s);
+                match z.next() {
+                    None => (),
+                    Some(b'0'..=b'9') => {
+                        bail!("exponent in decimal has more than two digits: {}", s)
+                    }
+                    Some(_) => bail!("malformed numeric literal: {}", s),
                 }
-            } else if scale > e_exponent {
-                scale -= e_exponent;
-            } else {
-                e_exponent -= scale;
-                scale = 0;
-                let p = 10_u128.checked_pow(e_exponent as u32).ok_or_else(|| {
-                    anyhow!(
-                        "exponent in numeric literal {} overflows i128: 10^{}",
-                        s,
-                        e_exponent
-                    )
-                })?;
 
-                significand = significand
-                    .checked_mul(p)
-                    .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
+                if e_negative {
+                    scale += e_exponent;
+                    if scale > MAX_DECIMAL_PRECISION {
+                        bail!("numeric literal exceeds maximum precision: {}", s);
+                    }
+                } else if scale > e_exponent {
+                    scale -= e_exponent;
+                } else {
+                    e_exponent -= scale;
+                    scale = 0;
+                    let p = 10_u128.checked_pow(e_exponent as u32).ok_or_else(|| {
+                        anyhow!(
+                            "exponent in numeric literal {} overflows i128: 10^{}",
+                            s,
+                            e_exponent
+                        )
+                    })?;
+                    significand = significand
+                        .checked_mul(p)
+                        .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
+                }
             }
+            Some(_) => bail!("malformed numeric literal: {}", s),
         }
+
+        // Compute the final significand.
         let mut significand = i128::try_from(significand)
             .map_err(|_| anyhow!("numeric literal overflows i128: {}", s))?;
         if negative {
+            // Significand is guaranteed to be positive, so the negation cannot
+            // overflow.
             significand *= -1;
         }
+
         Ok(Decimal { scale, significand })
     }
 }

--- a/src/repr/src/adt/decimal.rs
+++ b/src/repr/src/adt/decimal.rs
@@ -48,6 +48,7 @@
 //! [fixed-point arithmetic]: https://en.wikipedia.org/wiki/Fixed-point_arithmetic
 
 use std::cmp::PartialEq;
+use std::convert::TryFrom;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::Sum;
@@ -364,7 +365,17 @@ impl FromStr for Decimal {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut significand: i128 = 0;
+        // WARNING: this function is hot! Please benchmark any modifications
+        // via bench_parse_decimal.
+
+        // Decimals significands are stored as i128s, but due to a Rust bug
+        // checked multiplication of i128 is orders of magnitude slower than one
+        // would expect. So we do all our arithmetic on a u128 significand
+        // instead, and convert to an i128 only as the last step.
+        //
+        // See: https://github.com/rust-lang/rust/issues/53023
+
+        let mut significand: u128 = 0;
         let mut precision = 0;
         let mut scale: u8 = 0;
         let mut seen_decimal = false;
@@ -395,7 +406,7 @@ impl FromStr for Decimal {
                         .checked_mul(10)
                         .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
                     significand = significand
-                        .checked_add(i128::from(digit))
+                        .checked_add(u128::from(digit))
                         .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
                 }
                 '.' => {
@@ -447,9 +458,6 @@ impl FromStr for Decimal {
         if precision > MAX_DECIMAL_PRECISION {
             bail!("numeric literal exceeds maximum precision: {}", s);
         }
-        if negative {
-            significand *= -1;
-        }
         if seen_e_notation {
             if e_negative {
                 scale = scale
@@ -463,7 +471,7 @@ impl FromStr for Decimal {
             } else {
                 e_exponent -= scale;
                 scale = 0;
-                let p = 10_i128.checked_pow(e_exponent as u32).ok_or_else(|| {
+                let p = 10_u128.checked_pow(e_exponent as u32).ok_or_else(|| {
                     anyhow!(
                         "exponent in numeric literal {} overflows i128: 10^{}",
                         s,
@@ -475,6 +483,11 @@ impl FromStr for Decimal {
                     .checked_mul(p)
                     .ok_or_else(|| anyhow!("numeric literal overflows i128: {}", s))?;
             }
+        }
+        let mut significand = i128::try_from(significand)
+            .map_err(|_| anyhow!("numeric literal overflows i128: {}", s))?;
+        if negative {
+            significand *= -1;
         }
         Ok(Decimal { scale, significand })
     }

--- a/test/sqllogictest/decimal.slt
+++ b/test/sqllogictest/decimal.slt
@@ -240,11 +240,41 @@ SELECT 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1.0
 ----
 1
 
-### e-notation ###
+### edge cases ###
+query error invalid input syntax for numeric: malformed numeric literal: : ""
+SELECT ''::decimal
+
 query R
-SELECT 0.03142529E2;
+SELECT '  3  '::decimal
 ----
-3.142529
+3
+
+query R
+SELECT '99999999999999999999999999999999999999'::decimal
+----
+99999999999999999999999999999999999999
+
+query R
+SELECT '-99999999999999999999999999999999999999'::decimal
+----
+-99999999999999999999999999999999999999
+
+query error numeric literal exceeds maximum precision
+SELECT '100000000000000000000000000000000000000'::decimal
+
+query error numeric literal exceeds maximum precision
+SELECT '-100000000000000000000000000000000000000'::decimal
+
+### e-notation ###
+query RRR
+SELECT 0.03142529e2, 0.03142529e+2, 0.03142529E2
+----
+3.142529 3.142529 3.142529
+
+query RRR
+SELECT '0.03142529e2'::decimal(38, 6), '0.03142529e+2'::decimal(38, 6), '0.03142529E2'::decimal(38, 6)
+----
+3.142529 3.142529 3.142529
 
 query R
 SELECT 314.2529E-2;
@@ -252,7 +282,17 @@ SELECT 314.2529E-2;
 3.142529
 
 query R
+SELECT '314.2529E-2'::decimal(38, 6);
+----
+3.142529
+
+query R
 SELECT -314.2529E-2;
+----
+-3.142529
+
+query R
+SELECT '-314.2529E-2'::decimal(38, 6);
 ----
 -3.142529
 


### PR DESCRIPTION
**repr: speed up decimal parsing by 100%**

Due to a Rust bug, checked multiplication of i128s is two orders of
magnitude slower than it should be. See rust-lang/rust#53023.  Work
around the issue by using a u128 to perform arithmetic while parsing.

```
parse_decimal/-135412353251
                        time:   [3.1434 us 3.1449 us 3.1467 us]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

parse_decimal/1.030340E11
                        time:   [2.1604 us 2.1613 us 2.1624 us]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

parse_decimal/-135412353251
                        time:   [28.306 ns 28.316 ns 28.330 ns]
                        change: [-99.083% -99.066% -99.045%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild
  12 (12.00%) high severe

parse_decimal/1.030340E11
                        time:   [33.069 ns 33.110 ns 33.150 ns]
                        change: [-98.474% -98.472% -98.470%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
```

----

**pgrepr,repr: fix some decimal parsing/encoding bugs**

Noticed while comparing the PostgreSQL implementation to ours.

Fix #4925.

----

**repr: further optimize decimal parsing**

Avoid checked arithmetic where limits on precision already ensures that
overflow cannot occur. Also iterate over bytes rather than chars, which
is a bit faster.

Combined, this yields another 25% speedup, from ~35ns to ~28ns, on the
parse_decimal microbenchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5343)
<!-- Reviewable:end -->
