### PR TITLE
include broker configuration when we validate the kafka config

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -167,8 +167,9 @@ pub fn extract_config(
 /// - `librdkafka` cannot create a BaseConsumer using the provided `options`.
 ///   For example, when using Kerberos auth, and the named principal does not
 ///   exist.
-pub fn test_config(options: &BTreeMap<String, String>) -> Result<(), anyhow::Error> {
+pub fn test_config(broker: &str, options: &BTreeMap<String, String>) -> Result<(), anyhow::Error> {
     let mut config = rdkafka::ClientConfig::new();
+    config.set("bootstrap.servers", broker);
     for (k, v) in options {
         config.set(k, v);
     }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -57,7 +57,7 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
 
                 // Verify that the provided security options are valid and then test them.
                 config_options = kafka_util::extract_config(&mut with_options_map)?;
-                kafka_util::test_config(&config_options)?;
+                kafka_util::test_config(&broker, &config_options)?;
             }
             Connector::AvroOcf { path, .. } => {
                 let path = path.clone();


### PR DESCRIPTION
During purification we do a shallow validation of the kafka config to
suss out any major issues with authentication early on.
Previously we didn't include the bootstrap.servers parameter when we did
this validation, resulting in a logged warning like:

```
INFO librdkafka: CONFWARN [thrd:app]: No bootstrap.servers configured: client will not be able to connect to Kafka cluster
```

This warning was benign since the config is never used to build a kafka
client, but it is extremely misleading when trying to debug unrelated
kafka issues.

This change includes the bootstrap.servers config parameter to remove
the misleading warning.

Related to https://github.com/MaterializeInc/materialize/issues/4939

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5821)
<!-- Reviewable:end -->
