### PR TITLE
Don't publish containers with simple Dockerfiles

### DIFF
--- a/play/wikirecent/create_views/mzbuild.yml
+++ b/play/wikirecent/create_views/mzbuild.yml
@@ -8,3 +8,4 @@
 # by the Apache License, Version 2.0.
 
 name: wikirecent-create-views
+publish: false

--- a/play/wikirecent/stream/mzbuild.yml
+++ b/play/wikirecent/stream/mzbuild.yml
@@ -8,3 +8,4 @@
 # by the Apache License, Version 2.0.
 
 name: wikirecent-stream
+publish: false

--- a/test/benchmark/avro_upsert/create_views/mzbuild.yml
+++ b/test/benchmark/avro_upsert/create_views/mzbuild.yml
@@ -8,3 +8,4 @@
 # by the Apache License, Version 2.0.
 
 name: avro-upsert-create-views
+publish: false

--- a/test/benchmark/avro_upsert/producer/mzbuild.yml
+++ b/test/benchmark/avro_upsert/producer/mzbuild.yml
@@ -8,3 +8,4 @@
 # by the Apache License, Version 2.0.
 
 name: avro-upsert-producer
+publish: false


### PR DESCRIPTION
These containers have build steps that are basically:

    FROM XYZ
    COPY
    COPY
    COMMAND

Since there are no actual build or package install steps, don't bother
publishing these containers on Docker Hub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5501)
<!-- Reviewable:end -->
