### PR TITLE
gate sink updates if an existing consistency topic is detected

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -7,13 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, bail, Context};
+use interchange::avro::get_debezium_transaction_schema;
+use mz_avro::types::Value;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
+use rdkafka::{Message, Offset, TopicPartitionList};
 
 use dataflow_types::{
     AvroOcfSinkConnector, AvroOcfSinkConnectorBuilder, KafkaSinkConnector,
@@ -21,6 +25,8 @@ use dataflow_types::{
 };
 use expr::GlobalId;
 use ore::collections::CollectionExt;
+use rdkafka::consumer::{BaseConsumer, Consumer};
+use repr::Timestamp;
 
 use crate::error::CoordError;
 
@@ -34,6 +40,143 @@ pub async fn build(
     }
 }
 
+/// Polls a message from a Kafka Source
+fn get_next_message(
+    consumer: &mut BaseConsumer,
+    timeout: Duration,
+) -> Result<Option<Vec<u8>>, anyhow::Error> {
+    if let Some(result) = consumer.poll(timeout) {
+        match result {
+            Ok(message) => match message.payload() {
+                Some(p) => Ok(Some(p.to_vec())),
+                None => {
+                    bail!("unexpected null payload")
+                }
+            },
+            Err(err) => {
+                bail!("Failed to process message {}", err)
+            }
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+/// Return the list of partition ids associated with a specific topic
+fn get_partitions(
+    consumer: &BaseConsumer,
+    topic: &str,
+    timeout: Duration,
+) -> Result<Vec<i32>, anyhow::Error> {
+    let meta = consumer.fetch_metadata(Some(&topic), timeout)?;
+    if meta.topics().len() != 1 {
+        bail!(
+            "topic {} has {} metadata entries; expected 1",
+            topic,
+            meta.topics().len()
+        );
+    }
+    let meta_topic = meta.topics().into_element();
+    if meta_topic.name() != topic {
+        bail!(
+            "got results for wrong topic {} (expected {})",
+            meta_topic.name(),
+            topic
+        );
+    }
+
+    if meta_topic.partitions().len() == 0 {
+        bail!("topic {} does not exist", topic);
+    }
+
+    Ok(meta_topic.partitions().iter().map(|x| x.id()).collect())
+}
+
+// Retrieves the latest committed timestamp from the consistency topic
+async fn get_latest_ts(
+    consistency_topic: &str,
+    consumer: &mut BaseConsumer,
+    timeout: Duration,
+) -> Result<Option<Timestamp>, anyhow::Error> {
+    // ensure the consistency topic has exactly one partition
+    let partitions = get_partitions(&consumer, consistency_topic, timeout).with_context(|| {
+        format!(
+            "Unable to fetch metadata about consistency topic {}",
+            consistency_topic
+        )
+    })?;
+
+    if partitions.len() != 1 {
+        bail!(
+            "Consistency topic {} should contain a single partition, but instead contains {} partitions",
+            consistency_topic, partitions.len(),
+            );
+    }
+
+    let partition = partitions.into_element();
+
+    // Seek to end-1 offset
+    let mut tps = TopicPartitionList::new();
+    tps.add_partition(consistency_topic, partition);
+    tps.set_partition_offset(consistency_topic, partition, Offset::OffsetTail(1))?;
+
+    consumer
+        .assign(&tps)
+        .with_context(|| format!("Error seeking in consistency topic {}", consistency_topic))?;
+
+    // Read the end-1 offset message
+    let m = match get_next_message(consumer, timeout)? {
+        None => {
+            // fetch watermarks to distinguish between a timeout reading end-1 and an empty topic
+            match consumer.fetch_watermarks(consistency_topic, 0, timeout) {
+                Ok((_, hi)) => {
+                    if hi == 0 {
+                        return Ok(None);
+                    } else {
+                        bail!("uninitializedlkajsdlkfjs");
+                    }
+                }
+                Err(e) => {
+                    bail!("Failed to fetch metadata while reading from consistency topic, will retry. Error was {}", e);
+                }
+            }
+        }
+        Some(m) => m,
+    };
+
+    // decode the timestamp from the end-1 message
+    let mut bytes = &m[5..];
+    let record = mz_avro::from_avro_datum(get_debezium_transaction_schema(), &mut bytes)
+        .context("Failed to decode consistency topic message")?;
+
+    if let Value::Record(r) = record {
+        let m: HashMap<String, Value> = r.into_iter().collect();
+        let status = m.get("status");
+        let id = m.get("id");
+        match (status, id) {
+            (Some(Value::String(status)), Some(Value::String(id))) if status == "END" => {
+                if let Ok(ts) = id.parse::<u64>() {
+                    Ok(Some(Timestamp::from(ts)))
+                } else {
+                    bail!(
+                        "Malformed consistency record, failed to parse timestamp {} in topic {}",
+                        id,
+                        consistency_topic
+                    );
+                }
+            }
+            _ => {
+                bail!(
+                    "Malformed consistency record in topic {}, expected END with a timestamp but record was {:?}, tried matching {:?} {:?}",
+                    consistency_topic, m, status, id);
+            }
+        }
+    } else {
+        bail!("Failed to decode consistency topic message, was not a parseable record");
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn register_kafka_topic(
     client: &AdminClient<DefaultClientContext>,
     topic: &str,
@@ -42,6 +185,7 @@ async fn register_kafka_topic(
     ccsr: &ccsr::Client,
     value_schema: &str,
     key_schema: Option<&str>,
+    succeed_if_exists: bool,
 ) -> Result<(Option<i32>, i32), CoordError> {
     // if either partition count or replication factor should be defaulted to the broker's config
     // (signaled by a value of -1), explicitly poll the broker to discover the defaults.
@@ -144,8 +288,13 @@ async fn register_kafka_topic(
             res.len()
         );
     }
-    res.into_element()
-        .map_err(|(_, e)| anyhow!("error creating topic {} for sink: {}", topic, e))?;
+    if let Err((_, e)) = res.into_element() {
+        // if the topic already exists and we reuse_existing, don't fail - instead proceed
+        // to read the schema
+        if !(succeed_if_exists && e == rdkafka::types::RDKafkaErrorCode::TopicAlreadyExists) {
+            coord_bail!("error creating topic {} for sink: {}", topic, e)
+        }
+    }
 
     // Publish value schema for the topic.
     //
@@ -173,7 +322,14 @@ async fn build_kafka(
     builder: KafkaSinkConnectorBuilder,
     id: GlobalId,
 ) -> Result<SinkConnector, CoordError> {
-    let topic = format!("{}-{}-{}", builder.topic_prefix, id, builder.topic_suffix);
+    let topic = if builder.exactly_once {
+        format!("{}-{}", builder.topic_prefix, id)
+    } else {
+        format!(
+            "{}-{}-{}",
+            builder.topic_prefix, id, builder.topic_suffix_nonce
+        )
+    };
 
     // Create Kafka topic with single partition.
     let mut config = ClientConfig::new();
@@ -194,12 +350,15 @@ async fn build_kafka(
         &ccsr,
         &builder.value_schema,
         builder.key_schema.as_deref(),
+        builder.exactly_once,
     )
     .await
     .context("error registering kafka topic for sink")?;
 
     let consistency = if let Some(consistency_value_schema) = builder.consistency_value_schema {
         let consistency_topic = format!("{}-consistency", topic);
+
+        // create consistency topic/schema and retrieve schema id
         let (_, consistency_schema_id) = register_kafka_topic(
             &client,
             &consistency_topic,
@@ -208,13 +367,35 @@ async fn build_kafka(
             &ccsr,
             &consistency_value_schema,
             None,
+            builder.exactly_once,
         )
         .await
         .context("error registering kafka consistency topic for sink")?;
 
+        // get latest committed timestamp from consistencty topic
+        let gate_ts = if builder.exactly_once {
+            let mut consumer_config = config.clone();
+            consumer_config
+                .set("group.id", format!("materialize-bootstrap-{}", topic))
+                .set("isolation.level", "read_committed")
+                .set("enable.auto.commit", "false")
+                .set("auto.offset.reset", "earliest");
+
+            let mut consumer = consumer_config
+                .create::<BaseConsumer>()
+                .expect("creating consumer client failed");
+
+            get_latest_ts(&consistency_topic, &mut consumer, Duration::from_secs(5))
+                .await
+                .context("error restarting from existing kafka consistency topic for sink")?
+        } else {
+            None
+        };
+
         Some(KafkaSinkConsistencyConnector {
             topic: consistency_topic,
             schema_id: consistency_schema_id,
+            gate_ts,
         })
     } else {
         None

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -752,6 +752,10 @@ pub enum SinkConnector {
 pub struct KafkaSinkConsistencyConnector {
     pub topic: String,
     pub schema_id: i32,
+    // gate_ts is the most recent high watermark tailed from the consistency topic
+    // Exactly-once sinks use this to determine when they should start publishing again. This
+    // tells them when they have caught up to where the previous materialize instance stopped.
+    pub gate_ts: Option<Timestamp>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -835,13 +839,14 @@ pub struct KafkaSinkConnectorBuilder {
     pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     pub value_desc: RelationDesc,
     pub topic_prefix: String,
-    pub topic_suffix: String,
+    pub topic_suffix_nonce: String,
     pub partition_count: i32,
     pub replication_factor: i32,
     pub fuel: usize,
     pub consistency_value_schema: Option<String>,
     pub config_options: BTreeMap<String, String>,
     pub ccsr_config: ccsr::ClientConfig,
+    pub exactly_once: bool,
 }
 
 /// An index storing processed updates so they can be queried

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -337,7 +337,15 @@ where
                     as_of.frontier.less_equal(&time)
                 };
 
-                if !should_emit {
+                let previously_published = match &connector.consistency {
+                    Some(consistency) => match consistency.gate_ts {
+                        Some(ts) => as_of.frontier.less_equal(&ts),
+                        None => false,
+                    },
+                    None => false,
+                };
+
+                if !should_emit || previously_published {
                     // Skip stale data for already published timestamps
                     continue;
                 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -933,7 +933,7 @@ fn kafka_sink_builder(
     topic_prefix: String,
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     value_desc: RelationDesc,
-    topic_suffix: String,
+    topic_suffix_nonce: String,
 ) -> Result<SinkConnectorBuilder, anyhow::Error> {
     let (schema_registry_url, ccsr_with_options) = match format {
         Some(Format::Avro(AvroSchema::CsrUrl {
@@ -1012,7 +1012,7 @@ fn kafka_sink_builder(
         schema_registry_url,
         value_schema,
         topic_prefix,
-        topic_suffix,
+        topic_suffix_nonce,
         partition_count,
         replication_factor,
         fuel: 10000,
@@ -1022,6 +1022,7 @@ fn kafka_sink_builder(
         key_schema,
         key_desc_and_indices,
         value_desc,
+        exactly_once: false,
     }))
 }
 
@@ -1081,7 +1082,7 @@ pub fn plan_create_sink(
     };
     let name = scx.allocate_name(normalize::unresolved_object_name(name)?);
     let from = scx.resolve_item(from)?;
-    let suffix = format!(
+    let suffix_nonce = format!(
         "{}-{}",
         scx.catalog
             .config()
@@ -1165,10 +1166,12 @@ pub fn plan_create_sink(
             topic,
             key_desc_and_indices,
             value_desc,
-            suffix,
+            suffix_nonce,
         )?,
         Connector::Kinesis { .. } => unsupported!("Kinesis sinks"),
-        Connector::AvroOcf { path } => avro_ocf_sink_builder(format, path, suffix, value_desc)?,
+        Connector::AvroOcf { path } => {
+            avro_ocf_sink_builder(format, path, suffix_nonce, value_desc)?
+        }
         Connector::S3 { .. } => unsupported!("S3 sinks"),
         Connector::Postgres { .. } => unsupported!("Postgres sinks"),
     };


### PR DESCRIPTION
If a sink is created and an existing consistency topic is detected, we
attempt to read the latest commited timestamp and gate publishing until
our own ts has passed it. This is used for exactly once - on restart an
mz instance should re-bootstrap using the same timestamp history as the
previous instance and only start publishing once it has 'caught up' to
where the previous instance left off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5564)
<!-- Reviewable:end -->
