### PR TITLE
MFP optimization

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2245,6 +2245,7 @@ where
             // out the contents from an existing arrangement.
             let (mut map_filter_project, inner) =
                 expr::MapFilterProject::extract_from_expression(source.as_ref());
+            map_filter_project.optimize();
 
             // We can use a fast path approach if our query corresponds to a read out of
             // an existing materialization. This is the case if the expression is now a

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -180,8 +180,8 @@ impl JoinClosure {
             }
         }
 
-        // TODO(mcsherry): perform more optimizations here.
-        before.remove_undemanded();
+        // `before` should not be modified after this point.
+        before.optimize();
 
         // Cons up an instance of the closure with the closed-over state.
         Self {
@@ -294,6 +294,7 @@ impl JoinBuildState {
             }
         }
         mfp.permute(&column_map, column_map.len());
+        mfp.optimize();
 
         JoinClosure {
             ready_equivalences: equivalences,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -848,7 +848,8 @@ where
         worker_index: usize,
     ) -> bool {
         // Extract a MapFilterProject and residual from `relation_expr`.
-        let (mfp, input) = MapFilterProject::extract_from_expression(relation_expr);
+        let (mut mfp, input) = MapFilterProject::extract_from_expression(relation_expr);
+        mfp.optimize();
         match input {
             MirRelationExpr::Get { .. } => {
                 // TODO: determine if `mfp` is no-op to simplify implementation.

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -157,16 +157,14 @@ where
                             &mut row_packer,
                         ) {
                             Err(e) => return Some(Err(DataflowError::from(e))),
-                            Ok(Some(key)) => key,
-                            _ => panic!("Row expected as no predicate was used"),
+                            Ok(key) => key.expect("Row expected as no predicate was used"),
                         };
                         // Evaluate the value expressions.
                         // The prior evaluation may have left additional columns we should delete.
                         datums_local.truncate(skips.len());
                         let val = match val_mfp.evaluate_iter(&mut datums_local, &temp_storage) {
                             Err(e) => return Some(Err(DataflowError::from(e))),
-                            Ok(Some(val)) => val,
-                            _ => panic!("Row expected as no predicate was used"),
+                            Ok(val) => val.expect("Row expected as no predicate was used"),
                         };
                         row_packer.extend(val);
                         drop(datums_local);

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -93,12 +93,12 @@ where
             // Form an operator for evaluating key expressions.
             let mut key_mfp = expr::MapFilterProject::new(input_arity)
                 .map(group_key.iter().cloned())
-                .project(input_arity..input_arity + group_key.len());
+                .project(input_arity..(input_arity + group_key.len()));
 
             // Form an operator for evaluating value expressions.
             let mut val_mfp = expr::MapFilterProject::new(input_arity)
                 .map(aggregates.iter().map(|a| a.expr.clone()))
-                .project(input_arity..input_arity + aggregates.len());
+                .project(input_arity..(input_arity + aggregates.len()));
 
             // Determine the columns we'll need from the row.
             let mut demand = Vec::new();

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -87,20 +87,41 @@ where
             // Our first step is to extract `(key, vals)` from `input`.
             // We do this carefully, attempting to avoid unneccesary allocations
             // that would result from cloning rows in input arrangements.
-            let group_key_clone = group_key.clone();
-            let aggregates_clone = aggregates.clone();
 
-            // Tracks the required number of columns to extract.
-            let mut columns_needed = 0;
-            for key in group_key.iter() {
-                for column in key.support() {
-                    columns_needed = std::cmp::max(columns_needed, column + 1);
-                }
+            let input_arity = input.arity();
+
+            // Form an operator for evaluating key expressions.
+            let mut key_mfp = expr::MapFilterProject::new(input_arity)
+                .map(group_key.iter().cloned())
+                .project(input_arity..input_arity + group_key.len());
+
+            // Form an operator for evaluating value expressions.
+            let mut val_mfp = expr::MapFilterProject::new(input_arity)
+                .map(aggregates.iter().map(|a| a.expr.clone()))
+                .project(input_arity..input_arity + aggregates.len());
+
+            // Determine the columns we'll need from the row.
+            let mut demand = Vec::new();
+            demand.extend(key_mfp.demand());
+            demand.extend(val_mfp.demand());
+            demand.sort();
+            demand.dedup();
+            // remap column references to the subset we use.
+            let mut demand_map = std::collections::HashMap::new();
+            for column in demand.iter() {
+                demand_map.insert(*column, demand_map.len());
             }
-            for aggr in aggregates.iter() {
-                for column in aggr.expr.support() {
-                    columns_needed = std::cmp::max(columns_needed, column + 1);
-                }
+            key_mfp.permute(&demand_map, demand_map.len());
+            key_mfp.optimize();
+            val_mfp.permute(&demand_map, demand_map.len());
+            val_mfp.optimize();
+
+            println!("KEY MFP: {:?}", key_mfp);
+            println!("VAL MFP: {:?}", val_mfp);
+
+            // transform `demand` into "skips" we'll do on an iterator.
+            for index in (1..demand.len()).rev() {
+                demand[index] -= demand[index - 1];
             }
 
             let mut row_packer = RowPacker::new();
@@ -114,34 +135,32 @@ where
                     |_expr| None,
                     move |row| {
                         let temp_storage = RowArena::new();
-                        // Ensure the packer is clear, and does not reflect
-                        // columns from prior rows that may have errored.
-                        row_packer.clear();
 
-                        // First, evaluate the key selector expressions.
+                        // Unpack only the demanded columns.
                         let mut datums_local = datums.borrow();
-                        datums_local.extend(row.iter().take(columns_needed));
-                        for expr in group_key_clone.iter() {
-                            match expr.eval(&datums_local, &temp_storage) {
-                                Ok(val) => row_packer.push(val),
-                                Err(e) => {
-                                    return Some(Err(e.into()));
-                                }
-                            }
+                        let mut row_iter = row.iter();
+                        for skip in demand.iter() {
+                            datums_local.push((&mut row_iter).skip(*skip).next().unwrap());
                         }
 
-                        // Second, evaluate the value selector expressions.
-                        let key = row_packer.finish_and_reuse();
-                        for aggr in aggregates_clone.iter() {
-                            match aggr.expr.eval(&datums_local, &temp_storage) {
-                                Ok(val) => {
-                                    row_packer.push(val);
-                                }
-                                Err(e) => {
-                                    return Some(Err(e.into()));
-                                }
-                            }
-                        }
+                        // Evaluate the key expressions.
+                        row_packer.clear();
+                        let key = match key_mfp.evaluate(
+                            &mut datums_local,
+                            &temp_storage,
+                            &mut row_packer,
+                        ) {
+                            Err(e) => return Some(Err(DataflowError::from(e))),
+                            Ok(Some(key)) => key,
+                            _ => panic!("Row expected as no predicate was used"),
+                        };
+                        // Evaluate the value expressions.
+                        let val = match val_mfp.evaluate_iter(&mut datums_local, &temp_storage) {
+                            Err(e) => return Some(Err(DataflowError::from(e))),
+                            Ok(Some(val)) => val,
+                            _ => panic!("Row expected as no predicate was used"),
+                        };
+                        row_packer.extend(val);
                         drop(datums_local);
 
                         // Mint the final row, ideally re-using resources.

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -601,9 +601,6 @@ impl MapFilterProject {
                     // Column references need to be rewritten, but do not need to be memoized.
                     *index = projection[index];
                 }
-                ScalarExpr::Literal(_, _) => {
-                    // Literals do not need to be memoized.
-                }
                 _ => {
                     // We should not eagerly memoize `if` branches that might not be taken.
                     // TODO: Memoize expressions in the intersection of `then` and `els`.
@@ -707,9 +704,10 @@ impl MapFilterProject {
                 if i < input_arity {
                     false
                 } else {
-                    match self.expressions[i - input_arity] {
-                        ScalarExpr::Column(_) | ScalarExpr::Literal(_, _) => true,
-                        _ => reference_count[i] == 1,
+                    if let ScalarExpr::Column(_) = self.expressions[i - input_arity] {
+                        true
+                    } else {
+                        reference_count[i] == 1
                     }
                 }
             })

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -736,8 +736,10 @@ impl MapFilterProject {
         }
         // We can only inline column references in `self.projection`, but we should.
         for proj in self.projection.iter_mut() {
-            if let ScalarExpr::Column(i) = self.expressions[*proj - self.input_arity] {
-                *proj = i;
+            if *proj >= self.input_arity {
+                if let ScalarExpr::Column(i) = self.expressions[*proj - self.input_arity] {
+                    *proj = i;
+                }
             }
         }
     }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -813,9 +813,8 @@ impl MapFilterProject {
     ///
     /// # Example
     ///
-    /// In this example, we see that with only a single reference to column 2,
-    /// there is no reason to produce its integer parse to be shared among the
-    /// expressions, and it can instead be inlined. Similarly, column references
+    /// In this example, we see that with only a single reference to columns
+    /// 0 and 2, their parsing can each be inlined. Similarly, column references
     /// can be cleaned up among expressions, and in the final projection.
     ///
     /// Also notice the remaining expressions, which can be cleaned up in a later
@@ -823,8 +822,7 @@ impl MapFilterProject {
     ///
     /// ```rust
     /// use expr::{MapFilterProject, MirScalarExpr, UnaryFunc, BinaryFunc};
-    /// // Use the output from `memoize_expression` example, minus the last column
-    /// // in order to introduce uniquess of reference to columns 0 and 2.
+    /// // Use the output from first `memoize_expression` example.
     /// let mut map_filter_project = MapFilterProject::new(5)
     ///     .map(vec![
     ///         MirScalarExpr::column(0).call_unary(UnaryFunc::CastStringToInt64),


### PR DESCRIPTION
This PR introduce CSE optimization for MFPs.

The motivation comes from examples like TPCH Q01 materialized against a non-materialized source/view, whose `Reduce` expression contains substantial re-use that doesn't fall under the `Map` cse logic, nor which is easily accommodated within the `Reduce` structure:
```
aggregates: [
    AggregateExpr { func: SumDecimal, expr: CallUnary { func: CastStringToDecimal(2), expr: Column(4) }, distinct: false }, 
    AggregateExpr { func: SumDecimal, expr: CallUnary { func: CastStringToDecimal(2), expr: Column(5) }, distinct: false }, 
    AggregateExpr { func: SumDecimal, expr: CallBinary { func: MulDecimal, expr1: CallUnary { func: CastStringToDecimal(2), expr: Column(5) }, expr2: CallBinary { func: SubDecimal, expr1: Literal(Ok(Row{[Decimal(Significand(100))]}), ColumnType { nullable: false, scalar_type: Decimal(38, 2) }), expr2: CallUnary { func: CastStringToDecimal(2), expr: Column(6) } } }, distinct: false }, 
    AggregateExpr { func: SumDecimal, expr: CallBinary { func: MulDecimal, expr1: CallBinary { func: MulDecimal, expr1: CallUnary { func: CastStringToDecimal(2), expr: Column(5) }, expr2: CallBinary { func: SubDecimal, expr1: Literal(Ok(Row{[Decimal(Significand(100))]}), ColumnType { nullable: false, scalar_type: Decimal(38, 2) }), expr2: CallUnary { func: CastStringToDecimal(2), expr: Column(6) } } }, expr2: CallBinary { func: AddDecimal, expr1: Literal(Ok(Row{[Decimal(Significand(100))]}), ColumnType { nullable: false, scalar_type: Decimal(38, 2) }), expr2: CallUnary { func: CastStringToDecimal(2), expr: Column(7) } } }, distinct: false }, 
    AggregateExpr { func: Count, expr: CallUnary { func: CastStringToDecimal(2), expr: Column(4) }, distinct: false }, 
    AggregateExpr { func: Count, expr: CallUnary { func: CastStringToDecimal(2), expr: Column(5) }, distinct: false }, 
    AggregateExpr { func: SumDecimal, expr: CallUnary { func: CastStringToDecimal(2), expr: Column(6) }, distinct: false }, 
    AggregateExpr { func: Count, expr: CallUnary { func: CastStringToDecimal(2), expr: Column(6) }, distinct: false }, 
    AggregateExpr { func: Count, expr: Literal(Ok(Row{[True]}), ColumnType { nullable: false, scalar_type: Bool }), distinct: false }
]
```
Note the substantial re-use of `CastStringToDecimal( )` on various columns, often repeated. These are relatively easy to extract in `reduce.rs` into a `MapFilterProject` which can then be optimized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5459)
<!-- Reviewable:end -->
