### PR TITLE
Update editorconfig with our current standard line lengths

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,10 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
+max_line_length = 100
+
+[*.md]
+max_line_length = 80
 
 [*.js]
 indent_size = 2


### PR DESCRIPTION
All code is generally configured to be max 100 chars wide, and as far as I can tell the majority
of our markdown files are wrapped at column 80.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5906)
<!-- Reviewable:end -->
