### PR TITLE
Disable control center in benchmarks

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -418,16 +418,13 @@ mzworkflows:
     - step: start-services
       services: [dashboard]
     - step: start-services
-      services: [kafka, schema-registry, control-center]
+      services: [kafka, schema-registry]
     - step: wait-for-tcp
       host: schema-registry
       port: 8081
     - step: wait-for-tcp
       host: kafka
       port: 9092
-    - step: wait-for-tcp
-      host: control-center
-      port: 9021
     - step: run
       service: kafka-util
       command: restore_topics.py --topic-filter ${KAFKA_TOPIC_FILTER:-debezium.tpcch.*}


### PR DESCRIPTION
We don't use it for anything programmatic, so let's disable it in the
benchmarks.

Fixes #5395

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5397)
<!-- Reviewable:end -->
