### PR TITLE
misc: add pip to bin venv

### DIFF
--- a/misc/python/requirements.txt
+++ b/misc/python/requirements.txt
@@ -5,3 +5,4 @@ pyyaml==5.3.1
 semver==2.9.1
 toml==0.10.0
 typing-extensions==3.7.4.2
+pip==20.3.3


### PR DESCRIPTION
In order to run bin/pyfmt locally, the venv in misc/python/venv needs
to have pip installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5418)
<!-- Reviewable:end -->
