### PR TITLE
dataflow: define interface for simple sources

### DIFF
--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -44,7 +44,7 @@ rusoto_sqs = { git = "https://github.com/rusoto/rusoto.git" }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.4.0", features = ["fs", "rt"] }
+tokio = { version = "1.4.0", features = ["fs", "rt", "sync" ] }
 tokio-util = { version = "0.6.4", features = ["codec"] }
 url = { version = "2.2.1", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }


### PR DESCRIPTION
This PR introduces a `SimpleSource` trait and a `Timestamper` struct in order to enable easier creation of sources.

The interface is such that the source implementation never sets the timestamps directly. It can only insert or delete rows and do so individually or as part of a transaction.

Internally, all rows are timestamped with an appropriate wall-clock time, maintaining the transaction boundaries as specified by the source. When there are no active transactions the clock is automatically advanced and timestamps are getting closed at the `timestamp_frequency` defined in the system.

While still a WIP, a fully functional example usage of this interface can be seen here:

https://github.com/petrosagg/materialize/blob/1e67b4b841d02d67d431bfa8c5f6df28c208be93/src/dataflow/src/source/postgres.rs#L334-L358

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6024)
<!-- Reviewable:end -->
