### PR TITLE
python: rewrite git tags test

### DIFF
--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -93,7 +93,7 @@ def get_version_tags(*, fetch: bool = True) -> List[semver.VersionInfo]:
     """List all the version-like tags in the repo
 
     Args:
-        fetch: If false, don't update git, only intended for testing
+        fetch: If false, don't automatically run `git fetch --tags`.
     """
     if fetch:
         spawn.runv(["git", "fetch", "--tags"])


### PR DESCRIPTION
I'm kind of skeptical that this test is pulling its weight, but I figured this was the solution least likely to be objectionable!

----

The test_tags_returns_ordered_newest_first test is dependent on there
existing tags in the local clone of the Git repository. Empirically this
is often not the case, though I'm not sure why. Rewrite the test so that
it mocks out the call to `git tag`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5407)
<!-- Reviewable:end -->
