### PR TITLE
Propagate initial errors in linear joins

### DIFF
--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -120,7 +120,7 @@ where
                         }
                     });
                     joined = j;
-                    errs.concat(&es);
+                    errs = errs.concat(&es);
                 }
             }
 

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -41,6 +41,7 @@ use repr::{Datum, Row, RowArena, RowPacker};
 /// as there is a relationship between the borrowed lifetime of the closed-over
 /// state and the arguments it takes when invoked. It was not clear how to do
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
+#[derive(Debug)]
 struct JoinClosure {
     ready_equivalences: Vec<Vec<MirScalarExpr>>,
     before: MapFilterProject,
@@ -205,6 +206,7 @@ impl JoinClosure {
 /// filtering, expressions, projection) and the physical organization of the current stream
 /// of data, which columns may be partially assembled in non-standard locations and which
 /// may already have been partially subjected to logic we need to apply.
+#[derive(Debug)]
 struct JoinBuildState {
     /// Map from expected locations in extended output column reckoning to physical locations.
     column_map: HashMap<usize, usize>,


### PR DESCRIPTION
We had a statement like
```
errs.concat(&new_errors);
```
rather than
```
errs = errs.concat(&new_errors);
```

Fixes #5663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5664)
<!-- Reviewable:end -->
