### PR TITLE
doc/user: fix documentation of our TLS preset

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -186,12 +186,12 @@ OpenSSL 1.1.1g  21 Apr 2020
 librdkafka v1.4.2
 ```
 
-Materialize configures OpenSSL according to Mozilla's [Modern
-compatibility][moz-modern] level, which requires TLS v1.3 and modern cipher
-suites. Using weaker cipher suites or older TLS protocol versions is not
+Materialize configures OpenSSL according to Mozilla's [Intermediate
+compatibility][moz-intermediate] level, which requires TLS v1.2+ and recent
+cipher suites. Using weaker cipher suites or older TLS protocol versions is not
 supported.
 
-[moz-modern]: https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+[moz-intermediate]: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 
 #### Generating TLS certificates
 

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -149,6 +149,12 @@ pub struct TlsConfig {
 
 impl TlsConfig {
     fn validate(&self) -> Result<SslContext, anyhow::Error> {
+        // Mozilla publishes three presets: old, intermediate, and modern. They
+        // recommend the intermediate preset for general purpose servers, which
+        // is what we use, as it is compatible with nearly every client released
+        // in the last five years but does not include any known-problematic
+        // ciphers. We once tried to use the modern preset, but it was
+        // incompatible with Fivetran, and presumably other JDBC-based tools.
         let mut builder = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls())?;
         builder.set_certificate_file(&self.cert, SslFiletype::PEM)?;
         builder.set_private_key_file(&self.key, SslFiletype::PEM)?;


### PR DESCRIPTION
Since #5279 we've used the intermediate TLS preset rather than the
modern TLS preset, but I forgot to update the user docs accordingly.
Also drop a note about why we use the intermediate preset into the code,
per @mjibson's request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5685)
<!-- Reviewable:end -->
