### PR TITLE
s3 sources: Don't block unknown formats

### DIFF
--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -81,11 +81,8 @@ impl SourceConstructor<Vec<u8>> for S3SourceInfo {
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
-        encoding: DataEncoding,
+        _encoding: DataEncoding,
     ) -> Result<S3SourceInfo, anyhow::Error> {
-        if !matches!(encoding, DataEncoding::Text | DataEncoding::Bytes) {
-            anyhow::bail!("S3 sources only support 'text' or 'bytes' encodings");
-        }
         let s3_conn = match connector {
             ExternalSourceConnector::S3(s3_conn) => s3_conn,
             _ => {

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -71,3 +71,49 @@ a3 3
 a1 1
 a2 2
 a3 3
+
+$ s3-put-object bucket=${bucket} key=csv.csv
+c,7
+c,8
+c,9
+
+> CREATE MATERIALIZED SOURCE csv_example (name, counts)
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '*.csv'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH 2 COLUMNS;
+
+> SELECT * FROM csv_example ORDER BY mz_record;
+c 7 1
+c 8 2
+c 9 3
+
+> SELECT * FROM csv_example WHERE counts = '8';
+c 8 2
+
+$ s3-put-object bucket=${bucket} key=server.log
+[2020-01-20T12:00:00] INFO 10.0.0.1 GET /login connection_established
+[2020-01-20T12:00:01] INFO 10.0.0.1 PUT /login logged_in
+
+> CREATE MATERIALIZED SOURCE re
+  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '*.log'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT REGEX '\[(?P<dt>[^]]+)\] (?P<level>\w+) (?P<ip>[^ ]+) (?P<method>\w+) (?P<path>[^ ]+) (?P<message>.*)';
+
+> SELECT * FROM re ORDER BY dt DESC
+2020-01-20T12:00:01 INFO 10.0.0.1 PUT /login logged_in 2
+2020-01-20T12:00:00 INFO 10.0.0.1 GET /login connection_established 1
+
+> SELECT * FROM re WHERE method = 'PUT'
+2020-01-20T12:00:01 INFO 10.0.0.1 PUT /login logged_in 2


### PR DESCRIPTION
Datadecoding happens inside of the dataflow, I thought I needed to do more work
to support it initially. Turns out just disabling the filter supports at least
CSV and Regex sources.

Part of #4914

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5514)
<!-- Reviewable:end -->
