### PR TITLE
devsite: document private items

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -29,7 +29,7 @@ do
     esac
 done
 
-cargo doc
+cargo doc --document-private-items
 
 crates=$(cargo metadata --format-version=1 \
   | jq -r -f misc/doc/crates.jq --arg pwd "$(pwd)")


### PR DESCRIPTION
I sometimes don't have my local mz buildable but need up-to-date docs,
including private items. Add the private items to the public site for
this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5752)
<!-- Reviewable:end -->
