### PR TITLE
coord: allow SHOW queries in transactions

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -655,6 +655,15 @@ where
                                 | Statement::Rollback(_)
                                 | Statement::Select(_)
                                 | Statement::SetTransaction(_)
+                                | Statement::ShowColumns(_)
+                                | Statement::ShowCreateIndex(_)
+                                | Statement::ShowCreateSink(_)
+                                | Statement::ShowCreateSource(_)
+                                | Statement::ShowCreateTable(_)
+                                | Statement::ShowCreateView(_)
+                                | Statement::ShowDatabases(_)
+                                | Statement::ShowIndexes(_)
+                                | Statement::ShowObjects(_)
                                 | Statement::ShowVariable(_)
                                 | Statement::StartTransaction(_)
                                 | Statement::Tail(_) => {}
@@ -674,15 +683,6 @@ where
                                 | Statement::DropObjects(_)
                                 | Statement::Insert(_)
                                 | Statement::SetVariable(_)
-                                | Statement::ShowColumns(_)
-                                | Statement::ShowCreateIndex(_)
-                                | Statement::ShowCreateSink(_)
-                                | Statement::ShowCreateSource(_)
-                                | Statement::ShowCreateTable(_)
-                                | Statement::ShowCreateView(_)
-                                | Statement::ShowDatabases(_)
-                                | Statement::ShowIndexes(_)
-                                | Statement::ShowObjects(_)
                                 | Statement::Update(_) => {
                                     let _ = tx.send(Response {
                                         result: Ok(ExecuteResponse::PgError {

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -135,3 +135,20 @@ SELECT 1; SELECT 2
 COMPLETE 1
 2
 COMPLETE 1
+
+# Verify that `SHOW` queries work in transactions.
+
+simple
+BEGIN
+----
+COMPLETE 0
+
+query T rowsort
+SHOW TABLES
+----
+t
+
+simple
+COMMIT
+----
+COMPLETE 0


### PR DESCRIPTION
SHOW queries are lowered to SELECT queries, so they are exactly as safe
as SELECT queries. There is probably some lingering incorrectness with
SELECT queries, but no need to punish SHOW queries for that.

Fix #5399.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5409)
<!-- Reviewable:end -->
