### PR TITLE
deps: bump minor versions for log, stacker, and tar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,11 +1819,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3795,12 +3795,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ccb4c06ec57bc82d0f610f1a2963d7648700e43a6f513e564b9c89f7991786"
+checksum = "c3f47e840d001df3b785fbc3b84c7228519bdf63d4fb61b9e9f50f7fa153ce10"
 dependencies = [
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "psm",
  "winapi",
@@ -3962,13 +3962,12 @@ checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "tar"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
+checksum = "0313546c01d59e29be4f09687bcb4fb6690cec931cc3607b6aec7a0e417f4cc6"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall 0.1.56",
  "xattr",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,9 @@ skip = [
     # Waiting for clap to upgrade to v0.12.
     { name = "ansi_term", version = "0.11.0" },
 
-    # Waiting for approximately the entire Rust ecosystem to upgrade to v1.0.
+    # Waiting on:
+    #   - Upgrade to rand v0.8.
+    #   - https://github.com/Alexhuszagh/rust-lexical/pull/54
     { name = "cfg-if", version = "0.1.0" },
 
     # Waiting on tracing-futures.
@@ -27,7 +29,6 @@ skip = [
 
     # Waiting on:
     #   - https://github.com/Amanieu/parking_lot/pull/275
-    #   - https://github.com/alexcrichton/tar-rs/pull/240
     { name = "redox_syscall", version = "0.1.56" },
 ]
 deny = [


### PR DESCRIPTION
This makes some progress on our duplicate dependencies in deny.toml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5474)
<!-- Reviewable:end -->
