### PR TITLE
Extend transform testing to involve type/key information

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -86,7 +86,7 @@ they test, or in a `tests/` subdirectory of the crate they test, respectively.
 
 ### Datadriven
 
-[Datadriven](ttps://github.com/justinj/datadriven) is a tool for writing
+[Datadriven](https://github.com/justinj/datadriven) is a tool for writing
 [table-driven tests](https://github.com/golang/go/wiki/TableDrivenTests) in
 Rust, with rewrite support. datadriven tests plug into `cargo test` as unit
 or integration tests, but store test data in separate files from the Rust code.
@@ -102,6 +102,9 @@ $ REWRITE=1 cargo test
 
 When using `REWRITE` it's important to inspect the diff carefully to ensure
 that nothing changed unexpectedly.
+
+For an example of what datadriven tests look like, check out
+[`src/transform/tests`](/src/transform/tests).
 
 ## System tests
 

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -364,7 +364,10 @@ impl<'a> Explanation<'a> {
             writeln!(
                 f,
                 "| | keys = ({})",
-                separated(", ", keys.iter().map(|key| Indices(key)))
+                separated(
+                    ", ",
+                    keys.iter().map(|key| bracketed("(", ")", Indices(key)))
+                )
             )?;
         }
 

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -1,0 +1,120 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that the test runner can properly construct sources with keys
+# and report on key information in plans
+
+cat
+(defsource x [int32 int64 int32] [[0] [1]])
+----
+ok
+
+build format=types
+(map (get x) [4145])
+----
+%0 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+| Map 4145
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: false, scalar_type: Int64 })
+| | keys = ((#0), (#1))
+
+# Run tests where a transform occuring depends on the input keys.
+
+## Joins of the same input to itself on the key of the input can be converted
+## into a project
+
+opt format=types
+(join [(get x) (get x)] [[#0 #3]])
+----
+%0 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+| Project (#0..#2, #0..#2)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+steps format=types
+(join [(get x) (get x)] [[#0 #3] [#2 #5]])
+----
+----
+%0 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+%1 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+%2 =
+| Join %0 %1 (= #0 #3) (= #2 #5)
+| | implementation = Unimplemented
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+====
+No change: JoinElision, InlineLet, FoldConstants, SplitPredicates, Filter, Map, ProjectionExtraction, Project, Join, JoinElision, EmptyMap, JoinElision, FoldConstants, Filter, Map, FoldConstants, DeMorgans, UndistributeAnd, SplitPredicates
+====
+Applied Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, EmptyMap, JoinElision, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, NegatePredicate, Demand], limit: 100 }:
+%0 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+| Project (#0..#2, #0..#2)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+====
+No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+====
+Final:
+%0 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+| Project (#0..#2, #0..#2)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+====
+----
+----
+
+opt format=types
+(join [(get x) (get x)] [[#2 #5]])
+----
+----
+%0 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+| ArrangeBy (#2)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+%1 =
+| Get x (u0)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ((#0), (#1))
+
+%2 =
+| Join %0 %1 (= #2 #5)
+| | implementation = Differential %1 %0.(#2)
+| | demand = (#0..#4)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ()
+| Project (#0..#4, #2)
+| | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
+| | keys = ()
+----
+----

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -203,23 +203,23 @@ EXPLAIN TYPED DECORRELATED PLAN FOR VIEW foo
 %0 = Let l0 =
 | Constant ()
 | | types = ()
-| | keys = ()
+| | keys = (())
 
 %1 =
 | Constant ()
 | | types = ()
-| | keys = ()
+| | keys = (())
 
 %2 =
 | Join %0 %1
 | | implementation = Unimplemented
 | | types = ()
-| | keys = ()
+| | keys = (())
 | Map 1
 | | types = (integer)
-| | keys = ()
+| | keys = (())
 | | types = (integer)
-| | keys = ()
+| | keys = (())
 
 EOF
 


### PR DESCRIPTION
Syntax changes:
* Add an optional third argument to `defsource` to specify unique keys in the source.
  ```
  cat 
  (defsource x [int32 int64] [[0] [1]])
  ```
* Add an argument `format=types` to build/opt/steps so instead of the results of `explain plan`, we would get the results of `explain typed plan`.

Developer doc changes:
* Fixed the broken link to the datadriven source code.
* Added a link to where you can find tests using datadriven so people who want to have datadriven tests in other packages can easily find an example. 

Code changes:
* While I only added a few tests, it immediately exposed a bug in our product, namely that explain typed plan would flat-map  sets of keys. So the key set `[[0], [1]]` would appear in our explanation as `(#0, #1)`. With my fix, the aforementioned key set will appear in our explanation as `((#0), (#1))`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5471)
<!-- Reviewable:end -->
