### PR TITLE
Two fixups for chbench ingest benchmark

### DIFF
--- a/demo/chbench/bin/generate_snapshot
+++ b/demo/chbench/bin/generate_snapshot
@@ -98,7 +98,7 @@ main() {
     # Record the arguments used to generate this snapshot
     env > "${snapshot}/snapshot.env"
 
-    "$project"/mzcompose run generate-snapshot
+    "$project"/mzcompose run prepare-snapshot
     "$project"/mzcompose down
 
     # Compress directories to reduce bytes transferred

--- a/demo/chbench/bin/ingest_bench
+++ b/demo/chbench/bin/ingest_bench
@@ -85,7 +85,7 @@ main() {
     export NUM_WAREHOUSES="${warehouses}"
     export CHBENCH_RUN_SECONDS="${chbench_seconds}"
 
-    "$project"/mzcompose run setup-ingest-benchmark
+    "$project"/mzcompose run prepare-snapshot
 
     for i in $(seq 1 "${num_measurements}"); do
         echo "Conducting measurement ${i} of ${num_measurements}"

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -338,15 +338,18 @@ mzworkflows:
         --only-initialize
         -q loadtest
 
-  # Run a test that populates Kafka with data from chbench for a set amount of time
-  # Once chbench exits, record offsets ingested by Materialize and view states
-  # Leaves the cluster running
-  setup-ingest-benchmark:
+  # After the first timer expires, stop chbench and wait for the data to stabilize
+  # Record offsets ingested by Materialize and the answers to our count(*) views
+  # Stops the load generator and source database but leaves the rest of the cluster running
+  prepare-snapshot:
     env:
       MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
       MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data
       MZ_CHBENCH_SNAPSHOT_ZK_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper
     steps:
+    - step: run
+      service: peeker
+      command: --write-config /snapshot/config.toml
     - step: workflow
       workflow: bring-up-source-data-mysql
     # start the dashboard before the load data get started so that we have data from
@@ -378,7 +381,7 @@ mzworkflows:
       command: snapshot_view_states.py
 
   # Run a workflow to measure the ingest performance of Materialize. Assumes that the you have
-  # already called setup-ingest-benchmark and the cluster is still running
+  # already called prepare-snapshot and the cluster is still running
   measure-ingest-performance:
     env:
       MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
@@ -390,22 +393,6 @@ mzworkflows:
     - step: run
       service: mzutil
       command: wait_for_view_states.py
-
-  # Run a test that populates Kafka with data from chbench for a set amount of time
-  # After the first timer expires, stop chbench and wait for the data to stabilize
-  # Record offsets ingested by Materialize and the answers to our count(*) views
-  # Take a snapshot of topic schemas and contents
-  generate-snapshot:
-    env:
-      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
-      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data
-      MZ_CHBENCH_SNAPSHOT_ZK_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper
-    steps:
-    - step: run
-      service: peeker
-      command: --write-config /snapshot/config.toml
-    - step: workflow
-      workflow: setup-ingest-benchmark
 
   # Run a test that populates Kafka with data from topic snapshots
   # Then run Materialize and measure time until it catches up to snapshotted view state

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -343,9 +343,9 @@ mzworkflows:
   # Leaves the cluster running
   setup-ingest-benchmark:
     env:
-      MZ_CHBENCH_SNAPSHOT: '${MZ_CHBENCH_SNAPSHOT:-./tmp}'
-      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
-      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper
     steps:
     - step: workflow
       workflow: bring-up-source-data-mysql
@@ -381,9 +381,9 @@ mzworkflows:
   # already called setup-ingest-benchmark and the cluster is still running
   measure-ingest-performance:
     env:
-      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
-      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper
     steps:
     - step: restart-services
       services: [materialized]
@@ -397,9 +397,9 @@ mzworkflows:
   # Take a snapshot of topic schemas and contents
   generate-snapshot:
     env:
-      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
-      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper
     steps:
     - step: run
       service: peeker
@@ -411,9 +411,9 @@ mzworkflows:
   # Then run Materialize and measure time until it catches up to snapshotted view state
   setup-replay-benchmark:
     env:
-      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-'./tmp'}
-      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data'
-      MZ_CHBENCH_SNAPSHOT_ZK_DATA: '${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper'
+      MZ_CHBENCH_SNAPSHOT: ${MZ_CHBENCH_SNAPSHOT:-./tmp}
+      MZ_CHBENCH_SNAPSHOT_KAFKA_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/kafka-data
+      MZ_CHBENCH_SNAPSHOT_ZK_DATA: ${MZ_CHBENCH_SNAPSHOT:-./tmp}/zookeeper
     steps:
     # start the dashboard before the load data get started so that we have data from
     # the beginning of time


### PR DESCRIPTION
The first issue was the strings in the variable names causing docker to treat a variable as a volume name, when we wanted docker to treat it like a pathname.

The second is that the ingest benchmark setup needs to write out the peeker configuration file, which makes it identical to the workflow for preparing a snapshot. Unify these workflows.

I'm still testing now to make sure this works.

Also, I'd love to get rid of the `./tmp` part of the pathname, but that's more complicated than I'd like to take on right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5942)
<!-- Reviewable:end -->
