### PR TITLE
materialized: attempt to produce nice backtraces on stack overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
 
 [[package]]
 name = "libm"
@@ -1955,8 +1955,10 @@ dependencies = [
  "jemallocator",
  "krb5-src",
  "lazy_static",
+ "libc",
  "log",
  "mz-process-collector",
+ "nix",
  "num_cpus",
  "openssl",
  "openssl-sys",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -48,8 +48,10 @@ include_dir = "0.6.0"
 itertools = "0.9.0"
 krb5-src = { version = "0.2.3", features = ["binaries"] }
 lazy_static = "1.4.0"
+libc = "0.2.84"
 log = "0.4.13"
 mz-process-collector = { path = "../mz-process-collector" }
+nix = "0.19.1"
 num_cpus = "1.0.0"
 openssl = { version = "0.10.32", features = ["vendored"] }
 openssl-sys = { version = "0.9.59", features = ["vendored"] }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -213,6 +213,7 @@ fn main() {
 
 fn run(args: Args) -> Result<(), anyhow::Error> {
     panic::set_hook(Box::new(handle_panic));
+    sys::enable_sigsegv_backtraces()?;
 
     if args.version > 0 {
         println!("materialized {}", materialized::BUILD_INFO.human_version());


### PR DESCRIPTION
Rust produces bad error messages on stack overflow, like

    "thread 'foo' has overflowed its stack"

which provides very little insight into where the recursion that caused
the stack to overflow occurred.

See https://github.com/rust-lang/rust/issues/51405 for details.

This commit adds a SIGSEGV handler that attempts to print a backtrace,
following the approach in the backtrace-on-stack-overflow crate. I
copied the code from that crate into Materialize and tweaked it because
it's a very small amount of code that we'll likely need to modify, and I
wanted to improve its error handling.

In my manual testing this produces a nice backtrace when Materialize
overflows its stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5549)
<!-- Reviewable:end -->
