### PR TITLE
sql: validate typmod for qualified varchars

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2911,7 +2911,10 @@ pub fn scalar_type_from_sql(
                         ScalarType::Decimal(precision, scale)
                     }
                     ScalarType::String => {
-                        match name.raw_name().to_string().as_str() {
+                        // TODO(justin): we should look up in the catalog to see
+                        // if this type is actually a length-parameterized
+                        // string.
+                        match name.raw_name().item.as_str() {
                             n @ "char" | n @ "varchar" => {
                                 validate_typ_mod(n, &typ_mod, &[("length", 1, 10_485_760)])?
                             }

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -851,3 +851,15 @@ SELECT ''::CHAR(0)
 
 query error length for type char must be within \[1-10485760\], have 10485761
 SELECT ''::CHAR(10485761)
+
+query error length for type varchar must be within \[1-10485760\], have 0
+SELECT ''::pg_catalog.VARCHAR(0)
+
+query error length for type varchar must be within \[1-10485760\], have 10485761
+SELECT ''::pg_catalog.VARCHAR(10485761)
+
+query error length for type char must be within \[1-10485760\], have 0
+SELECT ''::pg_catalog.CHAR(0)
+
+query error length for type char must be within \[1-10485760\], have 10485761
+SELECT ''::pg_catalog.CHAR(10485761)


### PR DESCRIPTION
Previously we wouldn't do this validation if the name of the type was
qualified. This hacky change fixes the immediate problem but I think
there's still a lingering issue where someone could make a namespaced
type of name varchar that was a string and be incorrectly beholden to
this behaviuor. This is a quick change to unblock #5816 which causes
names to be qualified in more contexts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5871)
<!-- Reviewable:end -->
