### PR TITLE
Order NULL greater than other values

### DIFF
--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -25,8 +25,6 @@ use crate::{ColumnName, ColumnType, DatumList, DatumMap};
 /// A single value.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Datum<'a> {
-    /// An unknown value.
-    Null,
     /// The `false` boolean value.
     False,
     /// The `true` boolean value.
@@ -91,6 +89,11 @@ pub enum Datum<'a> {
     // TODO(benesch): get rid of this variant. With a more capable optimizer, I
     // don't think there would be any need for dummy datums.
     Dummy,
+    /// An unknown value.
+    ///
+    /// Leave this variant last, to ensure that it compares greater than all
+    /// other variants.
+    Null,
 }
 
 impl<'a> Datum<'a> {


### PR DESCRIPTION
We order `NULL` before all other `Datum` variants, which causes us to produce different results from postgres, and at least one optimization to be wrong (`nonnull_requirements.rs` at `TopK`). This PR is just to check out what happens if we change that order. If folks have any thoughts on being clearer about specification, I'm game for writing this down somewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5998)
<!-- Reviewable:end -->
