### PR TITLE
Change negative multiplicity error message to be human-readable

### DIFF
--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -898,8 +898,8 @@ impl PendingPeek {
             });
             if copies < 0 {
                 return Err(format!(
-                    "Negative multiplicity: {} for {}",
-                    copies,
+                    "Invalid data in source, saw retractions ({}) for row that does not exist: {}",
+                    copies * -1,
                     cursor.key(&storage),
                 ));
             }
@@ -952,8 +952,8 @@ impl PendingPeek {
                     });
                     if copies < 0 {
                         return Err(format!(
-                            "Negative multiplicity: {} for {:?}",
-                            copies,
+                            "Invalid data in source, saw retractions ({}) for row that does not exist: {:?}",
+                            copies * -1,
                             row.unpack(),
                         ));
                     }

--- a/test/testdrive/negative-multiplicities.td
+++ b/test/testdrive/negative-multiplicities.td
@@ -49,7 +49,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 -1
 
 ! SELECT * FROM data
-Negative multiplicity: -1
+Invalid data in source, saw retractions (1) for row that does not exist: [Int64(1)]
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": {"row": {"a": 1}}, "after": null}
@@ -58,4 +58,4 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 -2
 
 ! SELECT * FROM data
-Negative multiplicity: -2
+Invalid data in source, saw retractions (2) for row that does not exist: [Int64(1)]


### PR DESCRIPTION
The reason that negative multiplicity errors are a problem is easy to explain
and understand, but the term "negative multiplicity" is confusing. Instead,
just describe the problem that exists and the most likely reason it happened.

This does not change the error message for any of the asserts around this
subject users should never see them and negative multiplicity is more
technically correct in their cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5977)
<!-- Reviewable:end -->
