### PR TITLE
Enable configuring the views exposed by wikirecent-app

### DIFF
--- a/play/wikirecent/app/Dockerfile
+++ b/play/wikirecent/app/Dockerfile
@@ -22,4 +22,4 @@ COPY src /app
 COPY utils /usr/local/bin
 
 WORKDIR /app
-CMD python3 serve.py
+ENTRYPOINT ["python3", "serve.py"]

--- a/play/wikirecent/app/src/serve.py
+++ b/play/wikirecent/app/src/serve.py
@@ -27,6 +27,7 @@ This file is written in a bottom-up structure. The code flows as follows:
   internal copy of the view that can be used to initialize state for new listeners.
 """
 
+import argparse
 import collections
 import logging
 import os
@@ -217,7 +218,7 @@ def configure_logging():
     )
 
 
-def run():
+def run(dsn, views):
     """Create the Wikirecent Tornado Application.
 
     Create a Tornado application configured with our HTTP / Websocket handlers and start listening
@@ -239,8 +240,8 @@ def run():
         static_path=static_path,
         template_path=template_path,
         debug=True,
-        configured_views=["counter", "top10"],
-        dsn="postgresql://materialize@materialized:6875/materialize",
+        configured_views=views,
+        dsn=dsn,
     )
 
     port = 8875
@@ -255,4 +256,28 @@ def run():
 
 
 if __name__ == "__main__":
-    run()
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--dbhost", help="materialized hostname", default="materialized", type=str
+    )
+    parser.add_argument(
+        "--dbname", help="materialized database name", default="materialize", type=str
+    )
+    parser.add_argument(
+        "--dbport", help="materialized port number", default=6875, type=int
+    )
+    parser.add_argument(
+        "--dbuser", help="materialized username", default="materialize", type=str
+    )
+
+    parser.add_argument(
+        "views", type=str, nargs="+", help="Views to expose as websockets"
+    )
+
+    args = parser.parse_args()
+
+    dsn = f"postgresql://{args.dbuser}@{args.dbhost}:{args.dbport}/{args.dbname}"
+
+    run(dsn, args.views)

--- a/play/wikirecent/create_views/create_views
+++ b/play/wikirecent/create_views/create_views
@@ -8,4 +8,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-psql -h materialized -p 6875 -f /data/views.sql materialize
+psql -U materialize -h materialized -p 6875 -f /data/views.sql materialize

--- a/play/wikirecent/mzcompose.yml
+++ b/play/wikirecent/mzcompose.yml
@@ -15,6 +15,10 @@ version: '3.7'
 services:
   app:
     mzbuild: wikirecent-app
+    command: >-
+      --dbport ${MZ_PORT:-6875}
+      top10
+      counter
     ports:
       - *app
   create-views:


### PR DESCRIPTION
This allows for the wikirecent-app image to be used as a generic `TAIL`
to websocket bridge. If there's interest, we can pull the generic parts
out into a completely generic image (this one still serves some HTML for
the wikirecent demo).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5694)
<!-- Reviewable:end -->
