### PR TITLE
Add uptime and number of timely workers to telemetry data

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -262,9 +262,17 @@ parameter.
 
 ### Telemetry
 
-Unless disabled with `--disable-telemetry`, upon startup `materialized`
-reports its current version and cluster id to a central server operated by
-materialize.com. If a newer version is available a warning will be logged.
+Unless disabled with `--disable-telemetry`, upon startup and once an hour
+`materialized` reports some anonymous telemetry data to a central server operated
+by materialize.com. If a newer version is available at startup a warning will be
+logged.
+
+Information reported to Materialize:
+
+* Cluster ID
+* Current Version
+* Number of worker threads
+* Uptime
 
 ### Dataflow tuning
 

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -52,7 +52,6 @@ pub struct Config {
     pub tls: Option<TlsConfig>,
     pub coord_client: coord::Client,
     pub start_time: Instant,
-    pub worker_count: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -76,10 +75,6 @@ pub struct Server {
 
 impl Server {
     pub fn new(config: Config) -> Server {
-        // Just set this metric once so that it shows up in the metric export.
-        crate::server_metrics::WORKER_COUNT
-            .with_label_values(&[&config.worker_count.to_string()])
-            .set(1);
         Server {
             tls: config.tls,
             coord_client: config.coord_client,

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -77,7 +77,7 @@ pub struct Server {
 impl Server {
     pub fn new(config: Config) -> Server {
         // Just set this metric once so that it shows up in the metric export.
-        metrics::WORKER_COUNT
+        crate::server_metrics::WORKER_COUNT
             .with_label_values(&[&config.worker_count.to_string()])
             .set(1);
         Server {

--- a/src/materialized/src/http/metrics.rs
+++ b/src/materialized/src/http/metrics.rs
@@ -9,70 +9,16 @@
 
 //! Metrics HTTP endpoints.
 
+use crate::BUILD_INFO;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
 use std::time::Instant;
 
 use askama::Template;
 use hyper::{Body, Request, Response};
-use lazy_static::lazy_static;
-use prometheus::{
-    register_gauge_vec, register_int_gauge_vec, Encoder, Gauge, GaugeVec, IntGauge, IntGaugeVec,
-};
-use sysinfo::{ProcessorExt, SystemExt};
+use prometheus::Encoder;
 
 use crate::http::util;
-use crate::BUILD_INFO;
-
-lazy_static! {
-    static ref SERVER_METADATA_RAW: GaugeVec = register_gauge_vec!(
-        "mz_server_metadata_seconds",
-        "server metadata, value is uptime",
-        &[
-            "build_time",
-            "build_version",
-            "build_sha",
-            "os",
-            "ncpus_logical",
-            "ncpus_physical",
-            "cpu0",
-            "memory_total",
-        ]
-    )
-    .expect("can build mz_server_metadata");
-    static ref SERVER_METADATA: Gauge = {
-        let mut system = sysinfo::System::new();
-        system.refresh_system();
-
-        SERVER_METADATA_RAW.with_label_values(&[
-            BUILD_INFO.time,
-            BUILD_INFO.version,
-            BUILD_INFO.sha,
-            &os_info::get().to_string(),
-            &num_cpus::get().to_string(),
-            &num_cpus::get_physical().to_string(),
-            &{
-                let cpu0 = &system.get_processors()[0];
-                format!("{} {}MHz", cpu0.get_brand(), cpu0.get_frequency())
-            },
-            &system.get_total_memory().to_string(),
-        ])
-    };
-    pub static ref WORKER_COUNT: IntGaugeVec = register_int_gauge_vec!(
-        "mz_server_metadata_timely_worker_threads",
-        "number of timely workers materialized is running with",
-        &["count"]
-    )
-    .unwrap();
-    static ref REQUEST_TIMES: IntGaugeVec = register_int_gauge_vec!(
-        "mz_server_scrape_metrics_times",
-        "how long it took to gather metrics, used for very low frequency high accuracy measures",
-        &["action"]
-    )
-    .unwrap();
-    static ref REQUEST_METRICS_GATHER: IntGauge = REQUEST_TIMES.with_label_values(&["gather"]);
-    static ref REQUEST_METRICS_ENCODE: IntGauge = REQUEST_TIMES.with_label_values(&["encode"]);
-}
+use crate::server_metrics::{load_prom_metrics, PromMetric, REQUEST_METRICS_ENCODE};
 
 #[derive(Template)]
 #[template(path = "http/templates/status.html")]
@@ -89,9 +35,8 @@ pub async fn handle_prometheus(
     start_time: Instant,
 ) -> Result<Response<Body>, anyhow::Error> {
     let metric_families = load_prom_metrics(start_time);
-    let encoder = prometheus::TextEncoder::new();
     let mut buffer = Vec::new();
-
+    let encoder = prometheus::TextEncoder::new();
     let start = Instant::now();
     encoder.encode(&metric_families, &mut buffer)?;
     REQUEST_METRICS_ENCODE.set(Instant::now().duration_since(start).as_micros() as i64);
@@ -175,107 +120,4 @@ pub async fn handle_status(
         start_time,
         metrics: metrics.values().collect(),
     }))
-}
-
-/// Call [`prometheus::gather`], ensuring that all our metrics are up to date
-fn load_prom_metrics(start_time: Instant) -> Vec<prometheus::proto::MetricFamily> {
-    let before_gather = Instant::now();
-    let uptime = before_gather - start_time;
-    let (secs, milli_part) = (uptime.as_secs() as f64, uptime.subsec_millis() as f64);
-    SERVER_METADATA.set(secs + milli_part / 1_000.0);
-    let result = prometheus::gather();
-
-    REQUEST_METRICS_GATHER.set(Instant::now().duration_since(before_gather).as_micros() as i64);
-    result
-}
-
-#[derive(Debug)]
-enum PromMetric<'a> {
-    Counter {
-        name: &'a str,
-        value: f64,
-        labels: BTreeMap<&'a str, &'a str>,
-    },
-    Gauge {
-        name: &'a str,
-        value: f64,
-        labels: BTreeMap<&'a str, &'a str>,
-    },
-    Histogram {
-        name: &'a str,
-        count: u64,
-        labels: BTreeMap<&'a str, &'a str>,
-    },
-}
-
-impl fmt::Display for PromMetric<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn fmt(
-            f: &mut fmt::Formatter,
-            name: &str,
-            value: impl fmt::Display,
-            labels: &BTreeMap<&str, &str>,
-        ) -> fmt::Result {
-            write!(f, "{} ", name)?;
-            for (n, v) in labels.iter() {
-                write!(f, "{}={} ", n, v)?;
-            }
-            writeln!(f, "{}", value)
-        }
-        match self {
-            PromMetric::Counter {
-                name,
-                value,
-                labels,
-            } => fmt(f, name, value, labels),
-            PromMetric::Gauge {
-                name,
-                value,
-                labels,
-            } => fmt(f, name, value, labels),
-            PromMetric::Histogram {
-                name,
-                count,
-                labels,
-            } => fmt(f, name, count, labels),
-        }
-    }
-}
-
-impl PromMetric<'_> {
-    fn from_metric_family<'a>(
-        m: &'a prometheus::proto::MetricFamily,
-    ) -> Result<Vec<PromMetric<'a>>, ()> {
-        use prometheus::proto::MetricType;
-        fn l2m(metric: &prometheus::proto::Metric) -> BTreeMap<&str, &str> {
-            metric
-                .get_label()
-                .iter()
-                .map(|lp| (lp.get_name(), lp.get_value()))
-                .collect()
-        }
-        m.get_metric()
-            .iter()
-            .map(|metric| {
-                Ok(match m.get_field_type() {
-                    MetricType::COUNTER => PromMetric::Counter {
-                        name: m.get_name(),
-                        value: metric.get_counter().get_value(),
-                        labels: l2m(metric),
-                    },
-                    MetricType::GAUGE => PromMetric::Gauge {
-                        name: m.get_name(),
-                        value: metric.get_gauge().get_value(),
-                        labels: l2m(metric),
-                    },
-                    MetricType::HISTOGRAM => PromMetric::Histogram {
-                        name: m.get_name(),
-                        count: metric.get_histogram().get_sample_count(),
-                        labels: l2m(metric),
-                    },
-                    _ => return Err(()),
-                })
-            })
-            .collect()
-    }
 }

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -34,6 +34,7 @@ use crate::mux::Mux;
 
 mod http;
 mod mux;
+mod server_metrics;
 mod version_check;
 
 // Disable jemalloc on macOS, as it is not well supported [0][1][2].

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -265,6 +265,7 @@ pub async fn serve(
         tokio::spawn(version_check::check_version_loop(
             telemetry_url,
             coord_handle.cluster_id().to_string(),
+            start_time,
         ));
     }
 

--- a/src/materialized/src/server_metrics.rs
+++ b/src/materialized/src/server_metrics.rs
@@ -10,7 +10,6 @@
 //! Tools for interacting with Prometheus metrics
 
 use std::collections::{BTreeMap, HashSet};
-use std::convert::TryInto;
 use std::fmt;
 use std::time::Instant;
 

--- a/src/materialized/src/server_metrics.rs
+++ b/src/materialized/src/server_metrics.rs
@@ -1,0 +1,174 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Tools for interacting with Prometheus metrics
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::time::Instant;
+
+use crate::BUILD_INFO;
+use lazy_static::lazy_static;
+use prometheus::{
+    register_gauge_vec, register_int_gauge_vec, Gauge, GaugeVec, IntGauge, IntGaugeVec,
+};
+use sysinfo::{ProcessorExt, SystemExt};
+
+lazy_static! {
+    static ref SERVER_METADATA_RAW: GaugeVec = register_gauge_vec!(
+        "mz_server_metadata_seconds",
+        "server metadata, value is uptime",
+        &[
+            "build_time",
+            "build_version",
+            "build_sha",
+            "os",
+            "ncpus_logical",
+            "ncpus_physical",
+            "cpu0",
+            "memory_total",
+        ]
+    )
+    .expect("can build mz_server_metadata");
+    static ref SERVER_METADATA: Gauge = {
+        let mut system = sysinfo::System::new();
+        system.refresh_system();
+
+        SERVER_METADATA_RAW.with_label_values(&[
+            BUILD_INFO.time,
+            BUILD_INFO.version,
+            BUILD_INFO.sha,
+            &os_info::get().to_string(),
+            &num_cpus::get().to_string(),
+            &num_cpus::get_physical().to_string(),
+            &{
+                let cpu0 = &system.get_processors()[0];
+                format!("{} {}MHz", cpu0.get_brand(), cpu0.get_frequency())
+            },
+            &system.get_total_memory().to_string(),
+        ])
+    };
+    pub static ref WORKER_COUNT: IntGaugeVec = register_int_gauge_vec!(
+        "mz_server_metadata_timely_worker_threads",
+        "number of timely workers materialized is running with",
+        &["count"]
+    )
+    .unwrap();
+    static ref REQUEST_TIMES: IntGaugeVec = register_int_gauge_vec!(
+        "mz_server_scrape_metrics_times",
+        "how long it took to gather metrics, used for very low frequency high accuracy measures",
+        &["action"]
+    )
+    .unwrap();
+    static ref REQUEST_METRICS_GATHER: IntGauge = REQUEST_TIMES.with_label_values(&["gather"]);
+    pub static ref REQUEST_METRICS_ENCODE: IntGauge = REQUEST_TIMES.with_label_values(&["encode"]);
+}
+
+/// Call [`prometheus::gather`], ensuring that all our metrics are up to date
+pub fn load_prom_metrics(start_time: Instant) -> Vec<prometheus::proto::MetricFamily> {
+    let before_gather = Instant::now();
+    let uptime = before_gather - start_time;
+    let (secs, milli_part) = (uptime.as_secs() as f64, uptime.subsec_millis() as f64);
+    SERVER_METADATA.set(secs + milli_part / 1_000.0);
+    let result = prometheus::gather();
+
+    REQUEST_METRICS_GATHER.set(Instant::now().duration_since(before_gather).as_micros() as i64);
+    result
+}
+
+#[derive(Debug)]
+pub enum PromMetric<'a> {
+    Counter {
+        name: &'a str,
+        value: f64,
+        labels: BTreeMap<&'a str, &'a str>,
+    },
+    Gauge {
+        name: &'a str,
+        value: f64,
+        labels: BTreeMap<&'a str, &'a str>,
+    },
+    Histogram {
+        name: &'a str,
+        count: u64,
+        labels: BTreeMap<&'a str, &'a str>,
+    },
+}
+
+impl fmt::Display for PromMetric<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(
+            f: &mut fmt::Formatter,
+            name: &str,
+            value: impl fmt::Display,
+            labels: &BTreeMap<&str, &str>,
+        ) -> fmt::Result {
+            write!(f, "{} ", name)?;
+            for (n, v) in labels.iter() {
+                write!(f, "{}={} ", n, v)?;
+            }
+            writeln!(f, "{}", value)
+        }
+        match self {
+            PromMetric::Counter {
+                name,
+                value,
+                labels,
+            } => fmt(f, name, value, labels),
+            PromMetric::Gauge {
+                name,
+                value,
+                labels,
+            } => fmt(f, name, value, labels),
+            PromMetric::Histogram {
+                name,
+                count,
+                labels,
+            } => fmt(f, name, count, labels),
+        }
+    }
+}
+
+impl PromMetric<'_> {
+    pub fn from_metric_family<'a>(
+        m: &'a prometheus::proto::MetricFamily,
+    ) -> Result<Vec<PromMetric<'a>>, ()> {
+        use prometheus::proto::MetricType;
+        fn l2m(metric: &prometheus::proto::Metric) -> BTreeMap<&str, &str> {
+            metric
+                .get_label()
+                .iter()
+                .map(|lp| (lp.get_name(), lp.get_value()))
+                .collect()
+        }
+        m.get_metric()
+            .iter()
+            .map(|metric| {
+                Ok(match m.get_field_type() {
+                    MetricType::COUNTER => PromMetric::Counter {
+                        name: m.get_name(),
+                        value: metric.get_counter().get_value(),
+                        labels: l2m(metric),
+                    },
+                    MetricType::GAUGE => PromMetric::Gauge {
+                        name: m.get_name(),
+                        value: metric.get_gauge().get_value(),
+                        labels: l2m(metric),
+                    },
+                    MetricType::HISTOGRAM => PromMetric::Histogram {
+                        name: m.get_name(),
+                        count: metric.get_histogram().get_sample_count(),
+                        labels: l2m(metric),
+                    },
+                    _ => return Err(()),
+                })
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
In order for uptime to be meaningful, we also report telemetry once an hour now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5780)
<!-- Reviewable:end -->
