### PR TITLE
sql, expr: implement encode/decode functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,6 +1066,7 @@ dependencies = [
  "csv",
  "encoding",
  "enum-iterator",
+ "hex",
  "hmac",
  "itertools",
  "md-5",

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -53,6 +53,11 @@ Wrap your release notes at the 80 character mark.
 
   Thanks to external contributor [@andrioni](https://github.com/andrioni).
 
+- Add the [`encode` and `decode` functions](/sql/functions/encode/) to convert
+  binary data to and from several textual representations.
+
+  Thanks to external contributor [@Posnet](https://github.com/Posnet).
+
 - Multipartition Kafka sinks with consistency enabled will create single-partition
   consistency topics.
 - **Breaking change.** Change the behavior of the

--- a/doc/user/content/sql/functions/encode.md
+++ b/doc/user/content/sql/functions/encode.md
@@ -1,0 +1,123 @@
+---
+title: "encode and decode Functions"
+description: "Converts binary data to and from textual representations"
+menu:
+  main:
+    parent: 'sql-functions'
+---
+
+The `encode` function encodes binary data into one of several textual
+representations. The `decode` function does the reverse.
+
+## Signatures
+
+```
+encode(b: bytea, format: text) -> text
+decode(s: text, format: text) -> bytea
+```
+
+## Details
+
+### Supported formats
+
+The following formats are supported by both `encode` and `decode`.
+
+#### `base64`
+
+The `base64` format is defined in [Section 6.8 of RFC 2045][rfc2045].
+
+To comply with the RFC, the `encode` function inserts a newline (`\n`) after
+every 76 characters. The `decode` function ignores any whitespace in its input.
+
+#### `escape`
+
+The `escape` format renders zero bytes and bytes with the high bit set (`0x80` -
+`0xff`) as an octal escape sequence (`\nnn`), renders backslashes as `\\`, and
+renders all other characters literally. The `decode` function rejects invalid
+escape sequences (e.g., `\9` or `\a`).
+
+#### `hex`
+
+The `hex` format represents each byte of input as two hexadecimal digits, with
+the most significant digit first. The `encode` function uses lowercase for the
+`a`-`f` digits, with no whitespace between digits. The `decode` function accepts
+lowercase or uppercase for the `a` - `f` digits and permits whitespace between
+each encoded byte, though not within a byte.
+
+## Examples
+
+Encoding and decoding in the `base64` format:
+
+```sql
+SELECT encode('\x00404142ff', 'base64');
+```
+```nofmt
+  encode
+----------
+ AEBBQv8=
+```
+
+```sql
+SELECT decode('A   EB BQv8 =', 'base64');
+```
+```nofmt
+    decode
+--------------
+ \x00404142ff
+```
+
+```sql
+SELECT encode('This message is long enough that the output will run to multiple lines.', 'base64');
+```
+```nofmt
+                                    encode
+------------------------------------------------------------------------------
+ VGhpcyBtZXNzYWdlIGlzIGxvbmcgZW5vdWdoIHRoYXQgdGhlIG91dHB1dCB3aWxsIHJ1biB0byBt+
+ dWx0aXBsZSBsaW5lcy4=
+```
+
+<hr>
+
+Encoding and decoding in the `escape` format:
+
+```sql
+SELECT encode('\x00404142ff', 'escape');
+```
+```nofmt
+   encode
+-------------
+ \000@AB\377
+```
+
+```sql
+SELECT decode('\000@AB\377', 'escape');
+```
+```nofmt
+    decode
+--------------
+ \x00404142ff
+```
+
+<hr>
+
+Encoding and decoding in the `hex` format:
+
+```sql
+SELECT encode('\x00404142ff', 'hex');
+```
+```nofmt
+   encode
+------------
+ 00404142ff
+```
+
+```sql
+SELECT decode('00  40  41  42  ff', 'hex');
+```
+```nofmt
+    decode
+--------------
+ \x00404142ff
+```
+
+[rfc2045]: https://tools.ietf.org/html/rfc2045#section-6.8

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -149,6 +149,14 @@
   - signature: 'char_length(s: str) -> int'
     description: Number of code points in `s`
 
+  - signature: 'decode(s: text, format: text) -> bytea'
+    description: Decode `s` using the specified textual representation.
+    url: encode
+
+  - signature: 'encode(b: bytea, format: text) -> text'
+    description: Encode `b` using the specified textual representation.
+    url: encode
+
   - signature: 'length(s: str) -> int'
     description: Number of code points in `s`
     url: length

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -63,6 +63,7 @@ impl CoordError {
     pub fn detail(&self) -> Option<String> {
         match self {
             CoordError::Catalog(c) => c.detail(),
+            CoordError::Eval(e) => e.detail(),
             _ => None,
         }
     }
@@ -71,6 +72,7 @@ impl CoordError {
     pub fn hint(&self) -> Option<String> {
         match self {
             CoordError::Catalog(c) => c.hint(),
+            CoordError::Eval(e) => e.hint(),
             CoordError::UnknownLoginRole(_) => {
                 // TODO(benesch): this will be a bad hint when people are used
                 // to creating roles in Materialize, since they might drop the

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -14,6 +14,7 @@ encoding = "0.2.0"
 enum-iterator = "0.6.0"
 hmac = "0.10.0"
 itertools = "0.9.0"
+hex = "0.4.2"
 md-5 = "0.9.0"
 num_enum = "0.5.1"
 ordered-float = { version = "2.1.1", features = ["serde"] }

--- a/src/expr/src/scalar/func/encoding.rs
+++ b/src/expr/src/scalar/func/encoding.rs
@@ -1,0 +1,216 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Encoding and decoding support for various formats that represent binary data
+//! as text data.
+
+use ore::ascii::UncasedStr;
+use ore::fmt::FormatBuffer;
+use repr::strconv;
+
+use crate::EvalError;
+
+/// An encoding format.
+pub trait Format {
+    /// Encodes a byte slice into its string representation according to this
+    /// format.
+    fn encode(&self, bytes: &[u8]) -> String;
+
+    /// Decodes a byte slice from its string representation according to this
+    /// format.
+    fn decode(&self, s: &str) -> Result<Vec<u8>, EvalError>;
+}
+
+/// PostgreSQL-style Base64 encoding.
+///
+/// PostgreSQL follows RFC 2045, which requires that lines are broken after 76
+/// characters when encoding and that all whitespace characters are ignored when
+/// decoding. See <http://materialize.com/docs/sql/functions/encode> for
+/// details.
+struct Base64Format;
+
+impl Base64Format {
+    const CHARSET: &'static [u8] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    fn encode_sextet(v: u8) -> char {
+        char::from(Self::CHARSET[usize::from(v)])
+    }
+
+    fn decode_sextet(b: u8) -> Result<u8, EvalError> {
+        match b {
+            b'A'..=b'Z' => Ok(b - b'A'),
+            b'a'..=b'z' => Ok(b - b'a' + 26),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err(EvalError::InvalidBase64Symbol(char::from(b))),
+        }
+    }
+}
+
+impl Format for Base64Format {
+    // Support for PostgreSQL-style (which is really MIME-style) Base64 encoding
+    // was, frustratingly, removed from Rust's `base64` crate. So we roll our
+    // own Base64 encoder and decoder here.
+
+    fn encode(&self, bytes: &[u8]) -> String {
+        // Process input in chunks of three octets. Each chunk is converted to
+        // four sextets. Each sextet is encoded as a printable ASCII character
+        // via `CHARSET`.
+        //
+        // When the input length is not divisible by three, the last chunk is
+        // partial. Sextets that are entirely determined by missing octets are
+        // encoded as `=`. Sextets that are partially determined by a missing
+        // octect assume the octet was zero.
+        //
+        // Line breaks are emitted after every 76 characters.
+
+        let mut buf = String::new();
+        for chunk in bytes.chunks(3) {
+            match chunk {
+                [o1, o2, o3] => {
+                    let s1 = (o1 & 0b11111100) >> 2;
+                    let s2 = (o1 & 0b00000011) << 4 | (o2 & 0b11110000) >> 4;
+                    let s3 = (o2 & 0b00001111) << 2 | (o3 & 0b11000000) >> 6;
+                    let s4 = o3 & 0b00111111;
+                    buf.push(Self::encode_sextet(s1));
+                    buf.push(Self::encode_sextet(s2));
+                    buf.push(Self::encode_sextet(s3));
+                    buf.push(Self::encode_sextet(s4));
+                }
+                [o1, o2] => {
+                    let s1 = (o1 & 0b11111100) >> 2;
+                    let s2 = (o1 & 0b00000011) << 4 | (o2 & 0b11110000) >> 4;
+                    let s3 = (o2 & 0b00001111) << 2;
+                    buf.push(Self::encode_sextet(s1));
+                    buf.push(Self::encode_sextet(s2));
+                    buf.push(Self::encode_sextet(s3));
+                    buf.push('=');
+                }
+                [o1] => {
+                    let s1 = (o1 & 0b11111100) >> 2;
+                    let s2 = (o1 & 0b00000011) << 4;
+                    buf.push(Self::encode_sextet(s1));
+                    buf.push(Self::encode_sextet(s2));
+                    buf.push('=');
+                    buf.push('=');
+                }
+                _ => unreachable!(),
+            }
+            if buf.len() % 77 == 76 {
+                buf.push('\n');
+            }
+        }
+        buf
+    }
+
+    fn decode(&self, s: &str) -> Result<Vec<u8>, EvalError> {
+        // Process input in chunks of four bytes, after filtering out any bytes
+        // that represent whitespace. Each byte is decoded into a sextet
+        // according to the reverse charset mapping maintained in
+        // `Self::decode_sextet`. The four sextets are converted to three octets
+        // and emitted.
+        //
+        // When the last character in a chunk is `=` or the last two characters
+        // in a chunk are both `=`, the chunk is missing its last one or two
+        // sextets, respectively. Octets that are entirely determined by missing
+        // sextets are elided. Octets that are partially determined by a missing
+        // sextet assume the sextet was zero.
+        //
+        // It is an error for a `=` character to appear in another position in
+        // a chunk. It is also an error if a chunk is incomplete.
+
+        let mut buf = vec![];
+        let mut bytes = s
+            .as_bytes()
+            .iter()
+            .copied()
+            .filter(|ch| !matches!(ch, b' ' | b'\t' | b'\n' | b'\r'));
+        loop {
+            match (bytes.next(), bytes.next(), bytes.next(), bytes.next()) {
+                (Some(c1), Some(c2), Some(b'='), Some(b'=')) => {
+                    let s1 = Self::decode_sextet(c1)?;
+                    let s2 = Self::decode_sextet(c2)?;
+                    buf.push(s1 << 2 | (s2 & 0b110000) >> 4);
+                }
+                (Some(c1), Some(c2), Some(c3), Some(b'=')) => {
+                    let s1 = Self::decode_sextet(c1)?;
+                    let s2 = Self::decode_sextet(c2)?;
+                    let s3 = Self::decode_sextet(c3)?;
+                    buf.push(s1 << 2 | (s2 & 0b110000) >> 4);
+                    buf.push((s2 & 0b001111) << 4 | (s3 & 0b111100) >> 2);
+                }
+                (Some(b'='), _, _, _) | (_, Some(b'='), _, _) | (_, _, Some(b'='), _) => {
+                    return Err(EvalError::InvalidBase64Equals)
+                }
+                (Some(c1), Some(c2), Some(c3), Some(c4)) => {
+                    let s1 = Self::decode_sextet(c1)?;
+                    let s2 = Self::decode_sextet(c2)?;
+                    let s3 = Self::decode_sextet(c3)?;
+                    let s4 = Self::decode_sextet(c4)?;
+                    buf.push(s1 << 2 | (s2 & 0b110000) >> 4);
+                    buf.push((s2 & 0b001111) << 4 | (s3 & 0b111100) >> 2);
+                    buf.push((s3 & 0b000011) << 6 | s4);
+                }
+                (None, None, None, None) => return Ok(buf),
+                _ => return Err(EvalError::InvalidBase64EndSequence),
+            }
+        }
+    }
+}
+
+struct EscapeFormat;
+
+impl Format for EscapeFormat {
+    fn encode(&self, bytes: &[u8]) -> String {
+        let mut buf = String::new();
+        for b in bytes {
+            match b {
+                b'\0' | (b'\x80'..=b'\xff') => {
+                    buf.push('\\');
+                    write!(&mut buf, "{:03o}", b);
+                }
+                b'\\' => buf.push_str("\\\\"),
+                _ => buf.push(char::from(*b)),
+            }
+        }
+        buf
+    }
+
+    fn decode(&self, s: &str) -> Result<Vec<u8>, EvalError> {
+        Ok(strconv::parse_bytes_traditional(s)?)
+    }
+}
+
+struct HexFormat;
+
+impl Format for HexFormat {
+    fn encode(&self, bytes: &[u8]) -> String {
+        hex::encode(bytes)
+    }
+
+    fn decode(&self, s: &str) -> Result<Vec<u8>, EvalError> {
+        // Can't use `hex::decode` here, as it doesn't tolerate whitespace
+        // between encoded bytes.
+        Ok(strconv::parse_bytes_hex(s)?)
+    }
+}
+
+pub fn lookup_format(s: &str) -> Result<&'static dyn Format, EvalError> {
+    let s = UncasedStr::new(s);
+    if s == "base64" {
+        Ok(&Base64Format)
+    } else if s == "escape" {
+        Ok(&EscapeFormat)
+    } else if s == "hex" {
+        Ok(&HexFormat)
+    } else {
+        Err(EvalError::InvalidEncodingName(s.as_str().into()))
+    }
+}

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -17,7 +17,7 @@ use ore::collections::CollectionExt;
 use repr::adt::array::InvalidArrayError;
 use repr::adt::datetime::DateTimeUnits;
 use repr::adt::regex::Regex;
-use repr::strconv::ParseError;
+use repr::strconv::{ParseError, ParseHexError};
 use repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
 use self::func::{BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
@@ -702,6 +702,9 @@ pub enum EvalError {
     Int64OutOfRange,
     IntervalOutOfRange,
     TimestampOutOfRange,
+    InvalidBase64Equals,
+    InvalidBase64Symbol(char),
+    InvalidBase64EndSequence,
     InvalidTimezone(String),
     InvalidTimezoneInterval,
     InvalidTimezoneConversion,
@@ -724,6 +727,7 @@ pub enum EvalError {
     UnsupportedDateTimeUnits(DateTimeUnits),
     UnterminatedLikeEscapeSequence,
     Parse(ParseError),
+    ParseHex(ParseHexError),
     Internal(String),
 }
 
@@ -738,6 +742,15 @@ impl fmt::Display for EvalError {
             EvalError::Int64OutOfRange => f.write_str("bigint out of range"),
             EvalError::IntervalOutOfRange => f.write_str("interval out of range"),
             EvalError::TimestampOutOfRange => f.write_str("timestamp out of range"),
+            EvalError::InvalidBase64Equals => {
+                f.write_str("unexpected \"=\" while decoding base64 sequence")
+            }
+            EvalError::InvalidBase64Symbol(c) => write!(
+                f,
+                "invalid symbol \"{}\" found while decoding base64 sequence",
+                c.escape_default()
+            ),
+            EvalError::InvalidBase64EndSequence => f.write_str("invalid base64 end sequence"),
             EvalError::InvalidTimezone(tz) => write!(f, "invalid time zone '{}'", tz),
             EvalError::InvalidTimezoneInterval => {
                 f.write_str("timezone interval must not contain months or years")
@@ -771,7 +784,23 @@ impl fmt::Display for EvalError {
                 f.write_str("unterminated escape sequence in LIKE")
             }
             EvalError::Parse(e) => e.fmt(f),
+            EvalError::ParseHex(e) => e.fmt(f),
             EvalError::Internal(s) => write!(f, "internal error: {}", s),
+        }
+    }
+}
+
+impl EvalError {
+    pub fn detail(&self) -> Option<String> {
+        None
+    }
+
+    pub fn hint(&self) -> Option<String> {
+        match self {
+            EvalError::InvalidBase64EndSequence => Some(
+                "Input data is missing padding, is truncated, or is otherwise corrupted.".into(),
+            ),
+            _ => None,
         }
     }
 }
@@ -781,6 +810,12 @@ impl std::error::Error for EvalError {}
 impl From<ParseError> for EvalError {
     fn from(e: ParseError) -> EvalError {
         EvalError::Parse(e)
+    }
+}
+
+impl From<ParseHexError> for EvalError {
+    fn from(e: ParseHexError) -> EvalError {
+        EvalError::ParseHex(e)
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1782,6 +1782,12 @@ lazy_static! {
                         column_names: vec![Some("jsonb_object_keys".into())],
                     })
                 }), 3931;
+            },
+            "encode" => Scalar {
+                params!(Bytes, String) => BinaryFunc::Encode, 1946;
+            },
+            "decode" => Scalar {
+                params!(String, String) => BinaryFunc::Decode, 1947;
             }
         }
     };

--- a/test/sqllogictest/encode.slt
+++ b/test/sqllogictest/encode.slt
@@ -1,0 +1,101 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for the `encode` and `decode` functions.
+
+mode cockroach
+
+statement ok
+CREATE TABLE unencoded (val bytea)
+
+statement ok
+INSERT INTO unencoded VALUES (NULL), ('\x00fffe65'), ('a'), ('ab'), ('abc'), ('abcd')
+
+# ==> base64 format
+
+query TT
+SELECT encode(val, 'base64'), decode(encode(val, 'base64'), 'base64') FROM unencoded ORDER BY val
+----
+NULL      NULL
+AP/+ZQ==  [0,␠255,␠254,␠101]
+YQ==      a
+YWI=      ab
+YWJj      abc
+YWJjZA==  abcd
+
+# base64 special case: test that the encoded output is wrapped at 76 characters.
+
+mode standard
+
+query T multiline
+SELECT encode('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz', 'base64')
+----
+YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5emFiY2Rl
+ZmdoaWprbG1ub3BxcnN0dXZ3eHl6YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlq
+a2xtbm9wcXJzdHV2d3h5emFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6
+EOF
+
+mode cockroach
+
+query error invalid base64 end sequence
+SELECT decode('a', 'base64')
+
+query error unexpected "=" while decoding base64 sequence
+SELECT decode('=', 'base64')
+
+query error invalid symbol "@" found while decoding base64 sequence
+SELECT decode('aaa@', 'base64')
+
+query error invalid symbol "\\u\{2\}" found while decoding base64 sequence
+SELECT decode(e'aaa\u0002', 'base64')
+
+# ==> hex format
+
+query TT
+SELECT encode(val, 'hex'), decode(encode(val, 'hex'), 'hex') FROM unencoded ORDER BY val
+----
+NULL      NULL
+00fffe65  [0,␠255,␠254,␠101]
+61        a
+6162      ab
+616263    abc
+61626364  abcd
+
+# hex special case: encoded bytes can be separated by whitespace.
+
+query T
+SELECT decode(E'41 42\t43', 'hex')
+----
+ABC
+
+# Though individual digits within a byte cannot.
+
+query error invalid hexadecimal digit: " "
+SELECT decode('a a', 'hex')
+
+query error invalid hexadecimal digit: "x"
+SELECT decode('xx', 'hex')
+
+query error invalid hexadecimal data: odd number of digits
+SELECT decode('0', 'hex')
+
+# ==> escape format
+
+query TT
+SELECT encode(val, 'escape'), decode(encode(val, 'escape'), 'escape') FROM unencoded ORDER BY val
+----
+NULL           NULL
+\000\377\376e  [0,␠255,␠254,␠101]
+a              a
+ab             ab
+abc            abc
+abcd           abcd
+
+query error invalid input syntax for type bytea
+SELECT decode('\9', 'escape')


### PR DESCRIPTION
Implement the PostgreSQL built-in functions encode and decode. Resubmission of #5767 with additional tests, documentation, and more PostgreSQL compatibility. 

@philip-stoev I realize I forgot to ask you to push your tests somewhere, but I needed to write a few tests to verify that these implementations worked as I intended. But I tried to hold off on writing anything too esoteric, to avoid duplicating effort.

/cc @Posnet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5785)
<!-- Reviewable:end -->
