### PR TITLE
bin/doc: build Rust documentation with and without private items

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -17,19 +17,7 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-for arg
-do
-    case "$arg" in
-        -h|--help)
-            printf "usage: %s\n\nBuild the rust documentation site\n" "$0"
-            exit 0
-            ;;
-        -*) die "unknown option $arg" ;;
-        *) die "usage: $0" ;;
-    esac
-done
-
-cargo doc
+cargo doc "$@"
 
 crates=$(cargo metadata --format-version=1 \
   | jq -r -f misc/doc/crates.jq --arg pwd "$(pwd)")

--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -13,10 +13,15 @@
 
 set -euo pipefail
 
-bin/doc
-bin/pydoc
 rsync misc/www/index.html buildkite@mtrlz.dev:/var/www/html/index.html
+
+bin/doc
 rsync --archive target/doc/ buildkite@mtrlz.dev:/var/www/html/api/rust
+
+bin/doc --document-private-items
+rsync --archive target/doc/ buildkite@mtrlz.dev:/var/www/html/api/rust-private
+
+bin/pydoc
 rsync --archive target/pydoc/ buildkite@mtrlz.dev:/var/www/html/api/python
 
 ssh -A buildkite@mtrlz.dev <<'EOF'

--- a/misc/www/index.html
+++ b/misc/www/index.html
@@ -50,7 +50,8 @@ by the Apache License, Version 2.0.
         <li>
           Internal API documentation
           <ul>
-            <li><a href="api/rust/">Rust</a></li>
+            <li><a href="api/rust/">Rust (public symbols only)</a></li>
+            <li><a href="api/rust-private/">Rust (private symbols included)</a></li>
             <li><a href="api/python/materialize/">Python</a></li>
           </ul>
         </li>


### PR DESCRIPTION
Alternative to #5752 that allows for both modes of operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5754)
<!-- Reviewable:end -->
