### PR TITLE
Add a mz_internal.mz_sleep(N) function

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1312,6 +1312,12 @@ fn power_dec<'a>(a: Datum<'a>, b: Datum<'a>, scale: u8) -> Result<Datum<'a>, Eva
     cast_float64_to_decimal(Datum::from(a.powf(b)), Datum::from(scale))
 }
 
+fn sleep<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    let duration = std::time::Duration::from_secs_f64(a.unwrap_float64());
+    std::thread::sleep(duration);
+    Ok(Datum::from(Utc::now()))
+}
+
 fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
     Datum::from(a == b)
 }
@@ -3076,6 +3082,7 @@ pub enum UnaryFunc {
     LnDecimal(u8),
     Exp,
     ExpDecimal(u8),
+    Sleep,
 }
 
 impl UnaryFunc {
@@ -3250,6 +3257,7 @@ impl UnaryFunc {
             UnaryFunc::LnDecimal(scale) => log_dec(a, f64::ln, "ln", *scale),
             UnaryFunc::Exp => exp(a),
             UnaryFunc::ExpDecimal(scale) => exp_dec(a, *scale),
+            UnaryFunc::Sleep => sleep(a),
         }
     }
 
@@ -3408,6 +3416,7 @@ impl UnaryFunc {
             Cot => ScalarType::Float64.nullable(in_nullable),
             Log10 | Ln | Exp => ScalarType::Float64.nullable(in_nullable),
             Log10Decimal(_) | LnDecimal(_) | ExpDecimal(_) => input_type,
+            Sleep => ScalarType::TimestampTz.nullable(false),
         }
     }
 
@@ -3587,6 +3596,7 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::LnDecimal(_) => f.write_str("lndec"),
             UnaryFunc::ExpDecimal(_) => f.write_str("expdec"),
             UnaryFunc::Exp => f.write_str("expf64"),
+            UnaryFunc::Sleep => f.write_str("mz_sleep"),
         }
     }
 }

--- a/src/pgrepr/src/oid.rs
+++ b/src/pgrepr/src/oid.rs
@@ -59,3 +59,4 @@ pub const OP_GET_VALUES_MAP_OID: u32 = 16_430;
 pub const OP_MOD_F32_OID: u32 = 16_431;
 pub const OP_MOD_F64_OID: u32 = 16_432;
 pub const OP_UNARY_PLUS_OID: u32 = 16_433;
+pub const FUNC_MZ_SLEEP_OID: u32 = 16_434;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2034,7 +2034,11 @@ lazy_static! {
             },
             "mz_render_typemod" => Scalar {
                 params!(Oid, Int32) => BinaryFunc::MzRenderTypemod, oid::FUNC_MZ_RENDER_TYPEMOD_OID;
+            },
+            "mz_sleep" => Scalar {
+                params!(Float64) => UnaryFunc::Sleep, oid::FUNC_MZ_SLEEP_OID;
             }
+
         }
     };
 }

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1084,3 +1084,8 @@ SELECT '"2020!03-17 #?~T~02:36:56#"'::timestamp;
 
 query error invalid input syntax for type timestamp: have unprocessed tokens 56
 select TIMESTAMP '"2020-03-17 ~02:36:~56~"';
+
+query T
+SELECT mz_internal.mz_sleep(0.1) - now() >= '0.1'::interval;
+----
+true


### PR DESCRIPTION
This function has side-effects, and behaves slightly differently from
pg_sleep(N): Where the postgres function returns a `void` type, this
function just returns the time at which sleeping finished.

That saves us from implementing evaluation / compilation rules for
void types, and weirdly enough it doesn't seem require us to declare
a function purely-side-effect-y to prevent it being optimized away.

Fixes: #5894

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6043)
<!-- Reviewable:end -->
