### PR TITLE
sql: add position() string function

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -113,6 +113,8 @@ Wrap your release notes at the 80 character mark.
 
 - Add the basic exponentiation, power and [logarithm functions](/sql/functions/#numbers-func).
 
+- Add `position` to the [string function](/sql/functions#string-func) suite.
+
 {{% version-header v0.7.0 %}}
 
 - **Known issue.** You cannot upgrade nodes created with versions v0.6.1 or

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -246,6 +246,9 @@
   - signature: 'octet_length(b: bytea) -> int'
     description: Number of bytes in `b`
 
+  - signature: 'position(sub: str IN s: str) -> int'
+    description: The starting index of `sub` within `s` or `0` if `sub` is not a substring of `s`.
+
   - signature: 'regexp_match(haystack: str, needle: str [, flags: str]]) -> str[]'
     description: >-
       Matches the regular expression `needle` against haystack, returning a

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -178,6 +178,7 @@ Over
 Partition
 Plan
 Plans
+Position
 Postgres
 Preceding
 Precision

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -330,6 +330,9 @@ impl<'a> Parser<'a> {
             }),
             Token::Keyword(ROW) => self.parse_row_expr(),
             Token::Keyword(TRIM) => self.parse_trim_expr(),
+            Token::Keyword(POSITION) if self.peek_token() == Some(Token::LParen) => {
+                self.parse_position_expr()
+            }
             Token::Keyword(kw) if kw.is_reserved() => {
                 return Err(self.error(
                     self.peek_prev_pos(),
@@ -712,6 +715,31 @@ impl<'a> Parser<'a> {
         self.expect_token(&Token::RParen)?;
         Ok(Expr::Function(Function {
             name: UnresolvedObjectName::unqualified(name),
+            args: FunctionArgs::Args(exprs),
+            filter: None,
+            over: None,
+            distinct: false,
+        }))
+    }
+
+    // Parse calls to position(), which has the special form position('string' in 'string').
+    fn parse_position_expr(&mut self) -> Result<Expr<Raw>, ParserError> {
+        self.expect_token(&Token::LParen)?;
+
+        let mut exprs = Vec::new();
+
+        // we must be greater-equal the precedence of IN, which is Like to avoid
+        // parsing away the IN as part of the sub expression
+        exprs.push(self.parse_subexpr(Precedence::Like)?);
+
+        self.expect_token(&Token::Keyword(IN))?;
+
+        exprs.push(self.parse_expr()?);
+
+        self.expect_token(&Token::RParen)?;
+
+        Ok(Expr::Function(Function {
+            name: UnresolvedObjectName::unqualified("position"),
             args: FunctionArgs::Args(exprs),
             filter: None,
             over: None,

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -492,3 +492,22 @@ parse-scalar
 ((x).*.*)
 ----
 Nested(WildcardAccess(WildcardAccess(Nested(Identifier([Ident("x")])))))
+
+# Special position syntax
+
+parse-scalar
+position('om' IN 'Thomas')
+----
+Function(Function { name: UnresolvedObjectName([Ident("position")]), args: Args([Value(String("om")), Value(String("Thomas"))]), filter: None, over: None, distinct: false })
+
+parse-scalar
+"position"('om', 'Thomas')
+----
+Function(Function { name: UnresolvedObjectName([Ident("position")]), args: Args([Value(String("om")), Value(String("Thomas"))]), filter: None, over: None, distinct: false })
+
+parse-scalar
+position('om', 'Thomas')
+----
+error: Expected IN, found comma
+position('om', 'Thomas')
+             ^

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1558,6 +1558,9 @@ lazy_static! {
                     Ok(HirScalarExpr::literal(Datum::String(&name), ScalarType::String))
                 }), 1619;
             },
+            "position" => Scalar {
+                params!(String, String) => BinaryFunc::Position, 849;
+            },
             "power" => Scalar {
                 params!(Float64, Float64) => BinaryFunc::Power, 1368;
                 params!(DecimalAny, DecimalAny) => Operation::binary(|ecx, lhs, rhs| {

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -863,3 +863,67 @@ SELECT ''::pg_catalog.CHAR(0)
 
 query error length for type char must be within \[1-10485760\], have 10485761
 SELECT ''::pg_catalog.CHAR(10485761)
+
+### position ###
+statement ok
+CREATE TABLE positiontest (strcol1 char(15), strcol2 char(15), vccol1 varchar(15), vccol2 varchar(15))
+
+statement ok
+INSERT INTO positiontest VALUES ('om', 'Thomas', 'om', 'Thomas'), ('foo', 'barbar', 'foo', 'barbar'),
+    (NULL, 'str', NULL, 'str'), ('str', NULL, 'str', NULL), ('释手', '爱不释手', '释手', '爱不释手'),
+    ('', 'str', '', 'str'), ('str', '', 'str', '')
+
+# invalid input
+statement error Expected IN, found right parenthesis
+SELECT position(42)
+
+statement error Expected IN, found right parenthesis
+SELECT position('str')
+
+statement error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT position(42 IN 'str')
+
+statement error arguments cannot be implicitly cast to any implementation's parameters; try providing explicit casts
+SELECT position('str' IN 42)
+
+statement error Expected right parenthesis, found comma
+SELECT position('str' IN 42, 172)
+
+# standard tests
+
+#TODO: materialize#589 select position(strcol1 IN strcol2) from positiontest
+
+query I rowsort
+SELECT position(vccol1 IN vccol2) FROM positiontest
+----
+3
+0
+NULL
+NULL
+3
+1
+0
+
+# NULL inputs
+query I
+SELECT position(NULL IN 'str')
+----
+NULL
+
+query I
+SELECT position('str' IN NULL)
+----
+NULL
+
+# combining characters
+
+query I
+SELECT position('ः॑' IN 'रः॑')
+----
+2
+
+# this is exactly the same as above, but using unicode escapes
+query I
+SELECT position(e'\u0903\u0951' IN e'\u0930\u0903\u0951')
+----
+2


### PR DESCRIPTION
CHAR columns don't work properly, see #589.

Potentially controversial bits:
 - The return type of `position()` is `Int32`, could make this an `Int64`.
 - The parser peeks ahead to know to parse `position(` as a function call, which still allows `position` as a column name. I found this because I previously didn't check here and some tests were failing where `position` is used as a column name.

Closes #5327

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6004)
<!-- Reviewable:end -->
