### PR TITLE
materialized: avoid infinite recursion footgun

### DIFF
--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -136,7 +136,10 @@ impl ConnectionHandler for pgwire::Server {
     }
 
     async fn handle_connection(&self, conn: SniffedStream<TcpStream>) -> Result<(), anyhow::Error> {
-        self.handle_connection(conn).await
+        // Using fully-qualified syntax means we won't accidentally call
+        // ourselves (i.e., silently infinitely recurse) if the name or type of
+        // `pgwire::Server::handle_connection` changes.
+        pgwire::Server::handle_connection(self, conn).await
     }
 }
 
@@ -151,7 +154,10 @@ impl ConnectionHandler for http::Server {
     }
 
     async fn handle_connection(&self, conn: SniffedStream<TcpStream>) -> Result<(), anyhow::Error> {
-        self.handle_connection(conn).await
+        // Using fully-qualified syntax means we won't accidentally call
+        // ourselves (i.e., silently infinitely recurse) if the name or type of
+        // `http::Server::handle_connection` changes.
+        http::Server::handle_connection(self, conn).await
     }
 }
 
@@ -166,6 +172,11 @@ impl ConnectionHandler for comm::Switchboard<SniffedStream<TcpStream>> {
     }
 
     async fn handle_connection(&self, conn: SniffedStream<TcpStream>) -> Result<(), anyhow::Error> {
-        self.handle_connection(conn).err_into().await
+        // Using fully-qualified syntax means we won't accidentally call
+        // ourselves (i.e., silently infinitely recurse) if the name or type of
+        // `comm::Switchboard::handle_connection` changes.
+        comm::Switchboard::handle_connection(self, conn)
+            .err_into()
+            .await
     }
 }


### PR DESCRIPTION
Restructure some code to avoid the possibility of infinite recursion
where a compile error is expected. Specifically, the Mux's
handle_connection trait method delegates to an inherent method of the
same name; but if that method of the same name changes its name or type
(e.g. due to a refactoring), the Mux will silently start infinitely
recursing instead of producing a compilation error as you might expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5617)
<!-- Reviewable:end -->
