### PR TITLE
materialized: tweak panic message some more

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -567,12 +567,26 @@ fn handle_panic(panic_info: &PanicInfo) {
     };
 
     let location = if let Some(loc) = panic_info.location() {
-        format!("at '{}'", loc)
+        loc.to_string()
     } else {
-        "(no location information)".to_string()
+        "<unknown>".to_string()
     };
 
-    log::error!(target: "panic", "{}: {} {}\n{:?}", thr_name, msg, location, Backtrace::new());
+    log::error!(
+        target: "panic",
+        "{msg}
+thread: {thr_name}
+location: {location}
+version: {version} ({sha})
+backtrace:
+{backtrace:?}",
+        msg = msg,
+        thr_name = thr_name,
+        location = location,
+        version = materialized::BUILD_INFO.version,
+        sha = materialized::BUILD_INFO.sha,
+        backtrace = Backtrace::new(),
+    );
     eprintln!(
         r#"materialized encountered an internal error and crashed.
 
@@ -580,8 +594,7 @@ We rely on bug reports to diagnose and fix these errors. Please
 copy and paste the above details and file a report at:
 
     https://materialize.com/s/bug
-
-To protect your privacy, we do not collect crash reports automatically."#,
+"#,
     );
     process::exit(1);
 }


### PR DESCRIPTION
Expand the panic message out to multiple lines, so the various fields
are more clear. The effect is that a panic that previously rendered like
so

    materialized v0.7.1-dev (4ffb6910a) listening on 0.0.0.0:6875...
    2021-02-11T02:59:38.549439Z ERROR panic: <unnamed>: something is wrong at '/home/benesch/Sites/materialize/materialize/src/coord/src/coord.rs:373:9'
       0: materialized::handle_panic
                 at src/materialized/src/bin/materialized/main.rs:575:78
       1: core::ops::function::Fn::call
    ...

now renders as:

    2021-02-11T03:14:16.915980Z ERROR panic: something is wrong
    thread: <unnamed>
    location: /home/benesch/Sites/materialize/materialize/src/coord/src/coord.rs:373:9
    version: 0.7.1-dev (4ffb6910a5deccede61abd9cb67c8a29fe38145c)
    backtrace:
       0: materialized::handle_panic
                 at src/materialized/src/bin/materialized/main.rs:588:21
       1: core::ops::function::Fn::call
    ...

I think this makes it much more clear that "&lt;unnamed>" refers to a
thread.

The other big win of the new format is the inclusion of the version
information. Empirically we've found users are good at getting us the
backtrace, but not always the whole log file. Reproducing the version
info in the panic handler should help with that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5728)
<!-- Reviewable:end -->
