### PR TITLE
test/lang/python: validate TAIL with psycopg3's new streaming API

### DIFF
--- a/test/lang/python/requirements.txt
+++ b/test/lang/python/requirements.txt
@@ -1,3 +1,3 @@
 psycopg2==2.8.6
-git+https://github.com/psycopg/psycopg3.git@76f81436f27adf6cd2a13e4e0d39e31ec7e0a037#subdirectory=psycopg3
+git+https://github.com/psycopg/psycopg3.git@4f053f14901454a7c7895b527ddeb9d8ab57d7fe#subdirectory=psycopg3
 SQLAlchemy==1.3.20


### PR DESCRIPTION
psycopg3's new streaming query API is a perfect fit for `TAIL`. It is
more ergonomic than using either `COPY` or server-side cursors and it
is as efficient as using `COPY`.

This commit adds a `TAIL` test that uses this new streaming API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5428)
<!-- Reviewable:end -->
