### PR TITLE
Top k optimizations

### DIFF
--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -215,18 +215,19 @@ impl<'a> Explanation<'a> {
 
         match node.expr {
             Constant { rows, .. } => {
-                write!(f, "| Constant ")?;
+                write!(f, "| Constant")?;
                 match rows {
-                    Ok(rows) => writeln!(
+                    Ok(rows) if !rows.is_empty() => writeln!(
                         f,
-                        "{}",
+                        " {}",
                         separated(
                             " ",
                             rows.iter()
                                 .flat_map(|(row, count)| (0..*count).map(move |_| row))
                         )
                     )?,
-                    Err(e) => writeln!(f, "Err({})", e.to_string().quoted())?,
+                    Ok(_) => writeln!(f)?,
+                    Err(e) => writeln!(f, " Err({})", e.to_string().quoted())?,
                 }
             }
             Get { id, .. } => match id {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -406,7 +406,20 @@ impl MirRelationExpr {
                 }
                 result
             }
-            MirRelationExpr::TopK { input, .. } => input.typ(),
+            MirRelationExpr::TopK {
+                input,
+                group_key,
+                limit,
+                ..
+            } => {
+                // If `limit` is `Some(1)` then the group key will become
+                // a unique key, as there will be only one record with that key.
+                let mut typ = input.typ();
+                if limit == &Some(1) {
+                    typ = typ.with_key(group_key.clone())
+                }
+                typ
+            }
             MirRelationExpr::Negate { input } => {
                 // Although negate may have distinct records for each key,
                 // the multiplicity is -1 rather than 1. This breaks many

--- a/src/transform/src/topk_elision.rs
+++ b/src/transform/src/topk_elision.rs
@@ -43,6 +43,8 @@ impl TopKElision {
         {
             if limit.is_none() && *offset == 0 {
                 *relation = input.take_dangerous();
+            } else if limit == &Some(0) {
+                relation.take_safely();
             }
         }
     }

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -101,7 +101,7 @@ EXPLAIN PLAN FOR SELECT state, COUNT(*) FROM (
     GROUP BY state
 ----
 %0 =
-| Constant 
+| Constant
 
 EOF
 

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -90,3 +90,35 @@ EXPLAIN PLAN FOR SELECT state, name FROM
 | Project (#0, #1)
 
 EOF
+
+# Test that LIMIT 0 is optimized out
+query T multiline
+EXPLAIN PLAN FOR SELECT state, COUNT(*) FROM (
+    SELECT state, name FROM
+        (SELECT DISTINCT state FROM cities) grp,
+        LATERAL (SELECT name, pop FROM cities WHERE state = grp.state ORDER BY pop DESC LIMIT 0)
+    )
+    GROUP BY state
+----
+%0 =
+| Constant 
+
+EOF
+
+
+# Test that LIMIT 1 results in a unique key
+query T multiline
+EXPLAIN PLAN FOR SELECT state, COUNT(*) FROM (
+    SELECT state, name FROM
+        (SELECT DISTINCT state FROM cities) grp,
+        LATERAL (SELECT name, pop FROM cities WHERE state = grp.state ORDER BY pop DESC LIMIT 1)
+    )
+    GROUP BY state
+----
+%0 =
+| Get materialize.public.cities (u1)
+| TopK group=(#1) order=(#2 desc) limit=1 offset=0
+| Map 1
+| Project (#1, #3)
+
+EOF


### PR DESCRIPTION
Two optimizations we weren't doing, surfaced by @philip-stoev testing:
1. TopK with a limit of zero can be removed as it will always produce zero results.
2. TopK with a limit of one can present as having a unique key of its grouping key, as it will produce at most one record with each key.

Simple tests added in `topk.slt`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5768)
<!-- Reviewable:end -->
