### PR TITLE
coord: error on duplicate portal

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -968,7 +968,7 @@ impl Coordinator {
         )?;
         let params = vec![];
         let result_formats = vec![pgrepr::Format::Text; desc.arity()];
-        session.set_portal(name, desc, Some(stmt), params, result_formats);
+        session.set_portal(name, desc, Some(stmt), params, result_formats)?;
         Ok(())
     }
 

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -24,6 +24,8 @@ pub enum CoordError {
     Catalog(catalog::Error),
     /// The specified session parameter is constrained to its current value.
     ConstrainedParameter(&'static (dyn Var + Send + Sync)),
+    /// The cursor already exists.
+    DuplicateCursor(String),
     /// An error while evaluating an expression.
     Eval(EvalError),
     /// The value for the specified parameter does not have the right type.
@@ -92,6 +94,9 @@ impl fmt::Display for CoordError {
                 p.name().quoted(),
                 p.value().quoted()
             ),
+            CoordError::DuplicateCursor(name) => {
+                write!(f, "cursor {} already exists", name.quoted())
+            }
             CoordError::Eval(e) => e.fmt(f),
             CoordError::InvalidParameterType(p) => write!(
                 f,

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -199,7 +199,11 @@ impl Session {
         stmt: Option<Statement<Raw>>,
         params: Vec<(Datum, ScalarType)>,
         result_formats: Vec<pgrepr::Format>,
-    ) {
+    ) -> Result<(), CoordError> {
+        // The empty portal can be silently replaced.
+        if !portal_name.is_empty() && self.portals.contains_key(&portal_name) {
+            return Err(CoordError::DuplicateCursor(portal_name));
+        }
         self.portals.insert(
             portal_name,
             Portal {
@@ -213,6 +217,7 @@ impl Session {
                 state: PortalState::NotStarted,
             },
         );
+        Ok(())
     }
 
     /// Removes the specified portal.

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -308,6 +308,7 @@ impl ErrorResponse {
         let code = match e {
             CoordError::Catalog(_) => SqlState::INTERNAL_ERROR,
             CoordError::ConstrainedParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
+            CoordError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             CoordError::Eval(_) => SqlState::INTERNAL_ERROR,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -592,9 +592,15 @@ where
 
         let desc = stmt.desc().clone();
         let stmt = stmt.sql().cloned();
-        self.coord_client
-            .session()
-            .set_portal(portal_name, desc, stmt, params, result_formats);
+        if let Err(err) =
+            self.coord_client
+                .session()
+                .set_portal(portal_name, desc, stmt, params, result_formats)
+        {
+            return self
+                .error(ErrorResponse::from_coord(Severity::Error, err))
+                .await;
+        }
 
         self.conn.send(BackendMessage::BindComplete).await?;
         Ok(State::Ready)

--- a/test/pgtest/portals.pt
+++ b/test/pgtest/portals.pt
@@ -93,3 +93,68 @@ PortalSuspended
 ReadyForQuery {"status":"I"}
 ErrorResponse {"fields":[{"typ":"M","value":"cursor \"c\" does not exist"}]}
 ReadyForQuery {"status":"I"}
+
+# Verify portal reuse errors.
+
+send
+Query {"query": "BEGIN; DECLARE c CURSOR FOR SELECT 1; DECLARE c CURSOR FOR SELECT 1"}
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ErrorResponse {"fields":[{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "BEGIN; DECLARE c CURSOR FOR SELECT 1"}
+Parse {"query": "VALUES (1), (2)"}
+Bind {"portal": "c"}
+Sync
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+CommandComplete {"tag":"DECLARE CURSOR"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+ErrorResponse {"fields":[{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+
+send
+Query {"query": "BEGIN"}
+Parse {"query": "VALUES (1), (2)"}
+Bind {"portal": "c"}
+Sync
+Query {"query": "DECLARE c CURSOR FOR SELECT 1"}
+Query {"query": "ROLLBACK"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"BEGIN"}
+ReadyForQuery {"status":"T"}
+ParseComplete
+BindComplete
+ReadyForQuery {"status":"T"}
+ErrorResponse {"fields":[{"typ":"C","value":"42P03"},{"typ":"M","value":"cursor \"c\" already exists"}]}
+ReadyForQuery {"status":"E"}
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Named portals cannot be overwritten. This fixes a file descriptor/memory
leak due to orphaned sinks being created during DECLARE TAIL.

Fixes #5543

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5753)
<!-- Reviewable:end -->
