### PR TITLE
Implement exp/log/power SQL functions

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -99,6 +99,8 @@ Wrap your release notes at the 80 character mark.
   operator still has a memory footprint proportional to the number of unique
   keys in the source.
 
+- Add the basic exponentiation, power and [logarithm functions](/sql/functions/#numbers-func).
+
 {{% version-header v0.7.0 %}}
 
 - **Known issue.** You cannot upgrade nodes created with versions v0.6.1 or

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -110,6 +110,9 @@
   - signature: 'floor(x: N) -> N'
     description: The largest integer <= `x`
 
+  - signature: 'log(x: N, b: N) -> N'
+    description: Base `b` logarithm of `x`
+
   - signature: 'log10(x: N) -> N'
     description: Base 10 logarithm of `x`
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -107,6 +107,9 @@
   - signature: 'ceil(x: N) -> N'
     description: The largest integer >= `x`
 
+  - signature: 'exp(x: N) -> N'
+    description: Exponential of `x` (e raised to the given power)
+
   - signature: 'floor(x: N) -> N'
     description: The largest integer <= `x`
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -110,6 +110,9 @@
   - signature: 'floor(x: N) -> N'
     description: The largest integer <= `x`
 
+  - signature: 'log10(x: N) -> N'
+    description: Base 10 logarithm of `x`
+
   - signature: 'mod(x: N, y: N) -> N'
     description: "`x % y`"
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -110,14 +110,17 @@
   - signature: 'floor(x: N) -> N'
     description: The largest integer <= `x`
 
-  - signature: 'log(x: N, b: N) -> N'
-    description: Base `b` logarithm of `x`
+  - signature: 'ln(x: N) -> N'
+    description: Natural logarithm of `x`
 
   - signature: 'log(x: N) -> N'
     description: Base 10 logarithm of `x`
 
   - signature: 'log10(x: N) -> N'
     description: Base 10 logarithm of `x`, same as `log`
+
+  - signature: 'log(x: N, b: N) -> N'
+    description: Base `b` logarithm of `x`
 
   - signature: 'mod(x: N, y: N) -> N'
     description: "`x % y`"

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -113,20 +113,23 @@
   - signature: 'floor(x: N) -> N'
     description: The largest integer <= `x`
 
-  - signature: 'ln(x: N) -> N'
+  - signature: 'ln(x: numeric) -> numeric'
     description: Natural logarithm of `x`
 
-  - signature: 'log(x: N) -> N'
+  - signature: 'log(x: numeric) -> numeric'
     description: Base 10 logarithm of `x`
 
-  - signature: 'log10(x: N) -> N'
+  - signature: 'log10(x: numeric) -> numeric'
     description: Base 10 logarithm of `x`, same as `log`
 
-  - signature: 'log(x: N, b: N) -> N'
+  - signature: 'log(x: numeric, b: numeric) -> numeric'
     description: Base `b` logarithm of `x`
 
   - signature: 'mod(x: N, y: N) -> N'
     description: "`x % y`"
+
+  - signature: 'power(x: numeric, y: numeric) -> numeric'
+    description: "`x` raised to the power of `y`"
 
   - signature: 'round(x: N) -> N'
     description: >-

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -113,11 +113,20 @@
   - signature: 'floor(x: N) -> N'
     description: The largest integer <= `x`
 
+  - signature: 'ln(x: double precision) -> double precision'
+    description: Natural logarithm of `x`
+
   - signature: 'ln(x: numeric) -> numeric'
     description: Natural logarithm of `x`
 
+  - signature: 'log(x: double precision) -> double precision'
+    description: Base 10 logarithm of `x`
+
   - signature: 'log(x: numeric) -> numeric'
     description: Base 10 logarithm of `x`
+
+  - signature: 'log10(x: double precision) -> double precision'
+    description: Base 10 logarithm of `x`, same as `log`
 
   - signature: 'log10(x: numeric) -> numeric'
     description: Base 10 logarithm of `x`, same as `log`
@@ -127,6 +136,9 @@
 
   - signature: 'mod(x: N, y: N) -> N'
     description: "`x % y`"
+
+  - signature: 'power(x: double precision, y: double precision) -> double precision'
+    description: "`x` raised to the power of `y`"
 
   - signature: 'power(x: numeric, y: numeric) -> numeric'
     description: "`x` raised to the power of `y`"

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -113,8 +113,11 @@
   - signature: 'log(x: N, b: N) -> N'
     description: Base `b` logarithm of `x`
 
-  - signature: 'log10(x: N) -> N'
+  - signature: 'log(x: N) -> N'
     description: Base 10 logarithm of `x`
+
+  - signature: 'log10(x: N) -> N'
+    description: Base 10 logarithm of `x`, same as `log`
 
   - signature: 'mod(x: N, y: N) -> N'
     description: "`x % y`"

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1244,6 +1244,21 @@ fn cot<'a>(a: Datum<'a>) -> Result<Datum, EvalError> {
     Ok(Datum::from(1.0 / f.tan()))
 }
 
+fn log<'a, 'b, F: Fn(f64) -> f64>(
+    a: Datum<'a>,
+    logic: F,
+    name: &'b str,
+) -> Result<Datum<'a>, EvalError> {
+    let f = a.unwrap_float64();
+    if f.is_sign_negative() {
+        return Err(EvalError::NegativeOutOfDomain(name.to_owned()));
+    }
+    if f == 0.0 {
+        return Err(EvalError::ZeroOutOfDomain(name.to_owned()));
+    }
+    Ok(Datum::from(logic(f)))
+}
+
 fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a == b)
 }
@@ -2987,6 +3002,7 @@ pub enum UnaryFunc {
     Tan,
     Tanh,
     Cot,
+    Log10,
 }
 
 impl UnaryFunc {
@@ -3155,6 +3171,8 @@ impl UnaryFunc {
             UnaryFunc::Tan => tan(a),
             UnaryFunc::Tanh => Ok(tanh(a)),
             UnaryFunc::Cot => cot(a),
+            UnaryFunc::Log10 => log(a, f64::log10, "log10"),
+            // UnaryFunc::Ln => ln(a),
         }
     }
 
@@ -3311,6 +3329,7 @@ impl UnaryFunc {
             Tan => ScalarType::Float64.nullable(in_nullable),
             Tanh => ScalarType::Float64.nullable(in_nullable),
             Cot => ScalarType::Float64.nullable(in_nullable),
+            Log10 => ScalarType::Float64.nullable(in_nullable),
         }
     }
 
@@ -3484,6 +3503,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::Tan => f.write_str("tan"),
             UnaryFunc::Tanh => f.write_str("tanh"),
             UnaryFunc::Cot => f.write_str("cot"),
+            UnaryFunc::Log10 => f.write_str("log10"),
         }
     }
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3033,6 +3033,8 @@ pub enum UnaryFunc {
     Cot,
     Log10,
     Log10Decimal(u8),
+    Ln,
+    LnDecimal(u8),
 }
 
 impl UnaryFunc {
@@ -3203,7 +3205,8 @@ impl UnaryFunc {
             UnaryFunc::Cot => cot(a),
             UnaryFunc::Log10 => log(a, f64::log10, "log10"),
             UnaryFunc::Log10Decimal(scale) => log_dec(a, f64::log10, "log10", *scale),
-            // UnaryFunc::Ln => ln(a),
+            UnaryFunc::Ln => log(a, f64::ln, "ln"),
+            UnaryFunc::LnDecimal(scale) => log_dec(a, f64::ln, "ln", *scale),
         }
     }
 
@@ -3360,8 +3363,8 @@ impl UnaryFunc {
             Tan => ScalarType::Float64.nullable(in_nullable),
             Tanh => ScalarType::Float64.nullable(in_nullable),
             Cot => ScalarType::Float64.nullable(in_nullable),
-            Log10 => ScalarType::Float64.nullable(in_nullable),
-            Log10Decimal(_) => input_type,
+            Log10 | Ln => ScalarType::Float64.nullable(in_nullable),
+            Log10Decimal(_) | LnDecimal(_) => input_type,
         }
     }
 
@@ -3536,7 +3539,9 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::Tanh => f.write_str("tanh"),
             UnaryFunc::Cot => f.write_str("cot"),
             UnaryFunc::Log10 => f.write_str("log10f64"),
-            UnaryFunc::Log10Decimal(_) => f.write_str("log10"),
+            UnaryFunc::Log10Decimal(_) => f.write_str("log10dec"),
+            UnaryFunc::Ln => f.write_str("lnf64"),
+            UnaryFunc::LnDecimal(_) => f.write_str("lndec"),
         }
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -730,6 +730,8 @@ pub enum EvalError {
     ParseHex(ParseHexError),
     Internal(String),
     InfinityOutOfDomain(String),
+    NegativeOutOfDomain(String),
+    ZeroOutOfDomain(String),
 }
 
 impl fmt::Display for EvalError {
@@ -789,6 +791,12 @@ impl fmt::Display for EvalError {
             EvalError::Internal(s) => write!(f, "internal error: {}", s),
             EvalError::InfinityOutOfDomain(s) => {
                 write!(f, "function {} is only defined for finite arguments", s)
+            }
+            EvalError::NegativeOutOfDomain(s) => {
+                write!(f, "function {} is not defined for negative numbers", s)
+            }
+            EvalError::ZeroOutOfDomain(s) => {
+                write!(f, "function {} is not defined for zero", s)
             }
         }
     }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1397,6 +1397,13 @@ lazy_static! {
                 params!(String, String) => BinaryFunc::DigestString, 44154;
                 params!(Bytes, String) => BinaryFunc::DigestBytes, 44155;
             },
+            "exp" => Scalar {
+                params!(Float64) => UnaryFunc::Exp, 1346;
+                params!(DecimalAny) => Operation::unary(|ecx, e| {
+                    let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
+                    Ok(e.call_unary(UnaryFunc::ExpDecimal(s)))
+                }), 1732;
+            },
             "floor" => Scalar {
                 params!(Float32) => UnaryFunc::FloorFloat32, oid::FUNC_FLOOR_F32_OID;
                 params!(Float64) => UnaryFunc::FloorFloat64, 2309;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1484,7 +1484,10 @@ lazy_static! {
                     let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
                     Ok(e.call_unary(UnaryFunc::Log10Decimal(s)))
                 }), 1340;
-                params!(Float64, Float64) => BinaryFunc::Log, 1736;
+                params!(DecimalAny, DecimalAny) => Operation::binary(|ecx, lhs, rhs| {
+                    let (_, s) = ecx.scalar_type(&lhs).unwrap_decimal_parts();
+                    Ok(lhs.call_binary(rhs, BinaryFunc::LogDecimal(s)))
+                }), 1736;
             },
             "lower" => Scalar {
                 params!(String) => UnaryFunc::Lower, 870;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1460,6 +1460,10 @@ lazy_static! {
             "log10" => Scalar {
                 params!(Float64) => UnaryFunc::Log10, 1194;
             },
+            "log" => Scalar {
+                params!(Float64) => UnaryFunc::Log10, 1340;
+                params!(Float64, Float64) => BinaryFunc::Log, 1736;
+            },
             "lower" => Scalar {
                 params!(String) => UnaryFunc::Lower, 870;
             },

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1459,6 +1459,10 @@ lazy_static! {
             },
             "log10" => Scalar {
                 params!(Float64) => UnaryFunc::Log10, 1194;
+                params!(DecimalAny) => Operation::unary(|ecx, e| {
+                    let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
+                    Ok(e.call_unary(UnaryFunc::Log10Decimal(s)))
+                }), 1481;
             },
             "log" => Scalar {
                 params!(Float64) => UnaryFunc::Log10, 1340;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1466,6 +1466,10 @@ lazy_static! {
             },
             "log" => Scalar {
                 params!(Float64) => UnaryFunc::Log10, 1340;
+                params!(DecimalAny) => Operation::unary(|ecx, e| {
+                    let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
+                    Ok(e.call_unary(UnaryFunc::Log10Decimal(s)))
+                }), 1340;
                 params!(Float64, Float64) => BinaryFunc::Log, 1736;
             },
             "lower" => Scalar {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1457,6 +1457,13 @@ lazy_static! {
                 params!(String) => UnaryFunc::CharLength, 1317;
                 params!(Bytes, String) => BinaryFunc::EncodedBytesCharLength, 1713;
             },
+            "ln" => Scalar {
+                params!(Float64) => UnaryFunc::Ln, 1341;
+                params!(DecimalAny) => Operation::unary(|ecx, e| {
+                    let (_, s) = ecx.scalar_type(&e).unwrap_decimal_parts();
+                    Ok(e.call_unary(UnaryFunc::LnDecimal(s)))
+                }), 1734;
+            },
             "log10" => Scalar {
                 params!(Float64) => UnaryFunc::Log10, 1194;
                 params!(DecimalAny) => Operation::unary(|ecx, e| {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1555,6 +1555,13 @@ lazy_static! {
                     Ok(HirScalarExpr::literal(Datum::String(&name), ScalarType::String))
                 }), 1619;
             },
+            "power" => Scalar {
+                params!(Float64, Float64) => BinaryFunc::Power, 1368;
+                params!(DecimalAny, DecimalAny) => Operation::binary(|ecx, lhs, rhs| {
+                    let (_, s) = ecx.scalar_type(&lhs).unwrap_decimal_parts();
+                    Ok(lhs.call_binary(rhs, BinaryFunc::PowerDecimal(s)))
+                }), 2169;
+            },
             "regexp_match" => Scalar {
                 params!(String, String) => VariadicFunc::RegexpMatch, 3396;
                 params!(String, String, String) => VariadicFunc::RegexpMatch, 3397;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1457,6 +1457,9 @@ lazy_static! {
                 params!(String) => UnaryFunc::CharLength, 1317;
                 params!(Bytes, String) => BinaryFunc::EncodedBytesCharLength, 1713;
             },
+            "log10" => Scalar {
+                params!(Float64) => UnaryFunc::Log10, 1194;
+            },
             "lower" => Scalar {
                 params!(String) => UnaryFunc::Lower, 870;
             },

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -947,3 +947,13 @@ query R
 SELECT log10(10.0::double)
 ----
 1.000
+
+query R
+SELECT log(10.0::double, 10)
+----
+1.000
+
+query R
+SELECT log(400.0::double, 20)
+----
+2.000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -949,6 +949,20 @@ SELECT log10(10.0::double)
 1.000
 
 query R
+SELECT log(10.0)
+----
+1.000
+
+query error function log is not defined for zero
+SELECT log(10, 0.0)
+
+query error function log is not defined for zero
+SELECT log(10, +0.0)
+
+query error function log is not defined for negative numbers
+SELECT log(10.0, -10)
+
+query R
 SELECT log(10.0::double, 10)
 ----
 1.000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -986,3 +986,19 @@ query R
 SELECT ln(13.0000::decimal(15, 5))
 ----
 2.565
+
+query R
+SELECT exp(2)
+----
+7.389
+
+query R
+SELECT exp(ln(2))
+----
+2.000
+
+# TODO: This is suuuuuper wrong.
+query R
+SELECT exp(ln(2::decimal(15, 5)))
+----
+2.000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -967,12 +967,12 @@ query error function log is not defined for negative numbers
 SELECT log(10.0, -10)
 
 query R
-SELECT log(10.0::double, 10)
+SELECT log(10, 10)
 ----
 1
 
 query R
-SELECT log(400.0::double, 20)
+SELECT log(400, 20)
 ----
 2
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -933,3 +933,17 @@ SELECT tanh('-inf'::double)
 
 query error function cot is only defined for finite arguments
 SELECT cot('-inf'::double)
+
+query error function log10 is not defined for zero
+SELECT log10(0.0::double)
+
+query error function log10 is not defined for zero
+SELECT log10(+0.0::double)
+
+query error function log10 is not defined for negative numbers
+SELECT log10(-1.0::double)
+
+query R
+SELECT log10(10.0::double)
+----
+1.000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -949,9 +949,9 @@ SELECT log10(10.0::double)
 1.000
 
 query R
-SELECT log(10.0)
+SELECT log(10.0::decimal(15, 5))
 ----
-1.000
+1.0000
 
 query error function log is not defined for zero
 SELECT log(10, 0.0)
@@ -973,6 +973,6 @@ SELECT log(400.0::double, 20)
 2.000
 
 query R
-SELECT log10(10::numeric)
+SELECT log10(10::decimal(15, 5))
 ----
 1.0000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -931,6 +931,10 @@ SELECT tanh('-inf'::double)
 ----
 -1.000
 
+# Use the more reasonable number representation, as the standard mode
+# causes all sorts of weird representation issues with exp and log:
+mode cockroach
+
 query error function cot is only defined for finite arguments
 SELECT cot('-inf'::double)
 
@@ -946,12 +950,12 @@ SELECT log10(-1.0::double)
 query R
 SELECT log10(10.0::double)
 ----
-1.000
+1
 
 query R
 SELECT log(10.0::decimal(15, 5))
 ----
-1.0000
+1
 
 query error function log is not defined for zero
 SELECT log(10, 0.0)
@@ -965,37 +969,37 @@ SELECT log(10.0, -10)
 query R
 SELECT log(10.0::double, 10)
 ----
-1.000
+1
 
 query R
 SELECT log(400.0::double, 20)
 ----
-2.000
+2
 
 query R
 SELECT log10(10::decimal(15, 5))
 ----
-1.0000
+1
 
 query R
-SELECT ln(13::float)
+SELECT round(ln(13::float)::decimal(15, 5), 3)
 ----
-2.565
+2.5650
 
 query R
 SELECT ln(13.0000::decimal(15, 5))
 ----
-2.565
+2.56494
 
 query R
-SELECT exp(2)
+SELECT round(exp(2)::decimal(15, 5), 3)
 ----
-7.389
+7.3890
 
 query R
 SELECT exp(ln(2))
 ----
-2.000
+2
 
 query T
 SELECT exp(ln(2::decimal(15, 5)))

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1005,3 +1005,18 @@ query T
 SELECT exp(ln(2::decimal(15, 5)))
 ----
 2
+
+query R
+SELECT power(382, 5);
+----
+8134236862432
+
+query T
+SELECT power(9, 0.5);
+----
+3.000
+
+query T
+SELECT power(9::decimal(15, 5), 0.5::decimal(15, 5));
+----
+3.000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1012,11 +1012,11 @@ SELECT power(382, 5);
 8134236862432
 
 query T
-SELECT power(9, 0.5);
+SELECT power(9::float, 0.5);
 ----
 3.000
 
 query T
 SELECT power(9::decimal(15, 5), 0.5::decimal(15, 5));
 ----
-3.000
+3

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -986,6 +986,12 @@ SELECT round(ln(13::float)::decimal(15, 5), 3)
 ----
 2.5650
 
+query error function ln is not defined for negative numbers
+SELECT ln(-1)
+
+query error function ln is not defined for zero
+SELECT ln(0)
+
 query R
 SELECT ln(13.0000::decimal(15, 5))
 ----

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -976,3 +976,13 @@ query R
 SELECT log10(10::decimal(15, 5))
 ----
 1.0000
+
+query R
+SELECT ln(13::float)
+----
+2.565
+
+query R
+SELECT ln(13.0000::decimal(15, 5))
+----
+2.565

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -957,3 +957,8 @@ query R
 SELECT log(400.0::double, 20)
 ----
 2.000
+
+query R
+SELECT log10(10::numeric)
+----
+1.0000

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -958,6 +958,15 @@ SELECT log(10.0::decimal(15, 5))
 1
 
 query error function log is not defined for zero
+SELECT log(0.0, 10)
+
+query error function log is not defined for zero
+SELECT log(+0.0, 10)
+
+query error function log is not defined for negative numbers
+SELECT log(-10, 10)
+
+query error function log is not defined for zero
 SELECT log(10, 0.0)
 
 query error function log is not defined for zero

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -997,8 +997,7 @@ SELECT exp(ln(2))
 ----
 2.000
 
-# TODO: This is suuuuuper wrong.
-query R
+query T
 SELECT exp(ln(2::decimal(15, 5)))
 ----
-2.000
+2


### PR DESCRIPTION
Fixes #5812, #5329

In this PR, we implement `log` (unary and binary), as well as `power` and the unary `ln`, `log10` and `exp` SQL functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5885)
<!-- Reviewable:end -->
