### PR TITLE
docs: add supported third-party tools

### DIFF
--- a/doc/user/content/third-party/dbt.md
+++ b/doc/user/content/third-party/dbt.md
@@ -1,0 +1,23 @@
+---
+title: "Using dbt"
+description: "Get details about using Materialize with dbt"
+menu:
+  main:
+    parent: 'third-party'
+---
+
+You can use [dbt] to easily create views and materialized views in your `materialized`
+instance. To do so, all you need to do is install our [`dbt-materialize`](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize/README.md)
+adapter.
+
+## What's missing?
+
+{{< warning >}}
+Materialize does not offer production-level support for dbt.
+{{< /warning >}}
+
+The [`dbt-materialize`](https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize/README.md)
+adapter is still a work in progress and is not yet suitable for production use-cases. You can check its limitations
+and track our progress [here](https://github.com/MaterializeInc/materialize/issues/5462).
+
+[dbt]: https://www.getdbt.com/

--- a/doc/user/content/third-party/metabase.md
+++ b/doc/user/content/third-party/metabase.md
@@ -1,0 +1,24 @@
+---
+title: "Using Metabase"
+description: "Get details about using Materialize with Metabase"
+menu:
+  main:
+    parent: 'third-party'
+---
+
+You can use [Metabase] to create business intelligence dashboards using the
+real-time data streams in your Materialize instance. To get started, check out
+our [`metabase-materialize-driver`](https://github.com/MaterializeInc/metabase-materialize-driver).
+
+## What's missing?
+
+{{< warning >}}
+Materialize does not offer production-level support for Metabase.
+{{< /warning >}}
+
+Our [`metabase-materialize-driver`](https://github.com/MaterializeInc/metabase-materialize-driver)
+uses a forked version of pgjdbc to connect to Materialize. While this should not have an affect
+for anyone using the driver, we still aim to connect to Metabase cleanly in the future. Track
+our progress in un-forking the pgjdbc code [here](https://github.com/MaterializeInc/materialize/issues/3727).
+
+[Metabase]: https://www.metabase.com/

--- a/doc/user/content/third-party/supported-tools.md
+++ b/doc/user/content/third-party/supported-tools.md
@@ -1,0 +1,28 @@
+---
+title: "Supported Tools Overview"
+description: "Get details about third-party tool support with Materialize"
+menu:
+  main:
+    parent: 'third-party'
+---
+
+## Production-level support
+
+| Tool | Purpose |
+|------|---------|
+| [Docker](/third-party/docker) | Easily deploy Materialize and other required infrastructure.
+| [Debezium](/third-party/debezium) | Propagate change data capture (CDC) data from an upstream database to Materialize.
+
+
+## Alpha-level support
+
+| Tool | Purpose | What's missing? |
+|------|---------|---------|
+| [metabase](/third-party/metabase) | Create business intelligence dashboards on top of your Materialize data | Running Metabase cleanly, without our forked changes, requires further [pgjdbc support](https://github.com/MaterializeInc/materialize/issues/3727).
+
+
+## Beta-level support
+
+| Tool | Purpose | What's missing? |
+|------|---------|---------|
+| [dbt](/third-party/dbt)  | Create views and materialized views in your Materialize instance using dbt | Full `dbt-materialize` adapter support is a [work in progress](https://github.com/MaterializeInc/materialize/issues/5462).


### PR DESCRIPTION
Adds a new 'Supported Tools Overview' page to our docs site, with a bit
of information about dbt and Metabase support.

Part of: https://github.com/MaterializeInc/materialize/issues/5333.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5467)
<!-- Reviewable:end -->
