### PR TITLE
Fixup zookeeper logs bind mount

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -99,7 +99,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
     volumes:
       - ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper-data:/var/lib/zookeeper/data
-      - ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper-logs:/var/lib/zookeeper/logs
+      - ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper-log:/var/lib/zookeeper/log
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:


### PR DESCRIPTION
I'm not sure why this worked when I tested this locally, but the
cloud benchmarks exposed that Zookeeper wasn't coming up with the
previous identity. Turns out it's because there was an extra s at the
end of the directory name.

It doesn't help that the example from Confluent's docs looks like
(notice that they called it logs?):

    -v /vol2/zk-txn-logs:/var/lib/zookeeper/log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5477)
<!-- Reviewable:end -->
