### PR TITLE
Allow materialized to be run in dev mode in mzcompose files

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -25,6 +25,7 @@ services:
     command: --workers ${MZ_WORKERS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
+      - MZ_DEV=1
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3
     environment:

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -55,6 +55,7 @@ services:
       # You can, for example, add `pgwire=trace` or change `info` to `debug` to
       # get more verbose logs.
       - MZ_LOG=pgwire=debug,info
+      - MZ_DEV=1
   mysql:
     mzbuild: chbench-mysql
     ports:

--- a/demo/http_logs/mzcompose.yml
+++ b/demo/http_logs/mzcompose.yml
@@ -25,6 +25,8 @@ services:
       - *materialized
     init: true
     command: -w4 --disable-telemetry
+    environment:
+      - MZ_DEV=1
     volumes:
       - logfile:/log
 

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -16,6 +16,8 @@ services:
     mzbuild: materialized
     init: true
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
     ports:
       - *materialized
   mysql:

--- a/misc/dbt-materialize/mzcompose.yml
+++ b/misc/dbt-materialize/mzcompose.yml
@@ -15,6 +15,8 @@ services:
   materialized:
     mzbuild: materialized
     command: --disable-telemetry
+    environment:
+      - MZ_DEV=1
     ports:
       - *materialized
     init: true

--- a/play/mbta/mzcompose.yml
+++ b/play/mbta/mzcompose.yml
@@ -16,6 +16,8 @@ services:
   materialized:
     mzbuild: materialized
     command: --disable-telemetry
+    environment:
+      - MZ_DEV=1
     ports:
       - *materialized
     init: true

--- a/play/wikirecent/mzcompose.yml
+++ b/play/wikirecent/mzcompose.yml
@@ -26,6 +26,8 @@ services:
   materialized:
     mzbuild: materialized
     command: --disable-telemetry
+    environment:
+      - MZ_DEV=1
     ports:
       - *materialized
     init: true

--- a/test/benchmark/avro-upsert/mzcompose.yml
+++ b/test/benchmark/avro-upsert/mzcompose.yml
@@ -46,7 +46,7 @@ services:
   materialized:
     mzbuild: materialized
     ports:
-     - *materialized
+      - *materialized
     init: true
     command:
       - --workers=${MZ_WORKERS:-16}
@@ -63,6 +63,7 @@ services:
       # You can, for example, add `pgwire=trace` or change `info` to `debug` to
       # get more verbose logs.
       - MZ_LOG=pgwire=debug,info
+      - MZ_DEV=1
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3
     environment:

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -35,6 +35,8 @@ services:
       - *materialized
     init: true
     command: -w4 --disable-telemetry
+    environment:
+      - MZ_DEV=1
 
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3

--- a/test/kafka-krb5/mzcompose.yml
+++ b/test/kafka-krb5/mzcompose.yml
@@ -84,6 +84,8 @@ services:
     volumes:
       - secrets:/share/secrets
       - ./kdc/krb5.conf:/etc/krb5.conf
+    environment:
+      - MZ_DEV=1
 
   testdrive:
     mzbuild: testdrive

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -48,6 +48,8 @@ services:
   materialized:
     mzbuild: materialized
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
     volumes:
       - secrets:/share/secrets
     depends_on: [test-certs]

--- a/test/kafka-ssl/mzcompose.yml
+++ b/test/kafka-ssl/mzcompose.yml
@@ -48,6 +48,8 @@ services:
     volumes:
       - secrets:/share/secrets
     depends_on: [test-certs]
+    environment:
+      - MZ_DEV=1
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3
     environment:

--- a/test/lang/csharp/mzcompose.yml
+++ b/test/lang/csharp/mzcompose.yml
@@ -12,6 +12,8 @@ services:
   materialized:
     mzbuild: materialized
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
   csharp:
     image: mcr.microsoft.com/dotnet/sdk:5.0-focal
     command: /workdir/test/lang/csharp/test.sh

--- a/test/lang/java/mzcompose.yml
+++ b/test/lang/java/mzcompose.yml
@@ -12,6 +12,8 @@ services:
   materialized:
     mzbuild: materialized
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
   java-smoketest:
     mzbuild: ci-java-smoketest
     command: mvn test

--- a/test/lang/js/mzcompose.yml
+++ b/test/lang/js/mzcompose.yml
@@ -12,6 +12,8 @@ services:
   materialized:
     mzbuild: materialized
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
   js:
     image: node:13.12.0
     command: /workdir/test/lang/js/test.sh

--- a/test/lang/python/mzcompose.yml
+++ b/test/lang/python/mzcompose.yml
@@ -12,6 +12,8 @@ services:
   materialized:
     mzbuild: materialized
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
   python:
     image: python:3.9.0-buster
     command: /workdir/test/lang/python/test.sh

--- a/test/metabase/mzcompose.yml
+++ b/test/metabase/mzcompose.yml
@@ -12,6 +12,8 @@ services:
   materialized:
     mzbuild: materialized
     command: -w1 --disable-telemetry
+    environment:
+      - MZ_DEV=1
   metabase:
     image: materialize/metabase:v0.0.5
     ports:

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -31,7 +31,8 @@ services:
       - *materialized
     init: true
     command: -w ${MZ_WORKERS:-4} --disable-telemetry
-
+    environment:
+      - MZ_DEV=1
   dashboard:
     mzbuild: dashboard
     environment:

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -22,6 +22,7 @@ services:
     command: --workers ${MZ_WORKERS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
+      - MZ_DEV=1
   zookeeper:
     image: confluentinc/cp-zookeeper:5.5.3
     environment:

--- a/test/smith/mzcompose.yml
+++ b/test/smith/mzcompose.yml
@@ -17,6 +17,7 @@ services:
     command: --workers 1 --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info
+      - MZ_DEV=1
   smith-fuzz:
     mzbuild: smith-fuzz
     environment:

--- a/test/tb/mzcompose.yml
+++ b/test/tb/mzcompose.yml
@@ -15,6 +15,8 @@ services:
     ports: [6875]
     volumes:
       - tbshare:/tbshare
+    environment:
+      - MZ_DEV=1
   mysql:
     image: debezium/example-mysql:1.4
     ports: [3306]


### PR DESCRIPTION
This is useful when debugging, and unlike other use cases people have to know a
lot to be able to trigger dev mode in mzcompose, making it unlikely to happen
by accident there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5958)
<!-- Reviewable:end -->
