### PR TITLE
sql: syntax parser and planning for postgres sources

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -1084,6 +1084,7 @@ impl Timestamper {
                         connector: RtTimestampConnector::S3(connector),
                     })
             }
+            ExternalSourceConnector::Postgres(_) => None,
         }
     }
 
@@ -1326,6 +1327,7 @@ impl Timestamper {
                 }
             }
             ExternalSourceConnector::S3(_) => None, // BYO is not supported for s3 sources
+            ExternalSourceConnector::Postgres(_) => None, // BYO is not supported for postgres sources
         }
     }
 

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -468,5 +468,8 @@ where
             ),
             None,
         ),
+        (DataEncoding::Postgres(_), _) => {
+            unreachable!("Internal error: postgres sources are never decoded");
+        }
     }
 }

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -354,6 +354,8 @@ where
                         decode_avro_values(&source, &envelope, reader_schema, &self.debug_name),
                         capability,
                     )
+                } else if let ExternalSourceConnector::Postgres(_pg_connector) = connector {
+                    unimplemented!("Postgres sources are not supported yet");
                 } else {
                     let ((ok_source, err_source), capability) = match connector {
                         ExternalSourceConnector::Kafka(_) => {
@@ -375,6 +377,7 @@ where
                             )
                         }
                         ExternalSourceConnector::AvroOcf(_) => unreachable!(),
+                        ExternalSourceConnector::Postgres(_) => unreachable!(),
                     };
                     err_collection = err_collection.concat(
                         &err_source

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -699,6 +699,10 @@ where
                             log::error!("BYO timestamping not supported for S3 sources");
                             None
                         }
+                        (ExternalSourceConnector::Postgres(_), _) => {
+                            log::error!("Postgres sources not supported yet");
+                            None
+                        }
                     }
                 } else {
                     log::debug!(

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -347,7 +347,7 @@ impl_display!(CreateSchemaStatement);
 pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
-    pub connector: Connector,
+    pub connector: Connector<T>,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Envelope<T>,
@@ -399,7 +399,7 @@ impl_display_t!(CreateSourceStatement);
 pub struct CreateSinkStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub from: UnresolvedObjectName,
-    pub connector: Connector,
+    pub connector: Connector<T>,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope<T>>,

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -110,6 +110,7 @@ Having
 Header
 Headers
 Hold
+Host
 Hour
 Hours
 If
@@ -151,6 +152,7 @@ Minute
 Minutes
 Month
 Months
+Namespace
 Natural
 Next
 No
@@ -176,10 +178,12 @@ Over
 Partition
 Plan
 Plans
+Postgres
 Preceding
 Precision
 Primary
 Protobuf
+Publication
 Range
 Raw
 Read

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -462,6 +462,13 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USIN
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka { broker: "zubat", topic: "hoothoot", key: None }, with_options: [], format: Some(Avro(Schema(File("path")))), envelope: Upsert(Some(Text)), if_not_exists: false, materialized: false })
 
 parse-statement
+CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLE 'psychic' (pokedex_id int NOT NULL, evolution int);
+----
+CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLE 'psychic' (pokedex_id int4 NOT NULL, evolution int4)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", namespace: "generation1", table: "psychic", columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+
+parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -24,7 +24,7 @@ use repr::ColumnName;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::visit_mut::{self, VisitMut};
 use sql_parser::ast::{
-    AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
+    AstInfo, Connector, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
     CreateTableStatement, CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident,
     IfExistsBehavior, Query, Raw, RawName, SqlOption, Statement, TableFactor, UnresolvedObjectName,
     Value,
@@ -260,7 +260,7 @@ pub fn create_statement(
         Statement::CreateSource(CreateSourceStatement {
             name,
             col_names: _,
-            connector: _,
+            connector,
             with_options: _,
             format: _,
             envelope: _,
@@ -270,6 +270,12 @@ pub fn create_statement(
             *name = allocate_name(name)?;
             *if_not_exists = false;
             *materialized = false;
+            if let Connector::Postgres { columns, .. } = connector {
+                let mut normalizer = QueryNormalizer::new(scx);
+                for c in columns {
+                    normalizer.visit_column_def_mut(c);
+                }
+            }
         }
 
         Statement::CreateTable(CreateTableStatement {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -94,6 +94,7 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
                 let aws_info = normalize::aws_connect_info(&mut with_options_map, Some(region))?;
                 aws_util::aws::validate_credentials(aws_info, Duration::from_secs(1)).await?;
             }
+            Connector::Postgres { .. } => (),
         }
 
         purify_format(format, connector, col_names, file, &config_options).await?;
@@ -106,7 +107,7 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
 
 async fn purify_format(
     format: &mut Option<Format<Raw>>,
-    connector: &mut Connector,
+    connector: &mut Connector<Raw>,
     col_names: &mut Vec<Ident>,
     file: Option<tokio::fs::File>,
     connector_options: &BTreeMap<String, String>,


### PR DESCRIPTION
This PR only adds syntax parsing and planning for the following syntax:

```sql
CREATE SOURCE "numbers"
FROM POSTGRES
    HOST 'host=localhost user=postgres password=postgres dbname=postgres'
    PUBLICATION 'mz_source'
    NAMESPACE 'public'
    TABLE 'numbers' (number int NOT NULL, is_prime bool, foo text);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5828)
<!-- Reviewable:end -->
