### PR TITLE
sql: use PG's signature for jsonb_build_object

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1300,14 +1300,19 @@ lazy_static! {
                 }))
             },
             "jsonb_build_object" => Scalar {
-                params!((Any, Any)...) => Operation::variadic(|ecx, exprs| Ok(ScalarExpr::CallVariadic {
-                    func: VariadicFunc::JsonbBuildObject,
-                    exprs: exprs.into_iter().tuples().map(|(key, val)| {
-                        let key = typeconv::to_string(ecx, key);
-                        let val = typeconv::to_jsonb(ecx, val);
-                        vec![key, val]
-                    }).flatten().collect(),
-                }))
+                params!((Any)...) => Operation::variadic(|ecx, exprs| {
+                    if exprs.len() % 2 != 0 {
+                        bail!("argument list must have even number of elements")
+                    }
+                    Ok(ScalarExpr::CallVariadic {
+                        func: VariadicFunc::JsonbBuildObject,
+                        exprs: exprs.into_iter().tuples().map(|(key, val)| {
+                            let key = typeconv::to_string(ecx, key);
+                            let val = typeconv::to_jsonb(ecx, val);
+                            vec![key, val]
+                        }).flatten().collect(),
+                    })
+                })
             },
             "jsonb_pretty" => Scalar {
                 params!(Jsonb) => UnaryFunc::JsonbPretty


### PR DESCRIPTION
The number and type of function arguments will end up in a system table (`pg_proc`), so just making our implementation more consistent with Postgres'. Namely, PG says that this function only takes one argument––which it does because PG provides an execution error message if supplied with the wrong number of arguments, rather than not being able to select the correct implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5371)
<!-- Reviewable:end -->
