### PR TITLE
sql: fix PartialName's impl of PartialEq

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -85,15 +85,17 @@ impl From<FullName> for ObjectName {
 }
 
 /// A partial name of an item in the catalog.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct PartialName {
     pub database: Option<String>,
     pub schema: Option<String>,
     pub item: String,
 }
 
-impl PartialEq for PartialName {
-    fn eq(&self, other: &Self) -> bool {
+impl PartialName {
+    // Whether either self or other might be a (possibly differently qualified)
+    // version of the other.
+    pub fn matches(&self, other: &Self) -> bool {
         match (&self.database, &other.database) {
             (Some(d1), Some(d2)) if d1 != d2 => return false,
             _ => (),


### PR DESCRIPTION
The existing implementation of PartialName::PartialEq was
non-transitive, so I moved that logic into a method named `matches` and
derived PartialEq instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5695)
<!-- Reviewable:end -->
