### PR TITLE
materialized: attempt backtraces on SIGBUS too

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -213,7 +213,7 @@ fn main() {
 
 fn run(args: Args) -> Result<(), anyhow::Error> {
     panic::set_hook(Box::new(handle_panic));
-    sys::enable_sigsegv_backtraces()?;
+    sys::enable_sigbus_sigsegv_backtraces()?;
 
     if args.version > 0 {
         println!("materialized {}", materialized::BUILD_INFO.human_version());


### PR DESCRIPTION
Memory errors may present as SIGBUS in addition to SIGSEGV. Configure
our backtrace-on-SIGSEGV code to handle SIGBUS too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5673)
<!-- Reviewable:end -->
