### PR TITLE
Increase inline storage of Row without changing inline size

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -75,7 +75,7 @@ use fmt::Debug;
 /// avoids the allocations involved in `RowPacker::new()`.
 #[derive(Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Row {
-    data: SmallVec<[u8; 16]>,
+    data: SmallVec<[u8; 23]>,
 }
 
 /// These implementations order first by length, and then by slice contents.
@@ -1492,5 +1492,15 @@ mod tests {
                 panic!("Disparity in claimed size for {:?}", value);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn row_size_is_stable() {
+        // nothin depends on this being exactly 32, we just want it to be an active decision if we
+        // change it
+        assert_eq!(std::mem::size_of::<super::Row>(), 32);
     }
 }


### PR DESCRIPTION
SmallVec allows you to specify how much inline storage it should use before heap
allocating. The `16` bytes value there seemed suspicious to me because it
doesn't seem like the right number of free bytes necessary for any particular
shape of "is overflowed" flag. Indeed, bumping it up to 23 doesn't change the
size from 32 bytes, the test passes with and without this change, but fails if I
bump it up to 24.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6026)
<!-- Reviewable:end -->
