### PR TITLE
Add errors throughout source construction

### DIFF
--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -13,6 +13,7 @@ use dataflow_types::LinearOperator;
 
 use log::error;
 
+use differential_dataflow::{AsCollection, Collection};
 use timely::dataflow::operators::Operator;
 use timely::dataflow::{Scope, Stream};
 
@@ -26,7 +27,10 @@ pub fn csv<G>(
     n_cols: usize,
     delimiter: u8,
     operators: &mut Option<LinearOperator>,
-) -> Stream<G, (Row, Timestamp, Diff)>
+) -> (
+    Collection<G, Row, Diff>,
+    Option<Collection<G, dataflow_types::DataflowError, Diff>>,
+)
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -43,6 +47,7 @@ where
         })
         .collect::<Vec<_>>();
 
+    let stream =
     stream.unary(
         SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
         "CsvDecode",
@@ -161,5 +166,7 @@ where
                 }
             }
         },
-    )
+    );
+
+    (stream.as_collection(), None)
 }

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -10,6 +10,7 @@
 use std::iter;
 use std::str;
 
+use differential_dataflow::{AsCollection, Collection};
 use log::warn;
 use regex::Regex;
 use timely::dataflow::operators::Operator;
@@ -23,60 +24,62 @@ pub fn regex<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     regex: Regex,
     name: &str,
-) -> Stream<G, (Row, Timestamp, Diff)>
+) -> Collection<G, Row, Diff>
 where
     G: Scope<Timestamp = Timestamp>,
 {
     let name = String::from(name);
     let pact = SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract();
     let mut row_packer = repr::RowPacker::new();
-    stream.unary(pact, "RegexDecode", |_cap, _op_info| {
-        move |input, output| {
-            input.for_each(|cap, lines| {
-                let mut session = output.session(&cap);
-                for SourceOutput {
-                    key: _,
-                    value: line,
-                    position: line_no,
-                    upstream_time_millis: _,
-                } in &*lines
-                {
-                    let line = match str::from_utf8(&line) {
-                        Ok(line) => line,
-                        Err(_) => {
-                            let line_no = match line_no {
-                                Some(line_no) => line_no.to_string(),
-                                None => "unknown".into(),
-                            };
-                            let line_prefix = String::from_utf8_lossy(&line)
-                                .chars()
-                                .take(64)
-                                .collect::<String>();
-                            warn!(
-                                "dropping line with invalid UTF-8 \
+    stream
+        .unary(pact, "RegexDecode", |_cap, _op_info| {
+            move |input, output| {
+                input.for_each(|cap, lines| {
+                    let mut session = output.session(&cap);
+                    for SourceOutput {
+                        key: _,
+                        value: line,
+                        position: line_no,
+                        upstream_time_millis: _,
+                    } in &*lines
+                    {
+                        let line = match str::from_utf8(&line) {
+                            Ok(line) => line,
+                            Err(_) => {
+                                let line_no = match line_no {
+                                    Some(line_no) => line_no.to_string(),
+                                    None => "unknown".into(),
+                                };
+                                let line_prefix = String::from_utf8_lossy(&line)
+                                    .chars()
+                                    .take(64)
+                                    .collect::<String>();
+                                warn!(
+                                    "dropping line with invalid UTF-8 \
                                 (source: {}, line number: {}, line prefix: {:?})",
-                                name, line_no, line_prefix,
-                            );
-                            continue;
-                        }
-                    };
+                                    name, line_no, line_prefix,
+                                );
+                                continue;
+                            }
+                        };
 
-                    let captures = match regex.captures(line) {
-                        Some(captures) => captures,
-                        None => continue,
-                    };
+                        let captures = match regex.captures(line) {
+                            Some(captures) => captures,
+                            None => continue,
+                        };
 
-                    // Skip the 0th capture, which is the entire match, so that
-                    // we only output the actual capture groups.
-                    let datums = captures
-                        .iter()
-                        .skip(1)
-                        .map(|c| Datum::from(c.map(|c| c.as_str())))
-                        .chain(iter::once(Datum::from(*line_no)));
+                        // Skip the 0th capture, which is the entire match, so that
+                        // we only output the actual capture groups.
+                        let datums = captures
+                            .iter()
+                            .skip(1)
+                            .map(|c| Datum::from(c.map(|c| c.as_str())))
+                            .chain(iter::once(Datum::from(*line_no)));
 
-                    session.give((row_packer.pack(datums), *cap.time(), 1));
-                }
-            });
-        }
-    })
+                        session.give((row_packer.pack(datums), *cap.time(), 1));
+                    }
+                });
+            }
+        })
+        .as_collection()
 }


### PR DESCRIPTION
This PR tweaks a few things about errors in source construction, mainly:
1. Adding optional error outputs for decoding. These default to `None` in almost all cases, but should be easier to locally improve.
2. Change various `Stream<G, (Row, Timestamp, Diff)>` to `Collection<G, Row, Diff>` to reflect the intended invariant that `Timestamp` is the same as `G::Timestamp`.

Errors in source construction are collected into a `Vec<Collection<_>>` which is later flattened; the thinking here was that this is simpler from a dataflow point of view and perhaps less error prone than threading `.concat(errs)` statements throughout the control flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5870)
<!-- Reviewable:end -->
