### PR TITLE
Optimization: Fix pushing down single-input predicates from join equivalences.

### DIFF
--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -240,11 +240,7 @@ impl JoinBuildState {
             column_map.insert(column, column_map.len());
         }
         let mut equivalences = equivalences.to_vec();
-        for equivalence in equivalences.iter_mut() {
-            equivalence.sort();
-            equivalence.dedup();
-        }
-        equivalences.sort();
+        expr::canonicalize::sort_dedup_equivalences(&mut equivalences);
         Self {
             column_map,
             equivalences,

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -240,7 +240,7 @@ impl JoinBuildState {
             column_map.insert(column, column_map.len());
         }
         let mut equivalences = equivalences.to_vec();
-        expr::canonicalize::sort_dedup_equivalences(&mut equivalences);
+        expr::canonicalize::canonicalize_equivalences(&mut equivalences);
         Self {
             column_map,
             equivalences,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -24,6 +24,8 @@ mod scalar;
 
 pub mod explain;
 
+pub use relation::canonicalize;
+
 pub use id::{GlobalId, Id, LocalId, PartitionId, SourceInstanceId};
 pub use linear::MapFilterProject;
 pub use relation::func::{AggregateFunc, TableFunc};

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -1,0 +1,91 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Utility functions to transform parts of a single `MirRelationExpr`
+//! into canonical form.
+
+use crate::MirScalarExpr;
+
+/// Fuse equivalence classes of a join.
+///
+/// This function makes it so that the same expression appears in only one
+/// equivalence class. It also sorts and dedups the equivalence classes. (See
+/// [`sort_dedup_equivalences`].)
+///
+/// This function should be called whenever a transformation has added
+/// equivalence classes to a join.
+///
+/// [`sort_dedup_equivalences`]: expr::canonicalize::sort_dedup_equivalences
+/// ```rust
+/// use expr::MirScalarExpr;
+/// use expr::canonicalize::fuse_equivalences;
+///
+/// let mut equivalences_to_fuse = vec![
+///     vec![MirScalarExpr::Column(3), MirScalarExpr::Column(5)],
+///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3)]
+/// ];
+/// let expected = vec![
+///     vec![MirScalarExpr::Column(0),
+///         MirScalarExpr::Column(3),
+///         MirScalarExpr::Column(5)]
+/// ];
+/// fuse_equivalences(&mut equivalences_to_fuse);
+/// assert_eq!(expected, equivalences_to_fuse)
+/// ````
+pub fn fuse_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
+    for index in 1..equivalences.len() {
+        for inner in 0..index {
+            if equivalences[index]
+                .iter()
+                .any(|pair| equivalences[inner].contains(pair))
+            {
+                let to_extend = std::mem::replace(&mut equivalences[index], Vec::new());
+                equivalences[inner].extend(to_extend);
+            }
+        }
+    }
+    sort_dedup_equivalences(equivalences)
+}
+
+/// Sorts equivalence classes of a join and deduplicates expressions within each
+/// equivalence class.
+///
+/// The equivalence classes are put into a canonical order, and the expressions
+/// within an equivalence class are also put into a canonical order. If an
+/// equivalence class has less than two expressions after deduplication, the
+/// equivalence class is removed.
+///
+/// Using this function is recommended even if what it does seems to be overkill
+/// because it will make it easier to track about what form the equivalences
+/// are guaranteed to be in. For example, it s
+///
+/// ```rust
+/// use expr::MirScalarExpr;
+/// use expr::canonicalize::sort_dedup_equivalences;
+///
+/// let mut equivalences_to_sort = vec![
+///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
+///     vec![MirScalarExpr::Column(3), MirScalarExpr::Column(5), MirScalarExpr::Column(0), MirScalarExpr::Column(3)],
+///     vec![MirScalarExpr::Column(2), MirScalarExpr::Column(2)],
+/// ];
+/// let expected = vec![
+///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3), MirScalarExpr::Column(5)],
+///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
+/// ];
+/// sort_dedup_equivalences(&mut equivalences_to_sort);
+/// assert_eq!(expected, equivalences_to_sort)
+/// ````
+pub fn sort_dedup_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
+    for equivalence in equivalences.iter_mut() {
+        equivalence.sort();
+        equivalence.dedup();
+    }
+    equivalences.retain(|es| es.len() > 1);
+    equivalences.sort();
+}

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -12,33 +12,31 @@
 
 use crate::MirScalarExpr;
 
-/// Fuse equivalence classes of a join.
+/// Canonicalize equivalence classes of a join.
 ///
 /// This function makes it so that the same expression appears in only one
-/// equivalence class. It also sorts and dedups the equivalence classes. (See
-/// [`sort_dedup_equivalences`].)
+/// equivalence class. It also sorts and dedups the equivalence classes.
 ///
-/// This function should be called whenever a transformation has added
-/// equivalence classes to a join.
-///
-/// [`sort_dedup_equivalences`]: expr::canonicalize::sort_dedup_equivalences
 /// ```rust
 /// use expr::MirScalarExpr;
-/// use expr::canonicalize::fuse_equivalences;
+/// use expr::canonicalize::canonicalize_equivalences;
 ///
-/// let mut equivalences_to_fuse = vec![
+/// let mut equivalences = vec![
+///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
 ///     vec![MirScalarExpr::Column(3), MirScalarExpr::Column(5)],
-///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3)]
+///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3)],
+///     vec![MirScalarExpr::Column(2), MirScalarExpr::Column(2)],
 /// ];
 /// let expected = vec![
 ///     vec![MirScalarExpr::Column(0),
 ///         MirScalarExpr::Column(3),
-///         MirScalarExpr::Column(5)]
+///         MirScalarExpr::Column(5)],
+///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
 /// ];
-/// fuse_equivalences(&mut equivalences_to_fuse);
-/// assert_eq!(expected, equivalences_to_fuse)
+/// canonicalize_equivalences(&mut equivalences);
+/// assert_eq!(expected, equivalences)
 /// ````
-pub fn fuse_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
+pub fn canonicalize_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
     for index in 1..equivalences.len() {
         for inner in 0..index {
             if equivalences[index]
@@ -50,38 +48,6 @@ pub fn fuse_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
             }
         }
     }
-    sort_dedup_equivalences(equivalences)
-}
-
-/// Sorts equivalence classes of a join and deduplicates expressions within each
-/// equivalence class.
-///
-/// The equivalence classes are put into a canonical order, and the expressions
-/// within an equivalence class are also put into a canonical order. If an
-/// equivalence class has less than two expressions after deduplication, the
-/// equivalence class is removed.
-///
-/// Using this function is recommended even if what it does seems to be overkill
-/// because it will make it easier to track about what form the equivalences
-/// are guaranteed to be in. For example, it s
-///
-/// ```rust
-/// use expr::MirScalarExpr;
-/// use expr::canonicalize::sort_dedup_equivalences;
-///
-/// let mut equivalences_to_sort = vec![
-///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
-///     vec![MirScalarExpr::Column(3), MirScalarExpr::Column(5), MirScalarExpr::Column(0), MirScalarExpr::Column(3)],
-///     vec![MirScalarExpr::Column(2), MirScalarExpr::Column(2)],
-/// ];
-/// let expected = vec![
-///     vec![MirScalarExpr::Column(0), MirScalarExpr::Column(3), MirScalarExpr::Column(5)],
-///     vec![MirScalarExpr::Column(1), MirScalarExpr::Column(4)],
-/// ];
-/// sort_dedup_equivalences(&mut equivalences_to_sort);
-/// assert_eq!(expected, equivalences_to_sort)
-/// ````
-pub fn sort_dedup_equivalences(equivalences: &mut Vec<Vec<MirScalarExpr>>) {
     for equivalence in equivalences.iter_mut() {
         equivalence.sort();
         equivalence.dedup();

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -24,10 +24,11 @@ use repr::RelationType;
 /// the local input and re-expressing them in global terms and vice versa.
 ///
 /// Methods in this class that take an argument `equivalences` are only
-/// guaranteed to return a correct answer if equivalence classes are fused.
-/// (See [`canonicalize::fuse_equivalences`].)
+/// guaranteed to return a correct answer if equivalence classes are in
+/// canonical form.
+/// (See [`canonicalize::canonicalize_equivalences`].)
 ///
-/// [`canonicalize::fuse_equivalences`]: expr::canonicalize::fuse_dedup_equivalences
+/// [`canonicalize::canonicalize_equivalences`]: expr::canonicalize::fuse_dedup_equivalences
 #[derive(Debug)]
 pub struct JoinInputMapper {
     /// The number of columns per input. All other fields in this struct are

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -22,6 +22,12 @@ use repr::RelationType;
 /// 2) It has a position relative to the specific input it came from (local)
 /// This utility focuses on taking expressions that are in terms of
 /// the local input and re-expressing them in global terms and vice versa.
+///
+/// Methods in this class that take an argument `equivalences` are only
+/// guaranteed to return a correct answer if equivalence classes are fused.
+/// (See [`canonicalize::fuse_equivalences`].)
+///
+/// [`canonicalize::fuse_equivalences`]: expr::canonicalize::fuse_dedup_equivalences
 #[derive(Debug)]
 pub struct JoinInputMapper {
     /// The number of columns per input. All other fields in this struct are

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -22,6 +22,7 @@ use self::func::{AggregateFunc, TableFunc};
 use crate::explain::Explanation;
 use crate::{DummyHumanizer, EvalError, ExprHumanizer, GlobalId, Id, LocalId, MirScalarExpr};
 
+pub mod canonicalize;
 pub mod func;
 pub mod join_input_mapper;
 

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -88,25 +88,7 @@ impl Join {
             *demand = None;
             *implementation = expr::JoinImplementation::Unimplemented;
 
-            // Join variables may not be an equivalence class. Better ensure!
-            for index in 1..equivalences.len() {
-                for inner in 0..index {
-                    if equivalences[index]
-                        .iter()
-                        .any(|pair| equivalences[inner].contains(pair))
-                    {
-                        let to_extend = std::mem::replace(&mut equivalences[index], Vec::new());
-                        equivalences[inner].extend(to_extend);
-                    }
-                }
-            }
-            equivalences.retain(|v| !v.is_empty());
-
-            // put join constraints in a canonical format.
-            for equivalence in equivalences.iter_mut() {
-                equivalence.sort();
-                equivalence.dedup();
-            }
+            expr::canonicalize::fuse_equivalences(equivalences);
         }
     }
 }

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -88,7 +88,7 @@ impl Join {
             *demand = None;
             *implementation = expr::JoinImplementation::Unimplemented;
 
-            expr::canonicalize::fuse_equivalences(equivalences);
+            expr::canonicalize::canonicalize_equivalences(equivalences);
         }
     }
 }

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -86,10 +86,7 @@ impl JoinImplementation {
         } = relation
         {
             // Canonicalize the equivalence classes
-            for equivalence in equivalences.iter_mut() {
-                equivalence.sort();
-            }
-            equivalences.sort();
+            expr::canonicalize::sort_dedup_equivalences(equivalences);
 
             let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
             // Common information of broad utility.

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -86,7 +86,7 @@ impl JoinImplementation {
         } = relation
         {
             // Canonicalize the equivalence classes
-            expr::canonicalize::sort_dedup_equivalences(equivalences);
+            expr::canonicalize::canonicalize_equivalences(equivalences);
 
             let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
             // Common information of broad utility.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -245,6 +245,8 @@ impl Default for Optimizer {
                 transforms: vec![
                     Box::new(crate::projection_lifting::ProjectionLifting),
                     Box::new(crate::join_implementation::JoinImplementation),
+                    Box::new(crate::column_knowledge::ColumnKnowledge),
+                    Box::new(crate::reduction::FoldConstants),
                     Box::new(crate::fusion::filter::Filter),
                     Box::new(crate::demand::Demand),
                     Box::new(crate::map_lifting::LiteralLifting),

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -224,22 +224,24 @@ impl PredicatePushdown {
                                 expr2,
                             } = &predicate
                             {
-                                // An equality predicate implies that both
-                                // expressions are not null.
-                                // Since we try to push non-equality predicates
-                                // at all inputs, we only need to push one
-                                // predicate into `pred_not_translated` for it
-                                // to be pushed at both expressions.
-                                pred_not_translated.push(
-                                    expr1
-                                        .clone()
-                                        .call_unary(UnaryFunc::IsNull)
-                                        .call_unary(UnaryFunc::Not),
-                                );
-                                equivalences.push(vec![(**expr1).clone(), (**expr2).clone()]);
-                            } else {
-                                pred_not_translated.push(predicate)
+                                if !expr1.is_literal() && !expr2.is_literal() {
+                                    // An equality predicate implies that both
+                                    // expressions are not null.
+                                    // Since we try to push non-equality predicates
+                                    // at all inputs, we only need to push one
+                                    // predicate into `pred_not_translated` for it
+                                    // to be pushed at both expressions.
+                                    pred_not_translated.push(
+                                        expr1
+                                            .clone()
+                                            .call_unary(UnaryFunc::IsNull)
+                                            .call_unary(UnaryFunc::Not),
+                                    );
+                                    equivalences.push(vec![(**expr1).clone(), (**expr2).clone()]);
+                                    continue;
+                                }
                             }
+                            pred_not_translated.push(predicate)
                         }
 
                         expr::canonicalize::fuse_equivalences(equivalences);

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -167,7 +167,7 @@ impl RedundantJoin {
                             expr.permute(&projection[..]);
                         }
                     }
-                    expr::canonicalize::sort_dedup_equivalences(equivalences);
+                    expr::canonicalize::canonicalize_equivalences(equivalences);
 
                     // Unset demand and implementation, as irrevocably hosed by this transformation.
                     *demand = None;

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -166,10 +166,8 @@ impl RedundantJoin {
                         for expr in equivalence.iter_mut() {
                             expr.permute(&projection[..]);
                         }
-                        equivalence.sort();
-                        equivalence.dedup();
                     }
-                    equivalences.retain(|es| es.len() > 1);
+                    expr::canonicalize::sort_dedup_equivalences(equivalences);
 
                     // Unset demand and implementation, as irrevocably hosed by this transformation.
                     *demand = None;

--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -39,28 +39,28 @@ opt
 ----
 %0 =
 | Get x (u0)
-| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), ((#1 = #2) || (isnull(#1) && isnull(#2)))
+| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), ((#0 = #2) || (isnull(#0) && isnull(#2)))
 
 opt
 (join [(get x)] [[#0 #2 #1 #2]])
 ----
 %0 =
 | Get x (u0)
-| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), ((#1 = #2) || (isnull(#1) && isnull(#2)))
+| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), ((#0 = #2) || (isnull(#0) && isnull(#2)))
 
 opt
 (join [(get x)] [[#0 #1 5]])
 ----
 %0 =
 | Get x (u0)
-| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), (#1 = 5)
+| Filter (#0 = 5), (#1 = 5)
 
 opt
 (join [(get x)] [[5 #0 #1]])
 ----
 %0 =
 | Get x (u0)
-| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), (#1 = 5)
+| Filter (#0 = 5), (#1 = 5)
 
 opt
 (join [(get x) (get x)] [[5 #0 5 #3]])

--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -39,28 +39,28 @@ opt
 ----
 %0 =
 | Get x (u0)
-| Filter (#0 = #1), (#1 = #2)
+| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), ((#1 = #2) || (isnull(#1) && isnull(#2)))
 
 opt
 (join [(get x)] [[#0 #2 #1 #2]])
 ----
 %0 =
 | Get x (u0)
-| Filter (#0 = #1), (#1 = #2)
+| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), ((#1 = #2) || (isnull(#1) && isnull(#2)))
 
 opt
 (join [(get x)] [[#0 #1 5]])
 ----
 %0 =
 | Get x (u0)
-| Filter (#0 = #1), (#1 = 5)
+| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), (#1 = 5)
 
 opt
 (join [(get x)] [[5 #0 #1]])
 ----
 %0 =
 | Get x (u0)
-| Filter (#0 = #1), (#1 = 5)
+| Filter ((#0 = #1) || (isnull(#0) && isnull(#1))), (#1 = 5)
 
 opt
 (join [(get x) (get x)] [[5 #0 5 #3]])

--- a/src/transform/tests/testdata/join-implementation
+++ b/src/transform/tests/testdata/join-implementation
@@ -8,12 +8,12 @@
 # by the Apache License, Version 2.0.
 
 cat
-(defsource x [int32 int64])
+(defsource x [int32 int64 int32])
 ----
 ok
 
 opt
-(join [(get x) (get x)] [[#0 #2]])
+(join [(get x) (get x)] [[#0 #3]])
 ----
 ----
 %0 =
@@ -24,9 +24,66 @@ opt
 | Get x (u0)
 
 %2 =
-| Join %0 %1 (= #0 #2)
+| Join %0 %1 (= #0 #3)
 | | implementation = Differential %1 %0.(#0)
-| | demand = (#0, #1, #3)
-| Project (#0, #1, #0, #3)
+| | demand = (#0..#2, #4, #5)
+| Project (#0..#2, #0, #4, #5)
 ----
 ----
+
+# tests single-input predicates properly get pushed out of join equivalences
+# using different combinations of literals and non-literals with different multiplicities
+
+opt
+(join [(get x)] [[#0 #1 #2]])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = #1), (#1 = #2)
+
+opt
+(join [(get x)] [[#0 #2 #1 #2]])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = #1), (#1 = #2)
+
+opt
+(join [(get x)] [[#0 #1 5]])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = #1), (#1 = 5)
+
+opt
+(join [(get x)] [[5 #0 #1]])
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = #1), (#1 = 5)
+
+opt
+(join [(get x) (get x)] [[5 #0 5 #3]])
+----
+----
+%0 =
+| Get x (u0)
+| Filter (#0 = 5)
+| ArrangeBy ()
+
+%1 =
+| Get x (u0)
+| Filter (#0 = 5)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0..#5)
+----
+----
+
+opt
+(join [(get x) (get x)] [[5 9 #0 #3]])
+----
+%0 =
+| Constant

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -75,7 +75,7 @@ Applied Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, J
 | | keys = ((#0), (#1))
 
 ====
-No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
 ====
 Final:
 %0 =

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -30,7 +30,7 @@ steps
 | Union %0 %1
 
 ====
-No change: JoinElision, InlineLet, FoldConstants, SplitPredicates, Filter, Map, ProjectionExtraction, Project, Join, JoinElision, EmptyMap, JoinElision, FoldConstants, Filter, Map, FoldConstants, DeMorgans, UndistributeAnd, SplitPredicates, Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, EmptyMap, JoinElision, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, NegatePredicate, Demand], limit: 100 }, FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+No change: JoinElision, InlineLet, FoldConstants, SplitPredicates, Filter, Map, ProjectionExtraction, Project, Join, JoinElision, EmptyMap, JoinElision, FoldConstants, Filter, Map, FoldConstants, DeMorgans, UndistributeAnd, SplitPredicates, Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, EmptyMap, JoinElision, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, NegatePredicate, Demand], limit: 100 }, FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
 ====
 Final:
 %0 =

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -472,6 +472,7 @@ ORDER BY revenue DESC
 
 %2 =
 | Get materialize.public.orderline (u19)
+| Filter !(isnull(#4))
 
 %3 =
 | Get materialize.public.stock (u26)
@@ -686,7 +687,7 @@ ORDER BY l_year
 | |   delta %7 %1.(#3) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
 | |   delta %8 %6.(#2) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
 | | demand = (#0, #4, #38, #44, #75, #79)
-| Filter !(isnull(#0)), "^.*b$" ~(#4), (#79 = "EUROPE"), (#0 < 1000), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
+| Filter "^.*b$" ~(#4), (#79 = "EUROPE"), (#0 < 1000), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
 | Reduce group=(date_part_year_tstz(datetotstz(#44)))
 | | agg sum(if (#75 = "GERMANY") then {#38} else {0dec})
 | | agg sum(#38)
@@ -1110,7 +1111,6 @@ ORDER BY su_suppkey
 | Join %0 %3 %6 (= #0 #7) (= #8 #9)
 | | implementation = Differential %0.(#0) %3.(#0) %6.(#0)
 | | demand = (#0..#2, #4, #8)
-| Filter !(isnull(#8))
 | Project (#0..#2, #4, #8)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#4)
@@ -1473,6 +1473,7 @@ ORDER BY numwait DESC, su_name
 
 %1 =
 | Get materialize.public.orderline (u19)
+| Filter !(isnull(#4))
 
 %2 =
 | Get materialize.public.order (u16)

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -169,7 +169,7 @@ WHERE l1.la IN (
 
 %4 =
 | Get %2 (l0)
-| Filter !(isnull(#0)), (#0 = (#1 + 1))
+| Filter !(isnull(#0)), ((#0 = (#1 + 1)) || (isnull(#0) && isnull(#1)))
 
 %5 =
 | Get %2 (l0)

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -169,7 +169,7 @@ WHERE l1.la IN (
 
 %4 =
 | Get %2 (l0)
-| Filter (#0 = (#1 + 1))
+| Filter !(isnull(#0)), (#0 = (#1 + 1))
 
 %5 =
 | Get %2 (l0)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -1592,7 +1592,7 @@ ORDER BY
 | ArrangeBy (#0, #1)
 
 %11 =
-| Join %7 %10 (= #11 #25) (= #12 #26)
+| Join %7 %10 (= #0 #26) (= #11 #25)
 | | implementation = Differential %7 %10.(#0, #1)
 | | demand = (#0, #13, #28)
 | Filter ((i32todec(#13) * 1000dec) > #28)

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -92,33 +92,6 @@ just
 is
 -1.0000
 
-query T multiline
-explain plan for select b, c from foo, bar, (select -1 as a) const where foo.a / bar.a = const.a
-----
-%0 =
-| Get materialize.public.foo (u1)
-| ArrangeBy ()
-
-%1 =
-| Get materialize.public.bar (u3)
-
-%2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
-| | demand = (#0..#3)
-| Filter (-1 = (#0 / #3))
-| Project (#1, #2)
-
-EOF
-
-query TR
-select b, c from foo, bar, (select -1 as a) const where foo.a / bar.a = const.a
-----
-just
-11.300
-this
--4.400
-
 statement ok
 create index foo_idx on foo(a);
 

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -43,8 +43,10 @@ select b, c from foo where a = 5
 this
 -4.400
 
+# Test that a query that joins to a (select literal) gets planned as a filter
+# and not a join.
 query T multiline
-explain plan for select b, c from foo, (select 5 as a) bar where foo.a = bar.a
+explain plan for select b, c from foo, (select 5 as a) const where foo.a = const.a
 ----
 %0 =
 | Get materialize.public.foo (u1)
@@ -54,29 +56,68 @@ explain plan for select b, c from foo, (select 5 as a) bar where foo.a = bar.a
 EOF
 
 query TR
-select b, c from foo, (select 5 as a) bar where foo.a = bar.a
+select b, c from foo, (select 5 as a) const where foo.a = const.a
 ----
 this
 -4.400
 
+# Test that equality with a literal predicate gets pushed down to both inputs
+# even when one of the join constraints is an expression as opposed to a column reference.
 query T multiline
-explain plan for select * from foo, bar where foo.a = mod(bar.a, 5) and foo.a = 5
+explain plan for select * from foo, bar where foo.a = abs(bar.a) and foo.a = 3
 ----
 %0 =
 | Get materialize.public.foo (u1)
-| Filter (#0 = 5)
+| Filter (#0 = 3)
 | ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.bar (u3)
-| Filter (5 = (#0 % 5))
+| Filter !(isnull(abs(#0))), (3 = abs(#0))
 
 %2 =
-| Join %0 %1 (= #0 (#3 % 5))
+| Join %0 %1 (= #0 abs(#3))
 | | implementation = Differential %1 %0.(#0)
 | | demand = (#0..#5)
 
 EOF
+
+query ITRITR
+select * from foo, bar where foo.a = abs(bar.a) and foo.a = 3
+----
+3
+just
+11.300
+-3
+is
+-1.0000
+
+query T multiline
+explain plan for select b, c from foo, bar, (select -1 as a) const where foo.a / bar.a = const.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.bar (u3)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0..#3)
+| Filter (-1 = (#0 / #3))
+| Project (#1, #2)
+
+EOF
+
+query TR
+select b, c from foo, bar, (select -1 as a) const where foo.a / bar.a = const.a
+----
+just
+11.300
+this
+-4.400
 
 statement ok
 create index foo_idx on foo(a);

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -65,15 +65,15 @@ explain plan for select * from foo, bar where foo.a = mod(bar.a, 5) and foo.a = 
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 5)
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.bar (u3)
 | Filter (5 = (#0 % 5))
 
 %2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
+| Join %0 %1 (= #0 (#3 % 5))
+| | implementation = Differential %1 %0.(#0)
 | | demand = (#0..#5)
 
 EOF

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -59,6 +59,25 @@ select b, c from foo, (select 5 as a) bar where foo.a = bar.a
 this
 -4.400
 
+query T multiline
+explain plan for select * from foo, bar where foo.a = mod(bar.a, 5) and foo.a = 5
+----
+%0 =
+| Get materialize.public.foo (u1)
+| Filter (#0 = 5)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.bar (u3)
+| Filter (5 = (#0 % 5))
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0..#5)
+
+EOF
+
 statement ok
 create index foo_idx on foo(a);
 

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -43,6 +43,22 @@ select b, c from foo where a = 5
 this
 -4.400
 
+query T multiline
+explain plan for select b, c from foo, (select 5 as a) bar where foo.a = bar.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| Filter (#0 = 5)
+| Project (#1, #2)
+
+EOF
+
+query TR
+select b, c from foo, (select 5 as a) bar where foo.a = bar.a
+----
+this
+-4.400
+
 statement ok
 create index foo_idx on foo(a);
 

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -32,15 +32,15 @@ EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = bar.a where foo.a =
 %0 =
 | Get materialize.public.foo (u1)
 | Filter !(isnull(#0)), (#0 = 1)
-| ArrangeBy (#0)
+| ArrangeBy ()
 
 %1 =
 | Get materialize.public.bar (u3)
 | Filter !(isnull(#0)), (#0 = 1)
 
 %2 =
-| Join %0 %1 (= #0 #2)
-| | implementation = Differential %1 %0.(#0)
+| Join %0 %1
+| | implementation = Differential %1 %0.()
 | | demand = (#0, #1, #3)
 | Project (#0, #1, #0, #3)
 
@@ -115,7 +115,7 @@ where foo.a = bar.a
 
 %1 =
 | Get materialize.public.bar (u3)
-| Filter !(isnull(#0))
+| Filter !(isnull(#0)), !(isnull(#1))
 
 %2 =
 | Get materialize.public.baz (u7)
@@ -125,7 +125,6 @@ where foo.a = bar.a
 | Join %0 %1 %2 (= #0 #2) (= #3 #4)
 | | implementation = Differential %1 %2.(#0) %0.(#0)
 | | demand = (#0, #5)
-| Filter !(isnull(#0))
 | Project (#0, #5)
 
 EOF

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -280,3 +280,62 @@ NULL
 2
 3
 2
+
+# tests that equalities involving multi-input equalities become join conditions.
+
+query T multiline
+explain plan for select foo.b, bar.b from foo, bar, (select 1 as a) const where foo.a / bar.a = const.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.bar (u3)
+
+%2 =
+| Join %0 %1 (= 1 (#0 / #2))
+| | implementation = Differential %1 %0.()
+| | demand = (#1, #3)
+| Project (#1, #3)
+
+EOF
+
+query II
+select foo.b, bar.b from foo, bar, (select 1 as a) const where foo.a / bar.a = const.a
+----
+4
+NULL
+2
+3
+
+query T multiline
+explain plan for
+select foo.b, bar.b
+from foo, bar, (select -1 as a) const
+where foo.a / bar.a = const.a
+and bar.b - foo.b = foo.a / bar.a
+----
+%0 =
+| Get materialize.public.foo (u1)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.bar (u3)
+
+%2 =
+| Join %0 %1 (= -1 (#3 - #1) (#0 / #2))
+| | implementation = Differential %1 %0.()
+| | demand = (#1, #3)
+| Project (#1, #3)
+
+EOF
+
+query II
+select foo.b, bar.b
+from foo, bar, (select -1 as a) const
+where foo.a / bar.a = const.a
+and bar.b - foo.b = foo.a / bar.a
+----
+4
+3

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -32,15 +32,15 @@ EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = bar.a where foo.a =
 %0 =
 | Get materialize.public.foo (u1)
 | Filter !(isnull(#0)), (#0 = 1)
-| ArrangeBy ()
+| ArrangeBy (#0)
 
 %1 =
 | Get materialize.public.bar (u3)
 | Filter !(isnull(#0)), (#0 = 1)
 
 %2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
 | | demand = (#0, #1, #3)
 | Project (#0, #1, #0, #3)
 
@@ -68,7 +68,7 @@ EXPLAIN PLAN FOR select * from foo inner join bar on foo.a = abs(bar.a) where mo
 
 %1 =
 | Get materialize.public.bar (u3)
-| Filter !(isnull(abs(#0)))
+| Filter !(isnull(abs(#0))), (1 = (abs(#0) % 2))
 
 %2 =
 | Join %0 %1 (= #0 abs(#2))


### PR DESCRIPTION
The main goal here is to fix predicate pushdown so it properly takes all single-input predicates out of join equivalence classes. That way, other transforms do not have to worry about a single-input predicate possibly being hidden in the equivalence class of a join.
Predicate pushdown's inability to ensure joins had no single-input predicates hidden in the equivalence class had two direct causes, both of which are fixed in this PR:  
1. The code for finding single-input predicates in equivalence classes (and pushing the predicates down) was really broken.
2. Predicate pushdown only triggered if it saw `Filter { Join { .. } }`. If a Join had no Filter around it,  predicate pushdown would never run.

------

As I tested my branch, I discovered that the tests would behave unexpected ways. I traced the strange behavior to this logic:
For every predicate in `Filter {Join {..}}`:
1. Try to push it down to every input of the join.
2. If it cannot be pushed down into any input, check to see if it is an equality. If yes, stick it into its own equivalence class in the join.

Suppose you had 
```
select *
from foo, bar, baz 
where foo.a < 5 
   and foo.a = bar.a 
   and bar.a = baz.a
```

With the logic above, if `foo.a < 5` is the predicate that comes first, then our code will not see any other equivalence classes in the join, so it will not know that it would be valid to push down `bar.a < 5` and `baz.a < 5`.

So I changed the aforementioned logic to work like this instead:
1. Push every equality predicate down into the equivalences classes of the joins.
2. Canonicalize the equivalences classes.
3. Try to push all non-equality predicates down to every input. 

The equivalence class canonicalization code originally only existed in fusion::join. I have opted to make it common code accessible from expr/relation/canonicalize.rs. While I was at it, I made a common sort/dedup function for all the places that want equivalences to be sorted and dedupped.

------

In the test diffs, you might notice some new !isnull(...) expressions or ones that shifted places. An explanation:
Suppose you had
```
Join %0 %1
Filter (#0 = #2)
``` 
When predicate pushdown happens, the plan would initially look like this.
```
Join %0 %1 (= #0 #2)
Filter !isnull(#0) !isnull(#2)
``` 
On main, the two new !isnull(...) expressions are not localized to their corresponding inputs until a second predicate pushdown pass. In this PR branch, they are localized immediately.

It turns out that if you do not immediately localize the !isnull(...) expression, they risk being prematurely removed by ColumnKnowledge (which arguably should not be running in the fixpoint with PredicatePushdown, but that's for another PR). In the example above, if `#0` is a nonnullable column, then if the filters are not immediately localized, ColumnKnowledge will remove both !isnull(...) expressions even though pushing down the `!isnull(#2)` expression might be helpful for reducing the number of rows coming from %1.

------

Other changes:
* The doc for PredicatePushdown had the incomplete starts of a doctest, which I filled in.
* I added a ColumnKnowledge transform after JoinImplementation because it turns out ColumnKnowledge can be used to eliminate !isnull(...) expressions that become unnecessary once lifted by join implementation.
* In addition, predicate pushdown has now gained the ability that if a join's equivalence class has two different literals, the whole join gets converted to an empty constant.
* Predicate pushdown for union used to push the predicate down to all inputs but still keep a copy of the original predicates. Keeping the predicates should be unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5873)
<!-- Reviewable:end -->
