### PR TITLE
dbt-materialize-wikirecent: move demo project to main repo

### DIFF
--- a/play/wikirecent-dbt/README.md
+++ b/play/wikirecent-dbt/README.md
@@ -1,0 +1,150 @@
+## dbt + Materialize
+
+Welcome! This demo project illustrates how to turn [streaming Wikipedia data](https://stream.wikimedia.org/?doc)
+into materialized views in [Materialize](https://materialize.com/product/) using [dbt](https://www.getdbt.com/).
+
+*Note*: the [`dbt-materialize`](https://github.com/MaterializeInc/dbt-materialize) adapter used for this
+project is still a work in progress! If you hit a snag along the way, please open an issue or submit a PR.
+
+
+To get everything you need to run dbt with Materialize, do the following:
+
+1. Git clone this repo.
+
+   ```
+   git clone https://github.com/MaterializeInc/materialize
+   ```
+
+1. Create a new Python virtual environment on your machine. Activate that environment,
+   and install the following:
+    ```nofmt
+    python3 -m venv dbt-venv
+    source dbt-venv/bin/activate
+    pip install dbt
+    pip install dbt-materialize
+    ```
+
+1. Replace or add the following profile to your `~/.dbt/profiles.yml` file:
+    ```nofmt
+    default:
+      outputs:
+        dev:
+          type: materialize
+          threads: 1
+          host: localhost
+          port: 6875
+          user: user
+          pass: pass
+          dbname: materialize
+          schema: public
+
+      target: dev
+    ```
+
+1. Spin up a [Materialize instance](https://materialize.com/quickstart/). If your Materialize
+   instance is not running at `localhost:6875`, update your materialize dbt profile.
+
+Once you've completed these steps, you're ready to run dbt with Materialize!
+
+### dbt + Materialize demo
+
+*Note: This project is a dbt-twist of our ["Getting Started"](https://materialize.com/docs/get-started/#create-a-real-time-stream)
+demo. If you want to try creating these materialized views manually, check it out!*
+
+Materialize is built to handle streams of data, and provide incredibly low-latency answers to queries over that data.
+To show off that capability, we're going to create [materialized views](https://materialize.com/docs/sql/create-materialized-view/#main)
+on top of streaming Wikipedia data using dbt.
+
+1. To start, let's set up a stream of Wikipedia's recent changes, and simply write all the data we see
+   to a file. From your shell, run:
+   ```nofmt
+   while true; do
+     curl --max-time 9999999 -N https://stream.wikimedia.org/v2/stream/recentchange >> wikirecent
+   done
+   ```
+   Note the absolute path of the location of `wikirecent`, which we’ll need in the next step.
+
+1. [Connect to your Materialize instance](https://materialize.com/docs/connect/cli/) from your shell.
+   Then, [create a source](https://materialize.com/docs/sql/create-source/text-file/#main) using your `wikirecent` file:
+   ```nofmt
+   CREATE SOURCE wikirecent
+   FROM FILE '[path to wikirecent]' WITH (tail = true)
+   FORMAT REGEX '^data: (?P<data>.*)';
+   ```
+   This source takes the lines from the stream, finds those that begins with `data:`, and then captures the rest of the
+   line in a column called `data`.
+
+   You can see the columns that get generated for this source:
+   ```nofmt
+    > SHOW SOURCES;
+      name
+    ------------
+     wikirecent
+
+    > SHOW COLUMNS FROM wikirecent;
+      name    | nullable | type
+     ------------+----------+------
+    data       | t        | text
+    mz_line_no | f        | int8
+   ```
+
+1. Now we can use dbt to create materialized views on top of `wikirecent`. In your shell, navigate to the
+   root of this repo on your local machine. Once you're there, run the following [dbt commands](https://docs.getdbt.com/reference/dbt-commands/)
+   inside your Python virtual environment:
+   ```nofmt
+   dbt compile
+   dbt run
+   ```
+   `dbt compile` generates executable SQL from our model files, which can be found in the `models` directory
+   of this project. `dbt run` executes the compiled SQL files against the target database, creating
+   our materialized views.
+
+   Note: If you haven't set up your Python environment with `dbt` and the `dbt-materialize` adapter,
+   please revisit the [setup](#setup-dbt--materialize) above.
+
+1. Congratulations! You just used dbt to create materialized views in Materialize. You can verify the
+   views were created from your `psql` shell connected to Materialize:
+      ```nofmt
+      > SHOW VIEWS;
+           name
+      ---------------
+       recentchanges
+       top10
+       useredits
+      ```
+
+   More importantly, you can now query each of the views you created interactively. For example:
+   ```nofmt
+   > SELECT * FROM top10;
+        user      | changes
+   ---------------+---------
+    Fæ            |   10834
+    Sic19         |    7970
+    Lockal        |   10450
+    Akbarali      |    9631
+    SuccuBot      |    8862
+    Merge bot     |    4019
+    Edoderoobot   |    3953
+    Sarri.greek   |    3900
+    BotMultichill |    4391
+    SchlurcherBot |    8005
+   (10 rows)
+   ```
+
+1. Now that you have your views, let's generate their docs using dbt. From your Python virtual environment, run:
+   ```nofmt
+   dbt docs generate
+   dbt docs serve
+   ```
+
+    `dbt docs generate` generates this project's documentation website. `dbt docs serve` makes those
+    docs available at http://localhost:8080.
+
+    Once the local docs site is available, click into `materialize_wikirecent/models` to inspect the documentation
+    for each of the created views.
+
+### Resources:
+- Learn more about Materialize [in the docs](https://materialize.com/docs/)
+- Join Materialize's [chat](https://materializecommunity.slack.com/join/shared_invite/zt-jjwe1t45-klG9k7V7xibdtqA6bcFpyQ#/) on Slack for live discussions and support
+- Learn more about dbt [in the docs](https://docs.getdbt.com/docs/introduction)
+- Join dbt's [chat](http://slack.getdbt.com/) on Slack for live discussions and support

--- a/play/wikirecent-dbt/models/recentchanges.sql
+++ b/play/wikirecent-dbt/models/recentchanges.sql
@@ -1,0 +1,40 @@
+-- Copyright Materialize, Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='materializedview') }}
+
+SELECT
+    val->>'$schema' AS r_schema,
+    (val->'bot')::bool AS bot,
+    val->>'comment' AS comment,
+    (val->'id')::float::int AS id,
+    (val->'length'->'new')::float::int AS length_new,
+    (val->'length'->'old')::float::int AS length_old,
+    val->'meta'->>'uri' AS meta_uri,
+    val->'meta'->>'id' as meta_id,
+    (val->'minor')::bool AS minor,
+    (val->'namespace')::float AS namespace,
+    val->>'parsedcomment' AS parsedcomment,
+    (val->'revision'->'new')::float::int AS revision_new,
+    (val->'revision'->'old')::float::int AS revision_old,
+    val->>'server_name' AS server_name,
+    (val->'server_script_path')::text AS server_script_path,
+    val->>'server_url' AS server_url,
+    (val->'timestamp')::float AS r_ts,
+    val->>'title' AS title,
+    val->>'type' AS type,
+    val->>'user' AS user,
+    val->>'wiki' AS wiki
+FROM (SELECT data::jsonb AS val FROM materialize.public.wikirecent)

--- a/play/wikirecent-dbt/models/schema.yml
+++ b/play/wikirecent-dbt/models/schema.yml
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+models:
+  - name: recentchanges
+    description: "Streaming Wikimedia event data"
+    columns:
+      - name: r_schema
+      - name: bot
+      - name: comment
+      - name: id
+      - name: length_new
+      - name: length_old
+      - name: meta_uri,
+      - name: meta_id
+      - name: minor
+      - name: namespace
+      - name: parsedcomment
+      - name: revision_new
+      - name: revision_old
+      - name: server_name
+      - name: server_script_path
+      - name: server_url
+      - name: r_ts
+      - name: title
+      - name: type
+      - name: user
+      - name: wiki
+  - name: useredits
+    description: "Edit counts per user"
+    columns:
+      - name: user
+        description: "The user"
+        tests:
+          - not_null
+      - name: changes
+        description: "The number of edits made by the user"
+  - name: top10
+    description: "Top 10 Wikipedia editors since the stream started"
+    columns:
+      - name: user
+        description: "The user"
+        tests:
+          - not_null
+      - name: changes
+        description: "The number of edits made by the user"

--- a/play/wikirecent-dbt/models/top10.sql
+++ b/play/wikirecent-dbt/models/top10.sql
@@ -1,0 +1,18 @@
+-- Copyright Materialize, Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='materializedview') }}
+
+SELECT * FROM {{ ref('useredits') }} ORDER BY changes DESC LIMIT 10

--- a/play/wikirecent-dbt/models/useredits.sql
+++ b/play/wikirecent-dbt/models/useredits.sql
@@ -1,0 +1,18 @@
+-- Copyright Materialize, Inc. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{{ config(materialized='materializedview') }}
+
+SELECT user, count(*) as changes FROM {{ ref('recentchanges') }}  GROUP BY user


### PR DESCRIPTION
Moves the `dbt-materialize-wikirecent` demo project from its own repo to
the main materialize repo under `play/`. Removes the prior LICENSE file,
replacing it with Apache 2.0 license headers in individual files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5452)
<!-- Reviewable:end -->
