### PR TITLE
misc. coord cleanup

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -240,10 +240,10 @@ impl CatalogItem {
         match &self {
             CatalogItem::Table(tbl) => Ok(&tbl.desc),
             CatalogItem::Source(src) => Ok(&src.desc),
-            CatalogItem::Sink(_) => Err(SqlCatalogError::InvalidSinkDependency(name.to_string())),
             CatalogItem::View(view) => Ok(&view.desc),
-            CatalogItem::Index(_) => Err(SqlCatalogError::InvalidIndexDependency(name.to_string())),
-            CatalogItem::Type(_) => Err(SqlCatalogError::InvalidTypeDependency(name.to_string())),
+            CatalogItem::Index(_) | CatalogItem::Sink(_) | CatalogItem::Type(_) => Err(
+                SqlCatalogError::InvalidDependency(name.to_string(), self.type_string()),
+            ),
         }
     }
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -28,7 +28,9 @@ use expr::{ExprHumanizer, GlobalId, MirScalarExpr, OptimizedMirRelationExpr};
 use repr::{ColumnType, RelationDesc, ScalarType};
 use sql::ast::display::AstDisplay;
 use sql::ast::{Expr, Raw};
-use sql::catalog::{Catalog as SqlCatalog, CatalogError as SqlCatalogError};
+use sql::catalog::{
+    Catalog as SqlCatalog, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
+};
 use sql::names::{DatabaseSpecifier, FullName, PartialName, SchemaName};
 use sql::plan::{Params, Plan, PlanContext};
 use transform::Optimizer;
@@ -225,14 +227,14 @@ impl From<sql::plan::TypeInner> for TypeInner {
 
 impl CatalogItem {
     /// Returns a string indicating the type of this catalog entry.
-    pub fn type_string(&self) -> &'static str {
+    fn typ(&self) -> sql::catalog::CatalogItemType {
         match self {
-            CatalogItem::Table(_) => "table",
-            CatalogItem::Source(_) => "source",
-            CatalogItem::Sink(_) => "sink",
-            CatalogItem::View(_) => "view",
-            CatalogItem::Index(_) => "index",
-            CatalogItem::Type(_) => "type",
+            CatalogItem::Table(_) => sql::catalog::CatalogItemType::Table,
+            CatalogItem::Source(_) => sql::catalog::CatalogItemType::Source,
+            CatalogItem::Sink(_) => sql::catalog::CatalogItemType::Sink,
+            CatalogItem::View(_) => sql::catalog::CatalogItemType::View,
+            CatalogItem::Index(_) => sql::catalog::CatalogItemType::Index,
+            CatalogItem::Type(_) => sql::catalog::CatalogItemType::Type,
         }
     }
 
@@ -241,9 +243,12 @@ impl CatalogItem {
             CatalogItem::Table(tbl) => Ok(&tbl.desc),
             CatalogItem::Source(src) => Ok(&src.desc),
             CatalogItem::View(view) => Ok(&view.desc),
-            CatalogItem::Index(_) | CatalogItem::Sink(_) | CatalogItem::Type(_) => Err(
-                SqlCatalogError::InvalidDependency(name.to_string(), self.type_string()),
-            ),
+            CatalogItem::Index(_) | CatalogItem::Sink(_) | CatalogItem::Type(_) => {
+                Err(SqlCatalogError::InvalidDependency {
+                    name: name.to_string(),
+                    typ: self.typ(),
+                })
+            }
         }
     }
 
@@ -887,7 +892,7 @@ impl Catalog {
         item: CatalogItem,
     ) -> Event {
         if !item.is_placeholder() {
-            info!("create {} {} ({})", item.type_string(), name, id);
+            info!("create {} {} ({})", item.typ(), name, id);
         }
 
         let entry = CatalogEntry {
@@ -1342,12 +1347,7 @@ impl Catalog {
                 Action::DropItem(id) => {
                     let metadata = self.by_id.remove(&id).unwrap();
                     if !metadata.item.is_placeholder() {
-                        info!(
-                            "drop {} {} ({})",
-                            metadata.item.type_string(),
-                            metadata.name,
-                            id
-                        );
+                        info!("drop {} {} ({})", metadata.item_type(), metadata.name, id);
                     }
                     for u in metadata.uses() {
                         if let Some(dep_metadata) = self.by_id.get_mut(&u) {
@@ -1402,12 +1402,7 @@ impl Catalog {
                     item,
                 } => {
                     let mut entry = self.by_id.remove(&id).unwrap();
-                    info!(
-                        "update {} {} ({})",
-                        entry.item.type_string(),
-                        entry.name,
-                        id
-                    );
+                    info!("update {} {} ({})", entry.item_type(), entry.name, id);
                     assert_eq!(entry.uses(), item.uses());
                     let conn_id = entry.item().conn_id().unwrap_or(SYSTEM_CONN_ID);
                     let schema = &mut self
@@ -2036,14 +2031,7 @@ impl sql::catalog::CatalogItem for CatalogEntry {
     }
 
     fn item_type(&self) -> sql::catalog::CatalogItemType {
-        match self.item() {
-            CatalogItem::Table(_) => sql::catalog::CatalogItemType::Table,
-            CatalogItem::Source(_) => sql::catalog::CatalogItemType::Source,
-            CatalogItem::Sink(_) => sql::catalog::CatalogItemType::Sink,
-            CatalogItem::View(_) => sql::catalog::CatalogItemType::View,
-            CatalogItem::Index(_) => sql::catalog::CatalogItemType::Index,
-            CatalogItem::Type(_) => sql::catalog::CatalogItemType::Type,
-        }
+        self.item().typ()
     }
 
     fn index_details(&self) -> Option<(&[MirScalarExpr], GlobalId)> {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -248,12 +248,8 @@ pub enum CatalogError {
     UnknownSchema(String),
     /// Unknown item.
     UnknownItem(String),
-    /// Invalid attempt to depend on a sink.
-    InvalidSinkDependency(String),
-    /// Invalid attempt to depend on an index.
-    InvalidIndexDependency(String),
-    /// Invalid attempt to depend on a type.
-    InvalidTypeDependency(String),
+    /// Invalid attempt to depend on a non-dependable item.
+    InvalidDependency(String, &'static str),
 }
 
 impl fmt::Display for CatalogError {
@@ -262,20 +258,10 @@ impl fmt::Display for CatalogError {
             Self::UnknownDatabase(name) => write!(f, "unknown database '{}'", name),
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
-            Self::InvalidSinkDependency(name) => write!(
+            Self::InvalidDependency(name, type_string) => write!(
                 f,
-                "catalog item '{}' is a sink and so cannot be depended upon",
-                name
-            ),
-            Self::InvalidIndexDependency(name) => write!(
-                f,
-                "catalog item '{}' is an index and so cannot be depended upon",
-                name
-            ),
-            Self::InvalidTypeDependency(name) => write!(
-                f,
-                "catalog item '{}' is a type and so cannot be depended upon",
-                name
+                "catalog item '{}' is a {} and so cannot be depended upon",
+                name, type_string,
             ),
         }
     }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -249,7 +249,12 @@ pub enum CatalogError {
     /// Unknown item.
     UnknownItem(String),
     /// Invalid attempt to depend on a non-dependable item.
-    InvalidDependency(String, &'static str),
+    InvalidDependency {
+        /// The invalid item's name.
+        name: String,
+        /// The invalid item's type.
+        typ: CatalogItemType,
+    },
 }
 
 impl fmt::Display for CatalogError {
@@ -258,10 +263,16 @@ impl fmt::Display for CatalogError {
             Self::UnknownDatabase(name) => write!(f, "unknown database '{}'", name),
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
-            Self::InvalidDependency(name, type_string) => write!(
+            Self::InvalidDependency { name, typ } => write!(
                 f,
-                "catalog item '{}' is a {} and so cannot be depended upon",
-                name, type_string,
+                "catalog item '{}' is {} {} and so cannot be depended upon",
+                name,
+                if matches!(typ, CatalogItemType::Index) {
+                    "an"
+                } else {
+                    "a"
+                },
+                typ,
             ),
         }
     }


### PR DESCRIPTION
This isn't very meaningful on its own, but is an attempt to atomize #5445.

These commits:
- Clean up some error handling that was growing unwieldy
- Defer printing `coord::catalog::CatalogItem` to `sql::catalog::CatalogItemType`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5504)
<!-- Reviewable:end -->
