### PR TITLE
Move Debezium flattening out of special-cased logic and into planning

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -350,28 +350,27 @@ impl DataEncoding {
                         .context("validating avro ocf reader schema")?
                         .into_iter()
                         .fold(key_desc, |desc, (name, ty)| desc.with_column(name, ty));
-                if envelope.get_avro_envelope_type() == avro::EnvelopeType::Debezium {
-                    desc.with_column(
-                        "diff",
-                        ColumnType {
-                            nullable: false,
-                            scalar_type: ScalarType::Int64,
-                        },
-                    )
-                } else {
-                    desc
-                }
+                desc
             }
             DataEncoding::Avro(AvroEncoding {
                 value_schema,
                 key_schema,
                 ..
             }) => {
-                let desc =
+                let mut columns =
                     avro::validate_value_schema(value_schema, envelope.get_avro_envelope_type())
                         .context("validating avro value schema")?
                         .into_iter()
-                        .fold(key_desc, |desc, (name, ty)| desc.with_column(name, ty));
+                        .collect::<Vec<_>>();
+                if envelope.get_avro_envelope_type() == avro::EnvelopeType::Debezium {
+                    // TODO [btv] - Get rid of this, when we can. Right now source processing is still not fully orthogonal,
+                    // so we have some special logic in the debezium processor that only passes on
+                    // the first two columns ("before" and "after"), and uses the information in the other ones itself
+                    columns.truncate(2);
+                }
+                let desc = columns
+                    .into_iter()
+                    .fold(key_desc, |desc, (name, ty)| desc.with_column(name, ty));
                 let key_schema_indices = key_schema.as_ref().and_then(|key_schema| {
                     avro::validate_key_schema(key_schema, &desc)
                         .map(Some)
@@ -381,13 +380,7 @@ impl DataEncoding {
                         })
                 });
                 if envelope.get_avro_envelope_type() == avro::EnvelopeType::Debezium {
-                    desc.with_column(
-                        "diff",
-                        ColumnType {
-                            nullable: false,
-                            scalar_type: ScalarType::Int64,
-                        },
-                    )
+                    desc
                 } else {
                     if let Some(key) = key_schema_indices {
                         desc.with_key(key)

--- a/src/dataflow/src/decode/protobuf.rs
+++ b/src/dataflow/src/decode/protobuf.rs
@@ -34,7 +34,7 @@ impl ProtobufDecoderState {
 }
 
 impl DecoderState for ProtobufDecoderState {
-    fn decode_key(&mut self, bytes: &[u8]) -> Result<Row, String> {
+    fn decode_key(&mut self, bytes: &[u8]) -> Result<Option<Row>, String> {
         // Note that we're passing `None` as the offset for the key -
         // since the key must remain stable (and we don't have an
         // offset available here anyway), we instruct the decoder to
@@ -43,7 +43,7 @@ impl DecoderState for ProtobufDecoderState {
             Ok(row) => {
                 if let Some(row) = row {
                     self.events_success += 1;
-                    Ok(row)
+                    Ok(Some(row))
                 } else {
                     self.events_error += 1;
                     Err("protobuf deserialization returned None".to_string())

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -219,7 +219,7 @@ where
                             &envelope,
                             &mut src.operators,
                             fast_forwarded,
-                            src.desc,
+                            src.bare_desc.clone(),
                         );
                         if let Some(tok) = extra_token {
                             self.additional_tokens

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -138,7 +138,7 @@ where
                         for (key, data) in map.drain() {
                             // decode key and value
                             match key_decoder_state.decode_key(&key) {
-                                Ok(decoded_key) => {
+                                Ok(Some(decoded_key)) => {
                                     let decoded_value = if data.value.is_empty() {
                                         Ok(None)
                                     } else {
@@ -178,6 +178,7 @@ where
                                         }
                                     }
                                 }
+                                Ok(None) => {}
                                 Err(err) => {
                                     error!("{}", err);
                                 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3391,7 +3391,7 @@ impl UnaryFunc {
             JsonbPretty => ScalarType::String.nullable(in_nullable),
 
             RecordGet(i) => match input_type.scalar_type {
-                ScalarType::Record { mut fields, .. } => fields.swap_remove(*i).1.nullable(true),
+                ScalarType::Record { mut fields, .. } => fields.swap_remove(*i).1,
                 _ => unreachable!("RecordGet specified nonexistent field"),
             },
 
@@ -3570,7 +3570,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::TrimWhitespace => f.write_str("btrim"),
             UnaryFunc::TrimLeadingWhitespace => f.write_str("ltrim"),
             UnaryFunc::TrimTrailingWhitespace => f.write_str("rtrim"),
-            UnaryFunc::RecordGet(_) => f.write_str("record_get"),
+            UnaryFunc::RecordGet(i) => write!(f, "record_get[{}]", i),
             UnaryFunc::ListLength => f.write_str("list_length"),
             UnaryFunc::Upper => f.write_str("upper"),
             UnaryFunc::Lower => f.write_str("lower"),

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -398,6 +398,7 @@ pub fn bench_avro(c: &mut Criterion) {
         Some(DebeziumDeduplicationStrategy::Ordered),
         None,
         false,
+        false,
     )
     .unwrap();
 

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -2236,11 +2236,7 @@ impl Decoder {
             let dedup = self.debezium_dedup.as_mut().unwrap();
             let (row, coords) = dsr.deserialize(&mut bytes, dec)?;
             if self.reject_non_inserts {
-                let row_has_before = match row.iter().next() {
-                    None | Some(Datum::Null) => false,
-                    _ => true,
-                };
-                if row_has_before {
+                if !matches!(row.iter().next(), None | Some(Datum::Null)) {
                     panic!("[customer-data] Updates and deletes are not allowed for this source! This probably means it was started with `start_offset`. Got row: {:?}", row)
                 }
             }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -15,7 +15,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::Read;
 use std::str::FromStr;
-use std::{cell::RefCell, iter, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Context;
 use anyhow::{anyhow, bail};
@@ -471,12 +471,12 @@ impl<'a> AvroDecode for DebeziumSourceDecoder<'a> {
         union_branch, array, map, enum_variant, scalar, decimal, bytes, string, json, uuid, fixed
     }
 }
-struct OptionalRowDecoder<'a> {
+struct OptionalRecordDecoder<'a> {
     pub packer: &'a mut RowPacker,
     pub buf: &'a mut Vec<u8>,
 }
 
-impl<'a> AvroDecode for OptionalRowDecoder<'a> {
+impl<'a> AvroDecode for OptionalRecordDecoder<'a> {
     type Out = bool;
     fn union_branch<'b, R: AvroRead, D: AvroDeserializer>(
         self,
@@ -493,7 +493,7 @@ impl<'a> AvroDecode for OptionalRowDecoder<'a> {
             let d = AvroFlatDecoder {
                 packer: self.packer,
                 buf: self.buf,
-                is_top: true,
+                is_top: false,
             };
             deserializer.deserialize(reader, d)?;
             Ok(true)
@@ -512,43 +512,33 @@ pub struct AvroDebeziumDecoder<'a> {
 }
 
 impl<'a> AvroDecode for AvroDebeziumDecoder<'a> {
-    type Out = (DiffPair<Row>, Option<DebeziumSourceCoordinates>);
+    type Out = (Row, Option<DebeziumSourceCoordinates>);
     fn record<R: AvroRead, A: AvroRecordAccess<R>>(
         self,
         a: &mut A,
     ) -> Result<Self::Out, AvroError> {
-        let mut before = None;
-        let mut after = None;
         let mut coords = None;
         let mut transaction = None;
         while let Some((name, _, field)) = a.next_field()? {
             match name {
                 "before" => {
-                    let d = OptionalRowDecoder {
+                    let d = OptionalRecordDecoder {
                         packer: self.packer,
                         buf: self.buf,
                     };
                     let decoded_row = field.decode_field(d)?;
-
-                    before = if decoded_row {
-                        self.packer.push(Datum::Int64(-1));
-                        Some(self.packer.finish_and_reuse())
-                    } else {
-                        None
+                    if !decoded_row {
+                        self.packer.push(Datum::Null);
                     }
                 }
                 "after" => {
-                    let d = OptionalRowDecoder {
+                    let d = OptionalRecordDecoder {
                         packer: self.packer,
                         buf: self.buf,
                     };
                     let decoded_row = field.decode_field(d)?;
-
-                    after = if decoded_row {
-                        self.packer.push(Datum::Int64(1));
-                        Some(self.packer.finish_and_reuse())
-                    } else {
-                        None
+                    if !decoded_row {
+                        self.packer.push(Datum::Null);
                     }
                 }
                 "source" => {
@@ -575,7 +565,7 @@ impl<'a> AvroDecode for AvroDebeziumDecoder<'a> {
                 *total_order = Some(transaction.total_order);
             }
         }
-        Ok((DiffPair { before, after }, coords))
+        Ok((self.packer.finish_and_reuse(), coords))
     }
     define_unexpected! {
         union_branch, array, map, enum_variant, scalar, decimal, bytes, string, json, uuid, fixed
@@ -960,7 +950,7 @@ pub fn validate_value_schema(
                                         bail!("Source schema 'before' and 'after' fields should be the same named record.");
                                     }
                                     match schema.lookup(*before_name).piece {
-                                        SchemaPiece::Record { .. } => node.step(before_piece),
+                                        SchemaPiece::Record { .. } => node,
                                         _ => bail!("Source schema 'before' and 'after' fields should contain a record."),
                                     }
                                 }
@@ -1552,7 +1542,7 @@ impl DebeziumDeduplicationState {
         debug_name: &str,
         worker_idx: usize,
         is_snapshot: bool,
-        update: &DiffPair<Row>,
+        update: &Row,
     ) -> bool {
         let (pos, row) = match row {
             RowCoordinates::MySql { pos, row } => (pos, row),
@@ -1630,21 +1620,21 @@ impl DebeziumDeduplicationState {
                         }
                         Some(ki) => ki,
                     };
-                    let mut row_iter = match update.after.as_ref() {
-                        None => {
+                    let mut after_iter = match update.iter().nth(1) {
+                        Some(Datum::List(after_elts)) => after_elts.iter(),
+                        _ => {
                             error!(
                                 "Snapshot row at pos {:?}, message_time={} source={} was not an insert.",
                                 coord, fmt_timestamp(upstream_time_millis), debug_name);
                             return false;
                         }
-                        Some(r) => r.iter(),
                     };
                     let key = {
                         let mut cumsum = 0;
                         for k in key_indices.iter() {
                             let adjusted_idx = *k - cumsum;
                             cumsum += adjusted_idx + 1;
-                            key_buf.push(row_iter.nth(adjusted_idx).unwrap());
+                            key_buf.push(after_iter.nth(adjusted_idx).unwrap());
                         }
                         key_buf.finish_and_reuse()
                     };
@@ -1935,6 +1925,8 @@ fn take_field_by_index(
     Ok(std::mem::replace(value, Value::Null))
 }
 
+// TODO [btv] - this entire struct is ONLY used in the OCF code path. It should be deleted and merged with
+// `Decoder` as part of the source-orthogonality refactor.
 impl DebeziumDecodeState {
     pub fn new(
         schema: &Schema,
@@ -1961,10 +1953,9 @@ impl DebeziumDecodeState {
     pub fn extract(
         &mut self,
         v: Value,
-        n: SchemaNode,
         coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-    ) -> anyhow::Result<DiffPair<Row>> {
+    ) -> anyhow::Result<Option<Row>> {
         fn is_snapshot(v: Value) -> anyhow::Result<Option<bool>> {
             let answer = match v {
                 Value::Union { inner, .. } => is_snapshot(*inner)?,
@@ -2018,8 +2009,6 @@ impl DebeziumDecodeState {
                         .ok_or_else(|| anyhow!("\"row\" is not an integer"))?;
                         let pos = usize::try_from(pos_val)?;
                         let row = usize::try_from(row_val)?;
-                        // TODO(btv) Add LSN handling here too (OCF code path).
-                        // Better yet, just delete this and make it go through the same code path as Kafka
                         if !self.dedup.should_use_record(
                             file_val.as_bytes(),
                             RowCoordinates::MySql { pos, row },
@@ -2028,28 +2017,39 @@ impl DebeziumDecodeState {
                             &self.debug_name,
                             self.worker_idx,
                             false,
-                            &DiffPair {
-                                before: None,
-                                after: None,
-                            },
+                            &Row::default(),
                         ) {
-                            return Ok(DiffPair {
-                                before: None,
-                                after: None,
-                            });
+                            return Ok(None);
                         }
                     }
                 }
-                let before_val = take_field_by_index(self.before_idx, "before", &mut fields)?;
-                let after_val = take_field_by_index(self.after_idx, "after", &mut fields)?;
-                // we will not have gotten this far if before/after aren't records, so the unwrap is okay.
-                let before_node = n.step(&unwrap_record_fields(n)[self.before_idx].schema);
-                let after_node = n.step(&unwrap_record_fields(n)[self.after_idx].schema);
-                let before =
-                    extract_nullable_row(before_val, iter::once(Datum::Int64(-1)), before_node)?;
-                let after =
-                    extract_nullable_row(after_val, iter::once(Datum::Int64(1)), after_node)?;
-                Ok(DiffPair { before, after })
+                let before_idx = fields.iter().position(|(name, _value)| "before" == name);
+                let after_idx = fields.iter().position(|(name, _value)| "after" == name);
+                if let (Some(before_idx), Some(after_idx)) = (before_idx, after_idx) {
+                    let before = &fields[before_idx].1;
+                    let after = &fields[after_idx].1;
+                    let mut packer = RowPacker::new();
+                    let mut buf = vec![];
+                    give_value(
+                        AvroFlatDecoder {
+                            packer: &mut packer,
+                            buf: &mut buf,
+                            is_top: false,
+                        },
+                        before,
+                    )?;
+                    give_value(
+                        AvroFlatDecoder {
+                            packer: &mut packer,
+                            buf: &mut buf,
+                            is_top: false,
+                        },
+                        after,
+                    )?;
+                    Ok(Some(packer.finish()))
+                } else {
+                    bail!("avro envelope does not contain `before` and `after`");
+                }
             }
             _ => bail!("avro envelope had unexpected type: {:?}", v),
         }
@@ -2161,6 +2161,7 @@ pub struct Decoder {
     buf1: Vec<u8>,
     buf2: Vec<u8>,
     packer: RowPacker,
+    reject_non_inserts: bool,
 }
 
 impl fmt::Debug for Decoder {
@@ -2190,6 +2191,7 @@ impl Decoder {
         debezium_dedup: Option<DebeziumDeduplicationStrategy>,
         key_indices: Option<Vec<usize>>,
         confluent_wire_format: bool,
+        reject_non_inserts: bool,
     ) -> anyhow::Result<Decoder> {
         assert!(
             (envelope == EnvelopeType::Debezium && debezium_dedup.is_some())
@@ -2209,6 +2211,7 @@ impl Decoder {
             buf1: vec![],
             buf2: vec![],
             packer: Default::default(),
+            reject_non_inserts,
         })
     }
 
@@ -2218,7 +2221,7 @@ impl Decoder {
         bytes: &[u8],
         coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-    ) -> anyhow::Result<DiffPair<Row>> {
+    ) -> anyhow::Result<Option<Row>> {
         let (mut bytes, resolved_schema) = self.csr_avro.resolve(bytes).await?;
         let result = if self.envelope == EnvelopeType::Debezium {
             let dec = AvroDebeziumDecoder {
@@ -2231,7 +2234,16 @@ impl Decoder {
             };
             // Unwrap is OK: we assert in Decoder::new that this is non-none when envelope == dbz.
             let dedup = self.debezium_dedup.as_mut().unwrap();
-            let (diff, coords) = dsr.deserialize(&mut bytes, dec)?;
+            let (row, coords) = dsr.deserialize(&mut bytes, dec)?;
+            if self.reject_non_inserts {
+                let row_has_before = match row.iter().next() {
+                    None | Some(Datum::Null) => false,
+                    _ => true,
+                };
+                if row_has_before {
+                    panic!("[customer-data] Updates and deletes are not allowed for this source! This probably means it was started with `start_offset`. Got row: {:?}", row)
+                }
+            }
             let should_use = if let Some(source) = coords {
                 let mssql_fsn_buf;
                 // This would have ideally been `Option<&[u8]>`,
@@ -2254,18 +2266,15 @@ impl Decoder {
                     &self.debug_name,
                     self.worker_index,
                     source.snapshot,
-                    &diff,
+                    &row,
                 )
             } else {
                 true
             };
             if should_use {
-                diff
+                Some(row)
             } else {
-                DiffPair {
-                    before: None,
-                    after: None,
-                }
+                None
             }
         } else {
             let dec = AvroFlatDecoder {
@@ -2277,13 +2286,10 @@ impl Decoder {
                 schema: resolved_schema.top_node(),
             };
             dsr.deserialize(&mut bytes, dec)?;
-            DiffPair {
-                before: None,
-                after: Some(self.packer.finish_and_reuse()),
-            }
+            Some(self.packer.finish_and_reuse())
         };
         log::trace!(
-            "[customer-data] Decoded diff pair {:?}{} in {}",
+            "[customer-data] Decoded row {:?}{} in {}",
             result,
             if let Some(coord) = coord {
                 format!(" at offset {}", coord)

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -230,6 +230,17 @@ impl RelationDesc {
         RelationDesc { typ, names }
     }
 
+    pub fn from_names_and_types<I, T, N>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = (Option<N>, T)>,
+        T: Into<ColumnType>,
+        N: Into<ColumnName>,
+    {
+        let (names, types): (Vec<_>, Vec<_>) = iter.into_iter().unzip();
+        let types = types.into_iter().map(Into::into).collect();
+        let typ = RelationType::new(types);
+        Self::new(typ, names)
+    }
     /// Concatenates a `RelationDesc` onto the end of this `RelationDesc`.
     pub fn concat(mut self, other: Self) -> Self {
         let self_len = self.typ.column_types.len();

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
+use std::iter;
 use std::path::PathBuf;
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -21,11 +22,16 @@ use anyhow::{anyhow, bail};
 use aws_arn::{Resource, ARN};
 use expr::MirRelationExpr;
 use expr::TableFunc;
+use expr::UnaryFunc;
 use globset::GlobBuilder;
 use itertools::Itertools;
+use log::error;
 use log::warn;
 use ore::str::StrExt;
 use repr::ColumnName;
+use repr::ColumnType;
+use repr::Datum;
+use repr::Row;
 
 use reqwest::Url;
 
@@ -221,16 +227,114 @@ pub fn describe_create_source(
     Ok(StatementDesc::new(None))
 }
 
+fn plan_dbz_flatten(
+    bare_desc: &RelationDesc,
+    input: HirRelationExpr,
+) -> Result<(HirRelationExpr, Vec<Option<ColumnName>>), anyhow::Error> {
+    // This looks horrible, but it is basically pretty simple:
+    // It aims to flatten rows of the shape
+    // (before, after)
+    // into rows whose columns are the individual fields of the before or after record,
+    // plus a "diff" column whose value is -1 for before, and +1 for after.
+    //
+    // They will then be joined with `repeat(diff)` to get the correct stream out.
+    let flattened_cols = match &bare_desc.typ().column_types[0].scalar_type {
+        ScalarType::Record { fields, .. } => fields.clone(),
+        _ => unreachable!(), // This was verified in `Encoding::desc`
+    };
+    let old_arity = input.arity();
+    let before_expr = HirRelationExpr::Map {
+        input: Box::new(HirRelationExpr::Filter {
+            input: Box::new(input.clone()),
+            predicates: vec![HirScalarExpr::CallUnary {
+                func: UnaryFunc::Not,
+                expr: Box::new(HirScalarExpr::CallUnary {
+                    func: UnaryFunc::IsNull,
+                    expr: Box::new(HirScalarExpr::Column(ColumnRef {
+                        level: 0,
+                        column: 0,
+                    })),
+                }),
+            }],
+        }),
+        scalars: flattened_cols
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| HirScalarExpr::CallUnary {
+                func: UnaryFunc::RecordGet(idx),
+                expr: Box::new(HirScalarExpr::Column(ColumnRef {
+                    level: 0,
+                    column: 0,
+                })),
+            })
+            .chain(iter::once(HirScalarExpr::Literal(
+                Row::pack(iter::once(Datum::Int64(-1))),
+                ColumnType {
+                    nullable: false,
+                    scalar_type: ScalarType::Int64,
+                },
+            )))
+            .collect(),
+    };
+    let after_expr = HirRelationExpr::Map {
+        input: Box::new(HirRelationExpr::Filter {
+            input: Box::new(input.clone()),
+            predicates: vec![HirScalarExpr::CallUnary {
+                func: UnaryFunc::Not,
+                expr: Box::new(HirScalarExpr::CallUnary {
+                    func: UnaryFunc::IsNull,
+                    expr: Box::new(HirScalarExpr::Column(ColumnRef {
+                        level: 0,
+                        column: 1,
+                    })),
+                }),
+            }],
+        }),
+        scalars: flattened_cols
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| HirScalarExpr::CallUnary {
+                func: UnaryFunc::RecordGet(idx),
+                expr: Box::new(HirScalarExpr::Column(ColumnRef {
+                    level: 0,
+                    column: 1,
+                })),
+            })
+            .chain(iter::once(HirScalarExpr::Literal(
+                Row::pack(iter::once(Datum::Int64(1))),
+                ColumnType {
+                    nullable: false,
+                    scalar_type: ScalarType::Int64,
+                },
+            )))
+            .collect(),
+    };
+    let new_arity = before_expr.arity();
+    assert!(new_arity == after_expr.arity());
+    let before_expr = before_expr.project((old_arity..new_arity).collect());
+    let after_expr = after_expr.project((old_arity..new_arity).collect());
+    let united_expr = HirRelationExpr::Union {
+        base: Box::new(before_expr),
+        inputs: vec![after_expr],
+    };
+    let mut col_names = flattened_cols
+        .into_iter()
+        .map(|(name, _)| Some(name))
+        .collect::<Vec<_>>();
+    col_names.push(Some("diff".into()));
+    Ok((united_expr, col_names))
+}
+
 fn plan_source_envelope(
     bare_desc: &RelationDesc,
     envelope: &SourceEnvelope,
     post_transform_key: Option<Vec<usize>>,
-) -> (MirRelationExpr, Vec<Option<ColumnName>>) {
+) -> Result<(MirRelationExpr, Vec<Option<ColumnName>>), anyhow::Error> {
     let get_expr = HirRelationExpr::Get {
         id: expr::Id::LocalBareSource,
         typ: bare_desc.typ().clone(),
     };
-    let hir_expr = if let SourceEnvelope::Debezium(_) = envelope {
+    let (hir_expr, column_names) = if let SourceEnvelope::Debezium(_) = envelope {
         // Debezium sources produce a diff in their last column.
         // Thus we need to select all rows but the last, which we repeat by.
         // I.e., for a source with four columns, we do
@@ -240,9 +344,12 @@ fn plan_source_envelope(
         // Then we would get some nice things; for example, automatic tracking of column names.
         //
         // For this simple case, it probably doesn't matter
-        let diff_col = get_expr.arity() - 1;
+
+        let (flattened, mut column_names) = plan_dbz_flatten(bare_desc, get_expr)?;
+
+        let diff_col = flattened.arity() - 1;
         let expr = HirRelationExpr::Join {
-            left: Box::new(get_expr),
+            left: Box::new(flattened),
             right: Box::new(HirRelationExpr::CallTable {
                 func: TableFunc::Repeat,
                 exprs: vec![HirScalarExpr::Column(ColumnRef {
@@ -254,23 +361,22 @@ fn plan_source_envelope(
             kind: JoinKind::Inner { lateral: true },
         }
         .project((0..diff_col).collect());
-        if let Some(post_transform_key) = post_transform_key {
+        let expr = if let Some(post_transform_key) = post_transform_key {
             expr.declare_keys(vec![post_transform_key])
         } else {
             expr
-        }
+        };
+        column_names.pop();
+        (expr, column_names)
     } else {
-        get_expr
+        (
+            get_expr,
+            bare_desc.iter_names().map(|name| name.cloned()).collect(),
+        )
     };
     let mir_expr = hir_expr.lower();
 
-    let column_names = bare_desc
-        .iter_names()
-        .map(|cn| cn.cloned())
-        .take(mir_expr.arity())
-        .collect();
-
-    (mir_expr, column_names)
+    Ok((mir_expr, column_names))
 }
 
 pub fn plan_create_source(
@@ -782,15 +888,26 @@ pub fn plan_create_source(
             if ignore_source_keys {
                 None
             } else {
-                let key_schema_indices = key_schema.as_ref().and_then(|key_schema| {
-                    avro::validate_key_schema(key_schema, &bare_desc)
-                        .map(Some)
-                        .unwrap_or_else(|e| {
-                            warn!("Not using key due to error: {}", e);
-                            None
-                        })
-                });
-                key_schema_indices
+                match &bare_desc.typ().column_types[0].scalar_type {
+                    ScalarType::Record { fields, .. } => {
+                        let row_desc = RelationDesc::from_names_and_types(
+                            fields.clone().into_iter().map(|(n, t)| (Some(n), t)),
+                        );
+                        let key_schema_indices = key_schema.as_ref().and_then(|key_schema| {
+                            avro::validate_key_schema(key_schema, &row_desc)
+                                .map(Some)
+                                .unwrap_or_else(|e| {
+                                    warn!("Not using key due to error: {}", e);
+                                    None
+                                })
+                        });
+                        key_schema_indices
+                    }
+                    _ => {
+                        error!("Not using key: expected `before` record in first column");
+                        None
+                    }
+                }
             }
         } else {
             None
@@ -820,7 +937,7 @@ pub fn plan_create_source(
     let name = scx.allocate_name(normalize::unresolved_object_name(name.clone())?);
     let create_sql = normalize::create_statement(&scx, Statement::CreateSource(stmt))?;
 
-    let (expr, column_names) = plan_source_envelope(&bare_desc, &envelope, post_transform_key);
+    let (expr, column_names) = plan_source_envelope(&bare_desc, &envelope, post_transform_key)?;
     let source = Source {
         create_sql,
         connector: SourceConnector::External {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -278,7 +278,7 @@ fn plan_dbz_flatten(
     };
     let after_expr = HirRelationExpr::Map {
         input: Box::new(HirRelationExpr::Filter {
-            input: Box::new(input.clone()),
+            input: Box::new(input),
             predicates: vec![HirScalarExpr::CallUnary {
                 func: UnaryFunc::Not,
                 expr: Box::new(HirScalarExpr::CallUnary {

--- a/test/testdrive/avro-ocf.td
+++ b/test/testdrive/avro-ocf.td
@@ -105,7 +105,7 @@ mz_obj_no  false     bigint
 ! CREATE MATERIALIZED SOURCE reader_schema
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
   WITH (reader_schema = '{"bad": "news", "bears"')
-validating avro ocf reader schema:
+validating avro value schema:
 
 > CREATE MATERIALIZED SOURCE tailed
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf' WITH (tail = true)


### PR DESCRIPTION
Continue the project of moving functionality out of special decoding logic, and into relational expressions. In this diff, we get rid of the special logic that flattens Debezium before and after records into their contained columns.

With this change, bare Kafka/debezium sources produce rows of the shape `(before, after)`, each of which is a nullable record. The plan for converting those into the final stream of data is (for a source with fields 0..=6):

```
%0 =
| Get Bare Source for ? (u3)
| Filter !(isnull(#0))
| Map record_get[0](#0), record_get[1](#0), record_get[2](#0), record_get[3](#0), record_get[4](#0), record_get[5](#0), record_get[6](#0)
| Map -1

%1 =
| Get Bare Source for ? (u3)
| Filter !(isnull(#1))
| Map record_get[0](#1), record_get[1](#1), record_get[2](#1), record_get[3](#1), record_get[4](#1), record_get[5](#1), record_get[6](#1)
| Map 1

%2 =
| Union %0 %1
| FlatMap repeat(#9)
| | demand = (#2..#8)
| Project (#2..#8)

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5888)
<!-- Reviewable:end -->
