### PR TITLE
coord,pgwire: require valid user when connecting

### DIFF
--- a/doc/user/content/connect/cli.md
+++ b/doc/user/content/connect/cli.md
@@ -14,8 +14,18 @@ using a compatible command-line client.
 Detail | Info
 -------|------
 **Database** | `materialize`
+**User** | Any valid [role](/sql/create-role) (usually `materialize`)
 **Port** | `6875`
 **SSL** | Not supported yet
+
+Materialize instances have a user named `materialize` installed, unless you drop
+this user with [`DROP USER`](/sql/drop-user). You can add additional users with
+[`CREATE ROLE`](/sql/create-role).
+
+{{< version-changed v0.6.2 >}}
+Materialize requires that you name a valid user when you connect. Previously,
+Materialize did not support the concept of roles, so it accepted all user names.
+{{< /version-changed >}}
 
 ### Supported tools
 
@@ -48,8 +58,8 @@ mzcli -h <host>
 You could use any of the following formats to connect to `materialized` with `psql`:
 
 ```shell
-psql postgres://<host>:6875/materialize
-psql -h <host> -p 6875 materialize
-psql -h <host> -p 6875 -d materialize
-psql host=<host> port=6875 dbname=materialize
+psql postgres://materialize@<host>:6875/materialize
+psql -U materialize -h <host> -p 6875 materialize
+psql -U materialize -h <host> -p 6875 -d materialize
+psql user=materialize host=<host> port=6875 dbname=materialize
 ```

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,15 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.6.2 %}}
 
+- **Breaking change.** Require a valid user name when [connecting to
+  Materialize](/connect/cli#connection-details). Previously, Materialize did not
+  support the concept of [roles](/sql/create-role), so it accepted all user
+  names.
+
+  Materialize instances have a user named `materialize` installed, unless you
+  drop this user with [`DROP USER`](/sql/drop-user). You can add additional
+  users with [`CREATE ROLE`](/sql/create-role).
+
 - Allow setting most [command-line flags](/cli#command-line-flags) via
   environment variables.
 

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -14,9 +14,13 @@ menu:
 
 A role is a user account in a Materialize instance.
 
+When you [connect to a Materialize instance](/connect/cli), you must specify
+the name of a valid role in the system.
+
 {{< warning >}}
-Roles in Materialize are currently inert. In the future they will be used for
-role-based access control. See GitHub issue {{% gh 677 %}} for details.
+Roles in Materialize are currently limited in functionality. In the future they
+will be used for role-based access control. See GitHub issue {{% gh 677 %}}
+for details.
 {{< /warning >}}
 
 ## Syntax

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -17,7 +17,7 @@
 target:
   type: materialize
   host: materialized
-  user: root
+  user: materialize
   pass: password
   database: materialize
   schema: "dbt_test_{{ var('_dbt_random_suffix') }}"

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -654,6 +654,7 @@ class WaitForMzStep(WaitForPgStep):
     def __init__(
         self,
         *,
+        user: str = "materialize",
         dbname: str = "materialize",
         host: str = "localhost",
         port: Optional[int] = None,
@@ -664,6 +665,7 @@ class WaitForMzStep(WaitForPgStep):
         service: str = "materialized",
     ) -> None:
         super().__init__(
+            user=user,
             dbname=dbname,
             host=host,
             port=port,

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -11,6 +11,7 @@ use std::fmt;
 
 use backtrace::Backtrace;
 
+use ore::str::StrExt;
 use sql::catalog::CatalogError as SqlCatalogError;
 
 #[derive(Debug)]
@@ -31,7 +32,8 @@ pub(crate) enum ErrorKind {
     SchemaAlreadyExists(String),
     RoleAlreadyExists(String),
     ItemAlreadyExists(String),
-    UnacceptableSchemaName(String),
+    ReservedSchemaName(String),
+    ReservedRoleName(String),
     ReadOnlySystemSchema(String),
     ReadOnlyItem(String),
     SchemaNotEmpty(String),
@@ -63,6 +65,24 @@ impl Error {
             backtrace: Backtrace::new_unresolved(),
         }
     }
+
+    /// Reports additional details about the error, if any are available.
+    pub fn detail(&self) -> Option<String> {
+        match &self.kind {
+            ErrorKind::ReservedSchemaName(_) => {
+                Some("The prefixes \"mz_\" and \"pg_\" are reserved for system schemas.".into())
+            }
+            ErrorKind::ReservedRoleName(_) => {
+                Some("The prefixes \"mz_\" and \"pg_\" are reserved for system roles.".into())
+            }
+            _ => None,
+        }
+    }
+
+    /// Reports a hint for the user about how the error could be fixed.
+    pub fn hint(&self) -> Option<String> {
+        None
+    }
 }
 
 impl From<rusqlite::Error> for Error {
@@ -87,7 +107,8 @@ impl std::error::Error for Error {
             | ErrorKind::SchemaAlreadyExists(_)
             | ErrorKind::RoleAlreadyExists(_)
             | ErrorKind::ItemAlreadyExists(_)
-            | ErrorKind::UnacceptableSchemaName(_)
+            | ErrorKind::ReservedSchemaName(_)
+            | ErrorKind::ReservedRoleName(_)
             | ErrorKind::ReadOnlySystemSchema(_)
             | ErrorKind::ReadOnlyItem(_)
             | ErrorKind::SchemaNotEmpty(_)
@@ -123,8 +144,11 @@ impl fmt::Display for Error {
             ErrorKind::ItemAlreadyExists(name) => {
                 write!(f, "catalog item '{}' already exists", name)
             }
-            ErrorKind::UnacceptableSchemaName(name) => {
+            ErrorKind::ReservedSchemaName(name) => {
                 write!(f, "unacceptable schema name '{}'", name)
+            }
+            ErrorKind::ReservedRoleName(name) => {
+                write!(f, "role name {} is reserved", name.quoted())
             }
             ErrorKind::ReadOnlySystemSchema(name) => {
                 write!(f, "system schema '{}' cannot be modified", name)

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -37,14 +37,15 @@ pub struct Session {
     prepared_statements: HashMap<String, PreparedStatement>,
     portals: HashMap<String, Portal>,
     transaction: TransactionStatus,
+    user: String,
     vars: Vars,
 }
 
 impl Session {
     /// Creates a new session for the specified connection ID.
-    pub fn new(conn_id: u32) -> Session {
+    pub fn new(conn_id: u32, user: String) -> Session {
         assert_ne!(conn_id, DUMMY_CONNECTION_ID);
-        Self::new_internal(conn_id)
+        Self::new_internal(conn_id, user)
     }
 
     /// Creates a new dummy session.
@@ -52,15 +53,16 @@ impl Session {
     /// Dummy sessions are intended for use when executing queries on behalf of
     /// the system itself, rather than on behalf of a user.
     pub fn dummy() -> Session {
-        Self::new_internal(DUMMY_CONNECTION_ID)
+        Self::new_internal(DUMMY_CONNECTION_ID, "system".into())
     }
 
-    fn new_internal(conn_id: u32) -> Session {
+    fn new_internal(conn_id: u32, user: String) -> Session {
         Session {
             conn_id,
             transaction: TransactionStatus::Default,
             prepared_statements: HashMap::new(),
             portals: HashMap::new(),
+            user,
             vars: Vars::default(),
         }
     }
@@ -229,6 +231,11 @@ impl Session {
         self.prepared_statements.clear();
         self.portals.clear();
         self.vars = Vars::default();
+    }
+
+    /// Returns the name of the user who owns this session.
+    pub fn user(&self) -> &str {
+        &self.user
     }
 
     /// Returns a reference to the variables in this session.

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -140,7 +140,7 @@ impl Server {
         config
             .host(&Ipv4Addr::LOCALHOST.to_string())
             .port(local_addr.port())
-            .user("root");
+            .user("materialize");
         config
     }
 
@@ -150,7 +150,7 @@ impl Server {
         config
             .host(&Ipv4Addr::LOCALHOST.to_string())
             .port(local_addr.port())
-            .user("root");
+            .user("materialize");
         config
     }
 

--- a/src/peeker/src/args.rs
+++ b/src/peeker/src/args.rs
@@ -40,7 +40,7 @@ pub struct Args {
     /// URL of materialized instance to collect metrics from.
     #[structopt(
         long,
-        default_value = "postgres://ignoreuser@materialized:6875/materialize",
+        default_value = "postgres://materialize@materialized:6875/materialize",
         value_name = "URL"
     )]
     pub materialized_url: String,

--- a/src/pgwire/src/codec.rs
+++ b/src/pgwire/src/codec.rs
@@ -14,6 +14,7 @@
 //!
 //! [1]: https://www.postgresql.org/docs/11/protocol-message-formats.html
 
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
@@ -414,11 +415,11 @@ where
         VERSION_SSL => FrontendStartupMessage::SslRequest,
         VERSION_GSSENC => FrontendStartupMessage::GssEncRequest,
         _ => {
-            let mut params = vec![];
+            let mut params = HashMap::new();
             while buf.peek_byte()? != 0 {
                 let name = buf.read_cstr()?.to_owned();
                 let value = buf.read_cstr()?.to_owned();
-                params.push((name, value));
+                params.insert(name, value);
             }
             FrontendStartupMessage::Startup { version, params }
         }

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -89,8 +89,12 @@ impl Server {
                 // `SslRequest`. This is considered a graceful termination.
                 None => return Ok(()),
 
-                Some(FrontendStartupMessage::Startup { version, params }) => {
-                    let coord_client = self.coord_client.for_session(Session::new(conn_id));
+                Some(FrontendStartupMessage::Startup {
+                    version,
+                    mut params,
+                }) => {
+                    let user = params.remove("user").unwrap_or_else(String::new);
+                    let coord_client = self.coord_client.for_session(Session::new(conn_id, user));
                     let machine = StateMachine {
                         conn: FramedConn::new(conn_id, conn),
                         conn_id,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -848,7 +848,7 @@ impl Runner {
 async fn connect(server: &materialized::Server) -> tokio_postgres::Client {
     let addr = server.local_addr();
     let (client, connection) = tokio_postgres::connect(
-        &format!("host={} port={} user=root", addr.ip(), addr.port()),
+        &format!("host={} port={} user=materialize", addr.ip(), addr.port()),
         NoTls,
     )
     .await

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -56,7 +56,7 @@ struct Args {
 
     // === Materialize options. ===
     /// materialized connection string.
-    #[structopt(long, default_value = "postgres://localhost:6875")]
+    #[structopt(long, default_value = "postgres://materialize@localhost:6875")]
     materialized_url: tokio_postgres::Config,
     /// Validate the on-disk state of the materialized catalog.
     #[structopt(long)]

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -19,7 +19,7 @@ say() {
 }
 
 run_sql() {
-    psql -h localhost -p 6875 materialize -c "\pset footer off" -c "$1" "$@"
+    psql -U materialize -h localhost -p 6875 materialize -c "\pset footer off" -c "$1" "$@"
 }
 
 launch_materialized() {

--- a/test/correctness/args.rs
+++ b/test/correctness/args.rs
@@ -25,7 +25,7 @@ pub struct Args {
     /// URL of the materialized instance to collect metrics from.
     #[structopt(
         long,
-        default_value = "postgres://ignoreuser@materialized:6875/materialize"
+        default_value = "postgres://materialize@materialized:6875/materialize"
     )]
     pub materialized_url: String,
     /// If set, initialize sources.

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -101,7 +101,7 @@ services:
         --kafka-option=sasl.kerberos.service.name=kafka
         --kafka-option=sasl.kerberos.principal=testdrive@CI.MATERIALIZE.IO
         --schema-registry-url=http://schema-registry:8081
-        --materialized-url=postgres://ignored@materialized:6875
+        --materialized-url=postgres://materialize@materialized:6875
         $$*
       - bash
     command: test/kafka-krb5/smoketest.td

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -34,7 +34,7 @@ services:
         --kafka-option=sasl.username=materialize
         --kafka-option=sasl.password=sekurity
         --schema-registry-url=https://materialize:sekurity@schema-registry:8081
-        --materialized-url=postgres://ignored@materialized:6875
+        --materialized-url=postgres://materialize@materialized:6875
         --cert=/share/secrets/producer.p12
         --cert-password=mzmzmz
         $$*

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -31,7 +31,7 @@ services:
         testdrive
         --kafka-addr=kafka1:9092
         --schema-registry-url=https://schema-registry:8081
-        --materialized-url=postgres://ignored@materialized:6875
+        --materialized-url=postgres://materialize@materialized:6875
         --cert=/share/secrets/producer.p12
         --cert-password=mzmzmz
         $$*

--- a/test/lang/csharp/SmokeTest.cs
+++ b/test/lang/csharp/SmokeTest.cs
@@ -18,7 +18,7 @@ namespace csharp
         private NpgsqlConnection conn;
 
         private NpgsqlConnection OpenConnection() {
-            var conn = new NpgsqlConnection("host=materialized;port=6875;database=materialize");
+            var conn = new NpgsqlConnection("host=materialized;port=6875;database=materialize;username=materialize");
             conn.Open();
             return conn;
         }

--- a/test/lang/java/smoketest/SmokeTest.java
+++ b/test/lang/java/smoketest/SmokeTest.java
@@ -30,7 +30,7 @@ class SmokeTest {
         if (port == null)
             port = "6875";
         String url = String.format("jdbc:postgresql://%s:%s/", host, port);
-        conn = DriverManager.getConnection(url);
+        conn = DriverManager.getConnection(url, "materialize", null);
     }
 
     @AfterEach

--- a/test/lang/js/params.test.ts
+++ b/test/lang/js/params.test.ts
@@ -12,6 +12,7 @@ import { Client } from "pg";
 const client = new Client({
   port: parseInt(process.env.PGPORT, 10) || 6875,
   database: process.env.PGDATABASE || "materialize",
+  user: process.env.PGUSER || "materialize",
 });
 
 beforeAll(async () => await client.connect());

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -13,7 +13,7 @@ import psycopg3
 import sqlalchemy
 import unittest
 
-MATERIALIZED_URL = "postgresql://materialized:6875/materialize"
+MATERIALIZED_URL = "postgresql://materialize@materialized:6875/materialize"
 
 
 class SmokeTest(unittest.TestCase):

--- a/test/metabase/smoketest/src/main.rs
+++ b/test/metabase/smoketest/src/main.rs
@@ -32,9 +32,12 @@ async fn connect_materialized() -> Result<tokio_postgres::Client, anyhow::Error>
         res
     })
     .await?;
-    let (client, conn) = tokio_postgres::connect("postgres://materialized:6875/materialize", NoTls)
-        .await
-        .context("failed connecting to materialized")?;
+    let (client, conn) = tokio_postgres::connect(
+        "postgres://materialize@materialized:6875/materialize",
+        NoTls,
+    )
+    .await
+    .context("failed connecting to materialized")?;
     tokio::spawn(async {
         if let Err(e) = conn.await {
             panic!("postgres connection error: {}", e);

--- a/test/test-util/src/mz_client.rs
+++ b/test/test-util/src/mz_client.rs
@@ -15,7 +15,7 @@ use tokio_postgres::{Client, Error, NoTls, Row};
 /// object along the way.
 pub async fn client(host: &str, port: u16) -> Result<Client> {
     let (mz_client, conn) = tokio_postgres::Config::new()
-        .user("mzd")
+        .user("materialize")
         .host(host)
         .port(port)
         .connect(NoTls)

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -56,7 +56,7 @@ services:
         testdrive
         --kafka-addr=kafka:9092
         --schema-registry-url=http://schema-registry:8081
-        --materialized-url=postgres://ignored@materialized:6875
+        --materialized-url=postgres://materialize@materialized:6875
         --validate-catalog=/share/mzdata/catalog
         $$*
       - bash

--- a/test/testdrive/roles.td
+++ b/test/testdrive/roles.td
@@ -62,3 +62,9 @@ current user cannot be dropped
 # No creating roles that already exist.
 ! CREATE ROLE materialize LOGIN SUPERUSER
 role 'materialize' already exists
+
+# No creating roles that look like system roles.
+! CREATE ROLE mz_system LOGIN SUPERUSER
+role name "mz_system" is reserved
+! CREATE ROLE mz_foo LOGIN SUPERUSER
+role name "mz_foo" is reserved


### PR DESCRIPTION
Require that the name of a valid user is specified when connecting to
Materialize. This is going to be a disruptive change, but it has to be
done to support authentication.

@sploiselle any ideas about messaging this more in the docs?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5555)
<!-- Reviewable:end -->
