### PR TITLE
Temporarily add printf debugging to flaky test

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -20,6 +20,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use log::info;
 use tempfile::NamedTempFile;
 
 use util::{MzTimestamp, PostgresErrorExt};
@@ -31,44 +32,58 @@ fn test_no_block() -> Result<(), Box<dyn Error>> {
     ore::test::init_logging();
 
     // Create a listener that will simulate a slow Confluent Schema Registry.
+    info!("test_no_block: creating listener");
     let listener = TcpListener::bind("localhost:0")?;
     let listener_port = listener.local_addr()?.port();
 
+    info!("test_no_block: starting server");
     let server = util::start_server(util::Config::default())?;
+    info!("test_no_block: connecting to server");
     let mut client = server.connect(postgres::NoTls)?;
 
+    info!("test_no_block: spawning thread");
     let slow_thread = thread::spawn(move || {
-        client.batch_execute(&format!(
+        info!("test_no_block: in thread; executing create source");
+        let result = client.batch_execute(&format!(
             "CREATE SOURCE foo \
              FROM KAFKA BROKER 'localhost:9092' TOPIC 'foo' \
              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:{}'",
             listener_port,
-        ))
+        ));
+        info!("test_no_block: in thread; create source done");
+        result
     });
 
     // Wait for materialized to contact the schema registry, which indicates
     // the coordinator is processing the CREATE SOURCE command. It will be
     // unable to complete the query until we respond.
+    info!("test_no_block: accepting fake schema registry connection");
     let (mut stream, _) = listener.accept()?;
 
     // Verify that the coordinator can still process other requests from other
     // sessions.
+    info!("test_no_block: connecting to server again");
     let mut client = server.connect(postgres::NoTls)?;
+    info!("test_no_block: executing query");
     let answer: i32 = client.query_one("SELECT 1 + 1", &[])?.get(0);
     assert_eq!(answer, 2);
 
     // Return an error to the coordinator, so that we can shutdown cleanly.
+    info!("test_no_block: writing fake schema registry error");
     write!(stream, "HTTP/1.1 503 Service Unavailable\r\n\r\n")?;
+    info!("test_no_block: dropping fake schema registry connection");
     drop(stream);
 
     // Verify that the schema registry error was returned to the client, for
     // good measure.
+    info!("test_no_block: joining thread");
     let slow_res = slow_thread.join().unwrap();
     assert!(slow_res
         .unwrap_err()
         .to_string()
         .contains("server error 503"));
 
+    info!("test_no_block: returning");
     Ok(())
 }
 


### PR DESCRIPTION
This test is hanging about half the time in CI, and I'm at a loss for how to reproduce it locally.

Temporarily add some print statements so we can see where it's actually blocking, which will hopefully narrow the search space.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5887)
<!-- Reviewable:end -->
