### PR TITLE
expr,sql: support for trigonometric functions

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -58,6 +58,11 @@ Wrap your release notes at the 80 character mark.
 
   Thanks to external contributor [@Posnet](https://github.com/Posnet).
 
+- Add many of the basic
+  [trigonometric functions](/sql/functions/#trigonometric-func).
+
+  Thanks again to external contributor [@andrioni](https://github.com/andrioni).
+
 - Multipartition Kafka sinks with consistency enabled will create single-partition
   consistency topics.
 - **Breaking change.** Change the behavior of the

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -129,6 +129,30 @@
   - signature: 'sqrt(x: double precision) -> double precision'
     description: The square root of `x`.
 
+- type: Trigonometric
+  description: Trigonometric functions take and return `double precision` values.
+  functions:
+  - signature: 'cos(x: double precision) -> double precision'
+    description: The cosine of `x`, with `x` in radians.
+
+  - signature: 'cosh(x: double precision) -> double precision'
+    description: The hyperbolic cosine of `x`, with `x` as a hyperbolic angle.
+
+  - signature: 'cot(x: double precision) -> double precision'
+    description: The cotangent of `x`, with `x` in radians.
+
+  - signature: 'sin(x: double precision) -> double precision'
+    description: The sine of `x`, with `x` in radians.
+
+  - signature: 'sinh(x: double precision) -> double precision'
+    description: The hyperbolic sine of `x`, with `x` as a hyperbolic angle.
+
+  - signature: 'tan(x: double precision) -> double precision'
+    description: The tangent of `x`, with `x` in radians.
+
+  - signature: 'tanh(x: double precision) -> double precision'
+    description: The hyperbolic tangent of `x`, with `x` as a hyperbolic angle.
+
 - type: String
   functions:
   - signature: 'ascii(s: str) -> int'

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1200,6 +1200,50 @@ fn cbrt_float64<'a>(a: Datum<'a>) -> Datum {
     Datum::from(a.unwrap_float64().cbrt())
 }
 
+fn cos<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+    if f.is_infinite() {
+        return Err(EvalError::InfinityOutOfDomain("cos".to_owned()));
+    }
+    Ok(Datum::from(f.cos()))
+}
+
+fn cosh<'a>(a: Datum<'a>) -> Datum {
+    Datum::from(a.unwrap_float64().cosh())
+}
+
+fn sin<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+    if f.is_infinite() {
+        return Err(EvalError::InfinityOutOfDomain("sin".to_owned()));
+    }
+    Ok(Datum::from(f.sin()))
+}
+
+fn sinh<'a>(a: Datum<'a>) -> Datum {
+    Datum::from(a.unwrap_float64().sinh())
+}
+
+fn tan<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+    if f.is_infinite() {
+        return Err(EvalError::InfinityOutOfDomain("tan".to_owned()));
+    }
+    Ok(Datum::from(f.tan()))
+}
+
+fn tanh<'a>(a: Datum<'a>) -> Datum {
+    Datum::from(a.unwrap_float64().tanh())
+}
+
+fn cot<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
+    let f = a.unwrap_float64();
+    if f.is_infinite() {
+        return Err(EvalError::InfinityOutOfDomain("cot".to_owned()));
+    }
+    Ok(Datum::from(1.0 / f.tan()))
+}
+
 fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a == b)
 }
@@ -2936,6 +2980,13 @@ pub enum UnaryFunc {
     ListLength,
     Upper,
     Lower,
+    Cos,
+    Cosh,
+    Sin,
+    Sinh,
+    Tan,
+    Tanh,
+    Cot,
 }
 
 impl UnaryFunc {
@@ -3097,6 +3148,13 @@ impl UnaryFunc {
             UnaryFunc::ListLength => Ok(list_length(a)),
             UnaryFunc::Upper => Ok(upper(a, temp_storage)),
             UnaryFunc::Lower => Ok(lower(a, temp_storage)),
+            UnaryFunc::Cos => cos(a),
+            UnaryFunc::Cosh => Ok(cosh(a)),
+            UnaryFunc::Sin => sin(a),
+            UnaryFunc::Sinh => Ok(sinh(a)),
+            UnaryFunc::Tan => tan(a),
+            UnaryFunc::Tanh => Ok(tanh(a)),
+            UnaryFunc::Cot => cot(a),
         }
     }
 
@@ -3245,6 +3303,14 @@ impl UnaryFunc {
             ListLength => ScalarType::Int64.nullable(true),
 
             RegexpMatch(_) => ScalarType::Array(Box::new(ScalarType::String)).nullable(true),
+
+            Cos => ScalarType::Float64.nullable(in_nullable),
+            Cosh => ScalarType::Float64.nullable(in_nullable),
+            Sin => ScalarType::Float64.nullable(in_nullable),
+            Sinh => ScalarType::Float64.nullable(in_nullable),
+            Tan => ScalarType::Float64.nullable(in_nullable),
+            Tanh => ScalarType::Float64.nullable(in_nullable),
+            Cot => ScalarType::Float64.nullable(in_nullable),
         }
     }
 
@@ -3411,6 +3477,13 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::ListLength => f.write_str("list_length"),
             UnaryFunc::Upper => f.write_str("upper"),
             UnaryFunc::Lower => f.write_str("lower"),
+            UnaryFunc::Cos => f.write_str("cos"),
+            UnaryFunc::Cosh => f.write_str("cosh"),
+            UnaryFunc::Sin => f.write_str("sin"),
+            UnaryFunc::Sinh => f.write_str("sinh"),
+            UnaryFunc::Tan => f.write_str("tan"),
+            UnaryFunc::Tanh => f.write_str("tanh"),
+            UnaryFunc::Cot => f.write_str("cot"),
         }
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -729,6 +729,7 @@ pub enum EvalError {
     Parse(ParseError),
     ParseHex(ParseHexError),
     Internal(String),
+    InfinityOutOfDomain(String),
 }
 
 impl fmt::Display for EvalError {
@@ -786,6 +787,9 @@ impl fmt::Display for EvalError {
             EvalError::Parse(e) => e.fmt(f),
             EvalError::ParseHex(e) => e.fmt(f),
             EvalError::Internal(s) => write!(f, "internal error: {}", s),
+            EvalError::InfinityOutOfDomain(s) => {
+                write!(f, "function {} is only defined for finite arguments", s)
+            }
         }
     }
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1351,6 +1351,15 @@ lazy_static! {
             "convert_from" => Scalar {
                 params!(Bytes, String) => BinaryFunc::ConvertFrom, 1714;
             },
+            "cos" => Scalar {
+                params!(Float64) => UnaryFunc::Cos, 1605;
+            },
+            "cosh" => Scalar {
+                params!(Float64) => UnaryFunc::Cosh, 2463;
+            },
+            "cot" => Scalar {
+                params!(Float64) => UnaryFunc::Cot, 1607;
+            },
             "current_schema" => Scalar {
                 params!() => sql_op!("current_schemas(false)[1]"), 1402;
             },
@@ -1540,6 +1549,12 @@ lazy_static! {
                 params!(String) => UnaryFunc::TrimTrailingWhitespace, 882;
                 params!(String, String) => BinaryFunc::TrimTrailing, 876;
             },
+            "sin" => Scalar {
+                params!(Float64) => UnaryFunc::Sin, 1604;
+            },
+            "sinh" => Scalar {
+                params!(Float64) => UnaryFunc::Sinh, 2462;
+            },
             "split_part" => Scalar {
                 params!(String, String, Int64) => VariadicFunc::SplitPart, 2088;
             },
@@ -1578,6 +1593,12 @@ lazy_static! {
                     let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
                     Ok(e.call_unary(UnaryFunc::SqrtDec(s)))
                 }), 1730;
+            },
+            "tan" => Scalar {
+                params!(Float64) => UnaryFunc::Tan, 1606;
+            },
+            "tanh" => Scalar {
+                params!(Float64) => UnaryFunc::Tanh, 246;
             },
             "timezone" => Scalar {
                 params!(String, Timestamp) => BinaryFunc::TimezoneTimestamp, 2069;

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -344,9 +344,9 @@ SELECT cbrt(-8::double)
 -2
 
 query R
-SELECT cbrt(2::int)
+SELECT cbrt(3::int)
 ----
-1.2599210498948734
+1.4422495703074083
 
 # Test coalesce.
 query I
@@ -726,3 +726,210 @@ alreadylow
 
 query error Cannot call function lower\(interval\): arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
 SELECT lower('1ms'::interval)
+
+# Test trigonometric functions.
+
+# Use standard mode to round floats to three digits of precision. This makes
+# tests more reliable across platforms, as platforms have different
+# implementations of the trigonometric functions that result in slight
+# variance in the least significant digits.
+mode standard
+
+query R
+SELECT sin(NULL)
+----
+NULL
+
+query R
+SELECT sinh(NULL)
+----
+NULL
+
+query R
+SELECT cos(NULL)
+----
+NULL
+
+query R
+SELECT cosh(NULL)
+----
+NULL
+
+query R
+SELECT tan(NULL)
+----
+NULL
+
+query R
+SELECT tanh(NULL)
+----
+NULL
+
+query R
+SELECT cot(NULL)
+----
+NULL
+
+query R
+SELECT sin('NaN'::double)
+----
+NaN
+
+query R
+SELECT sinh('NaN'::double)
+----
+NaN
+
+query R
+SELECT cos('NaN'::double)
+----
+NaN
+
+query R
+SELECT cosh('NaN'::double)
+----
+NaN
+
+query R
+SELECT tan('NaN'::double)
+----
+NaN
+
+query R
+SELECT tanh('NaN'::double)
+----
+NaN
+
+query R
+SELECT cot('NaN'::double)
+----
+NaN
+
+query R
+SELECT sin(0::double)
+----
+0.000
+
+query R
+SELECT sinh(0::double)
+----
+0.000
+
+query R
+SELECT cos(0::double)
+----
+1.000
+
+query R
+SELECT cosh(0::double)
+----
+1.000
+
+query R
+SELECT tan(0::double)
+----
+0.000
+
+query R
+SELECT tanh(0::double)
+----
+0.000
+
+query R
+SELECT cot(0::double)
+----
+inf
+
+query R
+SELECT cot(-0::double)
+----
+-inf
+
+query R
+SELECT sin(1::double)
+----
+0.841
+
+query R
+SELECT sinh(1::double)
+----
+1.175
+
+query R
+SELECT cos(1::double)
+----
+0.540
+
+query R
+SELECT cosh(1::double)
+----
+1.543
+
+query R
+SELECT tan(1.01::double)
+----
+1.592
+
+query R
+SELECT tanh(1::double)
+----
+0.762
+
+query R
+SELECT cot(1.01::double)
+----
+0.628
+
+query error function sin is only defined for finite arguments
+SELECT sin('inf'::double)
+
+query R
+SELECT sinh('inf'::double)
+----
+inf
+
+query error function cos is only defined for finite arguments
+SELECT cos('inf'::double)
+
+query R
+SELECT cosh('inf'::double)
+----
+inf
+
+query error function tan is only defined for finite arguments
+SELECT tan('inf'::double)
+
+query R
+SELECT tanh('inf'::double)
+----
+1.000
+
+query error function cot is only defined for finite arguments
+SELECT cot('inf'::double)
+
+query error function sin is only defined for finite arguments
+SELECT sin('-inf'::double)
+
+query R
+SELECT sinh('-inf'::double)
+----
+-inf
+
+query error function cos is only defined for finite arguments
+SELECT cos('-inf'::double)
+
+query R
+SELECT cosh('-inf'::double)
+----
+inf
+
+query error function tan is only defined for finite arguments
+SELECT tan('-inf'::double)
+
+query R
+SELECT tanh('-inf'::double)
+----
+-1.000
+
+query error function cot is only defined for finite arguments
+SELECT cot('-inf'::double)


### PR DESCRIPTION
Add support for the main trigonometric and hyperbolic functions (sin, cos, tan, cot, sinh, cosh, tanh), including tests to ensure it matches the semantics from Postgres, as Rust returns `NaN` instead of an exception in the case of invalid arguments.

This time I also added docs, but I've skipped the release notes to let someone more familiar with them see the best way of describing this changes.

I might open a future PR with the inverse trig functions, but I wanted some input on the error handling approach used here before that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5800)
<!-- Reviewable:end -->
