### PR TITLE
sql: fix resolution of qualified columns in nested scopes

### DIFF
--- a/test/sqllogictest/cte.slt
+++ b/test/sqllogictest/cte.slt
@@ -105,6 +105,13 @@ WITH foo AS (SELECT 1)
 1
 2
 
+# See 5766.
+query error column "a2.f1" does not exist
+SELECT * FROM (VALUES (true)) a2 (f1) WHERE (
+    SELECT TRUE FROM (VALUES (true)) AS a2 (f2)
+    WHERE (SELECT a2.f1)
+)
+
 statement ok
 CREATE TABLE squares (x int, y int);
 


### PR DESCRIPTION
Per @philip-stoev, the following query was incorrectly succeeding in
Materialize:

    SELECT * FROM (VALUES (true)) a2 (f1) WHERE (
        SELECT TRUE FROM (VALUES (true)) AS a2 (f2)
        WHERE (SELECT a2.f1)
    )

The issue is that we were searching outwards for the first column named
"a2.f1". The correct behavior is to search outwards for the first
*table* named "a2"; if that table doesn't contain a column named "f1"
then we stop searching.

Fix #5766.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5789)
<!-- Reviewable:end -->
