### PR TITLE
Doc + upsert: Cleanup + Release notes for arrangementless upsert

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -90,6 +90,15 @@ Wrap your release notes at the 80 character mark.
   -  Views whose embdedded queries contain functions whose arguments are functions {{% gh 5802 %}}.
   -  Sinks using `WITH SNAPSHOT AS OF` {{% gh 5808 %}}.
 
+- Reduce memory usage and increase processing speed in materialized views
+  involving sources with the "upsert" envelope. {{% gh 5509 %}}.
+
+  Users of the [memory usage visualization](/ops/monitoring#memory-usage-visualization)
+  will see that the operator "UpsertArrange" has changed to "Upsert", and that
+  the "Upsert" operator no longer shows any records. Actually, the "Upsert"
+  operator still has a memory footprint proportional to the number of unique
+  keys in the source.
+
 {{% version-header v0.7.0 %}}
 
 - **Known issue.** You cannot upgrade nodes created with versions v0.6.1 or

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -40,9 +40,9 @@ where
 {
     // Currently, the upsert-specific transformations run in the
     // following order:
-    // 1. Applies `as_of` frontier compaction. The compaction is important as	
-    /// downstream upsert preparation can compact away updates for the same keys	
-    /// at the same times, and by advancing times we make more of them the same.
+    // 1. Applies `as_of` frontier compaction. The compaction is important as
+    // downstream upsert preparation can compact away updates for the same keys
+    // at the same times, and by advancing times we make more of them the same.
     // 2. compact away updates for the same keys at the same times
     // 3. decoding records
     // 4. prepending the key to the value so that the stream becomes

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, HashMap};
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::generic::Operator;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -22,32 +22,6 @@ use repr::{Diff, Row, Timestamp};
 
 use crate::decode::DecoderState;
 use crate::source::{SourceData, SourceOutput};
-
-/// This operator changes the timestamp from capability to message payload,
-/// and applies `as_of` frontier compaction. The compaction is important as
-/// downstream upsert preparation can compact away updates for the same keys
-/// at the same times, and by advancing times we make more of them the same.
-fn apply_as_of_frontier<G>(
-    stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
-    as_of_frontier: Antichain<Timestamp>,
-) -> Stream<G, (SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    stream.unary(Pipeline, "AppendTimestamp", move |_, _| {
-        let mut vector = Vec::new();
-        move |input, output| {
-            input.for_each(|cap, data| {
-                data.swap(&mut vector);
-                let mut time = cap.time().clone();
-                time.advance_by(as_of_frontier.borrow());
-                output
-                    .session(&cap)
-                    .give_iterator(vector.drain(..).map(|x| (x, time.clone())));
-            });
-        }
-    })
-}
 
 /// Entrypoint to the upsert-specific transformations involved
 /// in rendering a stream that came from an upsert source.
@@ -66,8 +40,10 @@ where
 {
     // Currently, the upsert-specific transformations run in the
     // following order:
-    // 1. as_of
-    // 2. deduplicating records by key
+    // 1. Applies `as_of` frontier compaction. The compaction is important as	
+    /// downstream upsert preparation can compact away updates for the same keys	
+    /// at the same times, and by advancing times we make more of them the same.
+    // 2. compact away updates for the same keys at the same times
     // 3. decoding records
     // 4. prepending the key to the value so that the stream becomes
     //        of the format (key, <entire record>)
@@ -80,8 +56,8 @@ where
     // to specify that they believe that they have a large number of unique
     // keys, at which point materialize may be more performant if it runs
     // decoding/linear operators before deduplicating.
-    (&apply_as_of_frontier(stream, as_of_frontier)).unary_frontier(
-        Exchange::new(move |x: &(SourceOutput<Vec<u8>, Vec<u8>>, Timestamp)| x.0.key.hashed()),
+    stream.unary_frontier(
+        Exchange::new(move |x: &SourceOutput<Vec<u8>, Vec<u8>>| x.key.hashed()),
         "Upsert",
         |_cap, _info| {
             // this is a map of (time) -> (capability, ((key) -> (value with max
@@ -101,16 +77,15 @@ where
                 // Digest each input, reduce by presented timestamp.
                 input.for_each(|cap, data| {
                     data.swap(&mut vector);
-                    for (
-                        SourceOutput {
-                            key,
-                            value: new_value,
-                            position: new_position,
-                            upstream_time_millis: new_upstream_time_millis,
-                        },
-                        time,
-                    ) in vector.drain(..)
+                    for SourceOutput {
+                        key,
+                        value: new_value,
+                        position: new_position,
+                        upstream_time_millis: new_upstream_time_millis,
+                    } in vector.drain(..)
                     {
+                        let mut time = cap.time().clone();
+                        time.advance_by(as_of_frontier.borrow());
                         if key.is_empty() {
                             error!("Encountered empty key for value {:?}", new_value);
                             continue;


### PR DESCRIPTION
Followup to PR #5608.

Merge `apply_as_of_frontier` with the rest of the upsert.

Add a release note for the upsert change, noting that arrangementless upsert unfortunately means that the upsert's memory usage disappears from the memory usage visualization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5807)
<!-- Reviewable:end -->
