### PR TITLE
Fuse LinearOperator into upsert

### DIFF
--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -14,6 +14,19 @@ use expr::EvalError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub enum DecodeError {
+    Text(String),
+}
+
+impl Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::Text(e) => write!(f, "Text: {}", e),
+        }
+    }
+}
+
+#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum SourceError {
     FileIO(String),
 }
@@ -28,6 +41,7 @@ impl Display for SourceError {
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum DataflowError {
+    DecodeError(DecodeError),
     EvalError(EvalError),
     SourceError(SourceError),
 }
@@ -35,9 +49,16 @@ pub enum DataflowError {
 impl Display for DataflowError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            DataflowError::DecodeError(e) => write!(f, "Decode error: {}", e),
             DataflowError::EvalError(e) => write!(f, "Evaluation error: {}", e),
             DataflowError::SourceError(e) => write!(f, "Source error: {}", e),
         }
+    }
+}
+
+impl From<DecodeError> for DataflowError {
+    fn from(e: DecodeError) -> Self {
+        Self::DecodeError(e)
     }
 }
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -208,6 +208,8 @@ where
                             self.as_of_frontier.clone(),
                             key_decoder,
                             value_decoder,
+                            &mut src.operators,
+                            src.bare_desc.typ().arity(),
                         )
                     } else {
                         // TODO(brennan) -- this should just be a MirRelationExpr::FlatMap using regexp_extract, csv_extract,

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -90,6 +90,16 @@ where
                 predicates.push(predicate);
             }
         }
+        // Temporal predicates will be applied after blanking out column,
+        // so ensure that their support is preserved.
+        // TODO: consider blanking out columns added by this processes in
+        // the temporal filtering operator.
+        for predicate in temporal.iter() {
+            operators.projection.extend(predicate.support());
+        }
+        operators.projection.sort();
+        operators.projection.dedup();
+
         // Overwrite `position_or` to reflect `operators.projection`.
         position_or = (0..source_arity)
             .map(|col| {


### PR DESCRIPTION
This PR fuses linear operator behavior (predicates and default values in projected out columns) into the upsert operator. It does this just after we first fully decode a row, and before we stash it in our large maintained collection.

Some changes: these predicates can error, so what we store is no longer a `Row`, but a `Result<Row, DataflowError>`. I added a `DecodeError` variant to `DataflowError`. Errors can be retracted just like rows, should a new row with the same key show up and produce something different (valid data, a different error).

Not everything works yet, but I wanted to put up the first draft. In particular, 
1. Not all errors are threaded through; some are less easily addressed.
2. We could filter more aggressively on key columns; I'm going to wait for MFP to do that.
3. Temporal filters are noticed and then ignored. Should be an easy patch up.

Probably some other things too, including having done no tests at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5905)
<!-- Reviewable:end -->
