### PR TITLE
Bulk rename MZ_THREADS to MZ_WORKERS

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -22,7 +22,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: --workers ${MZ_THREADS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
+    command: --workers ${MZ_WORKERS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
   zookeeper:

--- a/demo/chbench/bin/generate_snapshot
+++ b/demo/chbench/bin/generate_snapshot
@@ -89,7 +89,7 @@ main() {
     # Ensure the directory exists so that Docker can mount it
     mkdir -p "${snapshot}"
 
-    export MZ_THREADS="${workers}"
+    export MZ_WORKERS="${workers}"
     export MZ_CHBENCH_SNAPSHOT="${snapshot}"
     export NUM_WAREHOUSES="${warehouses}"
     export OLTP_THREADS="${oltp_threads}"

--- a/demo/chbench/bin/ingest_bench
+++ b/demo/chbench/bin/ingest_bench
@@ -80,7 +80,7 @@ main() {
 
     parse_args "$@"
 
-    export MZ_THREADS="${workers}"
+    export MZ_WORKERS="${workers}"
     export OLTP_THREADS="${oltp_threads}"
     export NUM_WAREHOUSES="${warehouses}"
     export CHBENCH_RUN_SECONDS="${chbench_seconds}"

--- a/demo/chbench/bin/snapshot_bench
+++ b/demo/chbench/bin/snapshot_bench
@@ -95,7 +95,7 @@ main() {
     fi
 
     export KAFKA_TOPIC_FILTER="${topic_filter}"
-    export MZ_THREADS="${workers}"
+    export MZ_WORKERS="${workers}"
     export MZ_CHBENCH_SNAPSHOT="${snapshot}"
     export PEEKER_QUERIES="${peeker_queries}"
 

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -555,7 +555,7 @@ mzworkflows:
   cloud-benchmark-mz:
     env:
       MZ_SQL_EXPORTER_PORT: "9400:9399"
-      MZ_THREADS: ${MZ_THREADS:-1}
+      MZ_WORKERS: ${MZ_WORKERS:-1}
       DEFAULT_PROGRESS_MODE: ${DEFAULT_PROGRESS_MODE}
     steps:
     - step: start-services

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - *materialized
     init: true
-    command: -w ${MZ_THREADS:-4} --disable-telemetry
+    command: -w ${MZ_WORKERS:-4} --disable-telemetry
 
   dashboard:
     mzbuild: dashboard

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -19,7 +19,7 @@ services:
     ports:
      - *materialized
     init: true
-    command: --workers ${MZ_THREADS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
+    command: --workers ${MZ_WORKERS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
   zookeeper:


### PR DESCRIPTION
MZ_THREADS is a deprecated name for MZ_WORKERS, so let's remove all
usages of MZ_THREADS from our codebase.

This will require a similar change in our infra repo.

Fixes #5349

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5381)
<!-- Reviewable:end -->
