### PR TITLE
Expand Mux's support for Connection types other than TcpStream

### DIFF
--- a/src/ore/src/netio/async_ready.rs
+++ b/src/ore/src/netio/async_ready.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use async_trait::async_trait;
-use tokio::io::{self, Interest, Ready};
+use tokio::{io::{self, Interest, Ready}, net::UnixStream};
 use tokio::net::TcpStream;
 use tokio_openssl::SslStream;
 
@@ -26,6 +26,13 @@ pub trait AsyncReady {
 
 #[async_trait]
 impl AsyncReady for TcpStream {
+    async fn ready(&self, interest: Interest) -> io::Result<Ready> {
+        self.ready(interest).await
+    }
+}
+
+#[async_trait]
+impl AsyncReady for UnixStream {
     async fn ready(&self, interest: Interest) -> io::Result<Ready> {
         self.ready(interest).await
     }


### PR DESCRIPTION
* Allow `Mux` to operate over arbitrary async streams
* Expand existing support for `UnixStream`s by implementing `AsyncReady` for it.
* Move tcp connection postprocessing (`set_nodelay(true)`) from `Mux` to `Server` so that `Mux` doesn't need to depend on `TcpStream` semantics. **Is this the right place to move it to?**

As I'm fairly new to Rust, it isn't entirely clear to me if there's a more idiomatic way to write `AsyncRead + AsyncWrite + Unpin + Send + Sync`.. it certainly seems like something that could be get wrapped up into a type that describes a bidirectional async stream, but I didn't see an obvious example of this in the docs, so I left it as is.

I also ended up having to make `mux` public so I could use it. If that feels smelly or has some unintended consequence, I'm happy to remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5516)
<!-- Reviewable:end -->
