### PR TITLE
s3 sources: Support scanning from multiple buckets

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -315,7 +315,7 @@ run LocalStack:
 
 ```shell
 $ pip install localstack
-$ START_WEB=false SERVICES=kinesis localstack start
+$ START_WEB=false SERVICES=iam,sts,kinesis,s3 localstack start
 ```
 
 If you've previously installed LocalStack, be sure it is v0.11 or later.

--- a/doc/user/content/sql/create-source/csv-s3.md
+++ b/doc/user/content/sql/create-source/csv-s3.md
@@ -41,7 +41,7 @@ We can load all these keys with the following command:
 
 ```sql
 CREATE MATERIALIZED SOURCE csv_example (user_id, status, usage)
-FROM S3 BUCKET 'analytics' OBJECTS FROM SCAN MATCHING '**/*.csv'
+FROM S3 OBJECTS FROM SCAN BUCKET 'analytics' MATCHING '**/*.csv'
 WITH (region = 'us-east-2')
 FORMAT CSV WITH 3 COLUMNS;
 ```
@@ -62,7 +62,7 @@ instead write an unmaterialized source and parse columns in a view materializati
 
 ```sql
 CREATE SOURCE csv_source (user_id, status, usage)
-FROM S3 BUCKET 'analytics' OBJECTS FROM SCAN MATCHING '**/*.csv'
+FROM S3 OBJECTS FROM SCAN BUCKET 'analytics' MATCHING '**/*.csv'
 WITH (region = 'us-east-2')
 FORMAT CSV WITH 3 COLUMNS;
 ```

--- a/doc/user/content/sql/create-source/json-s3.md
+++ b/doc/user/content/sql/create-source/json-s3.md
@@ -41,7 +41,7 @@ We can load all these keys with the following command:
 
 ```sql
 > CREATE SOURCE json_source
-  FROM S3 BUCKET 'analytics' OBJECTS FROM SCAN MATCHING '**/*.json
+  FROM S3 OBJECTS FROM SCAN BUCKET 'analytics' MATCHING '**/*.json
   WITH (region = 'us-east-2')
   FORMAT TEXT;
 ```

--- a/doc/user/content/sql/create-source/text-s3.md
+++ b/doc/user/content/sql/create-source/text-s3.md
@@ -56,7 +56,7 @@ quick and dirty analysis:
 
 ```sql
 CREATE MATERIALIZED SOURCE frontend_logs
-FROM S3 BUCKET 'frontend' OBJECTS FROM SCAN MATCHING 'logs/202?/**/*.log'
+FROM S3 OBJECTS FROM SCAN BUCKET 'frontend' MATCHING 'logs/202?/**/*.log'
 WITH (region = 'us-east-2')
 FORMAT TEXT;
 ```
@@ -83,7 +83,7 @@ can use the REGEX format specifier to extract useful data:
 
 ```sql
 CREATE MATERIALIZED SOURCE frontend_logs
-FROM S3 BUCKET 'frontend' OBJECTS FROM SCAN MATCHING 'logs/202?/**/*.log'
+FROM S3 OBJECTS FROM SCAN BUCKET 'frontend' MATCHING 'logs/202?/**/*.log'
 WITH (region = 'us-east-2')
 FORMAT REGEX '(?P<ip>[^ ]+) - - \[?P<dt>([^]]_)\] "(?P<method>\w+) (?P<path>[^ ]+)[^"]+" (?P<status>\d+) (?P<content_length>\d+) "-" "(?P<user_agent>[^"]+)"';
 ```

--- a/doc/user/layouts/partials/create-source/connector/s3/details.html
+++ b/doc/user/layouts/partials/create-source/connector/s3/details.html
@@ -11,7 +11,7 @@ The S3 source is designed to ingest a large volume of static data from S3.
 
 #### Scanning S3 Buckets
 
-The **OBJECTS FROM SCAN** syntax causes S3 sources to issue [ListBucket][] requests to collect the
+The **OBJECTS FROM SCAN BUCKET** syntax causes S3 sources to issue [ListBucket][] requests to collect the
 names of objects to collect. After collecting the list of keys, their names are checked against
 the **MATCHING** clause, if present, before downloading and extracting objects line by line.
 

--- a/doc/user/layouts/partials/create-source/connector/s3/syntax.html
+++ b/doc/user/layouts/partials/create-source/connector/s3/syntax.html
@@ -1,3 +1,3 @@
 *bucket_name* | The name of the bucket to scan through.
-**OBJECTS FROM SCAN** | Materialized will scan the bucket to find the set of objects to download. See [S3 Source Details](#s3-source-details)
+**OBJECTS FROM SCAN BUCKET** | Materialized will scan the bucket to find the set of objects to download. See [S3 Source Details](#s3-source-details)
 *pattern* | A glob-style pattern to filter objects to ingest. See [Patterns](#patterns). Default is to ingest all files.

--- a/doc/user/layouts/partials/create-source/connector/s3/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/s3/with-options.html
@@ -15,7 +15,7 @@ the list of objects to download.
 The **OBJECTS FROM** clause describes how `materialized` will load objects, and so its parameters
 will determine what permissions `materialized` requires.. For example, since the **SCAN** key name
 source (as in **OBJECTS FORM SCAN**) must perform repeated `ListObjects` actions to create a list
-of key names to download, specifying **OBJECTS FROM SCAN** means that **MATERIALIZED** requires
+of key names to download, specifying **OBJECTS FROM SCAN BUCKET** means that **MATERIALIZED** requires
 the `ListObjects` permission.
 
 | Key Name Source | Permissions Required                                                        |

--- a/doc/user/layouts/partials/sql-grammar/create-source-s3-csv.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-s3-csv.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="583" height="457">
+<svg xmlns="http://www.w3.org/2000/svg" width="583" height="567">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,141 +33,149 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="38" y="145" width="80" height="32"/>
-   <rect x="36" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="46" y="163">src_name</text>
-   <rect x="158" y="145" width="24" height="32" rx="10"/>
-   <rect x="156"
+   <rect x="119" y="145" width="80" height="32"/>
+   <rect x="117" y="143" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="127" y="163">src_name</text>
+   <rect x="239" y="145" width="24" height="32" rx="10"/>
+   <rect x="237"
          y="143"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="166" y="163">(</text>
-   <rect x="222" y="145" width="80" height="32"/>
-   <rect x="220" y="143" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="230" y="163">col_name</text>
-   <rect x="222" y="101" width="24" height="32" rx="10"/>
-   <rect x="220"
+   <text class="terminal" x="247" y="163">(</text>
+   <rect x="303" y="145" width="80" height="32"/>
+   <rect x="301" y="143" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="311" y="163">col_name</text>
+   <rect x="303" y="101" width="24" height="32" rx="10"/>
+   <rect x="301"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="230" y="119">,</text>
-   <rect x="342" y="145" width="24" height="32" rx="10"/>
-   <rect x="340"
+   <text class="terminal" x="311" y="119">,</text>
+   <rect x="423" y="145" width="24" height="32" rx="10"/>
+   <rect x="421"
          y="143"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="350" y="163">)</text>
-   <rect x="406" y="145" width="142" height="32" rx="10"/>
-   <rect x="404"
-         y="143"
-         width="142"
+   <text class="terminal" x="431" y="163">)</text>
+   <rect x="45" y="271" width="196" height="32" rx="10"/>
+   <rect x="43"
+         y="269"
+         width="196"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="414" y="163">FROM S3 BUCKET</text>
-   <rect x="29" y="227" width="102" height="32"/>
-   <rect x="27" y="225" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="37" y="245">bucket_name</text>
-   <rect x="151" y="227" width="168" height="32" rx="10"/>
-   <rect x="149"
+   <text class="terminal" x="53" y="289">FROM S3 OBJECTS FROM </text>
+   <rect x="281" y="271" width="118" height="32" rx="10"/>
+   <rect x="279"
+         y="269"
+         width="118"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="289" y="289">SCAN BUCKET</text>
+   <rect x="419" y="271" width="102" height="32"/>
+   <rect x="417" y="269" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="427" y="289">bucket_name</text>
+   <rect x="281" y="227" width="24" height="32" rx="10"/>
+   <rect x="279"
          y="225"
-         width="168"
+         width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="159" y="245">OBJECTS FROM SCAN</text>
-   <rect x="359" y="259" width="94" height="32" rx="10"/>
-   <rect x="357"
-         y="257"
+   <text class="terminal" x="289" y="245">,</text>
+   <rect x="60" y="369" width="94" height="32" rx="10"/>
+   <rect x="58"
+         y="367"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="367" y="277">MATCHING</text>
-   <rect x="473" y="259" width="64" height="32"/>
-   <rect x="471" y="257" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="481" y="277">pattern</text>
-   <rect x="48" y="325" width="56" height="32" rx="10"/>
-   <rect x="46"
-         y="323"
+   <text class="terminal" x="68" y="387">MATCHING</text>
+   <rect x="174" y="369" width="64" height="32"/>
+   <rect x="172" y="367" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="182" y="387">pattern</text>
+   <rect x="278" y="337" width="56" height="32" rx="10"/>
+   <rect x="276"
+         y="335"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="56" y="343">WITH</text>
-   <rect x="124" y="325" width="24" height="32" rx="10"/>
-   <rect x="122"
-         y="323"
+   <text class="terminal" x="286" y="355">WITH</text>
+   <rect x="354" y="337" width="24" height="32" rx="10"/>
+   <rect x="352"
+         y="335"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="132" y="343">(</text>
-   <rect x="168" y="325" width="70" height="32" rx="10"/>
-   <rect x="166"
-         y="323"
+   <text class="terminal" x="362" y="355">(</text>
+   <rect x="398" y="337" width="70" height="32" rx="10"/>
+   <rect x="396"
+         y="335"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="176" y="343">region =</text>
-   <rect x="258" y="325" width="58" height="32"/>
-   <rect x="256" y="323" width="58" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="266" y="343">region</text>
-   <rect x="356" y="357" width="118" height="32"/>
-   <rect x="354" y="355" width="118" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="364" y="375">aws_credentials</text>
-   <rect x="514" y="325" width="24" height="32" rx="10"/>
-   <rect x="512"
-         y="323"
+   <text class="terminal" x="406" y="355">region =</text>
+   <rect x="488" y="337" width="58" height="32"/>
+   <rect x="486" y="335" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="496" y="355">region</text>
+   <rect x="91" y="467" width="118" height="32"/>
+   <rect x="89" y="465" width="118" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="99" y="485">aws_credentials</text>
+   <rect x="249" y="435" width="24" height="32" rx="10"/>
+   <rect x="247"
+         y="433"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="522" y="343">)</text>
-   <rect x="95" y="423" width="78" height="32" rx="10"/>
-   <rect x="93"
-         y="421"
+   <text class="terminal" x="257" y="453">)</text>
+   <rect x="293" y="435" width="78" height="32" rx="10"/>
+   <rect x="291"
+         y="433"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="103" y="441">FORMAT</text>
-   <rect x="193" y="423" width="48" height="32" rx="10"/>
-   <rect x="191"
-         y="421"
+   <text class="terminal" x="301" y="453">FORMAT</text>
+   <rect x="391" y="435" width="48" height="32" rx="10"/>
+   <rect x="389"
+         y="433"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="201" y="441">CSV</text>
-   <rect x="261" y="423" width="56" height="32" rx="10"/>
-   <rect x="259"
-         y="421"
+   <text class="terminal" x="399" y="453">CSV</text>
+   <rect x="459" y="435" width="56" height="32" rx="10"/>
+   <rect x="457"
+         y="433"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="269" y="441">WITH</text>
-   <rect x="337" y="423" width="108" height="32"/>
-   <rect x="335" y="421" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="345" y="441">column_count</text>
-   <rect x="465" y="423" width="90" height="32" rx="10"/>
+   <text class="terminal" x="467" y="453">WITH</text>
+   <rect x="337" y="533" width="108" height="32"/>
+   <rect x="335" y="531" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="345" y="551">column_count</text>
+   <rect x="465" y="533" width="90" height="32" rx="10"/>
    <rect x="463"
-         y="421"
+         y="531"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="473" y="441">COLUMNS</text>
+   <text class="terminal" x="473" y="551">COLUMNS</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-567 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m20 -34 h10 m142 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-563 82 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m102 0 h10 m0 0 h10 m168 0 h10 m20 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-553 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-487 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m78 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
-   <polygon points="573 437 581 433 581 441"/>
-   <polygon points="573 437 565 433 565 441"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-486 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m20 0 h10 m24 0 h10 m20 0 h10 m80 0 h10 m-120 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m100 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-100 0 h10 m24 0 h10 m0 0 h56 m20 44 h10 m24 0 h10 m-248 0 h20 m228 0 h20 m-268 0 q10 0 10 10 m248 0 q0 -10 10 -10 m-258 10 v14 m248 0 v-14 m-248 14 q0 10 10 10 m228 0 q10 0 10 -10 m-238 10 h10 m0 0 h218 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-466 126 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m196 0 h10 m20 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m-280 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m260 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-260 0 h10 m24 0 h10 m0 0 h216 m22 44 l2 0 m2 0 l2 0 m2 0 l2 0 m-545 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-519 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-222 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
+   <polygon points="573 547 581 543 581 551"/>
+   <polygon points="573 547 565 543 565 551"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-s3-json.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-s3-json.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="599" height="343">
+<svg xmlns="http://www.w3.org/2000/svg" width="583" height="485">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,103 +33,111 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="25" y="101" width="80" height="32"/>
-   <rect x="23" y="99" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="119">src_name</text>
-   <rect x="125" y="101" width="142" height="32" rx="10"/>
-   <rect x="123"
+   <rect x="145" y="101" width="80" height="32"/>
+   <rect x="143" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="153" y="119">src_name</text>
+   <rect x="245" y="101" width="196" height="32" rx="10"/>
+   <rect x="243"
          y="99"
-         width="142"
+         width="196"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="133" y="119">FROM S3 BUCKET</text>
-   <rect x="287" y="101" width="102" height="32"/>
-   <rect x="285" y="99" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="295" y="119">bucket_name</text>
-   <rect x="409" y="101" width="168" height="32" rx="10"/>
-   <rect x="407"
-         y="99"
-         width="168"
+   <text class="terminal" x="253" y="119">FROM S3 OBJECTS FROM </text>
+   <rect x="54" y="211" width="118" height="32" rx="10"/>
+   <rect x="52"
+         y="209"
+         width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="417" y="119">OBJECTS FROM SCAN</text>
-   <rect x="68" y="199" width="94" height="32" rx="10"/>
-   <rect x="66"
-         y="197"
+   <text class="terminal" x="62" y="229">SCAN BUCKET</text>
+   <rect x="192" y="211" width="102" height="32"/>
+   <rect x="190" y="209" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="200" y="229">bucket_name</text>
+   <rect x="54" y="167" width="24" height="32" rx="10"/>
+   <rect x="52"
+         y="165"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="62" y="185">,</text>
+   <rect x="354" y="243" width="94" height="32" rx="10"/>
+   <rect x="352"
+         y="241"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="76" y="217">MATCHING</text>
-   <rect x="182" y="199" width="64" height="32"/>
-   <rect x="180" y="197" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="190" y="217">pattern</text>
-   <rect x="286" y="167" width="56" height="32" rx="10"/>
-   <rect x="284"
-         y="165"
+   <text class="terminal" x="362" y="261">MATCHING</text>
+   <rect x="468" y="243" width="64" height="32"/>
+   <rect x="466" y="241" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="476" y="261">pattern</text>
+   <rect x="48" y="309" width="56" height="32" rx="10"/>
+   <rect x="46"
+         y="307"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="294" y="185">WITH</text>
-   <rect x="362" y="167" width="24" height="32" rx="10"/>
-   <rect x="360"
-         y="165"
+   <text class="terminal" x="56" y="327">WITH</text>
+   <rect x="124" y="309" width="24" height="32" rx="10"/>
+   <rect x="122"
+         y="307"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="370" y="185">(</text>
-   <rect x="406" y="167" width="70" height="32" rx="10"/>
-   <rect x="404"
-         y="165"
+   <text class="terminal" x="132" y="327">(</text>
+   <rect x="168" y="309" width="70" height="32" rx="10"/>
+   <rect x="166"
+         y="307"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="414" y="185">region =</text>
-   <rect x="496" y="167" width="58" height="32"/>
-   <rect x="494" y="165" width="58" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="504" y="185">region</text>
-   <rect x="167" y="297" width="118" height="32"/>
-   <rect x="165" y="295" width="118" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="175" y="315">aws_credentials</text>
-   <rect x="325" y="265" width="24" height="32" rx="10"/>
-   <rect x="323"
-         y="263"
+   <text class="terminal" x="176" y="327">region =</text>
+   <rect x="258" y="309" width="58" height="32"/>
+   <rect x="256" y="307" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="266" y="327">region</text>
+   <rect x="356" y="341" width="118" height="32"/>
+   <rect x="354" y="339" width="118" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="364" y="359">aws_credentials</text>
+   <rect x="514" y="309" width="24" height="32" rx="10"/>
+   <rect x="512"
+         y="307"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="333" y="283">)</text>
-   <rect x="369" y="265" width="78" height="32" rx="10"/>
-   <rect x="367"
-         y="263"
+   <text class="terminal" x="522" y="327">)</text>
+   <rect x="353" y="407" width="78" height="32" rx="10"/>
+   <rect x="351"
+         y="405"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="377" y="283">FORMAT</text>
-   <rect x="487" y="265" width="54" height="32" rx="10"/>
-   <rect x="485"
-         y="263"
+   <text class="terminal" x="361" y="425">FORMAT</text>
+   <rect x="471" y="407" width="54" height="32" rx="10"/>
+   <rect x="469"
+         y="405"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="495" y="283">TEXT</text>
-   <rect x="487" y="309" width="64" height="32" rx="10"/>
-   <rect x="485"
-         y="307"
+   <text class="terminal" x="479" y="425">TEXT</text>
+   <rect x="471" y="451" width="64" height="32" rx="10"/>
+   <rect x="469"
+         y="449"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="495" y="327">BYTES</text>
+   <text class="terminal" x="479" y="469">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m0 0 h10 m142 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-573 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-451 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m54 0 h10 m0 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m23 -44 h-3"/>
-   <polygon points="589 279 597 275 597 283"/>
-   <polygon points="589 279 581 275 581 283"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-460 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m0 0 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-451 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m-280 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m260 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-260 0 h10 m24 0 h10 m0 0 h216 m40 44 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-548 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-229 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m78 0 h10 m20 0 h10 m54 0 h10 m0 0 h10 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m23 -44 h-3"/>
+   <polygon points="573 421 581 417 581 425"/>
+   <polygon points="573 421 565 417 565 425"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-source-s3-text.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-s3-text.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="599" height="387">
+<svg xmlns="http://www.w3.org/2000/svg" width="583" height="529">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="74" height="32" rx="10"/>
@@ -33,114 +33,122 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="431" y="53">IF NOT EXISTS</text>
-   <rect x="25" y="101" width="80" height="32"/>
-   <rect x="23" y="99" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="33" y="119">src_name</text>
-   <rect x="125" y="101" width="142" height="32" rx="10"/>
-   <rect x="123"
+   <rect x="145" y="101" width="80" height="32"/>
+   <rect x="143" y="99" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="153" y="119">src_name</text>
+   <rect x="245" y="101" width="196" height="32" rx="10"/>
+   <rect x="243"
          y="99"
-         width="142"
+         width="196"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="133" y="119">FROM S3 BUCKET</text>
-   <rect x="287" y="101" width="102" height="32"/>
-   <rect x="285" y="99" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="295" y="119">bucket_name</text>
-   <rect x="409" y="101" width="168" height="32" rx="10"/>
-   <rect x="407"
-         y="99"
-         width="168"
+   <text class="terminal" x="253" y="119">FROM S3 OBJECTS FROM </text>
+   <rect x="54" y="211" width="118" height="32" rx="10"/>
+   <rect x="52"
+         y="209"
+         width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="417" y="119">OBJECTS FROM SCAN</text>
-   <rect x="68" y="199" width="94" height="32" rx="10"/>
-   <rect x="66"
-         y="197"
+   <text class="terminal" x="62" y="229">SCAN BUCKET</text>
+   <rect x="192" y="211" width="102" height="32"/>
+   <rect x="190" y="209" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="200" y="229">bucket_name</text>
+   <rect x="54" y="167" width="24" height="32" rx="10"/>
+   <rect x="52"
+         y="165"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="62" y="185">,</text>
+   <rect x="354" y="243" width="94" height="32" rx="10"/>
+   <rect x="352"
+         y="241"
          width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="76" y="217">MATCHING</text>
-   <rect x="182" y="199" width="64" height="32"/>
-   <rect x="180" y="197" width="64" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="190" y="217">pattern</text>
-   <rect x="286" y="167" width="56" height="32" rx="10"/>
-   <rect x="284"
-         y="165"
+   <text class="terminal" x="362" y="261">MATCHING</text>
+   <rect x="468" y="243" width="64" height="32"/>
+   <rect x="466" y="241" width="64" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="476" y="261">pattern</text>
+   <rect x="48" y="309" width="56" height="32" rx="10"/>
+   <rect x="46"
+         y="307"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="294" y="185">WITH</text>
-   <rect x="362" y="167" width="24" height="32" rx="10"/>
-   <rect x="360"
-         y="165"
+   <text class="terminal" x="56" y="327">WITH</text>
+   <rect x="124" y="309" width="24" height="32" rx="10"/>
+   <rect x="122"
+         y="307"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="370" y="185">(</text>
-   <rect x="406" y="167" width="70" height="32" rx="10"/>
-   <rect x="404"
-         y="165"
+   <text class="terminal" x="132" y="327">(</text>
+   <rect x="168" y="309" width="70" height="32" rx="10"/>
+   <rect x="166"
+         y="307"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="414" y="185">region =</text>
-   <rect x="496" y="167" width="58" height="32"/>
-   <rect x="494" y="165" width="58" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="504" y="185">region</text>
-   <rect x="91" y="297" width="118" height="32"/>
-   <rect x="89" y="295" width="118" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="99" y="315">aws_credentials</text>
-   <rect x="249" y="265" width="24" height="32" rx="10"/>
-   <rect x="247"
-         y="263"
+   <text class="terminal" x="176" y="327">region =</text>
+   <rect x="258" y="309" width="58" height="32"/>
+   <rect x="256" y="307" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="266" y="327">region</text>
+   <rect x="356" y="341" width="118" height="32"/>
+   <rect x="354" y="339" width="118" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="364" y="359">aws_credentials</text>
+   <rect x="514" y="309" width="24" height="32" rx="10"/>
+   <rect x="512"
+         y="307"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="257" y="283">)</text>
-   <rect x="293" y="265" width="78" height="32" rx="10"/>
-   <rect x="291"
-         y="263"
+   <text class="terminal" x="522" y="327">)</text>
+   <rect x="277" y="407" width="78" height="32" rx="10"/>
+   <rect x="275"
+         y="405"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="283">FORMAT</text>
-   <rect x="411" y="265" width="66" height="32" rx="10"/>
-   <rect x="409"
-         y="263"
+   <text class="terminal" x="285" y="425">FORMAT</text>
+   <rect x="395" y="407" width="66" height="32" rx="10"/>
+   <rect x="393"
+         y="405"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="419" y="283">REGEX</text>
-   <rect x="497" y="265" width="54" height="32"/>
-   <rect x="495" y="263" width="54" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="505" y="283">regex</text>
-   <rect x="411" y="309" width="54" height="32" rx="10"/>
-   <rect x="409"
-         y="307"
+   <text class="terminal" x="403" y="425">REGEX</text>
+   <rect x="481" y="407" width="54" height="32"/>
+   <rect x="479" y="405" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="489" y="425">regex</text>
+   <rect x="395" y="451" width="54" height="32" rx="10"/>
+   <rect x="393"
+         y="449"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="419" y="327">TEXT</text>
-   <rect x="411" y="353" width="64" height="32" rx="10"/>
-   <rect x="409"
-         y="351"
+   <text class="terminal" x="403" y="469">TEXT</text>
+   <rect x="395" y="495" width="64" height="32" rx="10"/>
+   <rect x="393"
+         y="493"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="419" y="371">BYTES</text>
+   <text class="terminal" x="403" y="513">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-580 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m0 0 h10 m142 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m168 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-573 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m58 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-527 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m0 0 h10 m78 0 h10 m20 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h76 m23 -88 h-3"/>
-   <polygon points="589 279 597 275 597 283"/>
-   <polygon points="589 279 581 275 581 283"/>
+         d="m17 17 h2 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m78 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-460 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m80 0 h10 m0 0 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-451 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m118 0 h10 m0 0 h10 m102 0 h10 m-280 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m260 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-260 0 h10 m24 0 h10 m0 0 h216 m40 44 h10 m0 0 h188 m-218 0 h20 m198 0 h20 m-238 0 q10 0 10 10 m218 0 q0 -10 10 -10 m-228 10 v12 m218 0 v-12 m-218 12 q0 10 10 10 m198 0 q10 0 10 -10 m-208 10 h10 m94 0 h10 m0 0 h10 m64 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-548 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m56 0 h10 m0 0 h10 m24 0 h10 m0 0 h10 m70 0 h10 m0 0 h10 m58 0 h10 m20 0 h10 m0 0 h128 m-158 0 h20 m138 0 h20 m-178 0 q10 0 10 10 m158 0 q0 -10 10 -10 m-168 10 v12 m158 0 v-12 m-158 12 q0 10 10 10 m138 0 q10 0 10 -10 m-148 10 h10 m118 0 h10 m20 -32 h10 m24 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-305 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m78 0 h10 m20 0 h10 m66 0 h10 m0 0 h10 m54 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m54 0 h10 m0 0 h86 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m64 0 h10 m0 0 h76 m23 -88 h-3"/>
+   <polygon points="573 421 581 417 581 425"/>
+   <polygon points="573 421 565 417 565 425"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -105,8 +105,12 @@ create_source_protobuf_kinesis ::=
   'USING SCHEMA' ('FILE' schema_file_path | inline_schema)
 create_source_s3_text ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  'FROM S3 BUCKET' bucket_name
-  'OBJECTS FROM SCAN'
+  'FROM S3 OBJECTS FROM ' (
+      'SCAN BUCKET' bucket_name
+  )
+  (
+    ',' 'SCAN BUCKET' bucket_name
+  )*
   ('MATCHING' pattern)?
   'WITH' '('
       'region =' region
@@ -119,8 +123,12 @@ create_source_s3_text ::=
   )
 create_source_s3_json ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')? src_name
-  'FROM S3 BUCKET' bucket_name
-  'OBJECTS FROM SCAN'
+  'FROM S3 OBJECTS FROM ' (
+      'SCAN BUCKET' bucket_name
+  )
+  (
+    ',' 'SCAN BUCKET' bucket_name
+  )*
   ('MATCHING' pattern)?
   'WITH' '('
       'region =' region
@@ -130,8 +138,12 @@ create_source_s3_json ::=
 create_source_s3_csv ::=
   'CREATE' 'MATERIALIZED'? 'SOURCE' ('IF NOT EXISTS')?
   src_name ( '(' col_name (',' col_name)* ')' )?
-  'FROM S3 BUCKET' bucket_name
-  'OBJECTS FROM SCAN'
+  'FROM S3 OBJECTS FROM ' (
+      'SCAN BUCKET' bucket_name
+  )
+  (
+    ',' 'SCAN BUCKET' bucket_name
+  )*
   ('MATCHING' pattern)?
   'WITH' '('
       'region =' region

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -668,7 +668,6 @@ pub struct FileSourceConnector {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct S3SourceConnector {
-    pub bucket: String,
     pub key_sources: Vec<S3KeySource>,
     pub pattern: Option<Glob>,
     pub aws_info: aws::ConnectInfo,
@@ -677,8 +676,8 @@ pub struct S3SourceConnector {
 /// A Source of Object Key names, the argument of the `OBJECTS FROM` clause
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum S3KeySource {
-    /// Scan the S3 Bucket in the S3 source connector to discover keys to download
-    Scan,
+    /// Scan the S3 Bucket to discover keys to download
+    Scan { bucket: String },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -125,20 +125,20 @@ impl fmt::Display for SourceInstanceId {
 ///     Kafka -> partition
 ///     Kinesis -> shard
 ///     File -> only one
-///     S3 -> only one
+///     S3 -> bucket
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum PartitionId {
     Kafka(i32),
     Kinesis(String),
     File,
-    // TODO(bwm): should this partition based on object keys?
-    S3,
+    S3 { bucket: String },
 }
 
 impl fmt::Display for PartitionId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             PartitionId::Kafka(id) => write!(f, "{}", id.to_string()),
+            PartitionId::S3 { bucket } => write!(f, "{}", bucket),
             _ => write!(f, "0"),
         }
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -443,28 +443,23 @@ pub fn plan_create_source(
             (connector, encoding)
         }
         Connector::S3 {
-            bucket,
             key_sources,
             pattern,
         } => {
             scx.require_experimental_mode("S3 Sources")?;
             let aws_info = normalize::aws_connect_info(&mut with_options, None)?;
             let mut converted_sources = Vec::new();
-            let mut parsed_scan = false;
             for ks in key_sources {
                 let dtks = match ks {
-                    sql_parser::ast::S3KeySource::Scan => {
-                        if parsed_scan {
-                            bail!("SCAN may only be specified once");
+                    sql_parser::ast::S3KeySource::Scan { bucket } => {
+                        dataflow_types::S3KeySource::Scan {
+                            bucket: bucket.clone(),
                         }
-                        parsed_scan = true;
-                        dataflow_types::S3KeySource::Scan
                     }
                 };
                 converted_sources.push(dtks);
             }
             let connector = ExternalSourceConnector::S3(S3SourceConnector {
-                bucket: bucket.clone(),
                 key_sources: converted_sources,
                 pattern: pattern
                     .as_ref()

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -22,7 +22,7 @@ b2
 b3
 
 > CREATE MATERIALIZED SOURCE s3_all
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN
+  FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -41,7 +41,7 @@ b2 5
 b3 6
 
 > CREATE MATERIALIZED SOURCE s3_glob_a
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '**/a'
+  FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}' MATCHING '**/a'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -57,7 +57,7 @@ a2 2
 a3 3
 
 > CREATE MATERIALIZED SOURCE s3_just_a
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING 'short/a'
+  FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}' MATCHING 'short/a'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -78,7 +78,7 @@ c,8
 c,9
 
 > CREATE MATERIALIZED SOURCE csv_example (name, counts)
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING '*.csv'
+  FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}' MATCHING '*.csv'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -119,7 +119,7 @@ $ s3-put-object bucket=${bucket} key=logs/2021/01/01/frontend.log
 173.203.139.108 - - [01/01/2021:00:00:39] "GET /downloads/materialized HTTP/1.1" 404 335 "-" "Python/Requests_22"
 
 > CREATE MATERIALIZED SOURCE frontend_logs
-  FROM S3 BUCKET '${bucket}' OBJECTS FROM SCAN MATCHING 'logs/**/*.log'
+  FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}' MATCHING 'logs/**/*.log'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -138,7 +138,18 @@ $ s3-put-object bucket=${bucket} key=logs/2021/01/01/frontend.log
 12/31/2020:23:55:52 37.26.93.214 Go_1.1_package_http
 12/31/2020:23:55:59 99.99.44.44 Python/Requests_22
 
-! CREATE SOURCE err FROM S3 BUCKET 'dog' OBJECTS FROM SCAN, SCAN
+$ set otherbucket=materialize-ci-td-other-${testdrive.seed}
+
+$ s3-create-bucket bucket=${otherbucket}
+
+$ s3-put-object bucket=${otherbucket} key=short/c
+c1
+c2
+c3
+
+> CREATE MATERIALIZED SOURCE s3_multi
+  FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}', SCAN BUCKET '${otherbucket}'
+  MATCHING 'short/*'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
@@ -146,5 +157,15 @@ $ s3-put-object bucket=${bucket} key=logs/2021/01/01/frontend.log
     secret_access_key = '${testdrive.aws-secret-access-key}',
     token = '${testdrive.aws-token}'
   )
-  FORMAT TEXT
-SCAN may only be specified once
+  FORMAT TEXT;
+
+> SELECT text FROM s3_multi ORDER BY text;
+a1
+a2
+a3
+b1
+b2
+b3
+c1
+c2
+c3

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -114,7 +114,7 @@ services:
   localstack:
     image: localstack/localstack:0.12.5
     environment:
-    - SERVICES=kinesis,s3
+    - SERVICES=sts,iam,kinesis,s3
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
With the new factoring of code necessary to support SQS updates this is actually easier to
implement than the old logic of requiring a different source for different buckets. This
implements a change first proposed in a comment due to the way external catalogs/manifests seem
likely to work[1].

This also more closely and accurately models the way that S3 sources are forced to work. Since SQS
queues can subscribe to multiple SNS topics[2], so they can be configured for multiple S3 buckets.
And since they can be configured for multiple S3 buckets we have the choice of either erroring if
a user configures the same queue for multiple topics or of handling it correctly.

Because of the way that I've architectured things, it's actually easier to do the more ergonomic
thing of allowing users to handle multiple buckets in one source, and so this refactors the source
syntax to explicitly allow it.

[1]: https://github.com/MaterializeInc/materialize/issues/4914#issuecomment-770002019
[2]: https://stackoverflow.com/questions/44254094

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5607)
<!-- Reviewable:end -->
