### PR TITLE
enable idempotent kafka writes

### DIFF
--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -246,6 +246,11 @@ where
     let mut config = ClientConfig::new();
     config.set("bootstrap.servers", &connector.addrs.to_string());
 
+    // Ensure that messages are sinked in order and without duplicates. Note that
+    // this only applies to a single instance of a producer - in the case of restarts,
+    // all bets are off and full exactly once support is required.
+    config.set("enable.idempotence", "true");
+
     // Increase limits for the Kafka producer's internal buffering of messages
     // Currently we don't have a great backpressure mechanism to tell indexes or
     // views to slow down, so the only thing we can do with a message that we


### PR DESCRIPTION
Idempotent kafka writes protect against reordered or duplicated messages
due to network errors and similar. Note that they do _not_ provide full
exactly once semantics and do _not_ prevent duplicate messages across
process restarts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5877)
<!-- Reviewable:end -->
