### PR TITLE
dbt-materialize: restore manual path extensions

### DIFF
--- a/misc/dbt-materialize/dbt/__init__.py
+++ b/misc/dbt-materialize/dbt/__init__.py
@@ -13,3 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/misc/dbt-materialize/dbt/adapters/__init__.py
+++ b/misc/dbt-materialize/dbt/adapters/__init__.py
@@ -13,3 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/misc/dbt-materialize/dbt/adapters/materialize/__init__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dbt.adapters.materialize.connections import MaterializeConnectionManager
 from dbt.adapters.materialize.connections import MaterializeCredentials
 from dbt.adapters.materialize.impl import MaterializeAdapter
 

--- a/misc/dbt-materialize/dbt/include/__init__.py
+++ b/misc/dbt-materialize/dbt/include/__init__.py
@@ -13,3 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/misc/dbt-materialize/dbt/include/materialize/__init__.py
+++ b/misc/dbt-materialize/dbt/include/materialize/__init__.py
@@ -13,3 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+
+PACKAGE_PATH = os.path.dirname(__file__)


### PR DESCRIPTION
This is currently required for the dbt-materialize adapter to be loaded correctly. (The issue seems [to be here](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize/dbt/adapters/materialize/__init__.py#L26)--I tested this incorrectly in my last PR!)

I'm happy to revisit this after I merge the fix, I don't want our adapter to be broken in the meantime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5454)
<!-- Reviewable:end -->
