### PR TITLE
Add test for non UTF-8 characters in CSV files

### DIFF
--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -77,9 +77,13 @@ where
                         if std::str::from_utf8(line.as_slice()).is_err() {
                             // Generate an error object for the error stream
                             events_error += 1;
+                            let line_no= match line_no {
+                                Some(line_no) => line_no.to_string(),
+                                None => "unknown".into(),
+                            };
                             session.give((
                                 Err(DataflowError::DecodeError(DecodeError::Text(format!(
-                                    "CSV error: input text is not utf8"
+                                    "CSV error at lineno {}: invalid UTF-8", line_no
                                 )))),
                                 *cap.time(),
                                 1,
@@ -128,11 +132,15 @@ where
                                     csv_core::ReadRecordResult::Record => {
                                         if bounds_valid != n_cols {
                                             events_error += 1;
+                                            let line_no= match line_no {
+                                                Some(line_no) => line_no.to_string(),
+                                                None => "unknown".into(),
+                                            };
                                             session.give((
                                                 Err(DataflowError::DecodeError(DecodeError::Text(
                                                     format!(
                                                         "CSV error at lineno {}: expected {} columns, got {}.",
-                                                        line_no.unwrap_or_default(), n_cols, bounds_valid
+                                                        line_no, n_cols, bounds_valid
                                                     ),
                                                 ))),
                                                 *cap.time(),

--- a/src/dataflow/src/decode/csv.rs
+++ b/src/dataflow/src/decode/csv.rs
@@ -77,14 +77,13 @@ where
                         if std::str::from_utf8(line.as_slice()).is_err() {
                             // Generate an error object for the error stream
                             events_error += 1;
-                            let line_no= match line_no {
-                                Some(line_no) => line_no.to_string(),
-                                None => "unknown".into(),
-                            };
                             session.give((
-                                Err(DataflowError::DecodeError(DecodeError::Text(format!(
-                                    "CSV error at lineno {}: invalid UTF-8", line_no
-                                )))),
+                                Err(DataflowError::DecodeError(DecodeError::Text(
+                                    match line_no {
+                                        Some(line_no) => format!("CSV error at lineno {}: invalid UTF-8", line_no),
+                                        None => format!("CSV error at lineno 'unknown': invalid UTF-8"),
+                                    }
+                                ))),
                                 *cap.time(),
                                 1,
                             ));
@@ -132,16 +131,12 @@ where
                                     csv_core::ReadRecordResult::Record => {
                                         if bounds_valid != n_cols {
                                             events_error += 1;
-                                            let line_no= match line_no {
-                                                Some(line_no) => line_no.to_string(),
-                                                None => "unknown".into(),
-                                            };
                                             session.give((
                                                 Err(DataflowError::DecodeError(DecodeError::Text(
-                                                    format!(
-                                                        "CSV error at lineno {}: expected {} columns, got {}.",
-                                                        line_no, n_cols, bounds_valid
-                                                    ),
+                                                    match line_no {
+                                                        Some(line_no) => format!( "CSV error at lineno {}: expected {} columns, got {}.", line_no, n_cols, bounds_valid),
+                                                        None => format!("CSV error at lineno 'unknown': expected {} columns, got {}.", n_cols, bounds_valid),
+                                                    }
                                                 ))),
                                                 *cap.time(),
                                                 1,

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -122,3 +122,15 @@ badint,
 
 ! SELECT * FROM malformed_csv
 Decode error: Text: CSV error at lineno 3: expected 2 columns, got 1.
+
+# Static non-utf-8 CSV
+$ file-append path=bad-text.csv
+Dollars,Category
+5161669,\x80
+
+> CREATE MATERIALIZED SOURCE bad_text_csv
+  FROM FILE '${testdrive.temp-dir}/bad-text.csv'
+  FORMAT CSV WITH HEADER
+
+! SELECT * FROM bad_text_csv
+Decode error: Text: CSV error at lineno 2: invalid UTF-8


### PR DESCRIPTION
Improve the error message to include a line number, if set.

This commit also changes how we print the line number. Instead of using
unwrap_or_default, print "unknown" when the line number is unset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5994)
<!-- Reviewable:end -->
