### PR TITLE
explicitly retrieve default partition/replication config from kafka

### DIFF
--- a/src/coord/src/sink_connector.rs
+++ b/src/coord/src/sink_connector.rs
@@ -11,7 +11,7 @@ use std::fs::OpenOptions;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
-use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
+use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
 
@@ -37,12 +37,94 @@ pub async fn build(
 async fn register_kafka_topic(
     client: &AdminClient<DefaultClientContext>,
     topic: &str,
-    partition_count: i32,
-    replication_factor: i32,
+    mut partition_count: i32,
+    mut replication_factor: i32,
     ccsr: &ccsr::Client,
     value_schema: &str,
     key_schema: Option<&str>,
 ) -> Result<(Option<i32>, i32), CoordError> {
+    // if either partition count or replication factor should be defaulted to the broker's config
+    // (signaled by a value of -1), explicitly poll the broker to discover the defaults.
+    // Newer versions of Kafka can instead send create topic requests with -1 and have this happen
+    // behind the scenes, but this is unsupported and will result in errors on pre-2.4 Kafka
+    if partition_count == -1 || replication_factor == -1 {
+        let metadata = client
+            .inner()
+            .fetch_metadata(None, Duration::from_secs(5))
+            .with_context(|| {
+                format!(
+                    "error fetching metadata when creating new topic {} for sink",
+                    topic
+                )
+            })?;
+
+        if metadata.brokers().len() == 0 {
+            coord_bail!("zero brokers discovered in metadata request");
+        }
+
+        let broker = metadata.brokers()[0].id();
+        let configs = client
+            .describe_configs(
+                &[ResourceSpecifier::Broker(broker)],
+                &AdminOptions::new().request_timeout(Some(Duration::from_secs(5))),
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "error fetching configuration from broker {} when creating new topic {} for sink",
+                    broker,
+                    topic
+                )
+        })?;
+
+        if configs.len() != 1 {
+            coord_bail!(
+                "error creating topic {} for sink: broker {} returned {} config results, but one was expected",
+                topic,
+                broker,
+                configs.len()
+            );
+        }
+
+        let config = configs.into_element().map_err(|e| {
+            anyhow!(
+                "error reading broker configuration when creating topic {} for sink: {}",
+                topic,
+                e
+            )
+        })?;
+
+        for entry in config.entries {
+            if entry.name == "num.partitions" && partition_count == -1 {
+                if let Some(s) = entry.value {
+                    partition_count = s.parse::<i32>().with_context(|| {
+                        format!(
+                            "default partition count {} cannot be parsed into an integer",
+                            s
+                        )
+                    })?;
+                }
+            } else if entry.name == "default.replication.factor" && replication_factor == -1 {
+                if let Some(s) = entry.value {
+                    replication_factor = s.parse::<i32>().with_context(|| {
+                        format!(
+                            "default replication factor {} cannot be parsed into an integer",
+                            s
+                        )
+                    })?;
+                }
+            }
+        }
+
+        if partition_count == -1 {
+            coord_bail!("default was requested for partition_count, but num.partitions was not found in broker config");
+        }
+
+        if replication_factor == -1 {
+            coord_bail!("default was requested for replication_factor, but default.replication.factor was not found in broker config");
+        }
+    }
+
     let res = client
         .create_topics(
             &[NewTopic::new(

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -196,3 +196,32 @@ snk7        user
 snk8        user
 sink9       user
 sink10      user
+
+# test explicit partition count
+> CREATE SINK sink11 FROM foo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink11'
+  WITH (partition_count=1)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# test explicit replication factor
+> CREATE SINK sink12 FROM foo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink12'
+  WITH (replication_factor=1)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# test explicit partition count and replication factor
+> CREATE SINK sink13 FROM foo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink13'
+  WITH (partition_count=1, replication_factor=1)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# test broker defaulted partition count and replication factor
+> CREATE SINK sink14 FROM foo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink14'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+# test explicit request for broker defaulted partition count and replication factor
+> CREATE SINK sink15 FROM foo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink15'
+  WITH (partition_count=-1, replication_factor=-1)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'


### PR DESCRIPTION
Kafka brokers have a notion of a default partition count and replication
factor. Newer versions of Kafka support setting -1 for these values in
client requests to pick up the default - older versions (pre 2.4) do not
and will instead throw an unsupported error.

This diff adds a code path that explicitly calls the Kafka API to
retrieve the default configurations.

To eliminate modality, this code path is used even for newer versions of
Kafka that support API calls setting -1.

There is extremely poor test coverage of this area. Notably, we do not
have test coverage for older versions of Kafka or Kafka with multiple
brokers (and thus do not have test coverage for partition counts or
replciation factors > 1).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5907)
<!-- Reviewable:end -->
