### PR TITLE
Narrow nonnull requirements for topk

### DIFF
--- a/test/testdrive/github-5984.td
+++ b/test/testdrive/github-5984.td
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Regression test for https://github.com/MaterializeInc/materialize/issues/5984
+#
+# wrong result with ORDER BY and NULLs in scalar subquery
+#
+
+> CREATE TABLE t1 (f1 INTEGER);
+> CREATE INDEX i1 ON t1(f1);
+
+> INSERT INTO t1 VALUES (1);
+
+> CREATE TABLE t2 (f1 INTEGER);
+
+> INSERT INTO t2 VALUES (1);
+
+> CREATE TABLE t3 (f1 INTEGER);
+
+> INSERT INTO t3 VALUES (NULL);
+> INSERT INTO t3 VALUES (1);
+
+# No rows expected. When #5982 is fixed, add ORDER BY DESC to make sure that the NULL row raises to the top of the query
+
+> SELECT COUNT(*) FROM t1 WHERE f1 = ( SELECT t2 . f1 FROM t3 LEFT JOIN t2 ON ( t3 . f1 = t1.f1 ) ORDER BY 1 LIMIT 1);
+0
+
+> SELECT f1 = ( SELECT t2 . f1 FROM t3 LEFT JOIN t2 ON ( t3 . f1 = t1.f1 ) ORDER BY 1 LIMIT 1) IS NULL FROM t1;
+true


### PR DESCRIPTION
The `TopK` stage was propagating non-null requirements for all columns. Such a requirement allows inputs to discard columns with null values in certain columns. This is not appropriate for non-key columns, as the removal of rows may cause other rows to be returned under the limit. The optimization could be permitted in certain settings based on the ordering of `NULL`, but great care needs to be taken to identify those settings (roughly: only columns that show up as the first entry of `order_by`; perhaps too esoteric to matter).

Fixes #5984

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/5999)
<!-- Reviewable:end -->
