### PR TITLE
Fixup docker volume mounts for mzutil / kafkautil

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -192,11 +192,11 @@ services:
   mzutil:
     mzbuild: mzutil
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-mzutil}:/snapshot
   kafka-util:
     mzbuild: kafka-util
     volumes:
-      - ${MZ_CHBENCH_SNAPSHOT}:/snapshot
+      - ${MZ_CHBENCH_SNAPSHOT:-kafkautil}:/snapshot
 
   # Metabase
   # We need to ~manually add our `metabase-materialize-driver` to /plugins
@@ -278,6 +278,8 @@ volumes:
   grafana:
   prometheus:
   view-snapshots:
+  mzutil:
+  kafkautil:
 
 mzworkflows:
   ci:


### PR DESCRIPTION
When running the ingest benchmark, there is no snapshot defined;
fallback to using a docker volume for mzutil and kafkautil.