### PR TITLE
pgwire: support transactional INSERTs

### DIFF
--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -79,6 +79,11 @@ these lines as a simple query over pgwire. This is needed because the
 other directives use the extended protocol, and we needed a way to test
 multi-statement queries and implicit transactions.
 
+An optional `conn=<name>` can be added to execute the message on a
+named connection. It will be created on first use. This can be used to
+test transaction isolation or otherwise do things that require multiple
+connections.
+
 The output is one line per row, one "COMPLETE X" (where X is the
 number of affected rows) per statement, or an error message.
 

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -15,7 +15,7 @@ use sql::plan::Params;
 use crate::command::{
     Command, ExecuteResponse, NoSessionExecuteResponse, Response, StartupMessage,
 };
-use crate::session::Session;
+use crate::session::{EndTransactionAction, Session};
 
 /// A client for a [`Coordinator`](crate::Coordinator).
 ///
@@ -138,6 +138,18 @@ impl SessionClient {
     pub async fn execute(&mut self, portal_name: String) -> Result<ExecuteResponse, anyhow::Error> {
         self.send(|tx, session| Command::Execute {
             portal_name,
+            session,
+            tx,
+        })
+        .await
+    }
+
+    pub async fn end_transaction(
+        &mut self,
+        action: EndTransactionAction,
+    ) -> Result<ExecuteResponse, anyhow::Error> {
+        self.send(|tx, session| Command::Commit {
+            action,
             session,
             tx,
         })

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -18,7 +18,7 @@ use sql::ast::{FetchDirection, ObjectType, Raw, Statement};
 use sql::plan::ExecuteTimeout;
 use tokio_postgres::error::SqlState;
 
-use crate::session::Session;
+use crate::session::{EndTransactionAction, Session};
 
 #[derive(Debug)]
 pub enum Command {
@@ -46,6 +46,12 @@ pub enum Command {
 
     Execute {
         portal_name: String,
+        session: Session,
+        tx: futures::channel::oneshot::Sender<Response<ExecuteResponse>>,
+    },
+
+    Commit {
+        action: EndTransactionAction,
         session: Session,
         tx: futures::channel::oneshot::Sender<Response<ExecuteResponse>>,
     },
@@ -97,7 +103,7 @@ pub enum ExecuteResponse {
     /// The active transaction was exited.
     TransactionExited {
         was_implicit: bool,
-        tag: String,
+        tag: &'static str,
     },
     // The requested object was altered.
     AlteredObject(ObjectType),

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -77,7 +77,9 @@ use crate::catalog::{self, Catalog, CatalogItem, Index, SinkConnectorState, Type
 use crate::command::{
     Command, ExecuteResponse, NoSessionExecuteResponse, Response, StartupMessage,
 };
-use crate::session::{PreparedStatement, Session, TransactionStatus};
+use crate::session::{
+    EndTransactionAction, PreparedStatement, Session, TransactionOps, TransactionStatus, WriteOp,
+};
 use crate::sink_connector;
 use crate::timestamp::{TimestampConfig, TimestampMessage, Timestamper};
 use crate::util::ClientTransmitter;
@@ -593,7 +595,7 @@ where
 
             Command::Execute {
                 portal_name,
-                session,
+                mut session,
                 tx,
             } => {
                 let result = session
@@ -609,15 +611,20 @@ where
                         return;
                     }
                 };
-                match &portal.stmt {
+                let stmt = portal.stmt.clone();
+                let params = portal.parameters.clone();
+                match stmt {
                     Some(stmt) => {
                         // Verify that this statetement type can be executed in the current
                         // transaction state.
                         match session.transaction() {
-                            // Idle is almost always safe (idle means there's a single statement being
-                            // executed). Failed transactions have already been checked in pgwire for a
-                            // safe statement (COMMIT, ROLLBACK, etc.) and can also proceed.
-                            &TransactionStatus::Idle | &TransactionStatus::Failed => {
+                            // By this point we should be in a running transaction.
+                            &TransactionStatus::Default => unreachable!(),
+
+                            // Started is almost always safe (started means there's a single statement
+                            // being executed). Failed transactions have already been checked in pgwire for
+                            // a safe statement (COMMIT, ROLLBACK, etc.) and can also proceed.
+                            &TransactionStatus::Started(_) | &TransactionStatus::Failed => {
                                 if let Statement::Declare(_) = stmt {
                                     // Declare is an exception. Although it's not against any spec to execute
                                     // it, it will always result in nothing happening, since all portals will be
@@ -634,7 +641,7 @@ where
                                 }
                             }
 
-                            // Implicit or explicit transactions only allow reads for now.
+                            // Implicit or explicit transactions.
                             //
                             // Implicit transactions happen when a multi-statement query is executed
                             // (a "simple query"). However if a "BEGIN" appears somewhere in there,
@@ -643,17 +650,17 @@ where
                             // transactions can do unless there's some additional checking to make sure
                             // something disallowed in explicit transactions did not previously take place
                             // in the implicit portion.
-                            &TransactionStatus::InTransactionImplicit
-                            | &TransactionStatus::InTransaction => match stmt {
+                            &TransactionStatus::InTransactionImplicit(_)
+                            | &TransactionStatus::InTransaction(_) => match stmt {
+                                // Statements that are safe in a transaction. We still need to verify that we
+                                // don't interleave reads and writes since we can't perform those serializably.
                                 Statement::Close(_)
                                 | Statement::Commit(_)
-                                | Statement::Copy(_)
                                 | Statement::Declare(_)
                                 | Statement::Discard(_)
                                 | Statement::Explain(_)
                                 | Statement::Fetch(_)
                                 | Statement::Rollback(_)
-                                | Statement::Select(_)
                                 | Statement::SetTransaction(_)
                                 | Statement::ShowColumns(_)
                                 | Statement::ShowCreateIndex(_)
@@ -665,9 +672,37 @@ where
                                 | Statement::ShowIndexes(_)
                                 | Statement::ShowObjects(_)
                                 | Statement::ShowVariable(_)
-                                | Statement::StartTransaction(_)
-                                | Statement::Tail(_) => {}
+                                | Statement::StartTransaction(_) => {
+                                    // Always safe.
+                                }
 
+                                Statement::Copy(_) | Statement::Select(_) | Statement::Tail(_) => {
+                                    if let Err(response) =
+                                        session.add_transaction_ops(TransactionOps::Reads)
+                                    {
+                                        let _ = tx.send(Response {
+                                            result: Ok(response),
+                                            session,
+                                        });
+                                        return;
+                                    }
+                                }
+
+                                Statement::Insert(_) => {
+                                    // Insert will add the actual operations later. We can still do a check to
+                                    // early exit here before processing it.
+                                    if let Err(response) =
+                                        session.add_transaction_ops(TransactionOps::Writes(vec![]))
+                                    {
+                                        let _ = tx.send(Response {
+                                            result: Ok(response),
+                                            session,
+                                        });
+                                        return;
+                                    }
+                                }
+
+                                // Statements below must by run singly (in Started).
                                 Statement::AlterIndexOptions(_)
                                 | Statement::AlterObjectRename(_)
                                 | Statement::CreateDatabase(_)
@@ -681,7 +716,6 @@ where
                                 | Statement::Delete(_)
                                 | Statement::DropDatabase(_)
                                 | Statement::DropObjects(_)
-                                | Statement::Insert(_)
                                 | Statement::SetVariable(_)
                                 | Statement::Update(_) => {
                                     let _ = tx.send(Response {
@@ -700,8 +734,6 @@ where
                         }
 
                         let mut internal_cmd_tx = internal_cmd_tx.clone();
-                        let stmt = stmt.clone();
-                        let params = portal.parameters.clone();
                         tokio::spawn(async move {
                             let result = sql::pure::purify(stmt).await;
                             internal_cmd_tx
@@ -795,6 +827,15 @@ where
 
             Command::Terminate { mut session } => {
                 self.handle_terminate(&mut session).await;
+            }
+
+            Command::Commit {
+                action,
+                mut session,
+                tx,
+            } => {
+                let result = self.sequence_end_transaction(&mut session, action).await;
+                let _ = tx.send(Response { result, session });
             }
         }
     }
@@ -1504,24 +1545,18 @@ where
             ),
 
             Plan::StartTransaction => {
-                session.start_transaction();
+                let session = session.start_transaction();
                 tx.send(Ok(ExecuteResponse::StartedTransaction), session)
             }
 
             Plan::CommitTransaction | Plan::AbortTransaction => {
-                let was_implicit = matches!(
-                    session.transaction(),
-                    TransactionStatus::InTransactionImplicit
-                );
-                let tag = match plan {
-                    Plan::CommitTransaction => "COMMIT",
-                    Plan::AbortTransaction => "ROLLBACK",
+                let action = match plan {
+                    Plan::CommitTransaction => EndTransactionAction::Commit,
+                    Plan::AbortTransaction => EndTransactionAction::Rollback,
                     _ => unreachable!(),
-                }
-                .to_string();
-                session.end_transaction();
+                };
                 tx.send(
-                    Ok(ExecuteResponse::TransactionExited { tag, was_implicit }),
+                    self.sequence_end_transaction(&mut session, action).await,
                     session,
                 )
             }
@@ -1586,12 +1621,15 @@ where
                 affected_rows,
                 kind,
             } => tx.send(
-                self.sequence_send_diffs(id, updates, affected_rows, kind)
+                self.sequence_send_diffs(&mut session, id, updates, affected_rows, kind)
                     .await,
                 session,
             ),
 
-            Plan::Insert { id, values } => tx.send(self.sequence_insert(id, values).await, session),
+            Plan::Insert { id, values } => tx.send(
+                self.sequence_insert(&mut session, id, values).await,
+                session,
+            ),
 
             Plan::AlterItemRename {
                 id,
@@ -1614,15 +1652,15 @@ where
             }
 
             Plan::DiscardAll => {
-                let ret = if session.transaction() != &TransactionStatus::Idle {
+                let ret = if let TransactionStatus::Started(_) = session.transaction() {
+                    self.drop_temp_items(session.conn_id()).await;
+                    session.reset();
+                    ExecuteResponse::DiscardedAll
+                } else {
                     ExecuteResponse::PgError {
                         code: SqlState::ACTIVE_SQL_TRANSACTION,
                         message: "DISCARD ALL cannot run inside a transaction block".to_string(),
                     }
-                } else {
-                    self.drop_temp_items(session.conn_id()).await;
-                    session.reset();
-                    ExecuteResponse::DiscardedAll
                 };
                 tx.send(Ok(ret), session);
             }
@@ -2110,6 +2148,53 @@ where
         Ok(ExecuteResponse::SetVariable { name })
     }
 
+    async fn sequence_end_transaction(
+        &mut self,
+        session: &mut Session,
+        action: EndTransactionAction,
+    ) -> Result<ExecuteResponse, anyhow::Error> {
+        let was_implicit = matches!(
+            session.transaction(),
+            TransactionStatus::InTransactionImplicit(_)
+        );
+
+        let txn = session.clear_transaction();
+
+        if let EndTransactionAction::Commit = action {
+            match txn {
+                TransactionStatus::Default | TransactionStatus::Failed => {}
+                TransactionStatus::Started(ops)
+                | TransactionStatus::InTransaction(ops)
+                | TransactionStatus::InTransactionImplicit(ops) => {
+                    if let TransactionOps::Writes(inserts) = ops {
+                        let timestamp = self.get_write_ts();
+                        for WriteOp { id, rows } in inserts {
+                            let updates = rows
+                                .into_iter()
+                                .map(|(row, diff)| Update {
+                                    row,
+                                    diff,
+                                    timestamp,
+                                })
+                                .collect();
+
+                            broadcast(
+                                &mut self.broadcast_tx,
+                                SequencedCommand::Insert { id, updates },
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ExecuteResponse::TransactionExited {
+            tag: action.tag(),
+            was_implicit,
+        })
+    }
+
     async fn sequence_peek(
         &mut self,
         conn_id: u32,
@@ -2535,36 +2620,28 @@ where
 
     async fn sequence_send_diffs(
         &mut self,
+        session: &mut Session,
         id: GlobalId,
-        updates: Vec<(Row, isize)>,
+        rows: Vec<(Row, isize)>,
         affected_rows: usize,
         kind: MutationKind,
     ) -> Result<ExecuteResponse, anyhow::Error> {
-        let timestamp = self.get_write_ts();
-        let updates = updates
-            .into_iter()
-            .map(|(row, diff)| Update {
-                row,
-                diff,
-                timestamp,
+        if let Err(response) =
+            session.add_transaction_ops(TransactionOps::Writes(vec![WriteOp { id, rows }]))
+        {
+            Ok(response)
+        } else {
+            Ok(match kind {
+                MutationKind::Delete => ExecuteResponse::Deleted(affected_rows),
+                MutationKind::Insert => ExecuteResponse::Inserted(affected_rows),
+                MutationKind::Update => ExecuteResponse::Updated(affected_rows),
             })
-            .collect();
-
-        broadcast(
-            &mut self.broadcast_tx,
-            SequencedCommand::Insert { id, updates },
-        )
-        .await;
-
-        Ok(match kind {
-            MutationKind::Delete => ExecuteResponse::Deleted(affected_rows),
-            MutationKind::Insert => ExecuteResponse::Inserted(affected_rows),
-            MutationKind::Update => ExecuteResponse::Updated(affected_rows),
-        })
+        }
     }
 
     async fn sequence_insert(
         &mut self,
+        session: &mut Session,
         id: GlobalId,
         values: RelationExpr,
     ) -> Result<ExecuteResponse, anyhow::Error> {
@@ -2584,9 +2661,8 @@ where
                         }
                     }
                 }
-
                 let affected_rows = rows.len();
-                self.sequence_send_diffs(id, rows, affected_rows, MutationKind::Insert)
+                self.sequence_send_diffs(session, id, rows, affected_rows, MutationKind::Insert)
                     .await
             }
             // If we couldn't optimize the INSERT statement to a constant, it

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -12,13 +12,18 @@
 #![forbid(missing_docs)]
 
 use std::collections::HashMap;
+use std::mem;
 
 use derivative::Derivative;
 use futures::Stream;
+use tokio_postgres::error::SqlState;
 
+use expr::GlobalId;
 use repr::{Datum, Row, ScalarType};
 use sql::ast::{Raw, Statement};
 use sql::plan::{Params, StatementDesc};
+
+use crate::ExecuteResponse;
 
 mod vars;
 
@@ -54,7 +59,7 @@ impl Session {
     fn new_internal(conn_id: u32) -> Session {
         Session {
             conn_id,
-            transaction: TransactionStatus::Idle,
+            transaction: TransactionStatus::Default,
             prepared_statements: HashMap::new(),
             portals: HashMap::new(),
             vars: Vars::default(),
@@ -66,25 +71,49 @@ impl Session {
         self.conn_id
     }
 
-    /// Starts a transaction.
-    pub fn start_transaction(&mut self) {
-        self.transaction = TransactionStatus::InTransaction;
+    /// Starts a transaction. This needs to consume and return self because an
+    /// implicit transaction can be bumped up to an explicit transaction, and we
+    /// want to keep around the inner ops. In order to do this in Rust we have to
+    /// take ownership instead of borrow.
+    pub fn start_transaction(mut self) -> Self {
+        self.transaction = match self.transaction {
+            TransactionStatus::Default | TransactionStatus::Started(_) => {
+                TransactionStatus::InTransaction(TransactionOps::None)
+            }
+            TransactionStatus::InTransaction(ops)
+            | TransactionStatus::InTransactionImplicit(ops) => {
+                TransactionStatus::InTransaction(ops)
+            }
+            TransactionStatus::Failed => unreachable!(),
+        };
+        self
     }
 
     /// Starts an implicit transaction.
-    pub fn start_transaction_implicit(&mut self) {
-        self.transaction = TransactionStatus::InTransactionImplicit;
+    pub fn start_transaction_implicit(&mut self, stmts: usize) {
+        if let TransactionStatus::Default = self.transaction {
+            match stmts {
+                1 => self.transaction = TransactionStatus::Started(TransactionOps::None),
+                n if n > 1 => {
+                    self.transaction =
+                        TransactionStatus::InTransactionImplicit(TransactionOps::None)
+                }
+                _ => {}
+            }
+        }
     }
 
-    /// Ends a transaction, setting its state to Idle and destroying all portals.
+    /// Clears a transaction, setting its state to Default and destroying all
+    /// portals. The cleared transaction is returned so its operations can be
+    /// handled.
     ///
     /// The [Postgres protocol docs](https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY) specify:
     /// > a named portal object lasts till the end of the current transaction
     /// and
     /// > An unnamed portal is destroyed at the end of the transaction
-    pub fn end_transaction(&mut self) {
-        self.transaction = TransactionStatus::Idle;
+    pub fn clear_transaction(&mut self) -> TransactionStatus {
         self.portals.clear();
+        mem::replace(&mut self.transaction, TransactionStatus::Default)
     }
 
     /// Marks the current transaction as failed.
@@ -95,6 +124,45 @@ impl Session {
     /// Returns the current transaction status.
     pub fn transaction(&self) -> &TransactionStatus {
         &self.transaction
+    }
+
+    /// Adds operations to the current transaction. An error is produced if they
+    /// cannot be merged (i.e., a read cannot be merged to an insert).
+    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps) -> Result<(), ExecuteResponse> {
+        match &mut self.transaction {
+            TransactionStatus::Started(txn_ops)
+            | TransactionStatus::InTransaction(txn_ops)
+            | TransactionStatus::InTransactionImplicit(txn_ops) => match txn_ops {
+                TransactionOps::None => *txn_ops = add_ops,
+                TransactionOps::Reads => match add_ops {
+                    TransactionOps::Reads => {}
+                    _ => {
+                        return Err(ExecuteResponse::PgError {
+                            code: SqlState::READ_ONLY_SQL_TRANSACTION,
+                            message: "transaction in read-only mode".to_string(),
+                        })
+                    }
+                },
+                TransactionOps::Writes(txn_writes) => match add_ops {
+                    TransactionOps::Writes(mut add_writes) => {
+                        txn_writes.append(&mut add_writes);
+                    }
+                    _ => {
+                        return Err(ExecuteResponse::PgError {
+                            // It's not immediately clear which error code to use here because a
+                            // "write-only transaction" is not a thing in Postgres. This error code is the
+                            // generic "bad txn thing" code, so it's probably the best choice.
+                            code: SqlState::INVALID_TRANSACTION_STATE,
+                            message: "transaction in write-only mode".to_string(),
+                        });
+                    }
+                },
+            },
+            TransactionStatus::Default | TransactionStatus::Failed => {
+                unreachable!()
+            }
+        }
+        Ok(())
     }
 
     /// Registers the prepared statement under `name`.
@@ -169,7 +237,7 @@ impl Session {
 
     /// Resets the session to its initial state.
     pub fn reset(&mut self) {
-        self.end_transaction();
+        self.transaction = TransactionStatus::Default;
         self.prepared_statements.clear();
         self.portals.clear();
         self.vars = Vars::default();
@@ -245,21 +313,64 @@ pub enum PortalState {
 pub type RowBatchStream = Box<dyn Stream<Item = Result<Vec<Row>, comm::Error>> + Send + Unpin>;
 
 /// The transaction status of a session. Postgres' transaction states are in
-/// backend/access/transam/xact.c. The states here don't cleanly match to all
-/// of those, but we try to have lots of tests that make sure our behavior is
-/// identical.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// backend/access/transam/xact.c.
+#[derive(Debug, Clone, PartialEq)]
 pub enum TransactionStatus {
-    /// Not in an explicit or implicit transaction. May execute a single
-    /// statement in this state. Matches both TBLOCK_DEFAULT and TBLOCK_STARTED.
-    Idle,
+    /// Idle. Matches TBLOCK_DEFAULT.
+    Default,
+    /// Running a single-query transaction. Matches TBLOCK_STARTED.
+    Started(TransactionOps),
     /// Currently in a transaction issued from a BEGIN. Matches TBLOCK_INPROGRESS.
-    InTransaction,
+    InTransaction(TransactionOps),
     /// Currently in an implicit transaction started from a multi-statement query
     /// with more than 1 statements. Matches TBLOCK_IMPLICIT_INPROGRESS.
-    InTransactionImplicit,
+    InTransactionImplicit(TransactionOps),
     /// In a failed transaction that was started explicitly (i.e., previously
     /// InTransaction). We do not use Failed for implicit transactions because
     /// those cleanup after themselves. Matches TBLOCK_ABORT.
     Failed,
+}
+
+/// The type of operation being performed by the transaction. This is
+/// needed because we currently do not allow mixing reads and writes in a
+/// transaction. Use this to record what we have done, and what may need to
+/// happen at commit.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TransactionOps {
+    /// The transaction has been initiated, but no statement has yet been executed
+    /// in it.
+    None,
+    /// This transaction has had a read (SELECT, TAIL) and must only do other reads.
+    Reads,
+    /// This transaction has had a write (INSERT, UPDATE, DELETE) and must only do
+    /// other writes.
+    Writes(Vec<WriteOp>),
+}
+
+/// An INSERT waiting to be committed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WriteOp {
+    /// The target table.
+    pub id: GlobalId,
+    /// The data rows.
+    pub rows: Vec<(Row, isize)>,
+}
+
+/// The action to take during end_transaction.
+#[derive(Debug)]
+pub enum EndTransactionAction {
+    /// Commit the transaction.
+    Commit,
+    /// Rollback the transaction.
+    Rollback,
+}
+
+impl EndTransactionAction {
+    /// Returns the pgwire tag for this action.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            EndTransactionAction::Commit => "COMMIT",
+            EndTransactionAction::Rollback => "ROLLBACK",
+        }
+    }
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -239,22 +239,16 @@ pub enum TransactionStatus {
     Failed,
 }
 
-impl From<CoordTransactionStatus> for TransactionStatus {
-    /// Convert from the Session's version
-    fn from(status: CoordTransactionStatus) -> TransactionStatus {
-        match status {
-            CoordTransactionStatus::Idle => TransactionStatus::Idle,
-            CoordTransactionStatus::InTransaction => TransactionStatus::InTransaction,
-            CoordTransactionStatus::InTransactionImplicit => TransactionStatus::InTransaction,
-            CoordTransactionStatus::Failed => TransactionStatus::Failed,
-        }
-    }
-}
-
 impl From<&CoordTransactionStatus> for TransactionStatus {
     /// Convert from the Session's version
     fn from(status: &CoordTransactionStatus) -> TransactionStatus {
-        TransactionStatus::from(*status)
+        match status {
+            CoordTransactionStatus::Default => TransactionStatus::Idle,
+            CoordTransactionStatus::Started(_) => TransactionStatus::InTransaction,
+            CoordTransactionStatus::InTransaction(_) => TransactionStatus::InTransaction,
+            CoordTransactionStatus::InTransactionImplicit(_) => TransactionStatus::InTransaction,
+            CoordTransactionStatus::Failed => TransactionStatus::Failed,
+        }
     }
 }
 

--- a/src/sqllogictest/src/ast.rs
+++ b/src/sqllogictest/src/ast.rs
@@ -127,6 +127,7 @@ pub enum Record<'a> {
     /// A `simple` directive.
     Simple {
         location: Location,
+        conn: Option<&'a str>,
         sql: &'a str,
         output: Output,
         output_str: &'a str,

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -67,44 +67,55 @@ SELECT * FROM t
 statement ok
 ROLLBACK
 
-# Multiple INSERTs not allowed.
+# Multiple INSERTs.
 simple
 INSERT INTO t VALUES (2);
 INSERT INTO t VALUES (3);
 ----
-db error: ERROR: INSERT INTO t VALUES (2) cannot be run inside a transaction block
+COMPLETE 1
+COMPLETE 1
 
-# INSERT in explicit transactions not allowed.
+# INSERT in explicit transactions.
 statement ok
 BEGIN
 
 simple
 INSERT INTO t VALUES (4);
 ----
-db error: ERROR: INSERT INTO t VALUES (4) cannot be run inside a transaction block
+COMPLETE 1
 
+# Verify ROLLBACK works by not expecting 4 below.
 statement ok
 ROLLBACK
 
-# INSERT rolled up from implicit txn into explicit is not allowed.
+# INSERT rolled up from implicit txn into explicit not ok because mixed
+# with a read.
 simple
 INSERT INTO t VALUES (5);
 BEGIN;
 SELECT 1;
 ----
-db error: ERROR: INSERT INTO t VALUES (5) cannot be run inside a transaction block
+db error: ERROR: transaction in write-only mode
 
+# This COMMIT should be ignored due to the failure above.
 statement ok
-ROLLBACK
+COMMIT
 
-# INSERT not allowed in explicit transactions.
+# INSERT allowed in explicit transactions.
 simple
 BEGIN; INSERT INTO t VALUES (6);
 ----
-db error: ERROR: INSERT INTO t VALUES (6) cannot be run inside a transaction block
+COMPLETE 0
+COMPLETE 1
+
+# Verify that the to-be-inserted data is not readable by another connection.
+simple conn=read
+SELECT * FROM t WHERE a=6
+----
+COMPLETE 0
 
 statement ok
-ROLLBACK
+COMMIT
 
 simple
 INSERT INTO t VALUES (7), (8)
@@ -116,6 +127,9 @@ query I
 SELECT * FROM t ORDER BY a
 ----
 1
+2
+3
+6
 7
 8
 


### PR DESCRIPTION
Allow INSERTs (and more generally any form of row write via symbiosis)
by bundling up operations into the session and committing them if
the transaction is committed. Introduce a "write-only transaction"
for this purpose. This is needed to ensure serializability. Since we
cannot currently interleave reads and writes, a user writing data is
not allowed to also read in that transaction.

Having transaction operations sets us up to have transaction reads
happen at a single time (by stashing the timestamp in the Read txn op),
so this design should work for the future.

Refactor (again) the transaction status model to now be even closer to
how postgres works. This allows the Started (i.e., single statement)
transaction state to work identically to explicit and implicit
transactions, reducing implementation complexity by having a single code
path for transaction operation handling.

Attempt to disambiguate transaction terms. "End"ing a transaction now
requires an action (commit, rollback) in any associated API.

A new Commit command has been added because transaction ending can happen
in two ways: 1) an explicit COMMIT or ROLLBACK SQL statement and 2)
implicitly at the end of a Query or Sync pgwire message.

Symbiosis mode is not yet guaranteed to work transactionally. Code changes
here happen to make tests that use symbiosis (SLT) pass, but we are not
worried about its correctness now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5458)
<!-- Reviewable:end -->
