### PR TITLE
Enable SHOW VIEWS in mzutil scripts

### DIFF
--- a/misc/mzutil/scripts/snapshot_view_states.py
+++ b/misc/mzutil/scripts/snapshot_view_states.py
@@ -49,6 +49,7 @@ def snapshot_materialize_views(args: argparse.Namespace) -> None:
     """Record the current table status of all views installed in Materialize."""
 
     with psycopg2.connect(f"postgresql://{args.host}:{args.port}/materialize") as conn:
+        conn.autocommit = True
         for view in view_names(conn):
             with conn.cursor() as cursor:
                 viewfile = os.path.join(args.snapshot_dir, f"{view}.sql")
@@ -61,6 +62,7 @@ def snapshot_source_offsets(args: argparse.Namespace) -> None:
     """Record the current topic offset of all sources installed in Materialize."""
 
     with psycopg2.connect(f"postgresql://{args.host}:{args.port}/materialize") as conn:
+        conn.autocommit = True
         for source in source_names(conn):
             with conn.cursor() as cursor:
                 query = "SELECT mz_source_info.offset as offset FROM mz_source_info WHERE source_name = %s"

--- a/misc/mzutil/scripts/wait_for_view_states.py
+++ b/misc/mzutil/scripts/wait_for_view_states.py
@@ -149,6 +149,7 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
             view_sources[view] = SourceInfo(topic_name, source_offsets[topic_name])
 
     with psycopg2.connect(f"postgresql://{args.host}:{args.port}/materialize") as conn:
+        conn.autocommit = True
         installed_views = set(view_names(conn))
 
     # Verify that we have snapshots for all views installed
@@ -163,6 +164,7 @@ def wait_for_materialize_views(args: argparse.Namespace) -> None:
 
     pending_views = installed_views
     with psycopg2.connect(f"postgresql://{args.host}:{args.port}/materialize") as conn:
+        conn.autocommit = True
         while pending_views:
             views_to_remove = []
             time_taken = time.monotonic() - start_time


### PR DESCRIPTION
After the change made as part 5b4afdac, SHOW VIEW cannot be run inside
of a transaction. Enable autocommit within the mzutil scripts so that
they can get the set of views configured.

Fixes #5399

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5400)
<!-- Reviewable:end -->
