### PR TITLE
s3 sources: Add testdrive support for S3 and related tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4071,6 +4071,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_credential",
  "rusoto_kinesis",
+ "rusoto_s3",
  "rusoto_sts",
  "serde",
  "serde-protobuf",

--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -266,7 +266,7 @@ run LocalStack:
 
 ```shell
 $ pip install localstack
-$ START_WEB=false SERVICES=kinesis localstack start
+$ START_WEB=false SERVICES=kinesis,s3 localstack start
 ```
 
 If you've previously installed LocalStack, be sure it is v0.11 or later.

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -35,6 +35,7 @@ reqwest = { version = "0.11.0", features = ["native-tls-vendored"] }
 rusoto_core = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_credential = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_kinesis = { git = "https://github.com/rusoto/rusoto.git" }
+rusoto_s3 = { git = "https://github.com/rusoto/rusoto.git" }
 rusoto_sts = { git = "https://github.com/rusoto/rusoto.git" }
 serde = "1.0.122"
 serde-protobuf = { git = "https://github.com/MaterializeInc/serde-protobuf.git", branch = "add-iter-messages" }

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -48,7 +48,7 @@ impl Action for CreateStreamAction {
             })
             .await
             .map_err(|e| format!("creating stream: {}", e))?;
-        state.kinesis_stream_names.push(stream_name.clone());
+        state.kinesis_stream_names.insert(stream_name.clone());
 
         util::kinesis::wait_for_stream_shards(&state.kinesis_client, stream_name, self.shard_count)
             .await

--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -1,0 +1,95 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::default::Default;
+
+use async_trait::async_trait;
+use rusoto_core::RusotoError;
+use rusoto_s3::{
+    CreateBucketConfiguration, CreateBucketError, CreateBucketRequest, PutObjectRequest, S3,
+};
+
+use crate::action::{Action, State};
+use crate::parser::BuiltinCommand;
+
+pub struct CreateBucketAction {
+    bucket: String,
+}
+
+pub fn build_create_bucket(mut cmd: BuiltinCommand) -> Result<CreateBucketAction, String> {
+    Ok(CreateBucketAction {
+        bucket: cmd.args.string("bucket")?,
+    })
+}
+
+#[async_trait]
+impl Action for CreateBucketAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        println!("Creating S3 bucket {}", self.bucket);
+
+        match state
+            .s3_client
+            .create_bucket(CreateBucketRequest {
+                bucket: self.bucket.clone(),
+                create_bucket_configuration: Some(CreateBucketConfiguration {
+                    location_constraint: Some(state.aws_region.name().to_string()),
+                }),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) | Err(RusotoError::Service(CreateBucketError::BucketAlreadyOwnedByYou(_))) => {
+                state.s3_bucket_names.insert(self.bucket.clone());
+                Ok(())
+            }
+            Err(e) => Err(format!("creating bucket: {}", e)),
+        }
+    }
+}
+
+pub struct PutObjectAction {
+    bucket: String,
+    key: String,
+    contents: String,
+}
+
+pub fn build_put_object(mut cmd: BuiltinCommand) -> Result<PutObjectAction, String> {
+    Ok(PutObjectAction {
+        bucket: cmd.args.string("bucket")?,
+        key: cmd.args.string("key")?,
+        contents: cmd.input.join("\n"),
+    })
+}
+
+#[async_trait]
+impl Action for PutObjectAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<(), String> {
+        println!("Uploading S3 object s3://{}/{}", self.bucket, self.key);
+
+        state
+            .s3_client
+            .put_object(PutObjectRequest {
+                bucket: self.bucket.clone(),
+                body: Some(self.contents.clone().into_bytes().into()),
+                key: self.key.clone(),
+                ..Default::default()
+            })
+            .await
+            .map(|_| ())
+            .map_err(|e| format!("putting s3 object: {}", e))
+    }
+}

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -100,6 +100,7 @@ async fn run_line_reader(config: &Config, line_reader: &mut LineReader<'_>) -> R
             redo.await.map_err(|e| InputError { msg: e, pos: a.pos })?;
         }
         state.reset_kinesis().await?;
+        state.reset_s3().await?;
         drop(state);
         state_cleanup.await?;
     }

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -1,0 +1,73 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set bucket=materialize-ci-testdrive-${testdrive.seed}
+
+$ s3-create-bucket bucket=${bucket}
+
+$ s3-put-object bucket=${bucket} key=short/a
+a1
+a2
+a3
+
+$ s3-put-object bucket=${bucket} key=short/b
+b1
+b2
+b3
+
+> CREATE MATERIALIZED SOURCE s3_all
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> SELECT * FROM s3_all ORDER BY mz_record;
+a1 1
+a2 2
+a3 3
+b1 4
+b2 5
+b3 6
+
+> CREATE MATERIALIZED SOURCE s3_glob_a
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '**/a'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> SELECT * FROM s3_glob_a ORDER BY mz_record;
+a1 1
+a2 2
+a3 3
+
+> CREATE MATERIALIZED SOURCE s3_just_a
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING 'short/a'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT;
+
+> SELECT * FROM s3_just_a ORDER BY mz_record;
+a1 1
+a2 2
+a3 3


### PR DESCRIPTION
This is a candidate minimum viable extraction as mentioned in #5331, since I don’t like to suggest things I haven’t tried! 

@quodlibetor this passes tests locally, and I believe it would also pass tests in CI if it had permissions to do so. I know a later change in that PR was attempting to work around some permissions issues, but I’m pretty sure they are surmountable per these docs: https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html. It is preferable if testdrive does not assume that any resources are present so that it can be easily run on other AWS accounts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5460)
<!-- Reviewable:end -->
