### PR TITLE
sql: rename ObjectName and AstInfo associated type

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -24,7 +24,7 @@
 use std::path::PathBuf;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{AstInfo, DataType, Expr, Ident, ObjectName, SqlOption};
+use crate::ast::{AstInfo, DataType, Expr, Ident, SqlOption, UnresolvedObjectName};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Schema {
@@ -359,7 +359,7 @@ pub enum TableConstraint<T: AstInfo> {
     ForeignKey {
         name: Option<Ident>,
         columns: Vec<Ident>,
-        foreign_table: ObjectName,
+        foreign_table: UnresolvedObjectName,
         referred_columns: Vec<Ident>,
     },
     /// `[ CONSTRAINT <name> ] CHECK (<expr>)`
@@ -418,7 +418,7 @@ impl_display_t!(TableConstraint);
 pub struct ColumnDef<T: AstInfo> {
     pub name: Ident,
     pub data_type: DataType,
-    pub collation: Option<ObjectName>,
+    pub collation: Option<UnresolvedObjectName>,
     pub options: Vec<ColumnOptionDef<T>>,
 }
 
@@ -482,7 +482,7 @@ pub enum ColumnOption<T: AstInfo> {
     /// A referential integrity constraint (`[FOREIGN KEY REFERENCES
     /// <foreign_table> (<referred_columns>)`).
     ForeignKey {
-        foreign_table: ObjectName,
+        foreign_table: UnresolvedObjectName,
         referred_columns: Vec<Ident>,
     },
     // `CHECK (<expr>)`

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -21,7 +21,7 @@
 use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{AstInfo, DataType, Ident, ObjectName, OrderByExpr, Query, Value};
+use crate::ast::{AstInfo, DataType, Ident, OrderByExpr, Query, UnresolvedObjectName, Value};
 
 /// An SQL expression of any type.
 ///
@@ -92,7 +92,7 @@ pub enum Expr<T: AstInfo> {
     /// `expr COLLATE collation`
     Collate {
         expr: Box<Expr<T>>,
-        collation: ObjectName,
+        collation: UnresolvedObjectName,
     },
     /// COALESCE(<expr>, ...)
     ///
@@ -516,7 +516,7 @@ impl<T: AstInfo> Expr<T> {
 
     pub fn call(name: Vec<&str>, args: Vec<Expr<T>>) -> Expr<T> {
         Expr::Function(Function {
-            name: ObjectName(name.into_iter().map(Into::into).collect()),
+            name: UnresolvedObjectName(name.into_iter().map(Into::into).collect()),
             args: FunctionArgs::Args(args),
             filter: None,
             over: None,
@@ -664,7 +664,7 @@ impl_display!(WindowFrameBound);
 /// A function call
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Function<T: AstInfo> {
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     pub args: FunctionArgs<T>,
     // aggregate functions may specify e.g. `COUNT(DISTINCT X) FILTER (WHERE ...)`
     pub filter: Option<Box<Expr<T>>>,

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -95,38 +95,38 @@ impl_display!(Ident);
 
 /// A name of a table, view, custom type, etc., possibly multi-part, i.e. db.schema.obj
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ObjectName(pub Vec<Ident>);
+pub struct UnresolvedObjectName(pub Vec<Ident>);
 
 pub enum CatalogName {
     ObjectName(Vec<Ident>),
     FuncName(Vec<Ident>),
 }
 
-impl ObjectName {
+impl UnresolvedObjectName {
     /// Creates an `ObjectName` with a single [`Ident`], i.e. it appears as
     /// "unqualified".
-    pub fn unqualified(n: &str) -> ObjectName {
-        ObjectName(vec![Ident::new(n)])
+    pub fn unqualified(n: &str) -> UnresolvedObjectName {
+        UnresolvedObjectName(vec![Ident::new(n)])
     }
 
     /// Creates an `ObjectName` with an [`Ident`] for each element of `n`.
     ///
     /// Panics if passed an in ineligible `&[&str]` whose length is 0 or greater
     /// than 3.
-    pub fn qualified(n: &[&str]) -> ObjectName {
+    pub fn qualified(n: &[&str]) -> UnresolvedObjectName {
         assert!(n.len() <= 3 && n.len() > 0);
-        ObjectName(n.iter().map(|n| (*n).into()).collect::<Vec<_>>())
+        UnresolvedObjectName(n.iter().map(|n| (*n).into()).collect::<Vec<_>>())
     }
 }
 
-impl AstDisplay for ObjectName {
+impl AstDisplay for UnresolvedObjectName {
     fn fmt(&self, f: &mut AstFormatter) {
         display::separated(&self.0, ".").fmt(f);
     }
 }
-impl_display!(ObjectName);
+impl_display!(UnresolvedObjectName);
 
-impl AstDisplay for &ObjectName {
+impl AstDisplay for &UnresolvedObjectName {
     fn fmt(&self, f: &mut AstFormatter) {
         display::separated(&self.0, ".").fmt(f);
     }

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -24,7 +24,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{Expr, FunctionArgs, Ident, ObjectName, SqlOption};
+use crate::ast::{Expr, FunctionArgs, Ident, SqlOption, UnresolvedObjectName};
 
 // This represents the metadata that lives next to an AST, as we take it through
 // various stages in the planning process.
@@ -42,8 +42,8 @@ use crate::ast::{Expr, FunctionArgs, Ident, ObjectName, SqlOption};
 // Currently this process brings an Ast<Raw> to Ast<Aug>, and lives in
 // sql/src/plan/query.rs:resolve_names.
 pub trait AstInfo: Clone {
-    // The type used for table references.
-    type Table: AstDisplay + Clone + Hash + Debug + Eq;
+    // The type used for catalog item references.
+    type ObjectName: AstDisplay + Clone + Hash + Debug + Eq;
     // The type stored next to CTEs for their assigned ID.
     type Id: Clone + Hash + Debug + Eq;
 }
@@ -72,7 +72,7 @@ impl AstDisplay for RawName {
 impl_display!(RawName);
 
 impl AstInfo for Raw {
-    type Table = RawName;
+    type ObjectName = RawName;
     type Id = ();
 }
 
@@ -396,11 +396,11 @@ impl<T: AstInfo> TableWithJoins<T> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TableFactor<T: AstInfo> {
     Table {
-        name: T::Table,
+        name: T::ObjectName,
         alias: Option<TableAlias>,
     },
     Function {
-        name: ObjectName,
+        name: UnresolvedObjectName,
         args: FunctionArgs<T>,
         alias: Option<TableAlias>,
     },

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -20,8 +20,8 @@
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    AstInfo, ColumnDef, Connector, DataType, Envelope, Expr, Format, Ident, ObjectName, Query,
-    TableConstraint, Value,
+    AstInfo, ColumnDef, Connector, DataType, Envelope, Expr, Format, Ident, Query, TableConstraint,
+    UnresolvedObjectName, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -145,7 +145,7 @@ impl_display_t!(SelectStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InsertStatement<T: AstInfo> {
     /// TABLE
-    pub table_name: ObjectName,
+    pub table_name: UnresolvedObjectName,
     /// COLUMNS
     pub columns: Vec<Ident>,
     /// A SQL query that specifies what to insert.
@@ -170,7 +170,7 @@ impl_display_t!(InsertStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CopyRelation<T: AstInfo> {
     Table {
-        name: ObjectName,
+        name: UnresolvedObjectName,
         columns: Vec<Ident>,
     },
     Select(SelectStatement<T>),
@@ -262,7 +262,7 @@ impl_display_t!(CopyStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UpdateStatement<T: AstInfo> {
     /// TABLE
-    pub table_name: ObjectName,
+    pub table_name: UnresolvedObjectName,
     /// Column assignments
     pub assignments: Vec<Assignment<T>>,
     /// WHERE
@@ -289,7 +289,7 @@ impl_display_t!(UpdateStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DeleteStatement<T: AstInfo> {
     /// `FROM`
-    pub table_name: ObjectName,
+    pub table_name: UnresolvedObjectName,
     /// `WHERE`
     pub selection: Option<Expr<T>>,
 }
@@ -327,7 +327,7 @@ impl_display!(CreateDatabaseStatement);
 /// `CREATE SCHEMA`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSchemaStatement {
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     pub if_not_exists: bool,
 }
 
@@ -345,7 +345,7 @@ impl_display!(CreateSchemaStatement);
 /// `CREATE SOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSourceStatement {
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
     pub connector: Connector,
     pub with_options: Vec<SqlOption>,
@@ -394,8 +394,8 @@ impl_display!(CreateSourceStatement);
 /// `CREATE SINK`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSinkStatement<T: AstInfo> {
-    pub name: ObjectName,
-    pub from: ObjectName,
+    pub name: UnresolvedObjectName,
+    pub from: UnresolvedObjectName,
     pub connector: Connector,
     pub with_options: Vec<SqlOption>,
     pub format: Option<Format>,
@@ -447,7 +447,7 @@ impl_display_t!(CreateSinkStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateViewStatement<T: AstInfo> {
     /// View name
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     pub columns: Vec<Ident>,
     pub with_options: Vec<SqlOption>,
     pub query: Query<T>,
@@ -500,7 +500,7 @@ impl_display_t!(CreateViewStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateTableStatement<T: AstInfo> {
     /// Table name
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     /// Optional schema
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
@@ -543,7 +543,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     /// Optional index name.
     pub name: Option<Ident>,
     /// `ON` table or view name
-    pub on_name: ObjectName,
+    pub on_name: UnresolvedObjectName,
     /// Expressions that form part of the index key. If not included, the
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
@@ -632,7 +632,7 @@ impl_display!(CreateRoleOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateTypeStatement {
     /// Name of the created type.
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     /// The new type's "base type".
     pub as_type: CreateTypeAs,
     /// Provides the name and type for the key
@@ -677,7 +677,7 @@ impl_display!(CreateTypeAs);
 pub struct AlterObjectRenameStatement {
     pub object_type: ObjectType,
     pub if_exists: bool,
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     pub to_item_name: Ident,
 }
 
@@ -705,7 +705,7 @@ pub enum AlterIndexOptionsList {
 /// `ALTER INDEX ... {RESET, SET}`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterIndexOptionsStatement {
-    pub index_name: ObjectName,
+    pub index_name: UnresolvedObjectName,
     pub if_exists: bool,
     pub options: AlterIndexOptionsList,
 }
@@ -794,7 +794,7 @@ pub struct DropObjectsStatement {
     /// An optional `IF EXISTS` clause. (Non-standard.)
     pub if_exists: bool,
     /// One or more objects to drop. (ANSI SQL requires exactly one.)
-    pub names: Vec<ObjectName>,
+    pub names: Vec<UnresolvedObjectName>,
     /// Whether `CASCADE` was specified. This will be `false` when
     /// `RESTRICT` or no drop behavior at all was specified.
     pub cascade: bool,
@@ -883,7 +883,7 @@ impl_display_t!(ShowDatabasesStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowObjectsStatement<T: AstInfo> {
     pub object_type: ObjectType,
-    pub from: Option<ObjectName>,
+    pub from: Option<UnresolvedObjectName>,
     pub extended: bool,
     pub full: bool,
     pub materialized: bool,
@@ -929,7 +929,7 @@ impl_display_t!(ShowObjectsStatement);
 /// `SHOW INDEX|INDEXES|KEYS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowIndexesStatement<T: AstInfo> {
-    pub table_name: ObjectName,
+    pub table_name: UnresolvedObjectName,
     pub extended: bool,
     pub filter: Option<ShowStatementFilter<T>>,
 }
@@ -957,7 +957,7 @@ impl_display_t!(ShowIndexesStatement);
 pub struct ShowColumnsStatement<T: AstInfo> {
     pub extended: bool,
     pub full: bool,
-    pub table_name: ObjectName,
+    pub table_name: UnresolvedObjectName,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
@@ -983,7 +983,7 @@ impl_display_t!(ShowColumnsStatement);
 /// `SHOW CREATE VIEW <view>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowCreateViewStatement {
-    pub view_name: ObjectName,
+    pub view_name: UnresolvedObjectName,
 }
 
 impl AstDisplay for ShowCreateViewStatement {
@@ -997,7 +997,7 @@ impl_display!(ShowCreateViewStatement);
 /// `SHOW CREATE SOURCE <source>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowCreateSourceStatement {
-    pub source_name: ObjectName,
+    pub source_name: UnresolvedObjectName,
 }
 
 impl AstDisplay for ShowCreateSourceStatement {
@@ -1011,7 +1011,7 @@ impl_display!(ShowCreateSourceStatement);
 /// `SHOW CREATE TABLE <table>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowCreateTableStatement {
-    pub table_name: ObjectName,
+    pub table_name: UnresolvedObjectName,
 }
 
 impl AstDisplay for ShowCreateTableStatement {
@@ -1025,7 +1025,7 @@ impl_display!(ShowCreateTableStatement);
 /// `SHOW CREATE SINK <sink>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowCreateSinkStatement {
-    pub sink_name: ObjectName,
+    pub sink_name: UnresolvedObjectName,
 }
 
 impl AstDisplay for ShowCreateSinkStatement {
@@ -1039,7 +1039,7 @@ impl_display!(ShowCreateSinkStatement);
 /// `SHOW CREATE INDEX <index>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowCreateIndexStatement {
-    pub index_name: ObjectName,
+    pub index_name: UnresolvedObjectName,
 }
 
 impl AstDisplay for ShowCreateIndexStatement {
@@ -1119,7 +1119,7 @@ impl_display!(RollbackStatement);
 /// `TAIL`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TailStatement<T: AstInfo> {
-    pub name: ObjectName,
+    pub name: UnresolvedObjectName,
     pub options: Vec<WithOption>,
     pub as_of: Option<Expr<T>>,
 }
@@ -1240,7 +1240,7 @@ pub enum SqlOption {
     },
     ObjectName {
         name: Ident,
-        object_name: ObjectName,
+        object_name: UnresolvedObjectName,
     },
     DataType {
         name: Ident,
@@ -1301,7 +1301,7 @@ impl_display!(WithOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum WithOptionValue {
     Value(Value),
-    ObjectName(ObjectName),
+    ObjectName(UnresolvedObjectName),
 }
 
 impl AstDisplay for WithOptionValue {
@@ -1429,7 +1429,7 @@ impl_display!(ExplainStage);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Explainee<T: AstInfo> {
-    View(ObjectName),
+    View(UnresolvedObjectName),
     Query(Query<T>),
 }
 

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use repr::adt::datetime::DateTimeField;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::ObjectName;
+use crate::ast::UnresolvedObjectName;
 
 #[derive(Debug)]
 pub struct ValueError(pub(crate) String);
@@ -188,7 +188,7 @@ pub enum DataType {
     },
     /// Types who don't embed other types, e.g. INT
     Other {
-        name: ObjectName,
+        name: UnresolvedObjectName,
         /// Typ modifiers appended to the type name, e.g. `numeric(38,0)`.
         typ_mod: Vec<u64>,
     },

--- a/src/sql-parser/src/ast/visit.rs
+++ b/src/sql-parser/src/ast/visit.rs
@@ -117,7 +117,7 @@
 //!         self.idents.push(node);
 //!         visit::visit_ident(self, node);
 //!     }
-//!     fn visit_table(&mut self, name: &'ast <Raw as AstInfo>::Table) {
+//!     fn visit_object_name(&mut self, name: &'ast <Raw as AstInfo>::ObjectName) {
 //!         match name {
 //!             RawName::Name(n) | RawName::Id(_, n) => {
 //!                 for node in &n.0 {

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -178,7 +178,7 @@ fn test_basic_visitor() -> Result<(), Box<dyn Error>> {
         fn visit_ident(&mut self, ident: &'a Ident) {
             self.seen_idents.push(ident.as_str());
         }
-        fn visit_table(&mut self, name: &'a <Raw as AstInfo>::Table) {
+        fn visit_object_name(&mut self, name: &'a <Raw as AstInfo>::ObjectName) {
             if let RawName::Name(name) = name {
                 for ident in &name.0 {
                     self.seen_idents.push(ident.as_str());

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -18,7 +18,8 @@ use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
 use crate::ast::{
     AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
-    CreateTableStatement, CreateViewStatement, Expr, Ident, ObjectName, Query, Raw, Statement,
+    CreateTableStatement, CreateViewStatement, Expr, Ident, Query, Raw, Statement,
+    UnresolvedObjectName,
 };
 use crate::names::FullName;
 
@@ -35,7 +36,7 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
         | Statement::CreateSource(CreateSourceStatement { name, .. })
         | Statement::CreateView(CreateViewStatement { name, .. })
         | Statement::CreateTable(CreateTableStatement { name, .. }) => {
-            // The last name in an ObjectName is the item name. The item name
+            // The last name in an UnresolvedObjectName is the item name. The item name
             // does not have a fixed index.
             // TODO: https://github.com/MaterializeInc/materialize/issues/5591
             let object_name_len = name.0.len() - 1;
@@ -62,10 +63,10 @@ pub fn create_stmt_rename_refs(
     from_name: FullName,
     to_item_name: String,
 ) -> Result<(), String> {
-    let from_object = ObjectName::from(from_name.clone());
-    let maybe_update_object_name = |object_name: &mut ObjectName| {
+    let from_object = UnresolvedObjectName::from(from_name.clone());
+    let maybe_update_object_name = |object_name: &mut UnresolvedObjectName| {
         if object_name.0 == from_object.0 {
-            // The last name in an ObjectName is the item name. The item name
+            // The last name in an UnresolvedObjectName is the item name. The item name
             // does not have a fixed index.
             // TODO: https://github.com/MaterializeInc/materialize/issues/5591
             let object_name_len = object_name.0.len() - 1;
@@ -236,7 +237,7 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
         }
     }
 
-    fn visit_object_name(&mut self, object_name: &'ast ObjectName) {
+    fn visit_unresolved_object_name(&mut self, object_name: &'ast UnresolvedObjectName) {
         let names = &object_name.0;
         self.check_failure(names);
         // Every item is used as an `ObjectName` at least once, which
@@ -256,10 +257,15 @@ impl<'a, 'ast> Visit<'ast, Raw> for QueryIdentAgg<'a> {
         }
     }
 
+<<<<<<< HEAD
     fn visit_table(&mut self, table: &'ast <Raw as AstInfo>::Table) {
         match table {
             RawName::Name(n) | RawName::Id(_, n) => self.visit_object_name(n),
         }
+=======
+    fn visit_object_name(&mut self, object_name: &'ast <Raw as AstInfo>::ObjectName) {
+        self.visit_unresolved_object_name(object_name);
+>>>>>>> sql: rename ObjectName and AstInfo associated type
     }
 }
 
@@ -311,11 +317,11 @@ impl<'ast> VisitMut<'ast, Raw> for CreateSqlRewriter {
             _ => visit_mut::visit_expr_mut(self, e),
         }
     }
-    fn visit_object_name_mut(&mut self, object_name: &'ast mut ObjectName) {
+    fn visit_unresolved_object_name_mut(&mut self, object_name: &'ast mut UnresolvedObjectName) {
         self.maybe_rewrite_idents(&mut object_name.0);
     }
-    fn visit_table_mut(&mut self, table_name: &'ast mut <sql_parser::ast::Raw as AstInfo>::Table) {
-        match table_name {
+    fn visit_object_name_mut(&mut self, object_name: &'ast mut <sql_parser::ast::Raw as AstInfo>::ObjectName) {
+        match object_name {
             RawName::Name(n) | RawName::Id(_, n) => self.maybe_rewrite_idents(&mut n.0),
         }
     }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -23,7 +23,7 @@ use lazy_static::lazy_static;
 use ore::collections::CollectionExt;
 use pgrepr::oid;
 use repr::{ColumnName, Datum, RelationType, ScalarBaseType, ScalarType};
-use sql_parser::ast::{Expr, ObjectName, Raw};
+use sql_parser::ast::{Expr, Raw, UnresolvedObjectName};
 
 use crate::catalog::CatalogItemType;
 use crate::names::PartialName;
@@ -1816,7 +1816,7 @@ lazy_static! {
                         Some(id) => id,
                         None => bail!("source passed to internal_read_cached_data must be literal string"),
                     };
-                    let item = ecx.qcx.scx.resolve_item(ObjectName::unqualified(&source))?;
+                    let item = ecx.qcx.scx.resolve_item(UnresolvedObjectName::unqualified(&source))?;
                     match item.item_type() {
                         CatalogItemType::Source => {},
                         _ =>  bail!("{} is a {}, but internal_read_cached_data requires a source", source, item.item_type()),

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -13,7 +13,7 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use sql_parser::ast::{Ident, ObjectName};
+use sql_parser::ast::{Ident, UnresolvedObjectName};
 
 /// A fully-qualified name of an item in the catalog.
 ///
@@ -84,15 +84,15 @@ impl fmt::Display for SchemaName {
     }
 }
 
-impl From<FullName> for ObjectName {
-    fn from(full_name: FullName) -> ObjectName {
+impl From<FullName> for UnresolvedObjectName {
+    fn from(full_name: FullName) -> UnresolvedObjectName {
         let mut name_parts = Vec::new();
         if let DatabaseSpecifier::Name(database) = full_name.database {
             name_parts.push(Ident::new(database));
         }
         name_parts.push(Ident::new(full_name.schema));
         name_parts.push(Ident::new(full_name.item));
-        ObjectName(name_parts)
+        UnresolvedObjectName(name_parts)
     }
 }
 

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -26,8 +26,8 @@ use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
     AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
     CreateTableStatement, CreateTypeStatement, CreateViewStatement, DataType, Function,
-    FunctionArgs, Ident, IfExistsBehavior, ObjectName, Query, Raw, RawName, SqlOption, Statement,
-    TableFactor, Value,
+    FunctionArgs, Ident, IfExistsBehavior, Query, Raw, SqlOption, Statement, TableFactor,
+    UnresolvedObjectName, Value,
 };
 
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
@@ -46,7 +46,7 @@ pub fn column_name(id: Ident) -> ColumnName {
 }
 
 /// Normalizes an object name.
-pub fn object_name(mut name: ObjectName) -> Result<PartialName, PlanError> {
+pub fn object_name(mut name: UnresolvedObjectName) -> Result<PartialName, PlanError> {
     if name.0.len() < 1 || name.0.len() > 3 {
         return Err(PlanError::MisqualifiedName(name.to_string()));
     }
@@ -93,14 +93,14 @@ pub fn option_objects(options: &[SqlOption]) -> BTreeMap<String, SqlOption> {
 /// Unnormalizes an object name.
 ///
 /// This is the inverse of the [`object_name`] function.
-pub fn unresolve(name: FullName) -> ObjectName {
+pub fn unresolve(name: FullName) -> UnresolvedObjectName {
     let mut out = vec![];
     if let DatabaseSpecifier::Name(n) = name.database {
         out.push(Ident::new(n));
     }
     out.push(Ident::new(name.schema));
     out.push(Ident::new(name.item));
-    ObjectName(out)
+    UnresolvedObjectName(out)
 }
 
 /// Normalizes a `CREATE` statement.
@@ -115,24 +115,24 @@ pub fn create_statement(
     scx: &StatementContext,
     mut stmt: Statement<Raw>,
 ) -> Result<String, PlanError> {
-    let allocate_name = |name: &ObjectName| -> Result<_, PlanError> {
+    let allocate_name = |name: &UnresolvedObjectName| -> Result<_, PlanError> {
         Ok(unresolve(scx.allocate_name(object_name(name.clone())?)))
     };
 
-    let allocate_temporary_name = |name: &ObjectName| -> Result<_, PlanError> {
+    let allocate_temporary_name = |name: &UnresolvedObjectName| -> Result<_, PlanError> {
         Ok(unresolve(
             scx.allocate_temporary_name(object_name(name.clone())?),
         ))
     };
 
-    let resolve_item = |name: &ObjectName| -> Result<_, PlanError> {
+    let resolve_item = |name: &UnresolvedObjectName| -> Result<_, PlanError> {
         let item = scx.resolve_item(name.clone())?;
         Ok(unresolve(item.name().clone()))
     };
 
     fn normalize_function_name(
         scx: &StatementContext,
-        name: &mut ObjectName,
+        name: &mut UnresolvedObjectName,
     ) -> Result<(), PlanError> {
         let full_name = scx.resolve_function(name.clone())?;
         *name = unresolve(full_name.name().clone());
@@ -221,7 +221,10 @@ pub fn create_statement(
             }
         }
 
-        fn visit_object_name_mut(&mut self, object_name: &'ast mut ObjectName) {
+        fn visit_unresolved_object_name_mut(
+            &mut self,
+            object_name: &'ast mut UnresolvedObjectName,
+        ) {
             // Single-part object names can refer to CTEs in addition to
             // catalog objects.
             if let [ident] = object_name.0.as_slice() {
@@ -235,9 +238,9 @@ pub fn create_statement(
             };
         }
 
-        fn visit_table_mut(&mut self, table: &'ast mut <Raw as AstInfo>::Table) {
+        fn visit_object_name_mut(&mut self, object_name: &'ast mut <Raw as AstInfo>::ObjectName) {
             match table {
-                RawName::Name(n) | RawName::Id(_, n) => self.visit_object_name_mut(n),
+                RawName::Name(n) | RawName::Id(_, n) => self.visit_unresolved_object_name_mut(n),
             }
         }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -36,8 +36,8 @@ use sql_parser::ast::fold::Fold;
 use sql_parser::ast::visit::{self, Visit};
 use sql_parser::ast::{
     AstInfo, Cte, DataType, Distinct, Expr, Function, FunctionArgs, Ident, InsertSource,
-    JoinConstraint, JoinOperator, Limit, ObjectName, OrderByExpr, Query, Raw, RawName, Select,
-    SelectItem, SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Value, Values,
+    JoinConstraint, JoinOperator, Limit, OrderByExpr, Query, Raw, Select, SelectItem, SetExpr,
+    SetOperator, TableAlias, TableFactor, TableWithJoins, UnresolvedObjectName, Value, Values,
 };
 
 use ::expr::{GlobalId, Id, RowSetFinishing};
@@ -69,25 +69,25 @@ use crate::plan::typeconv::{self, CastContext};
 pub struct Aug;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ResolvedTableName {
+pub struct ResolvedObjectName {
     id: Id,
     raw_name: PartialName,
 }
 
-impl AstDisplay for ResolvedTableName {
+impl AstDisplay for ResolvedObjectName {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_str(format!("[{}: {}]", self.id, self.raw_name));
     }
 }
 
-impl std::fmt::Display for ResolvedTableName {
+impl std::fmt::Display for ResolvedObjectName {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.write_str(self.to_ast_string().as_str())
     }
 }
 
 impl AstInfo for Aug {
-    type Table = ResolvedTableName;
+    type ObjectName = ResolvedObjectName;
     type Id = Id;
 }
 
@@ -157,14 +157,14 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
         panic!("this should have been handled when walking the CTE");
     }
 
-    fn fold_table(&mut self, table: <Raw as AstInfo>::Table) -> <Aug as AstInfo>::Table {
-        match table {
+    fn fold_object_name(&mut self, object_name: <Raw as AstInfo>::ObjectName) -> <Aug as AstInfo>::ObjectName {
+        match object_name {
             RawName::Name(raw_name) => {
                 // Check if unqualified name refers to a CTE.
                 if raw_name.0.len() == 1 {
                     let norm_name = normalize::ident(raw_name.0[0].clone());
                     if let Some(id) = self.ctes.get(&norm_name) {
-                        return ResolvedTableName {
+                        return ResolvedObjectName {
                             id: Id::Local(*id),
                             raw_name: normalize::object_name(raw_name).unwrap(),
                         };
@@ -173,7 +173,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
 
                 let name = normalize::object_name(raw_name).unwrap();
                 match self.catalog.resolve_item(&name) {
-                    Ok(item) => ResolvedTableName {
+                    Ok(item) => ResolvedObjectName {
                         id: Id::Global(item.id()),
                         raw_name: name,
                     },
@@ -181,7 +181,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                         if self.status.is_ok() {
                             self.status = Err(e.into());
                         }
-                        ResolvedTableName {
+                        ResolvedObjectName {
                             id: Id::Local(LocalId::new(0)),
                             raw_name: name,
                         }
@@ -193,7 +193,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 if self.catalog.try_get_item_by_id(&gid).is_none() {
                     self.status = Err(anyhow!("invalid id {}", &gid));
                 }
-                ResolvedTableName {
+                ResolvedObjectName {
                     id: Id::Global(gid),
                     raw_name: normalize::object_name(raw_name).unwrap(),
                 }
@@ -232,6 +232,29 @@ pub fn resolve_names_expr(
     n.status?;
     Ok(result)
 }
+
+// // These should live in Statement, not here.
+// pub fn resolve_names_data_type(scx: &mut StatementContext, data_type: DataType<Raw>) -> Result<DataType<Aug>, anyhow::Error> {
+//     let mut n = NameResolver {
+//         status: Ok(()),
+//         catalog: scx.catalog,
+//         ctes: HashMap::new(),
+//     };
+//     let result = n.fold_data_type(data_type);
+//     n.status?;
+//     Ok(result)
+// }
+
+// pub fn resolve_names_sql_options(scx: &mut StatementContext, sql_options: Vec<SqlOption<Raw>>) -> Result<Vec<SqlOption<Aug>>, anyhow::Error> {
+//     let mut n = NameResolver {
+//         status: Ok(()),
+//         catalog: scx.catalog,
+//         ctes: HashMap::new(),
+//     };
+//     let result = n.fold_sql_options(sql_options);
+//     n.status?;
+//     Ok(result)
+// }
 
 /// Plans a top-level query, returning the `HirRelationExpr` describing the query
 /// plan, the `RelationDesc` describing the shape of the result set, a
@@ -304,7 +327,7 @@ fn try_push_projection_order_by(
 
 pub fn plan_insert_query(
     scx: &StatementContext,
-    table_name: ObjectName,
+    table_name: UnresolvedObjectName,
     columns: Vec<Ident>,
     source: InsertSource<Raw>,
 ) -> Result<(GlobalId, HirRelationExpr), anyhow::Error> {
@@ -1546,11 +1569,11 @@ fn plan_table_factor(
 
 fn plan_table_function(
     ecx: &ExprContext,
-    name: &ObjectName,
+    name: &UnresolvedObjectName,
     alias: Option<&TableAlias>,
     args: &FunctionArgs<Aug>,
 ) -> Result<(HirRelationExpr, Scope), anyhow::Error> {
-    if *name == ObjectName::unqualified("values") {
+    if *name == UnresolvedObjectName::unqualified("values") {
         // Produce a nice error message for the common typo
         // `SELECT * FROM VALUES (1)`.
         bail!("VALUES expression in FROM clause must be surrounded by parentheses");
@@ -1692,7 +1715,7 @@ fn expand_select_item<'a>(
             expr: Expr::QualifiedWildcard(table_name),
             alias: _,
         } => {
-            let table_name = normalize::object_name(ObjectName(table_name.clone()))?;
+            let table_name = normalize::object_name(UnresolvedObjectName(table_name.clone()))?;
             let out: Vec<_> = ecx
                 .scope
                 .items
@@ -2530,7 +2553,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, 
 
     // If the name is qualified, it must refer to a column in a table.
     if !names.is_empty() {
-        let table_name = normalize::object_name(ObjectName(names))?;
+        let table_name = normalize::object_name(UnresolvedObjectName(names))?;
         let (i, _name) = ecx.scope.resolve_table_column(&table_name, &col_name)?;
         return Ok(HirScalarExpr::Column(i));
     }
@@ -2647,7 +2670,7 @@ fn plan_function<'a>(
 /// If the name does not specify a known built-in function, returns an error.
 pub fn resolve_func(
     ecx: &ExprContext,
-    name: &ObjectName,
+    name: &UnresolvedObjectName,
     args: &sql_parser::ast::FunctionArgs<Aug>,
 ) -> Result<&'static Func, anyhow::Error> {
     if let Ok(i) = ecx.qcx.scx.resolve_function(name.clone()) {
@@ -2872,12 +2895,12 @@ pub fn scalar_type_from_sql(
     })
 }
 
-pub fn canonicalize_type_name_internal(name: &ObjectName) -> ObjectName {
+pub fn canonicalize_type_name_internal(name: &UnresolvedObjectName) -> UnresolvedObjectName {
     // Rewrite some unqualified aliases to the name we know they should
     // use in the catalog, i.e. canonicalize the catalog name.
     match name.to_string().as_str() {
-        "char" | "varchar" => ObjectName::unqualified("text"),
-        "smallint" => ObjectName::unqualified("int4"),
+        "char" | "varchar" => UnresolvedObjectName::unqualified("text"),
+        "smallint" => UnresolvedObjectName::unqualified("int4"),
         _ => name.clone(),
     }
 }
@@ -3122,7 +3145,7 @@ impl<'a> QueryContext<'a> {
     /// CTE.
     pub fn resolve_table_name(
         &self,
-        object: ResolvedTableName,
+        object: ResolvedObjectName,
     ) -> Result<(HirRelationExpr, Scope), PlanError> {
         match object.id {
             Id::Local(id) => {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -21,7 +21,7 @@ use expr::GlobalId;
 use ore::collections::CollectionExt;
 use repr::{ColumnType, RelationDesc, ScalarType};
 
-use crate::ast::{Ident, ObjectName, ObjectType, Raw, Statement};
+use crate::ast::{Ident, ObjectType, Raw, Statement, UnresolvedObjectName};
 use crate::catalog::{Catalog, CatalogDatabase, CatalogItem, CatalogItemType, CatalogSchema};
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
 use crate::normalize;
@@ -299,10 +299,13 @@ impl<'a> StatementContext<'a> {
     }
 
     pub fn resolve_default_schema(&self) -> Result<&dyn CatalogSchema, PlanError> {
-        self.resolve_schema(ObjectName::unqualified("public"))
+        self.resolve_schema(UnresolvedObjectName::unqualified("public"))
     }
 
-    pub fn resolve_database(&self, name: ObjectName) -> Result<&dyn CatalogDatabase, PlanError> {
+    pub fn resolve_database(
+        &self,
+        name: UnresolvedObjectName,
+    ) -> Result<&dyn CatalogDatabase, PlanError> {
         if name.0.len() != 1 {
             return Err(PlanError::OverqualifiedDatabaseName(name.to_string()));
         }
@@ -314,7 +317,10 @@ impl<'a> StatementContext<'a> {
         Ok(self.catalog.resolve_database(&name)?)
     }
 
-    pub fn resolve_schema(&self, mut name: ObjectName) -> Result<&dyn CatalogSchema, PlanError> {
+    pub fn resolve_schema(
+        &self,
+        mut name: UnresolvedObjectName,
+    ) -> Result<&dyn CatalogSchema, PlanError> {
         if name.0.len() > 2 {
             return Err(PlanError::OverqualifiedSchemaName(name.to_string()));
         }
@@ -323,12 +329,15 @@ impl<'a> StatementContext<'a> {
         Ok(self.catalog.resolve_schema(database_spec, &schema_name)?)
     }
 
-    pub fn resolve_item(&self, name: ObjectName) -> Result<&dyn CatalogItem, PlanError> {
+    pub fn resolve_item(&self, name: UnresolvedObjectName) -> Result<&dyn CatalogItem, PlanError> {
         let name = normalize::object_name(name)?;
         Ok(self.catalog.resolve_item(&name)?)
     }
 
-    pub fn resolve_function(&self, name: ObjectName) -> Result<&dyn CatalogItem, PlanError> {
+    pub fn resolve_function(
+        &self,
+        name: UnresolvedObjectName,
+    ) -> Result<&dyn CatalogItem, PlanError> {
         let name = normalize::object_name(name)?;
         Ok(self.catalog.resolve_function(&name)?)
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -45,7 +45,7 @@ use crate::ast::{
     CreateRoleStatement, CreateSchemaStatement, CreateSinkStatement, CreateSourceStatement,
     CreateTableStatement, CreateTypeAs, CreateTypeStatement, CreateViewStatement, DataType,
     DropDatabaseStatement, DropObjectsStatement, Envelope, Expr, Format, Ident, IfExistsBehavior,
-    ObjectName, ObjectType, Raw, SqlOption, Statement, Value,
+    ObjectType, Raw, SqlOption, Statement, UnresolvedObjectName, Value,
 };
 use crate::catalog::{CatalogItem, CatalogItemType};
 use crate::kafka_util;
@@ -1357,7 +1357,7 @@ pub fn plan_drop_objects(
 pub fn plan_drop_schema(
     scx: &StatementContext,
     if_exists: bool,
-    names: Vec<ObjectName>,
+    names: Vec<UnresolvedObjectName>,
     cascade: bool,
 ) -> Result<Plan, anyhow::Error> {
     if names.len() != 1 {
@@ -1401,7 +1401,7 @@ pub fn plan_drop_schema(
 pub fn plan_drop_role(
     scx: &StatementContext,
     if_exists: bool,
-    names: Vec<ObjectName>,
+    names: Vec<UnresolvedObjectName>,
 ) -> Result<Plan, anyhow::Error> {
     let mut out = vec![];
     for name in names {
@@ -1429,7 +1429,7 @@ pub fn plan_drop_items(
     scx: &StatementContext,
     object_type: ObjectType,
     if_exists: bool,
-    names: Vec<ObjectName>,
+    names: Vec<UnresolvedObjectName>,
     cascade: bool,
 ) -> Result<Plan, anyhow::Error> {
     let items = names
@@ -1590,7 +1590,10 @@ pub fn plan_alter_object_rename(
             let mut proposed_name = name.0;
             let last = proposed_name.last_mut().unwrap();
             *last = to_item_name.clone();
-            if scx.resolve_item(ObjectName(proposed_name)).is_ok() {
+            if scx
+                .resolve_item(UnresolvedObjectName(proposed_name))
+                .is_ok()
+            {
                 bail!("{} is already taken by item in schema", to_item_name)
             }
             Some(entry.id())

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -19,10 +19,10 @@ use ore::collections::CollectionExt;
 use repr::{Datum, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
-    ObjectName, ObjectType, Raw, SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
+    ObjectType, Raw, SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
     ShowCreateSinkStatement, ShowCreateSourceStatement, ShowCreateTableStatement,
     ShowCreateViewStatement, ShowDatabasesStatement, ShowIndexesStatement, ShowObjectsStatement,
-    ShowStatementFilter, Statement, Value,
+    ShowStatementFilter, Statement, UnresolvedObjectName, Value,
 };
 use crate::catalog::CatalogItemType;
 use crate::parse;
@@ -195,7 +195,7 @@ fn show_schemas<'a>(
     scx: &'a StatementContext<'a>,
     extended: bool,
     full: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     let database = if let Some(from) = from {
@@ -237,7 +237,7 @@ fn show_tables<'a>(
     scx: &'a StatementContext<'a>,
     extended: bool,
     full: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     if extended {
@@ -270,7 +270,7 @@ fn show_sources<'a>(
     scx: &'a StatementContext<'a>,
     full: bool,
     materialized: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     let schema = if let Some(from) = from {
@@ -316,7 +316,7 @@ fn show_views<'a>(
     scx: &'a StatementContext<'a>,
     full: bool,
     materialized: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     let schema = if let Some(from) = from {
@@ -361,7 +361,7 @@ fn show_views<'a>(
 fn show_sinks<'a>(
     scx: &'a StatementContext<'a>,
     full: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     let schema = if let Some(from) = from {
@@ -390,7 +390,7 @@ fn show_types<'a>(
     scx: &'a StatementContext<'a>,
     extended: bool,
     full: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     let schema = if let Some(from) = from {
@@ -420,7 +420,7 @@ fn show_all_objects<'a>(
     scx: &'a StatementContext<'a>,
     extended: bool,
     full: bool,
-    from: Option<ObjectName>,
+    from: Option<UnresolvedObjectName>,
     filter: Option<ShowStatementFilter<Raw>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
     let schema = if let Some(from) = from {


### PR DESCRIPTION
This is one of a few necessary changes to correctly track type dependencies in the catalog (see https://github.com/MaterializeInc/materialize/pull/5679). 

This PR renames the existing `ObjectName` struct to `UnresolvedObjectName`, allowing us to rename `AstInfo`'s associated `Table` type to `ObjectName`.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5698)
<!-- Reviewable:end -->
