### PR TITLE
python: Update black, fix formatting

### DIFF
--- a/ci/cleanup/bintray.py
+++ b/ci/cleanup/bintray.py
@@ -19,16 +19,14 @@ def get_old_versions(pc: bintray.PackageClient) -> List[str]:
     versions = (pc.get_version(v).json() for v in version_strs)
 
     def is_old(v: Dict[str, str]) -> bool:
-        return datetime.now() - datetime.strptime(
-            v["created"],
-            # match the `Z` literally to work around
-            # python3.6 timezone parsing bugs.
-            #
-            # If Bintray ever sends us dates in a
-            # different time zone than `Z`, this
-            # will break.
-            "%Y-%m-%dT%H:%M:%S.%fZ",
-        ) > timedelta(days=14)
+        # match the `Z` literally to work around python3.6 timezone parsing
+        # bugs.
+        #
+        # If Bintray ever sends us dates in a different time zone than `Z`,
+        # this will break.
+        created_time = datetime.strptime(v["created"], "%Y-%m-%dT%H:%M:%S.%fZ")
+
+        return datetime.now() - created_time > timedelta(days=14)
 
     old_versions = [
         v["name"] for v in versions if dateutil.parser.parse(v["created"]) if is_old(v)

--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -70,8 +70,7 @@ def tag_docker(repo: mzbuild.Repository, tag: str) -> None:
 
 
 def tag_docker_latest_maybe(repo: mzbuild.Repository, tag: str) -> None:
-    """If this tag is greater than all other tags, and is a release, tag it `latest`
-    """
+    """If this tag is greater than all other tags, and is a release, tag it `latest`"""
     this_tag = semver.VersionInfo.parse(tag.lstrip("v"))
     if this_tag.prerelease is not None:
         return

--- a/misc/civiz/migrate/versions/3da7700dba2d_rename_inference_failure_to_wrong_.py
+++ b/misc/civiz/migrate/versions/3da7700dba2d_rename_inference_failure_to_wrong_.py
@@ -18,12 +18,8 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column(
-        "slt", "inference_failure", new_column_name="wrong_column_count",
-    )
+    op.alter_column("slt", "inference_failure", new_column_name="wrong_column_count")
 
 
 def downgrade():
-    op.alter_column(
-        "slt", "wrong_column_count", new_column_name="inference_failure",
-    )
+    op.alter_column("slt", "wrong_column_count", new_column_name="inference_failure")

--- a/misc/monitoring/dashboard/bin/log-prefixer.py
+++ b/misc/monitoring/dashboard/bin/log-prefixer.py
@@ -22,8 +22,7 @@ def main() -> None:
 
 
 def echo_files_with_prefixes(outfile: str, prefixes_files: Dict[str, str]) -> None:
-    """Start as many threads as there are files in prefixes_files, writing their output
-    """
+    """Start as many threads as there are files in prefixes_files, writing their output"""
     max_prefix_len = max(len(prefix) for prefix in prefixes_files)
     threads = []
     for prefix, fname in prefixes_files.items():
@@ -75,9 +74,7 @@ def parse_args() -> argparse.Namespace:
         description="Print all lines from files with different prefixes"
     )
     parser.add_argument("--output-file", default="/dev/stdout")
-    parser.add_argument(
-        "prefix_file", help="prefix=/the/file/to/read", nargs="*",
-    )
+    parser.add_argument("prefix_file", help="prefix=/the/file/to/read", nargs="*")
     args = parser.parse_args()
     print(args.prefix_file)
     args.prefix_file = [pf.split("=", 1) for pf in args.prefix_file]

--- a/misc/python/materialize/cli/mzbench.py
+++ b/misc/python/materialize/cli/mzbench.py
@@ -204,11 +204,11 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-v", "--verbose", action="store_true", help="Enable verbose logging output",
+        "-v", "--verbose", action="store_true", help="Enable verbose logging output"
     )
 
     parser.add_argument(
-        "composition", type=str, help="Name of the mzcompose composition to run",
+        "composition", type=str, help="Name of the mzcompose composition to run"
     )
 
     parser.add_argument(

--- a/misc/python/materialize/cli/mzimage.py
+++ b/misc/python/materialize/cli/mzimage.py
@@ -68,8 +68,7 @@ def main() -> int:
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse known args, or exit the program
-    """
+    """Parse known args, or exit the program"""
     parser = argparse.ArgumentParser(
         prog="mzimage",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -120,7 +120,7 @@ def docker_images() -> Set[str]:
     """List the Docker images available on the local machine."""
     return set(
         spawn.capture(
-            ["docker", "images", "--format", "{{.Repository}}:{{.Tag}}"], unicode=True,
+            ["docker", "images", "--format", "{{.Repository}}:{{.Tag}}"], unicode=True
         )
         .strip()
         .split("\n")
@@ -195,9 +195,7 @@ class CargoBuild(CargoPreImage):
         cargo_build = [self.rd.xcargo(), "build", "--bin", self.bin]
         if self.rd.release_mode:
             cargo_build.append("--release")
-        spawn.runv(
-            cargo_build, cwd=self.rd.root,
-        )
+        spawn.runv(cargo_build, cwd=self.rd.root)
         cargo_profile = "release" if self.rd.release_mode else "debug"
         shutil.copy(self.rd.xcargo_target_dir() / cargo_profile / self.bin, self.path)
         if self.strip:
@@ -693,14 +691,14 @@ class Repository:
     def resolve_dependencies(self, targets: Iterable[Image]) -> DependencySet:
         """Compute the dependency set necessary to build target images.
 
-         The dependencies of `targets` will be crawled recursively until the
-         complete set of transitive dependencies is determined or a circular
-         dependency is discovered. The returned dependency set will be sorted
-         in topological order.
+        The dependencies of `targets` will be crawled recursively until the
+        complete set of transitive dependencies is determined or a circular
+        dependency is discovered. The returned dependency set will be sorted
+        in topological order.
 
-         Raises:
-            ValueError: A circular dependency was discovered in the images
-                in the repository.
+        Raises:
+           ValueError: A circular dependency was discovered in the images
+               in the repository.
         """
         resolved = OrderedDict()
         visiting = set()

--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -199,7 +199,7 @@ class Composition:
                 if isinstance(env, dict):
                     env = {k: str(v) for k, v in env.items()}
                 self.workflows[workflow_name] = Workflow(
-                    workflow_name, built_steps, env=env, composition=self,
+                    workflow_name, built_steps, env=env, composition=self
                 )
 
         # Resolve all services that reference an `mzbuild` image to a specific
@@ -304,9 +304,7 @@ class Composition:
         # however, and we can pipe the container IDs into `docker inspect`,
         # which supports machine-readable output.
         containers = self.run(["ps", "-q"], capture=True).stdout.splitlines()
-        metadata = spawn.capture(
-            ["docker", "inspect", "-f", "{{json .}}", *containers,]
-        )
+        metadata = spawn.capture(["docker", "inspect", "-f", "{{json .}}", *containers])
         metadata = [json.loads(line) for line in metadata.splitlines()]
         ports = []
         for md in metadata:
@@ -349,7 +347,7 @@ class Composition:
         except subprocess.CalledProcessError as e:
             ui.log_in_automation(
                 "docker inspect ({}): error running {}: {}, stdout:\n{}\nstderr:\n{}".format(
-                    container_id, ui.shell_quote(cmd), e, e.stdout, e.stderr,
+                    container_id, ui.shell_quote(cmd), e, e.stdout, e.stderr
                 )
             )
             raise errors.Failed(f"failed to inspect Docker container: {e}")
@@ -796,9 +794,7 @@ class WaitForTcpStep(WorkflowStep):
         self._timeout_secs = timeout_secs
 
     def run(self, workflow: Workflow) -> None:
-        ui.progress(
-            f"waiting for {self._host}:{self._port}", "C",
-        )
+        ui.progress(f"waiting for {self._host}:{self._port}", "C")
         for remaining in ui.timeout_loop(self._timeout_secs):
             cmd = f"docker run --rm -t --network {workflow.composition.name}_default ubuntu:bionic-20200403".split()
             cmd.extend(
@@ -884,7 +880,7 @@ class RandomChaos(WorkflowStep):
     ]
 
     def __init__(
-        self, chaos: List[str] = [], services: List[str] = [], other_service: str = "",
+        self, chaos: List[str] = [], services: List[str] = [], other_service: str = ""
     ):
         self._chaos = chaos
         self._services = services

--- a/misc/python/materialize/spawn.py
+++ b/misc/python/materialize/spawn.py
@@ -63,7 +63,7 @@ def runv(
         stdout = subprocess.PIPE
         stderr = subprocess.PIPE
     return subprocess.run(
-        args, cwd=cwd, stdin=stdin, stdout=stdout, stderr=stderr, check=True, env=env,
+        args, cwd=cwd, stdin=stdin, stdout=stdout, stderr=stderr, check=True, env=env
     )
 
 

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -65,8 +65,7 @@ def confirm(question: str) -> bool:
 def progress(
     msg: str = "", prefix: Optional[str] = None, *, finish: bool = False
 ) -> None:
-    """Print a progress message to stderr, using the same prefix format as speaker
-    """
+    """Print a progress message to stderr, using the same prefix format as speaker"""
     if prefix is not None:
         msg = f"{prefix}> {msg}"
     end = "" if not finish else "\n"
@@ -124,8 +123,7 @@ def env_is_truthy(env_var: str) -> bool:
 
 
 def warn_docker_resource_limits() -> None:
-    """Check docker for recommended resource limits
-    """
+    """Check docker for recommended resource limits"""
     warn = speaker("WARN:")
 
     limits = docker.resource_limits()

--- a/misc/python/requirements-dev.txt
+++ b/misc/python/requirements-dev.txt
@@ -1,5 +1,5 @@
 awscli==1.18.43
-black==19.10b0
+black==20.8b1
 humanize==2.3.0
 mypy==0.790
 pdoc3==0.8.1


### PR DESCRIPTION
A 2020 version of black updated to change the way that it formats arg lists and
lists, such that a trailing comma means "always do multiline formatting".

A couple of the changes in here are black being stricter about docstrings, but
many of them are just getting rid of trailing commas so that it preserves our
existing formatting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5926)
<!-- Reviewable:end -->
