### PR TITLE
Upsert: If value is being replaced with new value, offset should be replaced with new offset.

### DIFF
--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -130,33 +130,33 @@ where
                     for (
                         SourceOutput {
                             key,
-                            value: val,
-                            position,
-                            upstream_time_millis,
+                            value: new_value,
+                            position: new_position,
+                            upstream_time_millis: new_upstream_time_millis,
                         },
                         time,
                     ) in vector.drain(..)
                     {
-                        let value = values
+                        let entry = values
                             .entry(cap.delayed(&time))
                             .or_insert_with(HashMap::new)
                             .entry(key)
                             .or_insert_with(Default::default);
 
-                        if let Some(new_offset) = position {
-                            if let Some(offset) = value.position {
+                        if let Some(new_offset) = new_position {
+                            if let Some(offset) = entry.position {
                                 if offset < new_offset {
-                                    *value = SourceData {
-                                        value: val,
-                                        position,
-                                        upstream_time_millis,
+                                    *entry = SourceData {
+                                        value: new_value,
+                                        position: new_position,
+                                        upstream_time_millis: new_upstream_time_millis,
                                     };
                                 }
                             } else {
-                                *value = SourceData {
-                                    value: val,
-                                    position,
-                                    upstream_time_millis,
+                                *entry = SourceData {
+                                    value: new_value,
+                                    position: new_position,
+                                    upstream_time_millis: new_upstream_time_millis,
                                 };
                             }
                         }

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -119,6 +119,7 @@ where
         Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
         "UpsertCompaction",
         |_cap, _info| {
+            // this is a map of (time) -> ((key) -> (value with max offset))
             let mut values = HashMap::<_, HashMap<_, SourceData>>::new();
             let mut vector = Vec::new();
 
@@ -147,14 +148,14 @@ where
                                 if offset < new_offset {
                                     *value = SourceData {
                                         value: val,
-                                        position: Some(offset),
+                                        position,
                                         upstream_time_millis,
                                     };
                                 }
                             } else {
                                 *value = SourceData {
                                     value: val,
-                                    position: Some(new_offset),
+                                    position,
                                     upstream_time_millis,
                                 };
                             }


### PR DESCRIPTION
It is the intent in `prepare_upsert_by_max_offset` that we store the value with the max offset for each key. It seems a bug was introduced in https://github.com/MaterializeInc/materialize/commit/ce01170c0922a5de56271a70365982cab82126e3 where we don't update the max recorded offset when we see a bigger offset though we do update the value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5552)
<!-- Reviewable:end -->
