### PR TITLE
expr,repr: handle zero-dimensional arrays per PostgreSQL

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -1029,7 +1029,10 @@ impl RowPacker {
 
         // Check that the number of elements written matches the dimension
         // information.
-        let cardinality = dims.iter().map(|d| d.length).product();
+        let cardinality = match dims {
+            [] => 0,
+            dims => dims.iter().map(|d| d.length).product(),
+        };
         if nelements != cardinality {
             self.data.truncate(start);
             return Err(InvalidArrayError::WrongCardinality {

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -912,6 +912,11 @@ pub fn format_array_inner<F, T>(
 ) where
     F: FormatBuffer,
 {
+    if dims.is_empty() {
+        buf.write_str("{}");
+        return;
+    }
+
     buf.write_char('{');
     for j in 0..dims[0].length {
         if j > 0 {

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -473,6 +473,8 @@ EXPLAIN PLAN FOR SELECT (a::bool AND b::bool) IS NULL FROM t
 
 EOF
 
+mode cockroach
+
 # Test qualified function names.
 
 query I
@@ -651,6 +653,22 @@ query I
 SELECT array_length(ARRAY[]::int[], 1)
 ----
 NULL
+
+# Test strange collapsing behavior of nested empty arrays. See #5545.
+
+query TIII
+SELECT arr, array_lower(arr, 1), array_upper(arr, 1), array_length(arr, 1) FROM
+    (VALUES
+        (ARRAY[]::int[]),
+        (ARRAY[ARRAY[]]::int[]),
+        (ARRAY[ARRAY[], ARRAY[], ARRAY[]]::int[]),
+        (ARRAY[ARRAY[ARRAY[ARRAY[]]]]::int[])
+    ) AS _ (arr)
+----
+{}  NULL  NULL  NULL
+{}  NULL  NULL  NULL
+{}  NULL  NULL  NULL
+{}  NULL  NULL  NULL
 
 query T
 SELECT upper('a1Bd')


### PR DESCRIPTION
Per PostgreSQL, arrays with no elements are represented as having zero
dimensions, rather than having one dimension of zero length.

We don't need to mention this in the release notes because these sorts
of details about arrays are intentionally undocumented.

Fix #5545.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5761)
<!-- Reviewable:end -->
