### PR TITLE
keep the consistency topic as a single partition

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,8 +48,8 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.7.1 %}}
 
-- Support [multi-partition](/sql/create-sink/#with-options) kafka sinks {{% gh 5537 %}}.
-- Support [gzip-compressed](/sql/create-source/text-file/#compression) file sources {{% gh 5392 %}}.
+- Multipartition Kafka sinks with consistency enabled will create single-partition
+  consistency topics.
 
 {{% version-header v0.7.0 %}}
 
@@ -85,6 +85,10 @@ Wrap your release notes at the 80 character mark.
   authentication in a later release.
 
 - Functions can now be resolved as schema-qualified objects, e.g. `SELECT pg_catalog.abs(-1);`.
+
+- Support [multi-partition](/sql/create-sink/#with-options) Kafka sinks {{% gh 5537 %}}.
+
+- Support [gzip-compressed](/sql/create-source/text-file/#compression) file sources {{% gh 5392 %}}.
 
 {{% version-header v0.6.1 %}}
 

--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -127,7 +127,7 @@ async fn build_kafka(
         let (_, consistency_schema_id) = register_kafka_topic(
             &client,
             &consistency_topic,
-            builder.partition_count,
+            1,
             builder.replication_factor,
             &ccsr,
             &consistency_value_schema,


### PR DESCRIPTION
Consuming a multipartition consistency topic is tricky. Consistency
topics represent a single stream of data, but when partitioned they
don't contain enough info for you to recreate that stream unless you
read it in lockstep with the data topic.

For now, keep consistency topics as a single partition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5672)
<!-- Reviewable:end -->
