### PR TITLE
Fixup mzcompose gen-shortcuts

### DIFF
--- a/ci/test/cargo-test/mzcompose
+++ b/ci/test/cargo-test/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -164,9 +164,9 @@ def gen_shortcuts(repo: mzbuild.Repository) -> int:
 exec "$(dirname "$0")/{}/bin/mzcompose" "$@"
 """
     for path in repo.compositions.values():
-        mzcompose_path = path / "mzcompose"
+        mzcompose_path = path.parent / "mzcompose"
         with open(mzcompose_path, "w") as f:
-            f.write(template.format(os.path.relpath(repo.root, path)))
+            f.write(template.format(os.path.relpath(repo.root, path.parent)))
         mzbuild.chmod_x(mzcompose_path)
 
     return 0

--- a/test/mzcompose/test_env_blanketed/mzcompose
+++ b/test/mzcompose/test_env_blanketed/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/test/mzcompose/test_env_override/mzcompose
+++ b/test/mzcompose/test_env_override/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/test/mzcompose/test_env_override_substitute/mzcompose
+++ b/test/mzcompose/test_env_override_substitute/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/test/mzcompose/test_env_passthrough/mzcompose
+++ b/test/mzcompose/test_env_passthrough/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/test/mzcompose/test_env_setting/mzcompose
+++ b/test/mzcompose/test_env_setting/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"

--- a/test/mzcompose/test_env_substitution/mzcompose
+++ b/test/mzcompose/test_env_substitution/mzcompose
@@ -11,4 +11,4 @@
 #
 # mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")/../../bin/mzcompose" "$@"
+exec "$(dirname "$0")/../../../bin/mzcompose" "$@"


### PR DESCRIPTION
Compositions used to be a set of directory names, where each directory
contained a composition. a811a31992 changed this set to be a dictionary
mapping composition name to composition filename. Since the path is now
the filename, use path.parent to get the directory for gen-shortcuts.

Fixes #5981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6042)
<!-- Reviewable:end -->
