### PR TITLE
add newline to fix broken markdown formatting

### DIFF
--- a/doc/user/content/sql/functions/date-trunc.md
+++ b/doc/user/content/sql/functions/date-trunc.md
@@ -31,6 +31,7 @@ SELECT date_trunc('hour', TIMESTAMP '2019-11-26 15:56:46.241150') AS hour_trunc;
  2019-11-26 15:00:00.000000000
 ```
 <hr/>
+
 ```sql
 SELECT date_trunc('year', TIMESTAMP '2019-11-26 15:56:46.241150') AS year_trunc;
 ```


### PR DESCRIPTION
I don't know why, but without this newline, the following text was being printed out literally, not rendered as markdown

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5868)
<!-- Reviewable:end -->
