### PR TITLE
doc: typo missing closing quote

### DIFF
--- a/doc/user/content/sql/create-source/json-s3.md
+++ b/doc/user/content/sql/create-source/json-s3.md
@@ -41,7 +41,7 @@ We can load all these keys with the following command:
 
 ```sql
 > CREATE SOURCE json_source
-  FROM S3 OBJECTS FROM SCAN BUCKET 'analytics' MATCHING '**/*.json
+  FROM S3 OBJECTS FROM SCAN BUCKET 'analytics' MATCHING '**/*.json'
   WITH (region = 'us-east-2')
   FORMAT TEXT;
 ```


### PR DESCRIPTION
Single quote is missing in example documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5880)
<!-- Reviewable:end -->
