### PR TITLE
s3 sources: Refactor source creation to support multiple key sources

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -669,8 +669,16 @@ pub struct FileSourceConnector {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct S3SourceConnector {
     pub bucket: String,
+    pub key_sources: Vec<S3KeySource>,
     pub pattern: Option<Glob>,
     pub aws_info: aws::ConnectInfo,
+}
+
+/// A Source of Object Key names, the argument of the `OBJECTS FROM` clause
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum S3KeySource {
+    /// Scan the S3 Bucket in the S3 source connector to discover keys to download
+    Scan,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -13,13 +13,13 @@ use std::convert::{From, TryInto};
 use std::default::Default;
 use std::ops::AddAssign;
 use std::sync::mpsc::{Receiver, SyncSender, TryRecvError};
-use std::sync::Arc;
 
 use anyhow::{anyhow, Error};
 use globset::GlobMatcher;
 use rusoto_s3::{GetObjectRequest, ListObjectsV2Request, S3Client, S3};
 use timely::scheduling::{Activator, SyncActivator};
 use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc as tokio_mpsc;
 use tokio::time::{self, Duration};
 
 use aws_util::aws;
@@ -91,29 +91,33 @@ impl SourceConstructor<Vec<u8>> for S3SourceInfo {
             }
         };
 
-        let activator = Arc::new(consumer_activator);
-
         // a single arbitrary worker is responsible for scanning the bucket
         let receiver = if active {
             log::debug!("reading bucket={} worker={}", s3_conn.bucket, worker_id);
-            let (tx, rx) = std::sync::mpsc::sync_channel(10000);
+            let (dataflow_tx, dataflow_rx) = std::sync::mpsc::sync_channel(10_000);
+            let (keys_tx, keys_rx) = tokio_mpsc::channel(10_000);
             let bucket = s3_conn.bucket.clone();
             let glob = s3_conn.pattern.map(|g| g.compile_matcher());
             let aws_info = s3_conn.aws_info;
+            tokio::spawn(download_objects_task(
+                keys_rx,
+                dataflow_tx,
+                aws_info.clone(),
+                consumer_activator,
+            ));
             for key_source in s3_conn.key_sources {
                 match key_source {
                     S3KeySource::Scan => {
-                        tokio::spawn(read_bucket_task(
+                        tokio::spawn(scan_bucket_task(
                             bucket.clone(),
                             glob.clone(),
                             aws_info.clone(),
-                            tx.clone(),
-                            activator.clone(),
+                            keys_tx.clone(),
                         ));
                     }
                 }
             }
-            rx
+            dataflow_rx
         } else {
             let (_tx, rx) = std::sync::mpsc::sync_channel(0);
             rx
@@ -137,19 +141,51 @@ impl SourceConstructor<Vec<u8>> for S3SourceInfo {
     }
 }
 
-async fn read_bucket_task(
+struct KeyInfo {
     bucket: String,
-    glob: Option<GlobMatcher>,
-    aws_info: aws::ConnectInfo,
+    key: String,
+}
+
+async fn download_objects_task(
+    mut rx: tokio_mpsc::Receiver<anyhow::Result<KeyInfo>>,
     tx: SyncSender<anyhow::Result<Vec<u8>>>,
-    activator: Arc<SyncActivator>,
+    aws_info: aws::ConnectInfo,
+    activator: SyncActivator,
 ) {
     let client = match aws_util::s3::client(aws_info).await {
         Ok(client) => client,
         Err(e) => {
             tx.send(Err(anyhow!("Unable to create s3 client: {}", e)))
                 .unwrap_or_else(|e| {
-                    log::trace!("unable to send error on stream creating s3 client: {}", e)
+                    log::debug!("unable to send error on stream creating s3 client: {}", e)
+                });
+            return;
+        }
+    };
+
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            Ok(msg) => download_object(&tx, &activator, &client, msg.bucket, msg.key).await,
+            Err(e) => tx
+                .send(Err(e))
+                .unwrap_or_else(|e| log::debug!("unable to send error: {}", e)),
+        }
+    }
+}
+
+async fn scan_bucket_task(
+    bucket: String,
+    glob: Option<GlobMatcher>,
+    aws_info: aws::ConnectInfo,
+    tx: tokio_mpsc::Sender<anyhow::Result<KeyInfo>>,
+) {
+    let client = match aws_util::s3::client(aws_info).await {
+        Ok(client) => client,
+        Err(e) => {
+            tx.send(Err(anyhow!("Unable to create s3 client: {}", e)))
+                .await
+                .unwrap_or_else(|e| {
+                    log::debug!("unable to send error on stream creating s3 client: {}", e)
                 });
             return;
         }
@@ -181,7 +217,14 @@ async fn read_bucket_task(
                         .filter(|k| glob.map(|g| g.is_match(k)).unwrap_or(true));
 
                     for key in keys {
-                        download_object(&tx, &activator, &client, bucket.clone(), key).await;
+                        tx.send(Ok(KeyInfo {
+                            bucket: bucket.clone(),
+                            key,
+                        }))
+                        .await
+                        .unwrap_or_else(|e| {
+                            log::debug!("unable to send keys to downloader: {}", e)
+                        });
                     }
                 }
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1667,13 +1667,27 @@ impl<'a> Parser<'a> {
                 // FROM S3 BUCKET '<bucket>' OBJECTS FROM SCAN MATCHING '<pattern>'
                 self.expect_keyword(BUCKET)?;
                 let bucket = self.parse_literal_string()?;
-                self.expect_keywords(&[OBJECTS, FROM, SCAN])?;
+                self.expect_keywords(&[OBJECTS, FROM])?;
+                let mut key_sources = Vec::new();
+                while let Some(keyword) = self.parse_one_of_keywords(&[SCAN]) {
+                    match keyword {
+                        SCAN => key_sources.push(S3KeySource::Scan),
+                        key => unreachable!("Keyword {} is not expected after OBJECTS FROM", key),
+                    }
+                    if !self.consume_token(&Token::Comma) {
+                        break;
+                    }
+                }
                 let pattern = if self.parse_keyword(MATCHING) {
                     Some(self.parse_literal_string()?)
                 } else {
                     None
                 };
-                Ok(Connector::S3 { bucket, pattern })
+                Ok(Connector::S3 {
+                    bucket,
+                    key_sources,
+                    pattern,
+                })
             }
             _ => unreachable!(),
         }

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -137,3 +137,14 @@ $ s3-put-object bucket=${bucket} key=logs/2021/01/01/frontend.log
 01/01/2021:00:00:57 91.234.194.89 Python/Requests_22
 12/31/2020:23:55:52 37.26.93.214 Go_1.1_package_http
 12/31/2020:23:55:59 99.99.44.44 Python/Requests_22
+
+! CREATE SOURCE err FROM S3 BUCKET 'dog' OBJECTS FROM SCAN, SCAN
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT TEXT
+SCAN may only be specified once


### PR DESCRIPTION
The next step in S3 sources is to support the `OBJECTS FROM SCAN, SQS
NOTIFICATIONS '<queue>'` syntax, which requires `OBJECTS FROM` to accept a list
of clauses.

This PR introduces no functional changes (although there are some error message
changes), it just moves things around to make SQS sources fit in nicely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5562)
<!-- Reviewable:end -->
