### PR TITLE
Reorganize linear join code

### DIFF
--- a/src/dataflow/src/render/context.rs
+++ b/src/dataflow/src/render/context.rs
@@ -40,17 +40,17 @@ pub type TraceKeyHandle<K, T, R> = TraceAgent<OrdKeySpine<K, T, R>>;
 /// A trace handle for key-value data.
 pub type TraceValHandle<K, V, T, R> = TraceAgent<OrdValSpine<K, V, T, R>>;
 
-type Diff = isize;
+pub type Diff = isize;
 
 // Local type definition to avoid the horror in signatures.
 pub type Arrangement<S, V> = Arranged<S, TraceValHandle<V, V, <S as ScopeParent>::Timestamp, Diff>>;
 pub type ErrArrangement<S> =
     Arranged<S, TraceKeyHandle<DataflowError, <S as ScopeParent>::Timestamp, Diff>>;
-type ArrangementImport<S, V, T> = Arranged<
+pub type ArrangementImport<S, V, T> = Arranged<
     S,
     TraceEnter<TraceFrontier<TraceValHandle<V, V, T, Diff>>, <S as ScopeParent>::Timestamp>,
 >;
-type ErrArrangementImport<S, T> = Arranged<
+pub type ErrArrangementImport<S, T> = Arranged<
     S,
     TraceEnter<
         TraceFrontier<TraceKeyHandle<DataflowError, T, Diff>>,

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -24,9 +24,145 @@ use expr::{MapFilterProject, MirRelationExpr, MirScalarExpr};
 use repr::{Datum, Row, RowArena, RowPacker};
 
 use crate::operator::CollectionExt;
-use crate::render::context::{ArrangementFlavor, Context};
+use crate::render::context::{Arrangement, ArrangementFlavor, ArrangementImport, Context, Diff};
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
+
+// TODO(mcsherry): Identical to `DeltaPathPlan`; consider unifying.
+pub struct LinearJoinPlan {
+    /// The source relation from which we start the join.
+    source_relation: usize,
+    /// An initial closure to apply before any stages.
+    ///
+    /// Values of `None` indicate the identity closure.
+    initial_closure: Option<JoinClosure>,
+    /// A *sequence* of stages to apply one after the other.
+    stage_plans: Vec<LinearStagePlan>,
+    /// A concluding closure to apply after the last stage.
+    ///
+    /// Values of `None` indicate the identity closure.
+    final_closure: Option<JoinClosure>,
+}
+
+// TODO(mcsherry): Identical to `DeltaStagePlan`; consider unifying.
+pub struct LinearStagePlan {
+    /// The relation index into which we will look up.
+    lookup_relation: usize,
+    /// The key expressions to use for the streamed relation.
+    ///
+    /// While this starts as a stream of the source relation,
+    /// it evolves through multiple lookups and ceases to be
+    /// the same thing, hence the different name.
+    stream_key: Vec<MirScalarExpr>,
+    /// The key expressions to use for the lookup relation.
+    lookup_key: Vec<MirScalarExpr>,
+    /// The closure to apply to the concatenation of columns
+    /// of the stream and lookup relations.
+    closure: JoinClosure,
+}
+
+impl LinearJoinPlan {
+    /// Create a new join plan from the required arguments.
+    pub fn create_from(
+        source_relation: usize,
+        equivalences: &[Vec<MirScalarExpr>],
+        join_order: &[(usize, Vec<MirScalarExpr>)],
+        input_mapper: expr::JoinInputMapper,
+        map_filter_project: MapFilterProject,
+    ) -> Self {
+        // Construct initial join build state.
+        // This state will evolves as we build the join dataflow.
+        let mut join_build_state = JoinBuildState::new(
+            input_mapper.global_columns(source_relation),
+            &equivalences,
+            &map_filter_project,
+        );
+
+        // We would prefer to extract a closure here, but we do not know if
+        // the input will be arranged or not.
+        let initial_closure = None;
+
+        // Sequence of steps to apply.
+        let mut stage_plans = Vec::with_capacity(join_order.len());
+
+        // Track the set of bound input relations, for equivalence resolution.
+        let mut bound_inputs = vec![source_relation];
+
+        // Iterate through the join order instructions, assembling keys and
+        // closures to use.
+        for (lookup_relation, lookup_key) in join_order.iter() {
+            // rebase the intended key to use global column identifiers.
+            let lookup_key_rebased = lookup_key
+                .iter()
+                .map(|k| input_mapper.map_expr_to_global(k.clone(), *lookup_relation))
+                .collect::<Vec<_>>();
+
+            // Expressions to use as a key for the stream of incoming updates
+            // are determined by locating the elements of `lookup_key` among
+            // the existing bound `columns`. If that cannot be done, the plan
+            // is irrecoverably defective and we panic.
+            // TODO: explicitly validate this before rendering.
+            let stream_key = lookup_key_rebased
+                .iter()
+                .map(|expr| {
+                    let mut bound_expr = input_mapper
+                        .find_bound_expr(expr, &bound_inputs, &join_build_state.equivalences)
+                        .expect("Expression in join plan is not bound at time of use");
+                    // Rewrite column references to physical locations.
+                    bound_expr.permute_map(&join_build_state.column_map);
+                    bound_expr
+                })
+                .collect::<Vec<_>>();
+
+            // Introduce new columns and expressions they enable. Form a new closure.
+            let closure = join_build_state.add_columns(
+                input_mapper.global_columns(*lookup_relation),
+                &lookup_key_rebased,
+            );
+
+            bound_inputs.push(*lookup_relation);
+
+            // record the stage plan as next in the path.
+            stage_plans.push(LinearStagePlan {
+                lookup_relation: *lookup_relation,
+                stream_key,
+                lookup_key: lookup_key.clone(),
+                closure,
+            });
+        }
+
+        // determine a final closure, and complete the path plan.
+        let final_closure = join_build_state.complete();
+        let final_closure = if final_closure.is_identity() {
+            None
+        } else {
+            Some(final_closure)
+        };
+
+        // Form and return the complete join plan.
+        LinearJoinPlan {
+            source_relation,
+            initial_closure,
+            stage_plans,
+            final_closure,
+        }
+    }
+}
+
+/// Different forms the streamed data might take.
+enum JoinedFlavor<G, T>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+{
+    /// Streamed data as a collection.
+    Collection(Collection<G, Row, Diff>),
+    /// A dataflow-local arrangement.
+    Local(Arrangement<G, Row>),
+    /// An imported arrangement.
+    Trace(ArrangementImport<G, Row, T>),
+}
 
 impl<G, T> Context<G, MirRelationExpr, Row, T>
 where
@@ -39,7 +175,7 @@ where
         relation_expr: &MirRelationExpr,
         map_filter_project: MapFilterProject,
         // TODO(frank): use this argument to create a region surrounding the join.
-        _scope: &mut G,
+        scope: &mut G,
     ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
         if let MirRelationExpr::Join {
             inputs,
@@ -77,31 +213,47 @@ where
                 .filter(filter)
                 .project(project);
 
-            // Construct initial join build state.
-            // This state will evolves as we build the join dataflow.
-            let mut join_build_state = JoinBuildState::new(
-                input_mapper.global_columns(*start),
-                &equivalences,
-                &map_filter_project,
+            // Create a join plan based on the linear join.
+            let linear_plan = LinearJoinPlan::create_from(
+                *start,
+                equivalences,
+                order,
+                input_mapper.clone(),
+                map_filter_project.clone(),
             );
 
-            // This collection will evolve as we join in more inputs.
-            // TODO(mcsherry): determine and apply closure here in `flat_map_ref` form.
-            // TODO(mcsherry): If we plan to use an arrangement, should one exist, then
-            // this is wasteful as it instantiates all rows which are then dropped.
-            let (mut joined, mut errs) = self.collection(&inputs[*start]).unwrap();
+            // Collect all error streams, and concatenate them at the end.
+            let mut errors = Vec::new();
 
-            let use_leading_arrangement = start_arr.is_some() && inputs.len() > 1;
-            if !use_leading_arrangement {
-                // NOTE(mcsherry): ideally this code is rarely/never relevant, as the associated logic
-                // could be pushed down to the input and perhaps beyond. I'm not certain under what
-                // circumstance we should just delete it, though.
-
-                // At this point we are able to construct a per-row closure that can be applied once
-                // we have the first wave of columns in place. We will not apply it quite yet, because
-                // we have three code paths that might produce data and it is complicated.
-                let closure = join_build_state.extract_closure();
-                if !closure.is_identity() {
+            // Determine what form the linear spine of updates will take.
+            // This could be a stream, or one of several arrangements.
+            let mut joined = if start_arr.is_some() && inputs.len() > 1 {
+                // Assert that we did not extract an initial closure.
+                assert!(linear_plan.initial_closure.is_none());
+                // We have some redundancy that we should check here.
+                let arrangement_key = &linear_plan.stage_plans[0].stream_key;
+                assert_eq!(start_arr.as_ref().unwrap(), arrangement_key);
+                match self.arrangement(&inputs[linear_plan.source_relation], arrangement_key) {
+                    Some(ArrangementFlavor::Local(oks, es)) => {
+                        errors.push(es.as_collection(|k, _v| k.clone()));
+                        JoinedFlavor::Local(oks)
+                    }
+                    Some(ArrangementFlavor::Trace(_gid, oks, es)) => {
+                        errors.push(es.as_collection(|k, _v| k.clone()));
+                        JoinedFlavor::Trace(oks)
+                    }
+                    None => {
+                        unreachable!("Arrangement intended to exist!");
+                    }
+                }
+            } else {
+                // TODO: extract closure from the first stage in the join plan, should it exist.
+                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+                let (mut joined, errs) = self.collection(&inputs[*start]).unwrap();
+                errors.push(errs);
+                // In the current code this should always be `None`, but we have this here should
+                // we change that and want to know what we should be doing.
+                if let Some(closure) = linear_plan.initial_closure {
                     // If there is no starting arrangement, then we can run filters
                     // directly on the starting collection.
                     // If there is only one input, we are done joining, so run filters
@@ -120,122 +272,58 @@ where
                         }
                     });
                     joined = j;
-                    errs = errs.concat(&es);
+                    errors.push(es);
                 }
-            }
 
-            // We track the input relations as they are
-            // added to the join so we can figure out
-            // which expressions have been bound.
-            let mut bound_inputs = vec![*start];
-            for (input_index, (input, next_keys)) in order.iter().enumerate() {
-                let next_keys_rebased = next_keys
-                    .iter()
-                    .map(|k| input_mapper.map_expr_to_global(k.clone(), *input))
-                    .collect::<Vec<_>>();
-                // Keys for the next input to be joined must be produced from
-                // ScalarExprs found in `equivalences`, re-written to bind the
-                // appropriate columns (as `joined` has permuted columns).
-                let prev_keys = next_keys_rebased
-                    .iter()
-                    .map(|expr| {
-                        let mut bound_expr = input_mapper
-                            .find_bound_expr(expr, &bound_inputs, &join_build_state.equivalences)
-                            .expect("Expression in join plan is not bound at time of use");
+                JoinedFlavor::Collection(joined)
+            };
 
-                        bound_expr.permute_map(&join_build_state.column_map);
-                        bound_expr
-                    })
-                    .collect::<Vec<_>>();
-
-                // Introduce new columns and expressions they enable. Form a new closure.
-                let closure = join_build_state
-                    .add_columns(input_mapper.global_columns(*input), &next_keys_rebased);
-
-                // When joining the first input, check to see if we are meant to use an existing
-                // arrangement.
-                let (j, es) = match (
-                    input_index,
-                    use_leading_arrangement,
-                    self.arrangement(&inputs[*start], &prev_keys),
-                ) {
-                    (0, true, Some(ArrangementFlavor::Local(oks, es))) => {
-                        let (j, next_es) =
-                            self.differential_join(oks, &inputs[*input], &next_keys[..], closure);
-                        (j, es.as_collection(|k, _v| k.clone()).concat(&next_es))
-                    }
-                    (0, true, Some(ArrangementFlavor::Trace(_gid, oks, es))) => {
-                        let (j, next_es) =
-                            self.differential_join(oks, &inputs[*input], &next_keys[..], closure);
-                        (j, es.as_collection(|k, _v| k.clone()).concat(&next_es))
-                    }
-                    _ => {
-                        // Otherwise, build a new arrangement from the collection of
-                        // joins of previous inputs.
-                        // We exploit the demand information to restrict `prev` to
-                        // its demanded columns.
-                        let (prev_keyed, es) = joined.map_fallible({
-                            // Reuseable allocation for unpacking.
-                            let mut datums = DatumVec::new();
-                            move |row| {
-                                let temp_storage = RowArena::new();
-                                let datums_local = datums.borrow_with(&row);
-                                let key = Row::try_pack(
-                                    prev_keys
-                                        .iter()
-                                        .map(|e| e.eval(&datums_local, &temp_storage)),
-                                )?;
-                                // Explicit drop here to allow `row` to be returned.
-                                drop(datums_local);
-                                // TODO(mcsherry): We could remove any columns used only for `key`.
-                                // This cannot be done any earlier, for example in a prior closure,
-                                // because we need the columns for key production.
-                                Ok((key, row))
-                            }
-                        });
-                        let prev_keyed = prev_keyed.arrange_named::<OrdValSpine<_, _, _, _>>(
-                            &format!("JoinStage-input{}", input),
-                        );
-                        let (j, next_es) = self.differential_join(
-                            prev_keyed,
-                            &inputs[*input],
-                            &next_keys[..],
-                            closure,
-                        );
-                        (j, es.concat(&next_es))
-                    }
-                };
-
-                joined = j;
-                errs = errs.concat(&es);
-                bound_inputs.push(*input);
+            // Progress through stages, updating partial results and errors.
+            for stage_plan in linear_plan.stage_plans.into_iter() {
+                // Different variants of `joined` implement this differently,
+                // and the logic is centralized there.
+                let stream = self.differential_join(
+                    joined,
+                    stage_plan.stream_key,
+                    &inputs[stage_plan.lookup_relation],
+                    stage_plan.lookup_key,
+                    stage_plan.closure,
+                    &mut errors,
+                );
+                // Update joined results and capture any errors.
+                joined = JoinedFlavor::Collection(stream);
             }
 
             // We have completed the join building, but may have work remaining.
             // For example, we may have expressions not pushed down (e.g. literals)
             // and projections that could not be applied (e.g. column repetition).
-            let closure = join_build_state.complete();
-            if !closure.is_identity() {
-                let (updates, errors) = joined.flat_map_fallible({
-                    // Reuseable allocation for unpacking.
-                    let mut datums = DatumVec::new();
-                    let mut row_packer = repr::RowPacker::new();
-                    move |row| {
-                        let temp_storage = RowArena::new();
-                        let mut datums_local = datums.borrow_with(&row);
-                        // TODO(mcsherry): re-use `row` allocation.
-                        closure
-                            .apply(&mut datums_local, &temp_storage, &mut row_packer)
-                            .map_err(DataflowError::from)
-                            .transpose()
-                    }
-                });
+            if let JoinedFlavor::Collection(mut joined) = joined {
+                if let Some(closure) = linear_plan.final_closure {
+                    let (updates, errs) = joined.flat_map_fallible({
+                        // Reuseable allocation for unpacking.
+                        let mut datums = DatumVec::new();
+                        let mut row_packer = repr::RowPacker::new();
+                        move |row| {
+                            let temp_storage = RowArena::new();
+                            let mut datums_local = datums.borrow_with(&row);
+                            // TODO(mcsherry): re-use `row` allocation.
+                            closure
+                                .apply(&mut datums_local, &temp_storage, &mut row_packer)
+                                .map_err(DataflowError::from)
+                                .transpose()
+                        }
+                    });
 
-                joined = updates;
-                errs = errs.concat(&errors);
+                    joined = updates;
+                    errors.push(errs);
+                }
+
+                // Collect all produced errors in one collection.
+                let errors = differential_dataflow::collection::concatenate(scope, errors);
+                (joined, errors)
+            } else {
+                panic!("Unexpectedly arranged join output");
             }
-
-            (joined, errs)
         } else {
             panic!("render_join called on invalid expression.")
         }
@@ -244,26 +332,53 @@ where
     /// Looks up the arrangement for the next input and joins it to the arranged
     /// version of the join of previous inputs. This is split into its own method
     /// to enable reuse of code with different types of `prev_keyed`.
-    fn differential_join<J>(
+    fn differential_join(
         &mut self,
-        prev_keyed: J,
-        next_input: &MirRelationExpr,
-        next_keys: &[MirScalarExpr],
+        mut joined: JoinedFlavor<G, T>,
+        stream_key: Vec<MirScalarExpr>,
+        lookup_relation: &MirRelationExpr,
+        lookup_key: Vec<MirScalarExpr>,
         closure: JoinClosure,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>)
-    where
-        J: JoinCore<G, Row, Row, repr::Diff>,
-    {
+        errors: &mut Vec<Collection<G, DataflowError>>,
+    ) -> Collection<G, Row> {
+        // If we have only a streamed collection, we must first form an arrangement.
+        if let JoinedFlavor::Collection(stream) = joined {
+            let (keyed, es) = stream.map_fallible({
+                // Reuseable allocation for unpacking.
+                let mut datums = DatumVec::new();
+                move |row| {
+                    let temp_storage = RowArena::new();
+                    let datums_local = datums.borrow_with(&row);
+                    let key = Row::try_pack(
+                        stream_key
+                            .iter()
+                            .map(|e| e.eval(&datums_local, &temp_storage)),
+                    )?;
+                    // Explicit drop here to allow `row` to be returned.
+                    drop(datums_local);
+                    // TODO(mcsherry): We could remove any columns used only for `key`.
+                    // This cannot be done any earlier, for example in a prior closure,
+                    // because we need the columns for key production.
+                    Ok((key, row))
+                }
+            });
+            errors.push(es);
+            let arranged = keyed.arrange_named::<OrdValSpine<_, _, _, _>>(&format!("JoinStage"));
+            joined = JoinedFlavor::Local(arranged);
+        }
+
         // Pre-test for the arrangement existence, so that we can populate it if the
         // collection is present but the arrangement is not.
-        if self.arrangement(next_input, next_keys).is_none() {
+        if self.arrangement(lookup_relation, &lookup_key[..]).is_none() {
             // The join may be faulty, and announce keys for an arrangement we have
             // not formed. This *shouldn't* happen, but we prefer to do something
             // sane rather than panic.
-            if self.collection(next_input).is_some() {
+            // TODO: If this ever trips, the `collection` call is a wasteful way to
+            // determine if we have rendered the collection.
+            if self.collection(lookup_relation).is_some() {
                 let arrange_by = MirRelationExpr::ArrangeBy {
-                    input: Box::new(next_input.clone()),
-                    keys: vec![next_keys.to_vec()],
+                    input: Box::new(lookup_relation.clone()),
+                    keys: vec![lookup_key.to_vec()],
                 };
                 self.render_arrangeby(&arrange_by, Some("MissingArrangement"));
             } else {
@@ -271,17 +386,48 @@ where
             }
         }
 
-        match self.arrangement(next_input, next_keys) {
-            Some(ArrangementFlavor::Local(oks, es)) => {
-                let (oks, err) = self.differential_join_inner(prev_keyed, oks, closure);
-                (oks, err.concat(&es.as_collection(|k, _v| k.clone())))
+        // Demultiplex the four different cross products of arrangement types we might have.
+        match joined {
+            JoinedFlavor::Collection(_) => {
+                unreachable!("JoinedFlavor::Collection variant avoided at top of method");
             }
-            Some(ArrangementFlavor::Trace(_gid, oks, es)) => {
-                let (oks, err) = self.differential_join_inner(prev_keyed, oks, closure);
-                (oks, err.concat(&es.as_collection(|k, _v| k.clone())))
+            JoinedFlavor::Local(local) => {
+                match self.arrangement(lookup_relation, &lookup_key[..]) {
+                    Some(ArrangementFlavor::Local(oks, es)) => {
+                        let (oks, err) = self.differential_join_inner(local, oks, closure);
+                        errors.push(es.as_collection(|k, _v| k.clone()));
+                        errors.push(err);
+                        oks
+                    }
+                    Some(ArrangementFlavor::Trace(_gid, oks, es)) => {
+                        let (oks, err) = self.differential_join_inner(local, oks, closure);
+                        errors.push(es.as_collection(|k, _v| k.clone()));
+                        errors.push(err);
+                        oks
+                    }
+                    None => {
+                        unreachable!("Arrangement absent despite explicit construction");
+                    }
+                }
             }
-            None => {
-                unreachable!("Arrangement absent despite explicit construction");
+            JoinedFlavor::Trace(trace) => {
+                match self.arrangement(lookup_relation, &lookup_key[..]) {
+                    Some(ArrangementFlavor::Local(oks, es)) => {
+                        let (oks, err) = self.differential_join_inner(trace, oks, closure);
+                        errors.push(es.as_collection(|k, _v| k.clone()));
+                        errors.push(err);
+                        oks
+                    }
+                    Some(ArrangementFlavor::Trace(_gid, oks, es)) => {
+                        let (oks, err) = self.differential_join_inner(trace, oks, closure);
+                        errors.push(es.as_collection(|k, _v| k.clone()));
+                        errors.push(err);
+                        oks
+                    }
+                    None => {
+                        unreachable!("Arrangement absent despite explicit construction");
+                    }
+                }
             }
         }
     }

--- a/src/dataflow/src/render/join/linear_join.rs
+++ b/src/dataflow/src/render/join/linear_join.rs
@@ -218,8 +218,8 @@ where
                 *start,
                 equivalences,
                 order,
-                input_mapper.clone(),
-                map_filter_project.clone(),
+                input_mapper,
+                map_filter_project,
             );
 
             // Collect all error streams, and concatenate them at the end.

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -22,7 +22,7 @@ use repr::RelationType;
 /// 2) It has a position relative to the specific input it came from (local)
 /// This utility focuses on taking expressions that are in terms of
 /// the local input and re-expressing them in global terms and vice versa.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct JoinInputMapper {
     /// The number of columns per input. All other fields in this struct are
     /// derived using the information in this field.

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -22,7 +22,7 @@ use repr::RelationType;
 /// 2) It has a position relative to the specific input it came from (local)
 /// This utility focuses on taking expressions that are in terms of
 /// the local input and re-expressing them in global terms and vice versa.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct JoinInputMapper {
     /// The number of columns per input. All other fields in this struct are
     /// derived using the information in this field.


### PR DESCRIPTION
This PR reorganizes the `linear_join.rs` code to first create a join plan, and then to implement that plan.

This is more awkward than `delta_join.rs` because there is still conditional logic based on the availability of certain arrangements. We react minimally (create arrangements if they are absent) but there is still conditional logic in rendering.

There is a regression here that we can look at where we do not extract an `initial_closure` because it is not appropriate to do this if the first input is arranged (we cannot apply it). We could do some closure extraction on the fly, but I wanted to start with the cleanest approach and that sacrifices the initial closure. In comments, it was argued that this code is ideally dead, as any of this work could be pushed down to a streaming first input, and ideally it would be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5962)
<!-- Reviewable:end -->
