### PR TITLE
coord: spawn timestamper before bootstrap

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -53,7 +53,7 @@ use expr::{
 };
 use ore::collections::CollectionExt;
 use ore::str::StrExt;
-use ore::thread::JoinHandleExt;
+use ore::thread::{JoinHandleExt, JoinOnDropHandle};
 use repr::adt::array::ArrayDimension;
 use repr::{ColumnName, Datum, RelationDesc, RelationType, Row, RowPacker, Timestamp};
 use sql::ast::display::AstDisplay;
@@ -162,12 +162,15 @@ pub struct Coordinator {
     /// Maps (global Id of arrangement) -> (frontier information)
     indexes: ArrangementFrontiers<Timestamp>,
     since_updates: Vec<(GlobalId, Antichain<Timestamp>)>,
-    timestamp_config: TimestampConfig,
     /// Delta from leading edge of an arrangement from which we allow compaction.
     logical_compaction_window_ms: Option<Timestamp>,
     /// Instance count: number of times sources have been instantiated in views. This is used
     /// to associate each new instance of a source with a unique instance id (iid)
     logging_granularity: Option<u64>,
+    // Channel to manange internal commands from the coordinator to itself.
+    internal_cmd_tx: mpsc::UnboundedSender<Message>,
+    // Channel to communicate source status updates to the timestamper thread.
+    ts_tx: std::sync::mpsc::Sender<TimestampMessage>,
     // Channel to communicate source status updates and shutdown notifications to the cacher
     // thread.
     cache_tx: Option<mpsc::UnboundedSender<CacheMessage>>,
@@ -369,26 +372,16 @@ impl Coordinator {
     /// You must call `bootstrap` before calling this method.
     async fn serve(
         mut self,
+        internal_cmd_rx: mpsc::UnboundedReceiver<Message>,
         cmd_rx: mpsc::UnboundedReceiver<Command>,
         feedback_rx: mpsc::UnboundedReceiver<WorkerFeedbackWithMeta>,
+        _timestamper_thread_handle: JoinOnDropHandle<()>,
     ) {
-        let (internal_cmd_tx, internal_cmd_rx) = mpsc::unbounded_channel();
-
         let cmd_stream = UnboundedReceiverStream::new(cmd_rx)
             .map(Message::Command)
             .chain(stream::once(future::ready(Message::Shutdown)));
 
         let feedback_stream = UnboundedReceiverStream::new(feedback_rx).map(Message::Worker);
-
-        let (ts_tx, ts_rx) = std::sync::mpsc::channel();
-        let mut timestamper =
-            Timestamper::new(&self.timestamp_config, internal_cmd_tx.clone(), ts_rx);
-        let executor = Handle::current();
-        let _timestamper_thread = thread::spawn(move || {
-            let _executor_guard = executor.enter();
-            timestamper.update()
-        })
-        .join_on_drop();
 
         let mut messages = ore::future::select_all_biased(vec![
             // Order matters here. We want to drain internal commands
@@ -401,11 +394,9 @@ impl Coordinator {
 
         while let Some(msg) = messages.next().await {
             match msg {
-                Message::Command(cmd) => self.message_command(cmd, &internal_cmd_tx).await,
-                Message::Worker(worker) => self.message_worker(worker, &ts_tx).await,
-                Message::StatementReady(ready) => {
-                    self.message_statement_ready(ready, &internal_cmd_tx).await
-                }
+                Message::Command(cmd) => self.message_command(cmd).await,
+                Message::Worker(worker) => self.message_worker(worker).await,
+                Message::StatementReady(ready) => self.message_statement_ready(ready).await,
                 Message::SinkConnectorReady(ready) => {
                     self.message_sink_connector_ready(ready).await
                 }
@@ -413,7 +404,7 @@ impl Coordinator {
                     self.message_advance_source_timestamp(advance).await
                 }
                 Message::Shutdown => {
-                    self.message_shutdown(&ts_tx).await;
+                    self.message_shutdown().await;
                     break;
                 }
             }
@@ -442,7 +433,7 @@ impl Coordinator {
 
         // Cleanly drain any pending messages from the worker before shutting
         // down.
-        drop(internal_cmd_tx);
+        drop(self.internal_cmd_tx);
         while messages.next().await.is_some() {}
     }
 
@@ -452,7 +443,6 @@ impl Coordinator {
             worker_id: _,
             message,
         }: WorkerFeedbackWithMeta,
-        ts_tx: &std::sync::mpsc::Sender<TimestampMessage>,
     ) {
         match message {
             WorkerFeedback::FrontierUppers(updates) => {
@@ -463,14 +453,14 @@ impl Coordinator {
             }
             WorkerFeedback::DroppedSource(source_id) => {
                 // Notify timestamping thread that source has been dropped
-                ts_tx
+                self.ts_tx
                     .send(TimestampMessage::DropInstance(source_id))
                     .expect("Failed to send Drop Instance notice to timestamper");
             }
             WorkerFeedback::CreateSource(src_instance_id) => {
                 if let Some(entry) = self.catalog.try_get_by_id(src_instance_id.source_id) {
                     if let CatalogItem::Source(s) = entry.item() {
-                        ts_tx
+                        self.ts_tx
                             .send(TimestampMessage::Add(src_instance_id, s.connector.clone()))
                             .expect("Failed to send CREATE Instance notice to timestamper");
                     } else {
@@ -491,16 +481,12 @@ impl Coordinator {
             result,
             params,
         }: StatementReady,
-        internal_cmd_tx: &mpsc::UnboundedSender<Message>,
     ) {
         match future::ready(result)
             .and_then(|stmt| self.handle_statement(&session, stmt, &params))
             .await
         {
-            Ok((pcx, plan)) => {
-                self.sequence_plan(&internal_cmd_tx, tx, session, pcx, plan)
-                    .await
-            }
+            Ok((pcx, plan)) => self.sequence_plan(tx, session, pcx, plan).await,
             Err(e) => tx.send(Err(e), session),
         }
     }
@@ -547,8 +533,8 @@ impl Coordinator {
         }
     }
 
-    async fn message_shutdown(&mut self, ts_tx: &std::sync::mpsc::Sender<TimestampMessage>) {
-        ts_tx.send(TimestampMessage::Shutdown).unwrap();
+    async fn message_shutdown(&mut self) {
+        self.ts_tx.send(TimestampMessage::Shutdown).unwrap();
         self.broadcast(SequencedCommand::Shutdown);
     }
 
@@ -559,11 +545,7 @@ impl Coordinator {
         self.broadcast(SequencedCommand::AdvanceSourceTimestamp { id, update });
     }
 
-    async fn message_command(
-        &mut self,
-        cmd: Command,
-        internal_cmd_tx: &mpsc::UnboundedSender<Message>,
-    ) {
+    async fn message_command(&mut self, cmd: Command) {
         match cmd {
             Command::Startup {
                 session,
@@ -736,7 +718,7 @@ impl Coordinator {
                             },
                         }
 
-                        let internal_cmd_tx = internal_cmd_tx.clone();
+                        let internal_cmd_tx = self.internal_cmd_tx.clone();
                         tokio::spawn(async move {
                             let result = sql::pure::purify(stmt).await.map_err(|e| e.into());
                             internal_cmd_tx
@@ -1468,7 +1450,6 @@ impl Coordinator {
 
     async fn sequence_plan(
         &mut self,
-        internal_cmd_tx: &mpsc::UnboundedSender<Message>,
         tx: ClientTransmitter<ExecuteResponse>,
         mut session: Session,
         pcx: PlanContext,
@@ -1525,7 +1506,6 @@ impl Coordinator {
             } => {
                 self.sequence_create_sink(
                     pcx,
-                    internal_cmd_tx.clone(),
                     tx,
                     session,
                     name,
@@ -1921,7 +1901,6 @@ impl Coordinator {
     async fn sequence_create_sink(
         &mut self,
         pcx: PlanContext,
-        internal_cmd_tx: mpsc::UnboundedSender<Message>,
         tx: ClientTransmitter<ExecuteResponse>,
         session: Session,
         name: FullName,
@@ -1989,6 +1968,7 @@ impl Coordinator {
         // Now we're ready to create the sink connector. Arrange to notify the
         // main coordinator thread when the future completes.
         let connector_builder = sink.connector_builder;
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
         tokio::spawn(async move {
             internal_cmd_tx
                 .send(Message::SinkConnectorReady(SinkConnectorReady {
@@ -3351,7 +3331,7 @@ pub async fn serve(
     } else {
         None
     };
-
+    let (internal_cmd_tx, internal_cmd_rx) = mpsc::unbounded_channel();
     let symbiosis = if let Some(symbiosis_url) = symbiosis_url {
         Some(symbiosis::Postgres::open_and_erase(symbiosis_url).await?)
     } else {
@@ -3375,6 +3355,18 @@ pub async fn serve(
         timely_worker,
     })
     .map_err(|s| CoordError::Unstructured(anyhow!("{}", s)))?;
+
+    // Spawn timestamper after any fallible operations so that if bootstrap fails we still
+    // tell it to shut down.
+    let (ts_tx, ts_rx) = std::sync::mpsc::channel();
+    let mut timestamper = Timestamper::new(&timestamp_config, internal_cmd_tx.clone(), ts_rx);
+    let executor = Handle::current();
+    let timestamper_thread_handle = thread::spawn(move || {
+        let _executor_guard = executor.enter();
+        timestamper.update()
+    })
+    .join_on_drop();
+
     let mut coord = Coordinator {
         worker_guards,
         worker_txs,
@@ -3386,8 +3378,9 @@ pub async fn serve(
         logging_granularity: logging
             .as_ref()
             .and_then(|c| c.granularity.as_millis().try_into().ok()),
-        timestamp_config,
         logical_compaction_window_ms: logical_compaction_window.map(duration_to_timestamp_millis),
+        internal_cmd_tx,
+        ts_tx: ts_tx.clone(),
         cache_tx,
         closed_up_to: 1,
         read_lower_bound: 1,
@@ -3412,10 +3405,22 @@ pub async fn serve(
     }
     match coord.bootstrap(initial_catalog_events).await {
         Ok(()) => {
-            let coord = thread::spawn(move || runtime.block_on(coord.serve(cmd_rx, feedback_rx)));
+            let coord = thread::spawn(move || {
+                runtime.block_on(coord.serve(
+                    internal_cmd_rx,
+                    cmd_rx,
+                    feedback_rx,
+                    timestamper_thread_handle,
+                ))
+            });
             Ok((coord, cluster_id))
         }
         Err(e) => {
+            // Tell the timestamper thread to shut down.
+            ts_tx.send(TimestampMessage::Shutdown).unwrap();
+            // Explicitly drop the timestamper handle here so we can wait for
+            // the thread to return.
+            drop(timestamper_thread_handle);
             coord.broadcast(SequencedCommand::Shutdown);
             Err(e)
         }


### PR DESCRIPTION
Touches #2915

This is in preparation of future work that will change the interface between
the coordinator, timestamper and dataflow worker threads. This commit moves
timestamper initialization to happen before catalog bootstrap and simplifies some
coordinator code along the way. There should be no functional changes with this
commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5699)
<!-- Reviewable:end -->
