### PR TITLE
AWS Sources: verify credentials before source creation

### DIFF
--- a/src/aws-util/src/kinesis.rs
+++ b/src/aws-util/src/kinesis.rs
@@ -15,9 +15,7 @@ use std::time::Duration;
 use anyhow::Context;
 use log::info;
 use rusoto_core::HttpClient;
-use rusoto_credential::{
-    AutoRefreshingProvider, AwsCredentials, ChainProvider, ProvideAwsCredentials, StaticProvider,
-};
+use rusoto_credential::{AutoRefreshingProvider, AwsCredentials, ChainProvider, StaticProvider};
 use rusoto_kinesis::{GetShardIteratorInput, Kinesis, KinesisClient, ListShardsInput, Shard};
 
 use crate::aws::ConnectInfo;
@@ -44,7 +42,6 @@ pub async fn client(conn_info: ConnectInfo) -> Result<KinesisClient, anyhow::Err
         );
         let mut provider = ChainProvider::new();
         provider.set_timeout(Duration::from_secs(10));
-        provider.credentials().await?; // ensure that credentials exist
         let provider =
             AutoRefreshingProvider::new(provider).context("generating AWS credentials")?;
 

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -29,7 +29,7 @@ use crate::plan::query;
 use crate::plan::{Params, Plan, PlanContext};
 
 #[macro_use]
-mod with_options;
+pub(crate) mod with_options;
 
 mod ddl;
 mod dml;


### PR DESCRIPTION
**This includes a commit from #5496**, and so should be reviewed after that is merged, or otherwise only the second commit in this PR should be reviewed.

The core of this change is to add a call to verify account credentials as part of the purify step of source creation. Since we are now purifying all forms of create source connector the exhaustiveness check on that match statement should make it unnecessary for us to do credential verification as part of client creation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5497)
<!-- Reviewable:end -->
