### PR TITLE
coord/sql: canonicalize data type during normalization

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2412,6 +2412,7 @@ impl<'a> Parser<'a> {
                 // Misc.
                 BOOLEAN => other("bool"),
                 BYTES => other("bytea"),
+                JSON => other("jsonb"),
                 REGCLASS => other("oid"),
 
                 _ => {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2650,7 +2650,6 @@ pub fn canonicalize_type_name_internal(name: &ObjectName) -> ObjectName {
     // use in the catalog, i.e. canonicalize the catalog name.
     match name.to_string().as_str() {
         "char" | "varchar" => ObjectName::unqualified("text"),
-        "json" => ObjectName::unqualified("jsonb"),
         "smallint" => ObjectName::unqualified("int4"),
         _ => name.clone(),
     }

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -92,6 +92,54 @@ timestamp        system
 timestamptz      system
 uuid             system
 
+# Support creating tables with catalog types and their aliases
+> CREATE TABLE bool_t (a bool);
+> CREATE TABLE boolean_t (a boolean);
+
+> CREATE TABLE bytea_t (a bytea);
+> CREATE TABLE bytes_t (a bytes);
+
+> CREATE TABLE date_t (a date);
+
+> CREATE TABLE float4_t (a float4);
+> CREATE TABLE real_t (a real);
+> CREATE TABLE float16_t (a float(16));
+
+> CREATE TABLE float8_t (a float8);
+> CREATE TABLE float_t (a float);
+> CREATE TABLE double_t (a double);
+
+> CREATE TABLE int4_t (a int4);
+> CREATE TABLE int_t (a int);
+> CREATE TABLE integer_t (a integer);
+
+> CREATE TABLE int8_t (a int8);
+> CREATE TABLE bigint_t (a bigint);
+
+> CREATE TABLE interval_t (a interval);
+
+> CREATE TABLE jsonb_t (a jsonb);
+> CREATE TABLE json_t (a json);
+
+> CREATE TABLE numeric_t (a numeric);
+> CREATE TABLE decimal_t (a decimal);
+> CREATE TABLE dec_t (a dec);
+
+> CREATE TABLE oid_t (a oid);
+> CREATE TABLE regclass_t (a regclass);
+
+> CREATE TABLE text_t (a text);
+> CREATE TABLE char_t (a char(100));
+> CREATE TABLE varchar_t (a varchar(100));
+
+> CREATE TABLE time_t (a time);
+
+> CREATE TABLE timestamp_t (a timestamp);
+
+> CREATE TABLE timestamptz_t (a timestamptz);
+
+> CREATE TABLE uuid_t (a uuid);
+
 # User-defined types
 
 > CREATE TYPE int_list_c AS LIST (element_type=int4);


### PR DESCRIPTION
Fixes #5541

making `canonicalize_type_name_internal` into a public function in `query` feels not-quite-right––any suggestions @benesch?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5561)
<!-- Reviewable:end -->
