### PR TITLE
mzcompose: Correctly propagate env vars to sub-workflows

### DIFF
--- a/bin/ci-mzcompose
+++ b/bin/ci-mzcompose
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# test-mzcompose: runs mzcompose workflows that verify mzcompose works
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+. misc/shlib/shlib.bash
+
+for test_dir in test/mzcompose/* ; do
+     [[ ! -d "$test_dir" ]] && continue
+    dirname=$(basename "$test_dir")
+    echo "$test_dir"
+    runv bin/mzcompose --mz-find "$dirname" run ci
+done

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -207,6 +207,12 @@ steps:
           composition: dbt-materialize
           run: ci
 
+  - id: mzcompose-self
+    label: "mzcompose self test"
+    timeout_in_minutes: 10
+    inputs: [test/mzcompose, 'misc/python/materialize']
+    command: bin/ci-mzcompose
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -344,16 +344,19 @@ any non-alphanumeric characters.)
 
 ## Development
 
-mzbuild is a Python 3 library that lives in
-[misc/python/mzbuild.py](/misc/python). Its only dependency is Python 3.5+,
-which is easy to find or pre-installed on most Linux distributions, and
-pre-installed on recent versions of macOS, too. Python dependencies are
-automatically installed into a virtualenv by the [pyactivate wrapper
-script](/bin/pyactivate).
+mzbuild and mzcompose are Python 3 libraries that lives in
+[misc/python/materialize/cli](/misc/python/materialize/cli).
+
+Its only dependency is Python 3.5+, which is easy to find or pre-installed on
+most Linux distributions, and pre-installed on recent versions of macOS, too.
+Python dependencies are automatically installed into a virtualenv by the
+[pyactivate wrapper script](/bin/pyactivate).
 
 Using Python 3.6 would be a good bit more convenient, but our CI image runs on
 Ubuntu 16.04, which is still shipping Python 3.5. Supporting the oldest Ubuntu
 LTS release seems like a decent baseline, anyway.
+
+Integration tests for `mzcompose` are in [`test/mzcompose`](/test/mzcompose).
 
 ## Reference
 

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -438,6 +438,15 @@ class Workflow:
         for step in self._steps:
             step.run(self)
 
+    def run_with_env(self, env: Dict[str, str]) -> None:
+        """Run a workflow with a parent environment"""
+        old_env = self.env
+        self.env = dict(**old_env, **env)
+        try:
+            self.run()
+        finally:
+            self.env = old_env
+
     def run_compose(
         self, args: List[str], capture: bool = False
     ) -> subprocess.CompletedProcess:
@@ -1088,7 +1097,7 @@ class WorkflowWorkflowStep(WorkflowStep):
         try:
             # Run the specified workflow with the context of the parent workflow
             sub_workflow = workflow.composition.workflows[self._workflow]
-            sub_workflow.run()
+            sub_workflow.run_with_env(workflow.env)
         except KeyError:
             raise errors.UnknownItem(
                 f"workflow in {workflow.composition.name}",

--- a/test/mzcompose/README.md
+++ b/test/mzcompose/README.md
@@ -1,0 +1,5 @@
+# Integration Tests for mzcompose
+
+Each directory in here must contain an `mzcompose.yml` file that has a `ci`
+workflow or service. The mzcompose files in here are executed by
+`bin/ci-mzcompose` in the root of the repo.

--- a/test/mzcompose/test_env_setting/mzcompose.yml
+++ b/test/mzcompose/test_env_setting/mzcompose.yml
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+services:
+  check_env_set:
+    image: alpine:3
+    command: |
+      /bin/sh -c '
+      set -x ;
+      test "$ENV_IS_SET" == yeah ;'
+
+mzworkflows:
+  ci:
+    env:
+      ENV_IS_SET: yeah
+    steps:
+      - step: workflow
+        workflow: inheritor
+  inheritor:
+    steps:
+      - step: run
+        service: check_env_set


### PR DESCRIPTION
This also adds a bare-bones integration testing framework for mzcompose.

Relates to #5588

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5925)
<!-- Reviewable:end -->
