### PR TITLE
Row rework

### DIFF
--- a/src/repr/src/cache.rs
+++ b/src/repr/src/cache.rs
@@ -71,7 +71,7 @@ impl CachedRecord {
         let (_, rest) = data.split_at(4);
         let row = rest[..len].to_vec();
 
-        let rec = unsafe { Row::new(row) };
+        let rec = unsafe { Row::from_bytes_unchecked(row) };
         let row = rec.unpack();
 
         let source_offset = row[0].unwrap_int64();

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -32,7 +32,7 @@ pub mod strconv;
 
 pub use cache::{CachedRecord, CachedRecordIter};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{datum_size, DatumList, DatumMap, Row, RowArena, RowPacker};
+pub use row::{datum_size, DatumList, DatumMap, Row, RowArena, RowPacker, RowRef};
 pub use scalar::{Datum, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -726,7 +726,7 @@ impl Row {
     ///
     /// Panics if the `Row` is empty.
     pub fn unpack_first(&self) -> Datum {
-        unsafe { read_datum(&self.data, &mut 0) }
+        self.iter().next().unwrap()
     }
 
     /// Iterate the `Datum` elements of the `Row`.
@@ -768,7 +768,7 @@ impl<'a> RowRef<'a> {
     ///
     /// Panics if the `Row` is empty.
     pub fn unpack_first(&self) -> Datum {
-        unsafe { read_datum(&self.data, &mut 0) }
+        self.iter().next().unwrap()
     }
 
     /// Iterate the `Datum` elements of the `Row`.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -751,7 +751,7 @@ impl<'a> RowRef<'a> {
     /// This method is unsafe because if the byte slice is not a valid
     /// row encoding, then unpacking its contents can cause undefined
     /// behavior.
-    pub unsafe fn from_slice(data: &'a [u8]) -> Self {
+    pub unsafe fn from_bytes_unchecked(data: &'a [u8]) -> Self {
         Self { data }
     }
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -746,6 +746,8 @@ impl Row {
 impl<'a> RowRef<'a> {
     /// Construct a `RowRef` from a byte slice.
     ///
+    /// # Safety
+    ///
     /// This method is unsafe because if the byte slice is not a valid
     /// row encoding, then unpacking its contents can cause undefined
     /// behavior.

--- a/src/storage/src/wal.rs
+++ b/src/storage/src/wal.rs
@@ -564,7 +564,7 @@ fn read_message(buf: &[u8], mut offset: usize) -> Option<(Message, usize)> {
         }
         let row = rest[..len].to_vec();
 
-        let row = unsafe { Row::new(row) };
+        let row = unsafe { Row::from_bytes_unchecked(row) };
         // Update the offset to account for the data we just read
         offset = offset + 24 + len;
         Some((


### PR DESCRIPTION
This PR is trying out what it would look like to have methods directly on `Row` that allow the `push` and `extend` behavior normally held by `RowPacker`. These methods were previously absent from `Row` when it was a `Box<[u8]>` as it was immutable, but as a `SmallVec<[u8; 16]>` it can be mutated.

Many uses of `RowPacker` know the full sequence of `Datum` ahead of time, which means it is appropriate to determine their size (via `datums_size`), pre-allocate a right-sized `Row`, and then push bytes directly. The insurance against re-allocation that the `RowPacker` provided is less necessary.

Each of these methods could be re-implemented atop `RowPacker` if that were important, but they (these methods) would be terrible antipatterns if `Row` did not support mutation. So, these proposed changes sort of lock us in to that. We could start with a narrower interface that provides just a few variants of `pack`; for example, most of the `RowPacker` uses provide an iterator of `Datum` and do not need to interactively build the `Row`.

I also tossed in a `RowRef<'a>` type that provides the read methods but wrapped around a borrowed allocation. This is probably important if we ever want to back row data with larger contiguous allocations; arrangements for example would likely provide `&[u8]` contents that need to be interpreted as a `Row` but which cannot be safely put behind a `Row` allocation.

Obviously just for discussion at the moment. A real PR would do a substantial amount of work ripping out `RowPacker`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5472)
<!-- Reviewable:end -->
