### PR TITLE
coord: add CHAR and VARCHAR as builtin types

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -387,6 +387,18 @@ pub const TYPE_ANYNONARRAY: BuiltinType = BuiltinType {
     pgtype: &postgres_types::Type::ANYNONARRAY,
 };
 
+pub const TYPE_CHAR: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1038),
+    pgtype: &postgres_types::Type::CHAR,
+};
+
+pub const TYPE_VARCHAR: BuiltinType = BuiltinType {
+    schema: PG_CATALOG_SCHEMA,
+    id: GlobalId::System(1039),
+    pgtype: &postgres_types::Type::VARCHAR,
+};
+
 lazy_static! {
     pub static ref TYPE_LIST: BuiltinType = BuiltinType {
         schema: PG_CATALOG_SCHEMA,
@@ -1172,6 +1184,7 @@ lazy_static! {
             Builtin::Type(&TYPE_BOOL_ARRAY),
             Builtin::Type(&TYPE_BYTEA),
             Builtin::Type(&TYPE_BYTEA_ARRAY),
+            Builtin::Type(&TYPE_CHAR),
             Builtin::Type(&TYPE_DATE),
             Builtin::Type(&TYPE_DATE_ARRAY),
             Builtin::Type(&TYPE_FLOAT4),
@@ -1190,6 +1203,8 @@ lazy_static! {
             Builtin::Type(&TYPE_MAP),
             Builtin::Type(&TYPE_NUMERIC),
             Builtin::Type(&TYPE_NUMERIC_ARRAY),
+            Builtin::Type(&TYPE_OID),
+            Builtin::Type(&TYPE_OID_ARRAY),
             Builtin::Type(&TYPE_RECORD),
             Builtin::Type(&TYPE_RECORD_ARRAY),
             Builtin::Type(&TYPE_TEXT),
@@ -1202,8 +1217,7 @@ lazy_static! {
             Builtin::Type(&TYPE_TIMESTAMPTZ_ARRAY),
             Builtin::Type(&TYPE_UUID),
             Builtin::Type(&TYPE_UUID_ARRAY),
-            Builtin::Type(&TYPE_OID),
-            Builtin::Type(&TYPE_OID_ARRAY),
+            Builtin::Type(&TYPE_VARCHAR),
             Builtin::Log(&MZ_DATAFLOW_OPERATORS),
             Builtin::Log(&MZ_DATAFLOW_OPERATORS_ADDRESSES),
             Builtin::Log(&MZ_DATAFLOW_CHANNELS),

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -98,7 +98,9 @@ impl Type {
             postgres_types::Type::JSONB => Some(Type::Jsonb),
             postgres_types::Type::NUMERIC => Some(Type::Numeric),
             postgres_types::Type::OID => Some(Type::Oid),
-            postgres_types::Type::TEXT | postgres_types::Type::VARCHAR => Some(Type::Text),
+            postgres_types::Type::TEXT
+            | postgres_types::Type::CHAR
+            | postgres_types::Type::VARCHAR => Some(Type::Text),
             postgres_types::Type::TIME => Some(Type::Time),
             postgres_types::Type::TIMESTAMP => Some(Type::Timestamp),
             postgres_types::Type::TIMESTAMPTZ => Some(Type::TimestampTz),

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -362,16 +362,20 @@ SELECT 'dog'::char(10)
 ----
 dog
 
-query error type "pg_catalog.char" does not exist
+query T
 SELECT '1'::pg_catalog.char(10)
+----
+1
 
 query T
 SELECT 'dog'::varchar(10)
 ----
 dog
 
-query error type "pg_catalog.varchar" does not exist
+query T
 SELECT 'dog'::pg_catalog.varchar(10)
+----
+dog
 
 # 🔬🔬 time
 
@@ -503,6 +507,16 @@ query T
 SELECT format_type(25, NULL)
 ----
 text
+
+query T
+SELECT format_type(18, NULL)
+----
+char
+
+query T
+SELECT format_type(1043, NULL)
+----
+varchar
 
 query T
 SELECT format_type(26, NULL)

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -38,6 +38,7 @@ anyelement
 anynonarray
 bool
 bytea
+char
 date
 float4
 float8
@@ -55,6 +56,7 @@ time
 timestamp
 timestamptz
 uuid
+varchar
 
 > SHOW EXTENDED FULL TYPES
 name             type
@@ -82,6 +84,7 @@ anyelement       system
 anynonarray      system
 bool             system
 bytea            system
+char             system
 date             system
 float4           system
 float8           system
@@ -99,6 +102,7 @@ time             system
 timestamp        system
 timestamptz      system
 uuid             system
+varchar          system
 
 # Support creating tables with catalog types and their aliases
 > CREATE TABLE bool_t (a bool);


### PR DESCRIPTION
`CHAR` and `VARCHAR` are not currently builtin types. Once
we start correctly tracking type dependencies in Materialize (https://github.com/MaterializeInc/materialize/issues/5577),
this will prevent users from creating objects that use `CHAR` and
`VARCHAR` because these types are not explicitly created on startup.

To illustrate, this is what happens when I try to create a table using type `CHAR`
on [the type dependency PR branch](https://github.com/MaterializeInc/materialize/pull/5757):
```
materialize=> CREATE TABLE char_t (a char);
ERROR:  unknown catalog item 'char'
```

With these changes, I'm able to successfully create `char_t`:
```
materialize=> CREATE TABLE char_t (a char);
CREATE TABLE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5777)
<!-- Reviewable:end -->
