### PR TITLE
interchange: reject recursive protobuf messages

### DIFF
--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -1031,7 +1031,7 @@ fn get_named_columns<'a>(
                 if let Some(named_idx) = named_idx {
                     if !seen_avro_nodes.insert(named_idx) {
                         bail!(
-                            "Recursively defined type in schema: {}",
+                            "Recursive types are not supported: {}",
                             v.get_human_name(schema.root)
                         );
                     }
@@ -1109,7 +1109,7 @@ fn validate_schema_2(
                 if let Some(named_idx) = named_idx {
                     if !seen_avro_nodes.insert(named_idx) {
                         bail!(
-                            "Recursively defined type in schema: {}",
+                            "Recursive types are not supported: {}",
                             f.schema.get_human_name(schema.root)
                         );
                     }
@@ -1134,7 +1134,7 @@ fn validate_schema_2(
             if let Some(named_idx) = named_idx {
                 if !seen_avro_nodes.insert(named_idx) {
                     bail!(
-                        "Recursively defined type in schema: {}",
+                        "Recursive types are not supported: {}",
                         inner.get_human_name(schema.root)
                     );
                 }

--- a/src/testdrive/src/format/protobuf/recursive.proto
+++ b/src/testdrive/src/format/protobuf/recursive.proto
@@ -7,12 +7,20 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-fn main() {
-    protoc::Protoc::new()
-        .serde(true)
-        .include("src/format/protobuf")
-        .input("src/format/protobuf/billing.proto")
-        .input("src/format/protobuf/recursive.proto")
-        .input("src/format/protobuf/simple.proto")
-        .build_script_exec();
+syntax = "proto3";
+
+message Self {
+    Self self = 1;
+}
+
+message Mutual1 {
+    Mutual2 m = 1;
+}
+
+message Mutual2 {
+    Mutual3 m = 1;
+}
+
+message Mutual3 {
+    Mutual1 m = 1;
 }

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -440,7 +440,7 @@ a b
 ! CREATE SOURCE recursive
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored'
   FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
-validating avro value schema: Recursively defined type in schema: .a
+validating avro value schema: Recursive types are not supported: .a
 
 $ set key-schema={"type": "string"}
 $ set value-schema={"type": "record", "name": "r", "fields": [{"name": "a", "type": "string"}]}

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -7,6 +7,16 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+! CREATE SOURCE bad FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Self' USING SCHEMA '${testdrive.protobuf-descriptors}'
+Recursive types are not supported: .Self
+
+! CREATE SOURCE bad FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Mutual1' USING SCHEMA '${testdrive.protobuf-descriptors}'
+Recursive types are not supported: .Mutual1
+
 > CREATE SOURCE protomessages FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA '${testdrive.protobuf-descriptors}'


### PR DESCRIPTION
We can't presently handle recursive types, so we need to reject Protobuf
messages that are recursively defined.

Fix #5609.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5791)
<!-- Reviewable:end -->
