### PR TITLE
sql-parser: parse CREATE TEMP and TEMPORARY INDEX

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -83,6 +83,7 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
                     on_name: _,
                     key_parts,
                     if_not_exists: _,
+                    temporary: _,
                 }) => {
                     if let Some(key_parts) = key_parts {
                         for key_part in key_parts {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3417,6 +3417,7 @@ pub fn index_sql(
                 .collect(),
         ),
         if_not_exists: false,
+        temporary: false,
     }
     .to_ast_string_stable()
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -543,6 +543,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
     pub if_not_exists: bool,
+    pub temporary: bool,
 }
 
 impl<T: AstInfo> AstDisplay for CreateIndexStatement<T> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1317,10 +1317,14 @@ impl<'a> Parser<'a> {
                 self.prev_token();
                 self.prev_token();
                 self.parse_create_view()
+            } else if self.parse_keyword(INDEX) {
+                self.prev_token();
+                self.prev_token();
+                self.parse_create_index()
             } else {
                 self.expected(
                     self.peek_pos(),
-                    "VIEW after CREATE TEMPORARY",
+                    "VIEW or INDEX after CREATE TEMPORARY",
                     self.peek_token(),
                 )
             }
@@ -1698,6 +1702,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_index(&mut self) -> Result<Statement<Raw>, ParserError> {
+        let temporary = self.parse_keyword(TEMPORARY) | self.parse_keyword(TEMP);
         let default_index = self.parse_keyword(DEFAULT);
         self.expect_keyword(INDEX)?;
 
@@ -1737,6 +1742,7 @@ impl<'a> Parser<'a> {
             on_name,
             key_parts,
             if_not_exists,
+            temporary,
         }))
     }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -571,42 +571,42 @@ CREATE INDEX foo ON myschema.bar (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), on_name: ObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), on_name: ObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 ----
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), on_name: ObjectName([Ident("baz")]), key_parts: Some([Function(Function { name: ObjectName([Ident("ascii")]), args: Args([Identifier([Ident("x")])]), filter: None, over: None, distinct: false }), IsNull { expr: Identifier([Ident("a")]), negated: true }, Nested(Exists(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("boop")]), alias: None }, joins: [] }], selection: Some(Op { op: "=", expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), on_name: ObjectName([Ident("baz")]), key_parts: Some([Function(Function { name: ObjectName([Ident("ascii")]), args: Args([Identifier([Ident("x")])]), filter: None, over: None, distinct: false }), IsNull { expr: Identifier([Ident("a")]), negated: true }, Nested(Exists(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: ObjectName([Ident("boop")]), alias: None }, joins: [] }], selection: Some(Op { op: "=", expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE INDEX ind ON tab ((col + 1))
 ----
 CREATE INDEX ind ON tab ((col + 1))
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), on_name: ObjectName([Ident("tab")]), key_parts: Some([Nested(Op { op: "+", expr1: Identifier([Ident("col")]), expr2: Some(Value(Number("1"))) })]), if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), on_name: ObjectName([Ident("tab")]), key_parts: Some([Nested(Op { op: "+", expr1: Identifier([Ident("col")]), expr2: Some(Value(Number("1"))) })]), if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 ----
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), on_name: ObjectName([Ident("no_parentheses")]), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), on_name: ObjectName([Ident("no_parentheses")]), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab
 ----
 CREATE DEFAULT INDEX ON tab
 =>
-CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 ----
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 =>
-CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: true })
+CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: None, if_not_exists: true, temporary: false })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab (a, b)
@@ -627,7 +627,7 @@ CREATE INDEX ON tab (a, b)
 ----
 CREATE INDEX ON tab (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: None, on_name: ObjectName([Ident("tab")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE INDEX IF NOT EXISTS ON tab (a, b)

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -290,6 +290,7 @@ pub fn create_statement(
             on_name,
             key_parts,
             if_not_exists,
+            temporary: _,
         }) => {
             *on_name = resolve_item(on_name)?;
             let mut normalizer = QueryNormalizer::new(scx);

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -991,7 +991,11 @@ pub fn plan_create_index(
         on_name,
         key_parts,
         if_not_exists,
+        temporary,
     } = &mut stmt;
+    if *temporary {
+        unsupported!("CREATE TEMPORARY INDEX")
+    }
     let on = scx.resolve_item(on_name.clone())?;
 
     if CatalogItemType::View != on.item_type()

--- a/test/testdrive/temporary-views.td
+++ b/test/testdrive/temporary-views.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> CREATE VIEW v AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar')
+> CREATE VIEW v (num, text) AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar')
 
 > SELECT * FROM v;
 1 "foo"
@@ -15,49 +15,55 @@
 2 "bar"
 3 "foo"
 
-> CREATE TEMPORARY VIEW temp_v AS SELECT * FROM v;
+> CREATE TEMPORARY VIEW temp_v AS SELECT * FROM v
 
-> SELECT * FROM temp_v;
+> SELECT * FROM temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-> SELECT * FROM mz_temp.temp_v;
+> SELECT * FROM mz_temp.temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-! CREATE VIEW non_temp AS SELECT * FROM temp_v;
+! CREATE VIEW non_temp AS SELECT * FROM temp_v
 non-temporary items cannot depend on temporary item
 
-> CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v;
+> CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
 
-! CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v;
+! CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
 catalog item 'double_temp_v' already exists
 
-> SELECT * FROM double_temp_v;
+> SELECT * FROM double_temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-> SELECT * FROM mz_temp.double_temp_v;
+> SELECT * FROM mz_temp.double_temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
+
+! CREATE TEMPORARY INDEX temp_idx ON temp_v(text)
+CREATE TEMPORARY INDEX not yet supported
+
+! CREATE TEMP INDEX temp_idx ON temp_v(num)
+CREATE TEMPORARY INDEX not yet supported
 
 #####################################################################
 # Test things we shouldn't be able to make temporary.
 
 ##### Temporary materialized views.
-! CREATE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v;
-Expected VIEW after CREATE TEMPORARY, found MATERIALIZED
+! CREATE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
+Expected VIEW or INDEX after CREATE TEMPORARY, found MATERIALIZED
 
-! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v;
-Expected VIEW after CREATE TEMPORARY, found MATERIALIZED
+! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v
+Expected VIEW or INDEX after CREATE TEMPORARY, found MATERIALIZED
 
 
 ##### Temporary sources.
@@ -71,28 +77,28 @@ $ set schema={
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-Expected VIEW after CREATE TEMPORARY, found SOURCE
+Expected VIEW or INDEX after CREATE TEMPORARY, found SOURCE
 
 
 ##### Temporary sinks.
 ! CREATE TEMPORARY SINK data_sink FROM data
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Expected VIEW after CREATE TEMPORARY, found SINK
+Expected VIEW or INDEX after CREATE TEMPORARY, found SINK
 
 #####################################################################
 
-! DROP VIEW temp_v;
+! DROP VIEW temp_v
 cannot drop mz_temp.temp_v: still depended upon by catalog item 'mz_temp.double_temp_v'
 
-> DROP VIEW double_temp_v;
+> DROP VIEW double_temp_v
 
-! SELECT * FROM double_temp_v;
+! SELECT * FROM double_temp_v
 unknown catalog item 'double_temp_v'
 
 > DISCARD TEMP
 
-! SELECT * FROM temp_v;
+! SELECT * FROM temp_v
 unknown catalog item 'temp_v'
 
 ! CREATE TEMP VIEW mz_foo.a AS SELECT 1


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/5470. Parses `CREATE TEMP` and `CREATE TEMPORARY INDEX`, but
leaves planning and sequencing unimplemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5482)
<!-- Reviewable:end -->
