### PR TITLE
dbt-materialize demo feedback

### DIFF
--- a/play/wikirecent-dbt/README.md
+++ b/play/wikirecent-dbt/README.md
@@ -66,7 +66,7 @@ on top of streaming Wikipedia data using dbt.
    Then, [create a source](https://materialize.com/docs/sql/create-source/text-file/#main) using your `wikirecent` file:
    ```nofmt
    CREATE SCHEMA wikimedia;
-   
+
    CREATE SOURCE wikimedia.wikirecent
    FROM FILE '[path to wikirecent]' WITH (tail = true)
    FORMAT REGEX '^data: (?P<data>.*)';
@@ -76,12 +76,12 @@ on top of streaming Wikipedia data using dbt.
 
    You can see the columns that get generated for this source:
    ```nofmt
-    > SHOW SOURCES;
+    > SHOW SOURCES FROM wikimedia;
       name
     ------------
      wikirecent
 
-    > SHOW COLUMNS FROM wikirecent;
+    > SHOW COLUMNS FROM wikimedia.wikirecent;
       name    | nullable | type
      ------------+----------+------
     data       | t        | text
@@ -89,7 +89,7 @@ on top of streaming Wikipedia data using dbt.
    ```
 
 1. Now we can use dbt to create materialized views on top of `wikirecent`. In your shell, navigate to
-   `play/wikirecent-dbt` within the clone of this repo on your local machine. Once 
+   `play/wikirecent-dbt` within the clone of this repo on your local machine. Once
    you're there, run the following [dbt command](https://docs.getdbt.com/reference/dbt-commands/):
    ```nofmt
    dbt run
@@ -104,7 +104,7 @@ on top of streaming Wikipedia data using dbt.
 1. Congratulations! You just used dbt to create materialized views in Materialize. You can verify the
    views were created from your `psql` shell connected to Materialize:
       ```nofmt
-      > SHOW VIEWS;
+      > SHOW VIEWS FROM analytics;
            name
       ---------------
        recentchanges
@@ -114,7 +114,7 @@ on top of streaming Wikipedia data using dbt.
 
    More importantly, you can now query each of the views you created interactively. For example:
    ```nofmt
-   > SELECT * FROM top10;
+   > SELECT * FROM analytics.top10;
         user      | changes
    ---------------+---------
     Fæ            |   10834

--- a/play/wikirecent-dbt/README.md
+++ b/play/wikirecent-dbt/README.md
@@ -15,12 +15,10 @@ To get everything you need to run dbt with Materialize, do the following:
    git clone https://github.com/MaterializeInc/materialize
    ```
 
-1. Create a new Python virtual environment on your machine. Activate that environment,
-   and install the following:
+1. Install the `dbt-materialize` plugin. You may wish to do this within a Python virtual environment on your machine:
     ```nofmt
     python3 -m venv dbt-venv
     source dbt-venv/bin/activate
-    pip install dbt
     pip install dbt-materialize
     ```
 
@@ -36,7 +34,7 @@ To get everything you need to run dbt with Materialize, do the following:
           user: user
           pass: pass
           dbname: materialize
-          schema: public
+          schema: analytics
 
       target: dev
     ```
@@ -67,7 +65,9 @@ on top of streaming Wikipedia data using dbt.
 1. [Connect to your Materialize instance](https://materialize.com/docs/connect/cli/) from your shell.
    Then, [create a source](https://materialize.com/docs/sql/create-source/text-file/#main) using your `wikirecent` file:
    ```nofmt
-   CREATE SOURCE wikirecent
+   CREATE SCHEMA wikimedia;
+   
+   CREATE SOURCE wikimedia.wikirecent
    FROM FILE '[path to wikirecent]' WITH (tail = true)
    FORMAT REGEX '^data: (?P<data>.*)';
    ```
@@ -88,19 +88,18 @@ on top of streaming Wikipedia data using dbt.
     mz_line_no | f        | int8
    ```
 
-1. Now we can use dbt to create materialized views on top of `wikirecent`. In your shell, navigate to the
-   root of this repo on your local machine. Once you're there, run the following [dbt commands](https://docs.getdbt.com/reference/dbt-commands/)
-   inside your Python virtual environment:
+1. Now we can use dbt to create materialized views on top of `wikirecent`. In your shell, navigate to
+   `play/wikirecent-dbt` within the clone of this repo on your local machine. Once 
+   you're there, run the following [dbt command](https://docs.getdbt.com/reference/dbt-commands/):
    ```nofmt
-   dbt compile
    dbt run
    ```
-   `dbt compile` generates executable SQL from our model files, which can be found in the `models` directory
-   of this project. `dbt run` executes the compiled SQL files against the target database, creating
+   This command generates executable SQL from our model files (found in the `models` directory
+   of this project), and executes that SQL against the target database, creating
    our materialized views.
 
-   Note: If you haven't set up your Python environment with `dbt` and the `dbt-materialize` adapter,
-   please revisit the [setup](#setup-dbt--materialize) above.
+   Note: If you installed `dbt-materialize` in a virtual environment, make sure it's activated.
+   If you don't have it installed, please revisit the [setup](#setup-dbt--materialize) above.
 
 1. Congratulations! You just used dbt to create materialized views in Materialize. You can verify the
    views were created from your `psql` shell connected to Materialize:
@@ -131,7 +130,12 @@ on top of streaming Wikipedia data using dbt.
    (10 rows)
    ```
 
-1. Now that you have your views, let's generate their docs using dbt. From your Python virtual environment, run:
+1. Now that you have your views, let's test expectations about those views. We believe that the `user` field in our `useredits` and `top10` models should never have null values. Run:
+    ```nofmt
+    dbt test
+    ```
+
+1. Finally, let's generate their docs using dbt. From your virtual environment, run:
    ```nofmt
    dbt docs generate
    dbt docs serve

--- a/play/wikirecent-dbt/dbt_project.yml
+++ b/play/wikirecent-dbt/dbt_project.yml
@@ -1,3 +1,18 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: wikirecent_dbt
 version: 1.0
 config-version: 2

--- a/play/wikirecent-dbt/dbt_project.yml
+++ b/play/wikirecent-dbt/dbt_project.yml
@@ -1,0 +1,7 @@
+name: wikirecent_dbt
+version: 1.0
+config-version: 2
+
+profile: default
+
+source-paths: ["models"]

--- a/play/wikirecent-dbt/models/recentchanges.sql
+++ b/play/wikirecent-dbt/models/recentchanges.sql
@@ -37,4 +37,4 @@ SELECT
     val->>'type' AS type,
     val->>'user' AS user,
     val->>'wiki' AS wiki
-FROM (SELECT data::jsonb AS val FROM materialize.public.wikirecent)
+FROM (SELECT data::jsonb AS val FROM {{ source('wikimedia', 'wikirecent') }})

--- a/play/wikirecent-dbt/models/schema.yml
+++ b/play/wikirecent-dbt/models/schema.yml
@@ -26,7 +26,7 @@ sources:
 models:
   - name: recentchanges
     description: "Event data, unnested and cast to columns"
-    
+
   - name: useredits
     description: "Edit counts per user"
     columns:
@@ -36,7 +36,7 @@ models:
           - not_null
       - name: changes
         description: "The number of edits made by the user"
-  
+
   - name: top10
     description: "Top 10 Wikipedia editors since the stream started"
     columns:

--- a/play/wikirecent-dbt/models/schema.yml
+++ b/play/wikirecent-dbt/models/schema.yml
@@ -15,31 +15,18 @@
 
 version: 2
 
+sources:
+  - name: wikimedia
+    description: https://stream.wikimedia.org/?doc
+    tables:
+      - name: wikirecent
+        description: >
+          Streaming event data of [recent Wikipedia changes](https://stream.wikimedia.org/v2/stream/recentchange)
+
 models:
   - name: recentchanges
-    description: "Streaming Wikimedia event data"
-    columns:
-      - name: r_schema
-      - name: bot
-      - name: comment
-      - name: id
-      - name: length_new
-      - name: length_old
-      - name: meta_uri,
-      - name: meta_id
-      - name: minor
-      - name: namespace
-      - name: parsedcomment
-      - name: revision_new
-      - name: revision_old
-      - name: server_name
-      - name: server_script_path
-      - name: server_url
-      - name: r_ts
-      - name: title
-      - name: type
-      - name: user
-      - name: wiki
+    description: "Event data, unnested and cast to columns"
+    
   - name: useredits
     description: "Edit counts per user"
     columns:
@@ -49,6 +36,7 @@ models:
           - not_null
       - name: changes
         description: "The number of edits made by the user"
+  
   - name: top10
     description: "Top 10 Wikipedia editors since the stream started"
     columns:


### PR DESCRIPTION
The demo is awesome! I had a few small recommendations as I worked through it this morning.

## Fixes

- The demo project needs a `dbt_project.yml` file
- Update language to reflect that demo project is not at root of repo

## Opinionated feedback

### Project contents
- Create `wikirecent` as a [source](https://docs.getdbt.com/docs/building-a-dbt-project/using-sources/)
- No need to define columns in YAML if not defining resource properties for them (e.g. descriptions, tests)
- Best practice: source and transformed data should be in different schemas, i.e. [environments](https://docs.getdbt.com/docs/guides/managing-environments/) (and not `public`)

### Demo sequence
- It's not necessary to install `dbt` before installing `dbt-materialize`, and it may actually be harder: `pip install dbt-materialize` includes only `dbt-core`, `dbt-postgres`, and `dbt-materialize`. `pip install dbt` also includes `dbt-redshift`, `dbt-snowflake`, and `dbt-bigquery`, which have more dependencies.
- It is not necessary to run `dbt compile` before running `dbt run`
- Add a step for `dbt test`

### Questions
- Is `dbt-materialize` on PyPi? I haven't been able to `pip install` it, I've just been able to locally install after cloning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5557)
<!-- Reviewable:end -->
