### PR TITLE
materialized: replace async-stream with official Tokio wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,27 +164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,7 +1928,6 @@ dependencies = [
  "anyhow",
  "askama",
  "assert_cmd",
- "async-stream",
  "async-trait",
  "backtrace",
  "build-info",
@@ -2016,6 +1994,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tokio-postgres",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -29,7 +29,6 @@ name = "materialized-unstable"
 [dependencies]
 anyhow = "1.0.38"
 askama = { version = "0.10.5", features = ["serde-json"] }
-async-stream = "0.3.0"
 async-trait = "0.1.42"
 backtrace = "0.3.56"
 build-info = { path = "../build-info" }
@@ -79,6 +78,7 @@ tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.2.0", features = ["sync"] }
 tokio-openssl = "0.6.1"
+tokio-stream = { version = "0.1.3", features = ["net"] }
 tracing = "0.1.23"
 # TODO(benesch): we can use the default features here once tracing-subscriber
 # does not enable chrono's "oldtime" feature.


### PR DESCRIPTION
Tokio now ships official wrappers for its stream-like objects, so we no
longer need to do it ourselves with async-stream.

This is minor but a nice simplification nonetheless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5883)
<!-- Reviewable:end -->
