### PR TITLE
Raise Dataflow errors on bad regex source inputs

### DIFF
--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -464,7 +464,7 @@ where
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
         (DataEncoding::Regex(RegexEncoding { regex }), SourceEnvelope::None) => {
-            (regex_fn(stream, regex), None)
+            (regex_fn(stream, regex, debug_name), None)
         }
         (DataEncoding::Protobuf(enc), SourceEnvelope::None) => (
             decode_values_inner(

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -464,7 +464,7 @@ where
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
         (DataEncoding::Regex(RegexEncoding { regex }), SourceEnvelope::None) => {
-            ((regex_fn(stream, regex, debug_name), None), None)
+            (regex_fn(stream, regex), None)
         }
         (DataEncoding::Protobuf(enc), SourceEnvelope::None) => (
             decode_values_inner(

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -48,19 +48,13 @@ where
                     let line = match str::from_utf8(&line) {
                         Ok(line) => line,
                         Err(_) => {
-                            let line_no = match line_no {
-                                Some(line_no) => line_no.to_string(),
-                                None => "unknown".into(),
-                            };
-                            let line_prefix = String::from_utf8_lossy(&line)
-                                .chars()
-                                .take(64)
-                                .collect::<String>();
                             session.give((
-                                Err(DataflowError::DecodeError(DecodeError::Text(format!(
-                                    "Regex error in source {} at lineno {}: invalid UTF-8, line prefix: {:?}",
-                                    name, line_no, line_prefix
-                                )))),
+                                Err(DataflowError::DecodeError(DecodeError::Text(
+                                    match line_no {
+                                        Some(line_no) => format!("Regex error in source {} at lineno {}: invalid UTF-8", name, line_no.to_string()),
+                                        None => format!("Regex error in source {} at lineno 'unknown': invalid UTF-8", name),
+                                    }
+                                ))),
                                 *cap.time(),
                                 1,
                             ));

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -11,11 +11,11 @@ use std::iter;
 use std::str;
 
 use differential_dataflow::{AsCollection, Collection};
-use log::warn;
 use regex::Regex;
-use timely::dataflow::operators::Operator;
+use timely::dataflow::operators::{OkErr, Operator};
 use timely::dataflow::{Scope, Stream};
 
+use dataflow_types::{DataflowError, DecodeError};
 use repr::{Datum, Diff, Row, Timestamp};
 
 use crate::source::SourceOutput;
@@ -23,63 +23,72 @@ use crate::source::SourceOutput;
 pub fn regex<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     regex: Regex,
-    name: &str,
-) -> Collection<G, Row, Diff>
+) -> (
+    Collection<G, Row, Diff>,
+    Option<Collection<G, dataflow_types::DataflowError, Diff>>,
+)
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let name = String::from(name);
     let pact = SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract();
     let mut row_packer = repr::RowPacker::new();
-    stream
-        .unary(pact, "RegexDecode", |_cap, _op_info| {
-            move |input, output| {
-                input.for_each(|cap, lines| {
-                    let mut session = output.session(&cap);
-                    for SourceOutput {
-                        key: _,
-                        value: line,
-                        position: line_no,
-                        upstream_time_millis: _,
-                    } in &*lines
-                    {
-                        let line = match str::from_utf8(&line) {
-                            Ok(line) => line,
-                            Err(_) => {
-                                let line_no = match line_no {
-                                    Some(line_no) => line_no.to_string(),
-                                    None => "unknown".into(),
-                                };
-                                let line_prefix = String::from_utf8_lossy(&line)
-                                    .chars()
-                                    .take(64)
-                                    .collect::<String>();
-                                warn!(
-                                    "dropping line with invalid UTF-8 \
-                                (source: {}, line number: {}, line prefix: {:?})",
-                                    name, line_no, line_prefix,
-                                );
-                                continue;
-                            }
-                        };
+    let stream = stream.unary(pact, "RegexDecode", |_cap, _op_info| {
+        move |input, output| {
+            input.for_each(|cap, lines| {
+                let mut session = output.session(&cap);
+                for SourceOutput {
+                    key: _,
+                    value: line,
+                    position: line_no,
+                    upstream_time_millis: _,
+                } in &*lines
+                {
+                    let line = match str::from_utf8(&line) {
+                        Ok(line) => line,
+                        Err(_) => {
+                            let line_no = match line_no {
+                                Some(line_no) => line_no.to_string(),
+                                None => "unknown".into(),
+                            };
+                            let line_prefix = String::from_utf8_lossy(&line)
+                                .chars()
+                                .take(64)
+                                .collect::<String>();
+                            session.give((
+                                Err(DataflowError::DecodeError(DecodeError::Text(format!(
+                                    "Regex error at lineno {}: invalid UTF-8, line prefix: {:?}",
+                                    line_no, line_prefix
+                                )))),
+                                *cap.time(),
+                                1,
+                            ));
+                            continue;
+                        }
+                    };
 
-                        let captures = match regex.captures(line) {
-                            Some(captures) => captures,
-                            None => continue,
-                        };
+                    let captures = match regex.captures(line) {
+                        Some(captures) => captures,
+                        None => continue,
+                    };
 
-                        // Skip the 0th capture, which is the entire match, so that
-                        // we only output the actual capture groups.
-                        let datums = captures
-                            .iter()
-                            .skip(1)
-                            .map(|c| Datum::from(c.map(|c| c.as_str())))
-                            .chain(iter::once(Datum::from(*line_no)));
+                    // Skip the 0th capture, which is the entire match, so that
+                    // we only output the actual capture groups.
+                    let datums = captures
+                        .iter()
+                        .skip(1)
+                        .map(|c| Datum::from(c.map(|c| c.as_str())))
+                        .chain(iter::once(Datum::from(*line_no)));
 
-                        session.give((row_packer.pack(datums), *cap.time(), 1));
-                    }
-                });
-            }
-        })
-        .as_collection()
+                    session.give((Ok(row_packer.pack(datums)), *cap.time(), 1));
+                }
+            });
+        }
+    });
+
+    let (oks, errs) = stream.ok_err(|(data, time, diff)| match data {
+        Ok(data) => Ok((data, time, diff)),
+        Err(err) => Err((err, time, diff)),
+    });
+
+    (oks.as_collection(), Some(errs.as_collection()))
 }

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -23,6 +23,7 @@ use crate::source::SourceOutput;
 pub fn regex<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
     regex: Regex,
+    name: &str,
 ) -> (
     Collection<G, Row, Diff>,
     Option<Collection<G, dataflow_types::DataflowError, Diff>>,
@@ -30,6 +31,7 @@ pub fn regex<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
+    let name = String::from(name);
     let pact = SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract();
     let mut row_packer = repr::RowPacker::new();
     let stream = stream.unary(pact, "RegexDecode", |_cap, _op_info| {
@@ -56,8 +58,8 @@ where
                                 .collect::<String>();
                             session.give((
                                 Err(DataflowError::DecodeError(DecodeError::Text(format!(
-                                    "Regex error at lineno {}: invalid UTF-8, line prefix: {:?}",
-                                    line_no, line_prefix
+                                    "Regex error in source {} at lineno {}: invalid UTF-8, line prefix: {:?}",
+                                    name, line_no, line_prefix
                                 )))),
                                 *cap.time(),
                                 1,

--- a/src/dataflow/src/decode/regex.rs
+++ b/src/dataflow/src/decode/regex.rs
@@ -18,7 +18,8 @@ use timely::dataflow::{Scope, Stream};
 use dataflow_types::{DataflowError, DecodeError};
 use repr::{Datum, Diff, Row, Timestamp};
 
-use crate::{operator::CollectionExt, source::SourceOutput};
+use crate::operator::CollectionExt;
+use crate::source::SourceOutput;
 
 pub fn regex<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -72,4 +72,4 @@ this line has invalid UTF-8 and will be cause dataflow errors --> \x80 <--
   FORMAT REGEX '(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -'
 
 ! SELECT * FROM bad_regex_source
-Decode error: Text: Regex error at lineno 3: invalid UTF-8, line prefix: "this line has invalid UTF-8 and will be cause dataflow errors --"
+Decode error: Text: Regex error in source materialize.public.bad_regex_source_primary_idx at lineno 3: invalid UTF-8, line prefix: "this line has invalid UTF-8 and will be cause dataflow errors --"

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -72,4 +72,4 @@ this line has invalid UTF-8 and will be cause dataflow errors --> \x80 <--
   FORMAT REGEX '(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -'
 
 ! SELECT * FROM bad_regex_source
-Decode error: Text: Regex error in source materialize.public.bad_regex_source_primary_idx at lineno 3: invalid UTF-8, line prefix: "this line has invalid UTF-8 and will be cause dataflow errors --"
+Decode error: Text: Regex error in source materialize.public.bad_regex_source_primary_idx at lineno 3: invalid UTF-8

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -10,7 +10,6 @@
 $ file-append path=request.log
 123.17.127.5 - - [22/Jan/2020 18:59:52] "GET / HTTP/1.1" 200 -
 8.15.119.56 - - [22/Jan/2020 18:59:52] "GET /detail/nNZpqxzR HTTP/1.1" 200 -
-this line has invalid UTF-8 and will be dropped --> \x80 <--
 96.12.83.72 - - [22/Jan/2020 18:59:52] "GET /search/?kw=helper+ins+hennaed HTTP/1.1" 200 -
 
 # Regex explained here: https://www.debuggex.com/r/k48kBEt-lTMUZbaw
@@ -33,7 +32,7 @@ ip            ts                      path                                      
 --------------------------------------------------------------------------------------------------------------------------------------------
 123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
 8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
-96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   4
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
 
 > SELECT search_kw FROM regex_source WHERE search_kw IS NOT NULL
 search_kw
@@ -60,4 +59,17 @@ ip            ts                      path                                      
 --------------------------------------------------------------------------------------------------------------------------------------------
 123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
 8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
-96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   4
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
+
+# Malformed regex with non-utf-8 characters
+$ file-append path=malformed-request.log
+123.17.127.5 - - [22/Jan/2020 18:59:52] "GET / HTTP/1.1" 200 -
+8.15.119.56 - - [22/Jan/2020 18:59:52] "GET /detail/nNZpqxzR HTTP/1.1" 200 -
+this line has invalid UTF-8 and will be cause dataflow errors --> \x80 <--
+96.12.83.72 - - [22/Jan/2020 18:59:52] "GET /search/?kw=helper+ins+hennaed HTTP/1.1" 200 -
+
+> CREATE MATERIALIZED SOURCE bad_regex_source FROM FILE '${testdrive.temp-dir}/malformed-request.log'
+  FORMAT REGEX '(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -'
+
+! SELECT * FROM bad_regex_source
+Decode error: Text: Regex error at lineno 3: invalid UTF-8, line prefix: "this line has invalid UTF-8 and will be cause dataflow errors --"


### PR DESCRIPTION
Instead of skipping lines with non-UTF-8 text, produce a Dataflow Error
to the error stream.

Fixes #5992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5993)
<!-- Reviewable:end -->
