### PR TITLE
python: update to latest mypy

### DIFF
--- a/misc/python/requirements-dev.txt
+++ b/misc/python/requirements-dev.txt
@@ -1,7 +1,7 @@
 awscli==1.18.43
 black==19.10b0
 humanize==2.3.0
-mypy==0.770
+mypy==0.790
 pdoc3==0.8.1
 pytest==5.4.2
 requests==2.23.0


### PR DESCRIPTION
This fixes a bug in which mypy mishandled Python 3.9 ASTs, resulting in
spurious type errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5406)
<!-- Reviewable:end -->
