### PR TITLE
sql,coord: support temporary materialized views and indexes

### DIFF
--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -22,6 +22,7 @@ query in memory. For more information, see [API Components: Materialized views](
 
 Field | Use
 ------|-----
+**TEMP** / **TEMPORARY** | Mark the materialized view as [temporary](#temporary-materialized-views).
 **OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views or sinks depend on, nor can you replace a non-view object with a view.
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a view of the same name already exists. <br/><br/>If _not_ specified, throw an error if a view of the same name already exists. _(Default)_
 _view&lowbar;name_ | A name for the view.
@@ -52,6 +53,16 @@ Some things you might want to do with indexes...
 - If you find that your queries would benefit from other indexes, e.g. you want
   to join two relations on some foreign key, you can [create
   indexes](../create-index).
+
+### Temporary materialized views
+
+The `TEMP`/`TEMPORARY` keyword creates a temporary materialized view. Temporary
+materialized views are automatically dropped at the end of the SQL session and
+are not visible to other connections. They are always created in the special `mz_temp`
+schema.
+
+Temporary materialized views may depend upon other temporary database objects,
+but non-temporary materialized views may not depend on temporary objects.
 
 ## Examples
 

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -24,7 +24,7 @@ shorthand for performing the query. For more information, see [API Components: S
 
 Field | Use
 ------|-----
-**TEMP** / **TEMPORARY** | Mark the view as temporary.
+**TEMP** / **TEMPORARY** | Mark the view as [temporary](#temporary-views).
 **OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views or sinks depend on, nor can you replace a non-view object with a view.
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a view of the same name already exists. <br/><br/>If _not_ specified, throw an error if a view of the same name already exists. _(Default)_
 _view&lowbar;name_ | A name for the view.
@@ -82,10 +82,8 @@ The `TEMP`/`TEMPORARY` keyword creates a temporary view. Temporary views are
 automatically dropped at the end of the SQL session and are not visible to other
 connections. They are always created in the special `mz_temp` schema.
 
-Temporary views may depend upon other temporary views, but non-temporary views
-may not depend on a temporary view.
-
-Materialize does not yet support creating indexes on temporary views.
+Temporary views may depend upon other temporary database objects, but non-temporary
+views may not depend on temporary objects.
 
 ## Examples
 

--- a/doc/user/layouts/partials/sql-grammar/create-materialized-view.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-materialized-view.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="525" height="179">
+<svg xmlns="http://www.w3.org/2000/svg" width="591" height="365">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -9,54 +9,86 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">CREATE</text>
-   <rect x="145" y="3" width="160" height="32" rx="10"/>
-   <rect x="143"
-         y="1"
+   <rect x="65" y="101" width="58" height="32" rx="10"/>
+   <rect x="63"
+         y="99"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="119">TEMP</text>
+   <rect x="65" y="145" width="106" height="32" rx="10"/>
+   <rect x="63"
+         y="143"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="163">TEMPORARY</text>
+   <rect x="211" y="69" width="160" height="32" rx="10"/>
+   <rect x="209"
+         y="67"
          width="160"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="21">MATERIALIZED VIEW</text>
-   <rect x="345" y="35" width="118" height="32" rx="10"/>
-   <rect x="343"
-         y="33"
+   <text class="terminal" x="219" y="87">MATERIALIZED VIEW</text>
+   <rect x="411" y="101" width="118" height="32" rx="10"/>
+   <rect x="409"
+         y="99"
          width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="353" y="53">IF NOT EXISTS</text>
-   <rect x="145" y="79" width="108" height="32" rx="10"/>
-   <rect x="143"
-         y="77"
+   <text class="terminal" x="419" y="119">IF NOT EXISTS</text>
+   <rect x="45" y="189" width="108" height="32" rx="10"/>
+   <rect x="43"
+         y="187"
          width="108"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="153" y="97">OR REPLACE</text>
-   <rect x="273" y="79" width="160" height="32" rx="10"/>
-   <rect x="271"
-         y="77"
+   <text class="terminal" x="53" y="207">OR REPLACE</text>
+   <rect x="193" y="221" width="58" height="32" rx="10"/>
+   <rect x="191"
+         y="219"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="239">TEMP</text>
+   <rect x="193" y="265" width="106" height="32" rx="10"/>
+   <rect x="191"
+         y="263"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="283">TEMPORARY</text>
+   <rect x="339" y="189" width="160" height="32" rx="10"/>
+   <rect x="337"
+         y="187"
          width="160"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="281" y="97">MATERIALIZED VIEW</text>
-   <rect x="241" y="145" width="88" height="32"/>
-   <rect x="239" y="143" width="88" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="249" y="163">view_name</text>
-   <rect x="349" y="145" width="38" height="32" rx="10"/>
-   <rect x="347"
-         y="143"
+   <text class="terminal" x="347" y="207">MATERIALIZED VIEW</text>
+   <rect x="307" y="331" width="88" height="32"/>
+   <rect x="305" y="329" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="315" y="349">view_name</text>
+   <rect x="415" y="331" width="38" height="32" rx="10"/>
+   <rect x="413"
+         y="329"
          width="38"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="357" y="163">AS</text>
-   <rect x="407" y="145" width="90" height="32"/>
-   <rect x="405" y="143" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="415" y="163">select_stmt</text>
+   <text class="terminal" x="423" y="349">AS</text>
+   <rect x="473" y="331" width="90" height="32"/>
+   <rect x="471" y="329" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="481" y="349">select_stmt</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m160 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m-358 -32 h20 m358 0 h20 m-398 0 q10 0 10 10 m378 0 q0 -10 10 -10 m-388 10 v56 m378 0 v-56 m-378 56 q0 10 10 10 m358 0 q10 0 10 -10 m-368 10 h10 m108 0 h10 m0 0 h10 m160 0 h10 m0 0 h50 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-306 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
-   <polygon points="515 159 523 155 523 163"/>
-   <polygon points="515 159 507 155 507 163"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-124 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h48 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m20 -76 h10 m160 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m-524 -32 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v100 m544 0 v-100 m-544 100 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m108 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h48 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m20 -76 h10 m160 0 h10 m0 0 h50 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-306 262 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m88 0 h10 m0 0 h10 m38 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
+   <polygon points="581 345 589 341 589 349"/>
+   <polygon points="581 345 573 341 573 349"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -25,9 +25,9 @@ create_index ::=
         | 'DEFAULT INDEX ON' obj_name
     )
 create_materialized_view ::=
-  'CREATE' 'MATERIALIZED VIEW' view_name 'AS' select_stmt |
-  'CREATE' 'MATERIALIZED VIEW' 'IF NOT EXISTS' view_name 'AS' select_stmt |
-  'CREATE' 'OR REPLACE' 'MATERIALIZED VIEW' view_name 'AS' select_stmt
+  'CREATE' ('TEMP' | 'TEMPORARY')? 'MATERIALIZED VIEW' view_name 'AS' select_stmt |
+  'CREATE' ('TEMP' | 'TEMPORARY')? 'MATERIALIZED VIEW' 'IF NOT EXISTS' view_name 'AS' select_stmt |
+  'CREATE' 'OR REPLACE' ('TEMP' | 'TEMPORARY')? 'MATERIALIZED VIEW' view_name 'AS' select_stmt
 create_role ::=
     'CREATE' 'ROLE' role_name ('LOGIN' | 'NOLOGIN' | 'SUPERUSER' | 'NOSUPERUSER')*
 create_schema ::=

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1798,8 +1798,13 @@ where
         let index_id = self.catalog.allocate_id()?;
         let mut index_name = name.clone();
         index_name.item += "_primary_idx";
-        let index =
-            auto_generate_primary_idx(index_name.item.clone(), name.clone(), table_id, &table.desc);
+        let index = auto_generate_primary_idx(
+            index_name.item.clone(),
+            name.clone(),
+            table_id,
+            &table.desc,
+            None,
+        );
         let table_oid = self.catalog.allocate_oid()?;
         let index_oid = self.catalog.allocate_oid()?;
         match self
@@ -1854,8 +1859,13 @@ where
         let index_id = if materialized {
             let mut index_name = name.clone();
             index_name.item += "_primary_idx";
-            let index =
-                auto_generate_primary_idx(index_name.item.clone(), name, source_id, &source.desc);
+            let index = auto_generate_primary_idx(
+                index_name.item.clone(),
+                name,
+                source_id,
+                &source.desc,
+                None,
+            );
             let index_id = self.catalog.allocate_id()?;
             let index_oid = self.catalog.allocate_oid()?;
             ops.push(catalog::Op::CreateItem {
@@ -2006,8 +2016,13 @@ where
         let index_id = if materialize {
             let mut index_name = name.clone();
             index_name.item += "_primary_idx";
-            let index =
-                auto_generate_primary_idx(index_name.item.clone(), name, view_id, &view.desc);
+            let index = auto_generate_primary_idx(
+                index_name.item.clone(),
+                name,
+                view_id,
+                &view.desc,
+                view.conn_id,
+            );
             let index_id = self.catalog.allocate_id()?;
             let index_oid = self.catalog.allocate_oid()?;
             ops.push(catalog::Op::CreateItem {
@@ -2048,6 +2063,7 @@ where
             plan_cx: pcx,
             keys: index.keys,
             on: index.on,
+            conn_id: None,
         };
         let id = self.catalog.allocate_id()?;
         let oid = self.catalog.allocate_oid()?;
@@ -3437,6 +3453,7 @@ fn auto_generate_primary_idx(
     on_name: FullName,
     on_id: GlobalId,
     on_desc: &RelationDesc,
+    conn_id: Option<u32>,
 ) -> catalog::Index {
     let default_key = on_desc.typ().default_key();
 
@@ -3448,6 +3465,7 @@ fn auto_generate_primary_idx(
             .iter()
             .map(|k| MirScalarExpr::Column(*k))
             .collect(),
+        conn_id,
     }
 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1327,10 +1327,15 @@ impl<'a> Parser<'a> {
                 self.prev_token();
                 self.prev_token();
                 self.parse_create_view()
+            } else if self.parse_keyword(MATERIALIZED) && self.parse_keyword(VIEW) {
+                self.prev_token();
+                self.prev_token();
+                self.prev_token();
+                self.parse_create_view()
             } else {
                 self.expected(
                     self.peek_pos(),
-                    "VIEW after CREATE TEMPORARY",
+                    "VIEW or MATERIALIZED VIEW after CREATE TEMPORARY",
                     self.peek_token(),
                 )
             }

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -9,56 +9,66 @@
 
 > CREATE VIEW v AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar')
 
-> SELECT * FROM v;
+> SELECT * FROM v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-> CREATE TEMPORARY VIEW temp_v AS SELECT * FROM v;
+> CREATE TEMPORARY VIEW temp_v AS SELECT * FROM v
 
-> SELECT * FROM temp_v;
+> SELECT * FROM temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-> SELECT * FROM mz_temp.temp_v;
+> SELECT * FROM mz_temp.temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-! CREATE VIEW non_temp AS SELECT * FROM temp_v;
+! CREATE VIEW non_temp AS SELECT * FROM temp_v
 non-temporary items cannot depend on temporary item
 
-> CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v;
+> CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
 
-! CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v;
+! CREATE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
 catalog item 'double_temp_v' already exists
 
-> SELECT * FROM double_temp_v;
+> CREATE OR REPLACE TEMP VIEW double_temp_v AS SELECT * FROM temp_v
+
+! CREATE OR REPLACE VIEW double_temp_v AS SELECT * FROM temp_v
+non-temporary items cannot depend on temporary item
+
+> SELECT * FROM double_temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
 
-> SELECT * FROM mz_temp.double_temp_v;
+> SELECT * FROM mz_temp.double_temp_v
 1 "foo"
 1 "bar"
 2 "bar"
 3 "foo"
+
+> CREATE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
+
+> SHOW INDEXES FROM foo
+ on_name    key_name         seq_in_index  column_name  expression  nullable
+---------------------------------------------------------------------------
+ foo        foo_primary_idx  1             column1      <null>      false
+ foo        foo_primary_idx  2             column2      <null>      false
+
+! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v
+catalog item 'foo' already exists
+
+> CREATE OR REPLACE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
 
 #####################################################################
 # Test things we shouldn't be able to make temporary.
-
-##### Temporary materialized views.
-! CREATE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v;
-Expected VIEW after CREATE TEMPORARY, found MATERIALIZED
-
-! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v;
-Expected VIEW after CREATE TEMPORARY, found MATERIALIZED
-
 
 ##### Temporary sources.
 $ set schema={
@@ -71,14 +81,14 @@ $ set schema={
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-Expected VIEW after CREATE TEMPORARY, found SOURCE
+Expected VIEW or MATERIALIZED VIEW after CREATE TEMPORARY, found SOURCE
 
 
 ##### Temporary sinks.
 ! CREATE TEMPORARY SINK data_sink FROM data
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-Expected VIEW after CREATE TEMPORARY, found SINK
+Expected VIEW or MATERIALIZED VIEW after CREATE TEMPORARY, found SINK
 
 #####################################################################
 
@@ -91,6 +101,8 @@ cannot drop mz_temp.temp_v: still depended upon by catalog item 'mz_temp.double_
 unknown catalog item 'double_temp_v'
 
 > DISCARD TEMP
+
+> SELECT * FROM mz_indexes WHERE name = 'foo_primary_idx'
 
 ! SELECT * FROM temp_v;
 unknown catalog item 'temp_v'


### PR DESCRIPTION
Fixes part of https://github.com/MaterializeInc/materialize/issues/5470.

This change allows users to `CREATE TEMPORARY MATERIALIZED VIEW`s. Any
temporary materialized view will be created with temporary indexes.
These objects behave identically to other temporary objects in our
catalog.

The new `CREATE MATERIALIZED VIEW` grammar diagram looks like:
<img width="1038" alt="Screen Shot 2021-02-01 at 12 08 20 PM" src="https://user-images.githubusercontent.com/5766027/106492696-386d1400-6486-11eb-8d8e-67b09d8dd1ce.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5542)
<!-- Reviewable:end -->
