### PR TITLE
Correct permutation detection

### DIFF
--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -84,7 +84,7 @@ impl JoinClosure {
         equivalences: &mut Vec<Vec<MirScalarExpr>>,
         mfp: &mut MapFilterProject,
     ) -> Self {
-        // First, determine which columns should be compare due to `equivalences`.
+        // First, determine which columns should be compared due to `equivalences`.
         let mut ready_equivalences = Vec::new();
         for equivalence in equivalences.iter_mut() {
             if let Some(pos) = equivalence
@@ -164,6 +164,7 @@ impl JoinClosure {
             && mfp.predicates.is_empty()
             && mfp.projection.len() == columns.len()
             && mfp.projection.iter().all(|col| columns.contains_key(col))
+            && columns.keys().all(|col| mfp.projection.contains(col))
         {
             // The projection we want to apply to `before`  comes to us from `mfp` in the
             // extended output column reckoning.


### PR DESCRIPTION
As an optimization, join planning would attempt to identify whether the residual MapFilterProject work was a permutation, and if so apply that in place to simplify the residual work down to the identity. Unfortunately, that detection logic was wrong, and would admit e.g. `[0, 0, 1]` as a permutation of `[0, 1, 2]` because .. well you could imagine the bug. Not all of the latter appear in the former.

Fixes #5578
Fixes #5623

cc: @philip-stoev for noticing the issues; thanks very much! The specific repros do not error any more, but there could still be lingering issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5641)
<!-- Reviewable:end -->
