### PR TITLE
Use fast-float to parse floats for 50-75% speedup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fast-float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
+
+[[package]]
 name = "filetime"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3236,7 @@ dependencies = [
  "chrono-tz",
  "criterion",
  "enum-kinds",
+ "fast-float",
  "hex",
  "itertools",
  "ordered-float",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = "1.4.2"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.5.0", features = ["serde"] }
 enum-kinds = "0.5.0"
+fast-float = "0.2.0"
 hex = "0.4.2"
 itertools = "0.9.0"
 ordered-float = { version = "2.0.0", features = ["serde"] }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -30,12 +30,11 @@ use std::fmt;
 
 use chrono::offset::{Offset, TimeZone};
 use chrono::{DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
-use ore::lex::LexBuf;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use ore::ascii::UncasedStr;
 use ore::fmt::FormatBuffer;
+use ore::lex::LexBuf;
 
 use crate::adt::array::ArrayDimension;
 use crate::adt::datetime::{self, DateTimeField, ParsedDateTime};
@@ -127,18 +126,7 @@ where
 
 /// Parses an `f32` from `s`.
 pub fn parse_float32(s: &str) -> Result<f32, ParseError> {
-    let s = UncasedStr::new(s.trim());
-    if s == "inf" || s == "infinity" || s == "+inf" || s == "+infinity" {
-        Ok(f32::INFINITY)
-    } else if s == "-inf" || s == "-infinity" {
-        Ok(f32::NEG_INFINITY)
-    } else if s == "nan" {
-        Ok(f32::NAN)
-    } else {
-        s.as_str()
-            .parse()
-            .map_err(|e| ParseError::new("real", s.as_str()).with_details(e))
-    }
+    fast_float::parse(s).map_err(|_| ParseError::new("real", s))
 }
 
 /// Writes an `f32` to `buf`.
@@ -160,18 +148,7 @@ where
 
 /// Parses an `f64` from `s`.
 pub fn parse_float64(s: &str) -> Result<f64, ParseError> {
-    let s = UncasedStr::new(s.trim());
-    if s == "inf" || s == "infinity" || s == "+inf" || s == "+infinity" {
-        Ok(f64::INFINITY)
-    } else if s == "-inf" || s == "-infinity" {
-        Ok(f64::NEG_INFINITY)
-    } else if s == "nan" {
-        Ok(f64::NAN)
-    } else {
-        s.as_str()
-            .parse()
-            .map_err(|e| ParseError::new("double precision", s.as_str()).with_details(e))
-    }
+    fast_float::parse(s).map_err(|_| ParseError::new("double precision", s))
 }
 
 /// Writes an `f64` to `buf`.

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -477,7 +477,7 @@ SELECT '1'::jsonb::double;
 ----
 1.000
 
-query error invalid input syntax for double precision: invalid float literal: "dog"
+query error invalid input syntax for double precision: "dog"
 SELECT 'dog'::text::double
 
 query error CAST does not support casting from time to double precision
@@ -534,7 +534,7 @@ SELECT '2'::jsonb::real;
 ----
 2.000
 
-query error invalid input syntax for real: invalid float literal: "dog"
+query error invalid input syntax for real: "dog"
 SELECT 'dog'::text::real
 
 query error CAST does not support casting from time to real


### PR DESCRIPTION
Came across
https://lemire.me/blog/2021/01/29/number-parsing-at-a-gigabyte-per-second/
which pointed out the rust library. Since we recently optimized this because it
was showing up in a customer profile I thought it'd be worth doing:

    $ cargo bench -- parse_float
    parse_float32/-3.0      time:   [10.227 ns 10.292 ns 10.364 ns]
                            change: [-74.777% -74.335% -73.827%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 8 outliers among 100 measurements (8.00%)
      1 (1.00%) low mild
      3 (3.00%) high mild
      4 (4.00%) high severe

    parse_float32/9.7       time:   [9.7706 ns 9.8281 ns 9.8885 ns]
                            change: [-76.467% -75.562% -74.784%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 7 outliers among 100 measurements (7.00%)
      2 (2.00%) low mild
      3 (3.00%) high mild
      2 (2.00%) high severe

    parse_float32/NaN       time:   [6.3433 ns 6.3743 ns 6.4075 ns]
                            change: [-69.361% -69.100% -68.846%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 10 outliers among 100 measurements (10.00%)
      7 (7.00%) high mild
      3 (3.00%) high severe

    parse_float32/inFiNiTy  time:   [9.1302 ns 9.1807 ns 9.2367 ns]
                            change: [-50.457% -50.038% -49.601%] (p = 0.00 < 0.05)
                            Performance has improved.
    Found 10 outliers among 100 measurements (10.00%)
      6 (6.00%) high mild
      4 (4.00%) high severe

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5517)
<!-- Reviewable:end -->
