### PR TITLE
expr,sql: correct many bugs in float casts and rounding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3321,10 +3321,13 @@ dependencies = [
  "fast-float",
  "hex",
  "itertools",
+ "lazy_static",
+ "num-traits",
  "ordered-float",
  "ore",
  "rand 0.8.3",
  "regex",
+ "ryu",
  "serde",
  "serde_json",
  "serde_regex",
@@ -3513,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "s3-datagen"

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -156,6 +156,8 @@ tests=(
     test/sqllogictest/cockroach/window.slt
     test/sqllogictest/cockroach/with.slt
     # test/sqllogictest/cockroach/zero.slt
+    test/sqllogictest/postgres/float4.slt
+    test/sqllogictest/postgres/float8.slt
     test/sqllogictest/postgres/join-lateral.slt
     test/sqllogictest/postgres/regex.slt
     test/sqllogictest/postgres/subselect.slt

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -50,6 +50,17 @@ Wrap your release notes at the 80 character mark.
 
 - Multipartition Kafka sinks with consistency enabled will create single-partition
   consistency topics.
+- **Breaking change.** Change the behavior of the
+  [`round` function](/sql/functions/#numbers-func) when applied to a `real` or
+  `double precision` argument to round ties to the nearest even number,
+  rather than away from zero. When applied to `numeric`, ties are rounded away
+  from zero, as before.
+
+  The new behavior matches PostgreSQL.
+
+- Support [multi-partition](/sql/create-sink/#with-options) kafka sinks {{% gh 5537 %}}.
+
+- Support [gzip-compressed](/sql/create-source/text-file/#compression) file sources {{% gh 5392 %}}.
 
 {{% version-header v0.7.0 %}}
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -111,11 +111,14 @@
     description: "`x % y`"
 
   - signature: 'round(x: N) -> N'
-    description: "`x` rounded to the nearest whole number; halves are rounded up"
+    description: >-
+      `x` rounded to the nearest whole number.
+      If `N` is `real` or `double precision`, rounds ties to the nearest even number.
+      If `N` is `numeric`, rounds ties away from zero.
 
   - signature: 'round(x: numeric, y: int) -> numeric'
     description: "`x` rounded to `y` decimal places, while retaining the same
-      [`numeric`](../types/numeric) scale; halves are rounded up"
+      [`numeric`](../types/numeric) scale; rounds ties away from zero."
 
 - type: String
   functions:

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -683,9 +683,11 @@ impl fmt::Display for MirScalarExpr {
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum EvalError {
     DivisionByZero,
+    FloatOverflow,
+    FloatUnderflow,
     NumericFieldOverflow,
-    FloatOutOfRange,
-    IntegerOutOfRange,
+    Int32OutOfRange,
+    Int64OutOfRange,
     IntervalOutOfRange,
     TimestampOutOfRange,
     InvalidTimezone(String),
@@ -717,9 +719,11 @@ impl fmt::Display for EvalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             EvalError::DivisionByZero => f.write_str("division by zero"),
+            EvalError::FloatOverflow => f.write_str("value out of range: overflow"),
+            EvalError::FloatUnderflow => f.write_str("value out of range: underflow"),
             EvalError::NumericFieldOverflow => f.write_str("numeric field overflow"),
-            EvalError::FloatOutOfRange => f.write_str("float out of range"),
-            EvalError::IntegerOutOfRange => f.write_str("integer out of range"),
+            EvalError::Int32OutOfRange => f.write_str("integer out of range"),
+            EvalError::Int64OutOfRange => f.write_str("bigint out of range"),
             EvalError::IntervalOutOfRange => f.write_str("interval out of range"),
             EvalError::TimestampOutOfRange => f.write_str("timestamp out of range"),
             EvalError::InvalidTimezone(tz) => write!(f, "invalid time zone '{}'", tz),

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -22,9 +22,12 @@ enum-kinds = "0.5.0"
 fast-float = "0.2.0"
 hex = "0.4.2"
 itertools = "0.9.0"
+lazy_static = "1.4.0"
+num-traits = "0.2.14"
 ordered-float = { version = "2.1.1", features = ["serde"] }
 ore = { path = "../ore" }
 regex = "1.4.3"
+ryu = "1.0.5"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 serde_regex = "1.1.0"

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -34,51 +34,51 @@ fn test_parse_date() {
 fn test_parse_date_errors() {
     run_test_parse_date_errors(
         "0000203",
-        "invalid input syntax for date: YEAR cannot be zero: \"0000203\"",
+        "invalid input syntax for type date: YEAR cannot be zero: \"0000203\"",
     );
     run_test_parse_date_errors(
         "00000203",
-        "invalid input syntax for date: YEAR cannot be zero: \"00000203\"",
+        "invalid input syntax for type date: YEAR cannot be zero: \"00000203\"",
     );
     run_test_parse_date_errors(
         "0010230",
-        "invalid input syntax for date: invalid or out-of-range date: \"0010230\"",
+        "invalid input syntax for type date: invalid or out-of-range date: \"0010230\"",
     );
     run_test_parse_date_errors(
         "00011303",
-        "invalid input syntax for date: MONTH must be [1, 12], got 13: \"00011303\"",
+        "invalid input syntax for type date: MONTH must be [1, 12], got 13: \"00011303\"",
     );
     run_test_parse_date_errors(
         "-123456789",
-        "invalid input syntax for date: MONTH must be [1, 12], got 123456789: \"-123456789\"",
+        "invalid input syntax for type date: MONTH must be [1, 12], got 123456789: \"-123456789\"",
     );
     run_test_parse_date_errors(
         "2001-01",
-        "invalid input syntax for date: YEAR, MONTH, DAY are all required: \"2001-01\"",
+        "invalid input syntax for type date: YEAR, MONTH, DAY are all required: \"2001-01\"",
     );
     run_test_parse_date_errors(
         "2001",
-        "invalid input syntax for date: YEAR, MONTH, DAY are all required: \"2001\"",
+        "invalid input syntax for type date: YEAR, MONTH, DAY are all required: \"2001\"",
     );
     run_test_parse_date_errors(
         "2019-02-29",
-        "invalid input syntax for date: invalid or out-of-range date: \"2019-02-29\"",
+        "invalid input syntax for type date: invalid or out-of-range date: \"2019-02-29\"",
     );
     run_test_parse_date_errors(
         "2020-02-30",
-        "invalid input syntax for date: invalid or out-of-range date: \"2020-02-30\"",
+        "invalid input syntax for type date: invalid or out-of-range date: \"2020-02-30\"",
     );
     run_test_parse_date_errors(
         "2001-13-01",
-        "invalid input syntax for date: MONTH must be [1, 12], got 13: \"2001-13-01\"",
+        "invalid input syntax for type date: MONTH must be [1, 12], got 13: \"2001-13-01\"",
     );
     run_test_parse_date_errors(
         "2001-12-32",
-        "invalid input syntax for date: DAY must be [1, 31], got 32: \"2001-12-32\"",
+        "invalid input syntax for type date: DAY must be [1, 31], got 32: \"2001-12-32\"",
     );
     run_test_parse_date_errors(
         "2001-01-02 04",
-        "invalid input syntax for date: have unprocessed tokens 4: \"2001-01-02 04\"",
+        "invalid input syntax for type date: have unprocessed tokens 4: \"2001-01-02 04\"",
     );
     fn run_test_parse_date_errors(s: &str, e: &str) {
         assert_eq!(
@@ -106,23 +106,23 @@ fn test_parse_time() {
 fn test_parse_time_errors() {
     run_test_parse_time_errors(
         "26:01:02.345",
-        "invalid input syntax for time: HOUR must be [0, 23], got 26: \"26:01:02.345\"",
+        "invalid input syntax for type time: HOUR must be [0, 23], got 26: \"26:01:02.345\"",
     );
     run_test_parse_time_errors(
         "01:60:02.345",
-        "invalid input syntax for time: MINUTE must be [0, 59], got 60: \"01:60:02.345\"",
+        "invalid input syntax for type time: MINUTE must be [0, 59], got 60: \"01:60:02.345\"",
     );
     run_test_parse_time_errors(
         "01:02:61.345",
-        "invalid input syntax for time: SECOND must be [0, 60], got 61: \"01:02:61.345\"",
+        "invalid input syntax for type time: SECOND must be [0, 60], got 61: \"01:02:61.345\"",
     );
     run_test_parse_time_errors(
         "03.456",
-        "invalid input syntax for time: have unprocessed tokens 3.456000000: \"03.456\"",
+        "invalid input syntax for type time: have unprocessed tokens 3.456000000: \"03.456\"",
     );
     run_test_parse_time_errors(
         "03.456",
-        "invalid input syntax for time: have unprocessed tokens 3.456000000: \"03.456\"",
+        "invalid input syntax for type time: have unprocessed tokens 3.456000000: \"03.456\"",
     );
 
     fn run_test_parse_time_errors(s: &str, e: &str) {
@@ -165,36 +165,36 @@ fn test_parse_timestamp() {
 fn test_parse_timestamp_errors() {
     run_test_parse_timestamp_errors(
         "2001-01",
-        "invalid input syntax for timestamp: YEAR, MONTH, DAY are all required: \"2001-01\"",
+        "invalid input syntax for type timestamp: YEAR, MONTH, DAY are all required: \"2001-01\"",
     );
     run_test_parse_timestamp_errors(
         "2001",
-        "invalid input syntax for timestamp: YEAR, MONTH, DAY are all required: \"2001\"",
+        "invalid input syntax for type timestamp: YEAR, MONTH, DAY are all required: \"2001\"",
     );
     run_test_parse_timestamp_errors(
         "2001-13-01",
-        "invalid input syntax for timestamp: MONTH must be [1, 12], got 13: \"2001-13-01\"",
+        "invalid input syntax for type timestamp: MONTH must be [1, 12], got 13: \"2001-13-01\"",
     );
     run_test_parse_timestamp_errors(
         "2001-12-32",
-        "invalid input syntax for timestamp: DAY must be [1, 31], got 32: \"2001-12-32\"",
+        "invalid input syntax for type timestamp: DAY must be [1, 31], got 32: \"2001-12-32\"",
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 04",
-        "invalid input syntax for timestamp: have unprocessed tokens 4: \"2001-01-02 04\"",
+        "invalid input syntax for type timestamp: have unprocessed tokens 4: \"2001-01-02 04\"",
     );
 
     run_test_parse_timestamp_errors(
         "2001-01-02 26:01:02.345",
-        "invalid input syntax for timestamp: HOUR must be [0, 23], got 26: \"2001-01-02 26:01:02.345\"",
+        "invalid input syntax for type timestamp: HOUR must be [0, 23], got 26: \"2001-01-02 26:01:02.345\"",
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 01:60:02.345",
-        "invalid input syntax for timestamp: MINUTE must be [0, 59], got 60: \"2001-01-02 01:60:02.345\"",
+        "invalid input syntax for type timestamp: MINUTE must be [0, 59], got 60: \"2001-01-02 01:60:02.345\"",
     );
     run_test_parse_timestamp_errors(
         "2001-01-02 01:02:61.345",
-        "invalid input syntax for timestamp: SECOND must be [0, 60], got 61: \"2001-01-02 01:02:61.345\"",
+        "invalid input syntax for type timestamp: SECOND must be [0, 60], got 61: \"2001-01-02 01:02:61.345\"",
     );
 
     fn run_test_parse_timestamp_errors(s: &str, e: &str) {
@@ -250,17 +250,17 @@ fn test_parse_timestamptz() {
 fn test_parse_timestamptz_errors() {
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 +25:45",
-        "invalid input syntax for timestamp with time zone: Invalid timezone string \
+        "invalid input syntax for type timestamp with time zone: Invalid timezone string \
          (+25:45): timezone hour invalid 25: \"1999-01-01 01:23:34.555 +25:45\"",
     );
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 +15:61",
-        "invalid input syntax for timestamp with time zone: Invalid timezone string \
+        "invalid input syntax for type timestamp with time zone: Invalid timezone string \
          (+15:61): timezone minute invalid 61: \"1999-01-01 01:23:34.555 +15:61\"",
     );
     run_test_parse_timestamptz_errors(
         "1999-01-01 01:23:34.555 4",
-        "invalid input syntax for timestamp with time zone: Cannot parse timezone offset 4: \
+        "invalid input syntax for type timestamp with time zone: Cannot parse timezone offset 4: \
          \"1999-01-01 01:23:34.555 4\"",
     );
 
@@ -418,7 +418,7 @@ fn parse_interval_error() {
 
     run_test_parse_interval_errors(
         "1 1-1",
-        "invalid input syntax for interval: Cannot determine format of all parts. Add explicit time \
+        "invalid input syntax for type interval: Cannot determine format of all parts. Add explicit time \
          components, e.g. INTERVAL '1 day' or INTERVAL '1' DAY: \"1 1-1\"",
     );
 }

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -369,7 +369,7 @@ fn push_column(
                     row.push(Datum::Date(d));
                 }
                 "float4" => {
-                    let f = get_column_inner::<f32>(postgres_row, i, nullable)?.map(f64::from);
+                    let f = get_column_inner::<f32>(postgres_row, i, nullable)?.map(f32::from);
                     row.push(f.into());
                 }
                 "float8" => {

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -67,7 +67,7 @@ true
 query error no overload for integer = text: arguments cannot be implicitly cast
 SELECT 1 = ANY(ARRAY['hi'::text])
 
-query error invalid input syntax for integer: invalid digit found in string: "hi"
+query error invalid input syntax for type integer: invalid digit found in string: "hi"
 select 'hi' = any(array[1]);
 
 query error cannot determine type of empty array

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -45,7 +45,7 @@ tR                true
 tRuE              true
 TRUE              true
 
-query error invalid input syntax for boolean: "blah"
+query error invalid input syntax for type boolean: "blah"
 SELECT 'blah'::bool
 
 query error NOT argument must have type boolean, not type integer

--- a/test/sqllogictest/cockroach/bytes.slt
+++ b/test/sqllogictest/cockroach/bytes.slt
@@ -47,7 +47,7 @@ SELECT '日本語'::text::bytea::text
 ----
 \xe697a5e69cace8aa9e
 
-query error invalid input syntax for bytea: invalid escape sequence
+query error invalid input syntax for type bytea: invalid escape sequence
 SELECT '\400'::bytea
 
 # TODO(benesch): support bytea_output.
@@ -115,13 +115,13 @@ SELECT length('a\\b'::text::bytea)
 ----
 3
 
-query error invalid input syntax for bytea: invalid escape sequence
+query error invalid input syntax for type bytea: invalid escape sequence
 SELECT 'a\bcde'::text::bytea
 
-query error invalid input syntax for bytea: invalid escape sequence
+query error invalid input syntax for type bytea: invalid escape sequence
 SELECT 'a\01'::text::bytea
 
-query error invalid input syntax for bytea: ends with escape character
+query error invalid input syntax for type bytea: ends with escape character
 SELECT 'a\'::text::bytea
 
 subtest Regression_27950

--- a/test/sqllogictest/cockroach/tuple.slt
+++ b/test/sqllogictest/cockroach/tuple.slt
@@ -172,7 +172,7 @@ SELECT
 a     b     c      d
 true  NULL  false  NULL
 
-statement error invalid input syntax for integer
+statement error invalid input syntax for type integer
 SELECT (1, 2) > (1, 'hi') FROM tb
 
 statement error unequal number of entries in row expressions
@@ -238,7 +238,7 @@ SELECT (ROW(sqrt(100.0)), 'ab') = (ROW(1 + 9), 'a' || 'b') AS a
 a
 true
 
-query error invalid input syntax for integer
+query error invalid input syntax for type integer
 SELECT ((1, 2), 'equal') = ((1, 'huh'), 'equal') FROM tb
 
 # Issue #3568

--- a/test/sqllogictest/cockroach/values.slt
+++ b/test/sqllogictest/cockroach/values.slt
@@ -72,5 +72,5 @@ VALUES ((SELECT 1)), ((SELECT 2))
 1
 2
 
-query error pgcode 42804 invalid input syntax for integer
+query error pgcode 42804 invalid input syntax for type integer
 VALUES (NULL, 1), (2, NULL), (NULL, 'a')

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1031,16 +1031,16 @@ SELECT DATE '2007-02-01   T  15:04:05+00'
 ----
 2007-02-01
 
-statement error invalid input syntax for date: invalid DateTimeField: X: "2007-02-01X15:04:05"
+statement error invalid input syntax for type date: invalid DateTimeField: X: "2007-02-01X15:04:05"
 SELECT DATE '2007-02-01X15:04:05'
 
-statement error invalid input syntax for date: invalid DateTimeField: TT: "2007-02-01TT15:04:05"
+statement error invalid input syntax for type date: invalid DateTimeField: TT: "2007-02-01TT15:04:05"
 SELECT DATE '2007-02-01TT15:04:05'
 
-statement error invalid input syntax for date: Cannot determine format of all parts: "2007-02-01  T  T  15:04:05"
+statement error invalid input syntax for type date: Cannot determine format of all parts: "2007-02-01  T  T  15:04:05"
 SELECT DATE '2007-02-01  T  T  15:04:05'
 
-statement error invalid input syntax for date: Invalid timezone string \(T\): 'T' is not a valid timezone. Failed to parse T at token index 0
+statement error invalid input syntax for type date: Invalid timezone string \(T\): 'T' is not a valid timezone. Failed to parse T at token index 0
 SELECT DATE '2007-02-01  T '
 
 # Test casting time to interval & vice versa
@@ -1082,5 +1082,5 @@ SELECT '"2020!03-17 #?~T~02:36:56#"'::timestamp;
 ----
 2020-03-17 02:36:56
 
-query error invalid input syntax for timestamp: have unprocessed tokens 56
+query error invalid input syntax for type timestamp: have unprocessed tokens 56
 select TIMESTAMP '"2020-03-17 ~02:36:~56~"';

--- a/test/sqllogictest/decimal.slt
+++ b/test/sqllogictest/decimal.slt
@@ -241,7 +241,7 @@ SELECT 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1 * 1.0
 1
 
 ### edge cases ###
-query error invalid input syntax for numeric: malformed numeric literal: : ""
+query error invalid input syntax for type numeric: malformed numeric literal: : ""
 SELECT ''::decimal
 
 query R

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -49,8 +49,24 @@ SELECT '2e40'::float8
 ----
 20000000000000000000000000000000000000000
 
-query error float out of range
+query error value out of range: overflow
 SELECT '2e40'::float8::float4
+
+query R
+SELECT '2147483583'::float4::int;
+----
+2147483520
+
+query error integer out of range
+SELECT '2147483648'::float4::int
+
+query R
+SELECT '-2147483648'::float4::int
+----
+-2147483648
+
+query error integer out of range
+SELECT '-2147483777'::float4::int;
 
 # Invalid type mods
 

--- a/test/sqllogictest/interval.slt
+++ b/test/sqllogictest/interval.slt
@@ -67,21 +67,21 @@ SELECT INTERVAL '1-2 3' HOUR;
 1 year 2 months 03:00:00
 
 # Disallow components to be set twice.
-statement error invalid input syntax for interval: YEAR field set twice: "1 year 2 years"
+statement error invalid input syntax for type interval: YEAR field set twice: "1 year 2 years"
 SELECT INTERVAL '1 year 2 years'
 
-statement error invalid input syntax for interval: YEAR or MONTH field set twice: "1-2 3-4"
+statement error invalid input syntax for type interval: YEAR or MONTH field set twice: "1-2 3-4"
 SELECT INTERVAL '1-2 3-4'
 
-statement error invalid input syntax for interval: YEAR field set twice: "1-2 3 year"
+statement error invalid input syntax for type interval: YEAR field set twice: "1-2 3 year"
 SELECT INTERVAL '1-2 3 year'
 
-statement error invalid input syntax for interval: MONTH field set twice: "1-2 3"
+statement error invalid input syntax for type interval: MONTH field set twice: "1-2 3"
 SELECT INTERVAL '1-2 3' MONTH;
 
 # 5 would be parsed as second, but the H:M:S.NS
 # group was already set by 3:4/
-statement error invalid input syntax for interval: SECOND field set twice: "1-2 3:4 5"
+statement error invalid input syntax for type interval: SECOND field set twice: "1-2 3:4 5"
 SELECT INTERVAL '1-2 3:4 5';
 
 # Treat trailing TimeUnit as terminating range.
@@ -142,7 +142,7 @@ SELECT INTERVAL '1:2:3.4 5-6 7' DAY;
 
 # Disambiguate component (YEAR), but disallow because
 # the group it's in has been closed.
-statement error invalid input syntax for interval: YEAR field set twice: "1:2:3.4 5-6 7"
+statement error invalid input syntax for type interval: YEAR field set twice: "1:2:3.4 5-6 7"
 SELECT INTERVAL '1:2:3.4 5-6 7' YEAR;
 
 # Negative components
@@ -220,17 +220,17 @@ SELECT INTERVAL '0-0 0 0:0:0.0';
 00:00:00
 
 # Oversized components in SQL standard-style variables
-statement error invalid input syntax for interval: MONTH must be \[-12, 12\], got 13: "100-13"
+statement error invalid input syntax for type interval: MONTH must be \[-12, 12\], got 13: "100-13"
 SELECT INTERVAL '100-13';
 
-statement error invalid input syntax for interval: MINUTE must be \[-59, 59\], got 61: "100-11 366 250:61"
+statement error invalid input syntax for type interval: MINUTE must be \[-59, 59\], got 61: "100-11 366 250:61"
 SELECT INTERVAL '100-11 366 250:61';
 
-statement error invalid input syntax for interval: SECOND must be \[-60, 60\], got 61: "100-11 366 250:59:61"
+statement error invalid input syntax for type interval: SECOND must be \[-60, 60\], got 61: "100-11 366 250:59:61"
 SELECT INTERVAL '100-11 366 250:59:61';
 
 # Invalid syntax
-statement error invalid input syntax for interval: have unprocessed tokens .500000000
+statement error invalid input syntax for type interval: have unprocessed tokens .500000000
 SELECT INTERVAL '1:2:3.4.5';
 
 statement error
@@ -415,11 +415,11 @@ SELECT INTERVAL '1-2 3:4 5 day';
 1 year 2 months 5 days 03:04:00
 
 # Mix style allowed, but cannot assigning to closed group.
-statement error invalid input syntax for interval: SECOND field set twice: "1-2 3:4 5 second"
+statement error invalid input syntax for type interval: SECOND field set twice: "1-2 3:4 5 second"
 SELECT INTERVAL '1-2 3:4 5 second';
 
 # Commutativity means this is also not allowed.
-statement error invalid input syntax for interval: HOUR, MINUTE, SECOND field set twice: "1-2 5 second 3:4"
+statement error invalid input syntax for type interval: HOUR, MINUTE, SECOND field set twice: "1-2 5 second 3:4"
 SELECT INTERVAL '1-2 5 second 3:4';
 
 # Fractional month in addition to other fields.
@@ -632,10 +632,10 @@ SELECT INTERVAL '1' YEAR / 0
 #----
 #-2236962132 days -07:59:59.999999
 
-statement error invalid input syntax for interval: exceeds min/max interval duration
+statement error invalid input syntax for type interval: exceeds min/max interval duration
 SELECT INTERVAL '2147483647 days 2147483648 hours'
 
-statement error invalid input syntax for interval: exceeds min/max interval duration
+statement error invalid input syntax for type interval: exceeds min/max interval duration
 SELECT INTERVAL '-2147483647 days -2147483648 hours'
 
 statement error interval out of range

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -665,7 +665,7 @@ SELECT (LIST[1,2,3][LIST[1][2.0 / 2]])::text
 
 # 🔬🔬 Err
 
-query error invalid input syntax for bigint: invalid digit found in string: "dog"
+query error invalid input syntax for type bigint: invalid digit found in string: "dog"
 SELECT LIST[1,2,3]['dog']
 
 query error subscript \(indexing\) does not support casting from date to bigint
@@ -674,7 +674,7 @@ SELECT LIST [[1, 2, 3], [4, 5]][DATE '2001-01-01']
 query error subscript \(indexing\) does not support casting from timestamp to bigint
 SELECT LIST [[1, 2, 3], [4, 5]][TIMESTAMP '2001-01-01']
 
-query error invalid input syntax for bigint: invalid digit found in string: "dog"
+query error invalid input syntax for type bigint: invalid digit found in string: "dog"
 SELECT (LIST[1,2,3][1:'dog'])::text
 
 query error subscript \(slicing\) does not support casting from date to bigint
@@ -1241,7 +1241,7 @@ NULL
 
 # 🔬🔬🔬🔬 Errors
 
-query error invalid input syntax for integer: invalid digit found in string: "dog"
+query error invalid input syntax for type integer: invalid digit found in string: "dog"
 SELECT (LIST['1', 'dog']::int list)::text
 
 query error CAST does not support casting from date list to integer list
@@ -1252,12 +1252,12 @@ SELECT LIST[DATE '2008-02-01']::int list
 query T
 SELECT (LIST[[1.4::float], [-1.5::float, 2.5::float]]::int list list)::text
 ----
-{{1},{-2,3}}
+{{1},{-2,2}}
 
 query T
 SELECT (LIST[[1.4::float], [-1.5::float, 2.5::float], NULL::float list]::int list list)::text
 ----
-{{1},{-2,3},NULL}
+{{1},{-2,2},NULL}
 
 # 🔬🔬🔬 Non-numeric types
 
@@ -1448,23 +1448,23 @@ SELECT ('{{a, "", "\""}, "{a, \"\", \"\\\"\"}"}'::text list list)::text
 {{a,"","\""},{a,"","\""}}
 
 # Unquoted elements cannot have special characters interleaved within them
-query error invalid input syntax for list: malformed literal; must escape special character '"'
+query error invalid input syntax for type list: malformed literal; must escape special character '"'
 SELECT ('{a"b"}'::text list)::text
 
-query error invalid input syntax for list: malformed literal; must escape special character '\{'
+query error invalid input syntax for type list: malformed literal; must escape special character '\{'
 SELECT ('{a{b}'::text list)::text
 
-query error invalid input syntax for list: malformed array literal; contains 'b' after terminal '\}'
+query error invalid input syntax for type list: malformed array literal; contains 'b' after terminal '\}'
 SELECT ('{a}b}'::text list)::text
 
 # No non-whitespace characters after the escape
-query error invalid input syntax for list: expected ',' or '\}', got 'b'
+query error invalid input syntax for type list: expected ',' or '\}', got 'b'
 SELECT ('{"a"b}'::text list)::text
 
-query error invalid input syntax for list: expected ',' or '\}', got '"'
+query error invalid input syntax for type list: expected ',' or '\}', got '"'
 SELECT ('{""""}'::text list)::text
 
-query error invalid input syntax for list: expected ',' or '\}', got '"'
+query error invalid input syntax for type list: expected ',' or '\}', got '"'
 SELECT ('{"""}'::text list)::text
 
 # 🔬🔬🔬🔬 Unquoted escapes
@@ -1580,10 +1580,10 @@ SELECT ('{N\ULL}'::text list)::text
 {"NULL"}
 
 # Escaping terminal character means it isn't available to close the list
-query error invalid input syntax for list: unterminated element
+query error invalid input syntax for type list: unterminated element
 SELECT ('{\}'::text list)::text
 
-query error invalid input syntax for list: unexpected end of input
+query error invalid input syntax for type list: unexpected end of input
 SELECT ('{{\}}'::text list list)::text
 
 # 🔬🔬🔬 text to other lists
@@ -1641,44 +1641,44 @@ SELECT ('{ {   } }'::text list list)::text
 # 🔬🔬🔬 errors
 
 # Empty string is invalid
-query error invalid input syntax for list: expected '\{', found empty string: ""
+query error invalid input syntax for type list: expected '\{', found empty string: ""
 SELECT (''::text list)::text
 
 # Not a list
-query error invalid input syntax for list: expected '\{', found 1: "1"
+query error invalid input syntax for type list: expected '\{', found 1: "1"
 SELECT ('1'::int list)::text
 
 # Invalid element
-query error invalid input syntax for list: invalid input syntax for integer: invalid digit found in string: "a": "\{a\}"
+query error invalid input syntax for type list: invalid input syntax for type integer: invalid digit found in string: "a": "\{a\}"
 SELECT ('{a}'::int list)::text
 
 # 'NULL' isn't a valid string for a list; just use unescaped NULL
-query error invalid input syntax for list: expected '\{', found N: "NULL"
+query error invalid input syntax for type list: expected '\{', found N: "NULL"
 SELECT ('NULL'::int list)::text
 
 # Too many leading brackets
-query error invalid input syntax for list: unescaped '\{' at beginning of element
+query error invalid input syntax for type list: unescaped '\{' at beginning of element
 SELECT ('{{1}}'::int list)::text
 
 # Too many leading brackets
-query error invalid input syntax for list: unescaped '\{' at beginning of element
+query error invalid input syntax for type list: unescaped '\{' at beginning of element
 SELECT ('{{1}'::int list)::text
 
-query error invalid input syntax for list: unexpected end of input: "\{\{1\}"
+query error invalid input syntax for type list: unexpected end of input: "\{\{1\}"
 SELECT ('{{1}'::int list list)::text
 
 # Too many following brackets
-query error invalid input syntax for list: malformed array literal; contains '\}' after terminal '\}': "\{1\}\}"
+query error invalid input syntax for type list: malformed array literal; contains '\}' after terminal '\}': "\{1\}\}"
 SELECT ('{1}}'::int list)::text
 
-query error invalid input syntax for list: invalid input syntax for list: expected '\{', found 1: "1": "\{1\}\}"
+query error invalid input syntax for type list: invalid input syntax for type list: expected '\{', found 1: "1": "\{1\}\}"
 SELECT ('{1}}'::int list list)::text
 
 # Cannot have commas followed or preceded by empty elements
-query error invalid input syntax for list: malformed literal; missing element: "\{a,  \}"
+query error invalid input syntax for type list: malformed literal; missing element: "\{a,  \}"
 SELECT ('{a,  }'::text list)::text
 
-query error invalid input syntax for list: malformed literal; missing element: "\{  ,a\}"
+query error invalid input syntax for type list: malformed literal; missing element: "\{  ,a\}"
 SELECT ('{  ,a}'::text list)::text
 
 # 🔬 Built-in operations
@@ -2042,7 +2042,7 @@ SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
 statement ok
 CREATE TYPE bool AS LIST (element_type=int4)
 
-query error invalid input syntax for boolean: "\{1,2\}"
+query error invalid input syntax for type boolean: "\{1,2\}"
 SELECT '{1,2}'::bool;
 
 query T

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -68,7 +68,7 @@ SELECT ('{}'::map[text=>int])::text
 ----
 {}
 
-query error invalid input syntax for boolean: "2.0"
+query error invalid input syntax for type boolean: "2.0"
 SELECT ('{a=>1, b=>false, c=>2.0}'::map[text=>bool])::text
 
 query T
@@ -285,7 +285,7 @@ SELECT '{hello=>{world=>"2020-11-23"}}'::map[text=>map[text=>date]] -> 'hello'::
 false
 
 ## @>
-query error invalid input syntax for map: expected '\{', found c: "c"
+query error invalid input syntax for type map: expected '\{', found c: "c"
 SELECT '{a=>1, b=>2}'::map[text=>int] @> 'c'
 
 query error  arguments cannot be implicitly cast to any implementation's parameters
@@ -570,7 +570,7 @@ SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
 statement ok
 CREATE TYPE bool AS MAP (key_type=text, value_type=int4)
 
-query error invalid input syntax for boolean: "\{a=>1\}"
+query error invalid input syntax for type boolean: "\{a=>1\}"
 SELECT '{a=>1}'::bool;
 
 query T

--- a/test/sqllogictest/postgres/float4.slt
+++ b/test/sqllogictest/postgres/float4.slt
@@ -1,0 +1,368 @@
+# Copyright 1994, Regents of the University of California.
+# Copyright 1996-2019 PostgreSQL Global Development Group.
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the regression test suite in PostgreSQL.
+# The original file was retrieved on February 10, 2021 from:
+#
+#     https://github.com/postgres/postgres/blob/64990081504661ff5c04dbf20cc4252be66ab149/src/test/regress/expected/float4.out
+#
+# The original source code is subject to the terms of the PostgreSQL
+# license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+mode cockroach
+
+statement ok
+CREATE TABLE float4_tbl (f1 float4)
+
+statement ok
+INSERT INTO float4_tbl (f1) VALUES ('    0.0'), ('1004.30   '), ('     -34.84    '), ('1.2345678901234e+20'), ('1.2345678901234e-20')
+
+# test for over and under flow
+query error "10e70" is out of range for type real
+SELECT '10e70'::float4
+
+query error "-10e70" is out of range for type real
+SELECT '-10e70'::float4
+
+query error "10e-70" is out of range for type real
+SELECT '10e-70'::float4
+
+query error "-10e-70" is out of range for type real
+SELECT '-10e-70'::float4
+
+query error value out of range: overflow
+SELECT '10e70'::float8::float4
+
+query error value out of range: overflow
+SELECT '-10e70'::float8::float4
+
+query error value out of range: underflow
+SELECT '10e-70'::float8::float4
+
+query error value out of range: underflow
+SELECT '-10e-70'::float8::float4
+
+query error "10e400" is out of range for type real
+SELECT '10e400'::float4
+
+query error "-10e400" is out of range for type real
+SELECT '-10e400'::float4
+
+query error "10e-400" is out of range for type real
+SELECT '10e-400'::float4
+
+query error "-10e-400" is out of range for type real
+SELECT '-10e-400'::float4
+
+query error invalid input syntax for type real: ""
+SELECT ''::float4
+
+query error invalid input syntax for type real: "       "
+SELECT '       '::float4
+
+query error invalid input syntax for type real: "xyz"
+SELECT 'xyz'::float4
+
+query error invalid input syntax for type real: "5.0.0"
+SELECT '5.0.0'::float4
+
+query error invalid input syntax for type real: "5 . 0"
+SELECT '5 . 0'::float4
+
+query error invalid input syntax for type real: "5.   0"
+SELECT '5.   0'::float4
+
+query error invalid input syntax for type real: "     - 3.0"
+SELECT '     - 3.0'::float4
+
+query error invalid input syntax for type real: "123            5"
+SELECT '123            5'::float4
+
+query T
+SELECT 'NaN'::float4::text
+----
+NaN
+
+query T
+SELECT 'nan'::float4::text
+----
+NaN
+
+query T
+SELECT '   NAN  '::float4::text
+----
+NaN
+
+query T
+SELECT 'infinity'::float4::text
+----
+Infinity
+
+query T
+SELECT '          -INFINiTY   '::float4::text
+----
+-Infinity
+
+query error invalid input syntax for type real: "N A N"
+SELECT 'N A N'::float4
+
+query error invalid input syntax for type real: "NaN x"
+SELECT 'NaN x'::float4;
+
+query error invalid input syntax for type real: " INFINITY    x"
+SELECT ' INFINITY    x'::float4
+
+query T
+SELECT ('Infinity'::float4 + 100.0)::text
+----
+Infinity
+
+query T
+SELECT ('Infinity'::float4 / 'Infinity'::float4)::text
+----
+NaN
+
+query T
+SELECT ('42'::float4 / 'Infinity'::float4)::text
+----
+0
+
+query T
+SELECT ('nan'::float4 / 'nan'::float4)::text
+----
+NaN
+
+query T
+SELECT ('nan'::float4 / '0'::float4)::text
+----
+NaN
+
+# TODO(benesch): re-enable when the numeric type supports NaN.
+#
+# query R
+# SELECT 'nan'::numeric::float4;
+# ----
+# NaN
+
+query T rowsort
+SELECT f1::text FROM float4_tbl
+----
+0
+1004.3
+-34.84
+1.2345679e+20
+1.2345679e-20
+
+query T rowsort
+SELECT f1::text FROM float4_tbl WHERE f1 <> '1004.3'
+----
+0
+-34.84
+1.2345679e+20
+1.2345679e-20
+
+query T
+SELECT f1::text FROM float4_tbl WHERE f1 = '1004.3'
+----
+1004.3
+
+query T rowsort
+SELECT f1::text FROM float4_tbl WHERE '1004.3' > f1
+----
+0
+-34.84
+1.2345679e-20
+
+query T rowsort
+SELECT f1::text FROM float4_tbl WHERE  f1 < '1004.3'
+----
+0
+-34.84
+1.2345679e-20
+
+query T rowsort
+SELECT f1::text FROM float4_tbl WHERE '1004.3' >= f1
+----
+0
+1004.3
+-34.84
+1.2345679e-20
+
+query T rowsort
+SELECT f1::text FROM float4_tbl WHERE  f1 <= '1004.3'
+----
+0
+1004.3
+-34.84
+1.2345679e-20
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 * '-10')::text AS x FROM float4_tbl f
+WHERE f.f1 > '0.0'
+----
+1004.3         -10043
+1.2345679e+20  -1.2345678e+21
+1.2345679e-20  -1.2345678e-19
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 + '-10')::text AS x FROM float4_tbl f
+WHERE f.f1 > '0.0'
+----
+1004.3         994.3
+1.2345679e+20  1.2345679e+20
+1.2345679e-20  -10
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 / '-10')::text AS x FROM float4_tbl f
+WHERE f.f1 > '0.0'
+----
+1004.3         -100.43
+1.2345679e+20  -1.2345679e+19
+1.2345679e-20  -1.2345679e-21
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 - '-10')::text AS x FROM float4_tbl f
+WHERE f.f1 > '0.0'
+----
+1004.3         1014.3
+1.2345679e+20  1.2345679e+20
+1.2345679e-20  10
+
+# test divide by zero
+query error division by zero
+SELECT f.f1 / '0.0' from float4_tbl f;
+
+query T rowsort
+SELECT f1::text FROM float4_tbl
+----
+0
+1004.3
+-34.84
+1.2345679e+20
+1.2345679e-20
+
+# -- test the unary float4abs operator
+# SELECT f.f1, @f.f1 AS abs_f1 FROM float4_tbl f;
+#       f1       |    abs_f1
+# ---------------+---------------
+#              0 |             0
+#         1004.3 |        1004.3
+#         -34.84 |         34.84
+#  1.2345679e+20 | 1.2345679e+20
+#  1.2345679e-20 | 1.2345679e-20
+# (5 rows)
+
+statement ok
+UPDATE float4_tbl SET f1 = float4_tbl.f1 * '-1' WHERE float4_tbl.f1 > '0.0'
+
+query T rowsort
+SELECT f1::text FROM float4_tbl
+----
+0
+-34.84
+-1004.3
+-1.2345679e+20
+-1.2345679e-20
+
+# test edge-case coercions to integer
+
+# TODO(benesch): enable when we support `int2`.
+#
+# SELECT '32767.4'::float4::int2;
+#  int2
+# -------
+#  32767
+# (1 row)
+#
+# SELECT '32767.6'::float4::int2;
+# ERROR:  smallint out of range
+# SELECT '-32768.4'::float4::int2;
+#   int2
+# --------
+#  -32768
+# (1 row)
+#
+# SELECT '-32768.6'::float4::int2;
+# ERROR:  smallint out of range
+# SELECT '2147483520'::float4::int4;
+#     int4
+# ------------
+#  2147483520
+# (1 row)
+
+query error integer out of range
+SELECT '2147483647'::float4::int4
+
+query I
+SELECT '-2147483648.5'::float4::int4
+----
+-2147483648
+
+query error integer out of range
+SELECT '-2147483900'::float4::int4
+
+query I
+SELECT '9223369837831520256'::float4::int8
+----
+9223369837831520256
+
+query error bigint out of range
+SELECT '9223372036854775807'::float4::int8;
+
+query I
+SELECT '-9223372036854775808.5'::float4::int8;
+----
+-9223372036854775808
+
+query error bigint out of range
+SELECT '-9223380000000000000'::float4::int8
+
+query T
+SELECT '36854775807.0'::float4::int8::text
+----
+36854775808
+
+query RI rowsort
+SELECT x, x::int4 AS int4_value
+FROM (VALUES (-2.5::float4),
+             (-1.5::float4),
+             (-0.5::float4),
+             (0.0::float4),
+             (0.5::float4),
+             (1.5::float4),
+             (2.5::float4)) t(x);
+----
+-2.5  -2
+-1.5  -2
+-0.5  0
+0     0
+0.5   0
+1.5   2
+2.5   2
+
+query RI rowsort
+SELECT x, x::int8 AS int8_value
+FROM (VALUES (-2.5::float4),
+             (-1.5::float4),
+             (-0.5::float4),
+             (0.0::float4),
+             (0.5::float4),
+             (1.5::float4),
+             (2.5::float4)) t(x);
+----
+-2.5  -2
+-1.5  -2
+-0.5  0
+0     0
+0.5   0
+1.5   2
+2.5   2

--- a/test/sqllogictest/postgres/float8.slt
+++ b/test/sqllogictest/postgres/float8.slt
@@ -1,0 +1,377 @@
+# Copyright 1994, Regents of the University of California.
+# Copyright 1996-2019 PostgreSQL Global Development Group.
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the regression test suite in PostgreSQL.
+# The original file was retrieved on February 10, 2021 from:
+#
+#     https://github.com/postgres/postgres/blob/64990081504661ff5c04dbf20cc4252be66ab149/src/test/regress/expected/float8.out
+#
+# The original source code is subject to the terms of the PostgreSQL
+# license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+mode cockroach
+
+statement ok
+CREATE TABLE float8_tbl (f1 float8)
+
+statement ok
+INSERT INTO float8_tbl (f1) VALUES ('    0.0   '), ('1004.30  '), ('   -34.84'), ('1.2345678901234e+200'), ('1.2345678901234e-200')
+
+# test for underflow and overflow handling
+query error "10e400" is out of range for type double precision
+SELECT '10e400'::float8
+
+query error "-10e400" is out of range for type double precision
+SELECT '-10e400'::float8
+
+query error "10e-400" is out of range for type double precision
+SELECT '10e-400'::float8
+
+query error "-10e-400" is out of range for type double precision
+SELECT '-10e-400'::float8
+
+# bad input
+query error invalid input syntax for type double precision: ""
+SELECT ''::float8
+
+query error invalid input syntax for type double precision: "     "
+SELECT '     '::float8
+
+query error invalid input syntax for type double precision: "xyz"
+SELECT 'xyz'::float8
+
+query error invalid input syntax for type double precision: "5.0.0"
+SELECT '5.0.0'::float8
+
+query error invalid input syntax for type double precision: "5 . 0"
+SELECT '5 . 0'::float8
+
+query error invalid input syntax for type double precision: "5.   0"
+SELECT '5.   0'::float8
+
+query error invalid input syntax for type double precision: "    - 3"
+SELECT '    - 3'::float8
+
+query error invalid input syntax for type double precision: "123           5"
+SELECT '123           5'::float8
+
+# special inputs
+query T
+SELECT 'NaN'::float8::text
+----
+NaN
+
+query T
+SELECT 'nan'::float8::text
+----
+NaN
+
+query T
+SELECT '   NAN  '::float8::text
+----
+NaN
+
+query T
+SELECT 'infinity'::float8::text
+----
+Infinity
+
+query T
+SELECT '          -INFINiTY   '::float8::text
+----
+-Infinity
+
+# bad special inputs
+query error invalid input syntax for type double precision: "N A N"
+SELECT 'N A N'::float8::text
+
+query error invalid input syntax for type double precision: "NaN x"
+SELECT 'NaN x'::float8;
+
+query error invalid input syntax for type double precision: " INFINITY    x"
+SELECT ' INFINITY    x'::float8
+
+query T
+SELECT ('Infinity'::float8 + 100.0)::text
+----
+Infinity
+
+query T
+SELECT ('Infinity'::float8 / 'Infinity'::float8)::text
+----
+NaN
+
+query R
+SELECT '42'::float8 / 'Infinity'::float8
+----
+0
+
+query T
+SELECT ('nan'::float8 / 'nan'::float8)::text
+----
+NaN
+
+query T
+SELECT ('nan'::float8 / '0'::float8)::text
+----
+NaN
+
+# TODO(benesch): re-enable when the numeric type supports NaN.
+#
+# query T
+# SELECT 'nan'::numeric::float8
+# ----
+# NaN
+
+query T rowsort
+SELECT f1::text FROM float8_tbl
+----
+0
+1004.3
+-34.84
+1.2345678901234e+200
+1.2345678901234e-200
+
+query T
+SELECT f.f1::text FROM float8_tbl f WHERE f.f1 <> '1004.3'
+----
+0
+-34.84
+1.2345678901234e+200
+1.2345678901234e-200
+
+query T
+SELECT f.f1::text FROM float8_tbl f WHERE f.f1 = '1004.3'
+----
+1004.3
+
+query T rowsort
+SELECT f.f1::text FROM float8_tbl f WHERE '1004.3' > f.f1
+----
+0
+-34.84
+1.2345678901234e-200
+
+query T rowsort
+SELECT f.f1::text FROM float8_tbl f WHERE  f.f1 < '1004.3'
+----
+0
+-34.84
+1.2345678901234e-200
+
+query T rowsort
+SELECT f.f1::text FROM float8_tbl f WHERE '1004.3' >= f.f1
+----
+0
+1004.3
+-34.84
+1.2345678901234e-200
+
+query T rowsort
+SELECT f.f1::text FROM float8_tbl f WHERE  f.f1 <= '1004.3'
+----
+0
+1004.3
+-34.84
+1.2345678901234e-200
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 * '-10')::text AS x FROM float8_tbl f WHERE f.f1 > '0.0'
+----
+1004.3                -10043
+1.2345678901234e+200  -1.2345678901234e+201
+1.2345678901234e-200  -1.2345678901234e-199
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 + '-10')::text AS x FROM float8_tbl f WHERE f.f1 > '0.0'
+----
+1004.3                994.3
+1.2345678901234e+200  1.2345678901234e+200
+1.2345678901234e-200  -10
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 / '-10')::text AS x FROM float8_tbl f WHERE f.f1 > '0.0'
+----
+              1004.3   -100.42999999999999
+1.2345678901234e+200  -1.2345678901234e+199
+1.2345678901234e-200  -1.2345678901234e-201
+
+query TT rowsort
+SELECT f.f1::text, (f.f1 - '-10')::text AS x FROM float8_tbl f WHERE f.f1 > '0.0';
+----
+1004.3                1014.3
+1.2345678901234e+200  1.2345678901234e+200
+1.2345678901234e-200  10
+
+# -- round
+query TT rowsort
+SELECT f.f1::text, round(f.f1)::text AS round_f1 FROM float8_tbl f
+----
+0                     0
+1004.3                1004
+-34.84                -35
+1.2345678901234e+200  1.2345678901234e+200
+1.2345678901234e-200  0
+
+# ceil / ceiling
+query T rowsort
+select ceil(f1)::text as ceil_f1 from float8_tbl f
+----
+0
+1005
+-34
+1.2345678901234e+200
+1
+
+# TODO(benesch): support ceiling.
+#
+# query T rowsort
+# select ceiling(f1)::text as ceiling_f1 from float8_tbl f;
+# ----
+# 0
+# 1005
+# -34
+# 1.2345678901234e+200
+# 1
+
+# floor
+query T rowsort
+select floor(f1)::text as floor_f1 from float8_tbl f
+----
+0
+1004
+-35
+1.2345678901234e+200
+0
+
+# TODO(benesch): support sign.
+#
+# -- sign
+# select sign(f1) as sign_f1 from float8_tbl f;
+#  sign_f1
+# ---------
+#        0
+#        1
+#       -1
+#        1
+#        1
+# (5 rows)
+
+# test for over- and underflow
+query error "10e400" is out of range for type double precision
+SELECT '10e400'::float8
+
+query error "-10e400" is out of range for type double precision
+SELECT '-10e400'::float8
+
+query error "10e-400" is out of range for type double precision
+SELECT '10e-400'::float8
+
+query error "-10e-400" is out of range for type double precision
+SELECT '-10e-400'::float8
+
+# test edge-case coercions to integer
+
+# TODO(benesch): enable when we support `int2`.
+#
+# SELECT '32767.4'::float8::int2;
+#  int2
+# -------
+#  32767
+# (1 row)
+#
+# SELECT '32767.6'::float8::int2;
+# ERROR:  smallint out of range
+# SELECT '-32768.4'::float8::int2;
+#   int2
+# --------
+#  -32768
+# (1 row)
+#
+# SELECT '-32768.6'::float8::int2;
+# ERROR:  smallint out of range
+# SELECT '2147483647.4'::float8::int4;
+#     int4
+# ------------
+#  2147483647
+# (1 row)
+
+query error integer out of range
+SELECT '2147483647.6'::float8::int4
+
+query I
+SELECT '-2147483648.4'::float8::int4
+----
+-2147483648
+
+query error integer out of range
+SELECT '-2147483648.6'::float8::int4
+
+query I
+SELECT '9223372036854773760'::float8::int8
+----
+9223372036854773760
+
+query error bigint out of range
+SELECT '9223372036854775807'::float8::int8
+
+query I
+SELECT '-9223372036854775808.5'::float8::int8
+----
+-9223372036854775808
+
+query error bigint out of range
+SELECT '-9223372036854780000'::float8::int8
+
+query error bigint out of range
+SELECT '922337203685477580700.0'::float8::int8
+
+query RI rowsort
+SELECT x, x::int4 AS int4_value
+FROM (VALUES (-2.5::float8),
+             (-1.5::float8),
+             (-0.5::float8),
+             (0.0::float8),
+             (0.5::float8),
+             (1.5::float8),
+             (2.5::float8)) t(x);
+----
+-2.5  -2
+-1.5  -2
+-0.5  0
+0     0
+0.5   0
+1.5   2
+2.5   2
+
+query RI rowsort
+SELECT x, x::int8 AS int8_value
+FROM (VALUES (-2.5::float8),
+             (-1.5::float8),
+             (-0.5::float8),
+             (0.0::float8),
+             (0.5::float8),
+             (1.5::float8),
+             (2.5::float8)) t(x);
+----
+-2.5  -2
+-1.5  -2
+-0.5  0
+0     0
+0.5   0
+1.5   2
+2.5   2
+
+query T
+SELECT 4567890123456789::int8::float8::text
+----
+4567890123456789

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -68,10 +68,10 @@ query error unable to determine which implementation to use
 SELECT generate_series FROM generate_series(null, null)
 ----
 
-statement error invalid input syntax for integer: invalid digit found in string: "foo"
+statement error invalid input syntax for type integer: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series('foo', 2)
 
-statement error invalid input syntax for integer: invalid digit found in string: "foo"
+statement error invalid input syntax for type integer: invalid digit found in string: "foo"
 SELECT generate_series FROM generate_series(1, 'foo')
 
 statement error arguments cannot be implicitly cast to any implementation's parameters

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -72,7 +72,7 @@ SELECT TIMESTAMPTZ '2007-02-01 00:00:00+5:30:16';
 statement error timezone interval must not contain months or years
 SELECT timezone(INTERVAL '+11'MONTH, TIME '18:53:49')
 
-statement error invalid input syntax for timestamp with time zone: Invalid timezone string \(\+16:60\): timezone hour invalid 16
+statement error invalid input syntax for type timestamp with time zone: Invalid timezone string \(\+16:60\): timezone hour invalid 16
 SELECT TIMESTAMPTZ '2020-01-01 00:00:00+16:60'
 
 query T

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -266,7 +266,7 @@ SELECT '1'::jsonb::bigint;
 ----
 1
 
-query error invalid input syntax for bigint: invalid digit found in string: "dog"
+query error invalid input syntax for type bigint: invalid digit found in string: "dog"
 SELECT 'dog'::text::bigint
 
 query error CAST does not support casting from time to bigint
@@ -319,7 +319,7 @@ SELECT '1'::jsonb::boolean;
 ----
 NULL
 
-query error invalid input syntax for boolean: "dog"
+query error invalid input syntax for type boolean: "dog"
 SELECT 'dog'::text::boolean
 
 query error CAST does not support casting from time to boolean
@@ -360,7 +360,7 @@ SELECT '1'::interval::date
 query error CAST does not support casting from jsonb to date
 SELECT '{}'::jsonb::date
 
-query error invalid input syntax for date: YEAR, MONTH, DAY are all required: "dog"
+query error invalid input syntax for type date: YEAR, MONTH, DAY are all required: "dog"
 SELECT 'dog'::text::date
 
 query error CAST does not support casting from time to date
@@ -420,7 +420,7 @@ SELECT '1'::jsonb::numeric;
 ----
 1.0000
 
-query error invalid input syntax for numeric: malformed numeric literal: dog: "dog"
+query error invalid input syntax for type numeric: malformed numeric literal: dog: "dog"
 SELECT 'dog'::text::numeric
 
 query error CAST does not support casting from time to numeric\(38,0\)
@@ -477,7 +477,7 @@ SELECT '1'::jsonb::double;
 ----
 1.000
 
-query error invalid input syntax for double precision: "dog"
+query error invalid input syntax for type double precision: "dog"
 SELECT 'dog'::text::double
 
 query error CAST does not support casting from time to double precision
@@ -534,7 +534,7 @@ SELECT '2'::jsonb::real;
 ----
 2.000
 
-query error invalid input syntax for real: "dog"
+query error invalid input syntax for type real: "dog"
 SELECT 'dog'::text::real
 
 query error CAST does not support casting from time to real
@@ -588,7 +588,7 @@ SELECT '1'::jsonb::integer;
 ----
 1
 
-query error invalid input syntax for integer: invalid digit found in string: "dog"
+query error invalid input syntax for type integer: invalid digit found in string: "dog"
 SELECT 'dog'::text::integer
 
 query error CAST does not support casting from time to integer
@@ -629,7 +629,7 @@ SELECT '1'::interval::interval;
 query error CAST does not support casting from jsonb to interval
 SELECT '{}'::jsonb::interval
 
-query error invalid input syntax for interval: invalid DateTimeField: DOG: "dog"
+query error invalid input syntax for type interval: invalid DateTimeField: DOG: "dog"
 SELECT 'dog'::text::interval
 
 query T
@@ -789,7 +789,7 @@ SELECT '1'::interval::time;
 query error CAST does not support casting from jsonb to time
 SELECT '{}'::jsonb::time
 
-query error invalid input syntax for time: invalid DateTimeField: DOG: "dog"
+query error invalid input syntax for type time: invalid DateTimeField: DOG: "dog"
 SELECT 'dog'::text::time
 
 query T
@@ -832,7 +832,7 @@ SELECT '1'::interval::timestamp
 query error CAST does not support casting from jsonb to timestamp
 SELECT '{}'::jsonb::timestamp
 
-query error invalid input syntax for timestamp: YEAR, MONTH, DAY are all required: "dog"
+query error invalid input syntax for type timestamp: YEAR, MONTH, DAY are all required: "dog"
 SELECT 'dog'::text::timestamp
 
 query error CAST does not support casting from time to timestamp
@@ -877,7 +877,7 @@ SELECT '1'::interval::timestamptz
 query error CAST does not support casting from jsonb to timestamp with time zone
 SELECT '{}'::jsonb::timestamptz
 
-query error invalid input syntax for timestamp with time zone: YEAR, MONTH, DAY are all required: "dog"
+query error invalid input syntax for type timestamp with time zone: YEAR, MONTH, DAY are all required: "dog"
 SELECT 'dog'::text::timestamptz
 
 query error CAST does not support casting from time to timestamp with time zone

--- a/test/sqllogictest/uuid.slt
+++ b/test/sqllogictest/uuid.slt
@@ -24,7 +24,7 @@ SELECT '63616665-6630-3064-6465-616462656568'::text::uuid
 ----
 63616665-6630-3064-6465-616462656568
 
-query error invalid input syntax for uuid
+query error invalid input syntax for type uuid
 SELECT 'Z3616665-6630-3064-6465-616462656568'::uuid
 
 query error does not support casting from uuid to bytea

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -176,7 +176,7 @@ foo.other.int_list
 
 > CREATE TYPE bool AS LIST (element_type=int4)
 ! SELECT '{1}'::bool
-invalid input syntax for boolean: "{1}"
+invalid input syntax for type boolean: "{1}"
 
 > SELECT pg_typeof('{1}'::public.bool);
 public.bool

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -152,7 +152,7 @@ null value in column "b" violates not-null constraint
 null value in column "b" violates not-null constraint
 
 ! INSERT INTO t VALUES ('d', 4);
-invalid input syntax for integer: invalid digit found in string: "d"
+invalid input syntax for type integer: invalid digit found in string: "d"
 
 # Test that the INSERT body can be a SELECT query.
 > INSERT INTO t SELECT 3, 'd'
@@ -308,10 +308,10 @@ a      b    c
 column "notpresent" of relation "materialize.public.t" does not exist
 
 ! INSERT INTO t (a, b, c) VALUES ('str', 1, 2);
-invalid input syntax for integer: invalid digit found in string: "str"
+invalid input syntax for type integer: invalid digit found in string: "str"
 
 ! INSERT INTO t (b, a, c) VALUES (1, 'str', 2);
-invalid input syntax for integer: invalid digit found in string: "str"
+invalid input syntax for type integer: invalid digit found in string: "str"
 
 ! INSERT INTO t (d, c, b, a) VALUES (1, 1, 1, 'str');
 column "d" of relation "materialize.public.t" does not exist


### PR DESCRIPTION
Import most of the PostgreSQL tests for the float4 and float8 types and
shake out most of the resulting bugs:

  * Floats round ties to the nearest even number, in conformance
    with IEEE 754 and PostgreSQL.

  * Overflow and underflow when casting to and from floats is reported
    as in PostgreSQL.

The upshot is that arithmetic on the result of `extract` properly
handles overflow, so fixes #5688.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5727)
<!-- Reviewable:end -->
