### PR TITLE
coord: structure many errors

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -39,7 +39,7 @@ use transform::Optimizer;
 use crate::catalog::builtin::{
     Builtin, BUILTINS, MZ_CATALOG_SCHEMA, MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
-use crate::catalog::error::{Error, ErrorKind};
+use crate::catalog::error::ErrorKind;
 use crate::catalog::migrate::CONTENT_MIGRATIONS;
 use crate::session::Session;
 
@@ -51,6 +51,7 @@ pub mod builtin;
 pub mod storage;
 
 pub use crate::catalog::config::Config;
+pub use crate::catalog::error::Error;
 
 const SYSTEM_CONN_ID: u32 = 0;
 

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -1,0 +1,127 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::error::Error;
+use std::fmt;
+
+use transform::TransformError;
+
+use crate::catalog;
+use crate::session::Var;
+
+/// Errors that can occur in the coordinator.
+#[derive(Debug)]
+pub enum CoordError {
+    /// An error occurred in a catalog operation.
+    Catalog(catalog::Error),
+    /// The specified session parameter is constrained to its current value.
+    ConstrainedParameter(&'static (dyn Var + Send + Sync)),
+    /// The value for the specified parameter does not have the right type.
+    InvalidParameterType(&'static (dyn Var + Send + Sync)),
+    /// The named operation cannot be run in a transaction.
+    OperationProhibitsTransaction(String),
+    /// The named operation requires an active transaction.
+    OperationRequiresTransaction(String),
+    /// The transaction is in read-only mode.
+    ReadOnlyTransaction,
+    /// The specified session parameter is read-only.
+    ReadOnlyParameter(&'static (dyn Var + Send + Sync)),
+    /// An error occurred in a SQL catalog operation.
+    SqlCatalog(sql::catalog::CatalogError),
+    /// An error occurred in the optimizer.
+    Transform(TransformError),
+    /// The named cursor does not exist.
+    UnknownCursor(String),
+    /// The named parameter is unknown to the system.
+    UnknownParameter(String),
+    /// A generic error occurred.
+    //
+    // TODO(benesch): convert all those errors to structured errors.
+    Unstructured(anyhow::Error),
+    /// The transaction is in write-only mode.
+    WriteOnlyTransaction,
+}
+
+impl CoordError {
+    /// Reports additional details about the error, if any are available.
+    pub fn detail(&self) -> Option<String> {
+        None
+    }
+
+    /// Reports a hint for the user about how the error could be fixed.
+    pub fn hint(&self) -> Option<String> {
+        None
+    }
+}
+
+impl fmt::Display for CoordError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CoordError::Catalog(e) => e.fmt(f),
+            CoordError::ConstrainedParameter(p) => write!(
+                f,
+                "parameter \"{}\" can only be set to \"{}\"",
+                p.name(),
+                p.value()
+            ),
+            CoordError::InvalidParameterType(p) => write!(
+                f,
+                "parameter \"{}\" requires a {} value",
+                p.name(),
+                p.type_name()
+            ),
+            CoordError::OperationProhibitsTransaction(op) => {
+                write!(f, "{} cannot be run inside a transaction block", op)
+            }
+            CoordError::OperationRequiresTransaction(op) => {
+                write!(f, "{} can only be used in transaction blocks", op)
+            }
+            CoordError::ReadOnlyTransaction => f.write_str("transaction in read-only mode"),
+            CoordError::ReadOnlyParameter(p) => {
+                write!(f, "parameter \"{}\" cannot be changed", p.name())
+            }
+            CoordError::SqlCatalog(e) => e.fmt(f),
+            CoordError::Transform(e) => e.fmt(f),
+            CoordError::UnknownCursor(name) => {
+                write!(f, "cursor \"{}\" does not exist", name)
+            }
+            CoordError::UnknownParameter(name) => {
+                write!(f, "unrecognized configuration parameter \"{}\"", name)
+            }
+            CoordError::Unstructured(e) => write!(f, "{:#}", e),
+            CoordError::WriteOnlyTransaction => f.write_str("transaction in write-only mode"),
+        }
+    }
+}
+
+impl From<anyhow::Error> for CoordError {
+    fn from(e: anyhow::Error) -> CoordError {
+        CoordError::Unstructured(e)
+    }
+}
+
+impl From<catalog::Error> for CoordError {
+    fn from(e: catalog::Error) -> CoordError {
+        CoordError::Catalog(e)
+    }
+}
+
+impl From<sql::catalog::CatalogError> for CoordError {
+    fn from(e: sql::catalog::CatalogError) -> CoordError {
+        CoordError::SqlCatalog(e)
+    }
+}
+
+impl From<TransformError> for CoordError {
+    fn from(e: TransformError) -> CoordError {
+        CoordError::Transform(e)
+    }
+}
+
+impl Error for CoordError {}

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -20,10 +20,18 @@
 //! [`pgwire`](../pgwire/index.html) produces, though they can, in theory, be
 //! provided by something other than a pgwire server.
 
+// TODO(benesch): delete this once we use structured errors everywhere.
+macro_rules! coord_bail {
+    ($($e:expr),*) => {
+        return Err(crate::error::CoordError::Unstructured(::anyhow::anyhow!($($e),*)))
+    }
+}
+
 mod cache;
 mod client;
 mod command;
 mod coord;
+mod error;
 mod sink_connector;
 mod timestamp;
 mod util;
@@ -35,4 +43,5 @@ pub use crate::cache::CacheConfig;
 pub use crate::client::{Client, SessionClient};
 pub use crate::command::{ExecuteResponse, NoSessionExecuteResponse, StartupMessage};
 pub use crate::coord::{describe, serve, Config, LoggingConfig};
+pub use crate::error::CoordError;
 pub use crate::timestamp::TimestampConfig;

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -16,18 +16,17 @@ use std::mem;
 
 use derivative::Derivative;
 use futures::Stream;
-use tokio_postgres::error::SqlState;
 
 use expr::GlobalId;
 use repr::{Datum, Row, ScalarType};
 use sql::ast::{Raw, Statement};
 use sql::plan::{Params, StatementDesc};
 
-use crate::ExecuteResponse;
+use crate::error::CoordError;
 
 mod vars;
 
-pub use self::vars::Vars;
+pub use self::vars::{Var, Vars};
 
 const DUMMY_CONNECTION_ID: u32 = 0;
 
@@ -128,7 +127,7 @@ impl Session {
 
     /// Adds operations to the current transaction. An error is produced if they
     /// cannot be merged (i.e., a read cannot be merged to an insert).
-    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps) -> Result<(), ExecuteResponse> {
+    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps) -> Result<(), CoordError> {
         match &mut self.transaction {
             TransactionStatus::Started(txn_ops)
             | TransactionStatus::InTransaction(txn_ops)
@@ -136,25 +135,14 @@ impl Session {
                 TransactionOps::None => *txn_ops = add_ops,
                 TransactionOps::Reads => match add_ops {
                     TransactionOps::Reads => {}
-                    _ => {
-                        return Err(ExecuteResponse::PgError {
-                            code: SqlState::READ_ONLY_SQL_TRANSACTION,
-                            message: "transaction in read-only mode".to_string(),
-                        })
-                    }
+                    _ => return Err(CoordError::ReadOnlyTransaction),
                 },
                 TransactionOps::Writes(txn_writes) => match add_ops {
                     TransactionOps::Writes(mut add_writes) => {
                         txn_writes.append(&mut add_writes);
                     }
                     _ => {
-                        return Err(ExecuteResponse::PgError {
-                            // It's not immediately clear which error code to use here because a
-                            // "write-only transaction" is not a thing in Postgres. This error code is the
-                            // generic "bad txn thing" code, so it's probably the best choice.
-                            code: SqlState::INVALID_TRANSACTION_STATE,
-                            message: "transaction in write-only mode".to_string(),
-                        });
+                        return Err(CoordError::WriteOnlyTransaction);
                     }
                 },
             },

--- a/src/coord/src/session/vars.rs
+++ b/src/coord/src/session/vars.rs
@@ -8,8 +8,9 @@
 // by the Apache License, Version 2.0.
 
 use std::borrow::Borrow;
+use std::fmt;
 
-use anyhow::bail;
+use crate::error::CoordError;
 
 const APPLICATION_NAME: ServerVar<str> = ServerVar {
     name: unicase::Ascii::new("application_name"),
@@ -192,7 +193,7 @@ impl Vars {
     /// named accessor to access the variable with its true Rust type. For
     /// example, `self.get("sql_safe_updates").value()` returns the string
     /// `"true"` or `"false"`, while `self.sql_safe_updates()` returns a bool.
-    pub fn get(&self, name: &str) -> Result<&dyn Var, anyhow::Error> {
+    pub fn get(&self, name: &str) -> Result<&dyn Var, CoordError> {
         if name == APPLICATION_NAME.name {
             Ok(&self.application_name)
         } else if name == CLIENT_ENCODING.name {
@@ -218,7 +219,7 @@ impl Vars {
         } else if name == TRANSACTION_ISOLATION.name {
             Ok(&self.transaction_isolation)
         } else {
-            bail!("unknown parameter: {}", name)
+            Err(CoordError::UnknownParameter(name.into()))
         }
     }
 
@@ -229,54 +230,43 @@ impl Vars {
     /// insensitively. If `value` is not valid, as determined by the underlying
     /// configuration parameter, or if the named configuration parameter does
     /// not exist, an error is returned.
-    pub fn set(&mut self, name: &str, value: &str) -> Result<(), anyhow::Error> {
+    pub fn set(&mut self, name: &str, value: &str) -> Result<(), CoordError> {
         if name == APPLICATION_NAME.name {
             self.application_name.set(value)
         } else if name == CLIENT_ENCODING.name {
-            bail!("parameter {} is read only", CLIENT_ENCODING.name);
+            Err(CoordError::ReadOnlyParameter(&CLIENT_ENCODING))
         } else if name == DATABASE.name {
             self.database.set(value)
         } else if name == DATE_STYLE.name {
             for value in value.split(',') {
                 let value = unicase::Ascii::new(value.trim());
                 if value != "ISO" && value != "MDY" {
-                    bail!(
-                        "parameter {} can only be set to {}",
-                        DATE_STYLE.name,
-                        DATE_STYLE.value
-                    );
+                    return Err(CoordError::ConstrainedParameter(&DATE_STYLE));
                 }
             }
             Ok(())
         } else if name == EXTRA_FLOAT_DIGITS.name {
             self.extra_float_digits.set(value)
         } else if name == INTEGER_DATETIMES.name {
-            bail!("parameter {} is read only", INTEGER_DATETIMES.name);
+            Err(CoordError::ReadOnlyParameter(&INTEGER_DATETIMES))
         } else if name == SEARCH_PATH.name {
-            bail!("parameter {} is read only", SEARCH_PATH.name);
+            Err(CoordError::ReadOnlyParameter(&SEARCH_PATH))
         } else if name == SERVER_VERSION.name {
-            bail!("parameter {} is read only", SERVER_VERSION.name);
+            Err(CoordError::ReadOnlyParameter(&SERVER_VERSION))
         } else if name == SQL_SAFE_UPDATES.name {
             self.sql_safe_updates.set(value)
         } else if name == STANDARD_CONFORMING_STRINGS.name {
-            bail!(
-                "parameter {} is read only",
-                STANDARD_CONFORMING_STRINGS.name
-            );
+            Err(CoordError::ReadOnlyParameter(&STANDARD_CONFORMING_STRINGS))
         } else if name == TIMEZONE.name {
             if unicase::Ascii::new(value) != TIMEZONE.value {
-                bail!(
-                    "parameter {} can only be set to {}",
-                    TIMEZONE.name,
-                    TIMEZONE.value
-                );
+                return Err(CoordError::ConstrainedParameter(&TIMEZONE));
             } else {
                 Ok(())
             }
         } else if name == TRANSACTION_ISOLATION.name {
-            bail!("parameter {} is read only", TRANSACTION_ISOLATION.name);
+            Err(CoordError::ReadOnlyParameter(&TRANSACTION_ISOLATION))
         } else {
-            bail!("unknown parameter: {}", name)
+            Err(CoordError::UnknownParameter(name.into()))
         }
     }
 
@@ -344,7 +334,7 @@ impl Vars {
 }
 
 /// A `Var` represents a configuration parameter of an arbitrary type.
-pub trait Var {
+pub trait Var: fmt::Debug {
     /// Returns the name of the configuration parameter.
     fn name(&self) -> &'static str;
 
@@ -355,13 +345,16 @@ pub trait Var {
     /// Returns a short sentence describing the purpose of the configuration
     /// parameter.
     fn description(&self) -> &'static str;
+
+    /// Returns the name of the type of this variable.
+    fn type_name(&self) -> &'static str;
 }
 
 /// A `ServerVar` is the default value for a configuration parameter.
 #[derive(Debug)]
 pub struct ServerVar<V>
 where
-    V: ?Sized + 'static,
+    V: fmt::Debug + ?Sized + 'static,
 {
     pub name: unicase::Ascii<&'static str>,
     pub value: &'static V,
@@ -370,7 +363,7 @@ where
 
 impl<V> Var for ServerVar<V>
 where
-    V: Value + ?Sized + 'static,
+    V: Value + fmt::Debug + ?Sized + 'static,
 {
     fn name(&self) -> &'static str {
         &self.name
@@ -383,6 +376,10 @@ where
     fn description(&self) -> &'static str {
         self.description
     }
+
+    fn type_name(&self) -> &'static str {
+        V::TYPE_NAME
+    }
 }
 
 /// A `SessionVar` is the session value for a configuration parameter. If unset,
@@ -390,7 +387,7 @@ where
 #[derive(Debug)]
 pub struct SessionVar<V>
 where
-    V: Value + ?Sized + 'static,
+    V: Value + fmt::Debug + ?Sized + 'static,
 {
     value: Option<V::Owned>,
     parent: &'static ServerVar<V>,
@@ -398,7 +395,7 @@ where
 
 impl<V> SessionVar<V>
 where
-    V: Value + ?Sized + 'static,
+    V: Value + fmt::Debug + ?Sized + 'static,
 {
     pub fn new(parent: &'static ServerVar<V>) -> SessionVar<V> {
         SessionVar {
@@ -407,17 +404,13 @@ where
         }
     }
 
-    pub fn set(&mut self, s: &str) -> Result<(), anyhow::Error> {
+    pub fn set(&mut self, s: &str) -> Result<(), CoordError> {
         match V::parse(s) {
             Ok(v) => {
                 self.value = Some(v);
                 Ok(())
             }
-            Err(()) => bail!(
-                "parameter {} requires a {} value",
-                self.name(),
-                V::TYPE_NAME
-            ),
+            Err(()) => Err(CoordError::InvalidParameterType(self.parent)),
         }
     }
 
@@ -431,7 +424,8 @@ where
 
 impl<V> Var for SessionVar<V>
 where
-    V: Value + ToOwned + ?Sized + 'static,
+    V: Value + ToOwned + fmt::Debug + ?Sized + 'static,
+    V::Owned: fmt::Debug,
 {
     fn name(&self) -> &'static str {
         &self.parent.name
@@ -444,10 +438,14 @@ where
     fn description(&self) -> &'static str {
         self.parent.description
     }
+
+    fn type_name(&self) -> &'static str {
+        V::TYPE_NAME
+    }
 }
 
 /// A value that can be stored in a session variable.
-pub trait Value: ToOwned {
+pub trait Value: ToOwned + Send + Sync {
     /// The name of the value type.
     const TYPE_NAME: &'static str;
     /// Parses a value of this type from a string.

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -10,7 +10,7 @@
 use std::fs::OpenOptions;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, Context};
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
@@ -24,12 +24,14 @@ use ore::collections::CollectionExt;
 use repr::Timestamp;
 use timely::progress::Antichain;
 
+use crate::error::CoordError;
+
 pub async fn build(
     builder: SinkConnectorBuilder,
     with_snapshot: bool,
     frontier: Antichain<Timestamp>,
     id: GlobalId,
-) -> Result<SinkConnector, anyhow::Error> {
+) -> Result<SinkConnector, CoordError> {
     match builder {
         SinkConnectorBuilder::Kafka(k) => build_kafka(k, with_snapshot, frontier, id).await,
         SinkConnectorBuilder::AvroOcf(a) => build_avro_ocf(a, with_snapshot, frontier, id),
@@ -44,7 +46,7 @@ async fn register_kafka_topic(
     ccsr: &ccsr::Client,
     value_schema: &str,
     key_schema: Option<&str>,
-) -> Result<(Option<i32>, i32), anyhow::Error> {
+) -> Result<(Option<i32>, i32), CoordError> {
     let res = client
         .create_topics(
             &[NewTopic::new(
@@ -57,7 +59,7 @@ async fn register_kafka_topic(
         .await
         .with_context(|| format!("error creating new topic {} for sink", topic))?;
     if res.len() != 1 {
-        bail!(
+        coord_bail!(
             "error creating topic {} for sink: \
              kafka topic creation returned {} results, but exactly one result was expected",
             topic,
@@ -94,7 +96,7 @@ async fn build_kafka(
     with_snapshot: bool,
     frontier: Antichain<Timestamp>,
     id: GlobalId,
-) -> Result<SinkConnector, anyhow::Error> {
+) -> Result<SinkConnector, CoordError> {
     let topic = format!("{}-{}-{}", builder.topic_prefix, id, builder.topic_suffix);
 
     // Create Kafka topic with single partition.
@@ -162,9 +164,9 @@ fn build_avro_ocf(
     with_snapshot: bool,
     frontier: Antichain<Timestamp>,
     id: GlobalId,
-) -> Result<SinkConnector, anyhow::Error> {
+) -> Result<SinkConnector, CoordError> {
     let mut name = match builder.path.file_stem() {
-        None => bail!(
+        None => coord_bail!(
             "unable to read file name from path {}",
             builder.path.display()
         ),

--- a/src/coord/src/util.rs
+++ b/src/coord/src/util.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::command::Response;
+use crate::error::CoordError;
 use crate::session::Session;
 
 /// Handles responding to clients.
@@ -23,7 +24,7 @@ impl<T> ClientTransmitter<T> {
 
     /// Transmits `result` to the client, returning ownership of the session
     /// `session` as well.
-    pub fn send(mut self, result: Result<T, anyhow::Error>, session: Session) {
+    pub fn send(mut self, result: Result<T, CoordError>, session: Session) {
         // We can safely ignore failure to send the message, as that simply
         // indicates that the client has disconnected and is no longer
         // interested in the response.

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -245,12 +245,7 @@ where
                 })
                 .collect(),
             Err(e) => {
-                return self
-                    .error(ErrorResponse::error(
-                        SqlState::INTERNAL_ERROR,
-                        format!("{:#}", e),
-                    ))
-                    .await;
+                return self.error(ErrorResponse::from(e)).await;
             }
         };
 
@@ -284,12 +279,7 @@ where
             .declare(EMPTY_PORTAL.to_string(), stmt.clone(), param_types)
             .await
         {
-            return self
-                .error(ErrorResponse::error(
-                    SqlState::INTERNAL_ERROR,
-                    format!("{:#}", e),
-                ))
-                .await;
+            return self.error(ErrorResponse::from(e)).await;
         }
 
         let stmt_desc = self
@@ -332,13 +322,7 @@ where
                 )
                 .await
             }
-            Err(e) => {
-                self.error(ErrorResponse::error(
-                    SqlState::INTERNAL_ERROR,
-                    format!("{:#}", e),
-                ))
-                .await
-            }
+            Err(e) => self.error(ErrorResponse::from(e)).await,
         };
 
         // Destroy the portal.
@@ -450,13 +434,7 @@ where
                 self.conn.send(BackendMessage::ParseComplete).await?;
                 Ok(State::Ready)
             }
-            Err(e) => {
-                self.error(ErrorResponse::error(
-                    SqlState::INTERNAL_ERROR,
-                    format!("{:#}", e),
-                ))
-                .await
-            }
+            Err(e) => self.error(ErrorResponse::from(e)).await,
         }
     }
 
@@ -616,13 +594,7 @@ where
                             )
                             .await
                         }
-                        Err(e) => {
-                            self.error(ErrorResponse::error(
-                                SqlState::INTERNAL_ERROR,
-                                format!("{:#}", e),
-                            ))
-                            .await
-                        }
+                        Err(e) => self.error(ErrorResponse::from(e)).await,
                     }
                 }
                 PortalState::InProgress(rows) => {
@@ -1043,9 +1015,6 @@ where
             ExecuteResponse::Updated(n) => command_complete!("UPDATE {}", n),
             ExecuteResponse::AlteredObject(o) => command_complete!("ALTER {}", o),
             ExecuteResponse::AlteredIndexLogicalCompaction => command_complete!("ALTER INDEX"),
-            ExecuteResponse::PgError { code, message } => {
-                self.error(ErrorResponse::error(code, message)).await
-            }
         }
     }
 

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -194,7 +194,7 @@ ReadyForQuery
 RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
-ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot run inside a transaction block"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
 ReadyForQuery {"status":"I"}
 
 # Should fail within an explicit transaction.
@@ -211,7 +211,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 ReadyForQuery {"status":"T"}
-ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot run inside a transaction block"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -272,7 +272,7 @@ BindComplete
 CommandComplete {"tag":"BEGIN"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot run inside a transaction block"}]}
+ErrorResponse {"fields":[{"typ":"C","value":"25001"},{"typ":"M","value":"DISCARD ALL cannot be run inside a transaction block"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -21,7 +21,7 @@ SET TIME ZONE 'uTc'
 statement ok
 SET TimeZone = 'uTc'
 
-statement error parameter TimeZone can only be set to UTC
+statement error parameter "TimeZone" can only be set to "UTC"
 SET TIME ZONE bad
 
 query T

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -245,7 +245,7 @@ unacceptable schema name 'pg_bar'
 > SHOW search_path
 "mz_catalog, pg_catalog, public, mz_temp"
 ! SET search_path = foo
-parameter search_path is read only
+parameter "search_path" cannot be changed
 
 # Creating views in non-existent databases should fail.
 ! CREATE VIEW noexist.ignored AS SELECT 1

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -30,7 +30,7 @@ UTF8
 UTF8
 
 ! SET client_encoding = UTF9
-parameter client_encoding is read only
+parameter "client_encoding" cannot be changed
 
 > SET sql_safe_updates = on
 > SHOW sql_safe_updates
@@ -54,15 +54,15 @@ off
 > SET DateStyle = 'MDY'
 > SET DateStyle = 'ISO,MDY'
 ! SET DateStyle = 'ooga booga'
-parameter DateStyle can only be set to ISO, MDY
+parameter "DateStyle" can only be set to "ISO, MDY"
 
 # `search_path` is tested elsewhere.
 
 ! SET server_version = "9.6.0"
-parameter server_version is read only
+parameter "server_version" cannot be changed
 
 ! SET TimeZone = 'nope'
-parameter TimeZone can only be set to UTC
+parameter "TimeZone" can only be set to "UTC"
 
 # The `transaction_isolation` variable has dedicated syntax as mandated by the
 # SQL standard.
@@ -70,7 +70,7 @@ parameter TimeZone can only be set to UTC
 serializable
 
 ! SET transaction_isolation = 'read committed'
-parameter transaction_isolation is read only
+parameter "transaction_isolation" cannot be changed
 
 ! SET integer_datetimes = false
-parameter integer_datetimes is read only
+parameter "integer_datetimes" cannot be changed


### PR DESCRIPTION
Introduce structured errors in the coord crate. This makes it possible
to return errors to the client over pgwire that report a SQLSTATE code,
details, and a hint in addition to the text of the error message.

The design here was proposed in #5340.

Converting all errors to structured errors is a large task, so this
commit largely limits the conversion to a few obvious places.
Unconverted errors remain in the CoordError::Unstructured variant as an
anyhow::Error. We'll want to continue converting these errors as we go.

The impetus for this change is to enable returning a hint with the "no
such role" method proposed in #5555.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5568)
<!-- Reviewable:end -->
