### PR TITLE
Attempt to fix build on M1 macs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,9 +387,9 @@ checksum = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 
 [[package]]
 name = "cc"
-version = "1.0.50"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.41"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c84c596dcf125d6781f58e3f4254677ec2a6d8aa56e8501ac277100990b3229"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
 dependencies = [
  "cc",
 ]
@@ -2401,9 +2401,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.9.0+1.1.1g"
+version = "111.13.0+1.1.1i"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
+checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Materialize doesn't currently build on M1. This is basically due to outdated build deps not passing the arch correctly when compiling certain dependencies, you know, that sort of thing. I've updated a couple of them here and it's at least a bit closer.

There is one remaining issue that I can see, and it is rdkafka-sys, which fails to link the built librdkafka library because Cargo is not yet capable of linking to Mach-O universal binaries. It fails with an `error: failed to add native library ... librdkafka.a: file too small to be an archive` message.

There is a cargo issue here https://github.com/rust-lang/cargo/issues/8875

For now, I'll leave this as a draft so at least people can see where it's at / google for why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5705)
<!-- Reviewable:end -->
