### PR TITLE
expr: make it impossible to get the nullability of literal wrong

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3127,7 +3127,10 @@ where
         expr.visit_mut(&mut |e| {
             if let MirScalarExpr::CallNullary(f @ NullaryFunc::MzLogicalTimestamp) = e {
                 observes_ts = true;
-                *e = MirScalarExpr::literal_ok(Datum::from(i128::from(ts)), f.output_type());
+                *e = MirScalarExpr::literal_ok(
+                    Datum::from(i128::from(ts)),
+                    f.output_type().scalar_type,
+                );
             }
         });
         if observes_ts && matches!(style, ExprPrepStyle::Static) {

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -60,7 +60,7 @@ where
                         demand_projection.push(column);
                     } else {
                         demand_projection.push(output_arity + dummies.len());
-                        dummies.push(MirScalarExpr::literal_ok(Datum::Dummy, typ));
+                        dummies.push(MirScalarExpr::literal_ok(Datum::Dummy, typ.scalar_type));
                     }
                 }
                 (dummies, demand_projection)

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -375,7 +375,7 @@ mod tests {
             expr1: Box::new(MirScalarExpr::Column(2)),
             expr2: Box::new(MirScalarExpr::literal(
                 Ok(Datum::Int32(4)),
-                ScalarType::Int32.nullable(false),
+                ScalarType::Int32,
             )),
         };
         let key22 = MirScalarExpr::Column(5);

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -585,10 +585,7 @@ impl HirScalarExpr {
                             expr1: Box::new(SS::CallBinary {
                                 func: expr::BinaryFunc::Eq,
                                 expr1: Box::new(cond_expr.clone()),
-                                expr2: Box::new(SS::literal_ok(
-                                    Datum::False,
-                                    ScalarType::Bool.nullable(false),
-                                )),
+                                expr2: Box::new(SS::literal_ok(Datum::False, ScalarType::Bool)),
                             }),
                             expr2: Box::new(SS::CallUnary {
                                 func: expr::UnaryFunc::IsNull,
@@ -993,7 +990,7 @@ fn attempt_outer_join(
                             .column_types
                             .into_iter()
                             .skip(oa)
-                            .map(|typ| expr::MirScalarExpr::literal_null(typ.nullable(true)))
+                            .map(|typ| expr::MirScalarExpr::literal_null(typ.scalar_type))
                             .collect();
 
                         // Add to `result` absent elements, filled with typed nulls.
@@ -1021,7 +1018,7 @@ fn attempt_outer_join(
                             .column_types
                             .into_iter()
                             .skip(oa)
-                            .map(|typ| expr::MirScalarExpr::literal_null(typ.nullable(true)))
+                            .map(|typ| expr::MirScalarExpr::literal_null(typ.scalar_type))
                             .collect();
 
                         // Add to `result` absent elemetns, prepended with typed nulls.

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -352,7 +352,7 @@ pub fn optimize(
                 expr.reduce(input_type);
                 optimize(expr, input_type, column_knowledge)?
             } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
-                *expr = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool.nullable(false));
+                *expr = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
                 optimize(expr, input_type, column_knowledge)?
             } else {
                 DatumKnowledge::default()

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -224,7 +224,7 @@ impl Demand {
                         let typ = aggregates[index].typ(&input_type);
                         aggregates[index] = AggregateExpr {
                             func: AggregateFunc::Dummy,
-                            expr: MirScalarExpr::literal_ok(Datum::Dummy, typ),
+                            expr: MirScalarExpr::literal_ok(Datum::Dummy, typ.scalar_type),
                             distinct: false,
                         };
                     }

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -85,7 +85,7 @@ impl LiteralLifting {
                         the_same.pop();
                         let datum = data.pop().unwrap();
                         let typum = typ.column_types.pop().unwrap();
-                        literals.push(MirScalarExpr::literal_ok(datum, typum));
+                        literals.push(MirScalarExpr::literal_ok(datum, typum.scalar_type));
                     }
                     literals.reverse();
 
@@ -362,7 +362,8 @@ impl LiteralLifting {
                         // This type information should be available in the `a.expr` literal,
                         // but extracting it with pattern matching seems awkward.
                         aggr.func
-                            .output_type(aggr.expr.typ(&repr::RelationType::empty())),
+                            .output_type(aggr.expr.typ(&repr::RelationType::empty()))
+                            .scalar_type,
                     ));
                 }
                 result.reverse();

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -250,10 +250,7 @@ mod tests {
                             },
                         ]),
                     }),
-                    scalars: vec![MirScalarExpr::literal_null(ColumnType {
-                        nullable: true,
-                        scalar_type: ScalarType::Int32,
-                    })],
+                    scalars: vec![MirScalarExpr::literal_null(ScalarType::Int32)],
                 }),
                 func: TableFunc::GenerateSeriesInt32,
                 exprs: vec![MirScalarExpr::Column(1)],

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -105,7 +105,7 @@ fn scalar_nonnullable(expr: &mut MirScalarExpr, metadata: &RelationType) {
         {
             if let MirScalarExpr::Column(c) = &**expr {
                 if !metadata.column_types[*c].nullable {
-                    *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool.nullable(false));
+                    *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
                 }
             }
         }
@@ -118,7 +118,7 @@ fn aggregate_nonnullable(expr: &mut AggregateExpr, metadata: &RelationType) {
     // count(true).
     if let (AggregateFunc::Count, MirScalarExpr::Column(c)) = (&expr.func, &expr.expr) {
         if !metadata.column_types[*c].nullable && !expr.distinct {
-            expr.expr = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool.nullable(false));
+            expr.expr = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
         }
     }
 }

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -35,7 +35,7 @@
 //! let predicate0 = MirScalarExpr::column(0);
 //! let predicate1 = MirScalarExpr::column(1);
 //! let predicate01 = MirScalarExpr::column(0).call_binary(MirScalarExpr::column(2), BinaryFunc::AddInt64);
-//! let predicate012 = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool.nullable(false));
+//! let predicate012 = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
 //!
 //! let mut expr = join.filter(
 //!    vec![
@@ -335,10 +335,8 @@ impl PredicatePushdown {
                                     && aggregates[0].func == AggregateFunc::Any
                                 {
                                     push_down.push(aggregates[0].expr.clone());
-                                    aggregates[0].expr = MirScalarExpr::literal_ok(
-                                        Datum::True,
-                                        ScalarType::Bool.nullable(false),
-                                    );
+                                    aggregates[0].expr =
+                                        MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
                                 } else {
                                     retain.push(predicate);
                                 }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -60,12 +60,9 @@ impl ReduceElision {
                             a.expr.clone().call_unary(UnaryFunc::IsNull).if_then_else(
                                 MirScalarExpr::literal_ok(
                                     Datum::Int64(0),
-                                    column_type.scalar_type.clone().nullable(false),
+                                    column_type.scalar_type.clone(),
                                 ),
-                                MirScalarExpr::literal_ok(
-                                    Datum::Int64(1),
-                                    column_type.scalar_type.nullable(false),
-                                ),
+                                MirScalarExpr::literal_ok(Datum::Int64(1), column_type.scalar_type),
                             )
                         }
 

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -530,7 +530,7 @@ pub mod undistribute_and {
             suppress_ands(expr2, ands);
 
             // If either argument is in our list, replace it by `true`.
-            let tru = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool.nullable(false));
+            let tru = MirScalarExpr::literal_ok(Datum::True, ScalarType::Bool);
             if ands.contains(expr1) {
                 *expr = std::mem::replace(expr2, tru);
             } else if ands.contains(expr2) {

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -423,20 +423,8 @@ mod tests {
         match s {
             // TODO(justin): support more scalar exprs.
             Sexp::Atom(s) => match s.as_str() {
-                "true" => Ok(MirScalarExpr::literal(
-                    Ok(Datum::True),
-                    ColumnType {
-                        nullable: false,
-                        scalar_type: ScalarType::Bool,
-                    },
-                )),
-                "false" => Ok(MirScalarExpr::literal(
-                    Ok(Datum::False),
-                    ColumnType {
-                        nullable: false,
-                        scalar_type: ScalarType::Bool,
-                    },
-                )),
+                "true" => Ok(MirScalarExpr::literal(Ok(Datum::True), ScalarType::Bool)),
+                "false" => Ok(MirScalarExpr::literal(Ok(Datum::False), ScalarType::Bool)),
                 s => {
                     match s.chars().next() {
                         None => {
@@ -450,7 +438,7 @@ mod tests {
                         | Some('6') | Some('7') | Some('8') | Some('9') => {
                             Ok(MirScalarExpr::literal(
                                 Ok(Datum::Int64(s.parse::<i64>()?)),
-                                ScalarType::Int64.nullable(false),
+                                ScalarType::Int64,
                             ))
                         }
                         _ => Err(anyhow!("couldn't parse scalar: {}", s)),


### PR DESCRIPTION
Make MirScalarExpr::literal and friends automatically ascertain the
nullability of the literal by checking if the literal is null. This is
guaranteed to be correct, unlike the prior approach which required that
the caller get the nullability right.

We made the equivalent change to HirScalarExpr in the sql crate to good
effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5584)
<!-- Reviewable:end -->
