### PR TITLE
ci: handle variable location of Docker config on new BK stack

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -119,7 +119,7 @@ case "$cmd" in
             # Forward Docker configuration too, if available.
             if [[ -d ~/.docker ]]; then
                 args+=(
-                    --volume "$HOME/.docker:/docker"
+                    --volume "${DOCKER_CONFIG:-$HOME/.docker}:/docker"
                     --env "DOCKER_CONFIG=/docker"
                 )
             fi


### PR DESCRIPTION
I recently upgraded our build agents to the latest version of the
Buildkite Cloudformation template, which unfortunately included a
breaking change in which Docker auth credentials are no longer stored in
the default $HOME/.docker but in a temporary directory pointed to by
$DOCKER_CONFIG.

Teach our ci-builder script to adapt to this new reality, so that it
can appropriately forward Docker auth credentials to the Docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5574)
<!-- Reviewable:end -->
