### PR TITLE
materialized: restore the -D shorthand flag for --data-directory

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -12,21 +12,20 @@ The `materialized` binary supports the following command line flags:
 Flag | Default | Modifies
 -----|---------|----------
 [`--cache-max-pending-records`](#source-cache) | 1000000 | Maximum number of input records buffered before flushing immediately to disk.
-[`--data-directory`](#data-directory) | `./mzdata` | Where data is persisted
+[`-D`](#data-directory) / [`--data-directory`](#data-directory) | `./mzdata` | Where data is persisted<br><br>**Known issue.** The short form of this option was inadvertently removed in v0.7.0. It will be restored in v0.7.1.
 [`--differential-idle-merge-effort`](#dataflow-tuning) | N/A | *Advanced.* Amount of compaction to perform when idle.
 `--help` | N/A | NOP&mdash;prints binary's list of command line flags
 [`--disable-telemetry`](#telemetry) | N/A | Disables telemetry reporting.
 [`--experimental`](#experimental-mode) | Disabled | *Dangerous.* Enable experimental features.
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
-[`--logical-compaction-window`](#compaction-window) | 60s | The amount of historical detail to retain in arrangements
+[`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 60s | The amount of historical detail to retain in arrangements
 [`--timely-progress-mode`](#dataflow-tuning) | demand | *Advanced.* Timely progress tracking mode.
 [`--tls-ca`](#tls-encryption) | N/A | Path to TLS certificate authority (CA) {{< version-added v0.7.1 />}}
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
 [`--tls-mode`](#tls-encryption) | N/A | How stringently to demand TLS authentication and encryption {{< version-added v0.7.1 />}}
 [`--tls-key`](#tls-encryption) | N/A | Path to TLS private key file
-[`--workers`](#worker-threads) | NCPUs / 2 | Dataflow worker threads
-[`-w`](#worker-threads) | REQ |  Dataflow worker threads
-`-v` | N/A | Print version and exit
+[`-w`](#worker-threads) / [`--workers`](#worker-threads) | NCPUs / 2 | Dataflow worker threads
+`-v` / `--version` | N/A | Print version and exit
 `-vv` | N/A | Print version and additional build information, and exit
 
 If a command line flag takes an argument, you can alternatively set that flag

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -62,7 +62,15 @@ Wrap your release notes at the 80 character mark.
 
 - Support [gzip-compressed](/sql/create-source/text-file/#compression) file sources {{% gh 5392 %}}.
 
+- Restore the `-D` command-line option as the short form of the
+  [`--data-directory`](/cli/#data-directory) option.
+
 {{% version-header v0.7.0 %}}
+
+- **Known issue.** The `-D` command-line option, shorthand for the
+  `--data-directory` option, was inadvertently removed.
+
+  It will be restored in the next release.
 
 - **Breaking change.** Require a valid user name when [connecting to
   Materialize](/connect/cli#connection-details). Previously, Materialize did not

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -191,6 +191,7 @@ struct Args {
     // === Storage options. ===
     /// Where to store data.
     #[structopt(
+        short = "D",
         long,
         env = "MZ_DATA_DIRECTORY",
         value_name = "PATH",


### PR DESCRIPTION
This was accidentally removed in #5441.

Fixes #5475.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5759)
<!-- Reviewable:end -->
