### PR TITLE
Add bashlike alt variable support to mzcompose

### DIFF
--- a/misc/python/tests/test_mzconduct.py
+++ b/misc/python/tests/test_mzconduct.py
@@ -28,3 +28,29 @@ def test_bash_subst() -> None:
     one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
     mzcompose._substitute_env_vars(one, env)
     assert step["cmd"] == "${NOPE NOPE}"
+
+
+def test_bash_alt_subst() -> None:
+    step = {"step": "run", "cmd": "${EXAMPLE:+baz}"}
+    one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
+    env = {"EXAMPLE": "foo"}
+    mzcompose._substitute_env_vars(one, env)
+    assert step["cmd"] == "baz"
+
+    step = {"step": "run", "cmd": "${EXAMPLE:+baz}"}
+    one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
+    del env["EXAMPLE"]
+    mzcompose._substitute_env_vars(one, env)
+    assert step["cmd"] == ""
+
+    step = {"step": "run", "cmd": "${EXAMPLE}${EXAMPLE:+baz}"}
+    one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
+    env = {"EXAMPLE": "foo"}
+    mzcompose._substitute_env_vars(one, env)
+    assert step["cmd"] == "foobaz"
+
+    step = {"step": "run", "cmd": "${EXAMPLE:-bar}${EXAMPLE:+baz}"}
+    one = {"mzconduct": {"workflows": {"ci": {"steps": [step]}}}}
+    del env["EXAMPLE"]
+    mzcompose._substitute_env_vars(one, env)
+    assert step["cmd"] == "bar"


### PR DESCRIPTION
This enables something like the following:

    ${MZ_CHBENCH_SNAPSHOT:-kafka-data}${MZ_CHBENCH_SNAPSHOT:+/kafka-data}

Where the above either returns `kafka-data` or
`${MZ_CHBENCH_SNAPSHOT}/kafka-data` but does not return
`kakfa-data/kafka-data`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6041)
<!-- Reviewable:end -->
