### PR TITLE
Various kgen improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,7 @@ dependencies = [
  "rdkafka",
  "serde",
  "serde_json",
+ "structopt",
  "tokio",
  "url",
 ]

--- a/src/avro/examples/benchmark.rs
+++ b/src/avro/examples/benchmark.rs
@@ -88,8 +88,8 @@ fn main() {
         {"namespace": "my.example", "type": "record", "name": "userInfo", "fields": [{"default": "NONE", "type": "string", "name": "username"}, {"default": -1, "type": "int", "name": "age"}, {"default": "NONE", "type": "string", "name": "phone"}, {"default": "NONE", "type": "string", "name": "housenum"}, {"default": {}, "type": {"fields": [{"default": "NONE", "type": "string", "name": "street"}, {"default": "NONE", "type": "string", "name": "city"}, {"default": "NONE", "type": "string", "name": "state_prov"}, {"default": "NONE", "type": "string", "name": "country"}, {"default": "NONE", "type": "string", "name": "zip"}], "type": "record", "name": "mailing_address"}, "name": "address"}]}
     "#;
 
-    let small_schema = Schema::parse_str(raw_small_schema).unwrap();
-    let big_schema = Schema::parse_str(raw_big_schema).unwrap();
+    let small_schema: Schema = raw_small_schema.parse().unwrap();
+    let big_schema: Schema = raw_big_schema.parse().unwrap();
 
     println!("{:?}", small_schema);
     println!("{:?}", big_schema);
@@ -99,7 +99,7 @@ fn main() {
     let small_record = small_record.avro();
 
     let raw_address_schema = r#"{"fields": [{"default": "NONE", "type": "string", "name": "street"}, {"default": "NONE", "type": "string", "name": "city"}, {"default": "NONE", "type": "string", "name": "state_prov"}, {"default": "NONE", "type": "string", "name": "country"}, {"default": "NONE", "type": "string", "name": "zip"}], "type": "record", "name": "mailing_address"}"#;
-    let address_schema = Schema::parse_str(raw_address_schema).unwrap();
+    let address_schema: Schema = raw_address_schema.parse().unwrap();
     let mut address = Record::new(address_schema.top_node()).unwrap();
     address.put("street", "street");
     address.put("city", "city");

--- a/src/avro/src/encode.rs
+++ b/src/avro/src/encode.rs
@@ -169,7 +169,7 @@ mod tests {
         let empty: Vec<Value> = Vec::new();
         encode(
             &Value::Array(empty),
-            &Schema::parse_str(r#"{"type": "array", "items": "int"}"#).unwrap(),
+            &r#"{"type": "array", "items": "int"}"#.parse().unwrap(),
             &mut buf,
         );
         assert_eq!(vec![0u8], buf);
@@ -181,7 +181,7 @@ mod tests {
         let empty: HashMap<String, Value> = HashMap::new();
         encode(
             &Value::Map(empty),
-            &Schema::parse_str(r#"{"type": "map", "values": "int"}"#).unwrap(),
+            &r#"{"type": "map", "values": "int"}"#.parse().unwrap(),
             &mut buf,
         );
         assert_eq!(vec![0u8], buf);

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -69,7 +69,7 @@
 //! "#;
 //!
 //! // if the schema is not valid, this function will return an error
-//! let schema = Schema::parse_str(raw_schema).unwrap();
+//! let schema: Schema = raw_schema.parse().unwrap();
 //!
 //! // schemas can be printed for debugging
 //! println!("{:?}", schema);
@@ -107,7 +107,7 @@
 //! #         ]
 //! #     }
 //! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let schema: Schema = raw_schema.parse().unwrap();
 //! // a writer needs a schema and something to write to
 //! let mut writer = Writer::new(schema.clone(), Vec::new());
 //!
@@ -165,7 +165,7 @@
 //! #         ]
 //! #     }
 //! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let schema: Schema = raw_schema.parse().unwrap();
 //! let mut writer = Writer::with_codec(schema, Vec::new(), Codec::Deflate);
 //! ```
 //!
@@ -192,7 +192,7 @@
 //! #         ]
 //! #     }
 //! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let schema: Schema = raw_schema.parse().unwrap();
 //! # let mut writer = Writer::new(schema.clone(), Vec::new());
 //! # let mut record = Record::new(schema.top_node()).unwrap();
 //! # record.put("a", 27i64);
@@ -222,7 +222,7 @@
 //! #         ]
 //! #     }
 //! # "#;
-//! # let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
+//! # let writer_schema: Schema = writer_raw_schema.parse().unwrap();
 //! # let mut writer = Writer::new(writer_schema.clone(), Vec::new());
 //! # let mut record = Record::new(writer_schema.top_node()).unwrap();
 //! # record.put("a", 27i64);
@@ -243,7 +243,7 @@
 //!     }
 //! "#;
 //!
-//! let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
+//! let reader_schema: Schema = reader_raw_schema.parse().unwrap();
 //!
 //! // reader creation can fail in case the input to read from is not Avro-compatible or malformed
 //! let reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
@@ -282,7 +282,7 @@
 //! #         ]
 //! #     }
 //! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let schema: Schema = raw_schema.parse().unwrap();
 //! # let mut writer = Writer::new(schema.clone(), Vec::new());
 //! # let mut record = Record::new(schema.top_node()).unwrap();
 //! # record.put("a", 27i64);
@@ -335,6 +335,8 @@ pub use crate::writer::{to_avro_datum, write_avro_datum, ValidationError, Writer
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::reader::Reader;
     use crate::schema::Schema;
@@ -372,8 +374,8 @@ mod tests {
                 ]
             }
         "#;
-        let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
-        let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
+        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
         let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
         let mut record = Record::new(writer_schema.top_node()).unwrap();
         record.put("a", 27i64);
@@ -415,7 +417,7 @@ mod tests {
                 ]
             }
         "#;
-        let schema = Schema::parse_str(raw_schema).unwrap();
+        let schema = Schema::from_str(raw_schema).unwrap();
         let mut writer = Writer::with_codec(schema.clone(), Vec::new(), Codec::Null);
         let mut record = Record::new(schema.top_node()).unwrap();
         record.put("a", 27i64);
@@ -477,8 +479,8 @@ mod tests {
                 ]
             }
         "#;
-        let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
-        let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
+        let reader_schema = Schema::from_str(reader_raw_schema).unwrap();
         let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
         let mut record = Record::new(writer_schema.top_node()).unwrap();
         record.put("a", 27i64);
@@ -514,7 +516,7 @@ mod tests {
                 ]
             }
         "#;
-        let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
         let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
         let mut record = Record::new(writer_schema.top_node()).unwrap();
         record.put("a", 27i64);
@@ -547,7 +549,7 @@ mod tests {
                 }
             }
         ]}"#;
-        let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
+        let writer_schema = Schema::from_str(writer_raw_schema).unwrap();
         let mut writer = Writer::with_codec(writer_schema.clone(), Vec::new(), Codec::Null);
         let mut record = Record::new(writer_schema.top_node()).unwrap();
         let dt = chrono::NaiveDateTime::from_timestamp(1_000, 995_000_000);
@@ -575,7 +577,7 @@ mod tests {
             }
         "#;
 
-        let schema = Schema::parse_str(raw_schema).unwrap();
+        let schema = Schema::from_str(raw_schema).unwrap();
 
         // Would allocated 18446744073709551605 bytes
         let illformed: &[u8] = &[0x3e, 0x15, 0xff, 0x1f, 0x15, 0xff];

--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -845,7 +845,7 @@ mod tests {
 
     #[test]
     fn test_from_avro_datum() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema: Schema = SCHEMA.parse().unwrap();
         let mut encoded: &'static [u8] = &[54, 6, 102, 111, 111];
 
         let mut record = Record::new(schema.top_node()).unwrap();
@@ -858,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_null_union() {
-        let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
+        let schema: Schema = UNION_SCHEMA.parse().unwrap();
         let mut encoded: &'static [u8] = &[2, 0];
 
         assert_eq!(
@@ -874,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_reader_stream() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema: Schema = SCHEMA.parse().unwrap();
         let reader = Reader::with_schema(&schema, ENCODED).unwrap();
 
         let mut record1 = Record::new(schema.top_node()).unwrap();
@@ -894,14 +894,14 @@ mod tests {
 
     #[test]
     fn test_reader_invalid_header() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema: Schema = SCHEMA.parse().unwrap();
         let invalid = ENCODED.to_owned().into_iter().skip(1).collect::<Vec<u8>>();
         assert!(Reader::with_schema(&schema, &invalid[..]).is_err());
     }
 
     #[test]
     fn test_reader_invalid_block() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema: Schema = SCHEMA.parse().unwrap();
         let invalid = ENCODED
             .to_owned()
             .into_iter()

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt;
 use std::rc::Rc;
+use std::str::FromStr;
 
 use digest::Digest;
 use itertools::Itertools;
@@ -866,7 +867,7 @@ impl SchemaParser {
                 "bytes" => SchemaPieceOrNamed::Piece(Self::parse_bytes(complex)?),
                 "int" => SchemaPieceOrNamed::Piece(Self::parse_int(complex)?),
                 "long" => SchemaPieceOrNamed::Piece(Self::parse_long(complex)?),
-                "string" => SchemaPieceOrNamed::Piece(Self::parse_string(complex)),
+                "string" => SchemaPieceOrNamed::Piece(Self::from_string(complex)),
                 other => {
                     let name = FullName {
                         name: other.into(),
@@ -1184,7 +1185,7 @@ impl SchemaParser {
         Ok(SchemaPiece::Long)
     }
 
-    fn parse_string(complex: &Map<String, Value>) -> SchemaPiece {
+    fn from_string(complex: &Map<String, Value>) -> SchemaPiece {
         const CONNECT_JSON: &str = "io.debezium.data.Json";
 
         if let Some(serde_json::Value::String(name)) = complex.get("connect.name") {
@@ -1252,13 +1253,6 @@ impl SchemaParser {
 }
 
 impl Schema {
-    /// Create a `Schema` from a string representing a JSON Avro schema.
-    pub fn parse_str(input: &str) -> Result<Self, AvroError> {
-        let value = serde_json::from_str(input)
-            .map_err(|e| ParseSchemaError::new(format!("Error parsing JSON: {}", e)))?;
-        Self::parse(&value)
-    }
-
     /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
     /// schema.
     pub fn parse(value: &Value) -> Result<Self, AvroError> {
@@ -1306,6 +1300,17 @@ impl Schema {
             "string" => Ok(SchemaPiece::String),
             other => Err(ParseSchemaError::new(format!("Unknown type: {}", other)).into()),
         }
+    }
+}
+
+impl FromStr for Schema {
+    type Err = AvroError;
+
+    /// Create a `Schema` from a string representing a JSON Avro schema.
+    fn from_str(input: &str) -> Result<Self, AvroError> {
+        let value = serde_json::from_str(input)
+            .map_err(|e| ParseSchemaError::new(format!("Error parsing JSON: {}", e)))?;
+        Self::parse(&value)
     }
 }
 
@@ -2066,12 +2071,12 @@ mod tests {
     use super::*;
 
     fn check_schema(schema: &str, expected: SchemaPiece) {
-        let schema = Schema::parse_str(schema).unwrap();
+        let schema = Schema::from_str(schema).unwrap();
         assert_eq!(&expected, schema.top_node().inner);
 
         // Test serialization round trip
         let schema = serde_json::to_string(&schema).unwrap();
-        let schema = Schema::parse_str(&schema).unwrap();
+        let schema = Schema::from_str(&schema).unwrap();
         assert_eq!(&expected, schema.top_node().inner);
     }
 
@@ -2114,7 +2119,7 @@ mod tests {
 
     #[test]
     fn test_multi_union_schema() {
-        let schema = Schema::parse_str(r#"["null", "int", "float", "string", "bytes"]"#);
+        let schema = Schema::from_str(r#"["null", "int", "float", "string", "bytes"]"#);
         assert!(schema.is_ok());
         let schema = schema.unwrap();
         let node = schema.top_node();
@@ -2209,7 +2214,7 @@ mod tests {
 
         check_schema(schema, expected);
 
-        let bad_schema = Schema::parse_str(
+        let bad_schema = Schema::from_str(
             r#"{"type": "enum", "name": "Suit", "symbols": ["diamonds", "spades", "jokers", "clubs", "hearts"], "default": "blah"}"#,
         );
 
@@ -2247,7 +2252,7 @@ mod tests {
         for kind in kinds {
             check_schema(*kind, SchemaPiece::Date);
 
-            let schema = Schema::parse_str(*kind).unwrap();
+            let schema = Schema::from_str(*kind).unwrap();
             assert_eq!(
                 serde_json::to_string(&schema).unwrap(),
                 r#"{"type":"int","logicalType":"date"}"#
@@ -2285,7 +2290,7 @@ mod tests {
         };
         check_schema(schema, expected);
 
-        let res = Schema::parse_str(
+        let res = Schema::from_str(
             r#"["bytes", {
                 "type": "bytes",
                 "logicalType": "decimal",
@@ -2298,13 +2303,13 @@ mod tests {
             "Schema parse error: Unions cannot contain duplicate types"
         );
 
-        let writer_schema = Schema::parse_str(
+        let writer_schema = Schema::from_str(
             r#"["null", {
                 "type": "bytes"
             }]"#,
         )
         .unwrap();
-        let reader_schema = Schema::parse_str(
+        let reader_schema = Schema::from_str(
             r#"["null", {
                 "type": "bytes",
                 "logicalType": "decimal",
@@ -2336,7 +2341,7 @@ mod tests {
     #[test]
     fn test_no_documentation() {
         let schema =
-            Schema::parse_str(r#"{"type": "enum", "name": "Coin", "symbols": ["heads", "tails"]}"#)
+            Schema::from_str(r#"{"type": "enum", "name": "Coin", "symbols": ["heads", "tails"]}"#)
                 .unwrap();
 
         let doc = match schema.top_node().inner {
@@ -2349,7 +2354,7 @@ mod tests {
 
     #[test]
     fn test_documentation() {
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
                 r#"{"type": "enum", "name": "Coin", "doc": "Some documentation", "symbols": ["heads", "tails"]}"#
             ).unwrap();
 
@@ -2364,7 +2369,7 @@ mod tests {
     #[test]
     fn test_namespaces_and_names() {
         // When name and namespace specified, full name should contain both.
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{"type": "fixed", "namespace": "namespace", "name": "name", "size": 1}"#,
         )
         .unwrap();
@@ -2378,10 +2383,9 @@ mod tests {
         );
 
         // When name contains dots, parse the dot-separated name as the namespace.
-        let schema = Schema::parse_str(
-            r#"{"type": "enum", "name": "name.has.dots", "symbols": ["A", "B"]}"#,
-        )
-        .unwrap();
+        let schema =
+            Schema::from_str(r#"{"type": "enum", "name": "name.has.dots", "symbols": ["A", "B"]}"#)
+                .unwrap();
         assert_eq!(schema.named.len(), 1);
         assert_eq!(
             schema.named[0].name,
@@ -2392,7 +2396,7 @@ mod tests {
         );
 
         // Same as above, ignore any provided namespace.
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{"type": "enum", "namespace": "namespace",
             "name": "name.has.dots", "symbols": ["A", "B"]}"#,
         )
@@ -2408,7 +2412,7 @@ mod tests {
 
         // Use default namespace when namespace is not provided.
         // Materialize uses "" as the default namespace.
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{"type": "record", "name": "TestDoc", "doc": "Doc string",
             "fields": [{"name": "name", "type": "string"}]}"#,
         )
@@ -2423,7 +2427,7 @@ mod tests {
         );
 
         // Empty namespace strings should be allowed.
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{"type": "record", "namespace": "", "name": "TestDoc", "doc": "Doc string",
             "fields": [{"name": "name", "type": "string"}]}"#,
         )
@@ -2438,36 +2442,36 @@ mod tests {
         );
 
         // Equality of names is defined on the FullName and is case-sensitive.
-        let first = Schema::parse_str(
+        let first = Schema::from_str(
             r#"{"type": "fixed", "namespace": "namespace",
             "name": "name", "size": 1}"#,
         )
         .unwrap();
-        let second = Schema::parse_str(
+        let second = Schema::from_str(
             r#"{"type": "fixed", "name": "namespace.name",
             "size": 1}"#,
         )
         .unwrap();
         assert_eq!(first.named[0].name, second.named[0].name);
 
-        let first = Schema::parse_str(
+        let first = Schema::from_str(
             r#"{"type": "fixed", "namespace": "namespace",
             "name": "name", "size": 1}"#,
         )
         .unwrap();
-        let second = Schema::parse_str(
+        let second = Schema::from_str(
             r#"{"type": "fixed", "name": "namespace.Name",
             "size": 1}"#,
         )
         .unwrap();
         assert_ne!(first.named[0].name, second.named[0].name);
 
-        let first = Schema::parse_str(
+        let first = Schema::from_str(
             r#"{"type": "fixed", "namespace": "Namespace",
             "name": "name", "size": 1}"#,
         )
         .unwrap();
-        let second = Schema::parse_str(
+        let second = Schema::from_str(
             r#"{"type": "fixed", "namespace": "namespace",
             "name": "name", "size": 1}"#,
         )
@@ -2476,26 +2480,26 @@ mod tests {
 
         // The name portion of a fullname, record field names, and enum symbols must:
         // start with [A-Za-z_] and subsequently contain only [A-Za-z0-9_]
-        assert!(Schema::parse_str(
+        assert!(Schema::from_str(
             r#"{"type": "record", "name": "99 problems but a name aint one",
             "fields": [{"name": "name", "type": "string"}]}"#
         )
         .is_err());
 
-        assert!(Schema::parse_str(
+        assert!(Schema::from_str(
             r#"{"type": "record", "name": "!!!",
             "fields": [{"name": "name", "type": "string"}]}"#
         )
         .is_err());
 
-        assert!(Schema::parse_str(
+        assert!(Schema::from_str(
             r#"{"type": "record", "name": "_valid_until_©",
             "fields": [{"name": "name", "type": "string"}]}"#
         )
         .is_err());
 
         // Use previously defined names and namespaces as type.
-        let schema = Schema::parse_str(r#"{"type": "record", "name": "org.apache.avro.tests.Hello", "fields": [
+        let schema = Schema::from_str(r#"{"type": "record", "name": "org.apache.avro.tests.Hello", "fields": [
               {"name": "f1", "type": {"type": "enum", "name": "MyEnum", "symbols": ["Foo", "Bar", "Baz"]}},
               {"name": "f2", "type": "org.apache.avro.tests.MyEnum"},
               {"name": "f3", "type": "MyEnum"},
@@ -2518,7 +2522,7 @@ mod tests {
             panic!("Expected SchemaPiece::Record, found something else");
         }
 
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{"type": "record", "name": "x.Y", "fields": [
               {"name": "e", "type":
                 {"type": "record", "name": "Z", "fields": [
@@ -2544,7 +2548,7 @@ mod tests {
             panic!("Expected SchemaPiece::Record, found something else");
         }
 
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{"type": "record", "name": "R", "fields": [
               {"name": "s", "type": {"type": "record", "namespace": "x", "name": "Y", "fields": [
                 {"name": "e", "type": {"type": "enum", "namespace": "", "name": "Z",
@@ -2608,7 +2612,7 @@ mod tests {
         }
     "#;
 
-        let schema = Schema::parse_str(raw_schema).unwrap();
+        let schema = Schema::from_str(raw_schema).unwrap();
         assert_eq!(
             "5ecb2d1f0eaa647d409e6adbd5d70cd274d85802aa9167f5fe3b73ba70b32c76",
             format!("{}", schema.fingerprint::<Sha256>())

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -443,6 +443,8 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::Schema;
 
@@ -505,7 +507,7 @@ mod tests {
         ];
 
         for (value, schema_str, valid) in value_schema_valid.into_iter() {
-            let schema = Schema::parse_str(schema_str).unwrap();
+            let schema = Schema::from_str(schema_str).unwrap();
             assert_eq!(
                 valid,
                 value.validate(schema.top_node()),
@@ -519,7 +521,7 @@ mod tests {
     #[test]
     fn validate_fixed() {
         let schema =
-            Schema::parse_str(r#"{"type": "fixed", "size": 4, "name": "some_fixed"}"#).unwrap();
+            Schema::from_str(r#"{"type": "fixed", "size": 4, "name": "some_fixed"}"#).unwrap();
 
         assert!(Value::Fixed(4, vec![0, 0, 0, 0]).validate(schema.top_node()));
         assert!(!Value::Fixed(5, vec![0, 0, 0, 0, 0]).validate(schema.top_node()));
@@ -527,7 +529,7 @@ mod tests {
 
     #[test]
     fn validate_enum() {
-        let schema = Schema::parse_str(r#"{"type": "enum", "name": "some_enum", "symbols": ["spades", "hearts", "diamonds", "clubs"]}"#).unwrap();
+        let schema = Schema::from_str(r#"{"type": "enum", "name": "some_enum", "symbols": ["spades", "hearts", "diamonds", "clubs"]}"#).unwrap();
 
         assert!(Value::Enum(0, "spades".to_string()).validate(schema.top_node()));
         assert!(Value::String("spades".to_string()).validate(schema.top_node()));
@@ -535,14 +537,14 @@ mod tests {
         assert!(!Value::Enum(1, "spades".to_string()).validate(schema.top_node()));
         assert!(!Value::String("lorem".to_string()).validate(schema.top_node()));
 
-        let other_schema = Schema::parse_str(r#"{"type": "enum", "name": "some_other_enum", "symbols": ["hearts", "diamonds", "clubs", "spades"]}"#).unwrap();
+        let other_schema = Schema::from_str(r#"{"type": "enum", "name": "some_other_enum", "symbols": ["hearts", "diamonds", "clubs", "spades"]}"#).unwrap();
 
         assert!(!Value::Enum(0, "spades".to_string()).validate(other_schema.top_node()));
     }
 
     #[test]
     fn validate_record() {
-        let schema = Schema::parse_str(
+        let schema = Schema::from_str(
             r#"{
            "type": "record",
            "fields": [
@@ -594,7 +596,7 @@ mod tests {
             scale: 5
         })
         .validate(
-            Schema::parse_str(
+            Schema::from_str(
                 r#"
             {
                 "type": "bytes",
@@ -614,7 +616,7 @@ mod tests {
             scale: 5
         })
         .validate(
-            Schema::parse_str(
+            Schema::from_str(
                 r#"
             {
                 "type": "bytes",

--- a/src/avro/src/writer.rs
+++ b/src/avro/src/writer.rs
@@ -347,6 +347,7 @@ pub fn to_avro_datum<T: ToAvro>(schema: &Schema, value: T) -> Result<Vec<u8>, Er
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
+    use std::str::FromStr;
 
     use serde::{Deserialize, Serialize};
 
@@ -371,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_to_avro_datum() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema = Schema::from_str(SCHEMA).unwrap();
         let mut record = Record::new(schema.top_node()).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");
@@ -386,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_union() {
-        let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
+        let schema = Schema::from_str(UNION_SCHEMA).unwrap();
         let union = Value::Union {
             index: 1,
             inner: Box::new(Value::Long(3)),
@@ -403,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_writer_append() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema = Schema::from_str(SCHEMA).unwrap();
         let mut writer = Writer::new(schema.clone(), Vec::new());
 
         let mut record = Record::new(schema.top_node()).unwrap();
@@ -454,7 +455,7 @@ mod tests {
 
     #[test]
     fn test_writer_extend() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema = Schema::from_str(SCHEMA).unwrap();
         let mut writer = Writer::new(schema.clone(), Vec::new());
 
         let mut record = Record::new(schema.top_node()).unwrap();
@@ -512,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_writer_with_codec() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema = Schema::from_str(SCHEMA).unwrap();
         let mut writer = Writer::with_codec(schema.clone(), Vec::new(), Codec::Deflate);
 
         let mut record = Record::new(schema.top_node()).unwrap();
@@ -564,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_writer_roundtrip() {
-        let schema = Schema::parse_str(SCHEMA).unwrap();
+        let schema = Schema::from_str(SCHEMA).unwrap();
         let make_record = |a: i64, b| {
             let mut record = Record::new(schema.top_node()).unwrap();
             record.put("a", a);

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -6,6 +6,7 @@
 //!     - https://github.com/apache/avro/blob/master/lang/py/avro/test/test_schema.py
 //!     - https://github.com/apache/avro/tree/master/lang/c/tests/schema_tests
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use chrono::{NaiveDate, NaiveDateTime};
 use lazy_static::lazy_static;
@@ -242,7 +243,7 @@ lazy_static! {
 fn test_unparseable_schemas() {
     for raw_schema in UNPARSEABLE_SCHEMAS.iter() {
         assert!(
-            Schema::parse_str(raw_schema).is_err(),
+            Schema::from_str(raw_schema).is_err(),
             format!("expected Avro schema not to parse: {}", raw_schema)
         );
     }
@@ -252,7 +253,7 @@ fn test_unparseable_schemas() {
 fn test_unparseable_logical_types() {
     for raw_schema in UNPARSEABLE_LOGICAL_TYPES.iter() {
         assert!(
-            Schema::parse_str(raw_schema).is_err(),
+            Schema::from_str(raw_schema).is_err(),
             format!("expected Avro schema not to parse: {}", raw_schema)
         );
     }
@@ -261,7 +262,7 @@ fn test_unparseable_logical_types() {
 #[test]
 fn test_valid_schemas() {
     for (raw_schema, value) in VALID_SCHEMAS.iter() {
-        let schema = Schema::parse_str(raw_schema).unwrap();
+        let schema = Schema::from_str(raw_schema).unwrap();
         assert!(
             value.validate(schema.top_node()),
             format!("value {:?} does not validate schema: {}", value, raw_schema)
@@ -272,7 +273,7 @@ fn test_valid_schemas() {
 #[test]
 fn test_valid_logical_types() {
     for (raw_schema, value) in VALID_LOGICAL_TYPES.iter() {
-        let schema = Schema::parse_str(raw_schema).unwrap();
+        let schema = Schema::from_str(raw_schema).unwrap();
         assert!(
             value.validate(schema.top_node()),
             format!("value {:?} does not validate schema: {}", value, raw_schema)
@@ -283,7 +284,7 @@ fn test_valid_logical_types() {
 #[test]
 fn test_ignored_logical_types() {
     for (raw_schema, value) in IGNORED_LOGICAL_TYPES.iter() {
-        let schema = Schema::parse_str(raw_schema).unwrap();
+        let schema = Schema::from_str(raw_schema).unwrap();
         assert!(
             value.validate(schema.top_node()),
             format!("value {:?} does not validate schema: {}", value, raw_schema)

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -50,7 +50,7 @@ use crate::coord;
 lazy_static! {
     /// Value schema for Avro-formatted BYO consistency sources.
     static ref BYO_CONSISTENCY_SCHEMA: Schema = {
-        Schema::parse_str(r#"{
+        r#"{
           "name": "materialize.byo.consistency",
           "type": "record",
           "fields": [
@@ -60,21 +60,21 @@ lazy_static! {
             {"name": "timestamp", "type": "long"},
             {"name": "offset", "type": "long"}
           ]
-        }"#).unwrap()
+        }"#.parse().unwrap()
     };
 
     /// Key schema for Debezium consistency sources.
     static ref DEBEZIUM_TRX_SCHEMA_KEY: Schema = {
-        Schema::parse_str(r#"{
+        r#"{
           "name": "io.debezium.connector.common.TransactionMetadataKey",
           "type": "record",
           "fields": [{"name": "id", "type": "string"}]
-        }"#).unwrap()
+        }"#.parse().unwrap()
     };
 
     /// Value schema for Debezium consistency sources.
     static ref DEBEZIUM_TRX_SCHEMA_VALUE: Schema = {
-        Schema::parse_str(r#"{
+        r#"{
           "type": "record",
           "name": "TransactionMetadataValue",
           "namespace": "io.debezium.connector.common",
@@ -103,7 +103,7 @@ lazy_static! {
             }
           ],
           "connect.name": "io.debezium.connector.common.TransactionMetadataValue"
-        }"#).unwrap()
+        }"#.parse().unwrap()
     };
 
     static ref MAX_AVAILABLE_OFFSET: IntGaugeVec = register_int_gauge_vec!(

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -395,7 +395,7 @@ where
                             ),
                         };
 
-                        let reader_schema = Schema::parse_str(reader_schema).unwrap();
+                        let reader_schema: Schema = reader_schema.parse().unwrap();
                         (
                             decode_avro_values(&source, &envelope, reader_schema, &self.debug_name),
                             capability,

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -97,7 +97,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
                         encoding
                     ),
                 };
-                let reader_schema = Schema::parse_str(reader_schema).unwrap();
+                let reader_schema: Schema = reader_schema.parse().unwrap();
                 let ctor = { move |file| mz_avro::Reader::with_schema(&reader_schema, file) };
                 let tail = if oc.tail {
                     FileReadStyle::TailFollowFd

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::fmt;
 use std::io::Read;
+use std::str::FromStr;
 use std::{cell::RefCell, iter, rc::Rc};
 
 use anyhow::Context;
@@ -2622,7 +2623,7 @@ impl SchemaCache {
                 // which  we don't want to repeat for every record. So, parse and resolve it, and cache the
                 // result (whether schema or error).
                 let rf = &self.reader_fingerprint.bytes;
-                let result = Schema::parse_str(&response.raw).and_then(|schema| {
+                let result = Schema::from_str(&response.raw).and_then(|schema| {
                     if &schema.fingerprint::<Sha256>().bytes == rf {
                         Ok(schema)
                     } else {

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -17,5 +17,6 @@ rand = "0.8.2"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.0"
+structopt = "0.3.21"
 tokio = { version = "1.1.0", features = ["macros"] }
 url = "2.0.0"

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -534,6 +534,11 @@ struct Args {
         conflicts_with_all(&["key-min", "key-max"])
     )]
     avro_value_distribution: Option<serde_json::Value>,
+
+    // == Output control. ==
+    /// Suppress printing progress messages.
+    #[structopt(short = "q", long)]
+    quiet: bool,
 }
 
 #[tokio::main]
@@ -601,7 +606,7 @@ async fn main() -> anyhow::Result<()> {
         None
     };
     for i in 0..args.num_records {
-        if i % 10000 == 0 {
+        if !args.quiet && i % 10000 == 0 {
             eprintln!("Generating message {}", i);
         }
         value_gen.next_value(&mut buf);

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -461,6 +461,9 @@ struct Args {
     /// cluster to connect to.
     #[structopt(short = "b", long, default_value = "localhost:9092")]
     bootstrap_server: String,
+    /// URL of the schema registry to connect to, if using Avro keys or values.
+    #[structopt(short = "s", long, default_value = "http://localhost:8081")]
+    schema_registry_url: Url,
     /// Topic into which to write records.
     #[structopt(short = "t", long = "topic")]
     topic: String,
@@ -548,8 +551,7 @@ async fn main() -> anyhow::Result<()> {
         }
         ValueFormat::Avro => {
             let value_schema = args.avro_value_schema.as_ref().unwrap();
-            let ccsr =
-                ccsr::ClientConfig::new(Url::parse("http://localhost:8081").unwrap()).build();
+            let ccsr = ccsr::ClientConfig::new(args.schema_registry_url.clone()).build();
             let schema_id = ccsr
                 .publish_schema(
                     &format!("{}-value", args.topic),
@@ -569,8 +571,7 @@ async fn main() -> anyhow::Result<()> {
     let mut key_gen = match args.key_format {
         KeyFormat::Avro => {
             let key_schema = args.avro_key_schema.as_ref().unwrap();
-            let ccsr =
-                ccsr::ClientConfig::new(Url::parse("http://localhost:8081").unwrap()).build();
+            let ccsr = ccsr::ClientConfig::new(args.schema_registry_url).build();
             let key_schema_id = ccsr
                 .publish_schema(&format!("{}-key", args.topic), &key_schema.canonical_form())
                 .await?;

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -17,7 +17,7 @@ use std::thread;
 use std::time::Duration;
 
 use chrono::{NaiveDate, NaiveDateTime};
-use clap::{App, Arg};
+use clap::arg_enum;
 use rand::distributions::{
     uniform::SampleUniform, Alphanumeric, Bernoulli, Uniform, WeightedIndex,
 };
@@ -29,6 +29,7 @@ use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::util::Timeout;
 use rdkafka::ClientConfig;
 use serde_json::Map;
+use structopt::StructOpt;
 use url::Url;
 
 use mz_avro::schema::{SchemaNode, SchemaPiece, SchemaPieceOrNamed};
@@ -437,162 +438,144 @@ impl<'a> ValueGenerator<'a> {
     }
 }
 
+arg_enum! {
+    pub enum KeyFormat {
+        Avro,
+        Random,
+        Sequential,
+    }
+}
+
+arg_enum! {
+    pub enum ValueFormat {
+        Bytes,
+        Avro,
+    }
+}
+
+/// Writes random data to Kafka.
+#[derive(StructOpt)]
+struct Args {
+    // == Kafka configuration arguments. ==
+    /// Address of one or more Kafka nodes, comma separated, in the Kafka
+    /// cluster to connect to.
+    #[structopt(short = "b", long, default_value = "localhost:9092")]
+    bootstrap_server: String,
+    /// Topic into which to write records.
+    #[structopt(short = "t", long = "topic")]
+    topic: String,
+    /// Number of records to write.
+    #[structopt(short = "n", long = "num-records")]
+    num_records: usize,
+    /// Number of partitions over which records should be distributed in a
+    /// round-robin fashion, regardless of the value of the keys of these
+    /// records.
+    ///
+    /// The default value, 0, indicates that Kafka's default strategy of
+    /// distributing writes based upon the hash of their keys should be used
+    /// instead.
+    #[structopt(long, default_value = "0")]
+    partitions_round_robin: usize,
+
+    // == Key arguments. ==
+    /// Format in which to generate keys.
+    #[structopt(
+        short = "k", long = "keys", case_insensitive = true,
+        possible_values = &KeyFormat::variants(), default_value = "sequential"
+    )]
+    key_format: KeyFormat,
+    /// Minimum key value to generate, if using random-formatted keys.
+    #[structopt(long, required_if("keys", "random"))]
+    key_min: Option<u64>,
+    /// Maximum key value to generate, if using random-formatted keys.
+    #[structopt(long, required_if("keys", "random"))]
+    key_max: Option<u64>,
+    /// Schema describing Avro key data to randomly generate, if using
+    /// Avro-formatted keys.
+    #[structopt(long, required_if("keys", "avro"), conflicts_with_all(&["key-min", "key-max"]))]
+    avro_key_schema: Option<Schema>,
+    /// JSON object describing the distribution parameters for each field of
+    /// the Avro key object, if using Avro-formatted keys.
+    #[structopt(long, required_if("keys", "avro"))]
+    avro_key_distribution: Option<serde_json::Value>,
+
+    // == Value arguments. ==
+    /// Format in which to generate values.
+    #[structopt(
+        short = "v", long = "values", case_insensitive = true,
+        possible_values = &ValueFormat::variants(), default_value = "bytes"
+    )]
+    value_format: ValueFormat,
+    /// Minimum value size to generate, if using bytes-formatted values.
+    #[structopt(
+        short = "m",
+        long = "min-message-size",
+        required_if("value-format", "bytes")
+    )]
+    min_value_size: Option<usize>,
+    /// Maximum value size to generate, if using bytes-formatted values.
+    #[structopt(
+        short = "M",
+        long = "max-message-size",
+        required_if("value-format", "bytes")
+    )]
+    max_value_size: Option<usize>,
+    /// Schema describing Avro value data to randomly generate, if using
+    /// Avro-formatted values.
+    #[structopt(long = "avro-schema", required_if("value-format", "avro"))]
+    avro_value_schema: Option<Schema>,
+    /// JSON object describing the distribution parameters for each field of
+    /// the Avro value object, if using Avro-formatted keys.
+    #[structopt(
+        long = "avro-distribution", required_if("value-format", "avro"),
+        conflicts_with_all(&["key-min", "key-max"])
+    )]
+    avro_value_distribution: Option<serde_json::Value>,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let matches = App::new("kgen")
-        .about("Put random data in Kafka")
-        .arg(
-            Arg::with_name("topic")
-                .short("t")
-                .long("topic")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("num-records")
-                .short("n")
-                .long("num-messages")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            // default 1
-            Arg::with_name("partitions-round-robin")
-                .long("partitions-round-robin")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("values")
-                .short("v")
-                .long("values")
-                .takes_value(true)
-                .possible_values(&["bytes", "avro"])
-                .default_value("bytes"),
-        )
-        .arg(
-            Arg::with_name("min")
-                .short("m")
-                .long("min-message-size")
-                .takes_value(true)
-                .required_if("values", "bytes"),
-        )
-        .arg(
-            Arg::with_name("max")
-                .short("M")
-                .long("max-message-size")
-                .takes_value(true)
-                .required_if("values", "bytes"),
-        )
-        .arg(
-            Arg::with_name("avro-schema")
-                .long("avro-schema")
-                .takes_value(true)
-                .required_if("values", "avro"),
-        )
-        .arg(
-            Arg::with_name("avro-key-schema")
-                .long("avro-key-schema")
-                .takes_value(true)
-                .required_if("keys", "avro")
-                .conflicts_with_all(&["key-min", "key-max"]),
-        )
-        .arg(
-            Arg::with_name("avro-distribution")
-                .long("avro-distribution")
-                .takes_value(true)
-                .required_if("values", "avro")
-                .conflicts_with_all(&["key-min", "key-max"]),
-        )
-        .arg(
-            Arg::with_name("avro-key-distribution")
-                .long("avro-key-distribution")
-                .takes_value(true)
-                .required_if("keys", "avro"),
-        )
-        .arg(
-            Arg::with_name("bootstrap")
-                .short("b")
-                .long("bootstrap-server")
-                .takes_value(true)
-                .default_value("localhost:9092"),
-        )
-        .arg(
-            Arg::with_name("keys")
-                .long("keys")
-                .short("k")
-                .takes_value(true)
-                .possible_values(&["avro", "sequential", "random"])
-                .default_value("sequential"),
-        )
-        .arg(
-            Arg::with_name("key-min")
-                .long("key-min")
-                .takes_value(true)
-                .required_if("keys", "random"),
-        )
-        .arg(
-            Arg::with_name("key-max")
-                .long("key-max")
-                .takes_value(true)
-                .required_if("keys", "random"),
-        )
-        .get_matches();
-    let topic = matches.value_of("topic").unwrap();
-    let n: usize = matches.value_of("num-records").unwrap().parse()?;
-    let partitions_round_robin: usize = matches
-        .value_of("partitions-round-robin")
-        .map(str::parse)
-        .transpose()?
-        .unwrap_or(0);
-    let bootstrap = matches.value_of("bootstrap").unwrap();
-    let mut _schema_holder = None;
-    let mut _key_schema_holder = None;
-    let mut value_gen = match matches.value_of("values").unwrap() {
-        "bytes" => {
-            let min: usize = matches.value_of("min").unwrap().parse()?;
-            let max: usize = matches.value_of("max").unwrap().parse()?;
-            let len = Uniform::new_inclusive(min, max);
+    let args: Args = ore::cli::parse_args();
+
+    let mut value_gen = match args.value_format {
+        ValueFormat::Bytes => {
+            let len =
+                Uniform::new_inclusive(args.min_value_size.unwrap(), args.max_value_size.unwrap());
             let bytes = Uniform::new_inclusive(0, 255);
             let rng = thread_rng();
 
             ValueGenerator::UniformBytes { len, bytes, rng }
         }
-        "avro" => {
-            let schema = matches.value_of("avro-schema").unwrap();
+        ValueFormat::Avro => {
+            let value_schema = args.avro_value_schema.as_ref().unwrap();
             let ccsr =
                 ccsr::ClientConfig::new(Url::parse("http://localhost:8081").unwrap()).build();
             let schema_id = ccsr
-                .publish_schema(&format!("{}-value", topic), schema)
+                .publish_schema(
+                    &format!("{}-value", args.topic),
+                    &value_schema.canonical_form(),
+                )
                 .await?;
-            _schema_holder = Some(Schema::parse_str(schema)?);
-            let schema = _schema_holder.as_ref().unwrap();
-            let annotations = matches.value_of("avro-distribution").unwrap();
-            let annotations: serde_json::Value = serde_json::from_str(annotations)?;
-            let generator = RandomAvroGenerator::new(schema, &annotations);
-
+            let generator =
+                RandomAvroGenerator::new(value_schema, &args.avro_value_distribution.unwrap());
             ValueGenerator::RandomAvro {
                 inner: generator,
-                schema,
+                schema: value_schema,
                 schema_id,
             }
         }
-        _ => unreachable!(),
     };
 
-    let mut key_gen = match matches.value_of("keys").unwrap() {
-        "avro" => {
-            let key_schema = matches.value_of("avro-key-schema").unwrap();
+    let mut key_gen = match args.key_format {
+        KeyFormat::Avro => {
+            let key_schema = args.avro_key_schema.as_ref().unwrap();
             let ccsr =
                 ccsr::ClientConfig::new(Url::parse("http://localhost:8081").unwrap()).build();
             let key_schema_id = ccsr
-                .publish_schema(&format!("{}-key", topic), key_schema)
+                .publish_schema(&format!("{}-key", args.topic), &key_schema.canonical_form())
                 .await?;
-            _key_schema_holder = Some(Schema::parse_str(key_schema)?);
-            let key_schema = _key_schema_holder.as_ref().unwrap();
-            let annotations = matches.value_of("avro-key-distribution").unwrap();
-            let annotations: serde_json::Value = serde_json::from_str(annotations)?;
-            let generator = RandomAvroGenerator::new(key_schema, &annotations);
-
+            let generator =
+                RandomAvroGenerator::new(key_schema, &args.avro_key_distribution.unwrap());
             Some(ValueGenerator::RandomAvro {
                 inner: generator,
                 schema: key_schema,
@@ -603,20 +586,20 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let producer: ThreadedProducer<DefaultProducerContext> = ClientConfig::new()
-        .set("bootstrap.servers", bootstrap)
+        .set("bootstrap.servers", args.bootstrap_server.to_string())
         .create()?;
     let mut buf = vec![];
 
     let mut rng = thread_rng();
-    let keys_random = matches.value_of("keys").unwrap() == "random";
-    let key_dist = if keys_random {
-        let key_min: u64 = matches.value_of("key-min").unwrap().parse()?;
-        let key_max: u64 = matches.value_of("key-max").unwrap().parse()?;
-        Some(Uniform::new_inclusive(key_min, key_max))
+    let key_dist = if let KeyFormat::Random = args.key_format {
+        Some(Uniform::new_inclusive(
+            args.key_min.unwrap(),
+            args.key_max.unwrap(),
+        ))
     } else {
         None
     };
-    for i in 0..n {
+    for i in 0..args.num_records {
         if i % 10000 == 0 {
             eprintln!("Generating message {}", i);
         }
@@ -635,10 +618,10 @@ async fn main() -> anyhow::Result<()> {
         } else {
             (i as u64).to_be_bytes().to_vec()
         };
-        let mut rec = BaseRecord::to(topic).key(&key).payload(&buf);
+        let mut rec = BaseRecord::to(&args.topic).key(&key).payload(&buf);
 
-        if partitions_round_robin != 0 {
-            rec = rec.partition((i % partitions_round_robin) as i32);
+        if args.partitions_round_robin != 0 {
+            rec = rec.partition((i % args.partitions_round_robin) as i32);
         }
 
         loop {


### PR DESCRIPTION
I've been sitting on this patch for a while to get kgen converted from clap to structopt, so that it matches the way we do argument parsing everywhere else. I was going to wait until #5511 merged, but that seems held up, and the argument parsing is changing fast enough that I figured I'd just get this out for review. To sweeten the pot this includes @cirego's new arguments from #5511, plus a fix for #5553, plus a fix for the extra allocation mentioned in #5548.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5554)
<!-- Reviewable:end -->
