### PR TITLE
dbt-materialize: add materialize.dbtspec test to CI

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -190,6 +190,15 @@ steps:
           composition: metabase
           run: smoketest
 
+  - id: dbt-materialize
+    label: "dbt-materialize"
+    depends_on: build
+    timeout_in_minutes: 10
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: dbt-materialize
+          run: ci
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build

--- a/misc/dbt-materialize/Dockerfile
+++ b/misc/dbt-materialize/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM python:3.8.6
+
+COPY . dbt-materialize/
+
+RUN pip install -r dbt-materialize/requirements.txt
+
+CMD [ "pytest", "dbt-materialize/test/materialize.dbtspec" ]

--- a/misc/dbt-materialize/mzbuild.yml
+++ b/misc/dbt-materialize/mzbuild.yml
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: dbt-materialize

--- a/misc/dbt-materialize/mzcompose
+++ b/misc/dbt-materialize/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/misc/dbt-materialize/mzcompose.yml
+++ b/misc/dbt-materialize/mzcompose.yml
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+x-port-mappings:
+  - &materialized ${MZ_PORT:-6875:6875}
+
+version: '3.7'
+services:
+  materialized:
+    mzbuild: materialized
+    command: --disable-telemetry
+    ports:
+      - *materialized
+    init: true
+  dbt-test:
+    mzbuild: dbt-materialize
+
+mzworkflows:
+  ci:
+    env:
+      MZ_PORT: 6875
+    steps:
+      - step: start-services
+        services: [materialized]
+      - step: wait-for-tcp
+        host: materialized
+        port: 6875
+      - step: run
+        service: dbt-test

--- a/misc/dbt-materialize/requirements.txt
+++ b/misc/dbt-materialize/requirements.txt
@@ -1,0 +1,3 @@
+dbt==0.18.1
+pytest-dbt-adapter==0.3.0
+../dbt-materialize

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -16,7 +16,7 @@
 
 target:
   type: materialize
-  host: localhost
+  host: materialized
   user: root
   pass: password
   database: materialize


### PR DESCRIPTION
As we commit to supporting the dbt-materialize adapter, we should
ensure that changes to Materialize do not break it unwittingly. This
change adds the materialize.dbtspec adapter tests to CI runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5461)
<!-- Reviewable:end -->
