### PR TITLE
www: remove netlify proxies

### DIFF
--- a/ci/www/public/_redirects
+++ b/ci/www/public/_redirects
@@ -22,6 +22,3 @@ http://materialize.com/* https://materialize.com/:splat 301!
 
 # The Slack invitation URL expires every 30 days, so we give it a stable alias.
 /s/chat https://join.slack.com/t/materializecommunity/shared_invite/zt-kn66colt-N8IB2s9T_62u2q8FoN1TdQ
-
-# Forward all paths unknown to Netlify to the marketing site.
-/* https://materializeinc.wpengine.com/:splat 200


### PR DESCRIPTION
The reverse proxy for the marketing is now handled upstream by
CloudFront. So remove the Netlify configuration for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5416)
<!-- Reviewable:end -->
