### PR TITLE
sql-parser: remove dependency on dataflow-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,7 +3840,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "datadriven",
- "dataflow-types",
  "itertools",
  "lazy_static",
  "log",

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -15,7 +15,6 @@ phf = { version = "0.8.0", features = ["unicase"] }
 repr = { path = "../repr" }
 stacker = "0.1.12"
 unicase = "2.4.0"
-dataflow-types = { path = "../dataflow-types" }
 
 [dev-dependencies]
 datadriven = "0.5.0"

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -236,15 +236,6 @@ impl AstDisplay for Compression {
 }
 impl_display!(Compression);
 
-impl From<Compression> for dataflow_types::Compression {
-    fn from(c: Compression) -> Self {
-        match c {
-            Compression::Gzip => Self::Gzip,
-            Compression::None => Self::None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Connector {
     File {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -24,11 +24,10 @@ use ore::str::StrExt;
 use reqwest::Url;
 
 use dataflow_types::{
-    AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Compression, Consistency,
-    CsvEncoding, DataEncoding, ExternalSourceConnector, FileSourceConnector,
-    KafkaSinkConnectorBuilder, KafkaSourceConnector, KinesisSourceConnector, ProtobufEncoding,
-    RegexEncoding, S3SourceConnector, SinkConnectorBuilder, SinkEnvelope, SourceConnector,
-    SourceEnvelope,
+    AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding,
+    DataEncoding, ExternalSourceConnector, FileSourceConnector, KafkaSinkConnectorBuilder,
+    KafkaSourceConnector, KinesisSourceConnector, ProtobufEncoding, RegexEncoding,
+    S3SourceConnector, SinkConnectorBuilder, SinkEnvelope, SourceConnector, SourceEnvelope,
 };
 use expr::GlobalId;
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
@@ -41,11 +40,12 @@ use repr::{strconv, RelationDesc, RelationType, ScalarType};
 use crate::ast::display::AstDisplay;
 use crate::ast::{
     AlterIndexOptionsList, AlterIndexOptionsStatement, AlterObjectRenameStatement, AvroSchema,
-    ColumnOption, Connector, CreateDatabaseStatement, CreateIndexStatement, CreateRoleOption,
-    CreateRoleStatement, CreateSchemaStatement, CreateSinkStatement, CreateSourceStatement,
-    CreateTableStatement, CreateTypeAs, CreateTypeStatement, CreateViewStatement, DataType,
-    DropDatabaseStatement, DropObjectsStatement, Envelope, Expr, Format, Ident, IfExistsBehavior,
-    ObjectType, Raw, SqlOption, Statement, UnresolvedObjectName, Value,
+    ColumnOption, Compression, Connector, CreateDatabaseStatement, CreateIndexStatement,
+    CreateRoleOption, CreateRoleStatement, CreateSchemaStatement, CreateSinkStatement,
+    CreateSourceStatement, CreateTableStatement, CreateTypeAs, CreateTypeStatement,
+    CreateViewStatement, DataType, DropDatabaseStatement, DropObjectsStatement, Envelope, Expr,
+    Format, Ident, IfExistsBehavior, ObjectType, Raw, SqlOption, Statement, UnresolvedObjectName,
+    Value,
 };
 use crate::catalog::{CatalogItem, CatalogItemType};
 use crate::kafka_util;
@@ -436,7 +436,10 @@ pub fn plan_create_source(
 
             let connector = ExternalSourceConnector::File(FileSourceConnector {
                 path: path.clone().into(),
-                compression: compression.clone().into(),
+                compression: match compression {
+                    Compression::Gzip => dataflow_types::Compression::Gzip,
+                    Compression::None => dataflow_types::Compression::None,
+                },
                 tail,
             });
             let encoding = get_encoding(format)?;
@@ -491,7 +494,7 @@ pub fn plan_create_source(
 
             let connector = ExternalSourceConnector::AvroOcf(FileSourceConnector {
                 path: path.clone().into(),
-                compression: Compression::None,
+                compression: dataflow_types::Compression::None,
                 tail,
             });
             if format.is_some() {


### PR DESCRIPTION
sql-parser should not depend on dataflow-types; it is the SQL planner's
exclusive responsibility to convert the SQL AST into the types in
dataflow-types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5749)
<!-- Reviewable:end -->
