### PR TITLE
Func catalog migration pt 2

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -30,6 +30,7 @@ use sql::ast::display::AstDisplay;
 use sql::ast::{Expr, Raw};
 use sql::catalog::{
     Catalog as SqlCatalog, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
+    CatalogItemType as SqlCatalogItemType,
 };
 use sql::names::{DatabaseSpecifier, FullName, PartialName, SchemaName};
 use sql::plan::{Params, Plan, PlanContext};
@@ -2030,7 +2031,7 @@ impl sql::catalog::CatalogItem for CatalogEntry {
         }
     }
 
-    fn item_type(&self) -> sql::catalog::CatalogItemType {
+    fn item_type(&self) -> SqlCatalogItemType {
         self.item().typ()
     }
 

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -16,12 +16,14 @@
 //! `Value`s are easily converted to and from [`repr::Datum`]s. See, for
 //! example, the [`values_from_row`] function.
 
-#![forbid(missing_docs)]
 #![deny(clippy::as_conversions)]
+#![deny(missing_docs)]
 
 mod format;
 mod types;
 mod value;
+
+pub mod oid;
 
 pub use format::Format;
 pub use types::{Type, LIST, MAP};

--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -1,0 +1,62 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![allow(missing_docs)]
+
+//! Reserved OIDs through Materialized.
+pub const TYPE_LIST_OID: u32 = 16_384;
+pub const TYPE_MAP_OID: u32 = 16_385;
+pub const FUNC_CEIL_F32_OID: u32 = 16_386;
+pub const FUNC_CONCAT_AGG_OID: u32 = 16_387;
+pub const FUNC_CSV_EXTRACT_OID: u32 = 16_388;
+pub const FUNC_CURRENT_TIMESTAMP_OID: u32 = 16_389;
+pub const FUNC_FLOOR_F32_OID: u32 = 16_390;
+pub const FUNC_INTERNAL_READ_CACHED_DATA_OID: u32 = 16_391;
+pub const FUNC_LIST_APPEND_OID: u32 = 16_392;
+pub const FUNC_LIST_CAT_OID: u32 = 16_393;
+pub const FUNC_LIST_LENGTH_MAX_OID: u32 = 16_394;
+pub const FUNC_LIST_LENGTH_OID: u32 = 16_395;
+pub const FUNC_LIST_NDIMS_OID: u32 = 16_396;
+pub const FUNC_LIST_PREPEND_OID: u32 = 16_397;
+pub const FUNC_MAX_BOOL_OID: u32 = 16_398;
+pub const FUNC_MIN_BOOL_OID: u32 = 16_399;
+pub const FUNC_MZ_ALL_OID: u32 = 16_400;
+pub const FUNC_MZ_ANY_OID: u32 = 16_401;
+pub const FUNC_MZ_AVG_PROMOTION_DECIMAL_OID: u32 = 16_402;
+pub const FUNC_MZ_AVG_PROMOTION_F32_OID: u32 = 16_403;
+pub const FUNC_MZ_AVG_PROMOTION_F64_OID: u32 = 16_404;
+pub const FUNC_MZ_AVG_PROMOTION_I32_OID: u32 = 16_405;
+pub const FUNC_MZ_CLASSIFY_OBJECT_ID_OID: u32 = 16_406;
+pub const FUNC_MZ_CLUSTER_ID_OID: u32 = 16_407;
+pub const FUNC_MZ_IS_MATERIALIZED_OID: u32 = 16_408;
+pub const FUNC_MZ_LOGICAL_TIMESTAMP_OID: u32 = 16_409;
+pub const FUNC_MZ_RENDER_TYPEMOD_OID: u32 = 16_410;
+pub const FUNC_MZ_VERSION_OID: u32 = 16_411;
+pub const FUNC_REGEXP_EXTRACT_OID: u32 = 16_412;
+pub const FUNC_REPEAT_OID: u32 = 16_413;
+pub const FUNC_ROUND_F32_OID: u32 = 16_434;
+pub const FUNC_SQRT_F32_OID: u32 = 16_435;
+pub const FUNC_UNNEST_LIST_OID: u32 = 16_416;
+pub const OP_CONCAT_ELEMENY_LIST_OID: u32 = 16_417;
+pub const OP_CONCAT_LIST_ELEMENT_OID: u32 = 16_418;
+pub const OP_CONCAT_LIST_LIST_OID: u32 = 16_419;
+pub const OP_CONTAINED_JSONB_STRING_OID: u32 = 16_420;
+pub const OP_CONTAINED_MAP_MAP_OID: u32 = 16_421;
+pub const OP_CONTAINED_STRING_JSONB_OID: u32 = 16_422;
+pub const OP_CONTAINS_ALL_KEYS_MAP_OID: u32 = 16_423;
+pub const OP_CONTAINS_ANY_KEYS_MAP_OID: u32 = 16_424;
+pub const OP_CONTAINS_JSONB_STRING_OID: u32 = 16_425;
+pub const OP_CONTAINS_KEY_MAP_OID: u32 = 16_426;
+pub const OP_CONTAINS_MAP_MAP_OID: u32 = 16_427;
+pub const OP_CONTAINS_STRING_JSONB_OID: u32 = 16_428;
+pub const OP_GET_VALUE_MAP_OID: u32 = 16_429;
+pub const OP_GET_VALUES_MAP_OID: u32 = 16_430;
+pub const OP_MOD_F32_OID: u32 = 16_431;
+pub const OP_MOD_F64_OID: u32 = 16_432;
+pub const OP_UNARY_PLUS_OID: u32 = 16_433;

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::oid;
 use lazy_static::lazy_static;
 use repr::ScalarType;
 
@@ -66,7 +67,7 @@ lazy_static! {
         // PostgreSQL. See the "OID Assignment" section of the PostgreSQL
         // documentation for details:
         // https://www.postgresql.org/docs/current/system-catalog-initial-data.html#SYSTEM-CATALOG-OID-ASSIGNMENT
-        16_384,
+        oid::TYPE_LIST_OID,
         postgres_types::Kind::Pseudo,
         "mz_catalog".to_owned(),
     );
@@ -75,7 +76,7 @@ lazy_static! {
     pub static ref MAP: postgres_types::Type = postgres_types::Type::new(
         "map".to_owned(),
         // OID chosen to follow our "LIST" type.
-        16_385,
+        oid::TYPE_MAP_OID,
         postgres_types::Kind::Pseudo,
         "mz_catalog".to_owned(),
     );

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -103,6 +103,15 @@ impl ObjectName {
     pub fn unqualified(n: &str) -> ObjectName {
         ObjectName(vec![Ident::new(n)])
     }
+
+    /// Creates an `ObjectName` with an [`Ident`] for each element of `n`.
+    ///
+    /// Panics if passed an in ineligible `&[&str]` whose length is 0 or greater
+    /// than 3.
+    pub fn qualified(n: &[&str]) -> ObjectName {
+        assert!(n.len() <= 3 && n.len() > 0);
+        ObjectName(n.iter().map(|n| (*n).into()).collect::<Vec<_>>())
+    }
 }
 
 impl AstDisplay for ObjectName {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -159,6 +159,7 @@ None
 Nosuperuser
 Not
 Null
+Nullif
 Objects
 Ocf
 Of

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -321,6 +321,7 @@ impl<'a> Parser<'a> {
             Token::Keyword(CASE) => self.parse_case_expr(),
             Token::Keyword(CAST) => self.parse_cast_expr(),
             Token::Keyword(COALESCE) => self.parse_coalesce_expr(),
+            Token::Keyword(NULLIF) => self.parse_nullif_expr(),
             Token::Keyword(EXISTS) => self.parse_exists_expr(),
             Token::Keyword(EXTRACT) => self.parse_extract_expr(),
             Token::Keyword(INTERVAL) => self.parse_literal_interval(),
@@ -638,6 +639,15 @@ impl<'a> Parser<'a> {
         let exprs = self.parse_comma_separated(Parser::parse_expr)?;
         self.expect_token(&Token::RParen)?;
         Ok(Expr::Coalesce { exprs })
+    }
+
+    fn parse_nullif_expr(&mut self) -> Result<Expr<Raw>, ParserError> {
+        self.expect_token(&Token::LParen)?;
+        let l_expr = Box::new(self.parse_expr()?);
+        self.expect_token(&Token::Comma)?;
+        let r_expr = Box::new(self.parse_expr()?);
+        self.expect_token(&Token::RParen)?;
+        Ok(Expr::NullIf { l_expr, r_expr })
     }
 
     fn parse_extract_expr(&mut self) -> Result<Expr<Raw>, ParserError> {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1177,6 +1177,18 @@ pub enum Func {
     Table(Vec<FuncImpl<TableFuncPlan>>),
 }
 
+/// Functions using this macro should be transformed/planned away before
+/// reaching function selection code, but still need to be present in the
+/// catalog during planning.
+macro_rules! catalog_name_only {
+    ($name:expr) => {
+        panic!(
+            "{} should be planned away before reaching function selection",
+            $name
+        )
+    };
+}
+
 lazy_static! {
     /// Correlates a built-in function name to its implementations.
     static ref PG_CATALOG_BUILTINS: HashMap<&'static str, Func> = {
@@ -1217,6 +1229,14 @@ lazy_static! {
             },
             "ascii" => Scalar {
                 params!(String) => UnaryFunc::Ascii, 1620;
+            },
+            "avg" => Scalar {
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("avg")), 2100;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("avg")), 2101;
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("avg")), 2103;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("avg")), 2104;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("avg")), 2105;
+                params!(Interval) => Operation::nullary(|_ecx| catalog_name_only!("avg")), 2105;
             },
             "bit_length" => Scalar {
                 params!(Bytes) => UnaryFunc::BitLengthBytes, 1810;
@@ -1364,6 +1384,11 @@ lazy_static! {
             "make_timestamp" => Scalar {
                 params!(Int64, Int64, Int64, Int64, Int64, Float64) => VariadicFunc::MakeTimestamp, 3461;
             },
+            "mod" => Scalar {
+                params!(DecimalAny, DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("mod")), 1728;
+                params!(Int32, Int32) => Operation::nullary(|_ecx| catalog_name_only!("mod")), 941;
+                params!(Int64, Int64) => Operation::nullary(|_ecx| catalog_name_only!("mod")), 947;
+            },
             "now" => Scalar {
                 params!() => Operation::nullary(|ecx| plan_current_timestamp(ecx, "now")), 1299;
             },
@@ -1440,6 +1465,27 @@ lazy_static! {
             "split_part" => Scalar {
                 params!(String, String, Int64) => VariadicFunc::SplitPart, 2088;
             },
+            "stddev" => Scalar {
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("stddev")), 2159;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("stddev")), 2157;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("stddev")), 2158;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("stddev")), 2155;
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("stddev")), 2154;
+            },
+            "stddev_pop" => Scalar {
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("stddev_pop")), 2729;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("stddev_pop")), 2727;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("stddev_pop")), 2728;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("stddev_pop")), 2725;
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("stddev_pop")), 2724;
+            },
+            "stddev_samp" => Scalar {
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("stddev_samp")), 2717;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("stddev_samp")), 2715;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("stddev_samp")), 2716;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("stddev_samp")), 2713;
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("stddev_samp")), 2712;
+            },
             "substr" => Scalar {
                 params!(String, Int64) => VariadicFunc::Substr, 883;
                 params!(String, Int64, Int64) => VariadicFunc::Substr, 877;
@@ -1488,6 +1534,27 @@ lazy_static! {
             },
             "upper" => Scalar {
                 params!(String) => UnaryFunc::Upper, 871;
+            },
+            "variance" => Scalar {
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("variance")), 2153;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("variance")), 2151;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("variance")), 2152;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("variance")), 2149;
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("variance")), 2148;
+            },
+            "var_pop" => Scalar {
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("var_pop")), 2723;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("var_pop")), 2721;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("var_pop")), 2722;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("var_pop")), 2719;
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("var_pop")), 2718;
+            },
+            "var_samp" => Scalar {
+                params!(DecimalAny) => Operation::nullary(|_ecx| catalog_name_only!("var_samp")), 2646;
+                params!(Float32) => Operation::nullary(|_ecx| catalog_name_only!("var_samp")), 2644;
+                params!(Float64) => Operation::nullary(|_ecx| catalog_name_only!("var_samp")), 2645;
+                params!(Int32) => Operation::nullary(|_ecx| catalog_name_only!("var_samp")), 2642;
+                params!(Int64) => Operation::nullary(|_ecx| catalog_name_only!("var_samp")), 2641;
             },
             "version" => Scalar {
                 params!() => Operation::nullary(|ecx| {

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -32,6 +32,7 @@ mod kafka_util;
 
 pub mod ast;
 pub mod catalog;
+pub mod func;
 pub mod names;
 pub mod normalize;
 pub mod parse;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -41,7 +41,6 @@ use crate::names::{DatabaseSpecifier, FullName, SchemaName};
 pub(crate) mod error;
 pub(crate) mod explain;
 pub(crate) mod expr;
-pub(crate) mod func;
 pub(crate) mod lowering;
 pub(crate) mod plan_utils;
 pub(crate) mod query;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -44,6 +44,7 @@ use repr::{
 };
 
 use crate::catalog::{Catalog, CatalogItemType};
+use crate::func::{self, Func, FuncSpec};
 use crate::names::PartialName;
 use crate::normalize;
 use crate::plan::error::PlanError;
@@ -51,7 +52,6 @@ use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, BinaryFunc, CoercibleScalarExpr, ColumnOrder,
     ColumnRef, HirRelationExpr, HirScalarExpr, JoinKind, UnaryFunc, VariadicFunc,
 };
-use crate::plan::func::{self, Func, FuncSpec};
 use crate::plan::plan_utils;
 use crate::plan::scope::{Scope, ScopeItem, ScopeItemName};
 use crate::plan::statement::StatementContext;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1465,6 +1465,7 @@ fn invent_column_name(ecx: &ExprContext, expr: &Expr<Raw>) -> Option<ScopeItemNa
             }
         }
         Expr::Coalesce { .. } => Some("coalesce".into()),
+        Expr::NullIf { .. } => Some("nullif".into()),
         Expr::Array { .. } => Some("array".into()),
         Expr::List { .. } => Some("list".into()),
         Expr::Cast { expr, .. } => return invent_column_name(ecx, expr),
@@ -1973,6 +1974,14 @@ pub fn plan_expr<'a>(
             };
             expr.into()
         }
+        Expr::NullIf { l_expr, r_expr } => plan_case(
+            ecx,
+            &None,
+            &[l_expr.clone().equals(*r_expr.clone())],
+            &[Expr::null()],
+            &Some(Box::new(*l_expr.clone())),
+        )?
+        .into(),
         Expr::FieldAccess { expr, field } => {
             let field = normalize::column_name(field.clone());
             let expr = plan_expr(ecx, expr)?.type_as_any(ecx)?;

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -84,9 +84,15 @@ impl<'a> FuncRewriter<'a> {
         }
     }
 
-    // Divides `lhs` by `rhs` but replaces division-by-zero errors with NULL.
+    // Divides `lhs` by `rhs` but replaces division-by-zero errors with NULL;
+    // note that this is semantically equivalent to `NULLIF(rhs, 0)`.
     fn plan_divide(lhs: Expr<Raw>, rhs: Expr<Raw>) -> Expr<Raw> {
-        lhs.divide(Self::plan_null_if(rhs, Expr::number("0")))
+        lhs.divide(Expr::Case {
+            operand: None,
+            conditions: vec![rhs.clone().equals(Expr::number("0"))],
+            results: vec![Expr::null()],
+            else_result: Some(Box::new(rhs)),
+        })
     }
 
     fn plan_agg(
@@ -181,15 +187,6 @@ impl<'a> FuncRewriter<'a> {
         Self::plan_variance(expr, filter, distinct, sample).call_unary(vec!["sqrt"])
     }
 
-    fn plan_null_if(left: Expr<Raw>, right: Expr<Raw>) -> Expr<Raw> {
-        Expr::Case {
-            operand: None,
-            conditions: vec![left.clone().equals(right)],
-            results: vec![Expr::null()],
-            else_result: Some(Box::new(left)),
-        }
-    }
-
     fn rewrite_expr(&mut self, expr: &Expr<Raw>) -> Option<(Ident, Expr<Raw>)> {
         match expr {
             Expr::Function(Function {
@@ -227,7 +224,6 @@ impl<'a> FuncRewriter<'a> {
                     let (lhs, rhs) = (args[0].clone(), args[1].clone());
                     match name.item.as_str() {
                         "mod" => lhs.modulo(rhs),
-                        "nullif" => Self::plan_null_if(lhs, rhs),
                         _ => return None,
                     }
                 } else {


### PR DESCRIPTION
pt2 of atomizing #5445
- `sql: promote func to its own module` will make more sense once you can create functions, but figured this was as good a time as any
- `sql: add OIDs to all builtin function and operators` facilitates ultimately generating a system table for functions
- `sql: add planned-away functions to builtins` adds some functions we plan away to the catalog and handles fully qualifying references to functions within those planned-away functions. This is a temporary stop gap until we rewrite them in terms of `sql_op!`, so know that those will be rewritten very soon
- `coord: use sql::catalog::CatalogItemType as SqlCatalogItemType` avoided a trip through CI for [this comment](https://github.com/MaterializeInc/materialize/pull/5504#discussion_r566463374)
- `sql: treat NULLIF as an expression` similar to adding planned-away functions to the catalog, preempts problems with resolving things in the catalog; in this case `NULLIF` is an expression and not a function so should not be handled on the function code path

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5505)
<!-- Reviewable:end -->
