### PR TITLE
expr: allow constant errors

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2324,6 +2324,10 @@ where
 
         // If this optimizes to a constant expression, we can immediately return the result.
         let resp = if let MirRelationExpr::Constant { rows, typ: _ } = source.as_ref() {
+            let rows = match rows {
+                Ok(rows) => rows,
+                Err(e) => return Err(CoordError::Eval(e.clone())),
+            };
             let mut results = Vec::new();
             for &(ref row, count) in rows {
                 assert!(
@@ -2755,7 +2759,10 @@ where
             logical_time: self.get_write_ts(),
         };
         match self.prep_relation_expr(values, prep_style)?.into_inner() {
-            MirRelationExpr::Constant { rows, typ: _ } => {
+            MirRelationExpr::Constant {
+                rows: Ok(rows),
+                typ: _,
+            } => {
                 let desc = self.catalog.get_by_id(&id).desc()?;
                 for (row, _) in &rows {
                     for (datum, (name, typ)) in row.unpack().iter().zip(desc.iter()) {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2326,7 +2326,7 @@ where
         let resp = if let MirRelationExpr::Constant { rows, typ: _ } = source.as_ref() {
             let rows = match rows {
                 Ok(rows) => rows,
-                Err(e) => return Err(CoordError::Eval(e.clone())),
+                Err(e) => return Err(e.clone().into()),
             };
             let mut results = Vec::new();
             for &(ref row, count) in rows {
@@ -2759,10 +2759,8 @@ where
             logical_time: self.get_write_ts(),
         };
         match self.prep_relation_expr(values, prep_style)?.into_inner() {
-            MirRelationExpr::Constant {
-                rows: Ok(rows),
-                typ: _,
-            } => {
+            MirRelationExpr::Constant { rows, typ: _ } => {
+                let rows = rows?;
                 let desc = self.catalog.get_by_id(&id).desc()?;
                 for (row, _) in &rows {
                     for (datum, (name, typ)) in row.unpack().iter().zip(desc.iter()) {

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -138,6 +138,12 @@ impl From<catalog::Error> for CoordError {
     }
 }
 
+impl From<EvalError> for CoordError {
+    fn from(e: EvalError) -> CoordError {
+        CoordError::Eval(e)
+    }
+}
+
 impl From<sql::catalog::CatalogError> for CoordError {
     fn from(e: sql::catalog::CatalogError) -> CoordError {
         CoordError::SqlCatalog(e)

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -10,6 +10,7 @@
 use std::error::Error;
 use std::fmt;
 
+use expr::EvalError;
 use ore::str::StrExt;
 use transform::TransformError;
 
@@ -23,6 +24,8 @@ pub enum CoordError {
     Catalog(catalog::Error),
     /// The specified session parameter is constrained to its current value.
     ConstrainedParameter(&'static (dyn Var + Send + Sync)),
+    /// An error while evaluating an expression.
+    Eval(EvalError),
     /// The value for the specified parameter does not have the right type.
     InvalidParameterType(&'static (dyn Var + Send + Sync)),
     /// The named operation cannot be run in a transaction.
@@ -89,6 +92,7 @@ impl fmt::Display for CoordError {
                 p.name().quoted(),
                 p.value().quoted()
             ),
+            CoordError::Eval(e) => e.fmt(f),
             CoordError::InvalidParameterType(p) => write!(
                 f,
                 "parameter {} requires a {} value",

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -23,7 +23,9 @@
 //!
 //! At the moment, only *scalar* expression evaluation can fail, so only
 //! operators that evaluate scalar expressions can fail. At the time of writing,
-//! that includes map, filter, reduce, and join operators.
+//! that includes map, filter, reduce, and join operators. Constants are a bit
+//! of a special case: they can be either a constant vector of rows *or* a
+//! constant, singular error.
 //!
 //! The approach taken is to build two parallel trees of computation: one for
 //! the rows that have been successfully evaluated (the "oks tree"), and one for

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::iter;
 
+use ore::str::StrExt;
 use repr::RelationType;
 
 use crate::{ExprHumanizer, Id, JoinImplementation, LocalId, MirRelationExpr, RowSetFinishing};
@@ -214,7 +215,7 @@ impl<'a> Explanation<'a> {
 
         match node.expr {
             Constant { rows, .. } => {
-                write!(f, "| Constant")?;
+                write!(f, "| Constant ")?;
                 match rows {
                     Ok(rows) => writeln!(
                         f,
@@ -225,7 +226,7 @@ impl<'a> Explanation<'a> {
                                 .flat_map(|(row, count)| (0..*count).map(move |_| row))
                         )
                     )?,
-                    Err(e) => writeln!(f, "{}", e)?,
+                    Err(e) => writeln!(f, "Err({})", e.to_string().quoted())?,
                 }
             }
             Get { id, .. } => match id {

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -213,15 +213,21 @@ impl<'a> Explanation<'a> {
         use MirRelationExpr::*;
 
         match node.expr {
-            Constant { rows, .. } => writeln!(
-                f,
-                "| Constant {}",
-                separated(
-                    " ",
-                    rows.iter()
-                        .flat_map(|(row, count)| (0..*count).map(move |_| row))
-                )
-            )?,
+            Constant { rows, .. } => {
+                write!(f, "| Constant")?;
+                match rows {
+                    Ok(rows) => writeln!(
+                        f,
+                        "{}",
+                        separated(
+                            " ",
+                            rows.iter()
+                                .flat_map(|(row, count)| (0..*count).map(move |_| row))
+                        )
+                    )?,
+                    Err(e) => writeln!(f, "{}", e)?,
+                }
+            }
             Get { id, .. } => match id {
                 Id::Local(local_id) => writeln!(
                     f,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -308,6 +308,7 @@ impl ErrorResponse {
         let code = match e {
             CoordError::Catalog(_) => SqlState::INTERNAL_ERROR,
             CoordError::ConstrainedParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
+            CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,
             CoordError::OperationRequiresTransaction(_) => SqlState::NO_ACTIVE_SQL_TRANSACTION,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -156,7 +156,7 @@ impl HirRelationExpr {
             Constant { rows, typ } => {
                 // Constant expressions are not correlated with `get_outer`, and should be cross-products.
                 get_outer.product(SR::Constant {
-                    rows: rows.into_iter().map(|row| (row, 1)).collect(),
+                    rows: Ok(rows.into_iter().map(|row| (row, 1)).collect()),
                     typ,
                 })
             }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 
-use expr::{MirRelationExpr, MirScalarExpr, UnaryFunc};
+use expr::{EvalError, MirRelationExpr, MirScalarExpr, UnaryFunc};
 use repr::Datum;
 use repr::{ColumnType, RelationType, ScalarType};
 
@@ -59,7 +59,7 @@ impl ColumnKnowledge {
                         .iter()
                         .zip(typ.column_types.iter())
                         .map(|(datum, typ)| DatumKnowledge {
-                            value: Some((row_packer.pack(Some(datum.clone())), typ.clone())),
+                            value: Some((Ok(row_packer.pack(Some(datum.clone()))), typ.clone())),
                             nullable: datum == Datum::Null,
                         })
                         .collect()
@@ -88,7 +88,7 @@ impl ColumnKnowledge {
             MirRelationExpr::Map { input, scalars } => {
                 let mut input_knowledge = ColumnKnowledge::harvest(input, knowledge)?;
                 for scalar in scalars.iter_mut() {
-                    let know = optimize(scalar, &input.typ(), &input_knowledge[..])?;
+                    let know = optimize(scalar, &input.typ(), &input_knowledge[..]);
                     input_knowledge.push(know);
                 }
                 input_knowledge
@@ -101,7 +101,7 @@ impl ColumnKnowledge {
             } => {
                 let mut input_knowledge = ColumnKnowledge::harvest(input, knowledge)?;
                 for expr in exprs {
-                    optimize(expr, &input.typ(), &input_knowledge[..])?;
+                    optimize(expr, &input.typ(), &input_knowledge[..]);
                 }
                 let func_typ = func.output_type();
                 input_knowledge.extend(func_typ.column_types.iter().map(DatumKnowledge::from));
@@ -110,7 +110,7 @@ impl ColumnKnowledge {
             MirRelationExpr::Filter { input, predicates } => {
                 let mut input_knowledge = ColumnKnowledge::harvest(input, knowledge)?;
                 for predicate in predicates.iter_mut() {
-                    optimize(predicate, &input.typ(), &input_knowledge[..])?;
+                    optimize(predicate, &input.typ(), &input_knowledge[..]);
                 }
                 // If any predicate tests a column for equality, truth, or is_null, we learn stuff.
                 for predicate in predicates.iter() {
@@ -199,11 +199,11 @@ impl ColumnKnowledge {
                 let mut output = group_key
                     .iter_mut()
                     .map(|k| optimize(k, &input.typ(), &input_knowledge[..]))
-                    .collect::<Result<Vec<_>, _>>()?;
+                    .collect::<Vec<_>>();
                 for aggregate in aggregates.iter_mut() {
                     use expr::AggregateFunc;
                     let knowledge =
-                        optimize(&mut aggregate.expr, &input.typ(), &input_knowledge[..])?;
+                        optimize(&mut aggregate.expr, &input.typ(), &input_knowledge[..]);
                     // This could be improved.
                     let knowledge = match aggregate.func {
                         AggregateFunc::MaxInt32
@@ -272,7 +272,7 @@ impl ColumnKnowledge {
 #[derive(Clone, Debug)]
 pub struct DatumKnowledge {
     /// If set, a specific value for the column.
-    value: Option<(repr::Row, ColumnType)>,
+    value: Option<(Result<repr::Row, EvalError>, ColumnType)>,
     /// If false, the value is not `Datum::Null`.
     nullable: bool,
 }
@@ -298,7 +298,7 @@ impl Default for DatumKnowledge {
 
 impl From<&MirScalarExpr> for DatumKnowledge {
     fn from(expr: &MirScalarExpr) -> Self {
-        if let MirScalarExpr::Literal(Ok(l), t) = expr {
+        if let MirScalarExpr::Literal(l, t) = expr {
             Self {
                 value: Some((l.clone(), t.clone())),
                 nullable: expr.is_literal_null(),
@@ -323,37 +323,34 @@ pub fn optimize(
     expr: &mut MirScalarExpr,
     input_type: &RelationType,
     column_knowledge: &[DatumKnowledge],
-) -> Result<DatumKnowledge, crate::TransformError> {
-    Ok(match expr {
+) -> DatumKnowledge {
+    match expr {
         MirScalarExpr::Column(index) => {
             let index = *index;
             if let Some((datum, typ)) = &column_knowledge[index].value {
-                *expr = MirScalarExpr::Literal(Ok(datum.clone()), typ.clone());
+                *expr = MirScalarExpr::Literal(datum.clone(), typ.clone());
             }
             column_knowledge[index].clone()
         }
-        MirScalarExpr::Literal(res, typ) => {
-            let row = match res {
-                Ok(row) => row,
-                Err(err) => return Err(err.clone().into()),
-            };
-            DatumKnowledge {
-                value: Some((row.clone(), typ.clone())),
-                nullable: row.unpack_first() == Datum::Null,
-            }
-        }
+        MirScalarExpr::Literal(row, typ) => DatumKnowledge {
+            value: Some((row.clone(), typ.clone())),
+            nullable: match row {
+                Ok(row) => row.unpack_first() == Datum::Null,
+                Err(_) => false,
+            },
+        },
         MirScalarExpr::CallNullary(_) => {
             expr.reduce(input_type);
-            optimize(expr, input_type, column_knowledge)?
+            optimize(expr, input_type, column_knowledge)
         }
         MirScalarExpr::CallUnary { func, expr: inner } => {
-            let knowledge = optimize(inner, input_type, column_knowledge)?;
+            let knowledge = optimize(inner, input_type, column_knowledge);
             if knowledge.value.is_some() {
                 expr.reduce(input_type);
-                optimize(expr, input_type, column_knowledge)?
+                optimize(expr, input_type, column_knowledge)
             } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
                 *expr = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
-                optimize(expr, input_type, column_knowledge)?
+                optimize(expr, input_type, column_knowledge)
             } else {
                 DatumKnowledge::default()
             }
@@ -363,11 +360,11 @@ pub fn optimize(
             expr1,
             expr2,
         } => {
-            let knowledge1 = optimize(expr1, input_type, column_knowledge)?;
-            let knowledge2 = optimize(expr2, input_type, column_knowledge)?;
+            let knowledge1 = optimize(expr1, input_type, column_knowledge);
+            let knowledge2 = optimize(expr2, input_type, column_knowledge);
             if knowledge1.value.is_some() && knowledge2.value.is_some() {
                 expr.reduce(input_type);
-                optimize(expr, input_type, column_knowledge)?
+                optimize(expr, input_type, column_knowledge)
             } else {
                 DatumKnowledge::default()
             }
@@ -375,27 +372,27 @@ pub fn optimize(
         MirScalarExpr::CallVariadic { func: _, exprs } => {
             let mut knows = Vec::new();
             for expr in exprs.iter_mut() {
-                knows.push(optimize(expr, input_type, column_knowledge)?);
+                knows.push(optimize(expr, input_type, column_knowledge));
             }
 
             if knows.iter().all(|k| k.value.is_some()) {
                 expr.reduce(input_type);
-                optimize(expr, input_type, column_knowledge)?
+                optimize(expr, input_type, column_knowledge)
             } else {
                 DatumKnowledge::default()
             }
         }
         MirScalarExpr::If { cond, then, els } => {
-            if let Some((value, _typ)) = optimize(cond, input_type, column_knowledge)?.value {
+            if let Some((Ok(value), _typ)) = optimize(cond, input_type, column_knowledge).value {
                 match value.unpack_first() {
                     Datum::True => *expr = (**then).clone(),
                     Datum::False | Datum::Null => *expr = (**els).clone(),
                     d => panic!("IF condition evaluated to non-boolean datum {:?}", d),
                 }
-                optimize(expr, input_type, column_knowledge)?
+                optimize(expr, input_type, column_knowledge)
             } else {
                 DatumKnowledge::default()
             }
         }
-    })
+    }
 }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -52,11 +52,9 @@ impl ColumnKnowledge {
                 .cloned()
                 .unwrap_or_else(|| typ.column_types.iter().map(DatumKnowledge::from).collect()),
             MirRelationExpr::Constant { rows, typ } => {
-                if rows.len() == 1 {
+                if let Ok([(row, _diff)]) = rows.as_deref() {
                     let mut row_packer = repr::RowPacker::new();
-                    rows[0]
-                        .0
-                        .iter()
+                    row.iter()
                         .zip(typ.column_types.iter())
                         .map(|(datum, typ)| DatumKnowledge {
                             value: Some((Ok(row_packer.pack(Some(datum.clone()))), typ.clone())),

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -320,7 +320,9 @@ pub mod monotonic {
                 }
                 monotonic
             }
-            MirRelationExpr::Constant { rows, .. } => rows.iter().all(|(_, diff)| diff > &0),
+            MirRelationExpr::Constant { rows: Ok(rows), .. } => {
+                rows.iter().all(|(_, diff)| diff > &0)
+            }
             MirRelationExpr::Threshold { input } => is_monotonic(input, sources),
             // Let and Negate remain
             _ => {

--- a/src/transform/src/join_elision.rs
+++ b/src/transform/src/join_elision.rs
@@ -45,7 +45,11 @@ impl JoinElision {
         } = relation
         {
             inputs.retain(|input| {
-                if let MirRelationExpr::Constant { rows, typ } = &input {
+                if let MirRelationExpr::Constant {
+                    rows: Ok(rows),
+                    typ,
+                } = &input
+                {
                     !(rows.len() == 1 && typ.column_types.len() == 0 && rows[0].1 == 1)
                 } else {
                     true

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -27,7 +27,7 @@ use std::fmt;
 
 use expr::MirRelationExpr;
 use expr::MirScalarExpr;
-use expr::{EvalError, GlobalId, IdGen};
+use expr::{GlobalId, IdGen};
 
 pub mod column_knowledge;
 pub mod cse;
@@ -84,8 +84,6 @@ pub trait Transform: std::fmt::Debug {
 /// Errors that can occur during a transformation.
 #[derive(Debug, Clone)]
 pub enum TransformError {
-    /// An error resulting from evaluation of a `ScalarExpr`.
-    Eval(EvalError),
     /// An unstructured error.
     Internal(String),
 }
@@ -93,19 +91,12 @@ pub enum TransformError {
 impl fmt::Display for TransformError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            TransformError::Eval(e) => write!(f, "{}", e),
             TransformError::Internal(msg) => write!(f, "internal transform error: {}", msg),
         }
     }
 }
 
 impl Error for TransformError {}
-
-impl From<EvalError> for TransformError {
-    fn from(e: EvalError) -> TransformError {
-        TransformError::Eval(e)
-    }
-}
 
 /// A sequence of transformations iterated some number of times.
 #[derive(Debug)]

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -98,8 +98,9 @@ impl LiteralLifting {
                         typ.keys.dedup();
 
                         let mut row_packer = repr::RowPacker::new();
+                        *row = row_packer.pack(row.iter().take(typ.arity()));
                         for (row, _cnt) in rows.iter_mut() {
-                            *row = row_packer.pack(row.unpack().into_iter().take(typ.arity()));
+                            *row = row_packer.pack(row.iter().take(typ.arity()));
                         }
                     }
                     literals

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -70,10 +70,10 @@ impl LiteralLifting {
                 // From the back to the front, check if all values are identical.
                 // TODO(frank): any subset of constant values can be extracted with a permute.
                 let mut the_same = vec![true; typ.arity()];
-                if let Some((row, _cnt)) = rows.first() {
+                if let Ok([(row, _cnt), rows @ ..]) = rows.as_deref_mut() {
                     let mut data = row.unpack();
                     assert_eq!(the_same.len(), data.len());
-                    for (row, _cnt) in rows[1..].iter() {
+                    for (row, _cnt) in rows.iter() {
                         let other = row.unpack();
                         assert_eq!(the_same.len(), other.len());
                         for index in 0..the_same.len() {

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -51,10 +51,14 @@ impl NonNullRequirements {
         gets: &mut HashMap<Id, Vec<HashSet<usize>>>,
     ) {
         match relation {
-            MirRelationExpr::Constant { rows, .. } => rows.retain(|(row, _)| {
-                let datums = row.unpack();
-                columns.iter().all(|c| datums[*c] != repr::Datum::Null)
-            }),
+            MirRelationExpr::Constant { rows, .. } => {
+                if let Ok(rows) = rows {
+                    rows.retain(|(row, _)| {
+                        let datums = row.unpack();
+                        columns.iter().all(|c| datums[*c] != repr::Datum::Null)
+                    })
+                }
+            }
             MirRelationExpr::Get { id, .. } => {
                 gets.entry(*id).or_insert_with(Vec::new).push(columns);
             }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -31,7 +31,6 @@ impl crate::Transform for FoldConstants {
         relation: &mut MirRelationExpr,
         _: TransformArgs,
     ) -> Result<(), TransformError> {
-        println!("{:#?}", relation);
         relation.try_visit_mut(&mut |e| self.action(e))
     }
 }

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -350,7 +350,7 @@ mod tests {
                     .collect::<Vec<(Row, isize)>>();
 
                 Ok(MirRelationExpr::Constant {
-                    rows,
+                    rows: Ok(rows),
                     typ: parse_type_list(nth(&s, 2)?)?,
                 })
             }

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -27,7 +27,7 @@ RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # There are two transactions here, the first (explicit) succeeds and
@@ -45,7 +45,7 @@ DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 CommandComplete {"tag":"COMMIT"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # The transaction fails, so statements after it should not be executed,
@@ -61,7 +61,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -122,7 +122,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"E"}
 ErrorResponse {"fields":[{"typ":"M","value":"current transaction is aborted, commands ignored until end of transaction block"}]}
 ReadyForQuery {"status":"E"}
@@ -175,7 +175,7 @@ until err_field_typs=M
 ReadyForQuery
 ----
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # Test DISCARD ALL, which "cannot be executed inside a transaction
@@ -311,7 +311,7 @@ DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # A ROLLBACK must be the first message in a new extended session.
@@ -360,7 +360,7 @@ DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
 ReadyForQuery {"status":"E"}
 ErrorResponse {"fields":[{"typ":"M","value":"current transaction is aborted, commands ignored until end of transaction block"}]}
 ReadyForQuery {"status":"E"}

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -27,7 +27,7 @@ RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # There are two transactions here, the first (explicit) succeeds and
@@ -45,7 +45,7 @@ DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 CommandComplete {"tag":"COMMIT"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # The transaction fails, so statements after it should not be executed,
@@ -61,7 +61,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"E"}
 CommandComplete {"tag":"ROLLBACK"}
 ReadyForQuery {"status":"I"}
@@ -122,7 +122,7 @@ ReadyForQuery
 ----
 CommandComplete {"tag":"BEGIN"}
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"E"}
 ErrorResponse {"fields":[{"typ":"M","value":"current transaction is aborted, commands ignored until end of transaction block"}]}
 ReadyForQuery {"status":"E"}
@@ -175,7 +175,7 @@ until err_field_typs=M
 ReadyForQuery
 ----
 RowDescription {"fields":[{"name":"?column?"}]}
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # Test DISCARD ALL, which "cannot be executed inside a transaction
@@ -311,7 +311,7 @@ DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"I"}
 
 # A ROLLBACK must be the first message in a new extended session.
@@ -360,7 +360,7 @@ DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ParseComplete
 BindComplete
-ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ErrorResponse {"fields":[{"typ":"M","value":"Evaluation error: division by zero"}]}
 ReadyForQuery {"status":"E"}
 ErrorResponse {"fields":[{"typ":"M","value":"current transaction is aborted, commands ignored until end of transaction block"}]}
 ReadyForQuery {"status":"E"}


### PR DESCRIPTION
@frankmcsherry this panics for some reason that I haven't tracked down, but I think the approach is fundamentally sound. Putting this up as a PR now because I won't have time to track down this panic for a bit.

----

Allow RelationExpr::Constant to represent constant errors. This makes it
possible for the optimizer to stuff any errors it generates during
constant folding back into the RelationExpr so that those errors occur
during execution of the query rather than during optimization.

This unblocks an issue uncovered in #5651.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5669)
<!-- Reviewable:end -->
