### PR TITLE
coord,sql: support CREATE TEMPORARY TABLE

### DIFF
--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -37,6 +37,7 @@ You might want to create a table when...
 
 Field | Use
 ------|-----
+**TEMP** / **TEMPORARY** | Mark the table as [temporary](#temporary-tables).
 _table&lowbar;name_ | A name for the table.
 _col&lowbar;name_ | The name of the column to be created in the table.
 _col&lowbar;type_ | The data type of the column indicated by _col&lowbar;name_.
@@ -59,6 +60,15 @@ Additionally, tables do not currently support:
   INSERT INTO t1 SELECT * FROM t2
   ```
 - `UPDATE ...` and `DELETE` statements
+
+### Temporary tables
+
+The `TEMP`/`TEMPORARY` keyword creates a temporary table. Temporary tables are
+automatically dropped at the end of the SQL session and are not visible to other
+connections. They are always created in the special `mz_temp` schema.
+
+Temporary tables may depend upon other temporary database objects, but non-temporary
+tables may not depend on temporary objects.
 
 ## Examples
 

--- a/doc/user/layouts/partials/sql-grammar/create-table.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-table.svg
@@ -1,60 +1,76 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="493" height="197">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="74" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="533" height="273">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="74" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">CREATE</text>
-   <rect x="127" y="3" width="64" height="32" rx="10"/>
-   <rect x="125"
+   <text class="terminal" x="39" y="21">CREATE</text>
+   <rect x="145" y="35" width="58" height="32" rx="10"/>
+   <rect x="143"
+         y="33"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="153" y="53">TEMP</text>
+   <rect x="145" y="79" width="106" height="32" rx="10"/>
+   <rect x="143"
+         y="77"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="153" y="97">TEMPORARY</text>
+   <rect x="291" y="3" width="64" height="32" rx="10"/>
+   <rect x="289"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="135" y="21">TABLE</text>
-   <rect x="211" y="3" width="92" height="32"/>
-   <rect x="209" y="1" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="219" y="21">table_name</text>
-   <rect x="323" y="3" width="24" height="32" rx="10"/>
-   <rect x="321"
+   <text class="terminal" x="299" y="21">TABLE</text>
+   <rect x="375" y="3" width="92" height="32"/>
+   <rect x="373" y="1" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="383" y="21">table_name</text>
+   <rect x="487" y="3" width="24" height="32" rx="10"/>
+   <rect x="485"
          y="1"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="331" y="21">(</text>
-   <rect x="65" y="147" width="80" height="32"/>
-   <rect x="63" y="145" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="73" y="165">col_name</text>
-   <rect x="165" y="147" width="72" height="32"/>
-   <rect x="163" y="145" width="72" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="173" y="165">col_type</text>
-   <rect x="277" y="113" width="84" height="32"/>
-   <rect x="275" y="111" width="84" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="285" y="131">col_option</text>
-   <rect x="65" y="69" width="24" height="32" rx="10"/>
-   <rect x="63"
-         y="67"
+   <text class="terminal" x="495" y="21">(</text>
+   <rect x="105" y="223" width="80" height="32"/>
+   <rect x="103" y="221" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="113" y="241">col_name</text>
+   <rect x="205" y="223" width="72" height="32"/>
+   <rect x="203" y="221" width="72" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="213" y="241">col_type</text>
+   <rect x="317" y="189" width="84" height="32"/>
+   <rect x="315" y="187" width="84" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="325" y="207">col_option</text>
+   <rect x="105" y="145" width="24" height="32" rx="10"/>
+   <rect x="103"
+         y="143"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="87">,</text>
-   <rect x="441" y="147" width="24" height="32" rx="10"/>
-   <rect x="439"
-         y="145"
+   <text class="terminal" x="113" y="163">,</text>
+   <rect x="481" y="223" width="24" height="32" rx="10"/>
+   <rect x="479"
+         y="221"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="449" y="165">)</text>
+   <text class="terminal" x="489" y="241">)</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m74 0 h10 m0 0 h10 m64 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-366 144 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m80 0 h10 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h94 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m104 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-104 0 h10 m84 0 h10 m-336 34 l20 0 m-1 0 q-9 0 -9 -10 l0 -58 q0 -10 10 -10 m336 78 l20 0 m-20 0 q10 0 10 -10 l0 -58 q0 -10 -10 -10 m-336 0 h10 m24 0 h10 m0 0 h292 m-376 78 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v14 m396 0 v-14 m-396 14 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m0 0 h366 m20 -34 h10 m24 0 h10 m3 0 h-3"/>
-   <polygon points="483 161 491 157 491 165"/>
-   <polygon points="483 161 475 157 475 165"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h116 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v12 m146 0 v-12 m-146 12 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m58 0 h10 m0 0 h48 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m20 -76 h10 m64 0 h10 m0 0 h10 m92 0 h10 m0 0 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-490 220 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m80 0 h10 m0 0 h10 m72 0 h10 m20 0 h10 m0 0 h94 m-124 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m104 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-104 0 h10 m84 0 h10 m-336 34 l20 0 m-1 0 q-9 0 -9 -10 l0 -58 q0 -10 10 -10 m336 78 l20 0 m-20 0 q10 0 10 -10 l0 -58 q0 -10 -10 -10 m-336 0 h10 m24 0 h10 m0 0 h292 m-376 78 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v14 m396 0 v-14 m-396 14 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m0 0 h366 m20 -34 h10 m24 0 h10 m3 0 h-3"/>
+   <polygon points="523 237 531 233 531 241"/>
+   <polygon points="523 237 515 233 515 241"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -178,7 +178,7 @@ create_view ::=
   'CREATE' ('TEMP' | 'TEMPORARY')? 'VIEW' 'IF NOT EXISTS' view_name 'AS' select_stmt |
   'CREATE' 'OR REPLACE' 'VIEW' view_name 'AS' select_stmt
 create_table ::=
-  'CREATE' 'TABLE' table_name
+  'CREATE' ('TEMP' | 'TEMPORARY')? 'TABLE' table_name
   '(' ((col_name col_type col_option*) (',' col_name col_type col_option*)*)? ')'
 declare ::=
   'DECLARE' cursor_name 'CURSOR' ('WITHOUT' 'HOLD')? 'FOR' query

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -62,6 +62,7 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
                     constraints: _,
                     with_options: _,
                     if_not_exists: _,
+                    temporary: _,
                 }) => {
                     for c in columns {
                         TypeNormalizer.visit_column_def_mut(c);

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1526,7 +1526,7 @@ where
                 table,
                 if_not_exists,
             } => tx.send(
-                self.sequence_create_table(pcx, name, table, if_not_exists)
+                self.sequence_create_table(pcx, name, table, if_not_exists, session.conn_id())
                     .await,
                 session,
             ),
@@ -1833,13 +1833,16 @@ where
         name: FullName,
         table: sql::plan::Table,
         if_not_exists: bool,
+        conn_id: u32,
     ) -> Result<ExecuteResponse, CoordError> {
+        let conn_id = if table.temporary { Some(conn_id) } else { None };
         let table_id = self.catalog.allocate_id()?;
         let table = catalog::Table {
             create_sql: table.create_sql,
             plan_cx: pcx,
             desc: table.desc,
             defaults: table.defaults,
+            conn_id,
         };
         let index_id = self.catalog.allocate_id()?;
         let mut index_name = name.clone();
@@ -1849,7 +1852,7 @@ where
             name.clone(),
             table_id,
             &table.desc,
-            None,
+            conn_id,
         );
         let table_oid = self.catalog.allocate_oid()?;
         let index_oid = self.catalog.allocate_oid()?;

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -506,11 +506,16 @@ pub struct CreateTableStatement<T: AstInfo> {
     pub constraints: Vec<TableConstraint<T>>,
     pub with_options: Vec<SqlOption>,
     pub if_not_exists: bool,
+    pub temporary: bool,
 }
 
 impl<T: AstInfo> AstDisplay for CreateTableStatement<T> {
     fn fmt(&self, f: &mut AstFormatter) {
-        f.write_str("CREATE TABLE ");
+        f.write_str("CREATE ");
+        if self.temporary {
+            f.write_str("TEMPORARY ");
+        }
+        f.write_str("TABLE ");
         if self.if_not_exists {
             f.write_str("IF NOT EXISTS ");
         }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1318,6 +1318,7 @@ impl<'a> Parser<'a> {
         } else if self.parse_keyword(SCHEMA) {
             self.parse_create_schema()
         } else if self.parse_keyword(TABLE) {
+            self.prev_token();
             self.parse_create_table()
         } else if self.parse_keyword(OR) || self.parse_keyword(VIEW) {
             self.prev_token();
@@ -1332,6 +1333,10 @@ impl<'a> Parser<'a> {
                 self.prev_token();
                 self.prev_token();
                 self.parse_create_view()
+            } else if self.parse_keyword(TABLE) {
+                self.prev_token();
+                self.prev_token();
+                self.parse_create_table()
             } else {
                 self.expected(
                     self.peek_pos(),
@@ -1885,6 +1890,8 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_table(&mut self) -> Result<Statement<Raw>, ParserError> {
+        let temporary = self.parse_keyword(TEMPORARY) | self.parse_keyword(TEMP);
+        self.expect_keyword(TABLE)?;
         let if_not_exists = self.parse_if_not_exists()?;
         let table_name = self.parse_object_name()?;
         // parse optional column list (schema)
@@ -1897,6 +1904,7 @@ impl<'a> Parser<'a> {
             constraints,
             with_options,
             if_not_exists,
+            temporary,
         }))
     }
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -29,7 +29,7 @@ CREATE TABLE uk_cities (
 ----
 CREATE TABLE uk_cities (name varchar(100) NOT NULL, lat float8 NULL, lng float8, constrained int4 NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), ref int4 REFERENCES othertable (a, b))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: ObjectName([Ident("float8")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: ObjectName([Ident("float8")]), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: ">", expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: ObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: ObjectName([Ident("float8")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: ObjectName([Ident("float8")]), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: ">", expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: ObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
@@ -43,7 +43,7 @@ CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
 CREATE TABLE t (c int4) WITH (foo = 'bar', a = 123)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [Value { name: Ident("foo"), value: String("bar") }, Value { name: Ident("a"), value: Number("123") }], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [Value { name: Ident("foo"), value: String("bar") }, Value { name: Ident("a"), value: Number("123") }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t
@@ -57,7 +57,14 @@ CREATE TABLE t ()
 ----
 CREATE TABLE t ()
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+
+parse-statement
+CREATE TEMP TABLE t ()
+----
+CREATE TEMPORARY TABLE t ()
+=>
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (bar int,)
@@ -71,21 +78,14 @@ CREATE TABLE foo (bar int list)
 ----
 CREATE TABLE foo (bar int4 list)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: ObjectName([Ident("int4")]), typ_mod: [] }), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: ObjectName([Ident("int4")]), typ_mod: [] }), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (bar int list list)
 ----
 CREATE TABLE foo (bar int4 list list)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: ObjectName([Ident("int4")]), typ_mod: [] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
-
-parse-statement
-CREATE TABLE t ()
-----
-CREATE TABLE t ()
-=>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: ObjectName([Ident("int4")]), typ_mod: [] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE tab (foo int,
@@ -99,91 +99,91 @@ CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: ObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: ObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
-CREATE TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
+CREATE TEMPORARY TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 ----
-CREATE TABLE foo (id int4, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
+CREATE TEMPORARY TABLE foo (id int4, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: "<>", expr1: Function(Function { name: ObjectName([Ident("rtrim")]), args: Args([Function(Function { name: ObjectName([Ident("ltrim")]), args: Args([Identifier([Ident("ref_code")])]), filter: None, over: None, distinct: false })]), filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: "<>", expr1: Function(Function { name: ObjectName([Ident("rtrim")]), args: Args([Function(Function { name: ObjectName([Ident("ltrim")]), args: Args([Identifier([Ident("ref_code")])]), filter: None, over: None, distinct: false })]), filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 ----
 CREATE TABLE foo (id int4, PRIMARY KEY (foo, bar))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, UNIQUE (id))
 ----
 CREATE TABLE foo (id int4, UNIQUE (id))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 ----
 CREATE TABLE foo (id int4, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: ObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: ObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
 ----
 CREATE TABLE foo (id int4, CHECK (end_date > start_date OR end_date IS NULL))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: ">", expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsNull { expr: Identifier([Ident("end_date")]), negated: false } } }], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: ">", expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsNull { expr: Identifier([Ident("end_date")]), negated: false } } }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
-CREATE TABLE t (c schema.type)
+CREATE TEMP TABLE t (c schema.type)
 ----
-CREATE TABLE t (c schema.type)
+CREATE TEMPORARY TABLE t (c schema.type)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c db.schema.type)
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "db"."schema"."type")
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c something.db.schema.type)
 ----
 CREATE TABLE t (c something.db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
-CREATE TABLE t (c db.schema.type(0,1,100))
+CREATE TEMP TABLE t (c db.schema.type(0,1,100))
 ----
-CREATE TABLE t (c db.schema.type(0, 1, 100))
+CREATE TEMPORARY TABLE t (c db.schema.type(0, 1, 100))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c time with time zone (0,1,100))
@@ -211,14 +211,14 @@ CREATE TABLE t (c "type"(1))
 ----
 CREATE TABLE t (c type(1))
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("type")]), typ_mod: [1] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: ObjectName([Ident("type")]), typ_mod: [1] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "type"(1) list list)
 ----
 CREATE TABLE t (c type(1) list list)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: ObjectName([Ident("type")]), typ_mod: [1] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: ObjectName([Ident("type")]), typ_mod: [1] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo
@@ -786,7 +786,7 @@ CREATE TABLE public.customer (
 ----
 CREATE TABLE public.customer (customer_id int4 DEFAULT nextval(public.customer_customer_id_seq), store_id smallint NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) NOT NULL, email varchar(50), address_id smallint NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamptz, active int4 NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 =>
-CreateTable(CreateTableStatement { name: ObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("nextval")]), args: Args([Identifier([Ident("public"), Ident("customer_customer_id_seq")])]), filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: ObjectName([Ident("smallint")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [45] }, collation: Some(ObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: ObjectName([Ident("smallint")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: ObjectName([Ident("bool")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: ObjectName([Ident("date")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false }), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: ObjectName([Ident("timestamp")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: ObjectName([Ident("timestamptz")]), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [Value { name: Ident("fillfactor"), value: Number("20") }, Value { name: Ident("user_catalog_table"), value: Boolean(true) }, Value { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false })
+CreateTable(CreateTableStatement { name: ObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("nextval")]), args: Args([Identifier([Ident("public"), Ident("customer_customer_id_seq")])]), filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: ObjectName([Ident("smallint")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [45] }, collation: Some(ObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: ObjectName([Ident("varchar")]), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: ObjectName([Ident("smallint")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: ObjectName([Ident("bool")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: ObjectName([Ident("date")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false }), data_type: Other { name: ObjectName([Ident("text")]), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: ObjectName([Ident("timestamp")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: ObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: ObjectName([Ident("timestamptz")]), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: ObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [Value { name: Ident("fillfactor"), value: Number("20") }, Value { name: Ident("user_catalog_table"), value: Boolean(true) }, Value { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false, temporary: false })
 
 parse-statement roundtrip
 CREATE TABLE public.customer (

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -34,7 +34,11 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
         | Statement::CreateSource(CreateSourceStatement { name, .. })
         | Statement::CreateView(CreateViewStatement { name, .. })
         | Statement::CreateTable(CreateTableStatement { name, .. }) => {
-            name.0[2] = Ident::new(to_item_name);
+            // The last name in an ObjectName is the item name. The item name
+            // does not have a fixed index.
+            // TODO: https://github.com/MaterializeInc/materialize/issues/5591
+            let object_name_len = name.0.len() - 1;
+            name.0[object_name_len] = Ident::new(to_item_name);
         }
         _ => unreachable!("Internal error: only catalog items can be renamed"),
     }
@@ -60,7 +64,11 @@ pub fn create_stmt_rename_refs(
     let from_object = ObjectName::from(from_name.clone());
     let maybe_update_object_name = |object_name: &mut ObjectName| {
         if object_name.0 == from_object.0 {
-            object_name.0[2] = Ident::new(to_item_name.clone());
+            // The last name in an ObjectName is the item name. The item name
+            // does not have a fixed index.
+            // TODO: https://github.com/MaterializeInc/materialize/issues/5591
+            let object_name_len = object_name.0.len() - 1;
+            object_name.0[object_name_len] = Ident::new(to_item_name.clone());
         }
     };
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -269,8 +269,13 @@ pub fn create_statement(
             constraints: _,
             with_options: _,
             if_not_exists,
+            temporary,
         }) => {
-            *name = allocate_name(name)?;
+            *name = if *temporary {
+                allocate_temporary_name(name)?
+            } else {
+                allocate_name(name)?
+            };
             let mut normalizer = QueryNormalizer::new(scx);
             for c in columns {
                 normalizer.visit_column_def_mut(c);

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -191,6 +191,7 @@ pub struct Table {
     pub create_sql: String,
     pub desc: RelationDesc,
     pub defaults: Vec<Expr<Raw>>,
+    pub temporary: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -130,6 +130,7 @@ END $$;
                 columns,
                 constraints,
                 if_not_exists,
+                temporary,
                 ..
             }) => {
                 let sql_types: Vec<_> = columns
@@ -204,10 +205,12 @@ END $$;
                 self.table_types
                     .insert(name.clone(), (sql_types, desc.clone()));
 
+                let temporary = *temporary;
                 let table = Table {
                     create_sql: stmt.to_string(),
                     desc,
                     defaults,
+                    temporary,
                 };
                 Plan::CreateTable {
                     name,

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -67,6 +67,131 @@ catalog item 'foo' already exists
 
 > CREATE OR REPLACE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
 
+# A temporary view should mask a normal view with the same name
+
+> CREATE VIEW v1 AS SELECT 1 AS f1;
+
+> CREATE TEMPORARY VIEW v1 AS SELECT 2 AS f2;
+
+> SELECT * FROM v1;
+ f2
+----
+  2
+
+> DROP VIEW v1;
+
+> SELECT * FROM v1;
+ f1
+----
+  1
+
+> DROP VIEW v1;
+
+! SELECT * FROM v1;
+unknown catalog item 'v1'
+
+# Rename temporary view
+
+> CREATE TEMPORARY VIEW v1 AS SELECT 1 AS f1;
+
+> ALTER VIEW v1 RENAME TO v2;
+
+! SELECT * FROM v1;
+unknown catalog item 'v1'
+
+> SELECT * FROM v2;
+ f1
+----
+  1
+
+> DROP VIEW v2;
+
+#####################################################################
+# Temporary tables
+
+> CREATE TEMPORARY TABLE temp_t (a int, b text NOT NULL)
+
+! CREATE TEMP TABLE temp_t (a int, b text NOT NULL)
+catalog item 'temp_t' already exists
+
+> INSERT INTO temp_t VALUES (1, 'testing')
+
+> SHOW INDEXES FROM temp_t
+ on_name    key_name            seq_in_index  column_name  expression  nullable
+---------------------------------------------------------------------------
+ temp_t     temp_t_primary_idx  1             a            <null>      true
+ temp_t     temp_t_primary_idx  2             b            <null>      false
+
+> DROP TABLE temp_t
+
+# A temporary table should mask a normal table with the same name
+
+> CREATE TABLE t1 (f1 INTEGER);
+
+> INSERT INTO t1 VALUES (1);
+
+> CREATE TEMPORARY TABLE t1 (f2 INTEGER);
+
+> INSERT INTO t1 VALUES (2);
+
+> SELECT * FROM t1;
+ f2
+----
+  2
+
+> SELECT * FROM public.t1;
+ f1
+----
+  1
+
+> DROP TABLE t1;
+
+> SELECT * FROM t1;
+ f1
+----
+  1
+
+> DROP TABLE t1;
+
+# Rename temporary table
+
+> CREATE TEMPORARY TABLE t1 (f1 INTEGER);
+
+> INSERT INTO t1 VALUES (1);
+
+> ALTER TABLE t1 RENAME TO t2;
+
+! SELECT * FROM t1;
+unknown catalog item 't1'
+
+> SELECT * FROM t2;
+ f1
+----
+  1
+
+> DROP TABLE t2;
+
+# A non-temporary view can not depend on a temporary table
+
+> CREATE TEMPORARY TABLE t1 (f1 INTEGER);
+
+! CREATE VIEW non_temp AS SELECT * FROM t1;
+non-temporary items cannot depend on temporary item
+
+! CREATE VIEW non_temp AS SELECT (SELECT * FROM t1);
+non-temporary items cannot depend on temporary item
+
+> DROP TABLE t1;
+
+#####################################################################
+# Make sure the mz_temp schema is protected
+
+! DROP SCHEMA mz_temp
+cannot drop schema mz_temp because it is required by the database system
+
+! CREATE TABLE mz_temp.table_in_mz_temp (f1 INTEGER)
+unknown schema 'mz_temp'
+
 #####################################################################
 # Test things we shouldn't be able to make temporary.
 
@@ -103,6 +228,8 @@ unknown catalog item 'double_temp_v'
 > DISCARD TEMP
 
 > SELECT * FROM mz_indexes WHERE name = 'foo_primary_idx'
+
+> SELECT * FROM mz_indexes WHERE name = 'temp_t_primary_idx'
 
 ! SELECT * FROM temp_v;
 unknown catalog item 'temp_v'


### PR DESCRIPTION
This change, along with https://github.com/MaterializeInc/materialize/pull/5542, fixes https://github.com/MaterializeInc/materialize/issues/5470. 

This change allows users to create temporary tables in their
Materialize instance. Temporary tables are only visible to the
user that created them, and are dropped when their connection is
dropped or the instance is stopped. Temporary tables behave identically
to other temporary objects.

The new `CREATE TABLE` grammar looks like:
<img width="1038" alt="Screen Shot 2021-02-01 at 4 11 13 PM" src="https://user-images.githubusercontent.com/5766027/106519430-42543e80-64a9-11eb-867f-7569057a8360.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5546)
<!-- Reviewable:end -->
