### PR TITLE
deps: upgrade to hyper v0.14.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,9 +1578,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
This includes a fix for a security vulnerability in hyper:
https://github.com/hyperium/hyper/security/advisories/GHSA-6hfq-h8hq-87mf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5639)
<!-- Reviewable:end -->
