### PR TITLE
dataflow: change assignment of source instance readers to dataflow wo…

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -298,11 +298,13 @@ where
                 };
 
                 // All workers are responsible for reading in Kafka sources. Other sources
-                // support single-threaded ingestion only
+                // support single-threaded ingestion only. Note that in all cases we want all
+                // readers of the same source or same partition to reside on the same worker,
+                // and only load-balance responsibility across distinct sources.
                 let active_read_worker = if let ExternalSourceConnector::Kafka(_) = connector {
                     true
                 } else {
-                    (usize::cast_from(uid.hashed()) % scope.peers()) == scope.index()
+                    (usize::cast_from(src_id.hashed()) % scope.peers()) == scope.index()
                 };
 
                 let caching_tx = if let (true, Some(caching_tx)) =


### PR DESCRIPTION
…rkers

Closes #5088. Touches #2915.

Previously, all source readers for non-Kafka sources were randomly distributed
across dataflow workers. So for example, if you had two instances of the same
file source, those could be assigned to different dataflow workers to be read
from. On the other side, Kafka sources had their read responsibilities distributed
only by partition. So, if you had two _different_ Kafka sources, both of their
partition 0's would be ingested by the same dataflow worker.

This commit changes that behavior and makes it so that:
- Active source / partition reading workers are the same for all instances of the
  same source. This is important for future work in unifying timestamping across
  source instances.
- For Kafka sources, reading responsibility is now distributed based on a hash
  of the source id + the partition id. This way, different partitions of the same
  source are still spread across many workers, but partition 0 doesn't get
  deterministically bound to worker 0 for all Kafka sources (note that since its
  based on a hash of the source id) partition 0 is still bound to the same worker
  for all instances of a given Kafka source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5691)
<!-- Reviewable:end -->
