### PR TITLE
sql,coord: implement CREATE TEMPORARY INDEX

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -190,6 +190,7 @@ pub struct Index {
     pub plan_cx: PlanContext,
     pub on: GlobalId,
     pub keys: Vec<ScalarExpr>,
+    pub conn_id: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -286,6 +287,7 @@ impl CatalogItem {
     pub fn conn_id(&self) -> Option<u32> {
         match self {
             CatalogItem::View(view) => view.conn_id,
+            CatalogItem::Index(index) => index.conn_id,
             _ => None,
         }
     }
@@ -510,6 +512,7 @@ impl Catalog {
                                     &log.variant.index_by(),
                                 ),
                                 plan_cx: PlanContext::default(),
+                                conn_id: Some(SYSTEM_CONN_ID),
                             }),
                         ),
                     );
@@ -554,6 +557,7 @@ impl Catalog {
                                     .collect(),
                                 create_sql: index_sql,
                                 plan_cx: PlanContext::default(),
+                                conn_id: None,
                             }),
                         ),
                     );
@@ -1519,6 +1523,7 @@ impl Catalog {
                 plan_cx: pcx,
                 on: index.on,
                 keys: index.keys,
+                conn_id: None,
             }),
             Plan::CreateSink {
                 sink,

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -158,9 +158,7 @@ impl Session {
                     }
                 },
             },
-            TransactionStatus::Default | TransactionStatus::Failed => {
-                unreachable!()
-            }
+            TransactionStatus::Default | TransactionStatus::Failed => unreachable!(),
         }
         Ok(())
     }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -216,6 +216,7 @@ pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
     pub keys: Vec<::expr::ScalarExpr>,
+    pub temporary: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -49,11 +49,27 @@ catalog item 'double_temp_v' already exists
 2 "bar"
 3 "foo"
 
-! CREATE TEMPORARY INDEX temp_idx ON temp_v(text)
-CREATE TEMPORARY INDEX not yet supported
+> CREATE TEMPORARY INDEX temp_text_idx ON temp_v(text)
 
-! CREATE TEMP INDEX temp_idx ON temp_v(num)
-CREATE TEMPORARY INDEX not yet supported
+> CREATE TEMP INDEX temp_num_idx ON temp_v(num)
+
+> SHOW INDEXES FROM temp_v
+ on_name    key_name      seq_in_index  column_name  expression  nullable
+-------------------------------------------------------------------------
+ temp_v     temp_num_idx  1              num         <null>      false
+ temp_v     temp_text_idx 1              text        <null>      false
+
+> CREATE VIEW non_temp_v (num, text) AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar')
+
+> CREATE TEMPORARY INDEX non_temp_text_idx ON non_temp_v(text)
+
+> CREATE TEMP INDEX non_temp_num_idx ON non_temp_v(num)
+
+> SHOW INDEXES FROM non_temp_v
+ on_name        key_name          seq_in_index  column_name  expression  nullable
+------------------------------------------------------------------------------
+ non_temp_v     non_temp_num_idx  1              num         <null>      false
+ non_temp_v     non_temp_text_idx 1              text        <null>      false
 
 #####################################################################
 # Test things we shouldn't be able to make temporary.
@@ -93,13 +109,21 @@ cannot drop mz_temp.temp_v: still depended upon by catalog item 'mz_temp.double_
 
 > DROP VIEW double_temp_v
 
+> DROP VIEW temp_v
+
 ! SELECT * FROM double_temp_v
 unknown catalog item 'double_temp_v'
 
 > DISCARD TEMP
 
+> SHOW INDEXES FROM non_temp_v
+
 ! SELECT * FROM temp_v
 unknown catalog item 'temp_v'
+
+> SELECT * FROM mz_indexes WHERE name = 'temp_num_idx'
+
+> SELECT * FROM mz_indexes WHERE name = 'temp_text_idx'
 
 ! CREATE TEMP VIEW mz_foo.a AS SELECT 1
 cannot create temporary item in non-temporary schema


### PR DESCRIPTION
Adds support for `CREATE TEMPORARY INDEX`, which behaves identically
to other temporary objects.

Next step: docs!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5489)
<!-- Reviewable:end -->
