### PR TITLE
ore: introduce str quoting helper

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -117,9 +117,10 @@ case "$cmd" in
             )
 
             # Forward Docker configuration too, if available.
-            if [[ -d ~/.docker ]]; then
+            docker_dir=${DOCKER_CONFIG:-$HOME/.docker}
+            if [[ -d "$docker_dir" ]]; then
                 args+=(
-                    --volume "${DOCKER_CONFIG:-$HOME/.docker}:/docker"
+                    --volume "$docker_dir:/docker"
                     --env "DOCKER_CONFIG=/docker"
                 )
             fi

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -49,6 +49,7 @@ use expr::{
     OptimizedMirRelationExpr, RowSetFinishing, SourceInstanceId,
 };
 use ore::collections::CollectionExt;
+use ore::str::StrExt;
 use ore::thread::JoinHandleExt;
 use repr::{ColumnName, Datum, RelationDesc, RelationType, Row, RowPacker, Timestamp};
 use sql::ast::display::AstDisplay;
@@ -2693,8 +2694,10 @@ where
                     for (datum, (name, typ)) in row.unpack().iter().zip(desc.iter()) {
                         if datum == &Datum::Null && !typ.nullable {
                             coord_bail!(
-                                "null value in column \"{}\" violates not-null constraint",
+                                "null value in column {} violates not-null constraint",
                                 name.unwrap_or(&ColumnName::from("unnamed column"))
+                                    .as_str()
+                                    .quoted()
                             )
                         }
                     }

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -10,6 +10,7 @@
 use std::error::Error;
 use std::fmt;
 
+use ore::str::StrExt;
 use transform::TransformError;
 
 use crate::catalog;
@@ -66,15 +67,15 @@ impl fmt::Display for CoordError {
             CoordError::Catalog(e) => e.fmt(f),
             CoordError::ConstrainedParameter(p) => write!(
                 f,
-                "parameter \"{}\" can only be set to \"{}\"",
-                p.name(),
-                p.value()
+                "parameter {} can only be set to {}",
+                p.name().quoted(),
+                p.value().quoted()
             ),
             CoordError::InvalidParameterType(p) => write!(
                 f,
-                "parameter \"{}\" requires a {} value",
-                p.name(),
-                p.type_name()
+                "parameter {} requires a {} value",
+                p.name().quoted(),
+                p.type_name().quoted()
             ),
             CoordError::OperationProhibitsTransaction(op) => {
                 write!(f, "{} cannot be run inside a transaction block", op)
@@ -84,15 +85,15 @@ impl fmt::Display for CoordError {
             }
             CoordError::ReadOnlyTransaction => f.write_str("transaction in read-only mode"),
             CoordError::ReadOnlyParameter(p) => {
-                write!(f, "parameter \"{}\" cannot be changed", p.name())
+                write!(f, "parameter {} cannot be changed", p.name().quoted())
             }
             CoordError::SqlCatalog(e) => e.fmt(f),
             CoordError::Transform(e) => e.fmt(f),
             CoordError::UnknownCursor(name) => {
-                write!(f, "cursor \"{}\" does not exist", name)
+                write!(f, "cursor {} does not exist", name.quoted())
             }
             CoordError::UnknownParameter(name) => {
-                write!(f, "unrecognized configuration parameter \"{}\"", name)
+                write!(f, "unrecognized configuration parameter {}", name.quoted())
             }
             CoordError::Unstructured(e) => write!(f, "{:#}", e),
             CoordError::WriteOnlyTransaction => f.write_str("transaction in write-only mode"),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -31,6 +31,7 @@ use sha2::{Sha224, Sha256, Sha384, Sha512};
 use ore::collections::CollectionExt;
 use ore::fmt::FormatBuffer;
 use ore::result::ResultExt;
+use ore::str::StrExt;
 use pgrepr::Type;
 use repr::adt::array::ArrayDimension;
 use repr::adt::datetime::{DateTimeUnits, Timezone};
@@ -3318,7 +3319,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::BitLengthString => f.write_str("bit_length"),
             UnaryFunc::ByteLengthBytes => f.write_str("byte_length"),
             UnaryFunc::ByteLengthString => f.write_str("byte_length"),
-            UnaryFunc::IsRegexpMatch(regex) => write!(f, "\"{}\" ~", regex.as_str()),
+            UnaryFunc::IsRegexpMatch(regex) => write!(f, "{} ~", regex.as_str().quoted()),
             UnaryFunc::RegexpMatch(regex) => write!(f, "regexp_match[{}]", regex.as_str()),
             UnaryFunc::DatePartInterval(units) => write!(f, "date_part_{}_iv", units),
             UnaryFunc::DatePartTimestamp(units) => write!(f, "date_part_{}_ts", units),

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -42,6 +42,7 @@ use mz_avro::{
     AvroArrayAccess, AvroDecode, AvroDeserializer, AvroMapAccess, AvroRead, AvroRecordAccess,
     GeneralDeserializer, StatefulAvroDecodable, TrivialDecoder, ValueDecoder, ValueOrReader,
 };
+use ore::str::StrExt;
 use repr::adt::decimal::{Significand, MAX_DECIMAL_PRECISION};
 use repr::adt::jsonb::{JsonbPacker, JsonbRef};
 use repr::{ColumnName, ColumnType, Datum, RelationDesc, Row, RowPacker, ScalarType};
@@ -1919,16 +1920,16 @@ fn take_field_by_index(
 ) -> anyhow::Result<Value> {
     let (name, value) = fields.get_mut(idx).ok_or_else(|| {
         anyhow!(
-            "Value does not match schema: \"{}\" field not at index {}",
-            expected_name,
+            "Value does not match schema: {} field not at index {}",
+            expected_name.quoted(),
             idx
         )
     })?;
     if name != expected_name {
         bail!(
-            "Value does not match schema: expected \"{}\", found \"{}\"",
-            expected_name,
-            name
+            "Value does not match schema: expected {}, found {}",
+            expected_name.quoted(),
+            name.quoted()
         );
     }
     Ok(std::mem::replace(value, Value::Null))

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -33,6 +33,7 @@ pub mod panic;
 pub mod result;
 pub mod retry;
 pub mod stats;
+pub mod str;
 pub mod sync;
 pub mod test;
 pub mod thread;

--- a/src/ore/src/str.rs
+++ b/src/ore/src/str.rs
@@ -1,0 +1,78 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! String utilities.
+
+use std::fmt::{self, Write};
+use std::ops::Deref;
+
+/// Extension methods for [`str`].
+pub trait StrExt {
+    /// Wraps the string slice in a type whose display implementation renders
+    /// the string surrounded by double quotes with any inner double quote
+    /// characters escaped.
+    ///
+    /// # Examples
+    ///
+    /// In the standard case, when the wrapped string does not contain any
+    /// double quote characters:
+    ///
+    /// ```
+    /// use ore::str::StrExt;
+    ///
+    /// let name = "bob";
+    /// let message = format!("unknown user {}", name.quoted());
+    /// assert_eq!(message, r#"unknown user "bob""#);
+    /// ```
+    ///
+    /// In a pathological case:
+    ///
+    /// ```
+    /// use ore::str::StrExt;
+    ///
+    /// let name = r#"b@d"inp!t""#;
+    /// let message = format!("unknown user {}", name.quoted());
+    /// assert_eq!(message, r#"unknown user "b@d\"inp!t\"""#);
+    /// ```
+    fn quoted(&self) -> QuotedStr;
+}
+
+impl StrExt for str {
+    fn quoted(&self) -> QuotedStr {
+        QuotedStr(self)
+    }
+}
+
+/// Displays a string slice surrounded by double quotes with any inner double
+/// quote characters escaped.
+///
+/// Constructed by [`StrExt::quoted`].
+#[derive(Debug)]
+pub struct QuotedStr<'a>(&'a str);
+
+impl<'a> fmt::Display for QuotedStr<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_char('"')?;
+        for c in self.chars() {
+            match c {
+                '"' => f.write_str("\\\"")?,
+                _ => f.write_char(c)?,
+            }
+        }
+        f.write_char('"')
+    }
+}
+
+impl<'a> Deref for QuotedStr<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -31,6 +31,7 @@ use coord::{ExecuteResponse, StartupMessage};
 use dataflow_types::PeekResponse;
 use ore::cast::CastFrom;
 use ore::netio::AsyncReady;
+use ore::str::StrExt;
 use repr::{Datum, RelationDesc, RelationType, Row, RowArena};
 use sql::ast::display::AstDisplay;
 use sql::ast::{FetchDirection, Ident, Raw, Statement};
@@ -559,7 +560,7 @@ where
                     return self
                         .error(ErrorResponse::error(
                             SqlState::INVALID_CURSOR_NAME,
-                            format!("portal \"{}\" does not exist", portal_name),
+                            format!("portal {} does not exist", portal_name.quoted()),
                         ))
                         .await;
                 }
@@ -678,7 +679,7 @@ where
             None => {
                 self.error(ErrorResponse::error(
                     SqlState::INVALID_CURSOR_NAME,
-                    format!("portal \"{}\" does not exist", name),
+                    format!("portal {} does not exist", name.quoted()),
                 ))
                 .await
             }

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -35,6 +35,7 @@ use uuid::Uuid;
 
 use ore::fmt::FormatBuffer;
 use ore::lex::LexBuf;
+use ore::str::StrExt;
 
 use crate::adt::array::ArrayDimension;
 use crate::adt::datetime::{self, DateTimeField, ParsedDateTime};
@@ -1119,7 +1120,7 @@ impl fmt::Display for ParseError {
         if let Some(details) = &self.details {
             write!(f, "{}: ", details)?;
         }
-        write!(f, "\"{}\"", self.input)
+        write!(f, "{}", self.input.quoted())
     }
 }
 

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -11,6 +11,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use ore::str::StrExt;
+
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
 use crate::ast::{
@@ -96,7 +98,11 @@ fn rewrite_query(from: FullName, to: String, query: &mut Query<Raw>) -> Result<(
 }
 
 fn ambiguous_err(n: &Ident, t: &str) -> String {
-    format!("\"{}\" potentially used ambiguously as item and {}", n, t)
+    format!(
+        "{} potentially used ambiguously as item and {}",
+        n.as_str().quoted(),
+        t
+    )
 }
 
 /// Visits a [`Query`], assessing catalog item [`Ident`]s' use of a specified `Ident`.
@@ -162,8 +168,8 @@ impl<'a> QueryIdentAgg<'a> {
 
         if v.min_qual_depth < req_depth {
             Err(format!(
-                "\"{}\" is not sufficiently qualified to support renaming",
-                name
+                "{} is not sufficiently qualified to support renaming",
+                name.as_str().quoted()
             ))
         } else {
             Ok(req_depth)
@@ -176,9 +182,10 @@ impl<'a> QueryIdentAgg<'a> {
         if let Some(f) = &self.fail_on {
             if v.iter().any(|i| i == f) {
                 self.err = Some(format!(
-                    "found reference to \"{}\"; cannot rename \"{}\" to any identity \
+                    "found reference to {}; cannot rename {} to any identity \
                     used in any existing view definitions",
-                    f, self.name
+                    f.as_str().quoted(),
+                    self.name.as_str().quoted()
                 ));
                 return;
             }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -21,6 +21,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 
 use ore::collections::CollectionExt;
+use ore::str::StrExt;
 use pgrepr::oid;
 use repr::{ColumnName, Datum, RelationType, ScalarBaseType, ScalarType};
 use sql_parser::ast::{Expr, ObjectName, Raw};
@@ -1965,7 +1966,7 @@ pub fn resolve_func(
             return Ok(func);
         }
     }
-    bail!("function \"{}\" does not exist", name)
+    bail!("function {} does not exist", name.to_string().quoted())
 }
 
 lazy_static! {

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -10,6 +10,8 @@
 use std::error::Error;
 use std::fmt;
 
+use ore::str::StrExt;
+
 use crate::catalog::CatalogError;
 
 #[derive(Debug)]
@@ -36,8 +38,8 @@ impl fmt::Display for PlanError {
                 }
                 Ok(())
             }
-            Self::UnknownColumn(name) => write!(f, "column \"{}\" does not exist", name),
-            Self::AmbiguousColumn(name) => write!(f, "column name \"{}\" is ambiguous", name),
+            Self::UnknownColumn(name) => write!(f, "column {} does not exist", name.quoted()),
+            Self::AmbiguousColumn(name) => write!(f, "column name {} is ambiguous", name.quoted()),
             Self::MisqualifiedName(name) => write!(
                 f,
                 "qualified name did not have between 1 and 3 components: {}",

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -20,6 +20,7 @@ use anyhow::{anyhow, bail};
 use aws_arn::{Resource, ARN};
 use globset::GlobBuilder;
 use itertools::Itertools;
+use ore::str::StrExt;
 use reqwest::Url;
 
 use dataflow_types::{
@@ -144,8 +145,8 @@ pub fn plan_create_table(
 
     if let Some(dup) = names.iter().duplicates().next() {
         bail!(
-            "cannot CREATE TABLE: column \"{}\" specified more than once",
-            dup
+            "cannot CREATE TABLE: column {} specified more than once",
+            dup.as_str().quoted()
         );
     }
 
@@ -1138,9 +1139,9 @@ pub fn plan_create_type(
                 DataType::Other { name, typ_mod } => {
                     if !typ_mod.is_empty() {
                         bail!(
-                            "CREATE TYPE ... AS {}option \"{}\" cannot accept type modifier on \
+                            "CREATE TYPE ... AS {}option {} cannot accept type modifier on \
                             {}, you must use the default type",
-                            as_type,
+                            as_type.to_string().quoted(),
                             key,
                             name
                         )
@@ -1148,9 +1149,9 @@ pub fn plan_create_type(
                     query::canonicalize_type_name_internal(&name)
                 }
                 d => bail!(
-                    "CREATE TYPE ... AS {}option \"{}\" can only use named data types, but \
+                    "CREATE TYPE ... AS {}option {} can only use named data types, but \
                     found unnamed data type {}. Use CREATE TYPE to create a named type first",
-                    as_type,
+                    as_type.to_string().quoted(),
                     key,
                     d.to_ast_string(),
                 ),
@@ -1186,7 +1187,7 @@ pub fn plan_create_type(
 
     let name = scx.allocate_name(normalize::object_name(name)?);
     if scx.catalog.item_exists(&name) {
-        bail!("catalog item \"{}\" already exists", name.to_string());
+        bail!("catalog item {} already exists", name.to_string().quoted());
     }
 
     let inner = match as_type {
@@ -1386,7 +1387,7 @@ pub fn plan_drop_role(
         let name = if name.0.len() == 1 {
             normalize::ident(name.0.into_element())
         } else {
-            bail!("invalid role name \"{}\"", name)
+            bail!("invalid role name {}", name.to_string().quoted())
         };
         if name == scx.catalog.user() {
             bail!("current user cannot be dropped");
@@ -1516,8 +1517,8 @@ pub fn plan_alter_index_options(
                     };
 
                     if !options.is_empty() {
-                        bail!("unrecognized parameter: \"{}\". Only \"logical_compaction_window\" is currently supported.",
-                              options.keys().next().expect("known to exist"))
+                        bail!("unrecognized parameter: {}. Only \"logical_compaction_window\" is currently supported.",
+                              options.keys().next().expect("known to exist").quoted())
                     }
 
                     logical_compaction_window

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1448,23 +1448,23 @@ SELECT ('{{a, "", "\""}, "{a, \"\", \"\\\"\"}"}'::text list list)::text
 {{a,"","\""},{a,"","\""}}
 
 # Unquoted elements cannot have special characters interleaved within them
-query error invalid input syntax for list: malformed literal; must escape special character '"': "\{a"b"\}"
+query error invalid input syntax for list: malformed literal; must escape special character '"'
 SELECT ('{a"b"}'::text list)::text
 
-query error invalid input syntax for list: malformed literal; must escape special character '\{': "\{a\{b\}"
+query error invalid input syntax for list: malformed literal; must escape special character '\{'
 SELECT ('{a{b}'::text list)::text
 
-query error invalid input syntax for list: malformed array literal; contains 'b' after terminal '\}': "\{a\}b\}"
+query error invalid input syntax for list: malformed array literal; contains 'b' after terminal '\}'
 SELECT ('{a}b}'::text list)::text
 
 # No non-whitespace characters after the escape
-query error invalid input syntax for list: expected ',' or '\}', got 'b': "\{"a"b\}"
+query error invalid input syntax for list: expected ',' or '\}', got 'b'
 SELECT ('{"a"b}'::text list)::text
 
-query error invalid input syntax for list: expected ',' or '\}', got '"': "\{""""\}"
+query error invalid input syntax for list: expected ',' or '\}', got '"'
 SELECT ('{""""}'::text list)::text
 
-query error invalid input syntax for list: expected ',' or '\}', got '"': "\{"""\}"
+query error invalid input syntax for list: expected ',' or '\}', got '"'
 SELECT ('{"""}'::text list)::text
 
 # 🔬🔬🔬🔬 Unquoted escapes


### PR DESCRIPTION
Introduce a helper that wraps a string in quotes, escaping any contained
quotes. This is useful for error messages like

    view "blah" did not exist

where the user-supplied name could potentially contain quotes. The
helper will automatically quote those internal quotes, resulting in
e.g.:

    view "bad\"quote" did not exist

I took a quick pass at converting constructions like

    format!("view \"{}\" did not exist", view_name)

but there are many, many places where we ought to be wrapping
user-supplied data in quotes but are not. We'll just have to improve
those as we go.

Per @mjibson's request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5573)
<!-- Reviewable:end -->
