### PR TITLE
ci: Trigger the lang-python tests for any python change

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -233,7 +233,7 @@ steps:
     label: ":python: tests"
     depends_on: build
     timeout_in_minutes: 10
-    inputs: [test/lang/python]
+    inputs: [test/lang/python, "**/*.py"]
     plugins:
       - ./ci/plugins/mzcompose:
           composition: python


### PR DESCRIPTION
Trigger the python tests if any *.py file within the repository
has changed. This has the added benefit of running mzcompose and
the entire associated machinery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5556)
<!-- Reviewable:end -->
