### PR TITLE
coord: track and enforce custom data type dependencies

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -167,6 +167,7 @@ pub struct Table {
     #[serde(skip)]
     pub defaults: Vec<Expr<Raw>>,
     pub conn_id: Option<u32>,
+    pub depends_on: Vec<GlobalId>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -188,6 +189,7 @@ pub struct Sink {
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
     pub as_of: Option<u64>,
+    pub depends_on: Vec<GlobalId>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -203,6 +205,7 @@ pub struct View {
     pub optimized_expr: OptimizedMirRelationExpr,
     pub desc: RelationDesc,
     pub conn_id: Option<u32>,
+    pub depends_on: Vec<GlobalId>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -212,6 +215,7 @@ pub struct Index {
     pub on: GlobalId,
     pub keys: Vec<MirScalarExpr>,
     pub conn_id: Option<u32>,
+    pub depends_on: Vec<GlobalId>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -219,6 +223,7 @@ pub struct Type {
     pub create_sql: String,
     pub plan_cx: PlanContext,
     pub inner: TypeInner,
+    pub depends_on: Vec<GlobalId>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -290,20 +295,15 @@ impl CatalogItem {
 
     /// Collects the identifiers of the dataflows that this item depends
     /// upon.
-    pub fn uses(&self) -> Vec<GlobalId> {
+    pub fn uses(&self) -> &[GlobalId] {
         match self {
-            CatalogItem::Func(_) => vec![],
-            CatalogItem::Index(idx) => vec![idx.on],
-            CatalogItem::Sink(sink) => vec![sink.from],
-            CatalogItem::Source(_) => vec![],
-            CatalogItem::Table(_) => vec![],
-            CatalogItem::Type(typ) => match &typ.inner {
-                TypeInner::Array { element_id } => vec![*element_id],
-                TypeInner::Base | TypeInner::Pseudo => vec![],
-                TypeInner::List { element_id } => vec![*element_id],
-                TypeInner::Map { key_id, value_id } => vec![*key_id, *value_id],
-            },
-            CatalogItem::View(view) => view.optimized_expr.as_ref().global_uses(),
+            CatalogItem::Func(_) => &[],
+            CatalogItem::Index(idx) => &idx.depends_on,
+            CatalogItem::Sink(sink) => &sink.depends_on,
+            CatalogItem::Source(_) => &[],
+            CatalogItem::Table(table) => &table.depends_on,
+            CatalogItem::Type(typ) => &typ.depends_on,
+            CatalogItem::View(view) => &view.depends_on,
         }
     }
 
@@ -410,7 +410,7 @@ impl CatalogEntry {
 
     /// Collects the identifiers of the dataflows that this dataflow depends
     /// upon.
-    pub fn uses(&self) -> Vec<GlobalId> {
+    pub fn uses(&self) -> &[GlobalId] {
         self.item.uses()
     }
 
@@ -587,6 +587,7 @@ impl Catalog {
                                 ),
                                 plan_cx: PlanContext::default(),
                                 conn_id: None,
+                                depends_on: vec![log.id],
                             }),
                         ),
                     );
@@ -612,6 +613,7 @@ impl Catalog {
                             desc: table.desc.clone(),
                             defaults: vec![Expr::null(); table.desc.arity()],
                             conn_id: None,
+                            depends_on: vec![],
                         }),
                     ));
                     let oid = catalog.allocate_oid()?;
@@ -633,6 +635,7 @@ impl Catalog {
                                 create_sql: index_sql,
                                 plan_cx: PlanContext::default(),
                                 conn_id: None,
+                                depends_on: vec![table.id],
                             }),
                         ),
                     );
@@ -676,6 +679,7 @@ impl Catalog {
                                 postgres_types::Kind::Simple => TypeInner::Base,
                                 _ => unreachable!(),
                             },
+                            depends_on: vec![],
                         }),
                     ));
                 }
@@ -1053,7 +1057,7 @@ impl Catalog {
                 Some(metadata) => metadata.used_by.push(entry.id),
                 None => panic!(
                     "Catalog: missing dependent catalog item {} while installing {}",
-                    u, entry.name
+                    &u, entry.name
                 ),
             }
         }
@@ -1711,12 +1715,15 @@ impl Catalog {
         let stmt = sql::parse::parse(&create_sql)?.into_element();
         let plan = sql::plan::plan(&pcx, &self.for_system_session(), stmt, &Params::empty())?;
         Ok(match plan {
-            Plan::CreateTable { table, .. } => CatalogItem::Table(Table {
+            Plan::CreateTable {
+                table, depends_on, ..
+            } => CatalogItem::Table(Table {
                 create_sql: table.create_sql,
                 plan_cx: pcx,
                 desc: table.desc,
                 defaults: table.defaults,
                 conn_id: None,
+                depends_on,
             }),
             Plan::CreateSource { source, .. } => {
                 let mut optimizer = Optimizer::default();
@@ -1732,7 +1739,9 @@ impl Catalog {
                     desc: transformed_desc,
                 })
             }
-            Plan::CreateView { view, .. } => {
+            Plan::CreateView {
+                view, depends_on, ..
+            } => {
                 let mut optimizer = Optimizer::default();
                 let optimized_expr = optimizer.optimize(view.expr, self.indexes())?;
                 let desc = RelationDesc::new(optimized_expr.as_ref().typ(), view.column_names);
@@ -1742,19 +1751,24 @@ impl Catalog {
                     optimized_expr,
                     desc,
                     conn_id: None,
+                    depends_on,
                 })
             }
-            Plan::CreateIndex { index, .. } => CatalogItem::Index(Index {
+            Plan::CreateIndex {
+                index, depends_on, ..
+            } => CatalogItem::Index(Index {
                 create_sql: index.create_sql,
                 plan_cx: pcx,
                 on: index.on,
                 keys: index.keys,
                 conn_id: None,
+                depends_on,
             }),
             Plan::CreateSink {
                 sink,
                 with_snapshot,
                 as_of,
+                depends_on,
                 ..
             } => CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
@@ -1764,11 +1778,15 @@ impl Catalog {
                 envelope: sink.envelope,
                 with_snapshot,
                 as_of,
+                depends_on,
             }),
-            Plan::CreateType { typ, .. } => CatalogItem::Type(Type {
+            Plan::CreateType {
+                typ, depends_on, ..
+            } => CatalogItem::Type(Type {
                 create_sql: typ.create_sql,
                 plan_cx: pcx,
                 inner: typ.inner.into(),
+                depends_on,
             }),
             _ => bail!("catalog entry generated inappropriate plan"),
         })
@@ -1798,14 +1816,20 @@ impl Catalog {
     /// one of the provided identifiers transitively depends on an
     /// unmaterialized source.
     pub fn nearest_indexes(&self, ids: &[GlobalId]) -> (Vec<GlobalId>, bool) {
+        fn has_indexes(catalog: &Catalog, id: GlobalId) -> bool {
+            matches!(catalog.get_by_id(&id).item(), CatalogItem::Table(_) | CatalogItem::Source(_) | CatalogItem::View(_))
+        }
+
         fn inner(
             catalog: &Catalog,
             id: GlobalId,
             indexes: &mut Vec<GlobalId>,
             complete: &mut bool,
         ) {
-            // If an index exists for `id`, record it in the output set and stop
-            // searching.
+            if !has_indexes(catalog, id) {
+                return;
+            }
+
             if let Some((index_id, _)) = catalog.indexes[&id].first() {
                 indexes.push(*index_id);
                 return;
@@ -1815,7 +1839,7 @@ impl Catalog {
                 view @ CatalogItem::View(_) => {
                     // Unmaterialized view. Recursively search its dependencies.
                     for id in view.uses() {
-                        inner(catalog, id, indexes, complete)
+                        inner(catalog, *id, indexes, complete)
                     }
                 }
                 CatalogItem::Source(_) => {
@@ -1823,17 +1847,8 @@ impl Catalog {
                     // least one index.
                     *complete = false;
                 }
-                CatalogItem::Table(_) => {
-                    unreachable!("tables always have at least one index");
-                }
-                CatalogItem::Func(_)
-                | CatalogItem::Index(_)
-                | CatalogItem::Sink(_)
-                | CatalogItem::Type(_) => {
-                    unreachable!(
-                        "cannot depend on functions, indexes, sinks, or user-defined types"
-                    );
-                }
+                CatalogItem::Table(_) => (),
+                _ => unreachable!(),
             }
         }
 
@@ -1850,14 +1865,12 @@ impl Catalog {
     pub fn uses_tables(&self, id: GlobalId) -> bool {
         match self.get_by_id(&id).item() {
             CatalogItem::Table(_) => true,
-            CatalogItem::Source(_) => false,
-            item @ CatalogItem::View(_) => item.uses().into_iter().any(|id| self.uses_tables(id)),
-            CatalogItem::Func(_)
+            item @ CatalogItem::View(_) => item.uses().iter().any(|id| self.uses_tables(*id)),
+            CatalogItem::Source(_)
+            | CatalogItem::Func(_)
             | CatalogItem::Index(_)
             | CatalogItem::Sink(_)
-            | CatalogItem::Type(_) => {
-                unreachable!("cannot depend on functions, indexes, sinks, or user-defined types");
-            }
+            | CatalogItem::Type(_) => false,
         }
     }
 
@@ -2362,7 +2375,7 @@ impl sql::catalog::CatalogItem for CatalogEntry {
         }
     }
 
-    fn uses(&self) -> Vec<GlobalId> {
+    fn uses(&self) -> &[GlobalId] {
         self.uses()
     }
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1479,9 +1479,17 @@ impl Coordinator {
                 name,
                 table,
                 if_not_exists,
+                depends_on,
             } => tx.send(
-                self.sequence_create_table(pcx, name, table, if_not_exists, session.conn_id())
-                    .await,
+                self.sequence_create_table(
+                    pcx,
+                    name,
+                    table,
+                    if_not_exists,
+                    depends_on,
+                    session.conn_id(),
+                )
+                .await,
                 session,
             ),
 
@@ -1502,6 +1510,7 @@ impl Coordinator {
                 with_snapshot,
                 as_of,
                 if_not_exists,
+                depends_on,
             } => {
                 self.sequence_create_sink(
                     pcx,
@@ -1512,6 +1521,7 @@ impl Coordinator {
                     with_snapshot,
                     as_of,
                     if_not_exists,
+                    depends_on,
                 )
                 .await
             }
@@ -1522,6 +1532,7 @@ impl Coordinator {
                 replace,
                 materialize,
                 if_not_exists,
+                depends_on,
             } => tx.send(
                 self.sequence_create_view(
                     pcx,
@@ -1531,6 +1542,7 @@ impl Coordinator {
                     session.conn_id(),
                     materialize,
                     if_not_exists,
+                    depends_on,
                 )
                 .await,
                 session,
@@ -1541,15 +1553,21 @@ impl Coordinator {
                 index,
                 options,
                 if_not_exists,
+                depends_on,
             } => tx.send(
-                self.sequence_create_index(pcx, name, index, options, if_not_exists)
+                self.sequence_create_index(pcx, name, index, options, if_not_exists, depends_on)
                     .await,
                 session,
             ),
 
-            Plan::CreateType { name, typ } => {
-                tx.send(self.sequence_create_type(pcx, name, typ).await, session)
-            }
+            Plan::CreateType {
+                name,
+                typ,
+                depends_on,
+            } => tx.send(
+                self.sequence_create_type(pcx, name, typ, depends_on).await,
+                session,
+            ),
 
             Plan::DropDatabase { name } => {
                 tx.send(self.sequence_drop_database(name).await, session)
@@ -1796,16 +1814,20 @@ impl Coordinator {
         name: FullName,
         table: sql::plan::Table,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
         conn_id: u32,
     ) -> Result<ExecuteResponse, CoordError> {
         let conn_id = if table.temporary { Some(conn_id) } else { None };
         let table_id = self.catalog.allocate_id()?;
+        let mut index_depends_on = depends_on.clone();
+        index_depends_on.push(table_id);
         let table = catalog::Table {
             create_sql: table.create_sql,
             plan_cx: pcx,
             desc: table.desc,
             defaults: table.defaults,
             conn_id,
+            depends_on,
         };
         let index_id = self.catalog.allocate_id()?;
         let mut index_name = name.clone();
@@ -1816,6 +1838,7 @@ impl Coordinator {
             table_id,
             &table.desc,
             conn_id,
+            index_depends_on,
         );
         let table_oid = self.catalog.allocate_oid()?;
         let index_oid = self.catalog.allocate_oid()?;
@@ -1883,6 +1906,7 @@ impl Coordinator {
                 source_id,
                 &source.desc,
                 None,
+                vec![source_id],
             );
             let index_id = self.catalog.allocate_id()?;
             let index_oid = self.catalog.allocate_oid()?;
@@ -1922,6 +1946,7 @@ impl Coordinator {
         with_snapshot: bool,
         as_of: Option<u64>,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     ) {
         // First try to allocate an ID and an OID. If either fails, we're done.
         let id = match self.catalog.allocate_id() {
@@ -1965,6 +1990,7 @@ impl Coordinator {
                 envelope: sink.envelope,
                 with_snapshot,
                 as_of,
+                depends_on,
             }),
         };
         match self.catalog_transact(vec![op]).await {
@@ -2007,6 +2033,7 @@ impl Coordinator {
         conn_id: u32,
         materialize: bool,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     ) -> Result<ExecuteResponse, CoordError> {
         let mut ops = vec![];
         if let Some(id) = replace {
@@ -2023,6 +2050,7 @@ impl Coordinator {
             optimized_expr,
             desc,
             conn_id: if view.temporary { Some(conn_id) } else { None },
+            depends_on,
         };
         ops.push(catalog::Op::CreateItem {
             id: view_id,
@@ -2039,6 +2067,7 @@ impl Coordinator {
                 view_id,
                 &view.desc,
                 view.conn_id,
+                vec![view_id],
             );
             let index_id = self.catalog.allocate_id()?;
             let index_oid = self.catalog.allocate_oid()?;
@@ -2072,6 +2101,7 @@ impl Coordinator {
         mut index: sql::plan::Index,
         options: Vec<IndexOption>,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     ) -> Result<ExecuteResponse, CoordError> {
         for key in &mut index.keys {
             Self::prep_scalar_expr(key, ExprPrepStyle::Static)?;
@@ -2082,6 +2112,7 @@ impl Coordinator {
             keys: index.keys,
             on: index.on,
             conn_id: None,
+            depends_on,
         };
         let id = self.catalog.allocate_id()?;
         let oid = self.catalog.allocate_oid()?;
@@ -2108,11 +2139,13 @@ impl Coordinator {
         pcx: PlanContext,
         name: FullName,
         typ: sql::plan::Type,
+        depends_on: Vec<GlobalId>,
     ) -> Result<ExecuteResponse, CoordError> {
         let typ = catalog::Type {
             create_sql: typ.create_sql,
             plan_cx: pcx,
             inner: typ.inner.into(),
+            depends_on,
         };
         let id = self.catalog.allocate_id()?;
         let oid = self.catalog.allocate_oid()?;
@@ -3479,6 +3512,7 @@ fn auto_generate_primary_idx(
     on_id: GlobalId,
     on_desc: &RelationDesc,
     conn_id: Option<u32>,
+    depends_on: Vec<GlobalId>,
 ) -> catalog::Index {
     let default_key = on_desc.typ().default_key();
 
@@ -3491,6 +3525,7 @@ fn auto_generate_primary_idx(
             .map(|k| MirScalarExpr::Column(*k))
             .collect(),
         conn_id,
+        depends_on,
     }
 }
 

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -70,6 +70,7 @@ fn datadriven() {
                             ),
                             defaults: vec![Expr::null(); 0],
                             conn_id: None,
+                            depends_on: vec![],
                         }),
                     );
                     id += 1;

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -224,7 +224,7 @@ pub trait CatalogItem {
 
     /// Returns the IDs of the catalog items upon which this catalog item
     /// depends.
-    fn uses(&self) -> Vec<GlobalId>;
+    fn uses(&self) -> &[GlobalId];
 
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -56,8 +56,8 @@ pub use error::PlanError;
 pub use explain::Explanation;
 // This is used by sqllogictest to turn SQL values into `Datum`s.
 pub use query::{
-    resolve_names, resolve_names_data_type, scalar_type_from_sql, unwrap_numeric_typ_mod, Aug,
-    QueryContext, QueryLifetime,
+    plan_default_expr, resolve_names, resolve_names_data_type, scalar_type_from_sql,
+    unwrap_numeric_typ_mod, Aug, QueryContext, QueryLifetime,
 };
 pub use statement::{describe, plan, StatementContext, StatementDesc};
 
@@ -88,11 +88,13 @@ pub enum Plan {
         with_snapshot: bool,
         as_of: Option<Timestamp>,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     },
     CreateTable {
         name: FullName,
         table: Table,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     },
     CreateView {
         name: FullName,
@@ -102,16 +104,19 @@ pub enum Plan {
         /// whether we should auto-materialize the view
         materialize: bool,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     },
     CreateIndex {
         name: FullName,
         index: Index,
         options: Vec<IndexOption>,
         if_not_exists: bool,
+        depends_on: Vec<GlobalId>,
     },
     CreateType {
         name: FullName,
         typ: Type,
+        depends_on: Vec<GlobalId>,
     },
     DiscardTemp,
     DiscardAll,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -267,6 +267,13 @@ pub fn resolve_names_data_type(
     Ok((result, n.ids))
 }
 
+pub struct PlannedQuery<E> {
+    pub expr: E,
+    pub desc: RelationDesc,
+    pub finishing: RowSetFinishing,
+    pub depends_on: Vec<GlobalId>,
+}
+
 /// Plans a top-level query, returning the `HirRelationExpr` describing the query
 /// plan, the `RelationDesc` describing the shape of the result set, a
 /// `RowSetFinishing` describing post-processing that must occur before results
@@ -279,7 +286,7 @@ pub fn plan_root_query(
     scx: &StatementContext,
     mut query: Query<Raw>,
     lifetime: QueryLifetime,
-) -> Result<(HirRelationExpr, RelationDesc, RowSetFinishing), anyhow::Error> {
+) -> Result<PlannedQuery<HirRelationExpr>, anyhow::Error> {
     transform_ast::transform_query(scx, &mut query)?;
     let mut qcx = QueryContext::root(scx, lifetime);
     let resolved_query = resolve_names(&mut qcx, query)?;
@@ -301,8 +308,14 @@ pub fn plan_root_query(
             .collect(),
     );
     let desc = RelationDesc::new(typ, scope.column_names());
+    let depends_on = qcx.ids.into_iter().collect();
 
-    Ok((expr, desc, finishing))
+    Ok(PlannedQuery {
+        expr,
+        desc,
+        finishing,
+        depends_on,
+    })
 }
 
 /// Attempts to push a projection through an order by.
@@ -476,9 +489,9 @@ pub fn plan_insert_query(
         if let Some(src_idx) = col_to_source.get(&col_idx) {
             project_key.push(*src_idx);
         } else {
-            let default_expr = plan_default_expr(scx, default, &col_typ.scalar_type)?;
+            let (hir, _) = plan_default_expr(scx, default, &col_typ.scalar_type)?;
             project_key.push(typ.arity() + map_exprs.len());
-            map_exprs.push(default_expr);
+            map_exprs.push(hir);
         }
     }
 
@@ -596,7 +609,7 @@ pub fn plan_default_expr(
     scx: &StatementContext,
     expr: &Expr<Raw>,
     target_ty: &ScalarType,
-) -> Result<HirScalarExpr, anyhow::Error> {
+) -> Result<(HirScalarExpr, Vec<GlobalId>), anyhow::Error> {
     let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     let expr = resolve_names_expr(&mut qcx, expr.clone())?;
     let ecx = &ExprContext {
@@ -607,14 +620,15 @@ pub fn plan_default_expr(
         allow_aggregates: false,
         allow_subqueries: false,
     };
-    plan_expr(ecx, &expr)?.cast_to(ecx.name, ecx, CastContext::Assignment, target_ty)
+    let hir = plan_expr(ecx, &expr)?.cast_to(ecx.name, ecx, CastContext::Assignment, target_ty)?;
+    Ok((hir, qcx.ids.into_iter().collect()))
 }
 
 pub fn plan_index_exprs<'a>(
     scx: &'a StatementContext,
     on_desc: &RelationDesc,
     exprs: Vec<Expr<Raw>>,
-) -> Result<Vec<::expr::MirScalarExpr>, anyhow::Error> {
+) -> Result<(Vec<::expr::MirScalarExpr>, Vec<GlobalId>), anyhow::Error> {
     let scope = Scope::from_source(None, on_desc.iter_names(), Some(Scope::empty(None)));
     let mut qcx = QueryContext::root(scx, QueryLifetime::Static);
 
@@ -639,7 +653,7 @@ pub fn plan_index_exprs<'a>(
         let expr = plan_expr_or_col_index(ecx, &expr)?;
         out.push(expr.lower_uncorrelated()?);
     }
-    Ok(out)
+    Ok((out, qcx.ids.into_iter().collect()))
 }
 
 fn plan_expr_or_col_index(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -162,9 +162,10 @@ pub fn plan_create_table(
     // and NOT NULL constraints.
     let mut column_types = Vec::with_capacity(columns.len());
     let mut defaults = Vec::with_capacity(columns.len());
+    let mut depends_on = Vec::new();
 
     for c in columns {
-        let (aug_data_type, _ids) = resolve_names_data_type(scx, c.data_type.clone())?;
+        let (aug_data_type, ids) = resolve_names_data_type(scx, c.data_type.clone())?;
         let ty = plan::scalar_type_from_sql(scx, &aug_data_type)?;
         let mut nullable = true;
         let mut default = Expr::null();
@@ -174,7 +175,8 @@ pub fn plan_create_table(
                 ColumnOption::Default(expr) => {
                     // Ensure expression can be planned and yields the correct
                     // type.
-                    query::plan_default_expr(scx, expr, &ty)?;
+                    let (_, expr_depends_on) = query::plan_default_expr(scx, expr, &ty)?;
+                    depends_on.extend(expr_depends_on);
                     default = expr.clone();
                 }
                 other => unsupported!(format!("CREATE TABLE with column constraint: {}", other)),
@@ -182,6 +184,7 @@ pub fn plan_create_table(
         }
         column_types.push(ty.nullable(nullable));
         defaults.push(default);
+        depends_on.extend(ids);
     }
 
     let typ = RelationType::new(column_types);
@@ -205,6 +208,7 @@ pub fn plan_create_table(
         name,
         table,
         if_not_exists: *if_not_exists,
+        depends_on,
     })
 }
 
@@ -805,12 +809,16 @@ pub fn plan_create_view(
     } else {
         scx.allocate_name(normalize::unresolved_object_name(name.to_owned())?)
     };
-    let (mut relation_expr, mut desc, finishing) =
-        query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
-    relation_expr.bind_parameters(&params)?;
+    let query::PlannedQuery {
+        mut expr,
+        mut desc,
+        finishing,
+        depends_on,
+    } = query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
+    expr.bind_parameters(&params)?;
     //TODO: materialize#724 - persist finishing information with the view?
-    relation_expr.finish(finishing);
-    let relation_expr = relation_expr.lower();
+    expr.finish(finishing);
+    let relation_expr = expr.lower();
     let replace = if *if_exists == IfExistsBehavior::Replace {
         if let Ok(item) = scx.catalog.resolve_item(&name.clone().into()) {
             if relation_expr.global_uses().contains(&item.id()) {
@@ -842,6 +850,7 @@ pub fn plan_create_view(
         replace,
         materialize,
         if_not_exists,
+        depends_on,
     })
 }
 
@@ -1090,6 +1099,8 @@ pub fn plan_create_sink(
             with_options.keys().join(",")
         )
     }
+    let mut depends_on = vec![from.id()];
+    depends_on.extend(from.uses());
 
     Ok(Plan::CreateSink {
         name,
@@ -1102,6 +1113,7 @@ pub fn plan_create_sink(
         with_snapshot,
         as_of,
         if_not_exists,
+        depends_on,
     })
 }
 
@@ -1155,7 +1167,7 @@ pub fn plan_create_index(
                 .collect()
         }
     };
-    let keys = query::plan_index_exprs(scx, on_desc, filled_key_parts.clone())?;
+    let (keys, exprs_depend_on) = query::plan_index_exprs(scx, on_desc, filled_key_parts.clone())?;
 
     let index_name = if let Some(name) = name {
         FullName {
@@ -1212,6 +1224,8 @@ pub fn plan_create_index(
     *key_parts = Some(filled_key_parts);
     let if_not_exists = *if_not_exists;
     let create_sql = normalize::create_statement(scx, Statement::CreateIndex(stmt))?;
+    let mut depends_on = vec![on.id()];
+    depends_on.extend(exprs_depend_on);
 
     Ok(Plan::CreateIndex {
         name: index_name,
@@ -1222,6 +1236,7 @@ pub fn plan_create_index(
         },
         options,
         if_not_exists,
+        depends_on,
     })
 }
 
@@ -1312,10 +1327,10 @@ pub fn plan_create_type(
 
     let inner = match as_type {
         CreateTypeAs::List => TypeInner::List {
-            element_id: ids.remove(0),
+            element_id: *ids.get(0).expect("custom type to have element id"),
         },
         CreateTypeAs::Map => {
-            let key_id = ids.remove(0);
+            let key_id = *ids.get(0).expect("key");
             match scx.catalog.try_get_lossy_scalar_type_by_id(&key_id) {
                 Some(ScalarType::String) => {}
                 Some(t) => bail!(
@@ -1327,16 +1342,15 @@ pub fn plan_create_type(
 
             TypeInner::Map {
                 key_id,
-                value_id: ids.remove(0),
+                value_id: *ids.get(1).expect("value"),
             }
         }
     };
 
-    assert!(ids.is_empty());
-
     Ok(Plan::CreateType {
         name,
         typ: Type { create_sql, inner },
+        depends_on: ids,
     })
 }
 
@@ -1570,20 +1584,27 @@ pub fn plan_drop_item(
     if !cascade {
         for id in catalog_entry.used_by() {
             let dep = scx.catalog.get_item_by_id(id);
-            match dep.item_type() {
-                CatalogItemType::Func
-                | CatalogItemType::Table
-                | CatalogItemType::Source
-                | CatalogItemType::View
-                | CatalogItemType::Sink
-                | CatalogItemType::Type => {
-                    bail!(
-                        "cannot drop {}: still depended upon by catalog item '{}'",
-                        catalog_entry.name(),
-                        dep.name()
-                    );
-                }
-                CatalogItemType::Index => (),
+            match object_type {
+                ObjectType::Type => bail!(
+                    "cannot drop {}: still depended upon by catalog item '{}'",
+                    catalog_entry.name(),
+                    dep.name()
+                ),
+                _ => match dep.item_type() {
+                    CatalogItemType::Func
+                    | CatalogItemType::Table
+                    | CatalogItemType::Source
+                    | CatalogItemType::View
+                    | CatalogItemType::Sink
+                    | CatalogItemType::Type => {
+                        bail!(
+                            "cannot drop {}: still depended upon by catalog item '{}'",
+                            catalog_entry.name(),
+                            dep.name()
+                        );
+                    }
+                    CatalogItemType::Index => (),
+                },
             }
         }
     }

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -130,6 +130,11 @@ catalog item 's1' already exists
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'v2'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
+> CREATE SINK s2 FROM s
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'v3'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  AS OF 0
+
 # Test that sinks cannot be depended upon.
 ! CREATE MATERIALIZED VIEW v2 AS SELECT * FROM s1;
 catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
@@ -332,8 +337,84 @@ unknown catalog item 'j2'
 
 > DROP SOURCE s5;
 
+# https://github.com/MaterializeInc/materialize/issues/5577
+> CREATE TYPE int4_list AS LIST (element_type=int4)
+
+> CREATE VIEW v1 AS SELECT CAST('{2}' AS int4_list)
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+
+> DROP VIEW v1
+
+> CREATE TABLE t1 (custom int4_list)
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.t1'
+
+> DROP TABLE t1
+
+> SHOW TABLES
+
+> CREATE MATERIALIZED VIEW v1 AS SELECT * FROM ( SELECT CAST('{2}' AS int4_list) )
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+
+> DROP VIEW v1
+
+> CREATE VIEW v1 AS SELECT CAST(CAST('{2}' AS int4_list) AS text)
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+
+> DROP VIEW v1
+
+> CREATE VIEW v1 AS VALUES (CAST('{2}' AS int4_list))
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+
+> DROP VIEW v1
+
+> CREATE VIEW v1 AS SELECT MIN(CAST(CAST('{1}' AS int4_list) AS string))
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.v1'
+
+> DROP VIEW v1
+
+> CREATE TABLE t1 (f1 TEXT DEFAULT CAST ('{}' AS int4_list))
+
+> DROP TABLE t1
+
+> CREATE TEMPORARY TABLE t1 (f1 int4_list)
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'mz_temp.t1'
+
+> DROP TABLE t1
+
+> CREATE TABLE t1 (f1 TEXT)
+
+> CREATE INDEX i1 ON t1 (CAST(f1 AS int4_list))
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.i1'
+
+> DROP TABLE t1
+
+> CREATE TYPE int4_list_list AS LIST (element_type=int4_list)
+
+! DROP TYPE int4_list
+cannot drop materialize.public.int4_list: still depended upon by catalog item 'materialize.public.int4_list_list'
+
+> DROP TYPE int4_list_list
+
 #cleanup
 > DROP SINK s1;
+
+> DROP SINK s2;
 
 > DROP SOURCE s;
 


### PR DESCRIPTION
Now that we resolve the names and GlobalIds of custom data types
during planning, we can use that information to correctly track
type dependencies while creating and dropping database objects.

This replaces my previous broken PR (https://github.com/MaterializeInc/materialize/pull/5679) and incorporates
(most of) @philip-stoev's tests! 

I only skipped the following suggested test:
```
CREATE VIEW v1 AS SELECT SUM(CAST(f1 AS int4_list)) FROM t1
```
_Because `SUM` does not currently accept custom param types:_ Corrected by Sean in the comments!
```
           "sum" => Aggregate {
                params!(Int32) => AggregateFunc::SumInt32, 2108;
                params!(Int64) => AggregateFunc::SumInt64, 2107;
                params!(Float32) => AggregateFunc::SumFloat32, 2110;
                params!(Float64) => AggregateFunc::SumFloat64, 2111;
                params!(DecimalAny) => AggregateFunc::SumDecimal, 2114;
                params!(Interval) => Operation::unary(|_ecx, _e| {
                    // Explicitly providing this unsupported overload
                    // prevents `sum(NULL)` from choosing the `Float64`
                    // implementation, so that we match PostgreSQL's behavior.
                    // Plus we will one day want to support this overload.
                    unsupported!("sum(interval)");
                }), 2113;
            },
``` 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5810)
<!-- Reviewable:end -->
