### PR TITLE
[Orthogonality] Split sources into "bare" and "transformed" versions

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1857,8 +1857,10 @@ impl Coordinator {
         let source = catalog::Source {
             create_sql: source.create_sql,
             plan_cx: pcx,
+            optimized_expr,
             connector: source.connector,
-            desc: source.desc,
+            bare_desc: source.bare_desc,
+            desc: transformed_desc,
         };
         let source_id = self.catalog.allocate_id()?;
         let source_oid = self.catalog.allocate_oid()?;

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1854,6 +1854,10 @@ impl Coordinator {
         if_not_exists: bool,
         materialized: bool,
     ) -> Result<ExecuteResponse, CoordError> {
+        let optimized_expr = self
+            .optimizer
+            .optimize(source.expr, self.catalog.indexes())?;
+        let transformed_desc = RelationDesc::new(optimized_expr.0.typ(), source.column_names);
         let source = catalog::Source {
             create_sql: source.create_sql,
             plan_cx: pcx,

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -72,6 +72,7 @@ impl<'a> DataflowBuilder<'a> {
                         SourceConnector::Local,
                         table.desc.clone(),
                         optimized_expr,
+                        table.desc.clone(),
                     );
                 }
                 CatalogItem::Source(source) => {
@@ -110,6 +111,7 @@ impl<'a> DataflowBuilder<'a> {
                         connector,
                         source.bare_desc.clone(),
                         source.optimized_expr.clone(),
+                        source.desc.clone(),
                     );
                 }
                 CatalogItem::View(view) => {

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -60,7 +60,19 @@ impl<'a> DataflowBuilder<'a> {
         } else {
             match self.catalog.get_by_id(id).item() {
                 CatalogItem::Table(table) => {
-                    dataflow.add_source_import(*id, SourceConnector::Local, table.desc.clone());
+                    let optimized_expr = OptimizedMirRelationExpr::declare_optimized(
+                        sql::plan::HirRelationExpr::Get {
+                            id: Id::BareSource(*id),
+                            typ: table.desc.typ().clone(),
+                        }
+                        .lower(),
+                    );
+                    dataflow.add_source_import(
+                        *id,
+                        SourceConnector::Local,
+                        table.desc.clone(),
+                        optimized_expr,
+                    );
                 }
                 CatalogItem::Source(source) => {
                     // If Materialize has caching enabled, check to see if the source has any
@@ -93,7 +105,12 @@ impl<'a> DataflowBuilder<'a> {
                     // Default back to the regular connector if we didn't get a augmented one.
                     let connector = connector.unwrap_or_else(|| source.connector.clone());
 
-                    dataflow.add_source_import(*id, connector, source.desc.clone());
+                    dataflow.add_source_import(
+                        *id,
+                        connector,
+                        source.bare_desc.clone(),
+                        source.optimized_expr.clone(),
+                    );
                 }
                 CatalogItem::View(view) => {
                     self.import_view_into_dataflow(id, &view.optimized_expr, dataflow);

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -132,12 +132,14 @@ impl DataflowDesc {
         connector: SourceConnector,
         bare_desc: RelationDesc,
         optimized_expr: OptimizedMirRelationExpr,
+        desc: RelationDesc,
     ) {
         let source_description = SourceDesc {
             connector,
             operators: None,
             bare_desc,
             optimized_expr,
+            desc,
         };
         self.source_imports.insert(id, source_description);
     }
@@ -376,19 +378,13 @@ impl DataEncoding {
                         })
                 });
                 if envelope.get_avro_envelope_type() == avro::EnvelopeType::Debezium {
-                    let desc = desc.with_column(
+                    desc.with_column(
                         "diff",
                         ColumnType {
                             nullable: false,
                             scalar_type: ScalarType::Int64,
                         },
-                    );
-                    if let Some(key) = key_schema_indices {
-                        let diff_column = desc.arity() - 1;
-                        desc.with_group_sum_key(key, diff_column)
-                    } else {
-                        desc
-                    }
+                    )
                 } else {
                     if let Some(key) = key_schema_indices {
                         desc.with_key(key)
@@ -489,6 +485,7 @@ pub struct SourceDesc {
     pub operators: Option<LinearOperator>,
     pub bare_desc: RelationDesc,
     pub optimized_expr: OptimizedMirRelationExpr,
+    pub desc: RelationDesc,
 }
 
 impl SourceDesc {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -340,10 +340,22 @@ impl DataEncoding {
         Ok(match self {
             DataEncoding::Bytes => key_desc.with_column("data", ScalarType::Bytes.nullable(false)),
             DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => {
-                avro::validate_value_schema(&*reader_schema, envelope.get_avro_envelope_type())
-                    .context("validating avro ocf reader schema")?
-                    .into_iter()
-                    .fold(key_desc, |desc, (name, ty)| desc.with_column(name, ty))
+                let desc =
+                    avro::validate_value_schema(&*reader_schema, envelope.get_avro_envelope_type())
+                        .context("validating avro ocf reader schema")?
+                        .into_iter()
+                        .fold(key_desc, |desc, (name, ty)| desc.with_column(name, ty));
+                if envelope.get_avro_envelope_type() == avro::EnvelopeType::Debezium {
+                    desc.with_column(
+                        "diff",
+                        ColumnType {
+                            nullable: false,
+                            scalar_type: ScalarType::Int64,
+                        },
+                    )
+                } else {
+                    desc
+                }
             }
             DataEncoding::Avro(AvroEncoding {
                 value_schema,

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -130,12 +130,14 @@ impl DataflowDesc {
         &mut self,
         id: GlobalId,
         connector: SourceConnector,
-        desc: RelationDesc,
+        bare_desc: RelationDesc,
+        optimized_expr: OptimizedMirRelationExpr,
     ) {
         let source_description = SourceDesc {
             connector,
             operators: None,
-            desc,
+            bare_desc,
+            optimized_expr,
         };
         self.source_imports.insert(id, source_description);
     }
@@ -276,7 +278,7 @@ impl DataflowDesc {
     pub fn arity_of(&self, id: &GlobalId) -> usize {
         for (source_id, desc) in self.source_imports.iter() {
             if source_id == id {
-                return desc.desc.typ().arity();
+                return desc.arity();
             }
         }
         for (_index_id, (desc, typ)) in self.index_imports.iter() {
@@ -353,16 +355,34 @@ impl DataEncoding {
                         .context("validating avro value schema")?
                         .into_iter()
                         .fold(key_desc, |desc, (name, ty)| desc.with_column(name, ty));
-                if let Some(key_schema) = key_schema {
-                    match avro::validate_key_schema(key_schema, &desc) {
-                        Ok(key) => desc.with_key(key),
-                        Err(e) => {
+                let key_schema_indices = key_schema.as_ref().and_then(|key_schema| {
+                    avro::validate_key_schema(key_schema, &desc)
+                        .map(Some)
+                        .unwrap_or_else(|e| {
                             warn!("Not using key due to error: {}", e);
-                            desc
-                        }
+                            None
+                        })
+                });
+                if envelope.get_avro_envelope_type() == avro::EnvelopeType::Debezium {
+                    let desc = desc.with_column(
+                        "diff",
+                        ColumnType {
+                            nullable: false,
+                            scalar_type: ScalarType::Int64,
+                        },
+                    );
+                    if let Some(key) = key_schema_indices {
+                        let diff_column = desc.arity() - 1;
+                        desc.with_group_sum_key(key, diff_column)
+                    } else {
+                        desc
                     }
                 } else {
-                    desc
+                    if let Some(key) = key_schema_indices {
+                        desc.with_key(key)
+                    } else {
+                        desc
+                    }
                 }
             }
             DataEncoding::Protobuf(ProtobufEncoding {
@@ -455,13 +475,14 @@ pub struct SourceDesc {
     /// Optionally, filtering and projection that may optimistically be applied
     /// to the output of the source.
     pub operators: Option<LinearOperator>,
-    pub desc: RelationDesc,
+    pub bare_desc: RelationDesc,
+    pub optimized_expr: OptimizedMirRelationExpr,
 }
 
 impl SourceDesc {
     /// Computes the arity of this source.
     pub fn arity(&self) -> usize {
-        self.desc.arity()
+        self.optimized_expr.0.arity()
     }
 }
 

--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -33,7 +33,7 @@ impl AvroDecoderState {
         debug_name: String,
         worker_index: usize,
         dedup_strat: Option<DebeziumDeduplicationStrategy>,
-        key_indices: Option<Vec<usize>>,
+        dbz_key_indices: Option<Vec<usize>>,
     ) -> Result<Self, anyhow::Error> {
         Ok(AvroDecoderState {
             decoder: Decoder::new(
@@ -43,7 +43,7 @@ impl AvroDecoderState {
                 debug_name,
                 worker_index,
                 dedup_strat,
-                key_indices,
+                dbz_key_indices,
             )?,
             events_success: 0,
             events_error: 0,

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -12,7 +12,9 @@ use std::{any::Any, cell::RefCell, collections::VecDeque, rc::Rc, time::Duration
 use anyhow::anyhow;
 use differential_dataflow::{capture::YieldingIter, hashable::Hashable};
 use futures::executor::block_on;
+use log::warn;
 use mz_avro::{AvroDeserializer, GeneralDeserializer};
+use repr::RelationDesc;
 use timely::{
     dataflow::{
         channels::pact::{Exchange, ParallelizationContract},
@@ -491,17 +493,13 @@ pub fn decode_values<G>(
     // `None`.
     operators: &mut Option<LinearOperator>,
     fast_forwarded: bool,
+    desc: RelationDesc,
 ) -> (Stream<G, (Row, Timestamp, Diff)>, Option<Box<dyn Any>>)
 where
     G: Scope<Timestamp = Timestamp>,
 {
     let op_name = format!("{}Decode", encoding.op_name());
     let worker_index = stream.scope().index();
-    let dbz_key_indices = encoding
-        .desc(envelope)
-        .ok()
-        .and_then(|desc| desc.typ().group_sum_keys.get(0).cloned())
-        .map(|(key, _diff_col)| key);
     match (encoding, envelope) {
         (_, SourceEnvelope::Upsert(_)) => {
             unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")
@@ -524,6 +522,14 @@ where
                 _ => unreachable!(),
             };
 
+            let dbz_key_indices = enc.key_schema.as_ref().and_then(|key_schema| {
+                interchange::avro::validate_key_schema(key_schema, &desc)
+                    .map(Some)
+                    .unwrap_or_else(|e| {
+                        warn!("Not using key due to error: {}", e);
+                        None
+                    })
+            });
             (
                 decode_values_inner(
                     stream,

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -497,10 +497,11 @@ where
 {
     let op_name = format!("{}Decode", encoding.op_name());
     let worker_index = stream.scope().index();
-    let key_indices = encoding
+    let dbz_key_indices = encoding
         .desc(envelope)
         .ok()
-        .and_then(|desc| desc.typ().keys.get(0).cloned());
+        .and_then(|desc| desc.typ().group_sum_keys.get(0).cloned())
+        .map(|(key, _diff_col)| key);
     match (encoding, envelope) {
         (_, SourceEnvelope::Upsert(_)) => {
             unreachable!("Internal error: Upsert is not supported yet on non-Kafka sources.")
@@ -534,7 +535,7 @@ where
                         debug_name.to_string(),
                         worker_index,
                         Some(dedup_strat),
-                        key_indices,
+                        dbz_key_indices,
                     )
                     .expect("Failed to create Avro decoder"),
                     &op_name,
@@ -554,7 +555,7 @@ where
                     debug_name.to_string(),
                     worker_index,
                     None,
-                    key_indices,
+                    None,
                 )
                 .expect("Failed to create Avro decoder"),
                 &op_name,

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -450,6 +450,7 @@ where
                             &envelope,
                             &mut src.operators,
                             fast_forwarded,
+                            src.desc,
                         );
                         if let Some(tok) = extra_token {
                             self.additional_tokens
@@ -1178,6 +1179,13 @@ where
                         self.ensure_rendered(input, scope, worker_index);
                     }
                     self.render_arrangeby(relation_expr, None);
+                }
+
+                MirRelationExpr::DeclareKey { input, key: _ } => {
+                    // TODO - some kind of debug mode where we assert that the keys are truly keys?
+                    self.ensure_rendered(input, scope, worker_index);
+                    let collections = self.collection(input).unwrap();
+                    self.collections.insert(relation_expr.clone(), collections);
                 }
             };
         }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -1181,11 +1181,10 @@ where
                     self.render_arrangeby(relation_expr, None);
                 }
 
-                MirRelationExpr::DeclareKey { input, key: _ } => {
+                MirRelationExpr::DeclareKeys { input, keys: _ } => {
                     // TODO - some kind of debug mode where we assert that the keys are truly keys?
                     self.ensure_rendered(input, scope, worker_index);
-                    let collections = self.collection(input).unwrap();
-                    self.collections.insert(relation_expr.clone(), collections);
+                    self.clone_from_to(input, relation_expr);
                 }
             };
         }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -264,7 +264,7 @@ where
                     .insert(src_id, LocalInput { handle, capability });
                 let err_collection = Collection::empty(scope);
                 self.collections.insert(
-                    MirRelationExpr::global_get(src_id, src.desc.typ().clone()),
+                    MirRelationExpr::global_get(src_id, src.bare_desc.typ().clone()),
                     (stream.as_collection(), err_collection),
                 );
             }
@@ -277,8 +277,6 @@ where
                 ts_frequency,
             } => {
                 // TODO(benesch): this match arm is hard to follow. Refactor.
-
-                let get_expr = MirRelationExpr::global_get(src_id, src.desc.typ().clone());
 
                 // This uid must be unique across all different instantiations of a source
                 let uid = SourceInstanceId {
@@ -351,7 +349,7 @@ where
                                     scope.index(),
                                     self.as_of_frontier.clone(),
                                     &mut src.operators,
-                                    src.desc.typ(),
+                                    src.bare_desc.typ(),
                                 );
 
                             let arranged = arrange_from_upsert(
@@ -365,10 +363,12 @@ where
                                     .as_collection(),
                             );
 
-                            let keys = src.desc.typ().keys[0]
+                            let keys = src.bare_desc.typ().keys[0]
                                 .iter()
                                 .map(|k| MirScalarExpr::Column(*k))
                                 .collect::<Vec<_>>();
+                            let get_expr =
+                                MirRelationExpr::global_get(src_id, src.bare_desc.typ().clone());
                             self.set_local(&get_expr, &keys, (arranged, err_collection.arrange()));
                             capability
                         }
@@ -462,19 +462,9 @@ where
                     };
 
                     let mut collection = match envelope {
-                        SourceEnvelope::None | SourceEnvelope::CdcV2 => stream.as_collection(),
-                        SourceEnvelope::Debezium(_) =>
-                        // TODO(btv) -- this should just be a MirRelationExpr::Explode (name TBD)
-                        {
-                            stream.as_collection().explode({
-                                let mut row_packer = repr::RowPacker::new();
-                                move |row| {
-                                    let mut datums = row.unpack();
-                                    let diff = datums.pop().unwrap().unwrap_int64() as isize;
-                                    Some((row_packer.pack(datums.into_iter()), diff))
-                                }
-                            })
-                        }
+                        SourceEnvelope::None
+                        | SourceEnvelope::CdcV2
+                        | SourceEnvelope::Debezium(_) => stream.as_collection(),
                         SourceEnvelope::Upsert(_) => unreachable!(),
                     };
 
@@ -483,7 +473,7 @@ where
                     // to demonstrate the intended use.
                     if let Some(mut operators) = src.operators.clone() {
                         // Determine replacement values for unused columns.
-                        let source_type = src.desc.typ();
+                        let source_type = src.bare_desc.typ();
                         let position_or = (0..source_type.arity())
                             .map(|col| {
                                 if operators.projection.contains(&col) {
@@ -539,11 +529,30 @@ where
                         .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
                         .as_collection();
 
+                    let get = MirRelationExpr::Get {
+                        id: Id::BareSource(src_id),
+                        typ: src.bare_desc.typ().clone(),
+                    };
                     // Introduce the stream by name, as an unarranged collection.
-                    self.collections.insert(
-                        MirRelationExpr::global_get(src_id, src.desc.typ().clone()),
-                        (collection, err_collection),
-                    );
+                    self.collections
+                        .insert(get.clone(), (collection, err_collection));
+
+                    let mut expr = src.optimized_expr.0;
+                    expr.visit_mut(&mut |node| {
+                        if let MirRelationExpr::Get {
+                            id: Id::LocalBareSource,
+                            ..
+                        } = node
+                        {
+                            *node = get.clone()
+                        }
+                    });
+
+                    // Do whatever envelope processing is required.
+                    self.ensure_rendered(&expr, scope, scope.index());
+                    let new_get = MirRelationExpr::global_get(src_id, expr.typ());
+                    self.clone_from_to(&expr, &new_get);
+
                     capability
                 };
                 let token = Rc::new(capability);
@@ -1008,10 +1017,10 @@ where
 
                 // A get should have been loaded into the context, and it is surprising to
                 // reach this point given the `has_collection()` guard at the top of the method.
-                MirRelationExpr::Get { id, typ: _ } => {
+                MirRelationExpr::Get { id, typ } => {
                     // TODO: something more tasteful.
                     // perhaps load an empty collection, warn?
-                    panic!("Collection {} not pre-loaded", id);
+                    panic!("Collection {} (typ: {:?}) not pre-loaded", id, typ);
                 }
 
                 MirRelationExpr::Let { id, value, body } => {

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -121,6 +121,7 @@ impl<'a> Explanation<'a> {
             // traversal.
             match expr {
                 // Leaf expressions. Nothing more to visit.
+                // TODO [btv] Explain complex sources.
                 Constant { .. } | Get { .. } => (),
                 // Single-input expressions continue the chain.
                 Project { input, .. }
@@ -247,6 +248,15 @@ impl<'a> Explanation<'a> {
                         .unwrap_or_else(|| "?".to_owned()),
                     id,
                 )?,
+                Id::BareSource(id) => writeln!(
+                    f,
+                    "| Get Bare Source for {} ({})",
+                    self.expr_humanizer
+                        .humanize_id(*id)
+                        .unwrap_or_else(|| "?".to_owned()),
+                    id
+                )?,
+                Id::LocalBareSource => writeln!(f, "| Get Bare Source for This Source")?,
             },
             // Lets are annotated on the chain ID that they correspond to.
             Let { .. } => (),
@@ -367,7 +377,12 @@ impl<'a> Explanation<'a> {
             )?,
         }
 
-        if let Some(RelationType { column_types, keys }) = &node.typ {
+        if let Some(RelationType {
+            column_types,
+            keys,
+            group_sum_keys: _, /*  These are a bit hard to describe, so don't bother trying to explain them */
+        }) = &node.typ
+        {
             let column_types: Vec<_> = column_types
                 .iter()
                 .map(|c| self.expr_humanizer.humanize_column_type(c))

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -132,7 +132,7 @@ impl<'a> Explanation<'a> {
                 | TopK { input, .. }
                 | Negate { input, .. }
                 | Threshold { input, .. }
-                | DeclareKey { input, .. }
+                | DeclareKeys { input, .. }
                 | ArrangeBy { input, .. } => walk(input, explanation),
                 // For join and union, each input may need to go in its own
                 // chain.
@@ -356,10 +356,14 @@ impl<'a> Explanation<'a> {
             }
             Negate { .. } => writeln!(f, "| Negate")?,
             Threshold { .. } => write!(f, "| Threshold")?,
-            DeclareKey { input: _, key } => write!(
+            DeclareKeys { input: _, keys } => write!(
                 f,
-                "| Declare primary key={}",
-                bracketed("(", ")", separated(", ", key))
+                "| Declare primary keys {}",
+                separated(
+                    " ",
+                    keys.iter()
+                        .map(|key| bracketed("(", ")", separated(", ", key)))
+                )
             )?,
             Union { base, inputs } => writeln!(
                 f,

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Id {
             Id::Local(id) => id.fmt(f),
             Id::Global(id) => id.fmt(f),
             Id::BareSource(id) => write!(f, "{}(bare)", id),
-            Id::LocalBareSource => write!(f, "(bare source for this source"),
+            Id::LocalBareSource => write!(f, "(bare source for this source)"),
         }
     }
 }

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -21,6 +21,12 @@ pub enum Id {
     Local(LocalId),
     /// An identifier that refers to a global dataflow.
     Global(GlobalId),
+    /// Bare sources don't (yet?) live in the same namespace as catalog items (including the final, possibly transformed source.)
+    /// This gives us a way to refer to them in relation expressions
+    BareSource(GlobalId),
+    /// Used to refer to a bare source within the RelationExpr defining the transformation of that source (before an ID has been
+    /// allocated for the bare source).
+    LocalBareSource,
 }
 
 impl fmt::Display for Id {
@@ -28,6 +34,8 @@ impl fmt::Display for Id {
         match self {
             Id::Local(id) => id.fmt(f),
             Id::Global(id) => id.fmt(f),
+            Id::BareSource(id) => write!(f, "{}(bare)", id),
+            Id::LocalBareSource => write!(f, "(bare source for this source"),
         }
     }
 }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -208,6 +208,18 @@ pub enum MirRelationExpr {
         /// Columns to arrange `input` by, in order of decreasing primacy
         keys: Vec<Vec<MirScalarExpr>>,
     },
+    /// Declares that `key` is a primary key for `input`.
+    /// Should be used *very* sparingly, and only if there's no plausible
+    /// way to derive the key information from the underlying expression.
+    /// The result of declaring a key that isn't actually a key for the underlying expression is undefined.
+    ///
+    /// There is no operator rendered for this IR node; thus, its runtime memory footprint is zero.
+    DeclareKey {
+        /// The source collection
+        input: Box<MirRelationExpr>,
+        /// The set of columns in the source collection that form a key.
+        key: Vec<usize>,
+    },
 }
 
 impl MirRelationExpr {
@@ -319,7 +331,7 @@ impl MirRelationExpr {
             MirRelationExpr::FlatMap {
                 input,
                 func,
-                exprs,
+                exprs: _,
                 demand: _,
             } => {
                 let mut input_typ = input.typ();
@@ -327,18 +339,7 @@ impl MirRelationExpr {
                     .column_types
                     .extend(func.output_type().column_types);
                 // FlatMap can add duplicate rows, so input keys are no longer valid
-                let mut typ = RelationType::new(input_typ.column_types);
-                // But we might know that repeat'ing by a column causes another column to be a key:
-                // in particular, this is true for Debezium sources. Account for that possibility here.
-                if let TableFunc::Repeat = func {
-                    if let MirScalarExpr::Column(col) = &exprs[0] {
-                        for (group_indices, sum_column) in input_typ.group_sum_keys.iter() {
-                            if sum_column == col {
-                                typ = typ.with_key(group_indices.clone());
-                            }
-                        }
-                    }
-                }
+                let typ = RelationType::new(input_typ.column_types);
                 typ
             }
             MirRelationExpr::Filter { input, .. } => input.typ(),
@@ -371,46 +372,8 @@ impl MirRelationExpr {
                     equivalences,
                 );
 
-                let mut group_sum_keys = vec![];
-                for (input_index, input_typ) in input_types.iter().enumerate() {
-                    for (group_indices, column_index) in input_typ.group_sum_keys.iter() {
-                        // If the group key refines a key for every other input, it is a group key for the join.
-                        let group_indices_global = group_indices
-                            .iter()
-                            .map(|&group_index| {
-                                input_mapper.map_column_to_global(group_index, input_index)
-                            })
-                            .collect::<Vec<_>>();
-                        if input_types
-                            .iter()
-                            .enumerate()
-                            .all(|(input2_index, input2_typ)| {
-                                input_index == input2_index
-                                    || input2_typ.keys.iter().any(|input2_key| {
-                                        input2_key.iter().all(|&input2_key_index| {
-                                            group_indices_global.contains(
-                                                &input_mapper.map_column_to_global(
-                                                    input2_key_index,
-                                                    input2_index,
-                                                ),
-                                            )
-                                        })
-                                    })
-                            })
-                        {
-                            let column_index_global =
-                                input_mapper.map_column_to_global(*column_index, input_index);
-                            group_sum_keys.push((group_indices_global, column_index_global));
-                        }
-                    }
-                }
-
                 for keys in global_keys {
                     typ = typ.with_key(keys.clone());
-                }
-                for group_sum_key in group_sum_keys {
-                    let (group_indices, sum_column) = group_sum_key;
-                    typ = typ.with_group_sum_key(group_indices, sum_column);
                 }
                 typ
             }
@@ -495,6 +458,7 @@ impl MirRelationExpr {
                 // Important: do not inherit keys of either input, as not unique.
             }
             MirRelationExpr::ArrangeBy { input, .. } => input.typ(),
+            MirRelationExpr::DeclareKey { input, key } => input.typ().with_key(key.clone()),
         }
     }
 
@@ -845,6 +809,9 @@ impl MirRelationExpr {
             MirRelationExpr::ArrangeBy { input, .. } => {
                 f(input)?;
             }
+            MirRelationExpr::DeclareKey { input, .. } => {
+                f(input)?;
+            }
         }
         Ok(())
     }
@@ -922,6 +889,9 @@ impl MirRelationExpr {
                 }
             }
             MirRelationExpr::ArrangeBy { input, .. } => {
+                f(input)?;
+            }
+            MirRelationExpr::DeclareKey { input, .. } => {
                 f(input)?;
             }
         }
@@ -1064,6 +1034,7 @@ impl MirRelationExpr {
             }
             | MirRelationExpr::Negate { input: _ }
             | MirRelationExpr::Threshold { input: _ }
+            | MirRelationExpr::DeclareKey { input: _, key: _ }
             | MirRelationExpr::Union { base: _, inputs: _ } => Ok(()),
         }
     }
@@ -1205,6 +1176,14 @@ impl MirRelationExpr {
                 default,
             ))
         })
+    }
+
+    /// Passes the collection through unchanged, but informs the optimizer that `key` is a primary key.
+    pub fn declare_key(self, key: Vec<usize>) -> Self {
+        Self::DeclareKey {
+            input: Box::new(self),
+            key,
+        }
     }
 }
 

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -319,13 +319,27 @@ impl MirRelationExpr {
             MirRelationExpr::FlatMap {
                 input,
                 func,
-                exprs: _,
+                exprs,
                 demand: _,
             } => {
-                let mut typ = input.typ();
-                typ.column_types.extend(func.output_type().column_types);
+                let mut input_typ = input.typ();
+                input_typ
+                    .column_types
+                    .extend(func.output_type().column_types);
                 // FlatMap can add duplicate rows, so input keys are no longer valid
-                RelationType::new(typ.column_types)
+                let mut typ = RelationType::new(input_typ.column_types);
+                // But we might know that repeat'ing by a column causes another column to be a key:
+                // in particular, this is true for Debezium sources. Account for that possibility here.
+                if let TableFunc::Repeat = func {
+                    if let MirScalarExpr::Column(col) = &exprs[0] {
+                        for (group_indices, sum_column) in input_typ.group_sum_keys.iter() {
+                            if sum_column == col {
+                                typ = typ.with_key(group_indices.clone());
+                            }
+                        }
+                    }
+                }
+                typ
             }
             MirRelationExpr::Filter { input, .. } => input.typ(),
             MirRelationExpr::Join {
@@ -357,8 +371,46 @@ impl MirRelationExpr {
                     equivalences,
                 );
 
+                let mut group_sum_keys = vec![];
+                for (input_index, input_typ) in input_types.iter().enumerate() {
+                    for (group_indices, column_index) in input_typ.group_sum_keys.iter() {
+                        // If the group key refines a key for every other input, it is a group key for the join.
+                        let group_indices_global = group_indices
+                            .iter()
+                            .map(|&group_index| {
+                                input_mapper.map_column_to_global(group_index, input_index)
+                            })
+                            .collect::<Vec<_>>();
+                        if input_types
+                            .iter()
+                            .enumerate()
+                            .all(|(input2_index, input2_typ)| {
+                                input_index == input2_index
+                                    || input2_typ.keys.iter().any(|input2_key| {
+                                        input2_key.iter().all(|&input2_key_index| {
+                                            group_indices_global.contains(
+                                                &input_mapper.map_column_to_global(
+                                                    input2_key_index,
+                                                    input2_index,
+                                                ),
+                                            )
+                                        })
+                                    })
+                            })
+                        {
+                            let column_index_global =
+                                input_mapper.map_column_to_global(*column_index, input_index);
+                            group_sum_keys.push((group_indices_global, column_index_global));
+                        }
+                    }
+                }
+
                 for keys in global_keys {
                     typ = typ.with_key(keys.clone());
+                }
+                for group_sum_key in group_sum_keys {
+                    let (group_indices, sum_column) = group_sum_key;
+                    typ = typ.with_group_sum_key(group_indices, sum_column);
                 }
                 typ
             }

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -97,6 +97,13 @@ impl RelationType {
         self
     }
 
+    pub fn with_keys(mut self, keys: Vec<Vec<usize>>) -> Self {
+        for key in keys {
+            self = self.with_key(key)
+        }
+        self
+    }
+
     /// Computes the number of columns in the relation.
     pub fn arity(&self) -> usize {
         self.column_types.len()

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -69,13 +69,6 @@ pub struct RelationType {
     /// A collection can contain multiple sets of keys, although it is common to
     /// have either zero or one sets of key indices.
     pub keys: Vec<Vec<usize>>,
-    /// Sets of (group, sum_column) indices, such that the following property holds:
-    /// `SELECT sum(sum_column) FROM relation GROUP BY <group>` is always 0 or 1.
-    /// This may sound like a niche property, but it amounts to saying "exploding by `sum_column` turns `group` into a key",
-    /// which is necessary for propagating Debezium key information.
-    // TODO [btv] - If in the future we start needing an unweildy amount of metadata to propagate Debezium key information,
-    // maybe we can do it in a hackier way (i.e., just have a `pre_debezium_keys` field here).
-    pub group_sum_keys: Vec<(Vec<usize>, usize)>,
 }
 
 impl RelationType {
@@ -92,7 +85,6 @@ impl RelationType {
         RelationType {
             column_types,
             keys: Vec::new(),
-            group_sum_keys: Vec::new(),
         }
     }
 
@@ -101,15 +93,6 @@ impl RelationType {
         indices.sort_unstable();
         if !self.keys.contains(&indices) {
             self.keys.push(indices);
-        }
-        self
-    }
-
-    pub fn with_group_sum_key(mut self, mut group_indices: Vec<usize>, sum_column: usize) -> Self {
-        group_indices.sort_unstable();
-        let entry = (group_indices, sum_column);
-        if !self.group_sum_keys.contains(&entry) {
-            self.group_sum_keys.push(entry);
         }
         self
     }
@@ -249,14 +232,6 @@ impl RelationDesc {
             let k = k.into_iter().map(|idx| idx + self_len).collect();
             self = self.with_key(k);
         }
-        for (group_indices, sum_column) in other.typ.group_sum_keys {
-            let group_indices = group_indices
-                .into_iter()
-                .map(|idx| idx + self_len)
-                .collect();
-            let sum_column = sum_column + self_len;
-            self = self.with_group_sum_key(group_indices, sum_column);
-        }
         self
     }
 
@@ -279,18 +254,6 @@ impl RelationDesc {
     /// Drops all existing keys.
     pub fn without_keys(mut self) -> Self {
         self.typ.keys.clear();
-        self
-    }
-
-    /// Drop all existing group sum keys.
-    pub fn without_group_sum_keys(mut self) -> Self {
-        self.typ.group_sum_keys.clear();
-        self
-    }
-
-    /// Add a new group sum key to this `RelationDesc`.
-    pub fn with_group_sum_key(mut self, group_indices: Vec<usize>, sum_column: usize) -> Self {
-        self.typ = self.typ.with_group_sum_key(group_indices, sum_column);
         self
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -213,7 +213,9 @@ pub struct Table {
 pub struct Source {
     pub create_sql: String,
     pub connector: SourceConnector,
-    pub desc: RelationDesc,
+    pub bare_desc: RelationDesc,
+    pub expr: ::expr::MirRelationExpr,
+    pub column_names: Vec<Option<ColumnName>>, // Column names for the transformed source; i.e. the expr
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -131,7 +131,7 @@ impl<'a> Explanation<'a> {
                 | Distinct { input }
                 | TopK { input, .. }
                 | Negate { input, .. }
-                | DeclareKey { input, .. }
+                | DeclareKeys { input, .. }
                 | Threshold { input, .. } => walk(input, explanation, id_gen),
                 // For join and union, each input needs to go in its own chain.
                 Join { left, right, .. } => {
@@ -160,7 +160,7 @@ impl<'a> Explanation<'a> {
                 | Negate { .. }
                 | Threshold { .. }
                 | Union { .. }
-                | DeclareKey { .. }
+                | DeclareKeys { .. }
                 | TopK { .. } => (),
                 Map { scalars: exprs, .. }
                 | Filter {
@@ -355,10 +355,14 @@ impl<'a> Explanation<'a> {
             }
             Negate { .. } => writeln!(f, "| Negate")?,
             Threshold { .. } => write!(f, "| Threshold")?,
-            DeclareKey { input: _, key } => write!(
+            DeclareKeys { input: _, keys } => write!(
                 f,
-                "| Declare primary key={}",
-                bracketed("(", ")", separated(", ", key))
+                "| Declare primary keys {}",
+                separated(
+                    " ",
+                    keys.iter()
+                        .map(|key| bracketed("(", ")", separated(", ", key)))
+                )
             )?,
             Union { base, inputs } => writeln!(
                 f,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -18,6 +18,7 @@ use std::fmt;
 use std::mem;
 
 use anyhow::bail;
+use expr::DummyHumanizer;
 use itertools::Itertools;
 
 use ore::collections::CollectionExt;
@@ -30,6 +31,8 @@ use crate::plan::Params;
 // these happen to be unchanged at the moment, but there might be additions later
 pub use expr::{BinaryFunc, ColumnOrder, NullaryFunc, TableFunc, UnaryFunc, VariadicFunc};
 use repr::adt::array::ArrayDimension;
+
+use super::Explanation;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Just like MirRelationExpr, except where otherwise noted below.
@@ -102,6 +105,10 @@ pub enum HirRelationExpr {
     Union {
         base: Box<HirRelationExpr>,
         inputs: Vec<HirRelationExpr>,
+    },
+    DeclareKey {
+        input: Box<HirRelationExpr>,
+        key: Vec<usize>,
     },
 }
 
@@ -553,6 +560,9 @@ impl HirRelationExpr {
                 }
                 RelationType::new(base_cols)
             }
+            HirRelationExpr::DeclareKey { input, key } => {
+                input.typ(outers, params).with_key(key.clone())
+            }
         }
     }
 
@@ -567,6 +577,7 @@ impl HirRelationExpr {
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::Negate { input }
+            | HirRelationExpr::DeclareKey { input, .. }
             | HirRelationExpr::Threshold { input } => input.arity(),
             HirRelationExpr::Join { left, right, .. } => left.arity() + right.arity(),
             HirRelationExpr::Union { base, .. } => base.arity(),
@@ -576,6 +587,11 @@ impl HirRelationExpr {
                 ..
             } => group_key.len() + aggregates.len(),
         }
+    }
+
+    /// Pretty-print this HirRelationExpr to a string.
+    pub fn pretty(&self) -> String {
+        Explanation::new(self, &DummyHumanizer).to_string()
     }
 
     pub fn is_join_identity(&self) -> bool {
@@ -621,6 +637,13 @@ impl HirRelationExpr {
         HirRelationExpr::Filter {
             input: Box::new(self),
             predicates,
+        }
+    }
+
+    pub fn declare_key(self, key: Vec<usize>) -> Self {
+        HirRelationExpr::DeclareKey {
+            input: Box::new(self),
+            key,
         }
     }
 
@@ -745,6 +768,9 @@ impl HirRelationExpr {
             HirRelationExpr::Threshold { input } => {
                 f(input);
             }
+            HirRelationExpr::DeclareKey { input, .. } => {
+                f(input);
+            }
             HirRelationExpr::Union { base, inputs } => {
                 f(base);
                 for input in inputs {
@@ -796,6 +822,9 @@ impl HirRelationExpr {
                 f(input);
             }
             HirRelationExpr::Threshold { input } => {
+                f(input);
+            }
+            HirRelationExpr::DeclareKey { input, .. } => {
                 f(input);
             }
             HirRelationExpr::Union { base, inputs } => {
@@ -863,6 +892,7 @@ impl HirRelationExpr {
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Negate { input }
+            | HirRelationExpr::DeclareKey { input, .. }
             | HirRelationExpr::Threshold { input } => {
                 input.visit_columns(depth, f);
             }
@@ -917,6 +947,7 @@ impl HirRelationExpr {
             | HirRelationExpr::Distinct { input, .. }
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Negate { input, .. }
+            | HirRelationExpr::DeclareKey { input, .. }
             | HirRelationExpr::Threshold { input, .. } => input.bind_parameters(params),
             HirRelationExpr::Constant { .. } | HirRelationExpr::Get { .. } => Ok(()),
         }
@@ -971,6 +1002,7 @@ impl HirRelationExpr {
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Negate { input }
+            | HirRelationExpr::DeclareKey { input, .. }
             | HirRelationExpr::Threshold { input } => {
                 input.splice_parameters(params, depth);
             }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -106,9 +106,9 @@ pub enum HirRelationExpr {
         base: Box<HirRelationExpr>,
         inputs: Vec<HirRelationExpr>,
     },
-    DeclareKey {
+    DeclareKeys {
         input: Box<HirRelationExpr>,
-        key: Vec<usize>,
+        keys: Vec<Vec<usize>>,
     },
 }
 
@@ -560,8 +560,8 @@ impl HirRelationExpr {
                 }
                 RelationType::new(base_cols)
             }
-            HirRelationExpr::DeclareKey { input, key } => {
-                input.typ(outers, params).with_key(key.clone())
+            HirRelationExpr::DeclareKeys { input, keys } => {
+                input.typ(outers, params).with_keys(keys.clone())
             }
         }
     }
@@ -577,7 +577,7 @@ impl HirRelationExpr {
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::Negate { input }
-            | HirRelationExpr::DeclareKey { input, .. }
+            | HirRelationExpr::DeclareKeys { input, .. }
             | HirRelationExpr::Threshold { input } => input.arity(),
             HirRelationExpr::Join { left, right, .. } => left.arity() + right.arity(),
             HirRelationExpr::Union { base, .. } => base.arity(),
@@ -640,10 +640,10 @@ impl HirRelationExpr {
         }
     }
 
-    pub fn declare_key(self, key: Vec<usize>) -> Self {
-        HirRelationExpr::DeclareKey {
+    pub fn declare_keys(self, keys: Vec<Vec<usize>>) -> Self {
+        HirRelationExpr::DeclareKeys {
             input: Box::new(self),
-            key,
+            keys,
         }
     }
 
@@ -768,7 +768,7 @@ impl HirRelationExpr {
             HirRelationExpr::Threshold { input } => {
                 f(input);
             }
-            HirRelationExpr::DeclareKey { input, .. } => {
+            HirRelationExpr::DeclareKeys { input, .. } => {
                 f(input);
             }
             HirRelationExpr::Union { base, inputs } => {
@@ -824,7 +824,7 @@ impl HirRelationExpr {
             HirRelationExpr::Threshold { input } => {
                 f(input);
             }
-            HirRelationExpr::DeclareKey { input, .. } => {
+            HirRelationExpr::DeclareKeys { input, .. } => {
                 f(input);
             }
             HirRelationExpr::Union { base, inputs } => {
@@ -892,7 +892,7 @@ impl HirRelationExpr {
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Negate { input }
-            | HirRelationExpr::DeclareKey { input, .. }
+            | HirRelationExpr::DeclareKeys { input, .. }
             | HirRelationExpr::Threshold { input } => {
                 input.visit_columns(depth, f);
             }
@@ -947,7 +947,7 @@ impl HirRelationExpr {
             | HirRelationExpr::Distinct { input, .. }
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Negate { input, .. }
-            | HirRelationExpr::DeclareKey { input, .. }
+            | HirRelationExpr::DeclareKeys { input, .. }
             | HirRelationExpr::Threshold { input, .. } => input.bind_parameters(params),
             HirRelationExpr::Constant { .. } | HirRelationExpr::Get { .. } => Ok(()),
         }
@@ -1002,7 +1002,7 @@ impl HirRelationExpr {
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Negate { input }
-            | HirRelationExpr::DeclareKey { input, .. }
+            | HirRelationExpr::DeclareKeys { input, .. }
             | HirRelationExpr::Threshold { input } => {
                 input.splice_parameters(params, depth);
             }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -478,9 +478,9 @@ impl HirRelationExpr {
                 // Threshold is uncomplicated.
                 input.applied_to(id_gen, get_outer, col_map).threshold()
             }
-            DeclareKey { input, key } => input
+            DeclareKeys { input, keys } => input
                 .applied_to(id_gen, get_outer, col_map)
-                .declare_key(key),
+                .declare_keys(keys),
         }
     }
 }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -478,6 +478,9 @@ impl HirRelationExpr {
                 // Threshold is uncomplicated.
                 input.applied_to(id_gen, get_outer, col_map).threshold()
             }
+            DeclareKey { input, key } => input
+                .applied_to(id_gen, get_outer, col_map)
+                .declare_key(key),
         }
     }
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3166,6 +3166,10 @@ impl<'a> QueryContext<'a> {
 
                 Ok((expr, scope))
             }
+            Id::BareSource(_) | Id::LocalBareSource => {
+                // These are never introduced except when planning source transformations.
+                unreachable!()
+            }
         }
     }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -247,7 +247,7 @@ fn plan_source_envelope(
         }
         .project((0..diff_col).collect());
         if let Some(post_transform_key) = post_transform_key {
-            expr.declare_key(post_transform_key)
+            expr.declare_keys(vec![post_transform_key])
         } else {
             expr
         }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -13,6 +13,7 @@
 //! `ALTER`, `CREATE`, and `DROP`.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -60,8 +61,8 @@ use crate::plan::expr::{ColumnRef, HirScalarExpr, JoinKind};
 use crate::plan::query::QueryLifetime;
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{
-    self, plan_utils, query, Index, IndexOption, IndexOptionName, Params, Plan, Sink, Source,
-    Table, Type, TypeInner, View,
+    self, plan_utils, query, HirRelationExpr, Index, IndexOption, IndexOptionName, Params, Plan,
+    Sink, Source, Table, Type, TypeInner, View,
 };
 use crate::pure::Schema;
 

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -607,6 +607,7 @@ fn plan_hypothetical_cast(
             scalar_type: from.clone(),
         }],
         keys: vec![vec![0]],
+        group_sum_keys: vec![],
     };
     let ecx = ExprContext {
         qcx: &qcx,

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -607,7 +607,6 @@ fn plan_hypothetical_cast(
             scalar_type: from.clone(),
         }],
         keys: vec![vec![0]],
-        group_sum_keys: vec![],
     };
     let ecx = ExprContext {
         qcx: &qcx,

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -171,11 +171,7 @@ END $$;
                     column_types.push(ty.nullable(nullable));
                     defaults.push(default);
                 }
-                let mut typ = RelationType {
-                    column_types,
-                    keys,
-                    group_sum_keys: vec![],
-                };
+                let mut typ = RelationType { column_types, keys };
 
                 // Handle table-level UNIQUE and PRIMARY KEY constraints.
                 // PRIMARY KEY implies UNIQUE and NOT NULL.

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -171,7 +171,11 @@ END $$;
                     column_types.push(ty.nullable(nullable));
                     defaults.push(default);
                 }
-                let mut typ = RelationType { column_types, keys };
+                let mut typ = RelationType {
+                    column_types,
+                    keys,
+                    group_sum_keys: vec![],
+                };
 
                 // Handle table-level UNIQUE and PRIMARY KEY constraints.
                 // PRIMARY KEY implies UNIQUE and NOT NULL.

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -244,6 +244,9 @@ impl ColumnKnowledge {
             MirRelationExpr::TopK { input, .. } => ColumnKnowledge::harvest(input, knowledge)?,
             MirRelationExpr::Negate { input } => ColumnKnowledge::harvest(input, knowledge)?,
             MirRelationExpr::Threshold { input } => ColumnKnowledge::harvest(input, knowledge)?,
+            MirRelationExpr::DeclareKey { input, .. } => {
+                ColumnKnowledge::harvest(input, knowledge)?
+            }
             MirRelationExpr::Union { base, inputs } => {
                 let mut know = ColumnKnowledge::harvest(base, knowledge)?;
                 for input in inputs {

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -244,7 +244,7 @@ impl ColumnKnowledge {
             MirRelationExpr::TopK { input, .. } => ColumnKnowledge::harvest(input, knowledge)?,
             MirRelationExpr::Negate { input } => ColumnKnowledge::harvest(input, knowledge)?,
             MirRelationExpr::Threshold { input } => ColumnKnowledge::harvest(input, knowledge)?,
-            MirRelationExpr::DeclareKey { input, .. } => {
+            MirRelationExpr::DeclareKeys { input, .. } => {
                 ColumnKnowledge::harvest(input, knowledge)?
             }
             MirRelationExpr::Union { base, inputs } => {

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -205,7 +205,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
 
     // Push demand information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
+        if let Some(columns) = demand.get(&Id::BareSource(*source_id)).clone() {
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -205,12 +205,16 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
 
     // Push demand information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
+        if let Some(columns) = demand.get(&Id::BareSource(*source_id)).clone() {
+            println!(
+                "Demanded columns for bare source {}: {:?}",
+                *source_id, columns
+            );
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
                     predicates: Vec::new(),
-                    projection: (0..source_desc.arity()).collect(),
+                    projection: (0..source_desc.bare_desc.arity()).collect(),
                 })
             }
             // Restrict required columns by those identified as demanded.
@@ -244,12 +248,12 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
 
     // Push predicate information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
+        if let Some(list) = predicates.get(&Id::BareSource(*source_id)).clone() {
             // Install no-op predicate information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
                     predicates: Vec::new(),
-                    projection: (0..source_desc.arity()).collect(),
+                    projection: (0..source_desc.bare_desc.arity()).collect(),
                 })
             }
             // Add any predicates that can be pushed to the source.

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -205,16 +205,12 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
 
     // Push demand information into the SourceDesc.
     for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
-        if let Some(columns) = demand.get(&Id::BareSource(*source_id)).clone() {
-            println!(
-                "Demanded columns for bare source {}: {:?}",
-                *source_id, columns
-            );
+        if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
                     predicates: Vec::new(),
-                    projection: (0..source_desc.bare_desc.arity()).collect(),
+                    projection: (0..source_desc.arity()).collect(),
                 })
             }
             // Restrict required columns by those identified as demanded.
@@ -253,7 +249,7 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
                     predicates: Vec::new(),
-                    projection: (0..source_desc.bare_desc.arity()).collect(),
+                    projection: (0..source_desc.arity()).collect(),
                 })
             }
             // Add any predicates that can be pushed to the source.

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -247,7 +247,7 @@ impl Demand {
             MirRelationExpr::Negate { input } => {
                 self.action(input, columns, gets);
             }
-            MirRelationExpr::DeclareKey { input, key: _ } => {
+            MirRelationExpr::DeclareKeys { input, keys: _ } => {
                 // TODO[btv] - If and when we add a "debug mode" that asserts whether this is truly a key,
                 // we will probably need to add the key to the set of demanded columns.
                 self.action(input, columns, gets);

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -247,6 +247,11 @@ impl Demand {
             MirRelationExpr::Negate { input } => {
                 self.action(input, columns, gets);
             }
+            MirRelationExpr::DeclareKey { input, key: _ } => {
+                // TODO[btv] - If and when we add a "debug mode" that asserts whether this is truly a key,
+                // we will probably need to add the key to the set of demanded columns.
+                self.action(input, columns, gets);
+            }
             MirRelationExpr::Threshold { input } => {
                 // Threshold requires all columns, as collapsing any distinct values
                 // has the potential to change how it thresholds counts. This could

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -397,6 +397,7 @@ impl LiteralLifting {
                 // Literals can just be lifted out of threshold.
                 self.action(input, gets)
             }
+            MirRelationExpr::DeclareKey { input, .. } => self.action(input, gets),
             MirRelationExpr::Union { base, inputs } => {
                 let mut base_literals = self.action(base, gets);
                 let mut input_literals = inputs

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -397,7 +397,7 @@ impl LiteralLifting {
                 // Literals can just be lifted out of threshold.
                 self.action(input, gets)
             }
-            MirRelationExpr::DeclareKey { input, .. } => self.action(input, gets),
+            MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
             MirRelationExpr::Union { base, inputs } => {
                 let mut base_literals = self.action(base, gets);
                 let mut input_literals = inputs

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -216,7 +216,7 @@ impl NonNullRequirements {
             MirRelationExpr::Threshold { input } => {
                 self.action(input, columns, gets);
             }
-            MirRelationExpr::DeclareKey { input, .. } => {
+            MirRelationExpr::DeclareKeys { input, .. } => {
                 self.action(input, columns, gets);
             }
             MirRelationExpr::Union { base, inputs } => {

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -216,6 +216,9 @@ impl NonNullRequirements {
             MirRelationExpr::Threshold { input } => {
                 self.action(input, columns, gets);
             }
+            MirRelationExpr::DeclareKey { input, .. } => {
+                self.action(input, columns, gets);
+            }
             MirRelationExpr::Union { base, inputs } => {
                 self.action(base, columns.clone(), gets);
                 for input in inputs {

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -264,7 +264,7 @@ impl ProjectionLifting {
                 // action on weights need to accumulate the restricted rows.
                 self.action(input, gets);
             }
-            MirRelationExpr::DeclareKey { input, .. } => {
+            MirRelationExpr::DeclareKeys { input, .. } => {
                 self.action(input, gets);
             }
             MirRelationExpr::Union { base, inputs } => {

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -264,6 +264,9 @@ impl ProjectionLifting {
                 // action on weights need to accumulate the restricted rows.
                 self.action(input, gets);
             }
+            MirRelationExpr::DeclareKey { input, .. } => {
+                self.action(input, gets);
+            }
             MirRelationExpr::Union { base, inputs } => {
                 // We cannot, in general, lift projections out of unions.
                 self.action(base, gets);

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -88,6 +88,11 @@ impl FoldConstants {
                     *relation = input.take_dangerous();
                 }
             }
+            MirRelationExpr::DeclareKey { input, key: _ } => {
+                if let MirRelationExpr::Constant { rows: _, .. } = &mut **input {
+                    *relation = input.take_dangerous();
+                }
+            }
             MirRelationExpr::Threshold { input } => {
                 if let MirRelationExpr::Constant { rows, .. } = &mut **input {
                     if let Ok(rows) = rows {

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -88,7 +88,7 @@ impl FoldConstants {
                     *relation = input.take_dangerous();
                 }
             }
-            MirRelationExpr::DeclareKey { input, key: _ } => {
+            MirRelationExpr::DeclareKeys { input, keys: _ } => {
                 if let MirRelationExpr::Constant { rows: _, .. } = &mut **input {
                     *relation = input.take_dangerous();
                 }

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -207,6 +207,7 @@ impl RedundantJoin {
             }
 
             MirRelationExpr::Map { input, .. } => self.action(input, lets),
+            MirRelationExpr::DeclareKey { input, .. } => self.action(input, lets),
 
             MirRelationExpr::Union { base, inputs } => {
                 let mut prov = self.action(base, lets);

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -207,7 +207,7 @@ impl RedundantJoin {
             }
 
             MirRelationExpr::Map { input, .. } => self.action(input, lets),
-            MirRelationExpr::DeclareKey { input, .. } => self.action(input, lets),
+            MirRelationExpr::DeclareKeys { input, .. } => self.action(input, lets),
 
             MirRelationExpr::Union { base, inputs } => {
                 let mut prov = self.action(base, lets);


### PR DESCRIPTION
We now split the concept of source into "bare source" and "source" (or: "transformed" source, "derived" source, etc.). The intent is that the bare source should represent the raw data from the connector, and the transformed version represents the full richness of what we have been calling a "source" until now, including decoding, Debezium processing, upsert envelope application, and so on.

In this PR, the only thing we move out of the bare source is the "explode" call on the diff column, so the bare source still involves relatively a lot of complex logic. But it's a start!

Next work: 
* Move more stuff out of the bare source and into the derived source; in particular, upsert envelope and avro/csv/etc. decoding.
* Expose the bare source and transformations on it to the user, in SQL (allowing custom transformations)
* Move timestamping to happen at the end of the derived source, rather than being a property of the bare source. This will make the end of source processing a clean boundary between the ingest pipeline and the rest of the system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5570)
<!-- Reviewable:end -->
