### PR TITLE
doc/user: avoid linking to W3Schools

### DIFF
--- a/doc/user/content/sql/functions/_index.md
+++ b/doc/user/content/sql/functions/_index.md
@@ -42,8 +42,8 @@ Operator | Computes
 `a IS NULL` | `a = NULL`
 `a ISNULL` | `a = NULL`
 `a IS NOT NULL` | `a != NULL`
-`a LIKE match_expr` | `a` matches `match_expr`, using [SQL LIKE matching](https://www.w3schools.com/sql/sql_like.asp)
-`a ILIKE match_expr` | `a` matches `match_expr`, using case-insensitive [SQL LIKE matching](https://www.w3schools.com/sql/sql_like.asp)
+`a LIKE match_expr` | `a` matches `match_expr`, using [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
+`a ILIKE match_expr` | `a` matches `match_expr`, using case-insensitive [SQL LIKE matching](https://www.postgresql.org/docs/13/functions-matching.html#FUNCTIONS-LIKE)
 
 ### Numbers
 

--- a/doc/user/content/sql/types/jsonb.md
+++ b/doc/user/content/sql/types/jsonb.md
@@ -19,7 +19,7 @@ Detail | Info
 **OID** | 3802
 
 Materialize does not yet support a type more similar to PostgreSQL's
-impplementation of `json`.
+implementation of `json`.
 
 ## Syntax
 
@@ -27,7 +27,7 @@ impplementation of `json`.
 
 Field | Use
 ------|-----
-_json&lowbar;string_ | A well-formed [JSON object](https://www.w3schools.com/js/js_json_syntax.asp).
+_json&lowbar;string_ | A well-formed [JSON object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON).
 
 ## JSONB functions + operators
 


### PR DESCRIPTION
W3Schools has historically been an untrustworthy source of information
[0]. While they've largely cleaned up their act, their reputation
remains, so I think it's best if we avoid linking to them when possible.

This commit replaces all links to w3schools.com with more reputable
sources, like the PostgreSQL documentation or MDN.

[0]: https://web.archive.org/web/20120113062049/http://w3fools.com/

Fix #5419.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5426)
<!-- Reviewable:end -->
