### PR TITLE
sql: don't mishandle reflexive equality conditions

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2797,7 +2797,9 @@ fn find_trivial_column_equivalences(expr: &HirScalarExpr) -> Vec<(usize, usize)>
                     }),
                 ) = (&**expr1, &**expr2)
                 {
-                    equivalences.push((*l, *r));
+                    if l != r {
+                        equivalences.push((*l, *r));
+                    }
                 }
             }
             CallBinary {

--- a/test/sqllogictest/scoping.slt
+++ b/test/sqllogictest/scoping.slt
@@ -33,6 +33,12 @@ query I
 SELECT t1.a FROM t1 JOIN (t2 JOIN t3 ON t2.a = t3.a) ON t1.a = t2.a GROUP BY t3.a
 ----
 
+# Ensure that reflexive equality expressions do not cause the specified column
+# to become unnameable. See #5765.
+query I
+SELECT t1.a FROM t1 JOIN t2 ON t1.a = t1.a GROUP BY t1.a
+----
+
 # This works in PostgreSQL.
 query I
 SELECT t1.a FROM t1 NATURAL JOIN t2


### PR DESCRIPTION
MySQL allows you to include a column in the SELECT list that is not
present in the GROUP BY

    SELECT t1.a FROM t1 JOIN t2 ON t1.a = t2.a GROUP BY t2.a

using a rudimentary analysis to determine whether the columns are
declared equivalent via a JOIN. We support this by searching the ON
clause for "trivial" column equivalences. If we find any, we mark the
right column as "unnameable" and add its name as an alias for the left
column.

It turns out this doesn't work in the degenerate case of

    SELECT t1.a FROM t1 JOIN t2 ON t1.a = t1.a

that is, when a column is declared equal to itself in an ON clause. In
this case, when we mark the right column as unnameable, we of course
also mark the left column as unnameable, and thus that query falsely
claimed that "t1.a" does not exist.

This commit fixes the issue by changing find_trivial_column_equivalences
to only surface equivalences if the columns involved in the equality are
distinct.

Fix #5765.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5788)
<!-- Reviewable:end -->
