### PR TITLE
WIP: coord/datflow: single copy of timestamp history info

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -47,7 +47,7 @@ use dataflow_types::{
 };
 use expr::{
     ExprHumanizer, GlobalId, Id, MirRelationExpr, MirScalarExpr, NullaryFunc,
-    OptimizedMirRelationExpr, RowSetFinishing, SourceInstanceId,
+    OptimizedMirRelationExpr, RowSetFinishing,
 };
 use ore::collections::CollectionExt;
 use ore::thread::JoinHandleExt;
@@ -98,7 +98,7 @@ pub enum Message {
 }
 
 pub struct AdvanceSourceTimestamp {
-    pub id: SourceInstanceId,
+    pub id: GlobalId,
     pub update: TimestampSourceUpdate,
 }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -15,6 +15,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
+use std::ops::Add;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -594,6 +595,16 @@ pub struct MzOffset {
 impl fmt::Display for MzOffset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.offset)
+    }
+}
+
+impl Add<i64> for MzOffset {
+    type Output = Self;
+
+    fn add(self, rhs: i64) -> Self {
+        Self {
+            offset: self.offset + rhs,
+        }
     }
 }
 

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -296,11 +296,13 @@ where
                 };
 
                 // All workers are responsible for reading in Kafka sources. Other sources
-                // support single-threaded ingestion only
+                // support single-threaded ingestion only. Note that in all cases, we want all
+                // active reading of a source to happen on one worker, and only distribute
+                // distinct sources between workers.
                 let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
                     true
                 } else {
-                    (usize::cast_from(uid.hashed()) % scope.peers()) == scope.index()
+                    (usize::cast_from(src_id.hashed()) % scope.peers()) == scope.index()
                 };
 
                 let caching_tx = if let (true, Some(caching_tx)) =

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -301,20 +301,13 @@ impl TimestampDataRecord {
 
 /// Type that defines timestamp history for a given source and all of its
 /// partitions
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TimestampDataRecords {
     pub partition_count: usize,
     pub partition_histories: HashMap<PartitionId, VecDeque<TimestampDataRecord>>,
 }
 
 impl TimestampDataRecords {
-    pub fn new() -> Self {
-        Self {
-            partition_count: 0,
-            partition_histories: HashMap::new(),
-        }
-    }
-
     fn add_timestamp_record(
         &mut self,
         partition_id: PartitionId,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -817,7 +817,7 @@ where
                                     partition_count as usize,
                                     timestamp,
                                     last_offset,
-                                    offset,
+                                    offset + 1,
                                 ));
                             } else {
                                 panic!("Unexpected message type. Expected BYO update.")

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -270,7 +270,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
     fn update_partition_count(
         &mut self,
         consistency_info: &mut ConsistencyInfo,
-        partition_count: i32,
+        partition_count: usize,
     ) {
         if partition_count > 1 {
             error!("Files cannot have multiple partitions");

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -210,7 +210,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
         if active {
             let empty_timestamp_history = match consistency {
                 Consistency::BringYourOwn(_) => {
-                    TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new())
+                    TimestampDataUpdate::BringYourOwn(TimestampDataRecords::default())
                 }
                 Consistency::RealTime => TimestampDataUpdate::RealTime(1),
             };

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
 use std::io::{self, BufRead, Read};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, TryRecvError};
@@ -33,7 +32,7 @@ use crate::source::{
 use crate::{
     logging::materialized::Logger,
     server::{
-        TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
+        TimestampDataRecords, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
         TimestampMetadataUpdates,
     },
 };
@@ -212,7 +211,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
             let prev = if let Consistency::BringYourOwn(_) = consistency {
                 timestamp_data_updates.borrow_mut().insert(
                     id.clone(),
-                    TimestampDataUpdate::BringYourOwn(HashMap::new()),
+                    TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new()),
                 )
             } else {
                 timestamp_data_updates

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -208,18 +208,18 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
         timestamp_metadata_channel: TimestampMetadataUpdates,
     ) -> Option<TimestampMetadataUpdates> {
         if active {
-            let prev = if let Consistency::BringYourOwn(_) = consistency {
-                timestamp_data_updates.borrow_mut().insert(
-                    id.clone(),
-                    TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new()),
-                )
-            } else {
-                timestamp_data_updates
-                    .borrow_mut()
-                    .insert(id.clone(), TimestampDataUpdate::RealTime(1))
+            let empty_timestamp_history = match consistency {
+                Consistency::BringYourOwn(_) => {
+                    TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new())
+                }
+                Consistency::RealTime => TimestampDataUpdate::RealTime(1),
             };
-            // Check that this is the first time this source id is registered
-            assert!(prev.is_none());
+
+            crate::server::maybe_add_source(
+                &timestamp_data_updates,
+                id.source_id.clone(),
+                empty_timestamp_history,
+            );
             timestamp_metadata_channel
                 .as_ref()
                 .borrow_mut()

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -259,9 +259,12 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
     fn update_partition_count(
         &mut self,
         consistency_info: &mut ConsistencyInfo,
-        partition_count: i32,
+        partition_count: usize,
     ) {
-        self.ensure_has_partition(consistency_info, PartitionId::Kafka(partition_count - 1));
+        self.ensure_has_partition(
+            consistency_info,
+            PartitionId::Kafka((partition_count as i32) - 1),
+        );
     }
 
     /// This function checks whether any messages have been buffered. If yes, returns the buffered

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -111,7 +111,7 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
     ) -> Option<TimestampMetadataUpdates> {
         let empty_timestamp_history = match consistency {
             Consistency::BringYourOwn(_) => {
-                TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new())
+                TimestampDataUpdate::BringYourOwn(TimestampDataRecords::default())
             }
             Consistency::RealTime => TimestampDataUpdate::RealTime(1),
         };

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp;
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::convert::TryInto;
 use std::fs;
 use std::path::PathBuf;
@@ -41,8 +41,8 @@ use crate::source::{
 use crate::{
     logging::materialized::Logger,
     server::{
-        CacheMessage, TimestampDataUpdate, TimestampDataUpdates, TimestampMetadataUpdate,
-        TimestampMetadataUpdates,
+        CacheMessage, TimestampDataRecords, TimestampDataUpdate, TimestampDataUpdates,
+        TimestampMetadataUpdate, TimestampMetadataUpdates,
     },
 };
 
@@ -112,7 +112,7 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
         let prev = if let Consistency::BringYourOwn(_) = consistency {
             timestamp_data_updates.borrow_mut().insert(
                 id.clone(),
-                TimestampDataUpdate::BringYourOwn(HashMap::new()),
+                TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new()),
             )
         } else {
             timestamp_data_updates

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -109,18 +109,18 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
         timestamp_data_updates: TimestampDataUpdates,
         timestamp_metadata_channel: TimestampMetadataUpdates,
     ) -> Option<TimestampMetadataUpdates> {
-        let prev = if let Consistency::BringYourOwn(_) = consistency {
-            timestamp_data_updates.borrow_mut().insert(
-                id.clone(),
-                TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new()),
-            )
-        } else {
-            timestamp_data_updates
-                .borrow_mut()
-                .insert(id.clone(), TimestampDataUpdate::RealTime(1))
+        let empty_timestamp_history = match consistency {
+            Consistency::BringYourOwn(_) => {
+                TimestampDataUpdate::BringYourOwn(TimestampDataRecords::new())
+            }
+            Consistency::RealTime => TimestampDataUpdate::RealTime(1),
         };
-        // Check that this is the first time this source id is registered
-        assert!(prev.is_none());
+
+        crate::server::maybe_add_source(
+            &timestamp_data_updates,
+            id.source_id.clone(),
+            empty_timestamp_history,
+        );
         timestamp_metadata_channel
             .as_ref()
             .borrow_mut()

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -185,9 +185,11 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
             error!("Kinesis sources do not currently support BYO consistency");
             None
         } else {
-            timestamp_data_updates
-                .borrow_mut()
-                .insert(id.clone(), TimestampDataUpdate::RealTime(1));
+            crate::server::maybe_add_source(
+                &timestamp_data_updates,
+                id.source_id.clone(),
+                TimestampDataUpdate::RealTime(1),
+            );
             timestamp_metadata_channel
                 .as_ref()
                 .borrow_mut()

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -235,7 +235,7 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
     fn update_partition_count(
         &mut self,
         _consistency_info: &mut ConsistencyInfo,
-        _partition_count: i32,
+        _partition_count: usize,
     ) {
         //TODO(natacha): do nothing for now as do not currently use timestamper
     }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -594,7 +594,13 @@ impl ConsistencyInfo {
                                         .set(self.partition_metadata.get(pid).unwrap().ts);
                                 }
 
-                                if source.can_close_timestamp(&self, pid, record.end_offset) {
+                                // Because everything is a half open interval now
+                                // we need to decrement the end to keep it consistent with the expectations of
+                                // all of the other code.
+                                // TODO(rkhaitan): make this less shitty
+                                let mut end_offset = record.end_offset;
+                                end_offset.offset -= 1;
+                                if source.can_close_timestamp(&self, pid, end_offset) {
                                     // We have either 1) seen all messages corresponding to this timestamp for this
                                     // partition 2) do not own this partition 3) the consumer has forwarded past the
                                     // timestamped offset. Either way, we have the guarantee tha we will never see a message with a < timestamp

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -357,7 +357,7 @@ impl SourceInfo<Vec<u8>> for S3SourceInfo {
     fn update_partition_count(
         &mut self,
         consistency_info: &mut ConsistencyInfo,
-        partition_count: i32,
+        partition_count: usize,
     ) {
         log::debug!(
             "ignoring partition count update type={:?} partition_count={}",

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -275,9 +275,11 @@ impl SourceInfo<Vec<u8>> for S3SourceInfo {
             log::error!("S3 sources do not currently support BYO consistency");
             None
         } else if active {
-            timestamp_data_updates
-                .borrow_mut()
-                .insert(id.clone(), TimestampDataUpdate::RealTime(1));
+            crate::server::maybe_add_source(
+                &timestamp_data_updates,
+                id.source_id.clone(),
+                TimestampDataUpdate::RealTime(1),
+            );
             timestamp_metadata_channel
                 .as_ref()
                 .borrow_mut()


### PR DESCRIPTION
this pr teaches the timestamper thread and the dataflow layer to only keep around one copy of timestamp histories for each RT / BYO sources, on each worker, rather than keeping one copy per source instance. Otherwise, these changes don't add any new functionality.
Broadly, these changes:

- make it so that we distribute source instances by source id rather than source id
- iterative turn the `Rc<RefCell<HashMap<SourceInstanceId, VecDeque<( ... )>>>>>` into a more usable and testable type
- teach the timestamper to keep around one copy of each source's timestamping logic

Broadly speaking there's 4 large todos I'd like to knock out before testing:

1. Theres still some complicated interaction between timestamp histories and the rest of the `SourceInfo` trait. I need to find a better abstraction for that and then move everything timestamp history related into a separate file
2. We need more unit tests for the timestamp history logic
3. We need a way to compact the timestamp history as currently it grows without bound in memory (since all source instances share a copy of the history its less obvious how to reject old updates. previously, each source instance kept its own history and threw away offset ranges when it was done with them). I think this roughly corresponds to "we need to set a `as_of` for sources
4. We need a way to actually drop sources in the timestamper. I think we have to now trigger this on the `DROP SOURCE` command if so its technically not challenging but it may be an unexpected product change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5473)
<!-- Reviewable:end -->
