### PR TITLE
sqs s3 tests: Increase SQS validation timeout, and make it configurable

### DIFF
--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -146,7 +146,7 @@ $ set otherbucket=materialize-ci-td-other-${testdrive.seed}
 $ set otherqueue=materialize-ci-other-${testdrive.seed}
 
 $ s3-create-bucket bucket=${otherbucket}
-$ s3-add-notifications bucket=${otherbucket} queue=${otherqueue}
+$ s3-add-notifications bucket=${otherbucket} queue=${otherqueue} sqs-validation-timout=5m
 
 $ s3-put-object bucket=${otherbucket} key=short/c
 c1


### PR DESCRIPTION
It's been a bit of time, but we still need to adjust the flakiness of this
test.

If 5 minutes isn't long enough we could try putting notification configuration
and validation into the bucket-creation logic, allowing us to destroy and
recreate buckets if the timeout elapses.

https://buildkite.com/materialize/tests/builds/15303#30546767-23fd-4cc7-93c4-834137cd89c3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5973)
<!-- Reviewable:end -->
