### PR TITLE
ore: forward port Iterator::is_sorted and friends

### DIFF
--- a/src/ore/src/iter.rs
+++ b/src/ore/src/iter.rs
@@ -9,6 +9,7 @@
 
 //! Iterator utilities.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::iter::{self, Chain, Once};
@@ -90,6 +91,80 @@ where
         Self::Item: Hash + Eq,
     {
         Duplicates::new(self)
+    }
+
+    /// Checks if the elements of this iterator are sorted.
+    ///
+    /// That is, for each element `a` and its following element `b`, `a <= b`
+    /// must hold. If the iterator yields exactly zero or one element, `true` is
+    /// returned.
+    ///
+    /// Note that if `Self::Item` is only `PartialOrd`, but not `Ord`, the above
+    /// definition implies that this function returns `false` if any two
+    /// consecutive items are not comparable.
+    ///
+    /// **Note:** this is a Materialize forward-port of a forthcoming feature
+    /// to the standard library.
+    /// See [rust-lang/rust#53485](https://github.com/rust-lang/rust/issues/53485).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ore::iter::IteratorExt;
+    /// assert!([1, 2, 2, 9].iter().mz_is_sorted());
+    /// assert!(![1, 3, 2, 4].iter().mz_is_sorted());
+    /// assert!([0].iter().mz_is_sorted());
+    /// assert!(std::iter::empty::<i32>().mz_is_sorted());
+    /// assert!(![0.0, 1.0, f32::NAN].iter().mz_is_sorted());
+    /// ```
+    fn mz_is_sorted(self) -> bool
+    where
+        Self: Sized,
+        Self::Item: PartialOrd,
+    {
+        self.mz_is_sorted_by(PartialOrd::partial_cmp)
+    }
+
+    /// Checks if the elements of this iterator are sorted using the given comparator function.
+    ///
+    /// Instead of using `PartialOrd::partial_cmp`, this function uses the given `compare`
+    /// function to determine the ordering of two elements. Apart from that, it's equivalent to
+    /// [`is_sorted`]; see its documentation for more information.
+    ///
+    /// **Note:** this is a Materialize forward-port of a forthcoming feature
+    /// to the standard library.
+    /// See [rust-lang/rust#53485](https://github.com/rust-lang/rust/issues/53485).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ore::iter::IteratorExt;
+    /// assert!([1, 2, 2, 9].iter().mz_is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// assert!(![1, 3, 2, 4].iter().mz_is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// assert!([0].iter().mz_is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// assert!(std::iter::empty::<i32>().mz_is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// assert!(![0.0, 1.0, f32::NAN].iter().mz_is_sorted_by(|a, b| a.partial_cmp(b)));
+    /// ```
+    ///
+    /// [`is_sorted`]: IteratorExt::is_sorted
+    fn mz_is_sorted_by<F>(mut self, mut compare: F) -> bool
+    where
+        Self: Sized,
+        F: FnMut(&Self::Item, &Self::Item) -> Option<Ordering>,
+    {
+        let mut last = match self.next() {
+            Some(e) => e,
+            None => return true,
+        };
+
+        for curr in self {
+            if let Some(Ordering::Greater) | None = compare(&last, &curr) {
+                return false;
+            }
+            last = curr;
+        }
+
+        true
     }
 
     /// Chains a single `item` onto the end of this iterator.


### PR DESCRIPTION
Iterator::is_sorted is a forthcoming method to the standard library. It
is quite useful, so copy and paste the implementation from the standard
library into `ore` with an `mz_` prefix so we can use it before it
stabilizes.

Once the feature stabilizes, we can remove the implementation from ore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5779)
<!-- Reviewable:end -->
