### PR TITLE
Optimization: Fix crash when a filter references output column of a TableFunc

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -856,6 +856,11 @@ impl TableFunc {
     }
 
     pub fn empty_on_null_input(&self) -> bool {
+        // Warning: this returns currently "true" for all TableFuncs.
+        // If adding a TableFunc for which this function will return "false",
+        // check the places where `empty_on_null_input` is called to ensure,
+        // such as NonNullRequirements that the case this function returns
+        // false is properly handled.
         match self {
             TableFunc::JsonbEach { .. }
             | TableFunc::JsonbObjectKeys

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -224,3 +224,58 @@ impl NonNullRequirements {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Transform;
+    use expr::{BinaryFunc, GlobalId, IdGen, MirScalarExpr, TableFunc};
+    use repr::{ColumnType, RelationType, ScalarType};
+
+    #[test]
+    fn issue5520_regression_map_test() {
+        let mut test_expr = MirRelationExpr::Filter {
+            input: Box::new(MirRelationExpr::FlatMap {
+                input: Box::new(MirRelationExpr::Map {
+                    input: Box::new(MirRelationExpr::Get {
+                        id: Id::Global(GlobalId::User(0)),
+                        typ: RelationType::new(vec![
+                            ColumnType {
+                                nullable: true,
+                                scalar_type: ScalarType::Int32,
+                            },
+                            ColumnType {
+                                nullable: true,
+                                scalar_type: ScalarType::Int64,
+                            },
+                        ]),
+                    }),
+                    scalars: vec![MirScalarExpr::literal_null(ColumnType {
+                        nullable: true,
+                        scalar_type: ScalarType::Int32,
+                    })],
+                }),
+                func: TableFunc::GenerateSeriesInt32,
+                exprs: vec![MirScalarExpr::Column(1)],
+                demand: None,
+            }),
+            predicates: vec![MirScalarExpr::CallBinary {
+                func: BinaryFunc::Eq,
+                expr1: Box::new(MirScalarExpr::Column(0)),
+                expr2: Box::new(MirScalarExpr::Column(3)),
+            }],
+        };
+        let expected = test_expr.clone();
+        let transform = NonNullRequirements;
+        assert!(transform
+            .transform(
+                &mut test_expr,
+                TransformArgs {
+                    id_gen: &mut IdGen::default(),
+                    indexes: &mut HashMap::new()
+                }
+            )
+            .is_ok());
+        assert_eq!(test_expr, expected);
+    }
+}

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -177,6 +177,15 @@ SELECT x.a, generate_series FROM x, LATERAL (SELECT * FROM generate_series(1, x.
 3  2
 3  3
 
+# Regression test for #5520: crash when a filter references an output column of
+# a table function
+query IIIII
+SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) WHERE x1.b = x2.b AND x1.a = x3.b
+----
+1 2 1 2 1
+2 3 2 3 2
+3 4 3 4 3
+
 query T multiline
 EXPLAIN RAW PLAN FOR SELECT * FROM x, generate_series(1, a)
 ----
@@ -262,6 +271,28 @@ EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.a) WHERE x1.
 | FlatMap generate_series(#0, #2)
 | | demand = (#0..#4)
 | Filter (#1 = #3)
+
+EOF
+
+# Regression test for #5520: crash when a filter references an output column of
+# a table function around a join
+query T multiline
+EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) WHERE x1.b = x2.b AND x1.a = x3.b
+----
+%0 =
+| Get materialize.public.x (u3)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.x (u3)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0..#3)
+| FlatMap generate_series(#0, #3)
+| | demand = (#0..#4)
+| Filter (#0 = #4), (#1 = #3)
 
 EOF
 


### PR DESCRIPTION
Resolves #5520.

My understanding of the bug:
Take this example query (which you can also find in the regression test in the PR): 
`SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) WHERE x1.b = x2.b AND x1.a = x3.b` 

Here, `x` has two columns. The plan looks like roughly this:
```
%0 =
| Get materialize.public.x (u3)
| ArrangeBy ()

%1 =
| Get materialize.public.x (u3)

%2 =
| Join %0 %1
| | implementation = Differential %1 %0.()
| | demand = (#0..#3)
| FlatMap generate_series(#0, #3)
| | demand = (#0..#4)
| Filter (#0 = #4), (#1 = #3)
```

My understanding of what `NonNullRequirements` does is this:
In SQL when you have a filter "foo.a = bar.a" not only does it imply that a rule that foo.a must be equal to bar.a, but it also implies that a rule that `foo.a is not null and bar.a is not null`. `NonNullRequirements` takes the `foo.a is not null and bar.a is not null` information and pushes it down, hoping to proactively remove parts of the `MirRelationExpr` where `foo.a` or `bar.a` would always evaluate to null and replace them with a no-row Constant. 

So in the example query, `NonNullRequirements` looks at the outermost filter and determines that the set of "columns where we can proactive filter out null values" is {0, 1, 3, 4}. This set in its entirety gets pushed down to `FlatMap` and then `Join`. The problem is that the "4" references a column created by the `FlatMap`. So Materialize crashes when the `Join` tries to figure out which input "4" belongs to.

Note that pushing down column 4 in this case is not a good idea even if the `FlatMap` were around something other than a `Join`. It's just that the `Join` is one of the few places where we verify the columns being pushed down. I think this bug will also cause a crash if the FlatMap were around a Map, but I'll add a test of this after posting the PR. 

The obvious solution in this case is to take the "4" out of the "columns that cannot be null" set that gets pushed down from `FlatMap` to the `Join`, which is what this PR does.

The open question is "does the fact we can proactively filter rows where column '4' is null imply anything about whether or not we proactively filter out null input arguments to the TableFunc?"
* If a TableFunc returns no rows if any input is null (all TableFuncs do this right now), we can proactively filter out all null input arguments anyway. Whether or not column 4 is in the set of "columns where we can proactive filter out null values" does not matter.
* If a TableFunc can return at least one row if any input is null, then I'm not sure what to do. I have decided to just leave TODO and warning comments for whomever adds the first TableFunc like this. Tell me if I should add an additional assert statement/panic due to unsupported-ness. I figure the person who adds the TableFunc is likely to be more qualified as to what to do in this case, and it would be a difficult-to-track-down correctness issue if I pass a wrong instruction to remove rows from an input where a particular column is null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5565)
<!-- Reviewable:end -->
