### PR TITLE
Hoist recursive call out of inner loop

### DIFF
--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -211,9 +211,14 @@ impl RedundantJoin {
             RelationExpr::Union { base, inputs } => {
                 let mut prov = self.action(base, lets);
                 for input in inputs {
+                    let input_prov = self.action(input, lets);
+                    // To merge a new list of provenances, we look at the cross
+                    // produce of things we might know about each source.
+                    // TODO(mcsherry): this can be optimized to use datastructures
+                    // keyed by the source identifier.
                     let mut new_prov = Vec::new();
                     for l in prov {
-                        new_prov.extend(self.action(input, lets).iter().flat_map(|r| l.meet(r)))
+                        new_prov.extend(input_prov.iter().flat_map(|r| l.meet(r)))
                     }
                     prov = new_prov;
                 }


### PR DESCRIPTION
Fixes #5382

A recursive call was in an inner loop. It was invariant across iterations of the loop, and there was no reason it should have been in there. This resulted in an increased branching factor when optimizing the AST rather than a linear traversal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5424)
<!-- Reviewable:end -->
