### PR TITLE
deps: bump to latest rust-rdkafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,8 +3115,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.25.0-dev"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#6ac37feb6931332422d604ed80a904caec1eabd7"
+version = "0.25.0"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#743bb258b3fea914cdcaec311d63c651927d07fb"
 dependencies = [
  "futures",
  "libc",
@@ -3131,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "2.1.1+1.5.3"
-source = "git+https://github.com/fede1024/rust-rdkafka.git#6ac37feb6931332422d604ed80a904caec1eabd7"
+version = "3.0.0+1.6.0"
+source = "git+https://github.com/fede1024/rust-rdkafka.git#743bb258b3fea914cdcaec311d63c651927d07fb"
 dependencies = [
  "cmake",
  "libc",

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -576,6 +576,15 @@ impl KafkaSourceInfo {
             .assign(&partition_list)
             .expect("assignment known to be valid");
 
+        // Since librdkafka v1.6.0, we need to recreate all partition queues
+        // after every call to `self.consumer.assign`.
+        for pc in &mut self.partition_consumers {
+            pc.partition_queue = self
+                .consumer
+                .split_partition_queue(&self.topic_name, pc.pid)
+                .expect("partition known to be valid");
+        }
+
         let partition_queue = self
             .consumer
             .split_partition_queue(&self.topic_name, partition_id)

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -33,7 +33,7 @@ impl KafkaClient {
         config.set("bootstrap.servers", kafka_url);
         config.set("group.id", group_id);
         for (key, val) in configs {
-            config.set(key, val);
+            config.set(*key, *val);
         }
 
         let producer: FutureProducer = config.create()?;


### PR DESCRIPTION
This bundles librdkafka v1.6.0, which notably includes several
transactional producer bugfixes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5478)
<!-- Reviewable:end -->
