### PR TITLE
Enable variable substitution in sub workflows

### DIFF
--- a/bin/ci-mzcompose
+++ b/bin/ci-mzcompose
@@ -17,6 +17,8 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
+export MZCOMPOSE_TESTING="yeah"
+
 for test_dir in test/mzcompose/* ; do
      [[ ! -d "$test_dir" ]] && continue
     dirname=$(basename "$test_dir")

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -501,6 +501,73 @@ mzworkflows:
   Also see the [chbench demo mzcompose](../../demo/chbench/mzcompose.yml) for
   a detailed example.
 
+#### Bash-like Environment Substitution
+
+`mzcompose` performs "bash-like" variable substitution within workflows. For example, you can
+define the following workflow, and it will pull `MZ_WORKERS` from your environment:
+
+```yaml
+mzworkflows:
+  example_workflow:
+    env:
+      # Use MZ_WORKERS from the environment. If not set, default to empty string
+      MZ_WORKERS: ${MZ_WORKERS}
+    - step: STEP-NAME
+      STEP-OPTION: STEP-OPTION-VALUE
+```
+
+The variable substitution can occur anywhere with the workflow specification:
+
+```yaml
+mzworkflows:
+  example_workflow:
+    env:
+      # Use MZ_WORKERS from the environment. If not set, default to empty string
+      MZ_WORKERS: ${MZ_WORKERS}
+    - step: STEP-NAME
+      STEP-OPTION: ${MZ_WORKERS}
+```
+
+Support for default values works exactly as in bash:
+
+```yaml
+mzworkflows:
+  example_workflow:
+    env:
+      # If MZ_WORKERS is set, use the value from the environment. Otherwise use 16
+      MZ_WORKERS: ${MZ_WORKERS:-16}
+    - step: STEP-NAME
+      STEP-OPTION: STEP-OPTION-VALUE
+```
+
+For workflows triggered by another workflow, variables substitution occurs at the time the
+workflow is triggered (as opposed to when the composition is loaded). This means that you can set
+an environment variable in one workflow and it will be picked up by the second workflow:
+
+```yaml
+mzworkflows:
+  workflow1:
+    env:
+      # Explicitly set the value to 16, ignoring the parent environment
+      MZ_WORKERS: 16
+    - step: workflow
+      workflow: workflow2
+  workflow2:
+    env:
+      # MZ_WORKERS will be 16 if called from workflow1
+      # If not called from workflow1, it pull the value from the environment or default
+      MZ_WORKERS: ${MZ_WORKERS:-32}
+    - step: STEP-NAME
+      STEP-OPTION: STEP-OPTION-VALUE
+```
+
+The preference order for variable subsitution is:
+
+1. The value specified by the mzworkflow.
+2. The value specified by the environment.
+3. The default value specified where the variable is being used.
+4. Empty string.
+
 ### mzbuild Dockerfile
 
 An mzbuild Dockerfile is like a [normal Dockerfile][dockerfile-ref], but it can depend on other

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -503,8 +503,11 @@ mzworkflows:
 
 #### Bash-like Environment Substitution
 
-`mzcompose` performs "bash-like" variable substitution within workflows. For example, you can
-define the following workflow, and it will pull `MZ_WORKERS` from your environment:
+`mzcompose` performs "bash-like" variable substitution within workflows (for `services` the block,
+docker-compose is responsible for [variable
+substitution](https://docs.docker.com/compose/compose-file/compose-file-v3/#variable-substitution)).
+For example, you can define the following workflow, and it will pull `MZ_WORKERS` from your
+environment:
 
 ```yaml
 mzworkflows:
@@ -531,7 +534,8 @@ mzworkflows:
 ```
 
 Support for default values similarly as it does in bash, but the full syntax is not supported. At
-the moment, `mzcompose` only supports default replacement via the `:-` operator:
+the moment, `mzcompose` only supports default replacement via the `:-` operator and only for
+variables using the `${VARIABLE}` syntax:
 
 ```yaml
 mzworkflows:

--- a/doc/developer/mzbuild.md
+++ b/doc/developer/mzbuild.md
@@ -512,6 +512,7 @@ mzworkflows:
     env:
       # Use MZ_WORKERS from the environment. If not set, default to empty string
       MZ_WORKERS: ${MZ_WORKERS}
+    steps:
     - step: STEP-NAME
       STEP-OPTION: STEP-OPTION-VALUE
 ```
@@ -524,11 +525,13 @@ mzworkflows:
     env:
       # Use MZ_WORKERS from the environment. If not set, default to empty string
       MZ_WORKERS: ${MZ_WORKERS}
+    steps:
     - step: STEP-NAME
       STEP-OPTION: ${MZ_WORKERS}
 ```
 
-Support for default values works exactly as in bash:
+Support for default values similarly as it does in bash, but the full syntax is not supported. At
+the moment, `mzcompose` only supports default replacement via the `:-` operator:
 
 ```yaml
 mzworkflows:
@@ -536,6 +539,7 @@ mzworkflows:
     env:
       # If MZ_WORKERS is set, use the value from the environment. Otherwise use 16
       MZ_WORKERS: ${MZ_WORKERS:-16}
+    steps:
     - step: STEP-NAME
       STEP-OPTION: STEP-OPTION-VALUE
 ```
@@ -550,6 +554,7 @@ mzworkflows:
     env:
       # Explicitly set the value to 16, ignoring the parent environment
       MZ_WORKERS: 16
+    steps:
     - step: workflow
       workflow: workflow2
   workflow2:
@@ -557,6 +562,7 @@ mzworkflows:
       # MZ_WORKERS will be 16 if called from workflow1
       # If not called from workflow1, it pull the value from the environment or default
       MZ_WORKERS: ${MZ_WORKERS:-32}
+    steps:
     - step: STEP-NAME
       STEP-OPTION: STEP-OPTION-VALUE
 ```

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -107,15 +107,6 @@ def main(argv: List[str]) -> int:
             workflow = composition.get_workflow(
                 dict(os.environ), args.first_command_arg
             )
-            # The user has specified a workflow rather than a service. Run the
-            # workflow instead of Docker Compose.
-            if args.remainder:
-                raise errors.MzRuntimeError(
-                    f"cannot specify extra arguments ({' '.join(args.remainder)}) "
-                    "when specifying a workflow (rather than a container)"
-                )
-            workflow.run()
-            return 0
         except KeyError:
             # Restart any dependencies whose definitions have changed. This is
             # Docker Compose's default behavior for `up`, but not for `run`,
@@ -131,6 +122,16 @@ def main(argv: List[str]) -> int:
                     args.first_command_arg,
                 ]
             )
+        else:
+            # The user has specified a workflow rather than a service. Run the
+            # workflow instead of Docker Compose.
+            if args.remainder:
+                raise errors.MzRuntimeError(
+                    f"cannot specify extra arguments ({' '.join(args.remainder)}) "
+                    "when specifying a workflow (rather than a container)"
+                )
+            workflow.run()
+            return 0
 
     # Hand over control to Docker Compose.
     announce("Delegating to Docker Compose")

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -103,8 +103,20 @@ def main(argv: List[str]) -> int:
 
     # The `run` command requires special handling.
     if args.command == "run":
-        workflow = composition.workflows.get(args.first_command_arg, None)
-        if workflow is None:
+        try:
+            workflow = composition.get_workflow(
+                dict(os.environ), args.first_command_arg
+            )
+            # The user has specified a workflow rather than a service. Run the
+            # workflow instead of Docker Compose.
+            if args.remainder:
+                raise errors.MzRuntimeError(
+                    f"cannot specify extra arguments ({' '.join(args.remainder)}) "
+                    "when specifying a workflow (rather than a container)"
+                )
+            workflow.run()
+            return 0
+        except KeyError:
             # Restart any dependencies whose definitions have changed. This is
             # Docker Compose's default behavior for `up`, but not for `run`,
             # which is a constant irritation that we paper over here. The trick,
@@ -119,16 +131,6 @@ def main(argv: List[str]) -> int:
                     args.first_command_arg,
                 ]
             )
-        else:
-            # The user has specified a workflow rather than a service. Run the
-            # workflow instead of Docker Compose.
-            if args.remainder:
-                raise errors.MzRuntimeError(
-                    f"cannot specify extra arguments ({' '.join(args.remainder)}) "
-                    "when specifying a workflow (rather than a container)"
-                )
-            workflow.run()
-            return 0
 
     # Hand over control to Docker Compose.
     announce("Delegating to Docker Compose")

--- a/misc/python/tests/test_mzconduct.py
+++ b/misc/python/tests/test_mzconduct.py
@@ -14,17 +14,17 @@ from materialize import mzcompose
 def test_bash_subst() -> None:
     step = {"step": "run", "cmd": "${EXAMPLE}"}
     one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
-    os.environ["EXAMPLE"] = "foo"
-    mzcompose._substitute_env_vars(one)
+    env = {"EXAMPLE": "foo"}
+    mzcompose._substitute_env_vars(one, env)
     assert step["cmd"] == "foo"
 
     step = {"step": "run", "cmd": "${EXAMPLE:-bar}"}
     one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
-    del os.environ["EXAMPLE"]
-    mzcompose._substitute_env_vars(one)
+    del env["EXAMPLE"]
+    mzcompose._substitute_env_vars(one, env)
     assert step["cmd"] == "bar"
 
     step = {"step": "run", "cmd": "${NOPE NOPE}"}
     one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
-    mzcompose._substitute_env_vars(one)
+    mzcompose._substitute_env_vars(one, env)
     assert step["cmd"] == "${NOPE NOPE}"

--- a/test/mzcompose/test_env_blanketed/Dockerfile
+++ b/test/mzcompose/test_env_blanketed/Dockerfile
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM alpine:3
+
+COPY test.sh /test.sh

--- a/test/mzcompose/test_env_blanketed/mzbuild.yml
+++ b/test/mzcompose/test_env_blanketed/mzbuild.yml
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: mzcompose-test-env-blanketed
+publish: false

--- a/test/mzcompose/test_env_blanketed/mzcompose.yml
+++ b/test/mzcompose/test_env_blanketed/mzcompose.yml
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+services:
+  check_env_unset:
+    mzbuild: mzcompose-test-env-blanketed
+    command: sh /test.sh
+
+mzworkflows:
+  # Test that workflows only have environment variables explicitly requested
+  ci:
+    steps:
+      - step: run
+        service: check_env_unset

--- a/test/mzcompose/test_env_blanketed/test.sh
+++ b/test/mzcompose/test_env_blanketed/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -x
+
+test "$MZCOMPOSE_TESTING" != yeah

--- a/test/mzcompose/test_env_override/mzcompose.yml
+++ b/test/mzcompose/test_env_override/mzcompose.yml
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+services:
+  check_env_set:
+    image: alpine:3
+    command: |
+      /bin/sh -c '
+      set -x ;
+      test "$ENV_IS_SET" == yeah ;'
+
+mzworkflows:
+  # Test that child workflows can override an environment variable for the docker run command
+  ci:
+    env:
+      ENV_IS_SET: nope
+    steps:
+      - step: workflow
+        workflow: overrider
+  overrider:
+    env:
+      ENV_IS_SET: yeah
+    steps:
+      - step: run
+        service: check_env_set

--- a/test/mzcompose/test_env_override_substitute/mzcompose.yml
+++ b/test/mzcompose/test_env_override_substitute/mzcompose.yml
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+services:
+  check_env_set:
+    image: alpine:3
+
+mzworkflows:
+  # Test that child workflow can explicitly override an environment variable
+  # when the variable is substitutedd during workflow creation.
+  ci:
+    env:
+      ENV_IS_SET: yeah
+    steps:
+      - step: workflow
+        workflow: substitute_overrider
+  substitute_overrider:
+    env:
+      ENV_IS_SET: nope
+    steps:
+      - step: run
+        service: check_env_set
+        command: |
+          /bin/sh -c '
+          set -x ;
+          test "${ENV_IS_SET}" == nope ;'

--- a/test/mzcompose/test_env_passthrough/Dockerfile
+++ b/test/mzcompose/test_env_passthrough/Dockerfile
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+FROM alpine:3
+
+COPY test.sh /test.sh

--- a/test/mzcompose/test_env_passthrough/mzbuild.yml
+++ b/test/mzcompose/test_env_passthrough/mzbuild.yml
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: mzcompose-test-env-passthrough
+publish: false

--- a/test/mzcompose/test_env_passthrough/mzcompose.yml
+++ b/test/mzcompose/test_env_passthrough/mzcompose.yml
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+services:
+  check_env_unset:
+    environment:
+      - MZCOMPOSE_TESTING
+    mzbuild: mzcompose-test-env-passthrough
+    command: sh /test.sh
+
+mzworkflows:
+  # Test that workflows only have environment variables explicitly requested
+  ci:
+    steps:
+      - step: run
+        service: check_env_unset

--- a/test/mzcompose/test_env_passthrough/test.sh
+++ b/test/mzcompose/test_env_passthrough/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -x
+
+test "$MZCOMPOSE_TESTING" == yeah

--- a/test/mzcompose/test_env_substitution/mzcompose.yml
+++ b/test/mzcompose/test_env_substitution/mzcompose.yml
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+services:
+  check_env_substituted:
+    image: alpine:3
+    command: |
+      /bin/sh -c '
+      set -x ;
+      test "$ENV_IS_SUBSTITUTED" == yeah ;'
+
+mzworkflows:
+  # Test that child workflows have their environment variables subsituted from the parent workflow
+  ci:
+    env:
+      ENV_IS_SET: yeah
+    steps:
+      - step: workflow
+        workflow: substituted
+  substituted:
+    env:
+      ENV_IS_SUBSTITUTED: ${ENV_IS_SET:-nope}
+    steps:
+      - step: run
+        service: check_env_substituted


### PR DESCRIPTION
c2c060e665a2971e89c0c2dff441093017e2ed77 added the ability for sub workflows to
inherit environment variables from parent workflows but only during the
run command itself. mzcompose variable substitution still only happened
when first loading the composition.

This commit gives sub workflows the ability to read and/or override
environment variables from the parent (either can be specified) and then
perform environment variable subsitution in the workflow spec itself.

This unblocks #5587 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6012)
<!-- Reviewable:end -->
