### PR TITLE
Report on errors when parsing CSV streams

### DIFF
--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -117,7 +117,7 @@ where
                                         if bounds_valid != n_cols {
                                             events_error += 1;
                                             session.give((Err(DataflowError::DecodeError(
-                                                DecodeError::Text(format!("CSV error: expected {} columns, got {}. Ignoring row.", n_cols, bounds_valid))
+                                                DecodeError::Text(format!("CSV error: expected {} columns, got {}.", n_cols, bounds_valid))
                                             )), *cap.time(), 1));
                                         } else {
                                             events_success += 1;

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -120,5 +120,5 @@ badint,
   FROM FILE '${testdrive.temp-dir}/malformed.csv'
   FORMAT CSV WITH HEADER
 
-> SELECT * FROM malformed_csv
-Source error:
+! SELECT * FROM malformed_csv
+Decode error: Text: CSV error: expected 2 columns, got 1. Ignoring row.

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -121,4 +121,4 @@ badint,
   FORMAT CSV WITH HEADER
 
 ! SELECT * FROM malformed_csv
-Decode error: Text: CSV error: expected 2 columns, got 1. Ignoring row.
+Decode error: Text: CSV error: expected 2 columns, got 1.

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -121,4 +121,4 @@ badint,
   FORMAT CSV WITH HEADER
 
 ! SELECT * FROM malformed_csv
-Decode error: Text: CSV error: expected 2 columns, got 1.
+Decode error: Text: CSV error at lineno 3: expected 2 columns, got 1.

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -107,3 +107,18 @@ Source error: File IO:
 
 ! CREATE SOURCE should_fail FROM FILE '/'
 / is a directory.
+
+# Static malformed CSV
+$ file-append path=malformed.csv
+Dollars,Category
+5161669,Clothing&Shoes
+1000000000
+,badrow
+badint,
+
+> CREATE MATERIALIZED SOURCE malformed_csv
+  FROM FILE '${testdrive.temp-dir}/malformed.csv'
+  FORMAT CSV WITH HEADER
+
+> SELECT * FROM malformed_csv
+Source error:


### PR DESCRIPTION
When CSV parsing encounters an error, report the errors via the error stream. This will cause the error to propagate to the user when they try to use the data from the source. Add test drive scenario to validate that malformed CSVs show the proper error handling.

Fixes #5923 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5974)
<!-- Reviewable:end -->
