### PR TITLE
Move chbench kafka directory back into Docker

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -437,10 +437,6 @@ mzworkflows:
       seconds: 1
 
   download-snapshot:
-    env:
-      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
-      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
       - step: run
         service: aws-cli

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -342,9 +342,9 @@ mzworkflows:
   # Leaves the cluster running
   setup-ingest-benchmark:
     env:
-      MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
+      MZ_KAFKA_SHARED: '${MZ_KAFKA_SHARED:-./tmp}'
+      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
@@ -380,9 +380,9 @@ mzworkflows:
   # already called setup-ingest-benchmark and the cluster is still running
   measure-ingest-performance:
     env:
-      MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
+      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
+      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
     steps:
     - step: restart-services
       services: [materialized]
@@ -396,9 +396,9 @@ mzworkflows:
   # Take a snapshot of topic schemas and contents
   generate-snapshot:
     env:
-      MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
+      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
+      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
     steps:
     - step: run
       service: peeker
@@ -410,9 +410,9 @@ mzworkflows:
   # Then run Materialize and measure time until it catches up to snapshotted view state
   setup-replay-benchmark:
     env:
-      MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
+      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
+      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
     steps:
     # start the dashboard before the load data get started so that we have data from
     # the beginning of time
@@ -437,9 +437,9 @@ mzworkflows:
 
   download-snapshot:
     env:
-      MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
+      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
+      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
     steps:
       - step: run
         service: aws-cli

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -34,7 +34,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT_DIR}:/snapshot
+      - ${MZ_KAFKA_SHARED_DIR}:/snapshot
   materialized:
     mzbuild: materialized
     ports:
@@ -98,8 +98,8 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper-data:/var/lib/zookeeper/data
-      - ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper-log:/var/lib/zookeeper/log
+      - ${MZ_KAFKA_SHARED:-kafka-data}/zookeeper-data:/var/lib/zookeeper/data
+      - ${MZ_KAFKA_SHARED:-kafka-data}/zookeeper-log:/var/lib/zookeeper/log
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
@@ -122,7 +122,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data:/var/lib/kafka/data
+      - ${MZ_KAFKA_SHARED_INTERNAL:-kafka-data}:/var/lib/kafka/data
   connect:
     image: debezium/connect:1.4
     environment:
@@ -192,11 +192,11 @@ services:
   mzutil:
     mzbuild: mzutil
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT:-mzutil}:/snapshot
+      - ${MZ_KAFKA_SHARED}:/snapshot
   kafka-util:
     mzbuild: kafka-util
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT:-kafkautil}:/snapshot
+      - ${MZ_KAFKA_SHARED}:/snapshot
 
   # Metabase
   # We need to ~manually add our `metabase-materialize-driver` to /plugins
@@ -259,7 +259,7 @@ services:
     command: ${PEEKER_CMD:---queries q01,q02,q17}
     volumes:
       - ./peeker-config:/etc/peeker
-      - ${MZ_CHBENCH_SNAPSHOT:-/tmp}:/snapshot
+      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
   test-correctness:
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
     mzbuild: test-correctness
@@ -278,8 +278,8 @@ volumes:
   grafana:
   prometheus:
   view-snapshots:
-  mzutil:
-  kafkautil:
+  # a shared volume for load tests, but a mounted directory for benchmarks
+  kafka-data:
 
 mzworkflows:
   ci:
@@ -340,6 +340,9 @@ mzworkflows:
   # Once chbench exits, record offsets ingested by Materialize and view states
   # Leaves the cluster running
   setup-ingest-benchmark:
+    env:
+      MZ_KAFKA_SHARED: './tmp'
+      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
@@ -374,6 +377,9 @@ mzworkflows:
   # Run a workflow to measure the ingest performance of Materialize. Assumes that the you have
   # already called setup-ingest-benchmark and the cluster is still running
   measure-ingest-performance:
+    env:
+      MZ_KAFKA_SHARED: './tmp'
+      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
     steps:
     - step: restart-services
       services: [materialized]
@@ -386,6 +392,9 @@ mzworkflows:
   # Record offsets ingested by Materialize and the answers to our count(*) views
   # Take a snapshot of topic schemas and contents
   generate-snapshot:
+    env:
+      MZ_KAFKA_SHARED: './tmp'
+      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
     steps:
     - step: run
       service: peeker
@@ -396,6 +405,9 @@ mzworkflows:
   # Run a test that populates Kafka with data from topic snapshots
   # Then run Materialize and measure time until it catches up to snapshotted view state
   setup-replay-benchmark:
+    env:
+      MZ_KAFKA_SHARED: './tmp'
+      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
     steps:
     # start the dashboard before the load data get started so that we have data from
     # the beginning of time

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -436,6 +436,10 @@ mzworkflows:
       seconds: 1
 
   download-snapshot:
+    env:
+      MZ_KAFKA_SHARED: './tmp'
+      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
     steps:
       - step: run
         service: aws-cli

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -34,7 +34,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
     volumes:
-      - ${MZ_KAFKA_SHARED_DIR}:/snapshot
+      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
   materialized:
     mzbuild: materialized
     ports:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -122,7 +122,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT_KAFKA_DATA:-kafka-data}:/var/lib/kafka/data
+      - ${MZ_CHBENCH_SNAPSHOT_KAFKA_DATA:-mzsnap-data}:/var/lib/kafka/data
   connect:
     image: debezium/connect:1.4
     environment:
@@ -192,11 +192,11 @@ services:
   mzutil:
     mzbuild: mzutil
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT:-kafka-data}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-mzsnap-data}:/snapshot
   kafka-util:
     mzbuild: kafka-util
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT:-kafka-data}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-mzsnap-data}:/snapshot
 
   # Metabase
   # We need to ~manually add our `metabase-materialize-driver` to /plugins
@@ -259,7 +259,7 @@ services:
     command: ${PEEKER_CMD:---queries q01,q02,q17}
     volumes:
       - ./peeker-config:/etc/peeker
-      - ${MZ_CHBENCH_SNAPSHOT:-kafka-data}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-mzsnap-data}:/snapshot
   test-correctness:
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
     mzbuild: test-correctness
@@ -280,7 +280,7 @@ volumes:
   view-snapshots:
 
   # shared volumes for load tests, but a mounted directories for benchmarks
-  kafka-data:
+  mzsnap-data:
   zk-data:
 
 mzworkflows:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -34,7 +34,8 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
     volumes:
-      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
+      # this is the dir that contains all the individual snapshot directories
+      - ${MZ_CHBENCH_SNAPSHOT_DIR}:/snapshot
   materialized:
     mzbuild: materialized
     ports:
@@ -98,7 +99,7 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     volumes:
-      - ${MZ_KAFKA_SHARED_ZK_DATA:-zk-data}:/var/lib/zookeeper
+      - ${MZ_CHBENCH_SNAPSHOT_ZK_DATA:-zk-data}:/var/lib/zookeeper
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
@@ -121,7 +122,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
     volumes:
-      - ${MZ_KAFKA_SHARED_SNAPSHOT:-kafka-data}:/var/lib/kafka/data
+      - ${MZ_CHBENCH_SNAPSHOT_SNAPSHOT:-kafka-data}:/var/lib/kafka/data
   connect:
     image: debezium/connect:1.4
     environment:
@@ -191,11 +192,11 @@ services:
   mzutil:
     mzbuild: mzutil
     volumes:
-      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-kafka-data}:/snapshot
   kafka-util:
     mzbuild: kafka-util
     volumes:
-      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-kafka-data}:/snapshot
 
   # Metabase
   # We need to ~manually add our `metabase-materialize-driver` to /plugins
@@ -258,7 +259,7 @@ services:
     command: ${PEEKER_CMD:---queries q01,q02,q17}
     volumes:
       - ./peeker-config:/etc/peeker
-      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-kafka-data}:/snapshot
   test-correctness:
     # NOTE: we really don't want to include depends_on, it causes dependencies to be restarted
     mzbuild: test-correctness
@@ -342,9 +343,9 @@ mzworkflows:
   # Leaves the cluster running
   setup-ingest-benchmark:
     env:
-      MZ_KAFKA_SHARED: '${MZ_KAFKA_SHARED:-./tmp}'
-      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}'
+      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
@@ -380,9 +381,9 @@ mzworkflows:
   # already called setup-ingest-benchmark and the cluster is still running
   measure-ingest-performance:
     env:
-      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
-      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
+      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     - step: restart-services
       services: [materialized]
@@ -396,9 +397,9 @@ mzworkflows:
   # Take a snapshot of topic schemas and contents
   generate-snapshot:
     env:
-      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
-      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
+      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     - step: run
       service: peeker
@@ -410,9 +411,9 @@ mzworkflows:
   # Then run Materialize and measure time until it catches up to snapshotted view state
   setup-replay-benchmark:
     env:
-      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
-      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
+      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     # start the dashboard before the load data get started so that we have data from
     # the beginning of time
@@ -437,9 +438,9 @@ mzworkflows:
 
   download-snapshot:
     env:
-      MZ_KAFKA_SHARED: ${MZ_KAFKA_SHARED:-'./tmp'}
-      MZ_KAFKA_SHARED_SNAPSHOT: '${MZ_KAFKA_SHARED:-./tmp}/kafka-data'
-      MZ_KAFKA_SHARED_ZK_DATA: '${MZ_KAFKA_SHARED:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
+      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
       - step: run
         service: aws-cli

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -191,11 +191,11 @@ services:
   mzutil:
     mzbuild: mzutil
     volumes:
-      - ${MZ_KAFKA_SHARED}:/snapshot
+      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
   kafka-util:
     mzbuild: kafka-util
     volumes:
-      - ${MZ_KAFKA_SHARED}:/snapshot
+      - ${MZ_KAFKA_SHARED:-kafka-data}:/snapshot
 
   # Metabase
   # We need to ~manually add our `metabase-materialize-driver` to /plugins

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -98,8 +98,7 @@ services:
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     volumes:
-      - ${MZ_KAFKA_SHARED:-kafka-data}/zookeeper-data:/var/lib/zookeeper/data
-      - ${MZ_KAFKA_SHARED:-kafka-data}/zookeeper-log:/var/lib/zookeeper/log
+      - ${MZ_KAFKA_SHARED_ZK_DATA:-zk-data}:/var/lib/zookeeper
   kafka:
     image: confluentinc/cp-enterprise-kafka:5.5.3
     ports:
@@ -122,7 +121,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
     volumes:
-      - ${MZ_KAFKA_SHARED_INTERNAL:-kafka-data}:/var/lib/kafka/data
+      - ${MZ_KAFKA_SHARED_SNAPSHOT:-kafka-data}:/var/lib/kafka/data
   connect:
     image: debezium/connect:1.4
     environment:
@@ -278,8 +277,10 @@ volumes:
   grafana:
   prometheus:
   view-snapshots:
-  # a shared volume for load tests, but a mounted directory for benchmarks
+
+  # shared volumes for load tests, but a mounted directories for benchmarks
   kafka-data:
+  zk-data:
 
 mzworkflows:
   ci:
@@ -342,7 +343,8 @@ mzworkflows:
   setup-ingest-benchmark:
     env:
       MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
@@ -379,7 +381,8 @@ mzworkflows:
   measure-ingest-performance:
     env:
       MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
     steps:
     - step: restart-services
       services: [materialized]
@@ -394,7 +397,8 @@ mzworkflows:
   generate-snapshot:
     env:
       MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
     steps:
     - step: run
       service: peeker
@@ -407,7 +411,8 @@ mzworkflows:
   setup-replay-benchmark:
     env:
       MZ_KAFKA_SHARED: './tmp'
-      MZ_KAFKA_SHARED_INTERNAL: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_SNAPSHOT: './tmp/kafka-data'
+      MZ_KAFKA_SHARED_ZK_DATA: './tmp/zookeeper'
     steps:
     # start the dashboard before the load data get started so that we have data from
     # the beginning of time

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -122,7 +122,7 @@ services:
       CONFLUENT_METRICS_REPORTER_TOPIC_CREATE: "false"
       KAFKA_JMX_PORT: 9991
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT_SNAPSHOT:-kafka-data}:/var/lib/kafka/data
+      - ${MZ_CHBENCH_SNAPSHOT_KAFKA_DATA:-kafka-data}:/var/lib/kafka/data
   connect:
     image: debezium/connect:1.4
     environment:
@@ -344,7 +344,7 @@ mzworkflows:
   setup-ingest-benchmark:
     env:
       MZ_CHBENCH_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}'
-      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
       MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     - step: workflow
@@ -382,7 +382,7 @@ mzworkflows:
   measure-ingest-performance:
     env:
       MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
       MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     - step: restart-services
@@ -398,7 +398,7 @@ mzworkflows:
   generate-snapshot:
     env:
       MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
       MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     - step: run
@@ -412,7 +412,7 @@ mzworkflows:
   setup-replay-benchmark:
     env:
       MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
       MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
     # start the dashboard before the load data get started so that we have data from
@@ -439,7 +439,7 @@ mzworkflows:
   download-snapshot:
     env:
       MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
       MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
     steps:
       - step: run


### PR DESCRIPTION
This ensures that the existing clean up logic works correctly and deletes
previous runs on re-used hardware.

It also guarantees that the data goes into the docker volume on our EC2
instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5928)
<!-- Reviewable:end -->
