### PR TITLE
coord: refactor function rename migration

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -11,7 +11,7 @@ use anyhow::bail;
 
 use ore::collections::CollectionExt;
 use sql::ast::display::AstDisplay;
-use sql::ast::visit_mut::VisitMut;
+use sql::ast::visit_mut::{self, VisitMut};
 use sql::ast::{
     CreateIndexStatement, CreateTableStatement, CreateTypeStatement, CreateViewStatement, DataType,
     Function, Ident, Raw, Statement, TableFactor, UnresolvedObjectName,
@@ -128,6 +128,20 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
         tx.commit()?;
         Ok(())
     },
+    // This was previously the place where the function name migration occurred;
+    // however #5802 showed that the implementation was insufficient.
+    //
+    // Introduced for v0.7.0
+    |_: &mut Catalog| Ok(()),
+    // Rewrites all function references to have `pg_catalog` qualification; this
+    // is necessary to support resolving all built-in functions to the catalog.
+    // (At the time of writing Materialize did not support user-defined
+    // functions.)
+    //
+    // The approach is to prepend `pg_catalog` to all `UnresolvedObjectName`
+    // names that could refer to functions.
+    //
+    // Introduced for v0.7.1
     |catalog: &mut Catalog| {
         fn normalize_function_name(name: &mut UnresolvedObjectName) {
             if name.0.len() == 1 {
@@ -150,11 +164,17 @@ pub const CONTENT_MIGRATIONS: &[fn(&mut Catalog) -> Result<(), anyhow::Error>] =
         impl<'ast> VisitMut<'ast, Raw> for FuncNormalizer {
             fn visit_function_mut(&mut self, func: &'ast mut Function<Raw>) {
                 normalize_function_name(&mut func.name);
+                // Function args can be functions themselves, so let the visitor
+                // find them.
+                visit_mut::visit_function_mut(self, func)
             }
             fn visit_table_factor_mut(&mut self, table_factor: &'ast mut TableFactor<Raw>) {
                 if let TableFactor::Function { ref mut name, .. } = table_factor {
                     normalize_function_name(name);
                 }
+                // Function args can be functions themselves, so let the visitor
+                // find them.
+                visit_mut::visit_table_factor_mut(self, table_factor)
             }
         }
 

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -91,6 +91,15 @@ a  b  c
 2  1  21
 3  1  31
 1  2  12
+
+# Checks for regressions against #5802; simply having this in the catalog is
+# sufficient, so it doesn't need to be requeried in each new "epoch".
+> CREATE MATERIALIZED VIEW regression_5802 AS SELECT length(length('')::text);
+
+> SELECT * FROM regression_5802
+length
+------
+1
 EOF
 
 say "killing materialized-golden010"


### PR DESCRIPTION
The original implementation of this migration "failed" for functions
whose arguments were themselves functions. This refactor now properly
descends into the AST to also examine the function's arguments for
potential migration opportunities.

Fixes #5802

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5804)
<!-- Reviewable:end -->
