### PR TITLE
doc: missing semicolon on sql example

### DIFF
--- a/doc/user/content/sql/create-source/json-kafka.md
+++ b/doc/user/content/sql/create-source/json-kafka.md
@@ -40,7 +40,7 @@ CREATE MATERIALIZED VIEW jsonified_kafka_source AS
   FROM (
       SELECT convert_from(data, 'utf8') AS data
       FROM json_kafka
-  )
+  );
 ```
 
 ### Caching records to local disk


### PR DESCRIPTION
Very minor missing semicolon in docs, but if I don't fix it while I'm on the page I'll probably forget about it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6017)
<!-- Reviewable:end -->
