### PR TITLE
Increase SQL timeout for tests that depend on SQS

### DIFF
--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -204,7 +204,7 @@ d
 # S3 has a very loose idea of how fast items should show up:
 # > Typically, event notifications are delivered in seconds but can sometimes take a minute or longer.
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/NotificationHowTo.html
-$ set-sql-timeout duration=32seconds
+$ set-sql-timeout duration=2minutes
 
 > SELECT text FROM s3_scan_notifications ORDER BY text;
 a1


### PR DESCRIPTION
SQS has essentially no SLA on how fast things show up, it seems like 32 seconds
got us to "usually works" hopefully 2 minutes gets us to "always works".

If this is regularly noticably slowing down our tests we should either move
this to a disabled test or work on parallelizing testdrive, since this is
usually one of the last tests to run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5879)
<!-- Reviewable:end -->
