### PR TITLE
Introduce sql::AggregateFunc with different type logic

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -505,8 +505,12 @@ impl AggregateFunc {
             AggregateFunc::SumInt64 => ScalarType::Decimal(MAX_DECIMAL_PRECISION, 0),
             _ => input_type.scalar_type,
         };
-        // max/min/sum return null on empty sets
-        let nullable = !matches!(self, AggregateFunc::Count);
+        // Count never produces null, and other aggregations only produce
+        // null in the presence of null inputs.
+        let nullable = match self {
+            AggregateFunc::Count => false,
+            _ => input_type.nullable,
+        };
         scalar_type.nullable(nullable)
     }
 }

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -854,7 +854,7 @@ impl AggregateExpr {
         } = self;
 
         expr::AggregateExpr {
-            func,
+            func: func.into_expr(),
             expr: expr.applied_to(id_gen, col_map, inner),
             distinct,
         }

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -426,7 +426,7 @@ impl RelationExpr {
                 let input_type = input.typ();
                 let default = applied_aggregates
                     .iter()
-                    .map(|agg| (agg.func.default(), agg.typ(&input_type)))
+                    .map(|agg| (agg.func.default(), agg.typ(&input_type).nullable(true)))
                     .collect();
                 // NOTE we don't need to remove any extra columns from aggregate.applied_to above because the reduce will do that anyway
                 let mut reduced =

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -426,7 +426,7 @@ impl RelationExpr {
                 let input_type = input.typ();
                 let default = applied_aggregates
                     .iter()
-                    .map(|agg| (agg.func.default(), agg.typ(&input_type).nullable(true)))
+                    .map(|agg| (agg.func.default(), agg.typ(&input_type).nullable(agg.func.default().is_null())))
                     .collect();
                 // NOTE we don't need to remove any extra columns from aggregate.applied_to above because the reduce will do that anyway
                 let mut reduced =

--- a/src/sql/src/plan/decorrelate.rs
+++ b/src/sql/src/plan/decorrelate.rs
@@ -426,7 +426,12 @@ impl RelationExpr {
                 let input_type = input.typ();
                 let default = applied_aggregates
                     .iter()
-                    .map(|agg| (agg.func.default(), agg.typ(&input_type).nullable(agg.func.default().is_null())))
+                    .map(|agg| {
+                        (
+                            agg.func.default(),
+                            agg.typ(&input_type).nullable(agg.func.default().is_null()),
+                        )
+                    })
                     .collect();
                 // NOTE we don't need to remove any extra columns from aggregate.applied_to above because the reduce will do that anyway
                 let mut reduced =

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -432,7 +432,7 @@ impl<'a> Explanation<'a> {
     }
 
     fn fmt_aggregate_expr(&self, f: &mut fmt::Formatter, expr: &AggregateExpr) -> fmt::Result {
-        write!(f, "{}(", expr.func)?;
+        write!(f, "{}(", expr.func.into_expr())?;
         if expr.distinct {
             write!(f, "distinct ")?;
         }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -346,7 +346,7 @@ pub struct AggregateExpr {
 /// here than in `expr`, as these aggregates may be applied over empty
 /// result sets and should be null in those cases, whereas `expr` variants
 /// only return null values when supplied nulls as input.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum AggregateFunc {
     MaxInt32,
     MaxInt64,
@@ -391,7 +391,7 @@ pub enum AggregateFunc {
 
 impl AggregateFunc {
     /// Converts the `sql::AggregateFunc` to a corresponding `expr::AggregateFunc`.
-    pub fn into_expr(&self) -> expr::AggregateFunc {
+    pub fn into_expr(self) -> expr::AggregateFunc {
         match self {
             AggregateFunc::MaxInt64 => expr::AggregateFunc::MaxInt64,
             AggregateFunc::MaxInt32 => expr::AggregateFunc::MaxInt32,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -426,18 +426,6 @@ impl AggregateFunc {
         }
     }
 
-    /// Returns the output of the aggregation function when applied on an empty
-    /// input relation.
-    pub fn default(&self) -> Datum<'static> {
-        match self {
-            AggregateFunc::Count => Datum::Int64(0),
-            AggregateFunc::Any => Datum::False,
-            AggregateFunc::All => Datum::True,
-            AggregateFunc::Dummy => Datum::Dummy,
-            _ => Datum::Null,
-        }
-    }
-
     /// Returns a datum whose inclusion in the aggregation will not change its
     /// result.
     pub fn identity_datum(&self) -> Datum<'static> {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -28,9 +28,7 @@ use crate::plan::typeconv::{self, CastContext};
 use crate::plan::Params;
 
 // these happen to be unchanged at the moment, but there might be additions later
-pub use expr::{
-    AggregateFunc, BinaryFunc, ColumnOrder, NullaryFunc, TableFunc, UnaryFunc, VariadicFunc,
-};
+pub use expr::{BinaryFunc, ColumnOrder, NullaryFunc, TableFunc, UnaryFunc, VariadicFunc};
 use repr::adt::array::ArrayDimension;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -339,6 +337,139 @@ pub struct AggregateExpr {
     pub func: AggregateFunc,
     pub expr: Box<ScalarExpr>,
     pub distinct: bool,
+}
+
+/// Aggregate functions analogous to `expr::AggregateFunc`, but whose
+/// types may be different.
+///
+/// Specifically, the nullability of the aggregate columns is more common
+/// here than in `expr`, as these aggregates may be applied over empty
+/// result sets and should be null in those cases, whereas `expr` variants
+/// only return null values when supplied nulls as input.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum AggregateFunc {
+    MaxInt32,
+    MaxInt64,
+    MaxFloat32,
+    MaxFloat64,
+    MaxDecimal,
+    MaxBool,
+    MaxString,
+    MaxDate,
+    MaxTimestamp,
+    MaxTimestampTz,
+    MinInt32,
+    MinInt64,
+    MinFloat32,
+    MinFloat64,
+    MinDecimal,
+    MinBool,
+    MinString,
+    MinDate,
+    MinTimestamp,
+    MinTimestampTz,
+    SumInt32,
+    SumInt64,
+    SumFloat32,
+    SumFloat64,
+    SumDecimal,
+    Count,
+    Any,
+    All,
+    /// Accumulates JSON-typed `Datum`s into a JSON list.
+    ///
+    /// WARNING: Unlike the `jsonb_agg` function that is exposed by the SQL
+    /// layer, this function filters out `Datum::Null`, for consistency with
+    /// the other aggregate functions.
+    JsonbAgg,
+    /// Accumulates any number of `Datum::Dummy`s into `Datum::Dummy`.
+    ///
+    /// Useful for removing an expensive aggregation while maintaining the shape
+    /// of a reduce operator.
+    Dummy,
+}
+
+impl AggregateFunc {
+    /// Converts the `sql::AggregateFunc` to a corresponding `expr::AggregateFunc`.
+    pub fn into_expr(&self) -> expr::AggregateFunc {
+        match self {
+            AggregateFunc::MaxInt64 => expr::AggregateFunc::MaxInt64,
+            AggregateFunc::MaxInt32 => expr::AggregateFunc::MaxInt32,
+            AggregateFunc::MaxFloat32 => expr::AggregateFunc::MaxFloat32,
+            AggregateFunc::MaxFloat64 => expr::AggregateFunc::MaxFloat64,
+            AggregateFunc::MaxDecimal => expr::AggregateFunc::MaxDecimal,
+            AggregateFunc::MaxBool => expr::AggregateFunc::MaxBool,
+            AggregateFunc::MaxString => expr::AggregateFunc::MaxString,
+            AggregateFunc::MaxDate => expr::AggregateFunc::MaxDate,
+            AggregateFunc::MaxTimestamp => expr::AggregateFunc::MaxTimestamp,
+            AggregateFunc::MaxTimestampTz => expr::AggregateFunc::MaxTimestampTz,
+            AggregateFunc::MinInt32 => expr::AggregateFunc::MinInt32,
+            AggregateFunc::MinInt64 => expr::AggregateFunc::MinInt64,
+            AggregateFunc::MinFloat32 => expr::AggregateFunc::MinFloat32,
+            AggregateFunc::MinFloat64 => expr::AggregateFunc::MinFloat64,
+            AggregateFunc::MinDecimal => expr::AggregateFunc::MinDecimal,
+            AggregateFunc::MinBool => expr::AggregateFunc::MinBool,
+            AggregateFunc::MinString => expr::AggregateFunc::MinString,
+            AggregateFunc::MinDate => expr::AggregateFunc::MinDate,
+            AggregateFunc::MinTimestamp => expr::AggregateFunc::MinTimestamp,
+            AggregateFunc::MinTimestampTz => expr::AggregateFunc::MinTimestampTz,
+            AggregateFunc::SumInt32 => expr::AggregateFunc::SumInt32,
+            AggregateFunc::SumInt64 => expr::AggregateFunc::SumInt64,
+            AggregateFunc::SumFloat32 => expr::AggregateFunc::SumFloat32,
+            AggregateFunc::SumFloat64 => expr::AggregateFunc::SumFloat64,
+            AggregateFunc::SumDecimal => expr::AggregateFunc::SumDecimal,
+            AggregateFunc::Count => expr::AggregateFunc::Count,
+            AggregateFunc::Any => expr::AggregateFunc::Any,
+            AggregateFunc::All => expr::AggregateFunc::All,
+            AggregateFunc::JsonbAgg => expr::AggregateFunc::JsonbAgg,
+            AggregateFunc::Dummy => expr::AggregateFunc::Dummy,
+        }
+    }
+
+    /// Returns the output of the aggregation function when applied on an empty
+    /// input relation.
+    pub fn default(&self) -> Datum<'static> {
+        match self {
+            AggregateFunc::Count => Datum::Int64(0),
+            AggregateFunc::Any => Datum::False,
+            AggregateFunc::All => Datum::True,
+            AggregateFunc::Dummy => Datum::Dummy,
+            _ => Datum::Null,
+        }
+    }
+
+    /// Returns a datum whose inclusion in the aggregation will not change its
+    /// result.
+    pub fn identity_datum(&self) -> Datum<'static> {
+        match self {
+            AggregateFunc::Any => Datum::False,
+            AggregateFunc::All => Datum::True,
+            AggregateFunc::Dummy => Datum::Dummy,
+            _ => Datum::Null,
+        }
+    }
+
+    /// The output column type for the result of an aggregation.
+    ///
+    /// The output column type also contains nullability information, which
+    /// is (without further information) true for aggregations that are not
+    /// counts.
+    pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        let scalar_type = match self {
+            AggregateFunc::Count => ScalarType::Int64,
+            AggregateFunc::Any => ScalarType::Bool,
+            AggregateFunc::All => ScalarType::Bool,
+            AggregateFunc::JsonbAgg => ScalarType::Jsonb,
+            AggregateFunc::SumInt32 => ScalarType::Int64,
+            AggregateFunc::SumInt64 => {
+                ScalarType::Decimal(repr::adt::decimal::MAX_DECIMAL_PRECISION, 0)
+            }
+            _ => input_type.scalar_type,
+        };
+        // max/min/sum return null on empty sets
+        let nullable = !matches!(self, AggregateFunc::Count);
+        scalar_type.nullable(nullable)
+    }
 }
 
 impl RelationExpr {

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1134,14 +1134,12 @@ ORDER BY
 
 %1 =
 | Get materialize.public.revenue (u27)
-| Filter !(isnull(#1))
 | ArrangeBy (#0)
 
 %2 =
 | Get materialize.public.revenue (u27)
 | Reduce group=()
 | | agg max(#1)
-| Filter !(isnull(#0))
 | ArrangeBy (#0)
 
 %3 =

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -70,7 +70,7 @@ b  sum
 name nullable type
 -------------------
 b     false   bigint
-sum   true    numeric
+sum   false   numeric
 
 > SHOW VIEWS LIKE '%data%'
 data_view


### PR DESCRIPTION
This PR introduces `sql::AggregateFunc` which maintains the existing `output_type()` logic, and changes `expr::AggregateFunc` to use more precise reasoning based on the nullability of input types. It is failing tests as the moment, which could be because this transformation was buggy, or because the new type reasoning is not appropriate. Posting so we can consider that publicly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5480)
<!-- Reviewable:end -->
