### PR TITLE
Int literal promotion + substr refactor

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3659,31 +3659,55 @@ fn pad_leading<'a>(
     Ok(Datum::String(temp_storage.push_string(buf)))
 }
 
-fn substr<'a>(datums: &[Datum<'a>]) -> Datum<'a> {
-    let string: &'a str = datums[0].unwrap_str();
-    let mut chars = string.chars();
+fn substr<'a>(datums: &[Datum<'a>]) -> Result<Datum<'a>, EvalError> {
+    let s: &'a str = datums[0].unwrap_str();
 
-    let start_in_chars = datums[1].unwrap_int64() - 1;
-    let mut start_in_bytes = 0;
-    for _ in 0..cmp::max(start_in_chars, 0) {
-        start_in_bytes += chars.next().map(|char| char.len_utf8()).unwrap_or(0);
-    }
+    let raw_start_idx = datums[1].unwrap_int64() - 1;
+    let start_idx = match usize::try_from(cmp::max(raw_start_idx, 0)) {
+        Ok(i) => i,
+        Err(_) => {
+            return Err(EvalError::InvalidParameterValue(format!(
+                "substring starting index ({}) exceeds min/max position",
+                raw_start_idx
+            )))
+        }
+    } as usize;
+
+    let mut char_indices = s.char_indices();
+    let get_str_index = |(index, _char)| index;
+
+    let str_len = s.len();
+    let start_char_idx = char_indices
+        .nth(start_idx as usize)
+        .map_or(str_len, &get_str_index);
 
     if datums.len() == 3 {
-        let mut length_in_chars = datums[2].unwrap_int64();
-        if length_in_chars < 0 {
-            return Datum::Null;
-        }
-        if start_in_chars < 0 {
-            length_in_chars += start_in_chars;
-        }
-        let mut length_in_bytes = 0;
-        for _ in 0..cmp::max(length_in_chars, 0) {
-            length_in_bytes += chars.next().map(|char| char.len_utf8()).unwrap_or(0);
-        }
-        Datum::String(&string[start_in_bytes..start_in_bytes + length_in_bytes])
+        let end_idx = match datums[2].unwrap_int64() {
+            e if e < 0 => {
+                return Err(EvalError::InvalidParameterValue(
+                    "negative substring length not allowed".to_owned(),
+                ))
+            }
+            e if e == 0 || e + raw_start_idx < 1 => return Ok(Datum::String("")),
+            e => {
+                let e = cmp::min(raw_start_idx + e - 1, e - 1);
+                match usize::try_from(e) {
+                    Ok(i) => i,
+                    Err(_) => {
+                        return Err(EvalError::InvalidParameterValue(format!(
+                            "substring length ({}) exceeds max position",
+                            e
+                        )))
+                    }
+                }
+            }
+        };
+
+        let end_char_idx = char_indices.nth(end_idx).map_or(str_len, &get_str_index);
+
+        Ok(Datum::String(&s[start_char_idx..end_char_idx]))
     } else {
-        Datum::String(&string[start_in_bytes..])
+        Ok(Datum::String(&s[start_char_idx..]))
     }
 }
 
@@ -4489,7 +4513,7 @@ impl VariadicFunc {
             VariadicFunc::Concat => Ok(eager!(text_concat_variadic, temp_storage)),
             VariadicFunc::MakeTimestamp => Ok(eager!(make_timestamp)),
             VariadicFunc::PadLeading => eager!(pad_leading, temp_storage),
-            VariadicFunc::Substr => Ok(eager!(substr)),
+            VariadicFunc::Substr => eager!(substr),
             VariadicFunc::Replace => Ok(eager!(replace, temp_storage)),
             VariadicFunc::JsonbBuildArray => Ok(eager!(jsonb_build_array, temp_storage)),
             VariadicFunc::JsonbBuildObject => Ok(eager!(jsonb_build_object, temp_storage)),

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -338,7 +338,29 @@ impl<'a> Parser<'a> {
             }
             Token::Keyword(id) => self.parse_qualified_identifier(id.into_ident()),
             Token::Ident(id) => self.parse_qualified_identifier(Ident::new(id)),
-            Token::Op(op) if op == "+" || op == "-" => Ok(Expr::Op {
+            Token::Op(op) if op == "-" => {
+                if let Some(Token::Number(n)) = self.peek_token() {
+                    let n = match n.parse::<f64>() {
+                        Ok(n) => n,
+                        Err(_) => {
+                            return Err(
+                                self.error(self.peek_prev_pos(), format!("invalid number {}", n))
+                            )
+                        }
+                    };
+                    if n != 0.0 {
+                        self.prev_token();
+                        return Ok(Expr::Value(self.parse_value()?));
+                    }
+                }
+
+                Ok(Expr::Op {
+                    op,
+                    expr1: Box::new(self.parse_subexpr(Precedence::PrefixPlusMinus)?),
+                    expr2: None,
+                })
+            }
+            Token::Op(op) if op == "+" => Ok(Expr::Op {
                 op,
                 expr1: Box::new(self.parse_subexpr(Precedence::PrefixPlusMinus)?),
                 expr2: None,

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -429,12 +429,22 @@ Op { op: "@@", expr1: Identifier([Ident("a")]), expr2: Some(Identifier([Ident("b
 parse-scalar
 1*-1
 ----
-Op { op: "*", expr1: Value(Number("1")), expr2: Some(Op { op: "-", expr1: Value(Number("1")), expr2: None }) }
+Op { op: "*", expr1: Value(Number("1")), expr2: Some(Value(Number("-1"))) }
 
 parse-scalar
 1+-1
 ----
-Op { op: "+", expr1: Value(Number("1")), expr2: Some(Op { op: "-", expr1: Value(Number("1")), expr2: None }) }
+Op { op: "+", expr1: Value(Number("1")), expr2: Some(Value(Number("-1"))) }
+
+parse-scalar
+1+-00.00
+----
+Op { op: "+", expr1: Value(Number("1")), expr2: Some(Op { op: "-", expr1: Value(Number("00.00")), expr2: None }) }
+
+parse-scalar
+1+-a
+----
+Op { op: "+", expr1: Value(Number("1")), expr2: Some(Op { op: "-", expr1: Identifier([Ident("a")]), expr2: None }) }
 
 parse-scalar
 1@+2

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -79,15 +79,11 @@ SELECT substr('from wrong type', 1.5, 2)
 statement error
 SELECT substr('for wrong type', 2, 1.5)
 
-query I
+query error negative substring length not allowed
 SELECT substr('for cannot be negative', 1, -3)
-----
-NULL
 
-query I
+query error negative substring length not allowed
 SELECT substr('for still cannot be negative', 30, -2)
-----
-NULL
 
 # standard tests
 
@@ -314,14 +310,15 @@ man
 
 # testing different kinds of int columns and NULL content in columns
 query T
-SELECT substr(vccol, smicol, smicol) AS vcres FROM substrtest ORDER BY vcres
+SELECT substr(vccol, smicol, smicol) AS vcres FROM substrtest WHERE smicol > -1  ORDER BY vcres
 ----
-NULL
-NULL
 NULL
 4.
 M
 nga
+
+query error negative substring length not allowed
+SELECT substr(vccol, smicol, smicol) AS vcres FROM substrtest ORDER BY vcres
 
 query T
 SELECT substr(vccol, intcol, intcol) AS vcres FROM substrtest ORDER BY vcres
@@ -344,10 +341,8 @@ NULL
 M
 
 query T
-SELECT substr(vccol, intcol, smicol) AS vcres FROM substrtest ORDER BY vcres
+SELECT substr(vccol, intcol, smicol) AS vcres FROM substrtest WHERE smicol > -1 ORDER BY vcres
 ----
-NULL
-NULL
 NULL
 NULL
 .9
@@ -357,6 +352,22 @@ query T
 SELECT substr('subexpression test', ascii(''), 3)
 ----
 su
+
+# testing large numbers
+query T
+SELECT substr('abcdef', 2, 2147483648);
+----
+bcdef
+
+query T
+SELECT substr('abcdef', 2147483648, 2);
+----
+(empty)
+
+query T
+SELECT substr('abcdef', 2147483648, 2147483648);
+----
+(empty)
 
 # TODO: materialize#606 Add tests for the alternate syntax if it is enabled
 

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -84,7 +84,7 @@ EXPLAIN RAW PLAN FOR SELECT generate_series FROM generate_series(-2, 2)
 | Constant ()
 
 %1 =
-| CallTable generate_series(-(2), 2)
+| CallTable generate_series(-2, 2)
 
 %2 =
 | InnerLateralJoin %0 %1 on true

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -63,6 +63,39 @@ SELECT 'true' OR 'false'
 ----
 true
 
+# Int literals less than i32::MAX/MIN are int4
+query T
+SELECT pg_typeof(100)
+----
+integer
+
+query T
+SELECT pg_typeof(-100)
+----
+integer
+
+# Int literals that exceed i32, are int8
+query T
+SELECT pg_typeof(2147483648)
+----
+bigint
+
+query T
+SELECT pg_typeof(-2147483649)
+----
+bigint
+
+# Int literals that exceed i64 are numeric
+query T
+SELECT pg_typeof(9223372036854775808)
+----
+numeric(38,0)
+
+query T
+SELECT pg_typeof(-9223372036854775809)
+----
+numeric(38,0)
+
 # Use comparison ops to check for type promotion
 
 # Check int4 promotes to numeric

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -63,7 +63,7 @@ SELECT 'true' OR 'false'
 ----
 true
 
-# Int literals less than i32::MAX/MIN are int4
+# Int literals <=32::MAX/>= MIN are int4
 query T
 SELECT pg_typeof(100)
 ----
@@ -74,7 +74,17 @@ SELECT pg_typeof(-100)
 ----
 integer
 
-# Int literals that exceed i32, are int8
+query T
+SELECT pg_typeof(2147483647)
+----
+integer
+
+query T
+SELECT pg_typeof(-2147483648)
+----
+integer
+
+# Int literals that exceed i32 are int8
 query T
 SELECT pg_typeof(2147483648)
 ----
@@ -82,6 +92,16 @@ bigint
 
 query T
 SELECT pg_typeof(-2147483649)
+----
+bigint
+
+query T
+SELECT pg_typeof(9223372036854775807)
+----
+bigint
+
+query T
+SELECT pg_typeof(-9223372036854775808)
 ----
 bigint
 


### PR DESCRIPTION
- Fixes #6015, pointed out by @aljoscha 
- Uncovered a performance problem with the implementation of `substr` where using large values for the string length took a very, very, very long time due to the [`for` loop](https://github.com/MaterializeInc/materialize/compare/main...sploiselle:int-literal-promotion#diff-6803539c802e2aee474fb1c0fab29db55cfb9e4d4bd3797509b7f18971f1480bL3681) that did the "char index" to byte index conversion. Instead used `char_indices` to move from char to byte indices, which is faster.

  We now also support erroring in these contexts, so added errors for PG compatibility.

  Pinging @wangandi just bc she did the initial implementation and want to make sure I'm not overlooking anything.

@JLDLaughlin do you mind taking a look, as well, just given your expertise in the SQL code?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6019)
<!-- Reviewable:end -->
