### PR TITLE
coord,sql: temporarily remove CREATE SINK ... AS OF

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,10 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.7.1 %}}
 
+- **Breaking change.** Remove `CREATE SINK ... AS OF`, which did not have
+  sensible behavior after Materialize restarted. The intent is to reintroduce
+  this feature with a more formal model of `AS OF` timestamps. {{% gh 3467 %}}
+
 - Add the [`cbrt` function](/sql/functions/#numbers-func) for computing the
   cube root of a [`double precision`](/sql/types/float).
 
@@ -678,7 +682,7 @@ Document new timezone stuff and add a release note about it.
   alongside the data topic; the combination of these two topics is considered
   the Materialize change data capture (CDC) format.
 
-- Introduce the [`AS OF`](/sql/create-sink/#as-of) and
+- Introduce the `AS OF` and
   [`WITH SNAPSHOT`](/sql/create-sink/#with-snapshot-or-without-snapshot) options
   for `CREATE SINK` to provide more control over what data the sink will
   produce.

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -27,9 +27,12 @@ Field | Use
 _sink&lowbar;name_ | A name for the sink. This name is only used within Materialize.
 _item&lowbar;name_ | The name of the source or view you want to send to the sink.
 **AVRO OCF** _path_ | The absolute path and file name of the Avro Object Container file (OCF) to create and write to. The filename will be modified to let Materialize create a unique file each time Materialize starts, but the file extension will not be modified. You can find more details [here](#avro-ocf-sinks).
-**AS OF** _timestamp&lowbar;expression_ | The logical time to tail from onwards (either a number of milliseconds since the Unix epoch, or a `TIMESTAMP` or `timestamp with time zone`).
 **ENVELOPE DEBEZIUM** | The generated schemas have a [Debezium-style diff envelope](#debezium-envelope-details) to capture changes in the input view or source. This is the default.
 **ENVELOPE UPSERT** | The sink emits data with upsert semantics: updates and inserts for the given key are expressed as a value, and deletes are expressed as a null value payload in Kafka. For more detail, see [Upsert source details](/sql/create-source/text-kafka/#upsert-envelope-details).
+
+{{< version-changed v0.7.1 >}}
+The `AS OF` option was removed.
+{{< /version-changed >}}
 
 ### Kafka connector
 
@@ -82,16 +85,11 @@ Field | Value | Description
 `sasl_kerberos_principal` | `text` | Materialize Kerberos principal name. Required if `sasl_mechanism` is `gssapi`.
 `sasl_kerberos_service_name` | `text` | Kafka's service name on its host, i.e. the service principal name not including `/hostname@REALM`. Required if `sasl_mechanism` is `gssapi`.
 
-### `AS OF`
-
-`AS OF` is the specific point in time to start emitting all events for a given `SINK`. If you don't
-use `AS OF`, Materialize will pick a timestamp itself.
-
 ### `WITH SNAPSHOT` or `WITHOUT SNAPSHOT`
 
-By default, each `SINK` is created with a `SNAPSHOT` which contains the results of the query at its `AS OF` timestamp.
-Any further updates to these results are produced at the time when they occur. To only see results after the
-`AS OF` timestamp, specify `WITHOUT SNAPSHOT`.
+By default, each `SINK` is created with a `SNAPSHOT` which contains the consolidated results of the
+query before the sink was created. Any further updates to these results are produced at the time when
+they occur. To only see results after the sink is created, specify `WITHOUT SNAPSHOT`.
 
 ## Detail
 

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -192,7 +192,6 @@ pub struct Sink {
     pub connector: SinkConnectorState,
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
-    pub as_of: Option<u64>,
     pub depends_on: Vec<GlobalId>,
 }
 
@@ -1773,7 +1772,6 @@ impl Catalog {
             Plan::CreateSink {
                 sink,
                 with_snapshot,
-                as_of,
                 depends_on,
                 ..
             } => CatalogItem::Sink(Sink {
@@ -1783,7 +1781,6 @@ impl Catalog {
                 connector: SinkConnectorState::Pending(sink.connector_builder),
                 envelope: sink.envelope,
                 with_snapshot,
-                as_of,
                 depends_on,
             }),
             Plan::CreateType {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -42,11 +42,11 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use build_info::BuildInfo;
 use dataflow::{CacheMessage, SequencedCommand, WorkerFeedback, WorkerFeedbackWithMeta};
 use dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
-use dataflow_types::SinkEnvelope;
 use dataflow_types::{
     AvroOcfSinkConnector, DataflowDesc, IndexDesc, KafkaSinkConnector, PeekResponse, SinkConnector,
     SourceConnector, TailSinkConnector, TimestampSourceUpdate, Update,
 };
+use dataflow_types::{SinkAsOf, SinkEnvelope};
 use expr::{
     ExprHumanizer, GlobalId, Id, MirRelationExpr, MirScalarExpr, NullaryFunc,
     OptimizedMirRelationExpr, RowSetFinishing,
@@ -318,14 +318,9 @@ impl Coordinator {
                             panic!("sink already initialized during catalog boot")
                         }
                     };
-                    let connector = sink_connector::build(
-                        builder.clone(),
-                        sink.with_snapshot,
-                        self.determine_frontier(sink.as_of, sink.from)?,
-                        *id,
-                    )
-                    .await
-                    .with_context(|| format!("recreating sink {}", name))?;
+                    let connector = sink_connector::build(builder.clone(), *id)
+                        .await
+                        .with_context(|| format!("recreating sink {}", name))?;
                     self.handle_sink_connector_ready(*id, *oid, connector)
                         .await?;
                 }
@@ -1033,13 +1028,17 @@ impl Coordinator {
             },
         ];
         self.catalog_transact(ops).await?;
-
+        let as_of = SinkAsOf {
+            frontier: self.determine_frontier(sink.from),
+            strict: !sink.with_snapshot,
+        };
         self.ship_dataflow(self.dataflow_builder().build_sink_dataflow(
             name.to_string(),
             id,
             sink.from,
             connector,
             sink.envelope,
+            as_of,
         ))
         .await
     }
@@ -1498,7 +1497,6 @@ impl Coordinator {
                 name,
                 sink,
                 with_snapshot,
-                as_of,
                 if_not_exists,
                 depends_on,
             } => {
@@ -1509,7 +1507,6 @@ impl Coordinator {
                     name,
                     sink,
                     with_snapshot,
-                    as_of,
                     if_not_exists,
                     depends_on,
                 )
@@ -1935,7 +1932,6 @@ impl Coordinator {
         name: FullName,
         sink: sql::plan::Sink,
         with_snapshot: bool,
-        as_of: Option<u64>,
         if_not_exists: bool,
         depends_on: Vec<GlobalId>,
     ) {
@@ -1951,14 +1947,6 @@ impl Coordinator {
             Ok(id) => id,
             Err(e) => {
                 tx.send(Err(e.into()), session);
-                return;
-            }
-        };
-
-        let frontier = match self.determine_frontier(as_of, sink.from) {
-            Ok(frontier) => frontier,
-            Err(e) => {
-                tx.send(Err(e), session);
                 return;
             }
         };
@@ -1980,7 +1968,6 @@ impl Coordinator {
                 connector: catalog::SinkConnectorState::Pending(sink.connector_builder.clone()),
                 envelope: sink.envelope,
                 with_snapshot,
-                as_of,
                 depends_on,
             }),
         };
@@ -2007,8 +1994,7 @@ impl Coordinator {
                     tx,
                     id,
                     oid,
-                    result: sink_connector::build(connector_builder, with_snapshot, frontier, id)
-                        .await,
+                    result: sink_connector::build(connector_builder, id).await,
                 }))
                 .expect("sending to internal_cmd_tx cannot fail");
         });
@@ -2474,7 +2460,19 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, CoordError> {
         // Determine the frontier of updates to tail *from*.
         // Updates greater or equal to this frontier will be produced.
-        let frontier = self.determine_frontier(ts, source_id)?;
+        let frontier = if let Some(ts) = ts {
+            // If a timestamp was explicitly requested, use that.
+            Antichain::from_elem(self.determine_timestamp(
+                &MirRelationExpr::Get {
+                    id: Id::Global(source_id),
+                    // TODO(justin): find a way to avoid synthesizing an arbitrary relation type.
+                    typ: RelationType::empty(),
+                },
+                PeekWhen::AtTimestamp(ts),
+            )?)
+        } else {
+            self.determine_frontier(source_id)
+        };
         let sink_name = format!(
             "tail-source-{}",
             self.catalog
@@ -2492,13 +2490,15 @@ impl Coordinator {
             source_id,
             SinkConnector::Tail(TailSinkConnector {
                 tx,
-                frontier,
-                strict: !with_snapshot,
                 emit_progress,
                 object_columns,
                 value_desc: desc,
             }),
             SinkEnvelope::Tail { emit_progress },
+            SinkAsOf {
+                frontier,
+                strict: !with_snapshot,
+            },
         ))
         .await?;
 
@@ -2635,28 +2635,15 @@ impl Coordinator {
         }
     }
 
-    /// Determine the frontier of updates to start *from*.
+    /// Determine the frontier of updates to start *from* for a sink based on
+    /// `source_id`.
+    ///
     /// Updates greater or equal to this frontier will be produced.
-    fn determine_frontier(
-        &mut self,
-        as_of: Option<u64>,
-        source_id: GlobalId,
-    ) -> Result<Antichain<u64>, CoordError> {
-        let frontier = if let Some(ts) = as_of {
-            // If a timestamp was explicitly requested, use that.
-            Antichain::from_elem(self.determine_timestamp(
-                &MirRelationExpr::Get {
-                    id: Id::Global(source_id),
-                    // TODO(justin): find a way to avoid synthesizing an arbitrary relation type.
-                    typ: RelationType::empty(),
-                },
-                PeekWhen::AtTimestamp(ts),
-            )?)
-        }
+    fn determine_frontier(&self, source_id: GlobalId) -> Antichain<Timestamp> {
         // TODO: The logic that follows is at variance from PEEK logic which consults the
         // "queryable" state of its inputs. We might want those to line up, but it is only
         // a "might".
-        else if let Some(index_id) = self.catalog.default_index_for(source_id) {
+        if let Some(index_id) = self.catalog.default_index_for(source_id) {
             let upper = self
                 .indexes
                 .upper_of(&index_id)
@@ -2671,8 +2658,7 @@ impl Coordinator {
             // Use the earliest time that is still valid for all sources.
             let (index_ids, _indexes_complete) = self.catalog.nearest_indexes(&[source_id]);
             self.indexes.least_valid_since(index_ids)
-        };
-        Ok(frontier)
+        }
     }
 
     fn sequence_explain_plan(

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -14,6 +14,8 @@
 //! and indicate which identifiers have arrangements available. This module
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
+use dataflow_types::SinkAsOf;
+
 use super::*;
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
@@ -186,12 +188,13 @@ impl<'a> DataflowBuilder<'a> {
         from: GlobalId,
         connector: SinkConnector,
         envelope: SinkEnvelope,
+        as_of: SinkAsOf,
     ) -> DataflowDesc {
         let mut dataflow = DataflowDesc::new(name);
-        dataflow.set_as_of(connector.get_frontier());
+        dataflow.set_as_of(as_of.frontier.clone());
         self.import_into_dataflow(&from, &mut dataflow);
         let from_type = self.catalog.get_by_id(&from).desc().unwrap().clone();
-        dataflow.add_sink_export(id, from, from_type, connector, envelope);
+        dataflow.add_sink_export(id, from, from_type, connector, envelope, as_of);
         dataflow
     }
 }

--- a/src/dataflow/src/render/sinks.rs
+++ b/src/dataflow/src/render/sinks.rs
@@ -172,6 +172,7 @@ where
                     c,
                     sink.key_desc.clone(),
                     sink.value_desc.clone(),
+                    sink.as_of.clone(),
                 );
                 needed_sink_tokens.push(token);
             }
@@ -184,7 +185,7 @@ where
                     })
                     .arrange_by_key()
                     .stream;
-                sink::tail(batches, sink_id, c);
+                sink::tail(batches, sink_id, c, sink.as_of.clone());
             }
             SinkConnector::AvroOcf(c) => {
                 sink::avro_ocf(collection, sink_id, c, sink.value_desc.clone());

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -31,7 +31,7 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::FrontieredInputHandle;
 use timely::dataflow::Scope;
 
-use dataflow_types::KafkaSinkConnector;
+use dataflow_types::{KafkaSinkConnector, SinkAsOf};
 use expr::GlobalId;
 use interchange::avro::{self, Encoder};
 use repr::{Diff, RelationDesc, Row, Timestamp};
@@ -237,6 +237,7 @@ pub fn kafka<G>(
     connector: KafkaSinkConnector,
     key_desc: Option<RelationDesc>,
     value_desc: RelationDesc,
+    as_of: SinkAsOf,
 ) -> Box<dyn Any>
 where
     G: Scope<Timestamp = Timestamp>,
@@ -325,10 +326,10 @@ where
         input.for_each(|_, rows| {
             rows.swap(&mut vector);
             for ((key, value), time, diff) in vector.drain(..) {
-                let should_emit = if connector.strict {
-                    connector.frontier.less_than(&time)
+                let should_emit = if as_of.strict {
+                    as_of.frontier.less_than(&time)
                 } else {
-                    connector.frontier.less_equal(&time)
+                    as_of.frontier.less_equal(&time)
                 };
 
                 if !should_emit {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -86,7 +86,6 @@ pub enum Plan {
         name: FullName,
         sink: Sink,
         with_snapshot: bool,
-        as_of: Option<Timestamp>,
         if_not_exists: bool,
         depends_on: Vec<GlobalId>,
     },

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1134,7 +1134,10 @@ pub fn plan_create_sink(
         }
     };
 
-    let as_of = as_of.map(|e| query::eval_as_of(scx, e)).transpose()?;
+    if as_of.is_some() {
+        bail!("CREATE SINK ... AS OF is no longer supported");
+    }
+
     let connector_builder = match connector {
         Connector::File { .. } => unsupported!("file sinks"),
         Connector::Kafka { broker, topic, .. } => kafka_sink_builder(
@@ -1170,7 +1173,6 @@ pub fn plan_create_sink(
             envelope,
         },
         with_snapshot,
-        as_of,
         if_not_exists,
         depends_on,
     })

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -115,11 +115,12 @@ testdrive --no-reset <<'EOF'
 > SELECT * FROM t
 42  def
 
-# Checks for regressions against #5808; simply having this in the catalog is
-# sufficient, so it doesn't need to be interacted with.
-> CREATE SINK regression_5808 FROM real_time
-  INTO AVRO OCF 'regression_5808.ocf'
-  WITH SNAPSHOT AS OF now()
+# TODO(benesch): re-enable when we support `CREATE SINK ... AS OF` again.
+# # Checks for regressions against #5808; simply having this in the catalog is
+# # sufficient, so it doesn't need to be interacted with.
+# > CREATE SINK regression_5808 FROM real_time
+#  INTO AVRO OCF 'regression_5808.ocf'
+# WITH SNAPSHOT AS OF now()
 EOF
 
 say "killing materialized-golden060"

--- a/test/testdrive/avro-sinks.td
+++ b/test/testdrive/avro-sinks.td
@@ -129,6 +129,21 @@ $ set trxschema={
 $ kafka-create-topic topic=consistency
 $ kafka-create-topic topic=input
 
+> CREATE MATERIALIZED SOURCE input
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE SINK input_sink FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
+  WITH (consistency = true) FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE SINK input_sink_multiple_keys FROM input
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b, a)
+  WITH (consistency = true) FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
 $ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 1, "b": 1}}}
 {"before": null, "after": {"row": {"a": 2, "b": 2}}}
@@ -146,11 +161,6 @@ $ kafka-ingest format=avro topic=consistency timestamp=1 schema=${trxschema}
 {"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
 {"status":"END","id":"3","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "testdrive-input-${testdrive.seed}"}]}}
 
-> CREATE MATERIALIZED SOURCE input
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
-    WITH (consistency = 'testdrive-consistency-${testdrive.seed}')
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
-
 > SELECT * FROM input;
 a  b
 ------
@@ -159,12 +169,6 @@ a  b
 3  1
 4  2
 1  7
-
-> CREATE SINK input_sink FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (a)
-  WITH (consistency = true) FORMAT AVRO
-  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  AS OF 1
 
 $ kafka-verify format=avro sink=materialize.public.input_sink
 {"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
@@ -190,12 +194,6 @@ Repeated column name in sink key: a
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 Ambiguous column: a
-
-> CREATE SINK input_sink_multiple_keys FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'input-sink' KEY (b, a)
-  WITH (consistency = true) FORMAT AVRO
-  USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  AS OF 1
 
 $ kafka-verify format=avro sink=materialize.public.input_sink_multiple_keys
 {"b": 1, "a": 1} {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -85,7 +85,7 @@ $ kafka-create-topic topic=tx
 # ==> Test consolidation.
 
 # Ingest several updates that consolidate. Some of these updates are in one
-# transaction, and some of them are in their own transactinos.
+# transaction, and some of them are in their own transactions.
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"before": null, "after": {"row": {"num": 1}}}
@@ -102,16 +102,28 @@ $ kafka-ingest format=avro topic=tx schema=${tx-schema}
 {"status": "BEGIN", "id": "3", "event_count": null, "data_collections": null}
 {"status": "END", "id": "3", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "testdrive-nums-${testdrive.seed}"}]}}
 
-# Test that a Debezium sink created `AS OF 3` (the latest completed timestamp)
-# is fully consolidated.
+# Test that by default updates that occurred at the same time are consolidated,
+# but updates that occurred at distinct times are not.
 
 > CREATE SINK nums_sink FROM nums
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'nums-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  AS OF 3
 
 $ kafka-verify format=avro sink=materialize.public.nums_sink
-{"before": null, "after": {"row": {"num": 5}}}
+{"before": null, "after": {"row": {"num": 3}}}
+{"before": {"row": {"num": 3}}, "after": {"row": {"num": 4}}}
+{"before": {"row": {"num": 4}}, "after": {"row": {"num": 5}}}
+
+# TODO(benesch): re-enable when we support `CREATE SINK ... AS OF`.
+# # Test that a Debezium sink created `AS OF 3` (the latest completed timestamp)
+# # is fully consolidated.
+# > CREATE SINK nums_sink FROM nums
+#   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'nums-sink'
+#   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+#   AS OF 3
+#
+# $ kafka-verify format=avro sink=materialize.public.nums_sink
+# {"before": null, "after": {"row": {"num": 5}}}
 
 # Validate that `TAIL` is similarly consolidated.
 # This protects against regression of #5421.

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -133,7 +133,6 @@ catalog item 's1' already exists
 > CREATE SINK s2 FROM s
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'v3'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  AS OF 0
 
 # Test that sinks cannot be depended upon.
 ! CREATE MATERIALIZED VIEW v2 AS SELECT * FROM s1;


### PR DESCRIPTION
`CREATE SINK ... AS OF` does not have sensible semantics on restart.
Creating a sink on a real-time source `AS OF` some timestamp is a
guaranteed way to cause Materialize to fail to boot on restart.

This commit temporarily removes the feature. We'll want to restore it
once we sort out how to unify `AS OF` behavior (see #2862).

As a side effect it fixes #5423. Since we no longer let users specify
`AS OF` timestamps, we can defer selection of the timestamp until the
moment we ship the sink dataflow, which allows us to ensure we choose a
valid time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5866)
<!-- Reviewable:end -->
