### PR TITLE
Don't sleep for infinite time in telemetry retry loop

### DIFF
--- a/src/materialized/src/version_check.rs
+++ b/src/materialized/src/version_check.rs
@@ -69,6 +69,7 @@ pub async fn check_version_loop(telemetry_url: String, cluster_id: String, start
 async fn fetch_latest_version(telemetry_url: &str, start_time: Instant) -> String {
     RetryBuilder::new()
         .max_sleep(None)
+        .max_backoff(TELEMETRY_FREQUENCY)
         .initial_backoff(Duration::from_secs(1))
         .build()
         .retry(|_state| async {


### PR DESCRIPTION
Before this the retryer would continue its exponential decay past an hour. Now
we say that we only want to sleep at most the maximum poll frequency.

Follow up on #5780

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5811)
<!-- Reviewable:end -->
