### PR TITLE
mzcompose: convert BUILD_MODE env var to command-line flag

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -308,7 +308,7 @@ and materialized binaries if you have changed them locally. From the
 
 ```
 ./mzcompose down -v
-BUILD_MODE=debug AWS_REGION= ./mzcompose run testdrive
+AWS_REGION= ./mzcompose run testdrive --build-mode=debug
 ```
 
 The `down` subcommand is needed to destroy any existing materialize

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -43,7 +43,7 @@ def main(argv: List[str]) -> int:
 
     # Load repository.
     root = Path(os.environ["MZ_ROOT"])
-    repo = mzbuild.Repository(root)
+    repo = mzbuild.Repository(root, release_mode=(args.mz_build_mode == "release"))
 
     # Handle special mzcompose commands that apply to the repo.
     if args.command == "gen-shortcuts":
@@ -188,6 +188,7 @@ class ArgumentParser(argparse.ArgumentParser):
         super().__init__(add_help=False)
         self.add_argument("--mz-quiet", action="store_true", default=None)
         self.add_argument("--mz-find")
+        self.add_argument("--mz-build-mode", default="release")
         self.add_argument("-f", "--file")
         self.add_argument("--project-directory")
         self.add_argument("command", nargs="?")
@@ -201,7 +202,12 @@ class ArgumentParser(argparse.ArgumentParser):
     ) -> Tuple[argparse.Namespace, List[str]]:
         ns = argparse.Namespace()
         try:
-            return super().parse_known_args(args, namespace=ns)
+            (pargs, unknown_args) = super().parse_known_args(args, namespace=ns)
+            if pargs.mz_build_mode not in ["dev", "release"]:
+                raise errors.BadSpec(
+                    f'unknown build mode {pargs.mz_build_mode!r} (expected "dev" or "release")'
+                )
+            return (pargs, unknown_args)
         except ValueError:
             return (ns, [])
 


### PR DESCRIPTION
This resolves a longstanding todo. Using a command-line flag is safer,
as it is more resilient to typos, and can't accidentally get lost via
layers of Docker containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5388)
<!-- Reviewable:end -->
