### PR TITLE
Keep symbols other than debug symbols

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -205,7 +205,7 @@ class CargoBuild(CargoPreImage):
             # down CI, since we're packaging these binaries up into Docker
             # images and shipping them around. A bit unfortunate, since it'd be
             # nice to have useful backtraces if the binary crashes.
-            spawn.runv([xstrip, self.path / self.bin])
+            spawn.runv([xstrip, "--strip-debug", self.path / self.bin])
         else:
             # Even if we've been asked not to strip the binary, remove the
             # `.debug_pubnames` and `.debug_pubtypes` sections. These are just


### PR DESCRIPTION
This should allow useful stack traces in CI (though they won't have line numbers). For example:

```
2021-02-17T15:18:16.321104Z ERROR panic: Datum::unwrap_list called on Int64(1)
thread: timely:work-5                                                                                             
location: src/expr/src/scalar/func.rs:3952:7                                                                      
version: 0.7.1-dev (dc6fbeb274d845ccdf2ab0a53fd5038dccfc80bc)                                                     
backtrace:            
   0: materialized::handle_panic  
   1: core::ops::function::Fn::call                                                                               
   2: std::panicking::rust_panic_with_hook               
   3: std::panicking::begin_panic_handler::{{closure}}
   4: std::sys_common::backtrace::__rust_end_short_backtrace                                                      
   5: rust_begin_unwind                                                                                           
   6: std::panicking::begin_panic_fmt
   7: repr::scalar::Datum::unwrap_list                                                                            
   8: expr::scalar::func::UnaryFunc::eval                                                                         
   9: expr::scalar::MirScalarExpr::eval
  10: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
  11: <timely::dataflow::operators::generic::builder_raw::OperatorCore<T,L> as timely::scheduling::Schedule>::schedule
  12: timely::progress::subgraph::PerOperatorState<T>::schedule
  13: <timely::progress::subgraph::Subgraph<TOuter,TInner> as timely::scheduling::Schedule>::schedule
  14: timely::progress::subgraph::PerOperatorState<T>::schedule
  15: <timely::progress::subgraph::Subgraph<TOuter,TInner> as timely::scheduling::Schedule>::schedule             
  16: timely::worker::Wrapper::step
  17: timely::worker::Worker<A>::step_or_park            
  18: dataflow::server::Worker<A>::run                                                                            
  19: std::sys_common::backtrace::__rust_begin_short_backtrace                                                    
  20: core::ops::function::FnOnce::call_once{{vtable.shim}}
  21: std::sys::unix::thread::Thread::new::thread_start  
  22: start_thread                                                                                                
  23: clone
  ```
  
  These non-debug symbols only occupy 10MB extra according to local testing:
  
```
brennan@New-Orleans ~/c/materialize ❯❯❯ du -h materialized
150M    materialized
brennan@New-Orleans ~/c/materialize ❯❯❯ objcopy -R .debug_pubnames -R .debug_pubtypes materialized
brennan@New-Orleans ~/c/materialize ❯❯❯ du -h materialized
138M    materialized
brennan@New-Orleans ~/c/materialize ❯❯❯ strip --strip-debug materialized
brennan@New-Orleans ~/c/materialize ❯❯❯ du -h materialized
65M     materialized
brennan@New-Orleans ~/c/materialize ❯❯❯ strip materialized
brennan@New-Orleans ~/c/materialize ❯❯❯ du -h materialized
55M     materialized
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5796)
<!-- Reviewable:end -->
