### PR TITLE
sql: support multiple start_offsets for partitioned Kafka topics

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -541,21 +541,35 @@ pub fn plan_create_source(
 
             // THIS IS EXPERIMENTAL - DO NOT DOCUMENT IT
             // until we have had time to think about what the right UX/design is on a non-urgent timeline!
-            // In particular, we almost certainly want the offsets to be specified per-partition.
-            // The other major caveat is that by using this feature, you are opting in to
-            // not using updates or deletes in CDC sources, and accepting panics if that constraint is violated.
-            let start_offset_err = "start_offset must be a nonnegative integer";
-            let start_offset = match with_options.remove("start_offset") {
-                None => 0,
-                Some(Value::Number(n)) => match n.parse::<i64>() {
-                    Ok(n) if n >= 0 => n,
-                    _ => bail!(start_offset_err),
-                },
-                Some(_) => bail!(start_offset_err),
+            // By using this feature, you are opting in to not using updates or deletes in CDC sources, and
+            // accepting panics if that constraint is violated.
+            if with_options.contains_key("start_offset") && consistency != Consistency::RealTime {
+                bail!("`start_offset` is not yet implemented for non-realtime consistency sources.")
+            }
+            let parse_offset = |s: &str| match s.parse::<i64>() {
+                Ok(n) if n >= 0 => Ok(n),
+                _ => bail!("start_offset must be a nonnegative integer"),
             };
 
-            if start_offset != 0 && consistency != Consistency::RealTime {
-                bail!("`start_offset` is not yet implemented for BYO consistency sources.")
+            let mut start_offsets = HashMap::new();
+            match with_options.remove("start_offset") {
+                None => {
+                    start_offsets.insert(0, 0);
+                }
+                Some(Value::Number(n)) => {
+                    start_offsets.insert(0, parse_offset(&n)?);
+                }
+                Some(Value::Array(vs)) => {
+                    for (i, v) in vs.iter().enumerate() {
+                        match v {
+                            Value::Number(n) => {
+                                start_offsets.insert(i32::try_from(i)?, parse_offset(n)?);
+                            }
+                            _ => bail!("start_offset value must be a number: {}", v),
+                        }
+                    }
+                }
+                Some(v) => bail!("invalid start_offset value: {}", v),
             }
 
             let enable_caching = match with_options.remove("cache") {
@@ -567,9 +581,6 @@ pub fn plan_create_source(
             if enable_caching && consistency != Consistency::RealTime {
                 unsupported!("BYO source caching")
             }
-
-            let mut start_offsets = HashMap::new();
-            start_offsets.insert(0, start_offset);
 
             let connector = ExternalSourceConnector::Kafka(KafkaSourceConnector {
                 addrs: broker.parse()?,

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -226,6 +226,133 @@ a b
 1 2
 2 3
 
+# Test an Avro source without a Debezium envelope starting at specified partition offsets.
+
+$ kafka-create-topic topic=non-dbz-data-multi-partition partitions=2
+
+$ kafka-ingest format=avro topic=non-dbz-data-multi-partition schema=${non-dbz-schema} timestamp=1 partition=1
+{"a": 4, "b": 1}
+
+$ kafka-ingest format=avro topic=non-dbz-data-multi-partition schema=${non-dbz-schema} timestamp=1 partition=0
+{"a": 1, "b": 2}
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
+  WITH (start_offset=1)
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT * FROM non_dbz_data_multi_partition
+a  b
+-----
+4  1
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition_2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
+  WITH (start_offset=[0,0])
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT * FROM non_dbz_data_multi_partition_2
+a  b
+-----
+1  2
+4  1
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition_fast_forwarded
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
+  WITH (start_offset=[0,1])
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT * FROM non_dbz_data_multi_partition_fast_forwarded
+a  b
+----
+1  2
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_multi_partition_fast_forwarded_2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
+  WITH (start_offset=[1,0])
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT * FROM non_dbz_data_multi_partition_fast_forwarded_2
+a  b
+----
+4  1
+
+# Test an Avro source without a Debezium envelope with specified offsets and varying partition numbers.
+
+$ kafka-create-topic topic=non-dbz-data-varying-partition partitions=1
+
+$ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz-schema} timestamp=1 partition=0
+{"a": 5, "b": 6}
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_varying_partition
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
+  WITH (start_offset=1)
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT * FROM non_dbz_data_varying_partition
+
+# Erroneously adds start_offsets for non-existent partitions.
+> CREATE MATERIALIZED SOURCE non_dbz_data_varying_partition_2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
+  WITH (start_offset=[0,1])
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+> SELECT * FROM non_dbz_data_varying_partition_2
+a  b
+----
+5  6
+
+$ kafka-add-partitions topic=non-dbz-data-varying-partition total-partitions=2
+
+# Reading data that's ingested to a new partition takes longer than the default timeout.
+$ set-sql-timeout duration=60s
+
+$ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz-schema} timestamp=1 partition=1
+{"a": 7, "b": 8}
+{"a": 9, "b": 10}
+
+# Because the start offset for any new partitions will be 0, the first record sent to the new
+# partition will be included.
+> SELECT * FROM non_dbz_data_varying_partition
+a  b
+-----
+7  8
+9  10
+
+# Because the start offsets erronously included an offset for partition 1 (which didn't exist at the time),
+# the first record ingested into partition 1 will be ignored.
+> SELECT * FROM non_dbz_data_varying_partition_2
+a  b
+-----
+5  6
+9  10
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_varying_partition_3
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
+  WITH (start_offset=[1,1])
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+$ kafka-add-partitions topic=non-dbz-data-varying-partition total-partitions=3
+
+$ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz-schema} timestamp=1 partition=2
+{"a": 11, "b": 12}
+
+# Because the start offset for any new partitions will be 0, the first record sent to the new
+# partition will be included.
+> SELECT * FROM non_dbz_data_varying_partition_3
+a  b
+-----
+9  10
+11 12
+
+$ set-sql-timeout duration=12.7s
 
 # Source with new-style three-valued "snapshot".
 $ set new-dbz-schema={

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -42,3 +42,31 @@ name       nullable  type
 --------------------------
 named_col  false     bytea
 mz_offset  false     bigint
+
+> CREATE MATERIALIZED SOURCE data_offset
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
+  WITH (start_offset=1)
+  FORMAT BYTES
+
+> SELECT * FROM data_offset
+data           mz_offset
+------------------------
+"\\xc2\\xa92"  2
+
+$ kafka-create-topic topic=bytes-partitions partitions=2
+
+$ kafka-ingest format=bytes topic=bytes-partitions timestamp=1 partition=0
+©1
+
+$ kafka-ingest format=bytes topic=bytes-partitions timestamp=1 partition=1
+©2
+
+> CREATE MATERIALIZED SOURCE data_offset_2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-partitions-${testdrive.seed}'
+  WITH (start_offset=[0,1])
+  FORMAT BYTES
+
+> SELECT * FROM data_offset_2
+data           mz_offset
+------------------------
+"\\xc2\\xa91"  1

--- a/test/testdrive/kafka-compression.td
+++ b/test/testdrive/kafka-compression.td
@@ -60,3 +60,10 @@ world
 > SELECT text FROM zstd
 hello
 world
+
+> CREATE MATERIALIZED SOURCE zstd_fast_forwarded
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
+  WITH (start_offset=1)
+  FORMAT TEXT
+> SELECT text FROM zstd_fast_forwarded
+world

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ kafka-create-topic topic=input_csv
+$ kafka-create-topic topic=input_csv_partitioned partitions=2
 $ kafka-create-topic topic=input_proto
 
 > CREATE MATERIALIZED SOURCE input_csv (first, second)
@@ -23,6 +24,22 @@ first second mz_offset
 ----------------------
 1     2      1
 2     3      2
+
+$ kafka-ingest format=bytes topic=input_csv_partitioned partition=0
+1,2
+
+$ kafka-ingest format=bytes topic=input_csv_partitioned partition=1
+2,3
+
+> CREATE MATERIALIZED SOURCE input_csv_partitioned (first, second)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_csv_partitioned-${testdrive.seed}'
+  WITH (start_offset=[1,0])
+  FORMAT CSV WITH 2 COLUMNS;
+
+> SELECT * FROM input_csv_partitioned
+first second mz_offset
+----------------------
+2     3      1
 
 > CREATE MATERIALIZED SOURCE input_proto
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_proto-${testdrive.seed}'

--- a/test/testdrive/protobuf.td
+++ b/test/testdrive/protobuf.td
@@ -55,3 +55,24 @@ $ kafka-ingest format=protobuf topic=corrupted-messages message=struct timestamp
 
 ! SELECT * from corrupted_proto_messages
 Decode error: Text: protobuf deserialization error: Deserializing into rust object: protobuf error: incorrect tag
+
+> CREATE MATERIALIZED SOURCE protomessages3 FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-${testdrive.seed}'
+  WITH (start_offset=1)
+  FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
+
+> SELECT * FROM protomessages3
+2 2 ONE  something-valid 2
+
+$ kafka-create-topic topic=messages-partitioned partitions=2
+
+$ kafka-ingest format=protobuf topic=messages-partitioned message=struct timestamp=1 partition=0
+{"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
+
+$ kafka-ingest format=protobuf topic=messages-partitioned message=struct timestamp=1 partition=1
+{"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+
+> CREATE MATERIALIZED SOURCE protomessages_partitioned FROM
+  KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-messages-partitioned-${testdrive.seed}'
+  WITH (start_offset=[1,0])
+  FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'


### PR DESCRIPTION
Previously, we only allowed users to indicate a single `start_offset` for their Kafka topics. This
change allows users to `CREATE SOURCE`s with a list of offsets instead. Users will be expected
to provide the offsets in partition order.

There are definitely some quirks here!
| Weird thing | Why it's weird | Fix? | 
|-------------|-----|---|
| `start_offset=X` | [As requested](https://github.com/MaterializeInc/materialize/issues/2736#issuecomment-786161010), the original `start_offset` behavior has been maintained. For a multi-partitioned topic, the `X` offset will only be applied to the first partition, not all of them. | Requiring `start_offset` to be an array in all cases. Or, some fiddling to apply `X` to all partitions (this isn't as straightforward as it seems). |
| `start_offset=[bad length]` | Because we don't instantiate a Kafka client before the source is rendered, it's impossible to say whether or not the user has provided the correct number of offsets. If the users provides too few, all extra partitions will start at offset 0. **If the user provides too many, new partitions that come online will be incorrectly truncated.** | Spinning up a client earlier to check the number of partitions. |

Also, do we want to document this? The previous comment in this code suggests we might not want to publicize this too widely, but I know multiple users have requested this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5960)
<!-- Reviewable:end -->
