### PR TITLE
sql: fix DROP CASCADE bug

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -90,6 +90,9 @@ Wrap your release notes at the 80 character mark.
 
   **Backwards-incompatible change**
 
+- Fix a bug that would cause `DROP` statements targeting multiple objects to fail
+  when those objects had dependent objects in common {{% gh 5316 %}}.
+
 {{% version-header v0.6.0 %}}
 
 - Support specifying default values for table columns via the new

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -971,8 +971,9 @@ impl Catalog {
 
     pub fn drop_items_ops(&mut self, ids: &[GlobalId]) -> Vec<Op> {
         let mut ops = vec![];
+        let mut seen = HashSet::new();
         for &id in ids {
-            Self::drop_item_cascade(id, &self.by_id, &mut ops, &mut HashSet::new());
+            Self::drop_item_cascade(id, &self.by_id, &mut ops, &mut seen);
         }
         ops
     }

--- a/test/testdrive/drop.td
+++ b/test/testdrive/drop.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test DROP ... CASCADE statements with multiple items
+# From https://github.com/MaterializeInc/materialize/issues/5316
+> CREATE TABLE t1 (f1 INTEGER)
+> CREATE TABLE t2 (f2 INTEGER)
+> CREATE MATERIALIZED VIEW v1 AS SELECT * FROM t1, t2
+> DROP TABLE t1, t2 CASCADE


### PR DESCRIPTION
Fixes #5316 

A user found that `DROP ... CASCADE` of multiple objects--where those
objects have dependent objects in common--failed.

The fix is to deduplicate the internal drop operations created by a
single `DROP` statement, ensuring that we only attempt to drop the common
dependent objects once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5375)
<!-- Reviewable:end -->
