### PR TITLE
Rename `{expr, sql}::{Relation, Scalar}Expr to `{Mir, Hir}{Relation, Scalar}Expr`

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -111,7 +111,7 @@ impl<'a> DataflowBuilder<'a> {
     pub fn import_view_into_dataflow(
         &self,
         view_id: &GlobalId,
-        view: &OptimizedRelationExpr,
+        view: &OptimizedMirRelationExpr,
         dataflow: &mut DataflowDesc,
     ) {
         // TODO: We only need to import Get arguments for which we cannot find arrangements.
@@ -120,8 +120,8 @@ impl<'a> DataflowBuilder<'a> {
         }
         // Collect sources, views, and indexes used.
         view.as_ref().visit(&mut |e| {
-            if let RelationExpr::ArrangeBy { input, keys } = e {
-                if let RelationExpr::Get {
+            if let MirRelationExpr::ArrangeBy { input, keys } = e {
+                if let MirRelationExpr::Get {
                     id: Id::Global(on_id),
                     typ,
                 } = &**input

--- a/src/dataflow/src/render/arrange_by.rs
+++ b/src/dataflow/src/render/arrange_by.rs
@@ -14,20 +14,20 @@ use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::*;
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 use repr::{Row, RowArena};
 
 use crate::operator::CollectionExt;
 use crate::render::context::{ArrangementFlavor, Context};
 
-impl<G, T> Context<G, RelationExpr, Row, T>
+impl<G, T> Context<G, MirRelationExpr, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,
     T: Timestamp + Lattice,
 {
-    pub fn render_arrangeby(&mut self, relation_expr: &RelationExpr, id: Option<&str>) {
-        if let RelationExpr::ArrangeBy { input, keys } = relation_expr {
+    pub fn render_arrangeby(&mut self, relation_expr: &MirRelationExpr, id: Option<&str>) {
+        if let MirRelationExpr::ArrangeBy { input, keys } = relation_expr {
             if keys.is_empty() {
                 let collection = self.collection(input).unwrap();
                 self.collections.insert(relation_expr.clone(), collection);

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -13,14 +13,14 @@ use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::*;
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 use repr::{Datum, Row, RowArena};
 
 use crate::operator::CollectionExt;
 use crate::render::context::Context;
 use crate::render::datum_vec::DatumVec;
 
-impl<G, T> Context<G, RelationExpr, Row, T>
+impl<G, T> Context<G, MirRelationExpr, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,
@@ -29,10 +29,10 @@ where
     /// Renders `relation_expr` followed by `map_filter_project` if provided.
     pub fn render_flat_map(
         &mut self,
-        relation_expr: &RelationExpr,
+        relation_expr: &MirRelationExpr,
         map_filter_project: Option<expr::MapFilterProject>,
     ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
-        if let RelationExpr::FlatMap {
+        if let MirRelationExpr::FlatMap {
             input,
             func,
             exprs,

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use timely::dataflow::Scope;
 
 use dataflow_types::DataflowError;
-use expr::{JoinInputMapper, MapFilterProject, RelationExpr, ScalarExpr};
+use expr::{JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr};
 use repr::{Datum, Row, RowArena, RowPacker, Timestamp};
 
 use super::super::context::{ArrangementFlavor, Context};
@@ -22,17 +22,17 @@ use crate::operator::CollectionExt;
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
 
-impl<G> Context<G, RelationExpr, Row, Timestamp>
+impl<G> Context<G, MirRelationExpr, Row, Timestamp>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    /// Renders `RelationExpr:Join` using dogs^3 delta query dataflows.
+    /// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
     ///
     /// The join is followed by the application of `map_filter_project`, whose
     /// implementation will be pushed in to the join pipeline if at all possible.
     pub fn render_delta_join<F>(
         &mut self,
-        relation_expr: &RelationExpr,
+        relation_expr: &MirRelationExpr,
         map_filter_project: MapFilterProject,
         scope: &mut G,
         worker_index: usize,
@@ -41,7 +41,7 @@ where
     where
         F: Fn(&G::Timestamp) -> G::Timestamp + Clone + 'static,
     {
-        if let RelationExpr::Join {
+        if let MirRelationExpr::Join {
             inputs,
             equivalences,
             demand: _,
@@ -339,7 +339,7 @@ use differential_dataflow::Collection;
 fn build_lookup<G, Tr>(
     updates: Collection<G, Row>,
     trace: Arranged<G, Tr>,
-    prev_key: Vec<ScalarExpr>,
+    prev_key: Vec<MirScalarExpr>,
     closure: JoinClosure,
 ) -> (Collection<G, Row>, Collection<G, DataflowError>)
 where

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -24,7 +24,7 @@ use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::DataflowError;
-use expr::{AggregateExpr, AggregateFunc, RelationExpr};
+use expr::{AggregateExpr, AggregateFunc, MirRelationExpr};
 use repr::{Datum, DatumList, Row, RowArena, RowPacker};
 
 use super::context::Context;
@@ -48,16 +48,16 @@ enum ReductionType {
     Basic = 3,
 }
 
-impl<G, T> Context<G, RelationExpr, Row, T>
+impl<G, T> Context<G, MirRelationExpr, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,
     T: Timestamp + Lattice,
 {
-    /// Renders a `RelationExpr::Reduce` using various non-obvious techniques to
+    /// Renders a `MirRelationExpr::Reduce` using various non-obvious techniques to
     /// minimize worst-case incremental update times and memory footprint.
-    pub fn render_reduce(&mut self, relation_expr: &RelationExpr, scope: &mut G) {
-        if let RelationExpr::Reduce {
+    pub fn render_reduce(&mut self, relation_expr: &MirRelationExpr, scope: &mut G) {
+        if let MirRelationExpr::Reduce {
             input,
             group_key,
             aggregates,

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -14,19 +14,19 @@ use differential_dataflow::trace::implementations::ord::OrdValSpine;
 use timely::dataflow::Scope;
 use timely::progress::{timestamp::Refines, Timestamp};
 
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 use repr::Row;
 
 use crate::render::context::{ArrangementFlavor, Context};
 
-impl<G, T> Context<G, RelationExpr, Row, T>
+impl<G, T> Context<G, MirRelationExpr, Row, T>
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T>,
     T: Timestamp + Lattice,
 {
-    pub fn render_threshold(&mut self, relation_expr: &RelationExpr) {
-        if let RelationExpr::Threshold { input } = relation_expr {
+    pub fn render_threshold(&mut self, relation_expr: &MirRelationExpr) {
+        if let MirRelationExpr::Threshold { input } = relation_expr {
             // TODO: re-use and publish arrangement here.
             let arity = input.arity();
             let keys = (0..arity).collect::<Vec<_>>();

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -13,18 +13,18 @@ use differential_dataflow::operators::Consolidate;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
 
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 use repr::{Diff, Row};
 
 use crate::render::context::Context;
 
 // The implementation requires integer timestamps to be able to delay feedback for monotonic inputs.
-impl<G> Context<G, RelationExpr, Row, repr::Timestamp>
+impl<G> Context<G, MirRelationExpr, Row, repr::Timestamp>
 where
     G: Scope<Timestamp = repr::Timestamp>,
 {
-    pub fn render_topk(&mut self, relation_expr: &RelationExpr) {
-        if let RelationExpr::TopK {
+    pub fn render_topk(&mut self, relation_expr: &MirRelationExpr) {
+        if let MirRelationExpr::TopK {
             input,
             group_key,
             order_key,

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -7,14 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! This module houses a pretty printer for [`RelationExpr`]s.
+//! This module houses a pretty printer for [`MirRelationExpr`]s.
 //!
 //! Format details:
 //!
-//!   * The nodes in a `RelationExpr` are printed in post-order, left to right.
+//!   * The nodes in a `MirRelationExpr` are printed in post-order, left to right.
 //!   * Nodes which only have a single input are grouped together
 //!     into "chains."
-//!   * Each chain of `RelationExpr`s is referred to by ID, e.g. %4.
+//!   * Each chain of `MirRelationExpr`s is referred to by ID, e.g. %4.
 //!   * Nodes may be followed by additional, indented annotations.
 //!   * Columns are referred to by position, e.g. #4.
 //!   * Collections of columns are written as ranges where possible,
@@ -30,9 +30,9 @@ use std::iter;
 
 use repr::RelationType;
 
-use crate::{ExprHumanizer, Id, JoinImplementation, LocalId, RelationExpr, RowSetFinishing};
+use crate::{ExprHumanizer, Id, JoinImplementation, LocalId, MirRelationExpr, RowSetFinishing};
 
-/// An `Explanation` facilitates pretty-printing of a [`RelationExpr`].
+/// An `Explanation` facilitates pretty-printing of a [`MirRelationExpr`].
 ///
 /// By default, the [`fmt::Display`] implementation renders the expression as
 /// described in the module docs. Additional information may be attached to the
@@ -40,13 +40,13 @@ use crate::{ExprHumanizer, Id, JoinImplementation, LocalId, RelationExpr, RowSet
 #[derive(Debug)]
 pub struct Explanation<'a> {
     expr_humanizer: &'a dyn ExprHumanizer,
-    /// One `ExplanationNode` for each `RelationExpr` in the plan, in
+    /// One `ExplanationNode` for each `MirRelationExpr` in the plan, in
     /// left-to-right post-order.
     nodes: Vec<ExplanationNode<'a>>,
     /// An optional `RowSetFinishing` to mention at the end.
     finishing: Option<RowSetFinishing>,
     /// Records the chain ID that was assigned to each expression.
-    expr_chains: HashMap<*const RelationExpr, usize>,
+    expr_chains: HashMap<*const MirRelationExpr, usize>,
     /// Records the chain ID that was assigned to each let.
     local_id_chains: HashMap<LocalId, usize>,
     /// Records the local ID that corresponds to a chain ID, if any.
@@ -59,7 +59,7 @@ pub struct Explanation<'a> {
 #[derive(Debug)]
 pub struct ExplanationNode<'a> {
     /// The expression being explained.
-    pub expr: &'a RelationExpr,
+    pub expr: &'a MirRelationExpr,
     /// The type of the expression, if desired.
     pub typ: Option<RelationType>,
     /// The ID of the linear chain to which this node belongs.
@@ -104,15 +104,18 @@ impl<'a> fmt::Display for Explanation<'a> {
 }
 
 impl<'a> Explanation<'a> {
-    /// Creates an explanation for a [`RelationExpr`].
-    pub fn new(expr: &'a RelationExpr, expr_humanizer: &'a dyn ExprHumanizer) -> Explanation<'a> {
-        use RelationExpr::*;
+    /// Creates an explanation for a [`MirRelationExpr`].
+    pub fn new(
+        expr: &'a MirRelationExpr,
+        expr_humanizer: &'a dyn ExprHumanizer,
+    ) -> Explanation<'a> {
+        use MirRelationExpr::*;
 
         // Do a post-order traversal of the expression, grouping "chains" of
         // nodes together as we go. We have to break the chain whenever we
         // encounter a node with multiple inputs, like a join.
 
-        fn walk<'a>(expr: &'a RelationExpr, explanation: &mut Explanation<'a>) {
+        fn walk<'a>(expr: &'a MirRelationExpr, explanation: &mut Explanation<'a>) {
             // First, walk the children, in order to perform a post-order
             // traversal.
             match expr {
@@ -156,22 +159,23 @@ impl<'a> Explanation<'a> {
             });
             explanation
                 .expr_chains
-                .insert(expr as *const RelationExpr, explanation.chain);
+                .insert(expr as *const MirRelationExpr, explanation.chain);
         }
 
         fn walk_many<'a, E>(exprs: E, explanation: &mut Explanation<'a>)
         where
-            E: IntoIterator<Item = &'a RelationExpr>,
+            E: IntoIterator<Item = &'a MirRelationExpr>,
         {
             for expr in exprs {
                 // Elide chains that would consist only a of single Get node.
-                if let RelationExpr::Get {
+                if let MirRelationExpr::Get {
                     id: Id::Local(id), ..
                 } = expr
                 {
-                    explanation
-                        .expr_chains
-                        .insert(expr as *const RelationExpr, explanation.local_id_chains[id]);
+                    explanation.expr_chains.insert(
+                        expr as *const MirRelationExpr,
+                        explanation.local_id_chains[id],
+                    );
                 } else {
                     walk(expr, explanation);
                     explanation.chain += 1;
@@ -206,7 +210,7 @@ impl<'a> Explanation<'a> {
     }
 
     fn fmt_node(&self, f: &mut fmt::Formatter, node: &ExplanationNode) -> fmt::Result {
-        use RelationExpr::*;
+        use MirRelationExpr::*;
 
         match node.expr {
             Constant { rows, .. } => writeln!(
@@ -377,7 +381,7 @@ impl<'a> Explanation<'a> {
     fn fmt_join_implementation(
         &self,
         f: &mut fmt::Formatter,
-        join_inputs: &[RelationExpr],
+        join_inputs: &[MirRelationExpr],
         implementation: &JoinImplementation,
     ) -> fmt::Result {
         match implementation {
@@ -430,8 +434,8 @@ impl<'a> Explanation<'a> {
     ///
     /// The `ExplanationNode` for `expr` must have already been inserted into
     /// the explanation.
-    fn expr_chain(&self, expr: &RelationExpr) -> usize {
-        self.expr_chains[&(expr as *const RelationExpr)]
+    fn expr_chain(&self, expr: &MirRelationExpr) -> usize {
+        self.expr_chains[&(expr as *const MirRelationExpr)]
     }
 }
 

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, Error};
 use serde::{Deserialize, Serialize};
 
 /// An opaque identifier for a dataflow component. In other words, identifies
-/// the target of a [`RelationExpr::Get`](crate::RelationExpr::Get).
+/// the target of a [`MirRelationExpr::Get`](crate::MirRelationExpr::Get).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum Id {
     /// An identifier that refers to a local component of a dataflow.

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -30,39 +30,39 @@ pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
-    compare_columns, AggregateExpr, ColumnOrder, IdGen, JoinImplementation, RelationExpr,
+    compare_columns, AggregateExpr, ColumnOrder, IdGen, JoinImplementation, MirRelationExpr,
     RowSetFinishing,
 };
 pub use scalar::func::{BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
-pub use scalar::{like_pattern, EvalError, ScalarExpr};
+pub use scalar::{like_pattern, EvalError, MirScalarExpr};
 
-/// A [`RelationExpr`] that claims to have been optimized, e.g., by an
+/// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an
 /// [`Optimizer`].
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct OptimizedRelationExpr(pub RelationExpr);
+pub struct OptimizedMirRelationExpr(pub MirRelationExpr);
 
-impl OptimizedRelationExpr {
+impl OptimizedMirRelationExpr {
     /// Declare that the input `expr` is optimized, without actually running it
     /// through an optimizer. This can be useful to mark as optimized literal
-    /// `RelationExpr`s that are obviously optimal, without invoking the whole
+    /// `MirRelationExpr`s that are obviously optimal, without invoking the whole
     /// machinery of the optimizer.
-    pub fn declare_optimized(expr: RelationExpr) -> OptimizedRelationExpr {
-        OptimizedRelationExpr(expr)
+    pub fn declare_optimized(expr: MirRelationExpr) -> OptimizedMirRelationExpr {
+        OptimizedMirRelationExpr(expr)
     }
 
-    pub fn into_inner(self) -> RelationExpr {
+    pub fn into_inner(self) -> MirRelationExpr {
         self.0
     }
 }
 
-impl AsRef<RelationExpr> for OptimizedRelationExpr {
-    fn as_ref(&self) -> &RelationExpr {
+impl AsRef<MirRelationExpr> for OptimizedMirRelationExpr {
+    fn as_ref(&self) -> &MirRelationExpr {
         &self.0
     }
 }
 
-impl AsMut<RelationExpr> for OptimizedRelationExpr {
-    fn as_mut(&mut self) -> &mut RelationExpr {
+impl AsMut<MirRelationExpr> for OptimizedMirRelationExpr {
+    fn as_mut(&mut self) -> &mut MirRelationExpr {
         &mut self.0
     }
 }

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -12,8 +12,8 @@ use std::ops::Range;
 
 use itertools::Itertools;
 
-use crate::RelationExpr;
-use crate::ScalarExpr;
+use crate::MirRelationExpr;
+use crate::MirScalarExpr;
 
 use repr::RelationType;
 
@@ -38,7 +38,7 @@ pub struct JoinInputMapper {
 impl JoinInputMapper {
     /// Creates a new `JoinInputMapper` and calculates the mapping of global context
     /// columns to local context columns.
-    pub fn new(inputs: &[RelationExpr]) -> Self {
+    pub fn new(inputs: &[MirRelationExpr]) -> Self {
         Self::new_from_input_types(&inputs.iter().map(|i| i.typ()).collect::<Vec<_>>())
     }
 
@@ -88,7 +88,7 @@ impl JoinInputMapper {
     pub fn global_keys(
         &self,
         local_keys: &[Vec<Vec<usize>>],
-        equivalences: &[Vec<ScalarExpr>],
+        equivalences: &[Vec<MirScalarExpr>],
     ) -> Vec<Vec<usize>> {
         // A relation's uniqueness constraint holds if there is a
         // sequence of the other relations such that each one has
@@ -116,7 +116,7 @@ impl JoinInputMapper {
                 for expr in equivalence {
                     // then store all columns in the constraint that don't come
                     // from the first input
-                    if let ScalarExpr::Column(c) = expr {
+                    if let MirScalarExpr::Column(c) = expr {
                         let (col, input) = self.map_column_to_local(*c);
                         if input > min_bound_input {
                             column_with_prior_bound_by_input[input - 1].insert(col);
@@ -163,9 +163,9 @@ impl JoinInputMapper {
     /// Takes an expression from the global context and creates a new version
     /// where column references have been remapped to the local context.
     /// Assumes that all columns in `expr` are from the same input.
-    pub fn map_expr_to_local(&self, mut expr: ScalarExpr) -> ScalarExpr {
+    pub fn map_expr_to_local(&self, mut expr: MirScalarExpr) -> MirScalarExpr {
         expr.visit_mut(&mut |e| {
-            if let ScalarExpr::Column(c) = e {
+            if let MirScalarExpr::Column(c) = e {
                 *c -= self.prior_arities[self.input_relation[*c]];
             }
         });
@@ -175,9 +175,9 @@ impl JoinInputMapper {
     /// Takes an expression from the local context of the `index`th input and
     /// creates a new version where column references have been remapped to the
     /// global context.
-    pub fn map_expr_to_global(&self, mut expr: ScalarExpr, index: usize) -> ScalarExpr {
+    pub fn map_expr_to_global(&self, mut expr: MirScalarExpr, index: usize) -> MirScalarExpr {
         expr.visit_mut(&mut |e| {
-            if let ScalarExpr::Column(c) = e {
+            if let MirScalarExpr::Column(c) = e {
                 *c += self.prior_arities[index];
             }
         });
@@ -209,7 +209,7 @@ impl JoinInputMapper {
     }
 
     /// Find the sorted, dedupped set of inputs an expression references
-    pub fn lookup_inputs(&self, expr: &ScalarExpr) -> impl Iterator<Item = usize> {
+    pub fn lookup_inputs(&self, expr: &MirScalarExpr) -> impl Iterator<Item = usize> {
         expr.support()
             .iter()
             .map(|c| self.input_relation[*c])
@@ -225,7 +225,7 @@ impl JoinInputMapper {
     ///
     /// ```
     /// use repr::{Datum, ColumnType, RelationType, ScalarType};
-    /// use expr::{JoinInputMapper, RelationExpr, ScalarExpr};
+    /// use expr::{JoinInputMapper, MirRelationExpr, MirScalarExpr};
     ///
     /// // A two-column schema common to each of the three inputs
     /// let schema = RelationType::new(vec![
@@ -235,32 +235,32 @@ impl JoinInputMapper {
     ///
     /// // the specific data are not important here.
     /// let data = vec![Datum::Int32(0), Datum::Int32(1)];
-    /// let input0 = RelationExpr::constant(vec![data.clone()], schema.clone());
-    /// let input1 = RelationExpr::constant(vec![data.clone()], schema.clone());
-    /// let input2 = RelationExpr::constant(vec![data.clone()], schema.clone());
+    /// let input0 = MirRelationExpr::constant(vec![data.clone()], schema.clone());
+    /// let input1 = MirRelationExpr::constant(vec![data.clone()], schema.clone());
+    /// let input2 = MirRelationExpr::constant(vec![data.clone()], schema.clone());
     ///
     /// // [input0(#0) = input2(#1)], [input0(#1) = input1(#0) = input2(#0)]
     /// let equivalences = vec![
-    ///   vec![ScalarExpr::Column(0), ScalarExpr::Column(5)],
-    ///   vec![ScalarExpr::Column(1), ScalarExpr::Column(2), ScalarExpr::Column(4)],
+    ///   vec![MirScalarExpr::Column(0), MirScalarExpr::Column(5)],
+    ///   vec![MirScalarExpr::Column(1), MirScalarExpr::Column(2), MirScalarExpr::Column(4)],
     /// ];
     ///
     /// let input_mapper = JoinInputMapper::new(&[input0, input1, input2]);
     /// assert_eq!(
-    ///   Some(ScalarExpr::Column(4)),
-    ///   input_mapper.find_bound_expr(&ScalarExpr::Column(2), &[2], &equivalences)
+    ///   Some(MirScalarExpr::Column(4)),
+    ///   input_mapper.find_bound_expr(&MirScalarExpr::Column(2), &[2], &equivalences)
     /// );
     /// assert_eq!(
     ///   None,
-    ///   input_mapper.find_bound_expr(&ScalarExpr::Column(0), &[1], &equivalences)
+    ///   input_mapper.find_bound_expr(&MirScalarExpr::Column(0), &[1], &equivalences)
     /// );
     /// ```
     pub fn find_bound_expr(
         &self,
-        expr: &ScalarExpr,
+        expr: &MirScalarExpr,
         bound_inputs: &[usize],
-        equivalences: &[Vec<ScalarExpr>],
-    ) -> Option<ScalarExpr> {
+        equivalences: &[Vec<MirScalarExpr>],
+    ) -> Option<MirScalarExpr> {
         if let Some(equivalence) = equivalences.iter().find(|equivs| equivs.contains(expr)) {
             if let Some(bound_expr) = equivalence
                 .iter()
@@ -280,9 +280,9 @@ impl JoinInputMapper {
     /// was only partially rewritten.
     fn try_map_to_input_with_bound_expr_sub(
         &self,
-        expr: &mut ScalarExpr,
+        expr: &mut MirScalarExpr,
         index: usize,
-        equivalences: &[Vec<ScalarExpr>],
+        equivalences: &[Vec<MirScalarExpr>],
     ) {
         {
             let mut inputs = self.lookup_inputs(expr);
@@ -309,10 +309,10 @@ impl JoinInputMapper {
     /// The return value, if not None, is in the context of the `index`th input
     pub fn try_map_to_input_with_bound_expr(
         &self,
-        mut expr: ScalarExpr,
+        mut expr: MirScalarExpr,
         index: usize,
-        equivalences: &[Vec<ScalarExpr>],
-    ) -> Option<ScalarExpr> {
+        equivalences: &[Vec<MirScalarExpr>],
+    ) -> Option<MirScalarExpr> {
         // call the recursive submethod
         self.try_map_to_input_with_bound_expr_sub(&mut expr, index, equivalences);
         // if the localization attempt is successful, all columns in `expr`
@@ -330,7 +330,7 @@ impl JoinInputMapper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BinaryFunc, ScalarExpr, UnaryFunc};
+    use crate::{BinaryFunc, MirScalarExpr, UnaryFunc};
     use repr::{Datum, ScalarType};
 
     #[test]
@@ -342,16 +342,16 @@ mod tests {
         };
 
         // keys are numbered by (equivalence class #, input #)
-        let key10 = ScalarExpr::Column(0);
-        let key12 = ScalarExpr::Column(6);
-        let localized_key12 = ScalarExpr::Column(1);
+        let key10 = MirScalarExpr::Column(0);
+        let key12 = MirScalarExpr::Column(6);
+        let localized_key12 = MirScalarExpr::Column(1);
 
         let mut equivalences = vec![vec![key10.clone(), key12.clone()]];
 
         // when the column is already part of the target input, all that happens
         // is that it gets localized
         assert_eq!(
-            Some(ScalarExpr::Column(1)),
+            Some(MirScalarExpr::Column(1)),
             input_mapper.try_map_to_input_with_bound_expr(key12.clone(), 2, &equivalences)
         );
 
@@ -366,20 +366,20 @@ mod tests {
             input_mapper.try_map_to_input_with_bound_expr(key12.clone(), 1, &equivalences)
         );
 
-        let key20 = ScalarExpr::CallUnary {
+        let key20 = MirScalarExpr::CallUnary {
             func: UnaryFunc::NegInt32,
-            expr: Box::new(ScalarExpr::Column(1)),
+            expr: Box::new(MirScalarExpr::Column(1)),
         };
-        let key21 = ScalarExpr::CallBinary {
+        let key21 = MirScalarExpr::CallBinary {
             func: BinaryFunc::AddInt32,
-            expr1: Box::new(ScalarExpr::Column(2)),
-            expr2: Box::new(ScalarExpr::literal(
+            expr1: Box::new(MirScalarExpr::Column(2)),
+            expr2: Box::new(MirScalarExpr::literal(
                 Ok(Datum::Int32(4)),
                 ScalarType::Int32.nullable(false),
             )),
         };
-        let key22 = ScalarExpr::Column(5);
-        let localized_key22 = ScalarExpr::Column(0);
+        let key22 = MirScalarExpr::Column(5);
+        let localized_key22 = MirScalarExpr::Column(0);
         equivalences.push(vec![key22.clone(), key20.clone(), key21.clone()]);
 
         // basic tests that we can find an expression's corresponding expression in a
@@ -395,13 +395,13 @@ mod tests {
 
         // test that `try_map_to_input_with_bound_expr` will map multiple
         // subexpressions to the corresponding expressions bound to a different input
-        let key_comp = ScalarExpr::CallBinary {
+        let key_comp = MirScalarExpr::CallBinary {
             func: BinaryFunc::MulInt32,
             expr1: Box::new(key12.clone()),
             expr2: Box::new(key22),
         };
         assert_eq!(
-            Some(ScalarExpr::CallBinary {
+            Some(MirScalarExpr::CallBinary {
                 func: BinaryFunc::MulInt32,
                 expr1: Box::new(key10.clone()),
                 expr2: Box::new(key20.clone()),
@@ -416,17 +416,17 @@ mod tests {
             input_mapper.try_map_to_input_with_bound_expr(key_comp.clone(), 1, &equivalences)
         );
 
-        let key_comp_plus_non_key = ScalarExpr::CallBinary {
+        let key_comp_plus_non_key = MirScalarExpr::CallBinary {
             func: BinaryFunc::Eq,
             expr1: Box::new(key_comp),
-            expr2: Box::new(ScalarExpr::Column(7)),
+            expr2: Box::new(MirScalarExpr::Column(7)),
         };
         assert_eq!(
             None,
             input_mapper.try_map_to_input_with_bound_expr(key_comp_plus_non_key, 0, &equivalences)
         );
 
-        let key_comp_multi_input = ScalarExpr::CallBinary {
+        let key_comp_multi_input = MirScalarExpr::CallBinary {
             func: BinaryFunc::Eq,
             expr1: Box::new(key12),
             expr2: Box::new(key21),
@@ -434,7 +434,7 @@ mod tests {
         // test that the function works when part of the expression is already
         // part of the target input
         assert_eq!(
-            Some(ScalarExpr::CallBinary {
+            Some(MirScalarExpr::CallBinary {
                 func: BinaryFunc::Eq,
                 expr1: Box::new(localized_key12),
                 expr2: Box::new(localized_key22),
@@ -448,7 +448,7 @@ mod tests {
         // test that the function works when parts of the expression come from
         // multiple inputs
         assert_eq!(
-            Some(ScalarExpr::CallBinary {
+            Some(MirScalarExpr::CallBinary {
                 func: BinaryFunc::Eq,
                 expr1: Box::new(key10),
                 expr2: Box::new(key20),

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -20,7 +20,7 @@ use repr::{ColumnType, Datum, RelationType, Row};
 
 use self::func::{AggregateFunc, TableFunc};
 use crate::explain::Explanation;
-use crate::{DummyHumanizer, ExprHumanizer, GlobalId, Id, LocalId, ScalarExpr};
+use crate::{DummyHumanizer, ExprHumanizer, GlobalId, Id, LocalId, MirScalarExpr};
 
 pub mod func;
 pub mod join_input_mapper;
@@ -30,7 +30,7 @@ pub mod join_input_mapper;
 /// The AST is meant reflect the capabilities of the [`differential_dataflow::Collection`] type,
 /// written generically enough to avoid run-time compilation work.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub enum RelationExpr {
+pub enum MirRelationExpr {
     /// A constant relation containing specified rows.
     ///
     /// The runtime memory footprint of this operator is zero.
@@ -56,16 +56,16 @@ pub enum RelationExpr {
         /// The identifier to be used in `Get` variants to retrieve `value`.
         id: LocalId,
         /// The collection to be bound to `name`.
-        value: Box<RelationExpr>,
+        value: Box<MirRelationExpr>,
         /// The result of the `Let`, evaluated with `name` bound to `value`.
-        body: Box<RelationExpr>,
+        body: Box<MirRelationExpr>,
     },
     /// Project out some columns from a dataflow
     ///
     /// The runtime memory footprint of this operator is zero.
     Project {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// Indices of columns to retain.
         outputs: Vec<usize>,
     },
@@ -74,22 +74,22 @@ pub enum RelationExpr {
     /// The runtime memory footprint of this operator is zero.
     Map {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// Expressions which determine values to append to each row.
         /// An expression may refer to columns in `input` or
         /// expressions defined earlier in the vector
-        scalars: Vec<ScalarExpr>,
+        scalars: Vec<MirScalarExpr>,
     },
     /// Like Map, but yields zero-or-more output rows per input row
     ///
     /// The runtime memory footprint of this operator is zero.
     FlatMap {
         /// The source collection
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// The table func to apply
         func: TableFunc,
         /// The argument to the table func
-        exprs: Vec<ScalarExpr>,
+        exprs: Vec<MirScalarExpr>,
         /// Output columns demanded by the surrounding expression.
         ///
         /// The input columns are often discarded and can be very
@@ -104,20 +104,20 @@ pub enum RelationExpr {
     /// The runtime memory footprint of this operator is zero.
     Filter {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// Predicates, each of which must be true.
-        predicates: Vec<ScalarExpr>,
+        predicates: Vec<MirScalarExpr>,
     },
     /// Join several collections, where some columns must be equal.
     ///
-    /// For further details consult the documentation for [`RelationExpr::join`].
+    /// For further details consult the documentation for [`MirRelationExpr::join`].
     ///
     /// The runtime memory footprint of this operator can be proportional to
     /// the sizes of all inputs and the size of all joins of prefixes.
     /// This may be reduced due to arrangements available at rendering time.
     Join {
         /// A sequence of input relations.
-        inputs: Vec<RelationExpr>,
+        inputs: Vec<MirRelationExpr>,
         /// A sequence of equivalence classes of expressions on the cross product of inputs.
         ///
         /// Each equivalence class is a list of scalar expressions, where for each class the
@@ -127,7 +127,7 @@ pub enum RelationExpr {
         /// from all inputs. In many cases this may just be column selection from specific
         /// inputs, but more general cases exist (e.g. complex functions of multiple columns
         /// from multiple inputs, or just constant literals).
-        equivalences: Vec<Vec<ScalarExpr>>,
+        equivalences: Vec<Vec<MirScalarExpr>>,
         /// This optional field is a hint for which columns are
         /// actually used by operators that use this collection. Although the
         /// join does not have permission to change the schema, it can introduce
@@ -148,9 +148,9 @@ pub enum RelationExpr {
     /// builds the associated dataflow.
     Reduce {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// Column indices used to form groups.
-        group_key: Vec<ScalarExpr>,
+        group_key: Vec<MirScalarExpr>,
         /// Expressions which determine values to append to each row, after the group keys.
         aggregates: Vec<AggregateExpr>,
         /// True iff the input is known to monotonically increase (only addition of records).
@@ -163,7 +163,7 @@ pub enum RelationExpr {
     /// The runtime memory footprint of this operator is proportional to its input and output.
     TopK {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// Column indices used to form groups.
         group_key: Vec<usize>,
         /// Column indices used to order rows within groups.
@@ -180,23 +180,23 @@ pub enum RelationExpr {
     /// The runtime memory footprint of this operator is zero.
     Negate {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
     },
     /// Keep rows from a dataflow where the row counts are positive
     ///
     /// The runtime memory footprint of this operator is proportional to its input and output.
     Threshold {
         /// The source collection.
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
     },
     /// Adds the frequencies of elements in contained sets.
     ///
     /// The runtime memory footprint of this operator is zero.
     Union {
         /// A source collection.
-        base: Box<RelationExpr>,
+        base: Box<MirRelationExpr>,
         /// Source collections to union.
-        inputs: Vec<RelationExpr>,
+        inputs: Vec<MirRelationExpr>,
     },
     /// Technically a no-op. Used to render an index. Will be used to optimize queries
     /// on finer grain
@@ -204,13 +204,13 @@ pub enum RelationExpr {
     /// The runtime memory footprint of this operator is proportional to its input.
     ArrangeBy {
         /// The source collection
-        input: Box<RelationExpr>,
+        input: Box<MirRelationExpr>,
         /// Columns to arrange `input` by, in order of decreasing primacy
-        keys: Vec<Vec<ScalarExpr>>,
+        keys: Vec<Vec<MirScalarExpr>>,
     },
 }
 
-impl RelationExpr {
+impl MirRelationExpr {
     /// Reports the schema of the relation.
     ///
     /// This method determines the type through recursive traversal of the
@@ -219,7 +219,7 @@ impl RelationExpr {
     /// judiciously.
     pub fn typ(&self) -> RelationType {
         match self {
-            RelationExpr::Constant { rows, typ } => {
+            MirRelationExpr::Constant { rows, typ } => {
                 for (row, _diff) in rows {
                     for (datum, column_typ) in row.iter().zip(typ.column_types.iter()) {
                         // If the record will be observed, we should validate its type.
@@ -240,9 +240,9 @@ impl RelationExpr {
                     result
                 }
             }
-            RelationExpr::Get { typ, .. } => typ.clone(),
-            RelationExpr::Let { body, .. } => body.typ(),
-            RelationExpr::Project { input, outputs } => {
+            MirRelationExpr::Get { typ, .. } => typ.clone(),
+            MirRelationExpr::Let { body, .. } => body.typ(),
+            MirRelationExpr::Project { input, outputs } => {
                 let input_typ = input.typ();
                 let mut output_typ = RelationType::new(
                     outputs
@@ -261,7 +261,7 @@ impl RelationExpr {
                 }
                 output_typ
             }
-            RelationExpr::Map { input, scalars } => {
+            MirRelationExpr::Map { input, scalars } => {
                 let mut typ = input.typ();
                 let arity = typ.column_types.len();
 
@@ -271,16 +271,16 @@ impl RelationExpr {
                     // assess whether the scalar preserves uniqueness,
                     // and could participate in a key!
 
-                    fn uniqueness(expr: &ScalarExpr) -> Option<usize> {
+                    fn uniqueness(expr: &MirScalarExpr) -> Option<usize> {
                         match expr {
-                            ScalarExpr::CallUnary { func, expr } => {
+                            MirScalarExpr::CallUnary { func, expr } => {
                                 if func.preserves_uniqueness() {
                                     uniqueness(expr)
                                 } else {
                                     None
                                 }
                             }
-                            ScalarExpr::Column(c) => Some(*c),
+                            MirScalarExpr::Column(c) => Some(*c),
                             _ => None,
                         }
                     }
@@ -313,7 +313,7 @@ impl RelationExpr {
 
                 typ
             }
-            RelationExpr::FlatMap {
+            MirRelationExpr::FlatMap {
                 input,
                 func,
                 exprs: _,
@@ -324,8 +324,8 @@ impl RelationExpr {
                 // FlatMap can add duplicate rows, so input keys are no longer valid
                 RelationType::new(typ.column_types)
             }
-            RelationExpr::Filter { input, .. } => input.typ(),
-            RelationExpr::Join {
+            MirRelationExpr::Filter { input, .. } => input.typ(),
+            MirRelationExpr::Join {
                 inputs,
                 equivalences,
                 ..
@@ -359,7 +359,7 @@ impl RelationExpr {
                 }
                 typ
             }
-            RelationExpr::Reduce {
+            MirRelationExpr::Reduce {
                 input,
                 group_key,
                 aggregates,
@@ -381,14 +381,14 @@ impl RelationExpr {
                 for key in input_typ.keys.iter() {
                     if key
                         .iter()
-                        .all(|k| group_key.contains(&ScalarExpr::Column(*k)))
+                        .all(|k| group_key.contains(&MirScalarExpr::Column(*k)))
                     {
                         keys.push(
                             key.iter()
                                 .map(|i| {
                                     group_key
                                         .iter()
-                                        .position(|k| k == &ScalarExpr::Column(*i))
+                                        .position(|k| k == &MirScalarExpr::Column(*i))
                                         .unwrap()
                                 })
                                 .collect::<Vec<_>>(),
@@ -403,8 +403,8 @@ impl RelationExpr {
                 }
                 result
             }
-            RelationExpr::TopK { input, .. } => input.typ(),
-            RelationExpr::Negate { input } => {
+            MirRelationExpr::TopK { input, .. } => input.typ(),
+            MirRelationExpr::Negate { input } => {
                 // Although negate may have distinct records for each key,
                 // the multiplicity is -1 rather than 1. This breaks many
                 // of the optimization uses of "keys".
@@ -412,8 +412,8 @@ impl RelationExpr {
                 typ.keys.clear();
                 typ
             }
-            RelationExpr::Threshold { input } => input.typ(),
-            RelationExpr::Union { base, inputs } => {
+            MirRelationExpr::Threshold { input } => input.typ(),
+            MirRelationExpr::Union { base, inputs } => {
                 let mut base_cols = base.typ().column_types;
                 for input in inputs {
                     for (base_col, col) in base_cols.iter_mut().zip_eq(input.typ().column_types) {
@@ -426,7 +426,7 @@ impl RelationExpr {
                 RelationType::new(base_cols)
                 // Important: do not inherit keys of either input, as not unique.
             }
-            RelationExpr::ArrangeBy { input, .. } => input.typ(),
+            MirRelationExpr::ArrangeBy { input, .. } => input.typ(),
         }
     }
 
@@ -442,7 +442,7 @@ impl RelationExpr {
     /// each row will have a multiplicity of one.
     pub fn constant(rows: Vec<Vec<Datum>>, typ: RelationType) -> Self {
         let rows = rows.into_iter().map(|row| (row, 1)).collect();
-        RelationExpr::constant_diff(rows, typ)
+        MirRelationExpr::constant_diff(rows, typ)
     }
 
     /// Constructs a constant collection from specific rows and schema, where
@@ -463,12 +463,12 @@ impl RelationExpr {
             .into_iter()
             .map(move |(row, diff)| (row_packer.pack(row), diff))
             .collect();
-        RelationExpr::Constant { rows, typ }
+        MirRelationExpr::Constant { rows, typ }
     }
 
     /// Constructs the expression for getting a global collection
     pub fn global_get(id: GlobalId, typ: RelationType) -> Self {
-        RelationExpr::Get {
+        MirRelationExpr::Get {
             id: Id::Global(id),
             typ,
         }
@@ -476,23 +476,23 @@ impl RelationExpr {
 
     /// Retains only the columns specified by `output`.
     pub fn project(self, outputs: Vec<usize>) -> Self {
-        RelationExpr::Project {
+        MirRelationExpr::Project {
             input: Box::new(self),
             outputs,
         }
     }
 
     /// Append to each row the results of applying elements of `scalar`.
-    pub fn map(self, scalars: Vec<ScalarExpr>) -> Self {
-        RelationExpr::Map {
+    pub fn map(self, scalars: Vec<MirScalarExpr>) -> Self {
+        MirRelationExpr::Map {
             input: Box::new(self),
             scalars,
         }
     }
 
     /// Like `map`, but yields zero-or-more output rows per input row
-    pub fn flat_map(self, func: TableFunc, exprs: Vec<ScalarExpr>) -> Self {
-        RelationExpr::FlatMap {
+    pub fn flat_map(self, func: TableFunc, exprs: Vec<MirScalarExpr>) -> Self {
+        MirRelationExpr::FlatMap {
             input: Box::new(self),
             func,
             exprs,
@@ -503,9 +503,9 @@ impl RelationExpr {
     /// Retain only the rows satisifying each of several predicates.
     pub fn filter<I>(self, predicates: I) -> Self
     where
-        I: IntoIterator<Item = ScalarExpr>,
+        I: IntoIterator<Item = MirScalarExpr>,
     {
-        RelationExpr::Filter {
+        MirRelationExpr::Filter {
             input: Box::new(self),
             predicates: predicates.into_iter().collect(),
         }
@@ -513,7 +513,7 @@ impl RelationExpr {
 
     /// Form the Cartesian outer-product of rows in both inputs.
     pub fn product(self, right: Self) -> Self {
-        RelationExpr::join(vec![self, right], vec![])
+        MirRelationExpr::join(vec![self, right], vec![])
     }
 
     /// Performs a relational equijoin among the input collections.
@@ -529,7 +529,7 @@ impl RelationExpr {
     ///
     /// ```rust
     /// use repr::{Datum, ColumnType, RelationType, ScalarType};
-    /// use expr::RelationExpr;
+    /// use expr::MirRelationExpr;
     ///
     /// // A common schema for each input.
     /// let schema = RelationType::new(vec![
@@ -541,14 +541,14 @@ impl RelationExpr {
     /// let data = vec![Datum::Int32(0), Datum::Int32(1)];
     ///
     /// // Three collections that could have been different.
-    /// let input0 = RelationExpr::constant(vec![data.clone()], schema.clone());
-    /// let input1 = RelationExpr::constant(vec![data.clone()], schema.clone());
-    /// let input2 = RelationExpr::constant(vec![data.clone()], schema.clone());
+    /// let input0 = MirRelationExpr::constant(vec![data.clone()], schema.clone());
+    /// let input1 = MirRelationExpr::constant(vec![data.clone()], schema.clone());
+    /// let input2 = MirRelationExpr::constant(vec![data.clone()], schema.clone());
     ///
     /// // Join the three relations looking for triangles, like so.
     /// //
     /// //     Output(A,B,C) := Input0(A,B), Input1(B,C), Input2(A,C)
-    /// let joined = RelationExpr::join(
+    /// let joined = MirRelationExpr::join(
     ///     vec![input0, input1, input2],
     ///     vec![
     ///         vec![(0,0), (2,0)], // fields A of inputs 0 and 2.
@@ -561,14 +561,14 @@ impl RelationExpr {
     /// // A projection resolves this and produces the correct output.
     /// let result = joined.project(vec![0, 1, 3]);
     /// ```
-    pub fn join(inputs: Vec<RelationExpr>, variables: Vec<Vec<(usize, usize)>>) -> Self {
+    pub fn join(inputs: Vec<MirRelationExpr>, variables: Vec<Vec<(usize, usize)>>) -> Self {
         let input_mapper = join_input_mapper::JoinInputMapper::new(&inputs);
 
         let equivalences = variables
             .into_iter()
             .map(|vs| {
                 vs.into_iter()
-                    .map(|(r, c)| input_mapper.map_expr_to_global(ScalarExpr::Column(c), r))
+                    .map(|(r, c)| input_mapper.map_expr_to_global(MirScalarExpr::Column(c), r))
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
@@ -577,8 +577,11 @@ impl RelationExpr {
     }
 
     /// Constructs a join operator from inputs and required-equal scalar expressions.
-    pub fn join_scalars(inputs: Vec<RelationExpr>, equivalences: Vec<Vec<ScalarExpr>>) -> Self {
-        RelationExpr::Join {
+    pub fn join_scalars(
+        inputs: Vec<MirRelationExpr>,
+        equivalences: Vec<Vec<MirScalarExpr>>,
+    ) -> Self {
+        MirRelationExpr::Join {
             inputs,
             equivalences,
             demand: None,
@@ -597,9 +600,9 @@ impl RelationExpr {
         aggregates: Vec<AggregateExpr>,
         expected_group_size: Option<usize>,
     ) -> Self {
-        RelationExpr::Reduce {
+        MirRelationExpr::Reduce {
             input: Box::new(self),
-            group_key: group_key.into_iter().map(ScalarExpr::Column).collect(),
+            group_key: group_key.into_iter().map(MirScalarExpr::Column).collect(),
             aggregates,
             monotonic: false,
             expected_group_size,
@@ -619,7 +622,7 @@ impl RelationExpr {
         limit: Option<usize>,
         offset: usize,
     ) -> Self {
-        RelationExpr::TopK {
+        MirRelationExpr::TopK {
             input: Box::new(self),
             group_key,
             order_key,
@@ -631,7 +634,7 @@ impl RelationExpr {
 
     /// Negates the occurrences of each row.
     pub fn negate(self) -> Self {
-        RelationExpr::Negate {
+        MirRelationExpr::Negate {
             input: Box::new(self),
         }
     }
@@ -650,7 +653,7 @@ impl RelationExpr {
 
     /// Discards rows with a negative frequency.
     pub fn threshold(self) -> Self {
-        RelationExpr::Threshold {
+        MirRelationExpr::Threshold {
             input: Box::new(self),
         }
     }
@@ -661,11 +664,11 @@ impl RelationExpr {
     /// constructed.
     pub fn union_many(mut inputs: Vec<Self>, typ: RelationType) -> Self {
         if inputs.len() == 0 {
-            RelationExpr::Constant { rows: vec![], typ }
+            MirRelationExpr::Constant { rows: vec![], typ }
         } else if inputs.len() == 1 {
             inputs.into_element()
         } else {
-            RelationExpr::Union {
+            MirRelationExpr::Union {
                 base: Box::new(inputs.remove(0)),
                 inputs,
             }
@@ -674,15 +677,15 @@ impl RelationExpr {
 
     /// Produces one collection where each row is present with the sum of its frequencies in each input.
     pub fn union(self, other: Self) -> Self {
-        RelationExpr::Union {
+        MirRelationExpr::Union {
             base: Box::new(self),
             inputs: vec![other],
         }
     }
 
     /// Arranges the collection by the specified columns
-    pub fn arrange_by(self, keys: &[Vec<ScalarExpr>]) -> Self {
-        RelationExpr::ArrangeBy {
+    pub fn arrange_by(self, keys: &[Vec<MirScalarExpr>]) -> Self {
+        MirRelationExpr::ArrangeBy {
             input: Box::new(self),
             keys: keys.to_owned(),
         }
@@ -693,7 +696,7 @@ impl RelationExpr {
     /// A false value does not mean the collection is known to be non-empty,
     /// only that we cannot currently determine that it is statically empty.
     pub fn is_empty(&self) -> bool {
-        if let RelationExpr::Constant { rows, .. } = self {
+        if let MirRelationExpr::Constant { rows, .. } = self {
             rows.is_empty()
         } else {
             false
@@ -714,10 +717,10 @@ impl RelationExpr {
 
     /// Appends global identifiers on which this expression depends to `out`.
     ///
-    /// Unlike [`RelationExpr::global_uses`], this method does not deduplicate
+    /// Unlike [`MirRelationExpr::global_uses`], this method does not deduplicate
     /// the global identifiers.
     pub fn global_uses_into(&self, out: &mut Vec<GlobalId>) {
-        if let RelationExpr::Get {
+        if let MirRelationExpr::Get {
             id: Id::Global(id), ..
         } = self
         {
@@ -726,56 +729,56 @@ impl RelationExpr {
         self.visit1(|expr| expr.global_uses_into(out))
     }
 
-    /// Applies a fallible `f` to each child `RelationExpr`.
+    /// Applies a fallible `f` to each child `MirRelationExpr`.
     pub fn try_visit1<'a, F, E>(&'a self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a Self) -> Result<(), E>,
     {
         match self {
-            RelationExpr::Constant { .. } | RelationExpr::Get { .. } => (),
-            RelationExpr::Let { value, body, .. } => {
+            MirRelationExpr::Constant { .. } | MirRelationExpr::Get { .. } => (),
+            MirRelationExpr::Let { value, body, .. } => {
                 f(value)?;
                 f(body)?;
             }
-            RelationExpr::Project { input, .. } => {
+            MirRelationExpr::Project { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Map { input, .. } => {
+            MirRelationExpr::Map { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::FlatMap { input, .. } => {
+            MirRelationExpr::FlatMap { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Filter { input, .. } => {
+            MirRelationExpr::Filter { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Join { inputs, .. } => {
+            MirRelationExpr::Join { inputs, .. } => {
                 for input in inputs {
                     f(input)?;
                 }
             }
-            RelationExpr::Reduce { input, .. } => {
+            MirRelationExpr::Reduce { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::TopK { input, .. } => {
+            MirRelationExpr::TopK { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Negate { input } => f(input)?,
-            RelationExpr::Threshold { input } => f(input)?,
-            RelationExpr::Union { base, inputs } => {
+            MirRelationExpr::Negate { input } => f(input)?,
+            MirRelationExpr::Threshold { input } => f(input)?,
+            MirRelationExpr::Union { base, inputs } => {
                 f(base)?;
                 for input in inputs {
                     f(input)?;
                 }
             }
-            RelationExpr::ArrangeBy { input, .. } => {
+            MirRelationExpr::ArrangeBy { input, .. } => {
                 f(input)?;
             }
         }
         Ok(())
     }
 
-    /// Applies an infallible `f` to each child `RelationExpr`.
+    /// Applies an infallible `f` to each child `MirRelationExpr`.
     pub fn visit1<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a Self),
@@ -787,7 +790,7 @@ impl RelationExpr {
         .unwrap()
     }
 
-    /// Post-order fallible visitor for each `RelationExpr`.
+    /// Post-order fallible visitor for each `MirRelationExpr`.
     pub fn try_visit<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a Self) -> Result<(), E>,
@@ -796,7 +799,7 @@ impl RelationExpr {
         f(self)
     }
 
-    /// Post-order infallible visitor for each `RelationExpr`.
+    /// Post-order infallible visitor for each `MirRelationExpr`.
     pub fn visit<'a, F>(&'a self, f: &mut F)
     where
         F: FnMut(&'a Self),
@@ -805,56 +808,56 @@ impl RelationExpr {
         f(self)
     }
 
-    /// Applies fallible `f` to each child `RelationExpr`.
+    /// Applies fallible `f` to each child `MirRelationExpr`.
     pub fn try_visit1_mut<'a, F, E>(&'a mut self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a mut Self) -> Result<(), E>,
     {
         match self {
-            RelationExpr::Constant { .. } | RelationExpr::Get { .. } => (),
-            RelationExpr::Let { value, body, .. } => {
+            MirRelationExpr::Constant { .. } | MirRelationExpr::Get { .. } => (),
+            MirRelationExpr::Let { value, body, .. } => {
                 f(value)?;
                 f(body)?;
             }
-            RelationExpr::Project { input, .. } => {
+            MirRelationExpr::Project { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Map { input, .. } => {
+            MirRelationExpr::Map { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::FlatMap { input, .. } => {
+            MirRelationExpr::FlatMap { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Filter { input, .. } => {
+            MirRelationExpr::Filter { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Join { inputs, .. } => {
+            MirRelationExpr::Join { inputs, .. } => {
                 for input in inputs {
                     f(input)?;
                 }
             }
-            RelationExpr::Reduce { input, .. } => {
+            MirRelationExpr::Reduce { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::TopK { input, .. } => {
+            MirRelationExpr::TopK { input, .. } => {
                 f(input)?;
             }
-            RelationExpr::Negate { input } => f(input)?,
-            RelationExpr::Threshold { input } => f(input)?,
-            RelationExpr::Union { base, inputs } => {
+            MirRelationExpr::Negate { input } => f(input)?,
+            MirRelationExpr::Threshold { input } => f(input)?,
+            MirRelationExpr::Union { base, inputs } => {
                 f(base)?;
                 for input in inputs {
                     f(input)?;
                 }
             }
-            RelationExpr::ArrangeBy { input, .. } => {
+            MirRelationExpr::ArrangeBy { input, .. } => {
                 f(input)?;
             }
         }
         Ok(())
     }
 
-    /// Applies infallible `f` to each child `RelationExpr`.
+    /// Applies infallible `f` to each child `MirRelationExpr`.
     pub fn visit1_mut<'a, F>(&'a mut self, mut f: F)
     where
         F: FnMut(&'a mut Self),
@@ -866,7 +869,7 @@ impl RelationExpr {
         .unwrap()
     }
 
-    /// Post-order fallible visitor for each `RelationExpr`.
+    /// Post-order fallible visitor for each `MirRelationExpr`.
     pub fn try_visit_mut<F, E>(&mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut Self) -> Result<(), E>,
@@ -875,7 +878,7 @@ impl RelationExpr {
         f(self)
     }
 
-    /// Post-order infallible visitor for each `RelationExpr`.
+    /// Post-order infallible visitor for each `MirRelationExpr`.
     pub fn visit_mut<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self),
@@ -884,7 +887,7 @@ impl RelationExpr {
         f(self)
     }
 
-    /// Pre-order fallible visitor for each `RelationExpr`.
+    /// Pre-order fallible visitor for each `MirRelationExpr`.
     pub fn try_visit_mut_pre<F, E>(&mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut Self) -> Result<(), E>,
@@ -893,7 +896,7 @@ impl RelationExpr {
         self.try_visit1_mut(|e| e.try_visit_mut_pre(f))
     }
 
-    /// Pre-order fallible visitor for each `RelationExpr`.
+    /// Pre-order fallible visitor for each `MirRelationExpr`.
     pub fn visit_mut_pre<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self),
@@ -902,18 +905,18 @@ impl RelationExpr {
         self.visit1_mut(|e| e.visit_mut_pre(f))
     }
 
-    /// Fallible visitor for the [`ScalarExpr`]s in the relation expression.
-    /// Note that this does not recurse into the `ScalarExpr`s themselves.
+    /// Fallible visitor for the [`MirScalarExpr`]s in the relation expression.
+    /// Note that this does not recurse into the `MirScalarExpr`s themselves.
     pub fn try_visit_scalars_mut<F, E>(&mut self, f: &mut F) -> Result<(), E>
     where
-        F: FnMut(&mut ScalarExpr) -> Result<(), E>,
+        F: FnMut(&mut MirScalarExpr) -> Result<(), E>,
     {
         // Match written out explicitly to reduce the possibility of adding a
-        // new field with a `ScalarExpr` within and forgetting to account for it
+        // new field with a `MirScalarExpr` within and forgetting to account for it
         // here.
         self.try_visit_mut(&mut |e| match e {
-            RelationExpr::Map { scalars, input: _ }
-            | RelationExpr::Filter {
+            MirRelationExpr::Map { scalars, input: _ }
+            | MirRelationExpr::Filter {
                 predicates: scalars,
                 input: _,
             } => {
@@ -922,7 +925,7 @@ impl RelationExpr {
                 }
                 Ok(())
             }
-            RelationExpr::FlatMap {
+            MirRelationExpr::FlatMap {
                 exprs,
                 input: _,
                 func: _,
@@ -933,13 +936,13 @@ impl RelationExpr {
                 }
                 Ok(())
             }
-            RelationExpr::Join {
+            MirRelationExpr::Join {
                 equivalences: keys,
                 inputs: _,
                 demand: _,
                 implementation: _,
             }
-            | RelationExpr::ArrangeBy { input: _, keys } => {
+            | MirRelationExpr::ArrangeBy { input: _, keys } => {
                 for key in keys {
                     for s in key {
                         f(s)?;
@@ -947,7 +950,7 @@ impl RelationExpr {
                 }
                 Ok(())
             }
-            RelationExpr::Reduce {
+            MirRelationExpr::Reduce {
                 group_key,
                 aggregates,
                 ..
@@ -960,18 +963,18 @@ impl RelationExpr {
                 }
                 Ok(())
             }
-            RelationExpr::Constant { rows: _, typ: _ }
-            | RelationExpr::Get { id: _, typ: _ }
-            | RelationExpr::Let {
+            MirRelationExpr::Constant { rows: _, typ: _ }
+            | MirRelationExpr::Get { id: _, typ: _ }
+            | MirRelationExpr::Let {
                 id: _,
                 value: _,
                 body: _,
             }
-            | RelationExpr::Project {
+            | MirRelationExpr::Project {
                 input: _,
                 outputs: _,
             }
-            | RelationExpr::TopK {
+            | MirRelationExpr::TopK {
                 input: _,
                 group_key: _,
                 order_key: _,
@@ -979,16 +982,16 @@ impl RelationExpr {
                 offset: _,
                 monotonic: _,
             }
-            | RelationExpr::Negate { input: _ }
-            | RelationExpr::Threshold { input: _ }
-            | RelationExpr::Union { base: _, inputs: _ } => Ok(()),
+            | MirRelationExpr::Negate { input: _ }
+            | MirRelationExpr::Threshold { input: _ }
+            | MirRelationExpr::Union { base: _, inputs: _ } => Ok(()),
         })
     }
 
     /// Like `try_visit_scalars_mut`, but the closure must be infallible.
     pub fn visit_scalars_mut<F>(&mut self, f: &mut F)
     where
-        F: FnMut(&mut ScalarExpr),
+        F: FnMut(&mut MirScalarExpr),
     {
         self.try_visit_scalars_mut(&mut |s| {
             f(s);
@@ -997,7 +1000,7 @@ impl RelationExpr {
         .unwrap()
     }
 
-    /// Pretty-print this RelationExpr to a string.
+    /// Pretty-print this MirRelationExpr to a string.
     ///
     /// This method allows an additional `ExprHumanizer` which can annotate
     /// identifiers with human-meaningful names for the identifiers.
@@ -1005,21 +1008,21 @@ impl RelationExpr {
         Explanation::new(self, id_humanizer).to_string()
     }
 
-    /// Pretty-print this RelationExpr to a string.
+    /// Pretty-print this MirRelationExpr to a string.
     pub fn pretty(&self) -> String {
         Explanation::new(self, &DummyHumanizer).to_string()
     }
 
-    /// Take ownership of `self`, leaving an empty `RelationExpr::Constant` with the correct type.
-    pub fn take_safely(&mut self) -> RelationExpr {
+    /// Take ownership of `self`, leaving an empty `MirRelationExpr::Constant` with the correct type.
+    pub fn take_safely(&mut self) -> MirRelationExpr {
         let typ = self.typ();
-        std::mem::replace(self, RelationExpr::Constant { rows: vec![], typ })
+        std::mem::replace(self, MirRelationExpr::Constant { rows: vec![], typ })
     }
-    /// Take ownership of `self`, leaving an empty `RelationExpr::Constant` with an **incorrect** type.
+    /// Take ownership of `self`, leaving an empty `MirRelationExpr::Constant` with an **incorrect** type.
     ///
     /// This should only be used if `self` is about to be dropped or otherwise overwritten.
-    pub fn take_dangerous(&mut self) -> RelationExpr {
-        let empty = RelationExpr::Constant {
+    pub fn take_dangerous(&mut self) -> MirRelationExpr {
+        let empty = MirRelationExpr::Constant {
             rows: vec![],
             typ: RelationType::new(Vec::new()),
         };
@@ -1029,9 +1032,9 @@ impl RelationExpr {
     /// Replaces `self` with some logic applied to `self`.
     pub fn replace_using<F>(&mut self, logic: F)
     where
-        F: FnOnce(RelationExpr) -> RelationExpr,
+        F: FnOnce(MirRelationExpr) -> MirRelationExpr,
     {
-        let empty = RelationExpr::Constant {
+        let empty = MirRelationExpr::Constant {
             rows: vec![],
             typ: RelationType::new(Vec::new()),
         };
@@ -1040,21 +1043,21 @@ impl RelationExpr {
     }
 
     /// Store `self` in a `Let` and pass the corresponding `Get` to `body`
-    pub fn let_in<Body>(self, id_gen: &mut IdGen, body: Body) -> super::RelationExpr
+    pub fn let_in<Body>(self, id_gen: &mut IdGen, body: Body) -> super::MirRelationExpr
     where
-        Body: FnOnce(&mut IdGen, RelationExpr) -> super::RelationExpr,
+        Body: FnOnce(&mut IdGen, MirRelationExpr) -> super::MirRelationExpr,
     {
-        if let RelationExpr::Get { .. } = self {
+        if let MirRelationExpr::Get { .. } = self {
             // already done
             body(id_gen, self)
         } else {
             let id = LocalId::new(id_gen.allocate_id());
-            let get = RelationExpr::Get {
+            let get = MirRelationExpr::Get {
                 id: Id::Local(id),
                 typ: self.typ(),
             };
             let body = (body)(id_gen, get);
-            RelationExpr::Let {
+            MirRelationExpr::Let {
                 id,
                 value: Box::new(self),
                 body: Box::new(body),
@@ -1067,12 +1070,12 @@ impl RelationExpr {
     pub fn anti_lookup(
         self,
         id_gen: &mut IdGen,
-        keys_and_values: RelationExpr,
+        keys_and_values: MirRelationExpr,
         default: Vec<(Datum, ColumnType)>,
-    ) -> RelationExpr {
+    ) -> MirRelationExpr {
         assert_eq!(keys_and_values.arity() - self.arity(), default.len());
         self.let_in(id_gen, |_id_gen, get_keys| {
-            RelationExpr::join(
+            MirRelationExpr::join(
                 vec![
                     // all the missing keys (with count 1)
                     keys_and_values
@@ -1092,7 +1095,7 @@ impl RelationExpr {
             // `.map(<default_expr>)`, but using a join allows for
             // potential predicate pushdown and elision in the
             // optimizer.
-            .product(RelationExpr::constant(
+            .product(MirRelationExpr::constant(
                 vec![default.iter().map(|(datum, _)| *datum).collect()],
                 RelationType::new(default.iter().map(|(_, typ)| typ.clone()).collect()),
             ))
@@ -1106,9 +1109,9 @@ impl RelationExpr {
     pub fn lookup(
         self,
         id_gen: &mut IdGen,
-        keys_and_values: RelationExpr,
+        keys_and_values: MirRelationExpr,
         default: Vec<(Datum<'static>, ColumnType)>,
-    ) -> RelationExpr {
+    ) -> MirRelationExpr {
         keys_and_values.let_in(id_gen, |id_gen, get_keys_and_values| {
             get_keys_and_values.clone().union(self.anti_lookup(
                 id_gen,
@@ -1139,7 +1142,7 @@ impl fmt::Display for ColumnOrder {
     }
 }
 
-/// Manages the allocation of locally unique IDs when building a [`RelationExpr`].
+/// Manages the allocation of locally unique IDs when building a [`MirRelationExpr`].
 #[derive(Debug, Default)]
 pub struct IdGen {
     id: u64,
@@ -1160,7 +1163,7 @@ pub struct AggregateExpr {
     /// Names the aggregation function.
     pub func: AggregateFunc,
     /// An expression which extracts from each row the input to `func`.
-    pub expr: ScalarExpr,
+    pub expr: MirScalarExpr,
     /// Should the aggregation be applied only to distinct results in each group.
     pub distinct: bool,
 }
@@ -1197,15 +1200,15 @@ pub enum JoinImplementation {
     /// Each collection index should occur exactly once, either in the first
     /// position or somewhere in the list.
     Differential(
-        (usize, Option<Vec<ScalarExpr>>),
-        Vec<(usize, Vec<ScalarExpr>)>,
+        (usize, Option<Vec<MirScalarExpr>>),
+        Vec<(usize, Vec<MirScalarExpr>)>,
     ),
     /// Perform independent delta query dataflows for each input.
     ///
     /// The argument is a sequence of plans, for the input collections in order.
     /// Each plan starts from the corresponding index, and then in sequence joins
     /// against collections identified by index and with the specified arrangement key.
-    DeltaQuery(Vec<Vec<(usize, Vec<ScalarExpr>)>>),
+    DeltaQuery(Vec<Vec<(usize, Vec<MirScalarExpr>)>>),
     /// No implementation yet selected.
     Unimplemented,
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -41,7 +41,7 @@ use repr::adt::regex::Regex;
 use repr::{strconv, ColumnName, ColumnType, Datum, RowArena, RowPacker, ScalarType};
 
 use crate::scalar::func::format::DateTimeFormat;
-use crate::{like_pattern, EvalError, ScalarExpr};
+use crate::{like_pattern, EvalError, MirScalarExpr};
 
 mod format;
 
@@ -69,8 +69,8 @@ impl fmt::Display for NullaryFunc {
 pub fn and<'a>(
     datums: &[Datum<'a>],
     temp_storage: &'a RowArena,
-    a_expr: &'a ScalarExpr,
-    b_expr: &'a ScalarExpr,
+    a_expr: &'a MirScalarExpr,
+    b_expr: &'a MirScalarExpr,
 ) -> Result<Datum<'a>, EvalError> {
     match a_expr.eval(datums, temp_storage)? {
         Datum::False => Ok(Datum::False),
@@ -86,8 +86,8 @@ pub fn and<'a>(
 pub fn or<'a>(
     datums: &[Datum<'a>],
     temp_storage: &'a RowArena,
-    a_expr: &'a ScalarExpr,
-    b_expr: &'a ScalarExpr,
+    a_expr: &'a MirScalarExpr,
+    b_expr: &'a MirScalarExpr,
 ) -> Result<Datum<'a>, EvalError> {
     match a_expr.eval(datums, temp_storage)? {
         Datum::True => Ok(Datum::True),
@@ -376,7 +376,7 @@ fn cast_string_to_date<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 fn cast_string_to_list<'a>(
     a: Datum<'a>,
     list_typ: &ScalarType,
-    cast_expr: &'a ScalarExpr,
+    cast_expr: &'a MirScalarExpr,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
     let parsed_datums = strconv::parse_list(
@@ -398,7 +398,7 @@ fn cast_string_to_list<'a>(
 fn cast_string_to_map<'a>(
     a: Datum<'a>,
     map_typ: &ScalarType,
-    cast_expr: &'a ScalarExpr,
+    cast_expr: &'a MirScalarExpr,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
     let parsed_map = strconv::parse_map(
@@ -623,7 +623,7 @@ fn cast_uuid_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a
 /// `cast_expr` and collecting the results into a new list ("list2").
 fn cast_list1_to_list2<'a>(
     a: Datum,
-    cast_expr: &'a ScalarExpr,
+    cast_expr: &'a MirScalarExpr,
     temp_storage: &'a RowArena,
 ) -> Result<Datum<'a>, EvalError> {
     let mut cast_datums = Vec::new();
@@ -2108,8 +2108,8 @@ impl BinaryFunc {
         &'a self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a_expr: &'a ScalarExpr,
-        b_expr: &'a ScalarExpr,
+        a_expr: &'a MirScalarExpr,
+        b_expr: &'a MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         macro_rules! eager {
             ($func:expr $(, $args:expr)*) => {{
@@ -2770,14 +2770,14 @@ pub enum UnaryFunc {
         return_ty: ScalarType,
         // The expression to cast the discovered list elements to the list's
         // elements' type
-        cast_expr: Box<ScalarExpr>,
+        cast_expr: Box<MirScalarExpr>,
     },
     CastStringToMap {
         // Target map's value type
         return_ty: ScalarType,
         // The expression used to cast the discovered values to the map's
         // values' type
-        cast_expr: Box<ScalarExpr>,
+        cast_expr: Box<MirScalarExpr>,
     },
     CastStringToTime,
     CastStringToTimestamp,
@@ -2818,7 +2818,7 @@ pub enum UnaryFunc {
         // List2's type
         return_ty: ScalarType,
         // The expression to cast List1's elements to List2's elements' type
-        cast_expr: Box<ScalarExpr>,
+        cast_expr: Box<MirScalarExpr>,
     },
     CastMapToString {
         ty: ScalarType,
@@ -2870,7 +2870,7 @@ impl UnaryFunc {
         &'a self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        a: &'a ScalarExpr,
+        a: &'a MirScalarExpr,
     ) -> Result<Datum<'a>, EvalError> {
         let a = a.eval(datums, temp_storage)?;
         if self.propagates_nulls() && a.is_null() {
@@ -3344,7 +3344,7 @@ impl fmt::Display for UnaryFunc {
 fn coalesce<'a>(
     datums: &[Datum<'a>],
     temp_storage: &'a RowArena,
-    exprs: &'a [ScalarExpr],
+    exprs: &'a [MirScalarExpr],
 ) -> Result<Datum<'a>, EvalError> {
     for e in exprs {
         let d = e.eval(datums, temp_storage)?;
@@ -4191,7 +4191,7 @@ impl VariadicFunc {
         &'a self,
         datums: &[Datum<'a>],
         temp_storage: &'a RowArena,
-        exprs: &'a [ScalarExpr],
+        exprs: &'a [MirScalarExpr],
     ) -> Result<Datum<'a>, EvalError> {
         macro_rules! eager {
             ($func:ident $(, $args:expr)*) => {{

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1403,11 +1403,11 @@ impl_display_t!(Assignment);
 /// Specifies what [Statement::Explain] is actually explaining
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ExplainStage {
-    /// The sql::RelationExpr after parsing
+    /// The sql::HirRelationExpr after parsing
     RawPlan,
-    /// The expr::RelationExpr after decorrelation
+    /// The expr::MirRelationExpr after decorrelation
     DecorrelatedPlan,
-    /// The expr::RelationExpr after optimization
+    /// The expr::MirRelationExpr after optimization
     OptimizedPlan,
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -17,7 +17,7 @@ use std::time::SystemTime;
 use std::{error::Error, unimplemented};
 
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};
-use expr::{DummyHumanizer, ExprHumanizer, GlobalId, ScalarExpr};
+use expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
 use repr::{ColumnType, RelationDesc, ScalarType};
 use sql_parser::ast::{Expr, Raw};
 use uuid::Uuid;
@@ -202,7 +202,7 @@ pub trait CatalogItem {
 
     /// Returns the index details associated with the catalog item, if the
     /// catalog item is an index.
-    fn index_details(&self) -> Option<(&[ScalarExpr], GlobalId)>;
+    fn index_details(&self) -> Option<(&[MirScalarExpr], GlobalId)>;
 
     /// Returns the column defaults associated with the catalog item, if the
     /// catalog item is a table.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -51,7 +51,7 @@ pub(crate) mod transform_ast;
 pub(crate) mod transform_expr;
 pub(crate) mod typeconv;
 
-pub use self::expr::RelationExpr;
+pub use self::expr::HirRelationExpr;
 pub use error::PlanError;
 pub use explain::Explanation;
 // This is used by sqllogictest to turn SQL values into `Datum`s.
@@ -129,7 +129,7 @@ pub enum Plan {
     CommitTransaction,
     AbortTransaction,
     Peek {
-        source: ::expr::RelationExpr,
+        source: ::expr::MirRelationExpr,
         when: PeekWhen,
         finishing: RowSetFinishing,
         copy_to: Option<CopyFormat>,
@@ -145,8 +145,8 @@ pub enum Plan {
     },
     SendRows(Vec<Row>),
     ExplainPlan {
-        raw_plan: RelationExpr,
-        decorrelated_plan: ::expr::RelationExpr,
+        raw_plan: HirRelationExpr,
+        decorrelated_plan: ::expr::MirRelationExpr,
         row_set_finishing: Option<RowSetFinishing>,
         stage: ExplainStage,
         options: ExplainOptions,
@@ -159,7 +159,7 @@ pub enum Plan {
     },
     Insert {
         id: GlobalId,
-        values: ::expr::RelationExpr,
+        values: ::expr::MirRelationExpr,
     },
     AlterItemRename {
         id: Option<GlobalId>,
@@ -206,7 +206,7 @@ pub struct Sink {
 #[derive(Clone, Debug)]
 pub struct View {
     pub create_sql: String,
-    pub expr: ::expr::RelationExpr,
+    pub expr: ::expr::MirRelationExpr,
     pub column_names: Vec<Option<ColumnName>>,
     pub temporary: bool,
 }
@@ -215,7 +215,7 @@ pub struct View {
 pub struct Index {
     pub create_sql: String,
     pub on: GlobalId,
-    pub keys: Vec<::expr::ScalarExpr>,
+    pub keys: Vec<::expr::MirScalarExpr>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -8,16 +8,16 @@
 // by the Apache License, Version 2.0.
 
 //! SQL `Query`s are the declarative, computational part of SQL.
-//! This module turns `Query`s into `RelationExpr`s - a more explicit, algebraic way of describing computation.
+//! This module turns `Query`s into `HirRelationExpr`s - a more explicit, algebraic way of describing computation.
 
 //! Functions named plan_* are typically responsible for handling a single node of the SQL ast. Eg `plan_query` is responsible for handling `sqlparser::ast::Query`.
-//! plan_* functions which correspond to operations on relations typically return a `RelationExpr`.
-//! plan_* functions which correspond to operations on scalars typically return a `ScalarExpr` and a `ScalarType`. (The latter is because it's not always possible to infer from a `ScalarExpr` what the intended type is - notably in the case of decimals where the scale/precision are encoded only in the type).
+//! plan_* functions which correspond to operations on relations typically return a `HirRelationExpr`.
+//! plan_* functions which correspond to operations on scalars typically return a `HirScalarExpr` and a `ScalarType`. (The latter is because it's not always possible to infer from a `HirScalarExpr` what the intended type is - notably in the case of decimals where the scale/precision are encoded only in the type).
 
 //! Aggregates are particularly twisty.
 //! In SQL, a GROUP BY turns any columns not in the group key into vectors of values. Then anywhere later in the scope, an aggregate function can be applied to that group. Inside the arguments of an aggregate function, other normal functions are applied element-wise over the vectors. Thus `SELECT sum(foo.x + foo.y) FROM foo GROUP BY x` means adding the scalar `x` to the vector `y` and summing the results.
-//! In `RelationExpr`, aggregates can only be applied immediately at the time of grouping.
-//! To deal with this, whenever we see a SQL GROUP BY we look ahead for aggregates and precompute them in the `RelationExpr::Reduce`. When we reach the same aggregates during normal planning later on, we look them up in an `ExprContext` to find the precomputed versions.
+//! In `HirRelationExpr`, aggregates can only be applied immediately at the time of grouping.
+//! To deal with this, whenever we see a SQL GROUP BY we look ahead for aggregates and precompute them in the `HirRelationExpr::Reduce`. When we reach the same aggregates during normal planning later on, we look them up in an `ExprContext` to find the precomputed versions.
 
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -49,7 +49,7 @@ use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, BinaryFunc, CoercibleScalarExpr, ColumnOrder,
-    ColumnRef, JoinKind, RelationExpr, ScalarExpr, UnaryFunc, VariadicFunc,
+    ColumnRef, HirRelationExpr, HirScalarExpr, JoinKind, UnaryFunc, VariadicFunc,
 };
 use crate::plan::func::{self, Func, FuncSpec};
 use crate::plan::plan_utils;
@@ -58,7 +58,7 @@ use crate::plan::statement::StatementContext;
 use crate::plan::transform_ast;
 use crate::plan::typeconv::{self, CastContext};
 
-/// Plans a top-level query, returning the `RelationExpr` describing the query
+/// Plans a top-level query, returning the `HirRelationExpr` describing the query
 /// plan, the `RelationDesc` describing the shape of the result set, a
 /// `RowSetFinishing` describing post-processing that must occur before results
 /// are sent to the client, and the types of the parameters in the query, if any
@@ -70,7 +70,7 @@ pub fn plan_root_query(
     scx: &StatementContext,
     mut query: Query<Raw>,
     lifetime: QueryLifetime,
-) -> Result<(RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
+) -> Result<(HirRelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
     transform_ast::transform_query(scx, &mut query)?;
     let mut qcx = QueryContext::root(scx, lifetime);
     let (mut expr, scope, mut finishing) = plan_query(&mut qcx, &query)?;
@@ -106,7 +106,7 @@ pub fn plan_root_query(
 /// replaced with the trivial projection. When unsuccessful, no changes are made
 /// to any of the inputs.
 fn try_push_projection_order_by(
-    expr: &mut RelationExpr,
+    expr: &mut HirRelationExpr,
     project: &mut Vec<usize>,
     order_by: &mut Vec<ColumnOrder>,
 ) -> bool {
@@ -131,7 +131,7 @@ pub fn plan_insert_query(
     table_name: ObjectName,
     columns: Vec<Ident>,
     source: InsertSource<Raw>,
-) -> Result<(GlobalId, RelationExpr), anyhow::Error> {
+) -> Result<(GlobalId, HirRelationExpr), anyhow::Error> {
     let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     let table = scx.resolve_item(table_name)?;
 
@@ -213,7 +213,9 @@ pub fn plan_insert_query(
                 }
             }
         }
-        InsertSource::DefaultValues => RelationExpr::constant(vec![vec![]], RelationType::empty()),
+        InsertSource::DefaultValues => {
+            HirRelationExpr::constant(vec![vec![]], RelationType::empty())
+        }
     };
 
     let typ = qcx.relation_type(&expr);
@@ -282,9 +284,9 @@ struct CastRelationError {
 fn cast_relation<'a, I>(
     qcx: &QueryContext,
     ccx: CastContext,
-    expr: RelationExpr,
+    expr: HirRelationExpr,
     target_types: I,
-) -> Result<RelationExpr, CastRelationError>
+) -> Result<HirRelationExpr, CastRelationError>
 where
     I: IntoIterator<Item = &'a ScalarType>,
 {
@@ -305,7 +307,7 @@ where
     let mut project_key = vec![];
     for (i, (typ, target_typ)) in source_types.zip_eq(target_types).enumerate() {
         if typ != target_typ {
-            let expr = ScalarExpr::Column(ColumnRef {
+            let expr = HirScalarExpr::Column(ColumnRef {
                 level: 0,
                 column: i,
             });
@@ -377,7 +379,7 @@ pub fn plan_default_expr(
     scx: &StatementContext,
     expr: &Expr<Raw>,
     target_ty: &ScalarType,
-) -> Result<ScalarExpr, anyhow::Error> {
+) -> Result<HirScalarExpr, anyhow::Error> {
     let qcx = &QueryContext::root(scx, QueryLifetime::OneShot);
     let ecx = &ExprContext {
         qcx: &qcx,
@@ -394,7 +396,7 @@ pub fn plan_index_exprs<'a>(
     scx: &'a StatementContext,
     on_desc: &RelationDesc,
     exprs: Vec<Expr<Raw>>,
-) -> Result<Vec<::expr::ScalarExpr>, anyhow::Error> {
+) -> Result<Vec<::expr::MirScalarExpr>, anyhow::Error> {
     let scope = Scope::from_source(None, on_desc.iter_names(), Some(Scope::empty(None)));
     let qcx = &QueryContext::root(scx, QueryLifetime::Static);
     let ecx = &ExprContext {
@@ -414,9 +416,12 @@ pub fn plan_index_exprs<'a>(
     Ok(out)
 }
 
-fn plan_expr_or_col_index(ecx: &ExprContext, e: &Expr<Raw>) -> Result<ScalarExpr, anyhow::Error> {
+fn plan_expr_or_col_index(
+    ecx: &ExprContext,
+    e: &Expr<Raw>,
+) -> Result<HirScalarExpr, anyhow::Error> {
     match check_col_index(&ecx.name, e, ecx.relation_type.column_types.len())? {
-        Some(column) => Ok(ScalarExpr::Column(ColumnRef { level: 0, column })),
+        Some(column) => Ok(HirScalarExpr::Column(ColumnRef { level: 0, column })),
         _ => plan_expr(ecx, e)?.type_as_any(ecx),
     }
 }
@@ -444,7 +449,7 @@ fn check_col_index(name: &str, e: &Expr<Raw>, max: usize) -> Result<Option<usize
 fn plan_query(
     qcx: &mut QueryContext,
     q: &Query<Raw>,
-) -> Result<(RelationExpr, Scope, RowSetFinishing), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope, RowSetFinishing), anyhow::Error> {
     // Retain the old values of various CTE names so that we can restore them after we're done
     // planning this SELECT.
     let mut old_cte_values = Vec::new();
@@ -549,10 +554,10 @@ fn plan_query(
 fn plan_subquery(
     qcx: &mut QueryContext,
     q: &Query<Raw>,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     let (mut expr, scope, finishing) = plan_query(qcx, q)?;
     if finishing.limit.is_some() || finishing.offset > 0 {
-        expr = RelationExpr::TopK {
+        expr = HirRelationExpr::TopK {
             input: Box::new(expr),
             group_key: vec![],
             order_key: finishing.order_by,
@@ -566,7 +571,7 @@ fn plan_subquery(
 fn plan_set_expr(
     qcx: &mut QueryContext,
     q: &SetExpr<Raw>,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     match q {
         SetExpr::Select(select) => {
             let order_by_exprs = &[];
@@ -585,7 +590,7 @@ fn plan_set_expr(
             let (left_expr, left_scope) = plan_set_expr(qcx, left)?;
             let (right_expr, _right_scope) = plan_set_expr(qcx, right)?;
 
-            // TODO(jamii) this type-checking is redundant with RelationExpr::typ, but currently it seems that we need both because RelationExpr::typ is not allowed to return errors
+            // TODO(jamii) this type-checking is redundant with HirRelationExpr::typ, but currently it seems that we need both because HirRelationExpr::typ is not allowed to return errors
             let left_types = qcx.relation_type(&left_expr).column_types;
             let right_types = qcx.relation_type(&right_expr).column_types;
             if left_types.len() != right_types.len() {
@@ -662,7 +667,7 @@ fn plan_values(
     qcx: &QueryContext,
     values: &[Vec<Expr<Raw>>],
     type_hints: Option<Vec<&ScalarType>>,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     ensure!(
         !values.is_empty(),
         "Can't infer a type for empty VALUES expression"
@@ -712,11 +717,11 @@ fn plan_values(
     let mut rows = vec![];
     for _ in 0..nrows {
         let row: Vec<_> = (0..ncols).map(|i| col_iters[i].next().unwrap()).collect();
-        let empty = RelationExpr::constant(vec![vec![]], RelationType::new(vec![]));
+        let empty = HirRelationExpr::constant(vec![vec![]], RelationType::new(vec![]));
         rows.push(empty.map(row));
     }
-    let out = RelationExpr::Union {
-        base: Box::new(RelationExpr::constant(vec![], typ)),
+    let out = HirRelationExpr::Union {
+        base: Box::new(HirRelationExpr::constant(vec![], typ)),
         inputs: rows,
     };
 
@@ -730,9 +735,9 @@ fn plan_values(
     Ok((out, scope))
 }
 
-fn plan_join_identity(qcx: &QueryContext) -> (RelationExpr, Scope) {
+fn plan_join_identity(qcx: &QueryContext) -> (HirRelationExpr, Scope) {
     let typ = RelationType::new(vec![]);
-    let expr = RelationExpr::constant(vec![vec![]], typ);
+    let expr = HirRelationExpr::constant(vec![vec![]], typ);
     let scope = Scope::from_source(
         None,
         iter::empty::<Option<ColumnName>>(),
@@ -748,7 +753,7 @@ fn plan_join_identity(qcx: &QueryContext) -> (RelationExpr, Scope) {
 /// projection has been applied.
 #[derive(Debug)]
 struct SelectPlan {
-    expr: RelationExpr,
+    expr: HirRelationExpr,
     scope: Scope,
     order_by: Vec<ColumnOrder>,
     project: Vec<usize>,
@@ -878,7 +883,7 @@ fn plan_view_select(
                 .find(|existing_expr| **existing_expr == expr)
                 .is_none()
             {
-                let scope_item = if let ScalarExpr::Column(ColumnRef {
+                let scope_item = if let HirScalarExpr::Column(ColumnRef {
                     level: 0,
                     column: old_column,
                 }) = &expr
@@ -971,14 +976,14 @@ fn plan_view_select(
             let expr = match select_item {
                 ExpandedSelectItem::InputOrdinal(i) => {
                     if let Some(column) = select_all_mapping.get(&i).copied() {
-                        ScalarExpr::Column(ColumnRef { level: 0, column })
+                        HirScalarExpr::Column(ColumnRef { level: 0, column })
                     } else {
                         bail!("column \"{}\" must appear in the GROUP BY clause or be used in an aggregate function", from_scope.items[*i].short_display_name());
                     }
                 }
                 ExpandedSelectItem::Expr(expr) => plan_expr(ecx, &expr)?.type_as_any(ecx)?,
             };
-            if let ScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
+            if let HirScalarExpr::Column(ColumnRef { level: 0, column }) = expr {
                 project_key.push(column);
                 // Mark the output name as prioritized, so that they shadow any
                 // input columns of the same name.
@@ -1071,7 +1076,7 @@ fn plan_view_select(
                 for ord in order_by.iter().take(distinct_exprs.len()) {
                     // The unusual construction of `expr` here is to ensure the
                     // temporary column expression lives long enough.
-                    let mut expr = &ScalarExpr::Column(ColumnRef {
+                    let mut expr = &HirScalarExpr::Column(ColumnRef {
                         level: 0,
                         column: ord.column,
                     });
@@ -1092,7 +1097,7 @@ fn plan_view_select(
                     // If the expression is a reference to an existing column,
                     // do not introduce a new column to support it.
                     let column = match expr {
-                        ScalarExpr::Column(ColumnRef { level: 0, column }) => column,
+                        HirScalarExpr::Column(ColumnRef { level: 0, column }) => column,
                         _ => {
                             map_exprs.push(expr);
                             map_scope.len() + map_exprs.len() - 1
@@ -1105,7 +1110,7 @@ fn plan_view_select(
                 // columns in `ORDER BY` that are not part of the distinct key,
                 // if there are any, determine the ordering within each group,
                 // per PostgreSQL semantics.
-                relation_expr = RelationExpr::TopK {
+                relation_expr = HirRelationExpr::TopK {
                     input: Box::new(relation_expr.map(map_exprs)),
                     order_key: order_by.iter().skip(distinct_key.len()).cloned().collect(),
                     group_key: distinct_key,
@@ -1146,11 +1151,11 @@ fn plan_group_by_expr<'a>(
     ecx: &ExprContext,
     group_expr: &'a Expr<Raw>,
     projection: &'a [(ExpandedSelectItem, Option<ColumnName>)],
-) -> Result<(Option<&'a Expr<Raw>>, ScalarExpr), anyhow::Error> {
+) -> Result<(Option<&'a Expr<Raw>>, HirScalarExpr), anyhow::Error> {
     let plan_projection = |column: usize| match &projection[column].0 {
         ExpandedSelectItem::InputOrdinal(column) => Ok((
             None,
-            ScalarExpr::Column(ColumnRef {
+            HirScalarExpr::Column(ColumnRef {
                 level: 0,
                 column: *column,
             }),
@@ -1202,7 +1207,7 @@ fn plan_group_by_expr<'a>(
 fn plan_order_by_exprs(
     ecx: &ExprContext,
     order_by_exprs: &[OrderByExpr<Raw>],
-) -> Result<(Vec<ColumnOrder>, Vec<ScalarExpr>), anyhow::Error> {
+) -> Result<(Vec<ColumnOrder>, Vec<HirScalarExpr>), anyhow::Error> {
     let project_key: Vec<_> = (0..ecx.scope.len()).collect();
     plan_projected_order_by_exprs(ecx, order_by_exprs, &project_key)
 }
@@ -1213,7 +1218,7 @@ fn plan_projected_order_by_exprs(
     ecx: &ExprContext,
     order_by_exprs: &[OrderByExpr<Raw>],
     project_key: &[usize],
-) -> Result<(Vec<ColumnOrder>, Vec<ScalarExpr>), anyhow::Error> {
+) -> Result<(Vec<ColumnOrder>, Vec<HirScalarExpr>), anyhow::Error> {
     let mut order_by = vec![];
     let mut map_exprs = vec![];
     for obe in order_by_exprs {
@@ -1221,7 +1226,7 @@ fn plan_projected_order_by_exprs(
         // If the expression is a reference to an existing column,
         // do not introduce a new column to support it.
         let column = match expr {
-            ScalarExpr::Column(ColumnRef { level: 0, column }) => column,
+            HirScalarExpr::Column(ColumnRef { level: 0, column }) => column,
             _ => {
                 map_exprs.push(expr);
                 ecx.relation_type.arity() + map_exprs.len() - 1
@@ -1244,9 +1249,9 @@ fn plan_order_by_or_distinct_expr(
     ecx: &ExprContext,
     expr: &Expr<Raw>,
     project_key: &[usize],
-) -> Result<ScalarExpr, anyhow::Error> {
+) -> Result<HirScalarExpr, anyhow::Error> {
     match check_col_index(&ecx.name, expr, project_key.len())? {
-        Some(i) => Ok(ScalarExpr::Column(ColumnRef {
+        Some(i) => Ok(HirScalarExpr::Column(ColumnRef {
             level: 0,
             column: project_key[i],
         })),
@@ -1256,11 +1261,11 @@ fn plan_order_by_or_distinct_expr(
 
 fn plan_table_with_joins<'a>(
     qcx: &QueryContext,
-    left: RelationExpr,
+    left: HirRelationExpr,
     left_scope: Scope,
     join_operator: &JoinOperator<Raw>,
     table_with_joins: &'a TableWithJoins<Raw>,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     let (mut left, mut left_scope) = plan_table_factor(
         qcx,
         left,
@@ -1279,11 +1284,11 @@ fn plan_table_with_joins<'a>(
 
 fn plan_table_factor(
     left_qcx: &QueryContext,
-    left: RelationExpr,
+    left: HirRelationExpr,
     left_scope: Scope,
     join_operator: &JoinOperator<Raw>,
     table_factor: &TableFactor<Raw>,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     let lateral = matches!(
         table_factor,
         TableFactor::Function { .. } | TableFactor::Derived { lateral: true, .. }
@@ -1356,7 +1361,7 @@ fn plan_table_function(
     name: &ObjectName,
     alias: Option<&TableAlias>,
     args: &FunctionArgs<Raw>,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     let name = normalize::object_name(name.clone())?;
 
     if name.database.is_none() && name.schema.is_none() && name.item == "values" {
@@ -1374,7 +1379,7 @@ fn plan_table_function(
         FunctionArgs::Args(args) => plan_exprs(ecx, args)?,
     };
     let tf = func::select_impl(ecx, FuncSpec::Func(&name), impls, args)?;
-    let call = RelationExpr::CallTable {
+    let call = HirRelationExpr::CallTable {
         func: tf.func,
         exprs: tf.exprs,
     };
@@ -1569,13 +1574,13 @@ fn expand_select_item<'a>(
 fn plan_join_operator(
     operator: &JoinOperator<Raw>,
     left_qcx: &QueryContext,
-    left: RelationExpr,
+    left: HirRelationExpr,
     left_scope: Scope,
     right_qcx: &QueryContext,
-    right: RelationExpr,
+    right: HirRelationExpr,
     right_scope: Scope,
     lateral: bool,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     match operator {
         JoinOperator::Inner(constraint) => plan_join_constraint(
             &constraint,
@@ -1639,10 +1644,10 @@ fn plan_join_operator(
             } else if right.is_join_identity() {
                 left
             } else {
-                RelationExpr::Join {
+                HirRelationExpr::Join {
                     left: Box::new(left),
                     right: Box::new(right),
-                    on: ScalarExpr::literal_true(),
+                    on: HirScalarExpr::literal_true(),
                     kind: JoinKind::Inner { lateral },
                 }
             };
@@ -1655,13 +1660,13 @@ fn plan_join_operator(
 fn plan_join_constraint<'a>(
     constraint: &'a JoinConstraint<Raw>,
     left_qcx: &QueryContext,
-    left: RelationExpr,
+    left: HirRelationExpr,
     left_scope: Scope,
     right_qcx: &QueryContext,
-    right: RelationExpr,
+    right: HirRelationExpr,
     right_scope: Scope,
     kind: JoinKind,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     let (expr, scope) = match constraint {
         JoinConstraint::On(expr) => {
             let mut product_scope = left_scope.product(right_scope);
@@ -1701,7 +1706,7 @@ fn plan_join_constraint<'a>(
                     product_scope.items[l].names.extend(right_names);
                 }
             }
-            let joined = RelationExpr::Join {
+            let joined = HirRelationExpr::Join {
                 left: Box::new(left),
                 right: Box::new(right),
                 on,
@@ -1756,13 +1761,13 @@ fn plan_join_constraint<'a>(
 fn plan_using_constraint(
     column_names: &[ColumnName],
     left_qcx: &QueryContext,
-    left: RelationExpr,
+    left: HirRelationExpr,
     left_scope: Scope,
     right_qcx: &QueryContext,
-    right: RelationExpr,
+    right: HirRelationExpr,
     right_scope: Scope,
     kind: JoinKind,
-) -> Result<(RelationExpr, Scope), anyhow::Error> {
+) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
     let mut join_exprs = vec![];
     let mut map_exprs = vec![];
     let mut new_items = vec![];
@@ -1809,19 +1814,19 @@ fn plan_using_constraint(
             &format!("NATURAL/USING join column \"{}\"", column_name),
             &ecx,
             vec![
-                CoercibleScalarExpr::Coerced(ScalarExpr::Column(lhs)),
-                CoercibleScalarExpr::Coerced(ScalarExpr::Column(rhs)),
+                CoercibleScalarExpr::Coerced(HirScalarExpr::Column(lhs)),
+                CoercibleScalarExpr::Coerced(HirScalarExpr::Column(rhs)),
             ],
             None,
         )?;
         let (expr1, expr2) = (exprs.remove(0), exprs.remove(0));
 
-        join_exprs.push(ScalarExpr::CallBinary {
+        join_exprs.push(HirScalarExpr::CallBinary {
             func: BinaryFunc::Eq,
             expr1: Box::new(expr1.clone()),
             expr2: Box::new(expr2.clone()),
         });
-        map_exprs.push(ScalarExpr::CallVariadic {
+        map_exprs.push(HirScalarExpr::CallVariadic {
             func: VariadicFunc::Coalesce,
             exprs: vec![expr1, expr2],
         });
@@ -1845,13 +1850,13 @@ fn plan_using_constraint(
         .collect::<Vec<_>>();
     both_scope.items.extend(new_items);
     let both_scope = both_scope.project(&project_key);
-    let both = RelationExpr::Join {
+    let both = HirRelationExpr::Join {
         left: Box::new(left),
         right: Box::new(right),
         on: join_exprs
             .into_iter()
-            .fold(ScalarExpr::literal_true(), |expr1, expr2| {
-                ScalarExpr::CallBinary {
+            .fold(HirScalarExpr::literal_true(), |expr1, expr2| {
+                HirScalarExpr::CallBinary {
                     func: BinaryFunc::And,
                     expr1: Box::new(expr1),
                     expr2: Box::new(expr2),
@@ -1870,7 +1875,7 @@ pub fn plan_expr<'a>(
 ) -> Result<CoercibleScalarExpr, anyhow::Error> {
     if let Some(i) = ecx.scope.resolve_expr(e) {
         // We've already calculated this expression.
-        return Ok(ScalarExpr::Column(i).into());
+        return Ok(HirScalarExpr::Column(i).into());
     }
 
     Ok(match e {
@@ -1889,7 +1894,7 @@ pub fn plan_expr<'a>(
                 bail!("there is no parameter ${}", n);
             }
             if ecx.param_types().borrow().contains_key(n) {
-                ScalarExpr::Parameter(*n).into()
+                HirScalarExpr::Parameter(*n).into()
             } else {
                 CoercibleScalarExpr::Parameter(*n)
             }
@@ -1929,7 +1934,7 @@ pub fn plan_expr<'a>(
         // Special functions and operators.
         Expr::Not { expr } => {
             let ecx = ecx.with_name("NOT argument");
-            ScalarExpr::CallUnary {
+            HirScalarExpr::CallUnary {
                 func: UnaryFunc::Not,
                 expr: Box::new(plan_expr(&ecx, expr)?.type_as(&ecx, &ScalarType::Bool)?),
             }
@@ -1937,7 +1942,7 @@ pub fn plan_expr<'a>(
         }
         Expr::And { left, right } => {
             let ecx = ecx.with_name("AND argument");
-            ScalarExpr::CallBinary {
+            HirScalarExpr::CallBinary {
                 func: BinaryFunc::And,
                 expr1: Box::new(plan_expr(&ecx, left)?.type_as(&ecx, &ScalarType::Bool)?),
                 expr2: Box::new(plan_expr(&ecx, right)?.type_as(&ecx, &ScalarType::Bool)?),
@@ -1946,7 +1951,7 @@ pub fn plan_expr<'a>(
         }
         Expr::Or { left, right } => {
             let ecx = ecx.with_name("OR argument");
-            ScalarExpr::CallBinary {
+            HirScalarExpr::CallBinary {
                 func: BinaryFunc::Or,
                 expr1: Box::new(plan_expr(&ecx, left)?.type_as(&ecx, &ScalarType::Bool)?),
                 expr2: Box::new(plan_expr(&ecx, right)?.type_as(&ecx, &ScalarType::Bool)?),
@@ -1962,7 +1967,7 @@ pub fn plan_expr<'a>(
         } => plan_case(ecx, operand, conditions, results, else_result)?.into(),
         Expr::Coalesce { exprs } => {
             assert!(!exprs.is_empty()); // `COALESCE()` is a syntax error
-            let expr = ScalarExpr::CallVariadic {
+            let expr = HirScalarExpr::CallVariadic {
                 func: VariadicFunc::Coalesce,
                 exprs: coerce_homogeneous_exprs("coalesce", ecx, plan_exprs(ecx, exprs)?, None)?,
             };
@@ -2051,7 +2056,7 @@ pub fn plan_expr<'a>(
                         &ScalarType::Int64,
                     )?
                 } else {
-                    ScalarExpr::literal(Datum::Int64(1), ScalarType::Int64)
+                    HirScalarExpr::literal(Datum::Int64(1), ScalarType::Int64)
                 };
 
                 let end = if let Some(end) = &p.end {
@@ -2062,14 +2067,14 @@ pub fn plan_expr<'a>(
                         &ScalarType::Int64,
                     )?
                 } else {
-                    ScalarExpr::literal(Datum::Int64(i64::MAX - 1), ScalarType::Int64)
+                    HirScalarExpr::literal(Datum::Int64(i64::MAX - 1), ScalarType::Int64)
                 };
 
                 exprs.push(start);
                 exprs.push(end);
             }
 
-            ScalarExpr::CallVariadic {
+            HirScalarExpr::CallVariadic {
                 func: VariadicFunc::ListSlice,
                 exprs,
             }
@@ -2159,7 +2164,7 @@ fn plan_array(
         let out = coerce_homogeneous_exprs("ARRAY expression", ecx, out, type_hint)?;
         (ecx.scalar_type(&out[0]), out)
     };
-    Ok(ScalarExpr::CallVariadic {
+    Ok(HirScalarExpr::CallVariadic {
         func: VariadicFunc::ArrayCreate { elem_type },
         exprs,
     }
@@ -2194,7 +2199,7 @@ fn plan_list(
         let out = coerce_homogeneous_exprs("LIST expression", ecx, out, type_hint)?;
         (ecx.scalar_type(&out[0]), out)
     };
-    Ok(ScalarExpr::CallVariadic {
+    Ok(HirScalarExpr::CallVariadic {
         func: VariadicFunc::ListCreate { elem_type },
         exprs,
     }
@@ -2217,7 +2222,7 @@ pub fn coerce_homogeneous_exprs(
     ecx: &ExprContext,
     exprs: Vec<CoercibleScalarExpr>,
     type_hint: Option<&ScalarType>,
-) -> Result<Vec<ScalarExpr>, anyhow::Error> {
+) -> Result<Vec<HirScalarExpr>, anyhow::Error> {
     assert!(!exprs.is_empty());
 
     let types: Vec<_> = exprs.iter().map(|e| ecx.scalar_type(e)).collect();
@@ -2289,10 +2294,10 @@ fn plan_aggregate(
         // where <identity> is the identity input for <agg>.
         let cond = plan_expr(&ecx.with_name("FILTER"), filter)?.type_as(ecx, &ScalarType::Bool)?;
         let expr_typ = ecx.scalar_type(&expr);
-        expr = ScalarExpr::If {
+        expr = HirScalarExpr::If {
             cond: Box::new(cond),
             then: Box::new(expr),
-            els: Box::new(ScalarExpr::literal(func.identity_datum(), expr_typ)),
+            els: Box::new(HirScalarExpr::literal(func.identity_datum(), expr_typ)),
         };
     }
 
@@ -2319,7 +2324,7 @@ fn plan_aggregate(
     })
 }
 
-fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<ScalarExpr, PlanError> {
+fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, PlanError> {
     let mut names = names.to_vec();
     let col_name = normalize::column_name(names.pop().unwrap());
 
@@ -2327,12 +2332,12 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<ScalarExpr, Pla
     if !names.is_empty() {
         let table_name = normalize::object_name(ObjectName(names))?;
         let (i, _name) = ecx.scope.resolve_table_column(&table_name, &col_name)?;
-        return Ok(ScalarExpr::Column(i));
+        return Ok(HirScalarExpr::Column(i));
     }
 
     // If the name is unqualified, first check if it refers to a column.
     match ecx.scope.resolve_column(&col_name) {
-        Ok((i, _name)) => return Ok(ScalarExpr::Column(i)),
+        Ok((i, _name)) => return Ok(HirScalarExpr::Column(i)),
         Err(PlanError::UnknownColumn(_)) => (),
         Err(e) => return Err(e),
     }
@@ -2355,7 +2360,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<ScalarExpr, Pla
             })
         })
         .map(|(level, column, item)| {
-            let expr = ScalarExpr::Column(ColumnRef {
+            let expr = HirScalarExpr::Column(ColumnRef {
                 level: *level,
                 column: *column,
             });
@@ -2368,7 +2373,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<ScalarExpr, Pla
         })
         .unzip();
     if !exprs.is_empty() {
-        return Ok(ScalarExpr::CallVariadic {
+        return Ok(HirScalarExpr::CallVariadic {
             func: VariadicFunc::RecordCreate { field_names },
             exprs,
         });
@@ -2382,7 +2387,7 @@ fn plan_op(
     op: &str,
     expr1: &Expr<Raw>,
     expr2: Option<&Expr<Raw>>,
-) -> Result<ScalarExpr, anyhow::Error> {
+) -> Result<HirScalarExpr, anyhow::Error> {
     let impls = func::resolve_op(op)?;
     let args = match expr2 {
         None => plan_exprs(ecx, &[expr1])?,
@@ -2394,7 +2399,7 @@ fn plan_op(
 fn plan_function<'a>(
     ecx: &ExprContext,
     sql_func: &'a Function<Raw>,
-) -> Result<ScalarExpr, anyhow::Error> {
+) -> Result<HirScalarExpr, anyhow::Error> {
     let name = normalize::object_name(sql_func.name.clone())?;
     let impls = match func::resolve_func(&ecx.qcx.scx, &name)? {
         Func::Aggregate(_) if ecx.allow_aggregates => {
@@ -2437,18 +2442,18 @@ fn plan_is_null_expr<'a>(
     ecx: &ExprContext,
     inner: &'a Expr<Raw>,
     not: bool,
-) -> Result<ScalarExpr, anyhow::Error> {
+) -> Result<HirScalarExpr, anyhow::Error> {
     // PostgreSQL can plan `NULL IS NULL` but not `$1 IS NULL`. This is at odds
     // with our type coercion rules, which treat `NULL` literals and
     // unconstrained parameters identically. Providing a type hint of string
     // means we wind up supporting both.
     let expr = plan_expr(ecx, inner)?.type_as_any(ecx)?;
-    let mut expr = ScalarExpr::CallUnary {
+    let mut expr = HirScalarExpr::CallUnary {
         func: UnaryFunc::IsNull,
         expr: Box::new(expr),
     };
     if not {
-        expr = ScalarExpr::CallUnary {
+        expr = HirScalarExpr::CallUnary {
             func: UnaryFunc::Not,
             expr: Box::new(expr),
         }
@@ -2462,7 +2467,7 @@ fn plan_case<'a>(
     conditions: &'a [Expr<Raw>],
     results: &'a [Expr<Raw>],
     else_result: &'a Option<Box<Expr<Raw>>>,
-) -> Result<ScalarExpr, anyhow::Error> {
+) -> Result<HirScalarExpr, anyhow::Error> {
     let mut cond_exprs = Vec::new();
     let mut result_exprs = Vec::new();
     for (c, r) in conditions.iter().zip(results) {
@@ -2483,7 +2488,7 @@ fn plan_case<'a>(
     let mut expr = result_exprs.pop().unwrap();
     assert_eq!(cond_exprs.len(), result_exprs.len());
     for (cexpr, rexpr) in cond_exprs.into_iter().zip(result_exprs).rev() {
-        expr = ScalarExpr::If {
+        expr = HirScalarExpr::If {
             cond: Box::new(cexpr),
             then: Box::new(rexpr),
             els: Box::new(expr),
@@ -2525,13 +2530,13 @@ fn plan_literal<'a>(l: &'a Value) -> Result<CoercibleScalarExpr, anyhow::Error> 
         Value::String(s) => return Ok(CoercibleScalarExpr::LiteralString(s.clone())),
         Value::Null => return Ok(CoercibleScalarExpr::LiteralNull),
     };
-    let expr = ScalarExpr::literal(datum, scalar_type);
+    let expr = HirScalarExpr::literal(datum, scalar_type);
     Ok(expr.into())
 }
 
-fn find_trivial_column_equivalences(expr: &ScalarExpr) -> Vec<(usize, usize)> {
+fn find_trivial_column_equivalences(expr: &HirScalarExpr) -> Vec<(usize, usize)> {
     use BinaryFunc::*;
-    use ScalarExpr::*;
+    use HirScalarExpr::*;
     let mut exprs = vec![expr];
     let mut equivalences = vec![];
     while let Some(expr) = exprs.pop() {
@@ -2813,7 +2818,7 @@ pub enum QueryLifetime {
 #[derive(Debug, Clone)]
 pub struct CteDesc {
     /// The CTE's expression.
-    val: RelationExpr,
+    val: HirRelationExpr,
     val_desc: RelationDesc,
     /// We evaluate CTEs when they're defined and not when they're referred to
     /// (i.e. it's like a pointer, not a macro). This means that we need to
@@ -2848,7 +2853,7 @@ impl<'a> QueryContext<'a> {
         }
     }
 
-    fn relation_type(&self, expr: &RelationExpr) -> RelationType {
+    fn relation_type(&self, expr: &HirRelationExpr) -> RelationType {
         expr.typ(&self.outer_relation_types, &self.scx.param_types.borrow())
     }
 
@@ -2876,7 +2881,10 @@ impl<'a> QueryContext<'a> {
 
     /// Resolves `name` to a table expr, i.e. getting a catalog table or
     /// inlining a CTE.
-    pub fn resolve_table_name(&self, name: ObjectName) -> Result<(RelationExpr, Scope), PlanError> {
+    pub fn resolve_table_name(
+        &self,
+        name: ObjectName,
+    ) -> Result<(HirRelationExpr, Scope), PlanError> {
         // Check if unqualified name refers to a CTE.
         if name.0.len() == 1 {
             let norm_name = normalize::ident(name.0[0].clone());
@@ -2910,7 +2918,7 @@ impl<'a> QueryContext<'a> {
         // Non-CTE table names must be retrieved from the catalog.
         let item = self.scx.resolve_item(name)?;
         let desc = item.desc()?.clone();
-        let expr = RelationExpr::Get {
+        let expr = HirRelationExpr::Get {
             id: Id::Global(item.id()),
             typ: desc.typ().clone(),
         };

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1043,7 +1043,7 @@ pub fn plan_create_index(
             let index_name_col_suffix = keys
                 .iter()
                 .map(|k| match k {
-                    expr::ScalarExpr::Column(i) => match on_desc.get_unambiguous_name(*i) {
+                    expr::MirScalarExpr::Column(i) => match on_desc.get_unambiguous_name(*i) {
                         Some(col_name) => col_name.to_string(),
                         None => format!("{}", i + 1),
                     },

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -210,13 +210,13 @@ pub fn plan_explain(
 }
 
 /// Plans and decorrelates a `Query`. Like `query::plan_root_query`, but returns
-/// an `::expr::RelationExpr`, which cannot include correlated expressions.
+/// an `::expr::MirRelationExpr`, which cannot include correlated expressions.
 pub fn plan_query(
     scx: &StatementContext,
     query: Query<Raw>,
     params: &Params,
     lifetime: QueryLifetime,
-) -> Result<(::expr::RelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
+) -> Result<(::expr::MirRelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
     let (mut expr, desc, finishing) = query::plan_root_query(scx, query, lifetime)?;
     expr.bind_parameters(&params)?;
     Ok((expr.decorrelate(), desc, finishing))

--- a/src/transform/src/aggregation.rs
+++ b/src/transform/src/aggregation.rs
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{RelationExpr, TransformArgs};
+use crate::TransformArgs;
+use expr::RelationExpr;
 
 #[derive(Debug)]
 pub struct FractureReduce;

--- a/src/transform/src/cse/map.rs
+++ b/src/transform/src/cse/map.rs
@@ -20,7 +20,7 @@
 //! expressions re-use complex subexpressions.
 
 use crate::TransformArgs;
-use expr::{RelationExpr, ScalarExpr};
+use expr::{MirRelationExpr, MirScalarExpr};
 
 /// Performs common sub-expression elimination.
 #[derive(Debug)]
@@ -29,7 +29,7 @@ pub struct Map;
 impl crate::Transform for Map {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
@@ -41,8 +41,8 @@ impl crate::Transform for Map {
 
 impl Map {
     /// Performs common sub-expression elimination.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::Map { input, scalars } = relation {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::Map { input, scalars } = relation {
             let input_arity = input.arity();
             let scalars_len = scalars.len();
             let (scalars, projection) = memoize_and_reuse(scalars, input_arity);
@@ -66,9 +66,9 @@ impl Map {
 /// Some care is taken to ensure that `if` expressions only memoize expresions
 /// they are certain to evaluate.
 fn memoize_and_reuse(
-    exprs: &mut [ScalarExpr],
+    exprs: &mut [MirScalarExpr],
     input_arity: usize,
-) -> (Vec<ScalarExpr>, Vec<usize>) {
+) -> (Vec<MirScalarExpr>, Vec<usize>) {
     let mut projection = (0..input_arity).collect::<Vec<_>>();
     let mut scalars = Vec::new();
     for expr in exprs.iter_mut() {
@@ -79,8 +79,8 @@ fn memoize_and_reuse(
         // been added to `scalars` and we should do so if it is a literal to make sure we
         // have a column reference we can record (for the ultimate projection).
         let position = match expr {
-            ScalarExpr::Column(index) => *index,
-            ScalarExpr::Literal(_, _) => {
+            MirScalarExpr::Column(index) => *index,
+            MirScalarExpr::Literal(_, _) => {
                 scalars.push(expr.clone());
                 input_arity + scalars.len() - 1
             }
@@ -99,23 +99,23 @@ fn memoize_and_reuse(
 /// Importantly, we should not memoize expressions that may not be excluded by virtue of
 /// being guarded by `if` expressions.
 fn memoize(
-    expr: &mut ScalarExpr,
-    scalars: &mut Vec<ScalarExpr>,
+    expr: &mut MirScalarExpr,
+    scalars: &mut Vec<MirScalarExpr>,
     projection: &[usize],
     input_arity: usize,
 ) {
     match expr {
-        ScalarExpr::Column(index) => {
+        MirScalarExpr::Column(index) => {
             // Column references need to be rewritten, but do not need to be memoized.
             *index = projection[*index];
         }
-        ScalarExpr::Literal(_, _) => {
+        MirScalarExpr::Literal(_, _) => {
             // Literals do not need to be memoized.
         }
         _ => {
             // We should not eagerly memoize `if` branches that might not be taken.
             // TODO: Memoize expressions in the intersection of `then` and `els`.
-            if let ScalarExpr::If { cond, then, els } = expr {
+            if let MirScalarExpr::If { cond, then, els } = expr {
                 memoize(cond, scalars, projection, input_arity);
                 // Conditionally evaluated expressions still need to update their
                 // column references.
@@ -127,13 +127,13 @@ fn memoize(
             if let Some(position) = scalars.iter().position(|e| e == expr) {
                 // Any complex expression that already exists as a prior column can
                 // be replaced by a reference to that column.
-                *expr = ScalarExpr::Column(input_arity + position);
+                *expr = MirScalarExpr::Column(input_arity + position);
             } else {
                 // A complex expression that does not exist should be memoized, and
                 // replaced by a reference to the column.
                 scalars.push(std::mem::replace(
                     expr,
-                    ScalarExpr::Column(input_arity + scalars.len()),
+                    MirScalarExpr::Column(input_arity + scalars.len()),
                 ));
             }
         }
@@ -144,7 +144,7 @@ fn memoize(
 ///
 /// This method in-lines expressions that are only referenced once, and then
 /// collects expressions that are no longer referenced, updating column indexes.
-fn inline_single_use(exprs: &mut Vec<ScalarExpr>, projection: &mut [usize], input_arity: usize) {
+fn inline_single_use(exprs: &mut Vec<MirScalarExpr>, projection: &mut [usize], input_arity: usize) {
     // Determine which columns are referred to by which others.
     let mut referenced = vec![0; input_arity + exprs.len()];
     for column in projection.iter() {
@@ -152,7 +152,7 @@ fn inline_single_use(exprs: &mut Vec<ScalarExpr>, projection: &mut [usize], inpu
     }
     for expr in exprs.iter() {
         expr.visit(&mut |e| {
-            if let ScalarExpr::Column(i) = e {
+            if let MirScalarExpr::Column(i) = e {
                 referenced[*i] += 1;
             }
         })
@@ -165,7 +165,7 @@ fn inline_single_use(exprs: &mut Vec<ScalarExpr>, projection: &mut [usize], inpu
     for index in 0..exprs.len() {
         let (prior, expr) = exprs.split_at_mut(index);
         expr[0].visit_mut(&mut |e| {
-            if let ScalarExpr::Column(i) = e {
+            if let MirScalarExpr::Column(i) = e {
                 if *i >= input_arity && referenced[*i] == 1 {
                     referenced[*i] -= 1;
                     *e = prior[*i - input_arity].clone();
@@ -184,7 +184,7 @@ fn inline_single_use(exprs: &mut Vec<ScalarExpr>, projection: &mut [usize], inpu
         if referenced[input_arity + index] > 0 {
             // keep the expression, but update column references.
             expr.visit_mut(&mut |e| {
-                if let ScalarExpr::Column(i) = e {
+                if let MirScalarExpr::Column(i) = e {
                     *i = column_rename[i];
                 }
             });

--- a/src/transform/src/empty_map.rs
+++ b/src/transform/src/empty_map.rs
@@ -9,7 +9,8 @@
 
 //! Remove empty `Map` operators.
 
-use crate::{RelationExpr, TransformArgs};
+use crate::TransformArgs;
+use expr::MirRelationExpr;
 
 /// Remove empty `Map` operators.
 #[derive(Debug)]
@@ -18,7 +19,7 @@ pub struct EmptyMap;
 impl crate::Transform for EmptyMap {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
@@ -30,8 +31,8 @@ impl crate::Transform for EmptyMap {
 
 impl EmptyMap {
     /// Remove empty `Map` operators.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::Map { input, scalars } = relation {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::Map { input, scalars } = relation {
             if scalars.is_empty() {
                 *relation = input.take_dangerous();
             }

--- a/src/transform/src/fusion/map.rs
+++ b/src/transform/src/fusion/map.rs
@@ -18,7 +18,7 @@
 use std::mem;
 
 use crate::TransformArgs;
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 
 /// Fuses a sequence of `Map` operators in to one `Map` operator.
 #[derive(Debug)]
@@ -27,7 +27,7 @@ pub struct Map;
 impl crate::Transform for Map {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
@@ -39,9 +39,9 @@ impl crate::Transform for Map {
 
 impl Map {
     /// Fuses a sequence of `Map` operators in to one `Map` operator.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::Map { input, scalars } = relation {
-            while let RelationExpr::Map {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::Map { input, scalars } = relation {
+            while let MirRelationExpr::Map {
                 input: inner_input,
                 scalars: inner_scalars,
             } = &mut **input

--- a/src/transform/src/fusion/project.rs
+++ b/src/transform/src/fusion/project.rs
@@ -12,7 +12,7 @@
 // TODO(frank): evaluate for redundancy with projection hoisting.
 
 use crate::TransformArgs;
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 
 /// Fuses Project operators with parent operators when possible.
 #[derive(Debug)]
@@ -21,7 +21,7 @@ pub struct Project;
 impl crate::Transform for Project {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut_pre(&mut |e| {
@@ -33,9 +33,9 @@ impl crate::Transform for Project {
 
 impl Project {
     /// Fuses Project operators with parent operators when possible.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::Project { input, outputs } = relation {
-            while let RelationExpr::Project {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::Project { input, outputs } = relation {
+            while let MirRelationExpr::Project {
                 input: inner,
                 outputs: outputs2,
             } = &mut **input
@@ -49,7 +49,7 @@ impl Project {
         }
 
         // Any reduce will absorb any project. Also, this happens often.
-        if let RelationExpr::Reduce {
+        if let MirRelationExpr::Reduce {
             input,
             group_key,
             aggregates,
@@ -57,7 +57,7 @@ impl Project {
             expected_group_size: _,
         } = relation
         {
-            if let RelationExpr::Project {
+            if let MirRelationExpr::Project {
                 input: inner,
                 outputs,
             } = &mut **input

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -9,7 +9,7 @@
 
 //! Hoist literal values from maps wherever possible.
 //!
-//! This transform specifically looks for `RelationExpr::Map` operators
+//! This transform specifically looks for `MirRelationExpr::Map` operators
 //! where any of the `ScalarExpr` expressions are literals. Whenever it
 //! can, it lifts those expressions through or around operators.
 //!
@@ -23,7 +23,7 @@
 use std::collections::HashMap;
 
 use crate::TransformArgs;
-use expr::{Id, JoinInputMapper, RelationExpr, ScalarExpr};
+use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 use itertools::Itertools;
 
 /// Hoist literal values from maps wherever possible.
@@ -33,7 +33,7 @@ pub struct LiteralLifting;
 impl crate::Transform for LiteralLifting {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         let literals = self.action(relation, &mut HashMap::new());
@@ -61,12 +61,12 @@ impl LiteralLifting {
     // TODO(frank): Fix this.
     pub fn action(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         // Map from names to literals required for appending.
-        gets: &mut HashMap<Id, Vec<ScalarExpr>>,
-    ) -> Vec<ScalarExpr> {
+        gets: &mut HashMap<Id, Vec<MirScalarExpr>>,
+    ) -> Vec<MirScalarExpr> {
         match relation {
-            RelationExpr::Constant { rows, typ } => {
+            MirRelationExpr::Constant { rows, typ } => {
                 // From the back to the front, check if all values are identical.
                 // TODO(frank): any subset of constant values can be extracted with a permute.
                 let mut the_same = vec![true; typ.arity()];
@@ -85,7 +85,7 @@ impl LiteralLifting {
                         the_same.pop();
                         let datum = data.pop().unwrap();
                         let typum = typ.column_types.pop().unwrap();
-                        literals.push(ScalarExpr::literal_ok(datum, typum));
+                        literals.push(MirScalarExpr::literal_ok(datum, typum));
                     }
                     literals.reverse();
 
@@ -107,7 +107,7 @@ impl LiteralLifting {
                     Vec::new()
                 }
             }
-            RelationExpr::Get { id, typ } => {
+            MirRelationExpr::Get { id, typ } => {
                 // A get expression may need to have literal expressions appended to it.
                 let literals = gets.get(id).cloned().unwrap_or_else(Vec::new);
                 if !literals.is_empty() {
@@ -127,7 +127,7 @@ impl LiteralLifting {
                 }
                 literals
             }
-            RelationExpr::Let { id, value, body } => {
+            MirRelationExpr::Let { id, value, body } => {
                 // Any literals appended to the `value` should be used
                 // at corresponding `Get`s throughout the `body`.
                 let literals = self.action(value, gets);
@@ -140,7 +140,7 @@ impl LiteralLifting {
                 gets.remove(&id);
                 result
             }
-            RelationExpr::Project { input, outputs } => {
+            MirRelationExpr::Project { input, outputs } => {
                 // We do not want to lift literals around projections.
                 // Projections are the highest lifted operator and lifting
                 // literals around projections could cause us to fail to
@@ -170,7 +170,7 @@ impl LiteralLifting {
                 // Policy: Do not lift literals around projects.
                 Vec::new()
             }
-            RelationExpr::Map { input, scalars } => {
+            MirRelationExpr::Map { input, scalars } => {
                 let mut literals = self.action(input, gets);
 
                 // Make the map properly formed again.
@@ -193,7 +193,7 @@ impl LiteralLifting {
 
                 result
             }
-            RelationExpr::FlatMap {
+            MirRelationExpr::FlatMap {
                 input,
                 func: _,
                 exprs,
@@ -204,7 +204,7 @@ impl LiteralLifting {
                     let input_arity = input.arity();
                     for expr in exprs.iter_mut() {
                         expr.visit_mut(&mut |e| {
-                            if let ScalarExpr::Column(c) = e {
+                            if let MirScalarExpr::Column(c) = e {
                                 if *c >= input_arity {
                                     *e = literals[*c - input_arity].clone();
                                 }
@@ -218,7 +218,7 @@ impl LiteralLifting {
                 }
                 Vec::new()
             }
-            RelationExpr::Filter { input, predicates } => {
+            MirRelationExpr::Filter { input, predicates } => {
                 let literals = self.action(input, gets);
                 if !literals.is_empty() {
                     // We should be able to instantiate all uses of `literals`
@@ -226,7 +226,7 @@ impl LiteralLifting {
                     let input_arity = input.arity();
                     for expr in predicates.iter_mut() {
                         expr.visit_mut(&mut |e| {
-                            if let ScalarExpr::Column(c) = e {
+                            if let MirScalarExpr::Column(c) = e {
                                 if *c >= input_arity {
                                     *e = literals[*c - input_arity].clone();
                                 }
@@ -236,7 +236,7 @@ impl LiteralLifting {
                 }
                 literals
             }
-            RelationExpr::Join {
+            MirRelationExpr::Join {
                 inputs,
                 equivalences,
                 demand,
@@ -265,7 +265,7 @@ impl LiteralLifting {
                     for equivalence in equivalences.iter_mut() {
                         for expr in equivalence.iter_mut() {
                             expr.visit_mut(&mut |e| {
-                                if let ScalarExpr::Column(c) = e {
+                                if let MirScalarExpr::Column(c) = e {
                                     let (col, input) = old_input_mapper.map_column_to_local(*c);
                                     if col >= new_input_mapper.input_arity(input) {
                                         // the column refers to a literal that
@@ -309,7 +309,7 @@ impl LiteralLifting {
                 }
                 Vec::new()
             }
-            RelationExpr::Reduce {
+            MirRelationExpr::Reduce {
                 input,
                 group_key,
                 aggregates,
@@ -323,7 +323,7 @@ impl LiteralLifting {
                     // Inline literals into group key expressions.
                     for expr in group_key.iter_mut() {
                         expr.visit_mut(&mut |e| {
-                            if let ScalarExpr::Column(c) = e {
+                            if let MirScalarExpr::Column(c) = e {
                                 if *c >= input_arity {
                                     *e = literals[*c - input_arity].clone();
                                 }
@@ -333,7 +333,7 @@ impl LiteralLifting {
                     // Inline literals into aggregate value selector expressions.
                     for aggr in aggregates.iter_mut() {
                         aggr.expr.visit_mut(&mut |e| {
-                            if let ScalarExpr::Column(c) = e {
+                            if let MirScalarExpr::Column(c) = e {
                                 if *c >= input_arity {
                                     *e = literals[*c - input_arity].clone();
                                 }
@@ -357,7 +357,7 @@ impl LiteralLifting {
                     let eval = aggr
                         .func
                         .eval(Some(aggr.expr.eval(&[], &temp).unwrap()), &temp);
-                    result.push(ScalarExpr::literal_ok(
+                    result.push(MirScalarExpr::literal_ok(
                         eval,
                         // This type information should be available in the `a.expr` literal,
                         // but extracting it with pattern matching seems awkward.
@@ -368,7 +368,7 @@ impl LiteralLifting {
                 result.reverse();
                 result
             }
-            RelationExpr::TopK {
+            MirRelationExpr::TopK {
                 input,
                 group_key,
                 order_key,
@@ -387,20 +387,20 @@ impl LiteralLifting {
                 }
                 literals
             }
-            RelationExpr::Negate { input } => {
+            MirRelationExpr::Negate { input } => {
                 // Literals can just be lifted out of negate.
                 self.action(input, gets)
             }
-            RelationExpr::Threshold { input } => {
+            MirRelationExpr::Threshold { input } => {
                 // Literals can just be lifted out of threshold.
                 self.action(input, gets)
             }
-            RelationExpr::Union { base, inputs } => {
+            MirRelationExpr::Union { base, inputs } => {
                 let mut base_literals = self.action(base, gets);
                 let mut input_literals = inputs
                     .iter_mut()
                     .map(|input| self.action(input, gets))
-                    .collect::<Vec<Vec<ScalarExpr>>>();
+                    .collect::<Vec<Vec<MirScalarExpr>>>();
 
                 // We need to find the longest common suffix between all the arms of the union.
                 let mut suffix = Vec::new();
@@ -433,7 +433,7 @@ impl LiteralLifting {
                 }
                 suffix
             }
-            RelationExpr::ArrangeBy { input, keys } => {
+            MirRelationExpr::ArrangeBy { input, keys } => {
                 // TODO(frank): Not sure if this is the right behavior,
                 // as we disrupt the set of used arrangements. Though,
                 // we are probably most likely to use arranged `Get`
@@ -444,7 +444,7 @@ impl LiteralLifting {
                     for key in keys.iter_mut() {
                         for expr in key.iter_mut() {
                             expr.visit_mut(&mut |e| {
-                                if let ScalarExpr::Column(c) = e {
+                                if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
                                     }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -13,7 +13,8 @@
 //! set of columns that form unique keys for the input, the reduce
 //! can be simplified to a map operation.
 
-use crate::{RelationExpr, ScalarExpr, TransformArgs};
+use crate::TransformArgs;
+use expr::{MirRelationExpr, MirScalarExpr};
 
 /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
 #[derive(Debug)]
@@ -22,7 +23,7 @@ pub struct ReduceElision;
 impl crate::Transform for ReduceElision {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
@@ -34,8 +35,8 @@ impl crate::Transform for ReduceElision {
 
 impl ReduceElision {
     /// Removes `Reduce` when the input has as unique keys the keys of the reduce.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::Reduce {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::Reduce {
             input,
             group_key,
             aggregates,
@@ -46,7 +47,7 @@ impl ReduceElision {
             let input_type = input.typ();
             if input_type.keys.iter().any(|keys| {
                 keys.iter()
-                    .all(|k| group_key.contains(&crate::ScalarExpr::Column(*k)))
+                    .all(|k| group_key.contains(&expr::MirScalarExpr::Column(*k)))
             }) {
                 use expr::{AggregateFunc, UnaryFunc, VariadicFunc};
                 use repr::Datum;
@@ -57,11 +58,11 @@ impl ReduceElision {
                         AggregateFunc::Count => {
                             let column_type = a.typ(&input_type);
                             a.expr.clone().call_unary(UnaryFunc::IsNull).if_then_else(
-                                ScalarExpr::literal_ok(
+                                MirScalarExpr::literal_ok(
                                     Datum::Int64(0),
                                     column_type.scalar_type.clone().nullable(false),
                                 ),
-                                ScalarExpr::literal_ok(
+                                MirScalarExpr::literal_ok(
                                     Datum::Int64(1),
                                     column_type.scalar_type.nullable(false),
                                 ),
@@ -79,7 +80,7 @@ impl ReduceElision {
                         }
 
                         // JsonbAgg takes _anything_ as input, but must output a Jsonb array.
-                        AggregateFunc::JsonbAgg => ScalarExpr::CallVariadic {
+                        AggregateFunc::JsonbAgg => MirScalarExpr::CallVariadic {
                             func: VariadicFunc::JsonbBuildArray,
                             exprs: vec![a.expr.clone()],
                         },

--- a/src/transform/src/split_predicates.rs
+++ b/src/transform/src/split_predicates.rs
@@ -10,7 +10,7 @@
 //! Transforms predicates of the form "A and B" into two: "A" and "B".
 
 use crate::TransformArgs;
-use expr::{BinaryFunc, RelationExpr, ScalarExpr};
+use expr::{BinaryFunc, MirRelationExpr, MirScalarExpr};
 
 /// Transforms predicates of the form "A and B" into two: "A" and "B".
 #[derive(Debug)]
@@ -20,14 +20,14 @@ impl crate::Transform for SplitPredicates {
     /// Transforms predicates of the form "A and B" into two: "A" and "B".
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |expr| {
-            if let RelationExpr::Filter { predicates, .. } = expr {
+            if let MirRelationExpr::Filter { predicates, .. } = expr {
                 let mut pending_predicates = predicates.drain(..).collect::<Vec<_>>();
                 while let Some(expr) = pending_predicates.pop() {
-                    if let ScalarExpr::CallBinary {
+                    if let MirScalarExpr::CallBinary {
                         func: BinaryFunc::And,
                         expr1,
                         expr2,

--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -10,7 +10,7 @@
 //! Remove TopK operators with both an offset of zero and no limit.
 
 use crate::TransformArgs;
-use expr::RelationExpr;
+use expr::MirRelationExpr;
 
 /// Remove TopK operators with both an offset of zero and no limit.
 #[derive(Debug)]
@@ -19,7 +19,7 @@ pub struct TopKElision;
 impl crate::Transform for TopKElision {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         relation.visit_mut(&mut |e| {
@@ -31,8 +31,8 @@ impl crate::Transform for TopKElision {
 
 impl TopKElision {
     /// Remove TopK operators with both an offset of zero and no limit.
-    pub fn action(&self, relation: &mut RelationExpr) {
-        if let RelationExpr::TopK {
+    pub fn action(&self, relation: &mut MirRelationExpr) {
+        if let MirRelationExpr::TopK {
             input,
             group_key: _,
             order_key: _,

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 
 use crate::TransformArgs;
-use expr::{Id, IdGen, LocalId, RelationExpr};
+use expr::{Id, IdGen, LocalId, MirRelationExpr};
 use repr::RelationType;
 
 /// Refreshes identifiers and types for local let bindings.
@@ -28,7 +28,7 @@ pub struct UpdateLet;
 impl crate::Transform for UpdateLet {
     fn transform(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         args: TransformArgs,
     ) -> Result<(), crate::TransformError> {
         *args.id_gen = IdGen::default(); // Get a fresh IdGen.
@@ -41,12 +41,12 @@ impl UpdateLet {
     /// Re-assign type information and identifier to each `Get`.
     pub fn action(
         &self,
-        relation: &mut RelationExpr,
+        relation: &mut MirRelationExpr,
         remap: &mut HashMap<LocalId, (LocalId, RelationType)>,
         id_gen: &mut IdGen,
     ) {
         match relation {
-            RelationExpr::Let { id, value, body } => {
+            MirRelationExpr::Let { id, value, body } => {
                 self.action(value, remap, id_gen);
                 // If a local id, assign a new identifier and refresh the type.
                 let new_id = LocalId::new(id_gen.allocate_id());
@@ -58,7 +58,7 @@ impl UpdateLet {
                 }
                 *id = new_id;
             }
-            RelationExpr::Get { id, typ } => {
+            MirRelationExpr::Get { id, typ } => {
                 if let Id::Local(local_id) = id {
                     if let Some((new_id, new_type)) = remap.get(local_id) {
                         *local_id = new_id.clone();


### PR DESCRIPTION
In a long Slack thread (https://materializeinc.slack.com/archives/CM7ATT65S/p1611772013041400) , this seemed to be the set of names that annoyed the fewest people!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5491)
<!-- Reviewable:end -->
