### PR TITLE
sql: resolve and store custom data type dependencies

### DIFF
--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -18,7 +18,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashSet},
+    rc::Rc,
+};
 
 use expr::GlobalId;
 use repr::{RelationDesc, RelationType};
@@ -80,6 +84,7 @@ fn datadriven() {
                     let scx = StatementContext {
                         catalog: &catalog,
                         pcx: &PlanContext::default(),
+                        ids: HashSet::new(),
                         param_types: Rc::new(RefCell::new(BTreeMap::new())),
                     };
                     let mut qcx = QueryContext::root(&scx, QueryLifetime::OneShot);

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -53,16 +53,16 @@ impl AstDisplay for Schema {
 impl_display!(Schema);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum AvroSchema {
+pub enum AvroSchema<T: AstInfo> {
     CsrUrl {
         url: String,
         seed: Option<CsrSeed>,
-        with_options: Vec<SqlOption>,
+        with_options: Vec<SqlOption<T>>,
     },
     Schema(Schema),
 }
 
-impl AstDisplay for AvroSchema {
+impl<T: AstInfo> AstDisplay for AvroSchema<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             Self::CsrUrl {
@@ -87,7 +87,7 @@ impl AstDisplay for AvroSchema {
         }
     }
 }
-impl_display!(AvroSchema);
+impl_display_t!(AvroSchema);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CsrSeed {
@@ -111,9 +111,9 @@ impl AstDisplay for CsrSeed {
 impl_display!(CsrSeed);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Format {
+pub enum Format<T: AstInfo> {
     Bytes,
-    Avro(AvroSchema),
+    Avro(AvroSchema<T>),
     Protobuf {
         message_name: String,
         schema: Schema,
@@ -129,20 +129,20 @@ pub enum Format {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Envelope {
+pub enum Envelope<T: AstInfo> {
     None,
     Debezium,
-    Upsert(Option<Format>),
+    Upsert(Option<Format<T>>),
     CdcV2,
 }
 
-impl Default for Envelope {
+impl<T: AstInfo> Default for Envelope<T> {
     fn default() -> Self {
         Self::None
     }
 }
 
-impl AstDisplay for Envelope {
+impl<T: AstInfo> AstDisplay for Envelope<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             Self::None => {
@@ -165,9 +165,9 @@ impl AstDisplay for Envelope {
         }
     }
 }
-impl_display!(Envelope);
+impl_display_t!(Envelope);
 
-impl AstDisplay for Format {
+impl<T: AstInfo> AstDisplay for Format<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             Self::Bytes => f.write_str("BYTES"),
@@ -212,7 +212,7 @@ impl AstDisplay for Format {
         }
     }
 }
-impl_display!(Format);
+impl_display_t!(Format);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Compression {
@@ -415,7 +415,7 @@ impl_display_t!(TableConstraint);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ColumnDef<T: AstInfo> {
     pub name: Ident,
-    pub data_type: DataType,
+    pub data_type: DataType<T>,
     pub collation: Option<UnresolvedObjectName>,
     pub options: Vec<ColumnOptionDef<T>>,
 }

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -87,7 +87,7 @@ pub enum Expr<T: AstInfo> {
     /// CAST an expression to a different data type e.g. `CAST(foo AS VARCHAR(123))`
     Cast {
         expr: Box<Expr<T>>,
-        data_type: DataType,
+        data_type: DataType<T>,
     },
     /// `expr COLLATE collation`
     Collate {

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -57,6 +57,15 @@ pub enum RawName {
     Id(u64, UnresolvedObjectName),
 }
 
+impl RawName {
+    pub fn name(&self) -> &UnresolvedObjectName {
+        match self {
+            RawName::Name(name) => name,
+            RawName::Id(_, name) => name,
+        }
+    }
+}
+
 impl AstDisplay for RawName {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
@@ -241,7 +250,7 @@ pub struct Select<T: AstInfo> {
     /// HAVING
     pub having: Option<Expr<T>>,
     /// OPTION
-    pub options: Vec<SqlOption>,
+    pub options: Vec<SqlOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for Select<T> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -35,12 +35,12 @@ pub enum Statement<T: AstInfo> {
     Delete(DeleteStatement<T>),
     CreateDatabase(CreateDatabaseStatement),
     CreateSchema(CreateSchemaStatement),
-    CreateSource(CreateSourceStatement),
+    CreateSource(CreateSourceStatement<T>),
     CreateSink(CreateSinkStatement<T>),
     CreateView(CreateViewStatement<T>),
     CreateTable(CreateTableStatement<T>),
     CreateIndex(CreateIndexStatement<T>),
-    CreateType(CreateTypeStatement),
+    CreateType(CreateTypeStatement<T>),
     CreateRole(CreateRoleStatement),
     AlterObjectRename(AlterObjectRenameStatement),
     AlterIndexOptions(AlterIndexOptionsStatement),
@@ -344,18 +344,18 @@ impl_display!(CreateSchemaStatement);
 
 /// `CREATE SOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CreateSourceStatement {
+pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
     pub connector: Connector,
-    pub with_options: Vec<SqlOption>,
-    pub format: Option<Format>,
-    pub envelope: Envelope,
+    pub with_options: Vec<SqlOption<T>>,
+    pub format: Option<Format<T>>,
+    pub envelope: Envelope<T>,
     pub if_not_exists: bool,
     pub materialized: bool,
 }
 
-impl AstDisplay for CreateSourceStatement {
+impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_str("CREATE ");
         if self.materialized {
@@ -383,13 +383,16 @@ impl AstDisplay for CreateSourceStatement {
             f.write_str(" FORMAT ");
             f.write_node(format);
         }
-        if self.envelope != Default::default() {
-            f.write_str(" ENVELOPE ");
-            f.write_node(&self.envelope);
+        match self.envelope {
+            Envelope::None => (),
+            _ => {
+                f.write_str(" ENVELOPE ");
+                f.write_node(&self.envelope);
+            }
         }
     }
 }
-impl_display!(CreateSourceStatement);
+impl_display_t!(CreateSourceStatement);
 
 /// `CREATE SINK`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -397,9 +400,9 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub from: UnresolvedObjectName,
     pub connector: Connector,
-    pub with_options: Vec<SqlOption>,
-    pub format: Option<Format>,
-    pub envelope: Option<Envelope>,
+    pub with_options: Vec<SqlOption<T>>,
+    pub format: Option<Format<T>>,
+    pub envelope: Option<Envelope<T>>,
     pub with_snapshot: bool,
     pub as_of: Option<Expr<T>>,
     pub if_not_exists: bool,
@@ -449,7 +452,7 @@ pub struct CreateViewStatement<T: AstInfo> {
     /// View name
     pub name: UnresolvedObjectName,
     pub columns: Vec<Ident>,
-    pub with_options: Vec<SqlOption>,
+    pub with_options: Vec<SqlOption<T>>,
     pub query: Query<T>,
     pub if_exists: IfExistsBehavior,
     pub temporary: bool,
@@ -504,7 +507,7 @@ pub struct CreateTableStatement<T: AstInfo> {
     /// Optional schema
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
-    pub with_options: Vec<SqlOption>,
+    pub with_options: Vec<SqlOption<T>>,
     pub if_not_exists: bool,
     pub temporary: bool,
 }
@@ -636,17 +639,17 @@ impl_display!(CreateRoleOption);
 
 /// `CREATE TYPE ..`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CreateTypeStatement {
+pub struct CreateTypeStatement<T: AstInfo> {
     /// Name of the created type.
     pub name: UnresolvedObjectName,
     /// The new type's "base type".
     pub as_type: CreateTypeAs,
     /// Provides the name and type for the key
     /// and value.
-    pub with_options: Vec<SqlOption>,
+    pub with_options: Vec<SqlOption<T>>,
 }
 
-impl AstDisplay for CreateTypeStatement {
+impl<T: AstInfo> AstDisplay for CreateTypeStatement<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         f.write_str("CREATE TYPE ");
         f.write_node(&self.name);
@@ -659,7 +662,7 @@ impl AstDisplay for CreateTypeStatement {
         f.write_str(" )");
     }
 }
-impl_display!(CreateTypeStatement);
+impl_display_t!(CreateTypeStatement);
 
 /// `CREATE TYPE .. AS <TYPE>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1239,7 +1242,7 @@ impl<T: AstInfo> AstDisplay for ShowStatementFilter<T> {
 impl_display_t!(ShowStatementFilter);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SqlOption {
+pub enum SqlOption<T: AstInfo> {
     Value {
         name: Ident,
         value: Value,
@@ -1250,11 +1253,11 @@ pub enum SqlOption {
     },
     DataType {
         name: Ident,
-        data_type: DataType,
+        data_type: DataType<T>,
     },
 }
 
-impl SqlOption {
+impl<T: AstInfo> SqlOption<T> {
     pub fn name(&self) -> &Ident {
         match self {
             SqlOption::Value { name, .. } => name,
@@ -1264,7 +1267,7 @@ impl SqlOption {
     }
 }
 
-impl AstDisplay for SqlOption {
+impl<T: AstInfo> AstDisplay for SqlOption<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             SqlOption::Value { name, value } => {
@@ -1285,7 +1288,7 @@ impl AstDisplay for SqlOption {
         }
     }
 }
-impl_display!(SqlOption);
+impl_display_t!(SqlOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WithOption {

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -22,8 +22,8 @@ use std::fmt;
 
 use repr::adt::datetime::DateTimeField;
 
+use crate::ast::defs::AstInfo;
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::UnresolvedObjectName;
 
 #[derive(Debug)]
 pub struct ValueError(pub(crate) String);
@@ -176,25 +176,25 @@ mod test {
 
 /// SQL data types
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum DataType {
+pub enum DataType<T: AstInfo> {
     /// Array
-    Array(Box<DataType>),
+    Array(Box<DataType<T>>),
     /// List
-    List(Box<DataType>),
+    List(Box<DataType<T>>),
     /// Map
     Map {
-        key_type: Box<DataType>,
-        value_type: Box<DataType>,
+        key_type: Box<DataType<T>>,
+        value_type: Box<DataType<T>>,
     },
     /// Types who don't embed other types, e.g. INT
     Other {
-        name: UnresolvedObjectName,
+        name: T::ObjectName,
         /// Typ modifiers appended to the type name, e.g. `numeric(38,0)`.
         typ_mod: Vec<u64>,
     },
 }
 
-impl AstDisplay for DataType {
+impl<T: AstInfo> AstDisplay for DataType<T> {
     fn fmt(&self, f: &mut AstFormatter) {
         match self {
             DataType::Array(ty) => {
@@ -226,4 +226,4 @@ impl AstDisplay for DataType {
         }
     }
 }
-impl_display!(DataType);
+impl_display_t!(DataType);

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -18,84 +18,84 @@ CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: UnresolvedObjectName([Ident("bool")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY_TYPE=text, VaLuE_tYpE=custom_type)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = custom_type )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: UnresolvedObjectName([Ident("custom_type")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text)
 ----
 CREATE TYPE custom AS MAP ( key_type = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( value_type = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("value_type"), data_type: Other { name: UnresolvedObjectName([Ident("bool")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, value_type=bool, random_type=int)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: UnresolvedObjectName([Ident("bool")]), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, random_type=int)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map, with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=text)
 ----
 CREATE TYPE custom AS LIST ( element_type = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=x)
 ----
 CREATE TYPE custom AS LIST ( element_type = x )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: UnresolvedObjectName([Ident("x")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=_text)
 ----
 CREATE TYPE custom AS LIST ( element_type = _text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: UnresolvedObjectName([Ident("_text")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE schema.t2 AS LIST (element_type=schema.t1)
 ----
 CREATE TYPE schema.t2 AS LIST ( element_type = schema.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: UnresolvedObjectName([Ident("schema"), Ident("t1")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE db2.schema2.t2 AS LIST (element_type=db1.schema1.t1)
 ----
 CREATE TYPE db2.schema2.t2 AS LIST ( element_type = db1.schema1.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")]), typ_mod: [] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] } }] })
 
 parse-statement
 CREATE TYPE numeric_list AS LIST (element_type=numeric(100,100,100))
 ----
 CREATE TYPE numeric_list AS LIST ( element_type = numeric(100, 100, 100) )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: UnresolvedObjectName([Ident("numeric")]), typ_mod: [100, 100, 100] } }] })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List, with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] } }] })
 
 parse-statement
 CREATE ROLE arjun

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -29,7 +29,7 @@ CREATE TABLE uk_cities (
 ----
 CREATE TABLE uk_cities (name varchar(100) NOT NULL, lat float8 NULL, lng float8, constrained int4 NULL CONSTRAINT pkey PRIMARY KEY NOT NULL UNIQUE CHECK (constrained > 0), ref int4 REFERENCES othertable (a, b))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: UnresolvedObjectName([Ident("varchar")]), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: UnresolvedObjectName([Ident("float8")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: UnresolvedObjectName([Ident("float8")]), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: ">", expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: UnresolvedObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities")]), columns: [ColumnDef { name: Ident("name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [100] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("lat"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }] }, ColumnDef { name: Ident("lng"), data_type: Other { name: Name(UnresolvedObjectName([Ident("float8")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("constrained"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Null }, ColumnOptionDef { name: Some(Ident("pkey")), option: Unique { is_primary: true } }, ColumnOptionDef { name: None, option: NotNull }, ColumnOptionDef { name: None, option: Unique { is_primary: false } }, ColumnOptionDef { name: None, option: Check(Op { op: ">", expr1: Identifier([Ident("constrained")]), expr2: Some(Value(Number("0"))) }) }] }, ColumnDef { name: Ident("ref"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: ForeignKey { foreign_table: UnresolvedObjectName([Ident("othertable")]), referred_columns: [Ident("a"), Ident("b")] } }] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
@@ -43,7 +43,7 @@ CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
 CREATE TABLE t (c int4) WITH (foo = 'bar', a = 123)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [Value { name: Ident("foo"), value: String("bar") }, Value { name: Ident("a"), value: Number("123") }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [Value { name: Ident("foo"), value: String("bar") }, Value { name: Ident("a"), value: Number("123") }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t
@@ -78,14 +78,14 @@ CREATE TABLE foo (bar int list)
 ----
 CREATE TABLE foo (bar int4 list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (bar int list list)
 ----
 CREATE TABLE foo (bar int4 list list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("bar"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE tab (foo int,
@@ -99,91 +99,91 @@ CREATE TABLE foo (id int, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT address_pkey PRIMARY KEY (address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("address_pkey")), columns: [Ident("address_id")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT uk_task UNIQUE (report_date, task_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: Some(Ident("uk_task")), columns: [Ident("report_date"), Ident("task_id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 ----
 CREATE TABLE foo (id int4, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: UnresolvedObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: UnresolvedObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMPORARY TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 ----
 CREATE TEMPORARY TABLE foo (id int4, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: "<>", expr1: Function(Function { name: UnresolvedObjectName([Ident("rtrim")]), args: Args([Function(Function { name: UnresolvedObjectName([Ident("ltrim")]), args: Args([Identifier([Ident("ref_code")])]), filter: None, over: None, distinct: false })]), filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: Some(Ident("ck")), expr: Op { op: "<>", expr1: Function(Function { name: UnresolvedObjectName([Ident("rtrim")]), args: Args([Function(Function { name: UnresolvedObjectName([Ident("ltrim")]), args: Args([Identifier([Ident("ref_code")])]), filter: None, over: None, distinct: false })]), filter: None, over: None, distinct: false }), expr2: Some(Value(String(""))) } }], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE foo (id int, PRIMARY KEY (foo, bar))
 ----
 CREATE TABLE foo (id int4, PRIMARY KEY (foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("foo"), Ident("bar")], is_primary: true }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, UNIQUE (id))
 ----
 CREATE TABLE foo (id int4, UNIQUE (id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Unique { name: None, columns: [Ident("id")], is_primary: false }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 ----
 CREATE TABLE foo (id int4, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: UnresolvedObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: UnresolvedObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
 ----
 CREATE TABLE foo (id int4, CHECK (end_date > start_date OR end_date IS NULL))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: ">", expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsNull { expr: Identifier([Ident("end_date")]), negated: false } } }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [Check { name: None, expr: Or { left: Op { op: ">", expr1: Identifier([Ident("end_date")]), expr2: Some(Identifier([Ident("start_date")])) }, right: IsNull { expr: Identifier([Ident("end_date")]), negated: false } } }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t (c schema.type)
 ----
 CREATE TEMPORARY TABLE t (c schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c db.schema.type)
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "db"."schema"."type")
 ----
 CREATE TABLE t (c db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c something.db.schema.type)
 ----
 CREATE TABLE t (c something.db.schema.type)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("something"), Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMP TABLE t (c db.schema.type(0,1,100))
 ----
 CREATE TEMPORARY TABLE t (c db.schema.type(0, 1, 100))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")]), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db"), Ident("schema"), Ident("type")])), typ_mod: [0, 1, 100] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: true })
 
 parse-statement
 CREATE TABLE t (c time with time zone (0,1,100))
@@ -211,14 +211,14 @@ CREATE TABLE t (c "type"(1))
 ----
 CREATE TABLE t (c type(1))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: UnresolvedObjectName([Ident("type")]), typ_mod: [1] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] }, collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE t (c "type"(1) list list)
 ----
 CREATE TABLE t (c type(1) list list)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: UnresolvedObjectName([Ident("type")]), typ_mod: [1] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: List(List(Other { name: Name(UnresolvedObjectName([Ident("type")])), typ_mod: [1] })), collation: None, options: [] }], constraints: [], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE DATABASE IF EXISTS foo
@@ -793,7 +793,7 @@ CREATE TABLE public.customer (
 ----
 CREATE TABLE public.customer (customer_id int4 DEFAULT nextval(public.customer_customer_id_seq), store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) NOT NULL, email varchar(50), address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamptz, active int4 NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("nextval")]), args: Args([Identifier([Ident("public"), Ident("customer_customer_id_seq")])]), filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: UnresolvedObjectName([Ident("int2")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: UnresolvedObjectName([Ident("varchar")]), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: UnresolvedObjectName([Ident("varchar")]), typ_mod: [45] }, collation: Some(UnresolvedObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: UnresolvedObjectName([Ident("varchar")]), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: UnresolvedObjectName([Ident("int2")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: UnresolvedObjectName([Ident("bool")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: UnresolvedObjectName([Ident("date")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false }), data_type: Other { name: UnresolvedObjectName([Ident("text")]), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: UnresolvedObjectName([Ident("timestamp")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: UnresolvedObjectName([Ident("timestamptz")]), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [Value { name: Ident("fillfactor"), value: Number("20") }, Value { name: Ident("user_catalog_table"), value: Boolean(true) }, Value { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("nextval")]), args: Args([Identifier([Ident("public"), Ident("customer_customer_id_seq")])]), filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: Some(UnresolvedObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false }), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args([]), filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [Value { name: Ident("fillfactor"), value: Number("20") }, Value { name: Ident("user_catalog_table"), value: Boolean(true) }, Value { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false, temporary: false })
 
 parse-statement roundtrip
 CREATE TABLE public.customer (

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -103,62 +103,62 @@ Value(HexString("deadBEEF"))
 parse-scalar
 DATE '1999-01-01'
 ----
-Cast { expr: Value(String("1999-01-01")), data_type: Other { name: UnresolvedObjectName([Ident("date")]), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01")), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] } }
 
 parse-scalar
 DATE 'invalid date'
 ----
-Cast { expr: Value(String("invalid date")), data_type: Other { name: UnresolvedObjectName([Ident("date")]), typ_mod: [] } }
+Cast { expr: Value(String("invalid date")), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] } }
 
 parse-scalar
 TIME '01:23:34'
 ----
-Cast { expr: Value(String("01:23:34")), data_type: Other { name: UnresolvedObjectName([Ident("time")]), typ_mod: [] } }
+Cast { expr: Value(String("01:23:34")), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] } }
 
 parse-scalar
 TIME 'invalid time'
 ----
-Cast { expr: Value(String("invalid time")), data_type: Other { name: UnresolvedObjectName([Ident("time")]), typ_mod: [] } }
+Cast { expr: Value(String("invalid time")), data_type: Other { name: Name(UnresolvedObjectName([Ident("time")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: UnresolvedObjectName([Ident("timestamp")]), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMPTZ '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: UnresolvedObjectName([Ident("timestamptz")]), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITH TIME ZONE '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: UnresolvedObjectName([Ident("timestamptz")]), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITHOUT TIME ZONE '1999-01-01 01:23:34.555'
 ----
-Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: UnresolvedObjectName([Ident("timestamp")]), typ_mod: [] } }
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: UnresolvedObjectName([Ident("timestamp")]), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMPTZ 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: UnresolvedObjectName([Ident("timestamptz")]), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITH TIME ZONE 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: UnresolvedObjectName([Ident("timestamptz")]), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] } }
 
 parse-scalar
 TIMESTAMP WITHOUT TIME ZONE 'invalid timestamptx'
 ----
-Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: UnresolvedObjectName([Ident("timestamp")]), typ_mod: [] } }
+Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] } }
 
 parse-scalar
 INTERVAL '1' YEAR

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -83,7 +83,7 @@ Op { op: "!~*", expr1: Identifier([Ident("a")]), expr2: Some(Value(String("foo")
 parse-scalar
 a !x 'foo'
 ----
-Op { op: "!", expr1: Identifier([Ident("a")]), expr2: Some(Cast { expr: Value(String("foo")), data_type: Other { name: UnresolvedObjectName([Ident("x")]), typ_mod: [] } }) }
+Op { op: "!", expr1: Identifier([Ident("a")]), expr2: Some(Cast { expr: Value(String("foo")), data_type: Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] } }) }
 
 parse-scalar
 a !x
@@ -347,17 +347,17 @@ SubscriptSlice { expr: List([List([Value(Number("1"))]), List([Value(Number("2")
 parse-scalar
 ARRAY[]::int[]
 ----
-Cast { expr: Array([]), data_type: Array(Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }) }
+Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }) }
 
 parse-scalar
 ARRAY[]::int[][][][]
 ----
-Cast { expr: Array([]), data_type: Array(Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }) }
+Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }) }
 
 parse-scalar
 ARRAY[]::int[2][2]
 ----
-Cast { expr: Array([]), data_type: Array(Other { name: UnresolvedObjectName([Ident("int4")]), typ_mod: [] }) }
+Cast { expr: Array([]), data_type: Array(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }) }
 
 parse-scalar
 a -> b

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -56,7 +56,8 @@ pub use error::PlanError;
 pub use explain::Explanation;
 // This is used by sqllogictest to turn SQL values into `Datum`s.
 pub use query::{
-    resolve_names, scalar_type_from_sql, unwrap_numeric_typ_mod, QueryContext, QueryLifetime,
+    resolve_names, resolve_names_data_type, scalar_type_from_sql, unwrap_numeric_typ_mod, Aug,
+    QueryContext, QueryLifetime,
 };
 pub use statement::{describe, plan, StatementContext, StatementDesc};
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -87,6 +87,12 @@ impl std::fmt::Display for ResolvedObjectName {
     }
 }
 
+impl ResolvedObjectName {
+    pub fn raw_name(&self) -> PartialName {
+        self.raw_name.clone()
+    }
+}
+
 impl AstInfo for Aug {
     type ObjectName = ResolvedObjectName;
     type Id = Id;
@@ -97,6 +103,7 @@ struct NameResolver<'a> {
     catalog: &'a dyn Catalog,
     ctes: HashMap<String, LocalId>,
     status: Result<(), anyhow::Error>,
+    ids: HashSet<GlobalId>,
 }
 
 impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
@@ -170,17 +177,20 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     if let Some(id) = self.ctes.get(&norm_name) {
                         return ResolvedObjectName {
                             id: Id::Local(*id),
-                            raw_name: normalize::object_name(raw_name).unwrap(),
+                            raw_name: normalize::unresolved_object_name(raw_name).unwrap(),
                         };
                     }
                 }
 
-                let name = normalize::object_name(raw_name).unwrap();
+                let name = normalize::unresolved_object_name(raw_name).unwrap();
                 match self.catalog.resolve_item(&name) {
-                    Ok(item) => ResolvedObjectName {
-                        id: Id::Global(item.id()),
-                        raw_name: name,
-                    },
+                    Ok(item) => {
+                        self.ids.insert(item.id());
+                        ResolvedObjectName {
+                            id: Id::Global(item.id()),
+                            raw_name: name,
+                        }
+                    }
                     Err(e) => {
                         if self.status.is_ok() {
                             self.status = Err(e.into());
@@ -197,9 +207,10 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 if self.catalog.try_get_item_by_id(&gid).is_none() {
                     self.status = Err(anyhow!("invalid id {}", &gid));
                 }
+                self.ids.insert(gid.clone());
                 ResolvedObjectName {
                     id: Id::Global(gid),
-                    raw_name: normalize::object_name(raw_name).unwrap(),
+                    raw_name: normalize::unresolved_object_name(raw_name).unwrap(),
                 }
             }
         }
@@ -217,9 +228,11 @@ pub fn resolve_names(
         status: Ok(()),
         catalog: qcx.scx.catalog,
         ctes: HashMap::new(),
+        ids: HashSet::new(),
     };
     let result = n.fold_query(query);
     n.status?;
+    qcx.ids.extend(n.ids.iter());
     Ok(result)
 }
 
@@ -231,10 +244,27 @@ pub fn resolve_names_expr(
         status: Ok(()),
         catalog: qcx.scx.catalog,
         ctes: HashMap::new(),
+        ids: HashSet::new(),
     };
     let result = n.fold_expr(expr);
     n.status?;
+    qcx.ids.extend(n.ids.iter());
     Ok(result)
+}
+
+pub fn resolve_names_data_type(
+    scx: &StatementContext,
+    data_type: DataType<Raw>,
+) -> Result<(DataType<Aug>, HashSet<GlobalId>), anyhow::Error> {
+    let mut n = NameResolver {
+        status: Ok(()),
+        catalog: scx.catalog,
+        ctes: HashMap::new(),
+        ids: HashSet::new(),
+    };
+    let result = n.fold_data_type(data_type);
+    n.status?;
+    Ok((result, n.ids))
 }
 
 /// Plans a top-level query, returning the `HirRelationExpr` describing the query
@@ -1568,7 +1598,7 @@ fn plan_table_function(
         FunctionArgs::Star => bail!("{} does not accept * as an argument", name),
         FunctionArgs::Args(args) => plan_exprs(ecx, args)?,
     };
-    let name = normalize::object_name(name.clone())?;
+    let name = normalize::unresolved_object_name(name.clone())?;
     let tf = func::select_impl(ecx, FuncSpec::Func(&name), impls, args)?;
     let call = HirRelationExpr::CallTable {
         func: tf.func,
@@ -1648,7 +1678,7 @@ fn invent_column_name(ecx: &ExprContext, expr: &Expr<Aug>) -> Option<ScopeItemNa
     let name = match expr {
         Expr::Identifier(names) => names.last().map(|n| normalize::column_name(n.clone())),
         Expr::Function(func) => {
-            let name = normalize::object_name(func.name.clone()).ok()?;
+            let name = normalize::unresolved_object_name(func.name.clone()).ok()?;
             if name.schema.as_deref() == Some("mz_internal") {
                 None
             } else {
@@ -1696,7 +1726,8 @@ fn expand_select_item<'a>(
             expr: Expr::QualifiedWildcard(table_name),
             alias: _,
         } => {
-            let table_name = normalize::object_name(UnresolvedObjectName(table_name.clone()))?;
+            let table_name =
+                normalize::unresolved_object_name(UnresolvedObjectName(table_name.clone()))?;
             let out: Vec<_> = ecx
                 .scope
                 .items
@@ -2465,7 +2496,7 @@ fn plan_aggregate(
         unsupported!(213, "window functions");
     }
 
-    let name = normalize::object_name(sql_func.name.clone())?;
+    let name = normalize::unresolved_object_name(sql_func.name.clone())?;
 
     // We follow PostgreSQL's rule here for mapping `count(*)` into the
     // generalized function selection framework. The rule is simple: the user
@@ -2534,7 +2565,7 @@ fn plan_identifier(ecx: &ExprContext, names: &[Ident]) -> Result<HirScalarExpr, 
 
     // If the name is qualified, it must refer to a column in a table.
     if !names.is_empty() {
-        let table_name = normalize::object_name(UnresolvedObjectName(names))?;
+        let table_name = normalize::unresolved_object_name(UnresolvedObjectName(names))?;
         let (i, _name) = ecx.scope.resolve_table_column(&table_name, &col_name)?;
         return Ok(HirScalarExpr::Column(i));
     }
@@ -2642,7 +2673,7 @@ fn plan_function<'a>(
         FunctionArgs::Args(args) => plan_exprs(ecx, args)?,
     };
 
-    let name = normalize::object_name(sql_func.name.clone())?;
+    let name = normalize::unresolved_object_name(sql_func.name.clone())?;
     func::select_impl(ecx, FuncSpec::Func(&name), impls, args)
 }
 
@@ -2816,7 +2847,7 @@ fn find_trivial_column_equivalences(expr: &HirScalarExpr) -> Vec<(usize, usize)>
 
 pub fn scalar_type_from_sql(
     scx: &StatementContext,
-    data_type: &DataType,
+    data_type: &DataType<Aug>,
 ) -> Result<ScalarType, anyhow::Error> {
     Ok(match data_type {
         DataType::Array(elem_type) => {
@@ -2844,11 +2875,12 @@ pub fn scalar_type_from_sql(
             }
         }
         DataType::Other { name, typ_mod } => {
-            let canonical_name = canonicalize_type_name_internal(name);
-            let canonical_name = normalize::object_name(canonical_name)?;
-            let item = match scx.catalog.resolve_item(&canonical_name) {
+            let item = match scx.catalog.resolve_item(&name.raw_name()) {
                 Ok(i) => i,
-                Err(_) => bail!("type {} does not exist", name.to_string().quoted()),
+                Err(_) => bail!(
+                    "type {} does not exist",
+                    name.raw_name().to_string().quoted()
+                ),
             };
             match scx.catalog.try_get_lossy_scalar_type_by_id(&item.id()) {
                 Some(t) => match t {
@@ -2857,7 +2889,7 @@ pub fn scalar_type_from_sql(
                         ScalarType::Decimal(precision, scale)
                     }
                     ScalarType::String => {
-                        match name.to_string().as_str() {
+                        match name.raw_name().to_string().as_str() {
                             n @ "char" | n @ "varchar" => {
                                 validate_typ_mod(n, &typ_mod, &[("length", 1, 10_485_760)])?
                             }
@@ -2870,20 +2902,13 @@ pub fn scalar_type_from_sql(
                         t
                     }
                 },
-                None => bail!("type {} does not exist", name.to_string().quoted()),
+                None => bail!(
+                    "type {} does not exist",
+                    name.raw_name().to_string().quoted()
+                ),
             }
         }
     })
-}
-
-pub fn canonicalize_type_name_internal(name: &UnresolvedObjectName) -> UnresolvedObjectName {
-    // Rewrite some unqualified aliases to the name we know they should
-    // use in the catalog, i.e. canonicalize the catalog name.
-    match name.to_string().as_str() {
-        "char" | "varchar" => UnresolvedObjectName::unqualified("text"),
-        "smallint" => UnresolvedObjectName::unqualified("int4"),
-        _ => name.clone(),
-    }
 }
 
 /// Returns the first two values provided as typ_mods as `u8`, which are
@@ -3083,6 +3108,8 @@ pub struct QueryContext<'a> {
     pub outer_relation_types: Vec<RelationType>,
     /// CTEs for this query, mapping their assigned LocalIds to their definition.
     pub ctes: HashMap<LocalId, CteDesc>,
+    /// The GlobalIds of the items the `Query` is dependent upon.
+    pub ids: HashSet<GlobalId>,
 }
 
 impl<'a> QueryContext<'a> {
@@ -3093,6 +3120,7 @@ impl<'a> QueryContext<'a> {
             outer_scope: Scope::empty(None),
             outer_relation_types: vec![],
             ctes: HashMap::new(),
+            ids: HashSet::new(),
         }
     }
 
@@ -3119,6 +3147,7 @@ impl<'a> QueryContext<'a> {
                 .cloned()
                 .collect(),
             ctes,
+            ids: HashSet::new(),
         }
     }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -12,6 +12,7 @@
 //! This module houses the handlers for statements that manipulate data, like
 //! `INSERT`, `SELECT`, `TAIL`, and `COPY`.
 
+use std::collections::HashSet;
 use std::convert::TryFrom;
 
 use anyhow::bail;
@@ -179,6 +180,7 @@ pub fn plan_explain(
             let scx = StatementContext {
                 pcx: view.plan_cx(),
                 catalog: scx.catalog,
+                ids: HashSet::new(),
                 param_types: scx.param_types.clone(),
             };
             (scx, query)

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -196,7 +196,7 @@ impl<'a> FuncRewriter<'a> {
                 distinct,
                 over: None,
             }) => {
-                let name = normalize::object_name(name.clone()).ok()?;
+                let name = normalize::unresolved_object_name(name.clone()).ok()?;
                 if let Some(database) = &name.database {
                     // If a database name is provided, we need only verify that
                     // the database exists, as presently functions can only

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -105,7 +105,7 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
 }
 
 async fn purify_format(
-    format: &mut Option<Format>,
+    format: &mut Option<Format<Raw>>,
     connector: &mut Connector,
     col_names: &mut Vec<Ident>,
     file: Option<tokio::fs::File>,

--- a/src/symbiosis/src/lib.rs
+++ b/src/symbiosis/src/lib.rs
@@ -25,6 +25,7 @@
 //! extremely slow and inefficient on large data sets.
 
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::TryInto;
 use std::env;
@@ -45,11 +46,13 @@ use sql::ast::{
 use sql::catalog::Catalog;
 use sql::names::FullName;
 use sql::normalize;
-use sql::plan::{MutationKind, Plan, PlanContext, StatementContext, Table};
+use sql::plan::{
+    resolve_names_data_type, Aug, MutationKind, Plan, PlanContext, StatementContext, Table,
+};
 
 pub struct Postgres {
     client: tokio_postgres::Client,
-    table_types: HashMap<FullName, (Vec<DataType>, RelationDesc)>,
+    table_types: HashMap<FullName, (Vec<DataType<Aug>>, RelationDesc)>,
 }
 
 impl Postgres {
@@ -122,6 +125,7 @@ END $$;
         let scx = StatementContext {
             pcx,
             catalog,
+            ids: HashSet::new(),
             param_types: Rc::new(RefCell::new(BTreeMap::new())),
         };
         Ok(match stmt {
@@ -133,11 +137,6 @@ END $$;
                 temporary,
                 ..
             }) => {
-                let sql_types: Vec<_> = columns
-                    .iter()
-                    .map(|column| column.data_type.clone())
-                    .collect();
-
                 let names: Vec<_> = columns
                     .iter()
                     .map(|c| Some(sql::normalize::column_name(c.name.clone())))
@@ -149,8 +148,12 @@ END $$;
                 let mut defaults = Vec::with_capacity(columns.len());
                 let mut keys = vec![];
 
+                let mut sql_types: Vec<_> = Vec::with_capacity(columns.len());
                 for (index, column) in columns.iter().enumerate() {
-                    let ty = sql::plan::scalar_type_from_sql(&scx, &column.data_type)?;
+                    let (aug_data_type, _ids) =
+                        resolve_names_data_type(&scx, column.data_type.clone())?;
+                    let ty = sql::plan::scalar_type_from_sql(&scx, &aug_data_type)?;
+                    sql_types.push(aug_data_type);
                     let mut nullable = true;
                     let mut default = Expr::null();
 
@@ -200,7 +203,7 @@ END $$;
                 }
 
                 self.client.execute(&*stmt.to_string(), &[]).await?;
-                let name = scx.allocate_name(normalize::object_name(name.clone())?);
+                let name = scx.allocate_name(normalize::unresolved_object_name(name.clone())?);
                 let desc = RelationDesc::new(typ, names);
                 self.table_types
                     .insert(name.clone(), (sql_types, desc.clone()));
@@ -342,15 +345,14 @@ fn push_column(
     mut row: RowPacker,
     postgres_row: &tokio_postgres::Row,
     i: usize,
-    sql_type: &DataType,
+    sql_type: &DataType<Aug>,
     nullable: bool,
 ) -> Result<RowPacker, anyhow::Error> {
     // NOTE this needs to stay in sync with materialize::sql::scalar_type_from_sql
     // in some cases, we use slightly different representations than postgres does for the same sql types, so we have to be careful about conversions
     match sql_type {
         DataType::Other { name, typ_mod } => {
-            let name = normalize::object_name(name.clone())?;
-            match name.to_string().as_str() {
+            match name.raw_name().to_string().as_str() {
                 "bool" => {
                     let bool = get_column_inner::<bool>(postgres_row, i, nullable)?;
                     row.push(bool.into());

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -1271,7 +1271,7 @@ OVER (PARTITION BY company_id ORDER BY id)
 FROM string_agg_test
 ORDER BY company_id, id;
 
-query error supported
+query error unknown catalog item 'b'
 SELECT company_id, string_agg(employee::BYTEA, b',')
 OVER (PARTITION BY company_id ORDER BY id)
 FROM string_agg_test
@@ -1283,7 +1283,7 @@ OVER (PARTITION BY company_id ORDER BY id)
 FROM string_agg_test
 ORDER BY company_id, id;
 
-query error supported
+query error unknown catalog item 'b'
 SELECT company_id, string_agg(employee::BYTEA, b'')
 OVER (PARTITION BY company_id ORDER BY id)
 FROM string_agg_test
@@ -1391,7 +1391,7 @@ FROM (
 GROUP BY e.company_id
 ORDER BY e.company_id;
 
-query error type "b" does not exist
+query error unknown catalog item 'b'
 SELECT e.company_id, string_agg(e.employee, b', ')
 FROM (
   SELECT employee::BYTEA, company_id
@@ -1411,7 +1411,7 @@ FROM (
 GROUP BY e.company_id
 ORDER BY e.company_id;
 
-query error type "b" does not exist
+query error unknown catalog item 'b'
 SELECT e.company_id, string_agg(e.employee, b', ')
 FROM (
   SELECT employee::BYTEA, company_id

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -33,7 +33,7 @@ SELECT pg_typeof('true'::boolean)
 ----
 boolean
 
-query error type "pg_catalog.boolean" does not exist
+query error unknown catalog item 'pg_catalog.boolean'
 SELECT 'true'::pg_catalog.boolean
 
 # 🔬🔬 bytea
@@ -55,7 +55,7 @@ SELECT 'a'::bytes
 ----
 a
 
-query error type "pg_catalog.bytes" does not exist
+query error unknown catalog item 'pg_catalog.bytes'
 SELECT ''::pg_catalog.bytes
 
 # 🔬🔬 date
@@ -89,7 +89,7 @@ SELECT '1.2'::float(1)
 ----
 1.200
 
-query error type "pg_catalog.float" does not exist
+query error unknown catalog item 'pg_catalog.float'
 SELECT '1.2'::pg_catalog.float(1)
 
 query T
@@ -102,7 +102,7 @@ SELECT '1.2'::real
 ----
 1.200
 
-query error type "pg_catalog.real" does not exist
+query error unknown catalog item 'pg_catalog.real'
 SELECT '1.2'::pg_catalog.real
 
 query T
@@ -129,7 +129,7 @@ SELECT '1.2'::float(53)
 ----
 1.200
 
-query error type "pg_catalog.float" does not exist
+query error unknown catalog item 'pg_catalog.float'
 SELECT '1.2'::pg_catalog.float(53)
 
 query T
@@ -142,7 +142,7 @@ SELECT '1.2'::double
 ----
 1.200
 
-query error type "pg_catalog.double" does not exist
+query error unknown catalog item 'pg_catalog.double'
 SELECT '1.2'::pg_catalog.double
 
 query T
@@ -169,7 +169,7 @@ SELECT '1'::int
 ----
 1
 
-query error type "pg_catalog.int" does not exist
+query error unknown catalog item 'pg_catalog.int'
 SELECT '1'::pg_catalog.int
 
 query T
@@ -182,7 +182,7 @@ SELECT '1'::integer
 ----
 1
 
-query error type "pg_catalog.integer" does not exist
+query error unknown catalog item 'pg_catalog.integer'
 SELECT '1'::pg_catalog.integer
 
 query T
@@ -195,7 +195,7 @@ SELECT '1'::smallint
 ----
 1
 
-query error type "pg_catalog.smallint" does not exist
+query error unknown catalog item 'pg_catalog.smallint'
 SELECT '1'::pg_catalog.smallint
 
 query T
@@ -222,7 +222,7 @@ SELECT '1'::bigint
 ----
 1
 
-query error type "pg_catalog.bigint" does not exist
+query error unknown catalog item 'pg_catalog.bigint'
 SELECT '1'::pg_catalog.bigint
 
 query T
@@ -277,7 +277,7 @@ SELECT '{"1":2,"3":4}'::json
 ----
 {"1":2.0,"3":4.0}
 
-query error type "pg_catalog.json" does not exist
+query error unknown catalog item 'pg_catalog.json'
 SELECT '{"1":2,"3":4}'::pg_catalog.json
 
 # 🔬🔬 numeric
@@ -300,7 +300,7 @@ SELECT '1'::decimal(38,0)
 ----
 1
 
-query error type "pg_catalog.decimal" does not exist
+query error unknown catalog item 'pg_catalog.decimal'
 SELECT '1'::pg_catalog.decimal(38,0)
 
 query T
@@ -308,7 +308,7 @@ SELECT '1'::dec(38,0)
 ----
 1
 
-query error type "pg_catalog.dec" does not exist
+query error unknown catalog item 'pg_catalog.dec'
 SELECT '1'::pg_catalog.dec(38,0)
 
 # 🔬🔬 oid
@@ -330,7 +330,7 @@ SELECT '1'::regclass
 ----
 1
 
-query error type "pg_catalog.regclass" does not exist
+query error unknown catalog item 'pg_catalog.regclass'
 SELECT '1'::pg_catalog.regclass
 
 # 🔬🔬 record


### PR DESCRIPTION
This change updates `DataType::Other`'s `name` field to `T::ObjectName`, meaning that custom data types will have their names and `GlobalId`s resolved during planning. This PR does not do anything with the resolved names yet, it just makes the information available for future changes. 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5757)
<!-- Reviewable:end -->
