### PR TITLE
Upsert: New arrangementless operator to increase speed

### DIFF
--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -77,7 +77,7 @@ impl DecoderState for AvroDecoderState {
         bytes: &[u8],
         coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-    ) -> Result<Option<Row>, ()> {
+    ) -> Result<Option<Row>, String> {
         match block_on(self.decoder.decode(bytes, coord, upstream_time_millis)) {
             Ok(diff_pair) => {
                 self.events_success += 1;
@@ -85,8 +85,7 @@ impl DecoderState for AvroDecoderState {
             }
             Err(err) => {
                 self.events_error += 1;
-                error!("avro deserialization error: {}", err);
-                Err(())
+                Err(format!("avro deserialization error: {}", err))
             }
         }
     }

--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -72,23 +72,21 @@ impl DecoderState for AvroDecoderState {
     }
 
     /// give a session a key-value pair
-    fn give_key_value<'a>(
+    fn decode_upsert_value<'a>(
         &mut self,
-        key: Row,
         bytes: &[u8],
         coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-        session: &mut PushSession<'a, (Row, Option<Row>, Timestamp)>,
-        time: Timestamp,
-    ) {
+    ) -> Result<Option<Row>, ()> {
         match block_on(self.decoder.decode(bytes, coord, upstream_time_millis)) {
             Ok(diff_pair) => {
                 self.events_success += 1;
-                session.give((key, diff_pair.after, time));
+                Ok(diff_pair.after)
             }
             Err(err) => {
                 self.events_error += 1;
-                error!("avro deserialization error: {}", err)
+                error!("avro deserialization error: {}", err);
+                Err(())
             }
         }
     }

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -125,14 +125,12 @@ pub type PushSession<'a, R> =
 pub trait DecoderState {
     fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String>;
     /// Decode the value in the upsert context, which means it might be a None.
-    /// The Error type is `()` because the caller assumes that this function
-    /// will handle whatever type of error that occurs during the decode process.
     fn decode_upsert_value(
         &mut self,
         bytes: &[u8],
         aux_num: Option<i64>,
         upstream_time_millis: Option<i64>,
-    ) -> Result<Option<Row>, ()>;
+    ) -> Result<Option<Row>, String>;
     /// give a session a plain value
     fn give_value<'a>(
         &mut self,
@@ -190,7 +188,7 @@ where
         bytes: &[u8],
         line_no: Option<i64>,
         _upstream_time_millis: Option<i64>,
-    ) -> Result<Option<Row>, ()> {
+    ) -> Result<Option<Row>, String> {
         Ok(Some(pack_with_line_no((self.datum_func)(bytes), line_no)))
     }
 
@@ -217,6 +215,8 @@ where
 /// Note that for code simplicity, this uses dynamic dispatch, which is said to
 /// be slower than using templates. The use of dynamic dispatch has not been
 /// observed to noticeably impact upsert performance at the time of this writing.
+/// TODO (wangandi): reimplement in terms of generics. DataEncoding could be a
+/// trait that returns a corresponding DecoderState.
 pub(crate) fn get_decoder(
     encoding: DataEncoding,
     debug_name: &str,

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -53,23 +53,21 @@ impl DecoderState for ProtobufDecoderState {
     }
 
     /// give a session a key-value pair
-    fn give_key_value<'a>(
+    fn decode_upsert_value<'a>(
         &mut self,
-        key: Row,
         bytes: &[u8],
         _: Option<i64>,
         _upstream_time_millis: Option<i64>,
-        session: &mut PushSession<'a, (Row, Option<Row>, Timestamp)>,
-        time: Timestamp,
-    ) {
+    ) -> Result<Option<Row>, ()> {
         match self.decoder.decode(bytes) {
             Ok(row) => {
                 self.events_success += 1;
-                session.give((key, row, time));
+                Ok(row)
             }
             Err(err) => {
                 self.events_error += 1;
-                error!("protobuf deserialization error: {:#}", err)
+                error!("protobuf deserialization error: {:#}", err);
+                Err(())
             }
         }
     }

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -58,7 +58,7 @@ impl DecoderState for ProtobufDecoderState {
         bytes: &[u8],
         _: Option<i64>,
         _upstream_time_millis: Option<i64>,
-    ) -> Result<Option<Row>, ()> {
+    ) -> Result<Option<Row>, String> {
         match self.decoder.decode(bytes) {
             Ok(row) => {
                 self.events_success += 1;
@@ -66,8 +66,7 @@ impl DecoderState for ProtobufDecoderState {
             }
             Err(err) => {
                 self.events_error += 1;
-                error!("protobuf deserialization error: {:#}", err);
-                Err(())
+                Err(format!("protobuf deserialization error: {:#}", err))
             }
         }
     }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -108,8 +108,7 @@ use std::{any::Any, cell::RefCell};
 
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
-use differential_dataflow::operators::arrange::arrangement::{Arrange, ArrangeByKey};
-use differential_dataflow::operators::arrange::upsert::arrange_from_upsert;
+use differential_dataflow::operators::arrange::arrangement::ArrangeByKey;
 use differential_dataflow::operators::Consolidate;
 use differential_dataflow::{AsCollection, Collection};
 use timely::communication::Allocate;
@@ -123,7 +122,7 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 
 use dataflow_types::*;
-use expr::{GlobalId, Id, MapFilterProject, MirRelationExpr, MirScalarExpr, SourceInstanceId};
+use expr::{GlobalId, Id, MapFilterProject, MirRelationExpr, SourceInstanceId};
 use interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
 use mz_avro::types::Value;
 use mz_avro::Schema;
@@ -133,7 +132,7 @@ use ore::iter::IteratorExt;
 use repr::adt::decimal::Significand;
 use repr::{Datum, RelationType, Row, RowArena, RowPacker, Timestamp};
 
-use crate::decode::{decode_avro_values, decode_upsert_collection, decode_values};
+use crate::decode::{decode_avro_values, decode_values, get_decoder};
 use crate::operator::{CollectionExt, StreamExt};
 use crate::render::context::{ArrangementFlavor, Context};
 use crate::server::{CacheMessage, LocalInput, TimestampDataUpdates, TimestampMetadataUpdates};
@@ -154,8 +153,6 @@ mod reduce;
 mod threshold;
 mod top_k;
 mod upsert;
-
-pub use self::upsert::no_arrangement_upsert;
 
 /// Worker-local state used during rendering.
 pub struct RenderState {
@@ -334,130 +331,73 @@ where
                     caching_tx,
                 };
 
-                let capability = if let SourceEnvelope::Upsert(key_encoding) = envelope {
-                    match connector {
-                        ExternalSourceConnector::Kafka(_) => {
-                            let (source, capability) = source::create_source::<_, KafkaSourceInfo, _>(
-                                source_config,
-                                connector,
-                            );
-
-                            let stream = upsert::apply_as_of_frontier(
-                                &source.0,
-                                self.as_of_frontier.clone(),
-                            );
-
-                            let stream = decode_upsert_collection(
-                                &stream,
-                                encoding,
-                                key_encoding,
-                                &self.debug_name,
-                                scope.index(),
-                            );
-                            let collection = stream.as_collection();
-                            /*let (transformed, new_err_collection) =
-                                upsert::pre_arrange_from_upsert_transforms(
-                                    &source.0,
-                                    encoding,
-                                    key_encoding,
-                                    &self.debug_name,
-                                    scope.index(),
-                                    self.as_of_frontier.clone(),
-                                    &mut src.operators,
-                                    src.bare_desc.typ(),
-                                );
-
-                            let arranged = arrange_from_upsert(
-                                &transformed,
-                                &format!("UpsertArrange: {}", src_id.to_string()),
-                            );
-
-                            err_collection.concat(
-                                &new_err_collection
-                                    .pass_through("upsert-linear-errors")
-                                    .as_collection(),
-                            );
-
-                            let keys = src.bare_desc.typ().keys[0]
-                                .iter()
-                                .map(|k| MirScalarExpr::Column(*k))
-                                .collect::<Vec<_>>();
-                            self.set_local(&get_expr, &keys, (arranged, err_collection.arrange())); */
-                            let get_expr =
-                            MirRelationExpr::global_get(src_id, src.bare_desc.typ().clone());
-                            self.collections
-                                .insert(get_expr, (collection, err_collection));
-                            capability
-                        }
-                        _ => unreachable!("Upsert envelope unsupported for non-Kafka sources"),
-                    }
-                } else {
-                    let (stream, capability) = if let ExternalSourceConnector::AvroOcf(_) =
-                        connector
-                    {
-                        let ((source, err_source), capability) =
-                            source::create_source::<_, FileSourceInfo<Value>, Value>(
-                                source_config,
-                                connector,
-                            );
-                        err_collection = err_collection.concat(
-                            &err_source
-                                .map(DataflowError::SourceError)
-                                .pass_through("AvroOCF-errors")
-                                .as_collection(),
+                let (stream, capability) = if let ExternalSourceConnector::AvroOcf(_) = connector {
+                    let ((source, err_source), capability) =
+                        source::create_source::<_, FileSourceInfo<Value>, Value>(
+                            source_config,
+                            connector,
                         );
-                        let reader_schema = match &encoding {
-                            DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => {
-                                reader_schema
-                            }
-                            _ => unreachable!(
-                                "Internal error: \
+                    err_collection = err_collection.concat(
+                        &err_source
+                            .map(DataflowError::SourceError)
+                            .pass_through("AvroOCF-errors")
+                            .as_collection(),
+                    );
+                    let reader_schema = match &encoding {
+                        DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => reader_schema,
+                        _ => unreachable!(
+                            "Internal error: \
                                      Avro OCF schema should have already been resolved.\n\
                                     Encoding is: {:?}",
-                                encoding
-                            ),
-                        };
+                            encoding
+                        ),
+                    };
 
-                        let reader_schema: Schema = reader_schema.parse().unwrap();
-                        (
-                            decode_avro_values(&source, &envelope, reader_schema, &self.debug_name),
-                            capability,
+                    let reader_schema: Schema = reader_schema.parse().unwrap();
+                    (
+                        decode_avro_values(&source, &envelope, reader_schema, &self.debug_name),
+                        capability,
+                    )
+                } else {
+                    let ((ok_source, err_source), capability) = match connector {
+                        ExternalSourceConnector::Kafka(_) => {
+                            source::create_source::<_, KafkaSourceInfo, _>(source_config, connector)
+                        }
+                        ExternalSourceConnector::Kinesis(_) => {
+                            source::create_source::<_, KinesisSourceInfo, _>(
+                                source_config,
+                                connector,
+                            )
+                        }
+                        ExternalSourceConnector::S3(_) => {
+                            source::create_source::<_, S3SourceInfo, _>(source_config, connector)
+                        }
+                        ExternalSourceConnector::File(_) => {
+                            source::create_source::<_, FileSourceInfo<Vec<u8>>, Vec<u8>>(
+                                source_config,
+                                connector,
+                            )
+                        }
+                        ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+                    };
+                    err_collection = err_collection.concat(
+                        &err_source
+                            .map(DataflowError::SourceError)
+                            .pass_through("source-errors")
+                            .as_collection(),
+                    );
+
+                    let stream = if let SourceEnvelope::Upsert(key_encoding) = &envelope {
+                        let value_decoder = get_decoder(encoding, &self.debug_name, scope.index());
+                        let key_decoder =
+                            get_decoder(key_encoding.clone(), &self.debug_name, scope.index());
+                        upsert::decode_stream(
+                            &ok_source,
+                            self.as_of_frontier.clone(),
+                            key_decoder,
+                            value_decoder,
                         )
                     } else {
-                        let ((ok_source, err_source), capability) = match connector {
-                            ExternalSourceConnector::Kafka(_) => {
-                                source::create_source::<_, KafkaSourceInfo, _>(
-                                    source_config,
-                                    connector,
-                                )
-                            }
-                            ExternalSourceConnector::Kinesis(_) => {
-                                source::create_source::<_, KinesisSourceInfo, _>(
-                                    source_config,
-                                    connector,
-                                )
-                            }
-                            ExternalSourceConnector::S3(_) => {
-                                source::create_source::<_, S3SourceInfo, _>(
-                                    source_config,
-                                    connector,
-                                )
-                            }
-                            ExternalSourceConnector::File(_) => {
-                                source::create_source::<_, FileSourceInfo<Vec<u8>>, Vec<u8>>(
-                                    source_config,
-                                    connector,
-                                )
-                            }
-                            ExternalSourceConnector::AvroOcf(_) => unreachable!(),
-                        };
-                        err_collection = err_collection.concat(
-                            &err_source
-                                .map(DataflowError::SourceError)
-                                .pass_through("source-errors")
-                                .as_collection(),
-                        );
-
                         // TODO(brennan) -- this should just be a MirRelationExpr::FlatMap using regexp_extract, csv_extract,
                         // a hypothetical future avro_extract, protobuf_extract, etc.
                         let (stream, extra_token) = decode_values(
@@ -475,77 +415,79 @@ where
                                 .or_insert_with(Vec::new)
                                 .push(Rc::new(tok));
                         }
-
-                        (stream, capability)
+                        stream
                     };
+                    (stream, capability)
+                };
 
-                    let mut collection = match envelope {
-                        SourceEnvelope::None
-                        | SourceEnvelope::CdcV2
-                        | SourceEnvelope::Debezium(_) => stream.as_collection(),
-                        SourceEnvelope::Upsert(_) => unreachable!(),
-                    };
+                let mut collection = stream.as_collection();
 
-                    // Implement source filtering and projection.
-                    // At the moment this is strictly optional, but we perform it anyhow
-                    // to demonstrate the intended use.
-                    if let Some(mut operators) = src.operators.clone() {
-                        // Determine replacement values for unused columns.
-                        let source_type = src.bare_desc.typ();
-                        let position_or = (0..source_type.arity())
-                            .map(|col| {
-                                if operators.projection.contains(&col) {
-                                    Some(col)
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>();
-
-                        // Apply predicates and insert dummy values into undemanded columns.
-                        let (collection2, errors) = collection.inner.flat_map_fallible({
-                            let mut datums = crate::render::datum_vec::DatumVec::new();
-                            let mut row_packer = repr::RowPacker::new();
-                            let predicates = std::mem::take(&mut operators.predicates);
-                            // The predicates may be temporal, which requires the nuance
-                            // of an explicit plan capable of evaluating the predicates.
-                            let filter_plan = filter::FilterPlan::create_from(predicates)
-                                .unwrap_or_else(|e| panic!(e));
-                            move |(input_row, time, diff)| {
-                                let mut datums_local = datums.borrow_with(&input_row);
-                                let times_diffs =
-                                    filter_plan.evaluate(&mut datums_local, time, diff);
-                                // The output row may need to have `Datum::Dummy` values stitched in.
-                                let output_row = row_packer.pack(position_or.iter().map(
-                                    |pos_or| match pos_or {
-                                        Some(index) => datums_local[*index],
-                                        None => Datum::Dummy,
-                                    },
-                                ));
-                                // Each produced (time, diff) results in a copy of `output_row` in the output.
-                                // TODO: It would be nice to avoid the `output_row.clone()` for the last output.
-                                times_diffs.map(move |time_diff| {
-                                    time_diff.map(|(t, d)| (output_row.clone(), t, d))
-                                })
+                // Implement source filtering and projection.
+                // At the moment this is strictly optional, but we perform it anyhow
+                // to demonstrate the intended use.
+                if let Some(mut operators) = src.operators.clone() {
+                    // Determine replacement values for unused columns.
+                    let source_type = src.bare_desc.typ();
+                    let position_or = (0..source_type.arity())
+                        .map(|col| {
+                            if operators.projection.contains(&col) {
+                                Some(col)
+                            } else {
+                                None
                             }
-                        });
+                        })
+                        .collect::<Vec<_>>();
 
-                        collection = collection2.as_collection();
-                        err_collection = err_collection.concat(&errors.as_collection());
-                    }
+                    // Apply predicates and insert dummy values into undemanded columns.
+                    let (collection2, errors) = collection.inner.flat_map_fallible({
+                        let mut datums = crate::render::datum_vec::DatumVec::new();
+                        let mut row_packer = repr::RowPacker::new();
+                        let predicates = std::mem::take(&mut operators.predicates);
+                        // The predicates may be temporal, which requires the nuance
+                        // of an explicit plan capable of evaluating the predicates.
+                        let filter_plan = filter::FilterPlan::create_from(predicates)
+                            .unwrap_or_else(|e| panic!(e));
+                        move |(input_row, time, diff)| {
+                            let mut datums_local = datums.borrow_with(&input_row);
+                            let times_diffs = filter_plan.evaluate(&mut datums_local, time, diff);
+                            // The output row may need to have `Datum::Dummy` values stitched in.
+                            let output_row =
+                                row_packer.pack(position_or.iter().map(|pos_or| match pos_or {
+                                    Some(index) => datums_local[*index],
+                                    None => Datum::Dummy,
+                                }));
+                            // Each produced (time, diff) results in a copy of `output_row` in the output.
+                            // TODO: It would be nice to avoid the `output_row.clone()` for the last output.
+                            times_diffs.map(move |time_diff| {
+                                time_diff.map(|(t, d)| (output_row.clone(), t, d))
+                            })
+                        }
+                    });
+
+                    collection = collection2.as_collection();
+                    err_collection = err_collection.concat(&errors.as_collection());
 
                     // Apply `as_of` to each timestamp.
-                    let as_of_frontier1 = self.as_of_frontier.clone();
-                    collection = collection
-                        .inner
-                        .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
-                        .as_collection();
+                    match envelope {
+                        SourceEnvelope::Upsert(_) => {}
+                        _ => {
+                            let as_of_frontier1 = self.as_of_frontier.clone();
+                            collection = collection
+                                .inner
+                                .map_in_place(move |(_, time, _)| {
+                                    time.advance_by(as_of_frontier1.borrow())
+                                })
+                                .as_collection();
 
-                    let as_of_frontier2 = self.as_of_frontier.clone();
-                    err_collection = err_collection
-                        .inner
-                        .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
-                        .as_collection();
+                            let as_of_frontier2 = self.as_of_frontier.clone();
+                            err_collection = err_collection
+                                .inner
+                                .map_in_place(move |(_, time, _)| {
+                                    time.advance_by(as_of_frontier2.borrow())
+                                })
+                                .as_collection();
+                        }
+                    }
 
                     let get = MirRelationExpr::Get {
                         id: Id::BareSource(src_id),
@@ -570,8 +512,6 @@ where
                     self.ensure_rendered(&expr, scope, scope.index());
                     let new_get = MirRelationExpr::global_get(src_id, expr.typ());
                     self.clone_from_to(&expr, &new_get);
-
-                    capability
                 };
                 let token = Rc::new(capability);
                 self.source_tokens.insert(src_id, token.clone());

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -13,85 +13,21 @@ use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
-use timely::dataflow::operators::generic::{operator, Operator};
-use timely::dataflow::operators::map::Map;
+use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 
-use dataflow_types::{DataEncoding, DataflowError, LinearOperator};
 use log::error;
-use repr::{Datum, Diff, RelationType, Row, RowArena, Timestamp};
+use repr::{Diff, Row, Timestamp};
 
-use crate::decode::{decode_upsert, DecoderState};
-use crate::operator::StreamExt;
+use crate::decode::DecoderState;
 use crate::source::{SourceData, SourceOutput};
 
-/// Entrypoint to the upsert-specific transformations involved
-/// in rendering a stream that came from an upsert source.
-/// Upsert-specific operators are different from the rest of
-/// the rendering pipeline in that their input is a stream
-/// with two components instead of one, and the second component
-/// can be null or empty.
-#[allow(clippy::too_many_arguments)]
-pub fn pre_arrange_from_upsert_transforms<G>(
-    stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
-    encoding: DataEncoding,
-    key_encoding: DataEncoding,
-    debug_name: &str,
-    worker_index: usize,
-    as_of_frontier: Antichain<Timestamp>,
-    linear_operator: &mut Option<LinearOperator>,
-    src_type: &RelationType,
-) -> (
-    Stream<G, (Row, Option<Row>, Timestamp)>,
-    Stream<G, DataflowError>,
-)
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    // Currently, the upsert-specific transformations run in the
-    // following order:
-    // 1. as_of
-    // 2. deduplicating records by key
-    // 3. decoding records
-    // 4. applying linear operator, which currently consist of
-    //     a. filter
-    //     b. project
-    //     c. prepending the key to the value so that the stream becomes
-    //        of the format (key, <entire record>)
-    //
-    // We may want to consider switching the order of the transformations to
-    // optimize performance trade-offs. In the current order, by running
-    // deduplicating before decoding/linear operators, we're reducing compute at the
-    // cost of requiring more memory.
-    //
-    // In the future, we may want to have optimization hints that enable people
-    // to specify that they believe that they have a large number of unique
-    // keys, at which point materialize may be more performant if it runs
-    // decoding/linear operators before deduplicating.
-
-    // This operator changes the timestamp from capability to message payload,
-    // and applies `as_of` frontier compaction. The compaction is important as
-    // downstream upsert preparation can compact away updates for the same keys
-    // at the same times, and by advancing times we make more of them the same.
-    let stream = apply_as_of_frontier(&stream, as_of_frontier);
-
-    // Deduplicate records by key
-    let deduplicated = prepare_upsert_by_max_offset(&stream);
-
-    // Decode
-    let decoded = decode_upsert(
-        &deduplicated,
-        encoding,
-        key_encoding,
-        debug_name,
-        worker_index,
-    );
-
-    apply_linear_operators(&decoded, linear_operator, src_type)
-}
-
-pub fn apply_as_of_frontier<G>(
+/// This operator changes the timestamp from capability to message payload,
+/// and applies `as_of` frontier compaction. The compaction is important as
+/// downstream upsert preparation can compact away updates for the same keys
+/// at the same times, and by advancing times we make more of them the same.
+fn apply_as_of_frontier<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     as_of_frontier: Antichain<Timestamp>,
 ) -> Stream<G, (SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)>
@@ -113,134 +49,51 @@ where
     })
 }
 
-/// Produces at most one entry for each `(key, time)` pair.
-///
-/// The incoming stream of `(key, (val, off), time)` records may have many
-/// entries with the same `key` and `time`. We are able to reduce this to
-/// at most one record for each pair, by retaining only the record with the
-/// greatest offset: its action summarizes the sequence of many actions that
-/// occur at the same moment and so are not distinguishable.
-fn prepare_upsert_by_max_offset<G>(
-    stream: &Stream<G, (SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)>,
-) -> Stream<G, ((Vec<u8>, SourceData), Timestamp)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    stream.unary_frontier(
-        Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
-        "UpsertCompaction",
-        |_cap, _info| {
-            // this is a map of (time) -> ((key) -> (value with max offset))
-            let mut values = HashMap::<_, HashMap<_, SourceData>>::new();
-            let mut vector = Vec::new();
-
-            move |input, output| {
-                // Digest each input, reduce by presented timestamp.
-                input.for_each(|cap, data| {
-                    data.swap(&mut vector);
-                    for (
-                        SourceOutput {
-                            key,
-                            value: new_value,
-                            position: new_position,
-                            upstream_time_millis: new_upstream_time_millis,
-                        },
-                        time,
-                    ) in vector.drain(..)
-                    {
-                        let entry = values
-                            .entry(cap.delayed(&time))
-                            .or_insert_with(HashMap::new)
-                            .entry(key)
-                            .or_insert_with(Default::default);
-
-                        if let Some(new_offset) = new_position {
-                            if let Some(offset) = entry.position {
-                                if offset < new_offset {
-                                    *entry = SourceData {
-                                        value: new_value,
-                                        position: new_position,
-                                        upstream_time_millis: new_upstream_time_millis,
-                                    };
-                                }
-                            } else {
-                                *entry = SourceData {
-                                    value: new_value,
-                                    position: new_position,
-                                    upstream_time_millis: new_upstream_time_millis,
-                                };
-                            }
-                        }
-                    }
-                });
-
-                // Produce (key, val) pairs at any complete times.
-                for (cap, map) in values.iter_mut() {
-                    if !input.frontier.less_equal(cap.time()) {
-                        let mut session = output.session(cap);
-                        for (key, val) in map.drain() {
-                            session.give(((key, val), cap.time().clone()))
-                        }
-                    }
-                }
-                // Discard entries, capabilities for complete times.
-                values.retain(|_cap, map| !map.is_empty());
-            }
-        },
-    )
-}
-
-/// Apply a filter followed by a project to an upsert stream.
-/// Also, prepend key columns to the beginning of the value so
-/// the return stream is `Stream<G, (key, Option<entire record>, Timestamp)>
-/// whereas the input stream is `Stream<G, (key, Option<value>, Timestamp)>
-fn apply_linear_operators<G>(
-    stream: &Stream<G, (Row, Option<Row>, Timestamp)>,
-    _linear_operator: &mut Option<LinearOperator>,
-    _src_type: &RelationType,
-) -> (
-    Stream<G, (Row, Option<Row>, Timestamp)>,
-    Stream<G, DataflowError>,
-)
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    let mut row_packer = repr::RowPacker::new();
-
-    // just prepend the key to the value without unpacking rows
-    let prepended = stream.map({
-        move |(key, value, timestamp)| {
-            if let Some(value) = value {
-                row_packer.extend_by_row(&key);
-                row_packer.extend_by_row(&value);
-                (key, Some(row_packer.finish_and_reuse()), timestamp)
-            } else {
-                (key, None, timestamp)
-            }
-        }
-    });
-    let scope = &prepended.scope();
-    (prepended, operator::empty(scope))
-}
-
-pub fn no_arrangement_upsert<G, K, V>(
-    stream: &Stream<G, (SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)>,
-    mut key_decoder_state: K,
-    mut value_decoder_state: V,
+/// Entrypoint to the upsert-specific transformations involved
+/// in rendering a stream that came from an upsert source.
+/// Upsert-specific operators are different from the rest of
+/// the rendering pipeline in that their input is a stream
+/// with two components instead of one, and the second component
+/// can be null or empty.
+pub fn decode_stream<G>(
+    stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
+    as_of_frontier: Antichain<Timestamp>,
+    mut key_decoder_state: Box<dyn DecoderState>,
+    mut value_decoder_state: Box<dyn DecoderState>,
 ) -> Stream<G, (Row, Timestamp, Diff)>
 where
     G: Scope<Timestamp = Timestamp>,
-    K: DecoderState + 'static,
-    V: DecoderState + 'static,
 {
-    stream.unary_frontier(
+    // Currently, the upsert-specific transformations run in the
+    // following order:
+    // 1. as_of
+    // 2. deduplicating records by key
+    // 3. decoding records
+    // 4. prepending the key to the value so that the stream becomes
+    //        of the format (key, <entire record>)
+    // We may want to consider switching the order of the transformations to
+    // optimize performance trade-offs. In the current order, by running
+    // deduplicating before decoding/linear operators, we're reducing compute at the
+    // cost of requiring more memory.
+    //
+    // In the future, we may want to have optimization hints that enable people
+    // to specify that they believe that they have a large number of unique
+    // keys, at which point materialize may be more performant if it runs
+    // decoding/linear operators before deduplicating.
+    (&apply_as_of_frontier(stream, as_of_frontier)).unary_frontier(
         Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
-        "LightUpsert",
+        "Upsert",
         |_cap, _info| {
-            // this is a map of (time) -> (capability, ((key) -> (value with max offset)))
+            // this is a map of (time) -> (capability, ((key) -> (value with max
+            // offset))) This is a BTreeMap because we want to ensure that if we
+            // receive (key1, value1, time 5) and (key1, value2, time 7) that we
+            // send (key1, value1, time 5) before (key1, value2, time 7)
             let mut to_send = BTreeMap::<_, (_, HashMap<_, SourceData>)>::new();
-            // this is a map of (decoded key) -> (decoded value)
+            // this is a map of (decoded key) -> (decoded_value). We store the
+            // latest value for a given key that way we know what to retract if
+            // a new value with the same key comes along
             let mut current_values = HashMap::new();
+
             let mut vector = Vec::new();
             let mut row_packer = repr::RowPacker::new();
 
@@ -319,16 +172,19 @@ where
                                         Err(())
                                     };
                                     if let Ok(decoded_value) = decoded_value {
-                                        // TODO: apply linear operator
+                                        // TODO: add linear operators such as
+                                        // filters and projects?
                                         let old_value = if let Some(new_value) = &decoded_value {
                                             current_values.insert(decoded_key, new_value.clone())
                                         } else {
                                             current_values.remove(&decoded_key)
                                         };
                                         if let Some(old_value) = old_value {
+                                            // retract old value
                                             session.give((old_value, cap.time().clone(), -1));
                                         }
                                         if let Some(new_value) = decoded_value {
+                                            // give new value
                                             session.give((new_value, cap.time().clone(), 1));
                                         }
                                     }
@@ -339,6 +195,10 @@ where
                             }
                         }
                     } else {
+                        // because this is a BTreeMap, the rest of the times in
+                        // the map will be greater than this time. So if the
+                        // input_frontier is less than or equal to this time,
+                        // it will be less than the times in the rest of the map
                         break;
                     }
                 }

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -341,6 +341,8 @@ where
             for time in removed_times {
                 to_send.remove(&time);
             }
+            key_decoder_state.log_error_count();
+            value_decoder_state.log_error_count();
         }
     })
 }

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -153,23 +153,25 @@ where
                                 Ok(decoded_key) => {
                                     let decoded_value = if data.value.is_empty() {
                                         Ok(None)
-                                    } else if let Ok(value) = value_decoder_state
+                                    } else {
+                                        match value_decoder_state
                                         .decode_upsert_value(
                                             &data.value,
                                             data.position,
                                             data.upstream_time_millis,
-                                        )
-                                    {
-                                        if let Some(value) = value {
-                                            // prepend key to row
-                                            row_packer.extend_by_row(&decoded_key);
-                                            row_packer.extend_by_row(&value);
-                                            Ok(Some(row_packer.finish_and_reuse()))
-                                        } else {
-                                            Ok(None)
+                                        ) {
+                                            Ok(value) => {
+                                                if let Some(value) = value {
+                                                    // prepend key to row
+                                                    row_packer.extend_by_row(&decoded_key);
+                                                    row_packer.extend_by_row(&value);
+                                                    Ok(Some(row_packer.finish_and_reuse()))
+                                                } else {
+                                                    Ok(None)
+                                                }
+                                            }
+                                            Err(err) => Err(err)
                                         }
-                                    } else {
-                                        Err(())
                                     };
                                     if let Ok(decoded_value) = decoded_value {
                                         // TODO: add linear operators such as


### PR DESCRIPTION
EDIT: Now ready for review! Best viewed using "hide whitespace changes".
`upsert_arrange` has been replaced with an arrangementless equivalent that store the most recent value for a given key in a hashmap. The arrangementless equivalent does not yet support linear operators.

Upsert decoding now uses dynamic dispatch since profiling on my machine has shown that the dynamic dispatch is not negatively impacting performance in any noticeable manner.

------------------
An initial implementation for #5509. 

This passes `test/testdrive/upsert-kafka.td`. I've also been running the MBTA demo against it for the last 30 minutes, and it has not crashed. If you encounter a crash while testing the branch, please at me directly on Slack. 

Important notes for performance testing:
* In upsert-with-arrangement, filters and projects may run before the UpsertArrangement operator. I have not yet implemented support for running filters and projects before upsert occurs.  
* If we want to test to see if `AHash` improves anything (see #5589), I assume it's not hard to rename `HashMap` references in `src/render/src/upsert.rs` to `AHashMap`.  
* I am assuming that in order to guarantee the output is consistent, if the current value of "key1" is stream is at time 3, and we see updates to "key1" for time 5 and 7 that we cannot throw away the update at time 5.

Overview of what this does:
* There is a `HashMap` of the current values in the stream. If an update comes along, we send along the new value. We also insert the new value into the `HashMap` and issue a retraction for the old value if an old value exists. If a delete comes along, remove the value from the `HashMap` corresponding to the key and issue a retraction for it.
* Because the `HashMap` only contains the current values in the stream, in order to have correct results, we have to ensure  that an update to "key1" at time 5 gets sent before an update to "key1" at time 7.  Thus, thus updates are grouped by time in. a `BTreeMap` instead of `HashMap`. The use of `BTreeMap` may have performance implications. 
* To avoid unnecessary decoding work, values get decoded after the time it belongs to is complete so we don't decode values immediately replaced by another value with a bigger offset. Values get decoded before being added to the `HashMap` of the current values in the stream.

What is necessary before merging:
* a decision on what to do with the upsert-with-arrangement path. I just commented it out for the time being.
* Code cleanup. I don't like the circular dependency between `src/render` and `src/decode` that the current iteration of the code introduces, but I worry about negative performance implications of using `dyn DecoderState`.
* Better comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5608)
<!-- Reviewable:end -->
