### PR TITLE
sql: make repeating param list like pg's variadics

### DIFF
--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -331,7 +331,7 @@ impl From<AggregateFunc> for Operation<(ScalarExpr, AggregateFunc)> {
 /// Note that this is not exhaustive and will likely require additions.
 pub enum ParamList {
     Exact(Vec<ParamType>),
-    Repeat(Vec<ParamType>),
+    Variadic(ParamType),
 }
 
 impl ParamList {
@@ -363,16 +363,16 @@ impl ParamList {
     fn validate_arg_len(&self, input_len: usize) -> bool {
         match self {
             Self::Exact(p) => p.len() == input_len,
-            Self::Repeat(p) => input_len % p.len() == 0,
+            Self::Variadic(_) => true,
         }
     }
 
     /// Reports whether the parameter list contains any polymorphic parameters.
     fn has_polymorphic(&self) -> bool {
-        let p = match self {
-            ParamList::Exact(p) | ParamList::Repeat(p) => p,
-        };
-        p.iter().any(|p| p.is_polymorphic())
+        match self {
+            ParamList::Exact(p) => p.iter().any(|p| p.is_polymorphic()),
+            ParamList::Variadic(p) => p.is_polymorphic(),
+        }
     }
 
     /// Enforces polymorphic type consistency by finding the concrete type that
@@ -653,7 +653,7 @@ impl std::ops::Index<usize> for ParamList {
     fn index(&self, i: usize) -> &Self::Output {
         match self {
             Self::Exact(p) => &p[i],
-            Self::Repeat(p) => &p[i % p.len()],
+            Self::Variadic(p) => &p,
         }
     }
 }
@@ -1127,7 +1127,7 @@ fn coerce_args_to_types(
 
 /// Provides shorthand for converting `Vec<ScalarType>` into `Vec<ParamType>`.
 macro_rules! params {
-    (($($p:expr),*)...) => { ParamList::Repeat(vec![$($p.into(),)*]) };
+    (($p:expr)...) => { ParamList::Variadic($p.into())};
     ($($p:expr),*)      => { ParamList::Exact(vec![$($p.into(),)*]) };
 }
 

--- a/src/sql/src/plan/func.rs
+++ b/src/sql/src/plan/func.rs
@@ -1127,7 +1127,7 @@ fn coerce_args_to_types(
 
 /// Provides shorthand for converting `Vec<ScalarType>` into `Vec<ParamType>`.
 macro_rules! params {
-    (($p:expr)...) => { ParamList::Variadic($p.into())};
+    ($p:ident...) => { ParamList::Variadic($p.into())};
     ($($p:expr),*)      => { ParamList::Exact(vec![$($p.into(),)*]) };
 }
 
@@ -1215,7 +1215,7 @@ lazy_static! {
                 params!(String) => UnaryFunc::CharLength
             },
             "concat" => Scalar {
-                 params!((Any)...) => Operation::variadic(|ecx, cexprs| {
+                 params!(Any...) => Operation::variadic(|ecx, cexprs| {
                     if cexprs.is_empty() {
                         bail!("No function matches the given name and argument types. \
                         You might need to add explicit type casts.")
@@ -1294,13 +1294,13 @@ lazy_static! {
                 params!(Jsonb) => UnaryFunc::JsonbArrayLength
             },
             "jsonb_build_array" => Scalar {
-                params!((Any)...) => Operation::variadic(|ecx, exprs| Ok(ScalarExpr::CallVariadic {
+                params!(Any...) => Operation::variadic(|ecx, exprs| Ok(ScalarExpr::CallVariadic {
                     func: VariadicFunc::JsonbBuildArray,
                     exprs: exprs.into_iter().map(|e| typeconv::to_jsonb(ecx, e)).collect(),
                 }))
             },
             "jsonb_build_object" => Scalar {
-                params!((Any)...) => Operation::variadic(|ecx, exprs| {
+                params!(Any...) => Operation::variadic(|ecx, exprs| {
                     if exprs.len() % 2 != 0 {
                         bail!("argument list must have even number of elements")
                     }


### PR DESCRIPTION
When developing the function selection code, we didn't have any
instances of bailing on execution after seleting the function,
which lead us to develop ParamList::Repeat for jsonb_build_object
because it requires an even number of arguments. However, PG doesn't
support multiple variadic args like ParamList::Repeat does. Because
PG doesn't support this, we don't need to, either. Instead, we
should just have a variadic paramlist that mirror's PG.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5377)
<!-- Reviewable:end -->
