### PR TITLE
sql: use the actual syntax for global ids

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -46,7 +46,7 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
                     }
                     *name = match name {
                         RawName::Name(_) => RawName::Name(unresolved_name),
-                        RawName::Id(id, _) => RawName::Id(*id, unresolved_name),
+                        RawName::Id(id, _) => RawName::Id(id.clone(), unresolved_name),
                     }
                 }
             }

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -54,7 +54,7 @@ pub struct Raw;
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum RawName {
     Name(UnresolvedObjectName),
-    Id(u64, UnresolvedObjectName),
+    Id(String, UnresolvedObjectName),
 }
 
 impl RawName {
@@ -71,7 +71,7 @@ impl AstDisplay for RawName {
         match self {
             RawName::Name(o) => f.write_node(o),
             RawName::Id(id, o) => {
-                f.write_str(format!("[{} AS", id));
+                f.write_str(format!("[{} AS ", id));
                 f.write_node(o);
                 f.write_str("]");
             }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3319,7 +3319,10 @@ impl<'a> Parser<'a> {
                 alias: self.parse_optional_table_alias()?,
             })
         } else if self.consume_token(&Token::LBracket) {
-            let id = self.parse_literal_uint()?;
+            let id = match self.next_token() {
+                Some(Token::Ident(id)) => id,
+                _ => return parser_err!(self, self.peek_prev_pos(), "expected id"),
+            };
             self.expect_keyword(AS)?;
             let name = self.parse_object_name()?;
             // TODO(justin): is there a more idiomatic way to detect a fully-qualified name?

--- a/src/sql-parser/tests/testdata/id
+++ b/src/sql-parser/tests/testdata/id
@@ -14,29 +14,29 @@
 # limitations under the License.
 
 parse-statement
-SELECT * FROM [123 AS materialize.public.foo]
+SELECT * FROM [u123 AS materialize.public.foo]
 ----
-SELECT * FROM [123 ASmaterialize.public.foo]
+SELECT * FROM [u123 AS materialize.public.foo]
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id(123, UnresolvedObjectName([Ident("materialize"), Ident("public"), Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Id("u123", UnresolvedObjectName([Ident("materialize"), Ident("public"), Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
-SELECT * FROM [123 AS foo]
+SELECT * FROM [u123 AS foo]
 ----
 error: table name in square brackets must be fully qualified
-SELECT * FROM [123 AS foo]
-                      ^
+SELECT * FROM [u123 AS foo]
+                       ^
 
 parse-statement
-SELECT * FROM [123]
+SELECT * FROM [u123]
 ----
 error: Expected AS, found right square bracket
-SELECT * FROM [123]
-                  ^
+SELECT * FROM [u123]
+                   ^
 
 parse-statement
-SELECT * FROM [123 AS materialize.public.foo
+SELECT * FROM [u123 AS materialize.public.foo
 ----
 error: Expected right square bracket, found EOF
-SELECT * FROM [123 AS materialize.public.foo
-                                            ^
+SELECT * FROM [u123 AS materialize.public.foo
+                                             ^

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -203,8 +203,14 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 }
             }
             RawName::Id(id, raw_name) => {
-                let gid = GlobalId::User(id);
-                if self.catalog.try_get_item_by_id(&gid).is_none() {
+                let gid: GlobalId = match id.parse() {
+                    Ok(id) => id,
+                    Err(e) => {
+                        self.status = Err(e);
+                        GlobalId::User(0)
+                    }
+                };
+                if self.status.is_ok() && self.catalog.try_get_item_by_id(&gid).is_none() {
                     self.status = Err(anyhow!("invalid id {}", &gid));
                 }
                 self.ids.insert(gid.clone());

--- a/test/sqllogictest/id.slt
+++ b/test/sqllogictest/id.slt
@@ -26,7 +26,7 @@ SELECT a FROM x
 3
 
 query I
-SELECT a FROM [1 AS materialize.public.y]
+SELECT a FROM [u1 AS materialize.public.y]
 ----
 1
 2
@@ -36,15 +36,18 @@ SELECT a FROM [1 AS materialize.public.y]
 
 # Referring to it by its "true" name should not work.
 statement error column "x.a" does not exist
-SELECT x.a FROM [1 AS materialize.public.y]
+SELECT x.a FROM [u1 AS materialize.public.y]
 
 # Referring to it by its assigned name should work.
 query I
-SELECT y.a FROM [1 AS materialize.public.y]
+SELECT y.a FROM [u1 AS materialize.public.y]
 ----
 1
 2
 3
 
 statement error invalid id
-SELECT y.a FROM [6 AS materialize.public.y]
+SELECT y.a FROM [u6 AS materialize.public.y]
+
+statement error invalid digit
+SELECT y.a FROM [xx AS materialize.public.y]


### PR DESCRIPTION
Previously we used raw ints and assumed they were user ids. This change
means we always parse the ids.

Seems kind of weird just passing the string around but I think the parser is not aware of GlobalIDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5801)
<!-- Reviewable:end -->
