### PR TITLE
Remove single quotes from some test strings

### DIFF
--- a/test/testdrive/esoteric/kinesis.td
+++ b/test/testdrive/esoteric/kinesis.td
@@ -10,17 +10,17 @@
 $ kinesis-create-stream stream=test shards=1
 
 $ kinesis-ingest format=bytes stream=test
-here's a test string
+here is a test string
 
 $ kinesis-verify stream=test
-here's a test string
+here is a test string
 
 $ kinesis-ingest format=bytes stream=test
-here's a second test string
+here is a second test string
 
 $ kinesis-verify stream=test
-here's a test string
-here's a second test string
+here is a test string
+here is a second test string
 
 ! CREATE SOURCE custom_source
   FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
@@ -41,5 +41,5 @@ If providing a custom region, an `endpoint` option must also be provided
   AS SELECT CONVERT_FROM(data, 'utf8') FROM f
 
 > SELECT * FROM f_view
-"here's a test string"
-"here's a second test string"
+"here is a test string"
+"here is a second test string"


### PR DESCRIPTION
It improves error output (since the quotes don't need to be escaped) and my
syntax highlighting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5413)
<!-- Reviewable:end -->
