### PR TITLE
interchange: Thread mz_offset through to the protobuf decoder

### DIFF
--- a/src/interchange/benches/protobuf.rs
+++ b/src/interchange/benches/protobuf.rs
@@ -72,7 +72,7 @@ pub fn bench_protobuf(c: &mut Criterion) {
     let mut bg = c.benchmark_group("protobuf");
     bg.throughput(Throughput::Bytes(len));
     bg.bench_function("decode", move |b| {
-        b.iter(|| black_box(decoder.decode(&buf).unwrap()))
+        b.iter(|| black_box(decoder.decode(&buf, None).unwrap()))
     });
     bg.finish();
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -730,9 +730,7 @@ pub fn plan_create_source(
     // TODO(brennan): They should not depend on the envelope either. Figure out a way to
     // make all of this more tasteful.
     match (&encoding, &envelope) {
-        (DataEncoding::Avro { .. }, _)
-        | (DataEncoding::Protobuf { .. }, _)
-        | (_, SourceEnvelope::Debezium(_)) => (),
+        (DataEncoding::Avro { .. }, _) | (_, SourceEnvelope::Debezium(_)) => (),
         _ => {
             for (name, ty) in external_connector.metadata_columns() {
                 bare_desc = bare_desc.with_column(name, ty);

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=input_csv
+$ kafka-create-topic topic=input_proto
+
+> CREATE MATERIALIZED SOURCE input_csv (first, second)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_csv-${testdrive.seed}'
+  FORMAT CSV WITH 2 COLUMNS;
+
+$ kafka-ingest format=bytes topic=input_csv
+1,2
+2,3
+
+> SELECT * from input_csv;
+first second mz_offset
+----------------------
+1     2      1
+2     3      2
+
+> CREATE MATERIALIZED SOURCE input_proto
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_proto-${testdrive.seed}'
+  FORMAT PROTOBUF MESSAGE '.Batch' USING SCHEMA '${testdrive.protobuf-descriptors}'
+
+$ kafka-ingest format=protobuf topic=input_proto message=batch timestamp=1
+{"id": "1", "interval_start": "2020-01-01_00:00:00", "interval_end": "2020-01-01_00:00:09", "records": []}
+{"id": "2", "interval_start": "2020-01-01_00:00:10", "interval_end": "2020-01-01_00:00:19", "records": []}
+
+# Ensure we have the offset column imported:
+> SELECT * from input_proto;
+id interval_start        interval_end      records mz_offset
+------------------------------------------------------------
+1  2020-01-01_00:00:00 2020-01-01_00:00:09 []      1
+2  2020-01-01_00:00:10 2020-01-01_00:00:19 []      2

--- a/test/testdrive/proto-billing.td
+++ b/test/testdrive/proto-billing.td
@@ -28,11 +28,12 @@ id              true text
 interval_end    true text
 interval_start  true text
 records         true jsonb
+mz_offset       false bigint
 
 > SELECT * FROM billing
-0 0                   0                   []
-1 2020-01-01_00:00:00 2020-01-01_00:00:09 []
-2 2020-01-01_00:00:10 2020-01-01_00:00:19 "[{\"interval_end\":\"2020-01-01_00:00:15\",\"interval_start\":\"2020-01-01_00:00:10\",\"measurements\":[{\"measured_value\":5.0,\"resource\":\"CPU\"},{\"measured_value\":128.0,\"resource\":\"MEM\"}],\"meter\":\"user\",\"value\":25.0},{\"interval_end\":\"2020-01-01_00:00:19\",\"interval_start\":\"2020-01-01_00:00:16\",\"measurements\":[{\"measured_value\":13.0,\"resource\":\"CPU\"},{\"measured_value\":256.0,\"resource\":\"MEM\"}],\"meter\":\"user\",\"value\":125.0}]"
+0 0                   0                   [] 3
+1 2020-01-01_00:00:00 2020-01-01_00:00:09 [] 1
+2 2020-01-01_00:00:10 2020-01-01_00:00:19 "[{\"interval_end\":\"2020-01-01_00:00:15\",\"interval_start\":\"2020-01-01_00:00:10\",\"measurements\":[{\"measured_value\":5.0,\"resource\":\"CPU\"},{\"measured_value\":128.0,\"resource\":\"MEM\"}],\"meter\":\"user\",\"value\":25.0},{\"interval_end\":\"2020-01-01_00:00:19\",\"interval_start\":\"2020-01-01_00:00:16\",\"measurements\":[{\"measured_value\":13.0,\"resource\":\"CPU\"},{\"measured_value\":256.0,\"resource\":\"MEM\"}],\"meter\":\"user\",\"value\":125.0}]" 2
 
 > SELECT
     records->0->'value',

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -37,5 +37,5 @@ $ kafka-ingest format=protobuf topic=messages message=struct timestamp=1
 
 # TODO: these should be fully json
 > SELECT * FROM pm
-1 1 ONE  my-string
-2 2 ONE  something-valid
+1 1 ONE  my-string 1
+2 2 ONE  something-valid 2


### PR DESCRIPTION
In order to have the `mz_offset` on a protobuf-decoded row, we need that position offset in the decoder, and add it to the row packer: Here we accomplish this, and add tests that validate the offset addition does happen for both protobuf (new) and CSV (already in existence).

This PR addresses (but does not close) #4990.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5861)
<!-- Reviewable:end -->
