### PR TITLE
errors: Add panic location to backtrace errors

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -566,7 +566,13 @@ fn handle_panic(panic_info: &PanicInfo) {
         },
     };
 
-    log::error!(target: "panic", "{}: {}\n{:?}", thr_name, msg, Backtrace::new());
+    let location = if let Some(loc) = panic_info.location() {
+        format!("at {}:{}:{}", loc.file(), loc.line(), loc.column())
+    } else {
+        "(no location information)".to_string()
+    };
+
+    log::error!(target: "panic", "{} {}: {}\n{:?}", thr_name, location, msg, Backtrace::new());
     eprintln!(
         r#"materialized encountered an internal error and crashed.
 


### PR DESCRIPTION
This adds the exact location that `panic!()` or `unrap()` was called to the
error line, making the right place to look in the backtrace much more obvious.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5708)
<!-- Reviewable:end -->
