### PR TITLE
sql: fix CREATE OR REPLACE VIEW bug

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,12 @@ Wrap your release notes at the 80 character mark.
 - Commit consumed offsets to Kafka to facilitate source ingest progress
   monitoring.
 
+- Fix a bug that would cause `DROP` statements targeting multiple objects to fail
+  when those objects had dependent objects in common {{% gh 5316 %}}.
+
+- Prevent a bug that would allow `CREATE OR REPLACE` statements to create dependencies
+  on objects that were about to be dropped {{% gh 5272 %}}.
+
 {{% version-header v0.6.1 %}}
 
 - Add the advanced [`--timely-progress-mode` and `--differential-idle-merge-effort` command-line arguments](/cli/#dataflow-tuning)
@@ -89,9 +95,6 @@ Wrap your release notes at the 80 character mark.
   Previously, `sum` over `bigint` returned `bigint`.
 
   **Backwards-incompatible change**
-
-- Fix a bug that would cause `DROP` statements targeting multiple objects to fail
-  when those objects had dependent objects in common {{% gh 5316 %}}.
 
 {{% version-header v0.6.0 %}}
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -712,8 +712,20 @@ pub fn plan_create_view(
     } else {
         scx.allocate_name(normalize::object_name(name.to_owned())?)
     };
+    let (mut relation_expr, mut desc, finishing) =
+        query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
+    relation_expr.bind_parameters(&params)?;
+    //TODO: materialize#724 - persist finishing information with the view?
+    relation_expr.finish(finishing);
+    let relation_expr = relation_expr.decorrelate();
     let replace = if *if_exists == IfExistsBehavior::Replace {
         if let Ok(item) = scx.catalog.resolve_item(&name.clone().into()) {
+            if relation_expr.global_uses().contains(&item.id()) {
+                bail!(
+                    "cannot replace view {0}: depended upon by new {0} definition",
+                    item.name()
+                );
+            }
             let cascade = false;
             plan_drop_item(scx, ObjectType::View, item, cascade)?
         } else {
@@ -722,12 +734,6 @@ pub fn plan_create_view(
     } else {
         None
     };
-    let (mut relation_expr, mut desc, finishing) =
-        query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
-    relation_expr.bind_parameters(&params)?;
-    //TODO: materialize#724 - persist finishing information with the view?
-    relation_expr.finish(finishing);
-    let relation_expr = relation_expr.decorrelate();
     desc = plan_utils::maybe_rename_columns(format!("view {}", name), desc, columns)?;
     let temporary = *temporary;
     let materialize = *materialized; // Normalize for `raw_sql` below.

--- a/test/testdrive/drop.td
+++ b/test/testdrive/drop.td
@@ -13,3 +13,12 @@
 > CREATE TABLE t2 (f2 INTEGER)
 > CREATE MATERIALIZED VIEW v1 AS SELECT * FROM t1, t2
 > DROP TABLE t1, t2 CASCADE
+
+# Test CREATE OR REPLACE statement that attempts to depend
+# on the object that is being replaced
+# https://github.com/MaterializeInc/materialize/issues/5272
+> CREATE VIEW v2 AS SELECT 1
+! CREATE OR REPLACE VIEW v2 AS SELECT * FROM v2
+cannot replace view materialize.public.v2: depended upon by new materialize.public.v2 definition
+! CREATE OR REPLACE MATERIALIZED VIEW v2 AS SELECT * FROM v2
+cannot replace view materialize.public.v2: depended upon by new materialize.public.v2 definition


### PR DESCRIPTION
Fixes #5272.

A user found that views created by `CREATE OR REPLACE VIEW` statements
are currently able to depend on the view that is about to be dropped.

The fix is to check during planning if the new view is attempting to
depend on the view that is about to be dropped, and throw an error if
so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5380)
<!-- Reviewable:end -->
