### PR TITLE
dbt-materialize: remove manual path manipulation

### DIFF
--- a/misc/dbt-materialize/dbt/__init__.py
+++ b/misc/dbt-materialize/dbt/__init__.py
@@ -13,5 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/misc/dbt-materialize/dbt/adapters/__init__.py
+++ b/misc/dbt-materialize/dbt/adapters/__init__.py
@@ -13,5 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/misc/dbt-materialize/dbt/include/__init__.py
+++ b/misc/dbt-materialize/dbt/include/__init__.py
@@ -13,5 +13,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
Removes manual Python path manipulation in `dbt-materialize`'s `__init__.py` files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5466)
<!-- Reviewable:end -->
