### PR TITLE
docker: embed tini init process in our images

### DIFF
--- a/demo/billing/mzcompose.yml
+++ b/demo/billing/mzcompose.yml
@@ -21,7 +21,6 @@ services:
       - db-data:/share/billing-demo/data
     ports:
      - *materialized
-    init: true
     command: --workers ${MZ_WORKERS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info

--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -40,7 +40,6 @@ services:
     mzbuild: materialized
     ports:
      - *materialized
-    init: true
     command:
       - --workers=${MZ_WORKERS:-1}
       # We want this to eventually count up to the size of the largest batch in

--- a/demo/http_logs/mzcompose.yml
+++ b/demo/http_logs/mzcompose.yml
@@ -23,7 +23,6 @@ services:
     mzbuild: materialized
     ports:
       - *materialized
-    init: true
     command: -w4 --disable-telemetry
     environment:
       - MZ_DEV=1

--- a/demo/simple/mzcompose.yml
+++ b/demo/simple/mzcompose.yml
@@ -14,7 +14,6 @@ version: "3.7"
 services:
   materialized:
     mzbuild: materialized
-    init: true
     command: -w1 --disable-telemetry
     environment:
       - MZ_DEV=1

--- a/misc/dbt-materialize/mzcompose.yml
+++ b/misc/dbt-materialize/mzcompose.yml
@@ -19,7 +19,6 @@ services:
       - MZ_DEV=1
     ports:
       - *materialized
-    init: true
   dbt-test:
     mzbuild: dbt-materialize
 

--- a/play/mbta/mzcompose.yml
+++ b/play/mbta/mzcompose.yml
@@ -20,7 +20,6 @@ services:
       - MZ_DEV=1
     ports:
       - *materialized
-    init: true
     volumes:
       - .:/workdir
   zookeeper:

--- a/play/wikirecent/mzcompose.yml
+++ b/play/wikirecent/mzcompose.yml
@@ -30,7 +30,6 @@ services:
       - MZ_DEV=1
     ports:
       - *materialized
-    init: true
     volumes:
       - type: volume
         source: wikidata

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -9,8 +9,14 @@
 
 FROM ubuntu:bionic-20200403
 
-RUN apt-get update && apt-get -qy install ca-certificates
+RUN apt-get update && apt-get -qy install ca-certificates gnupg wget
+
+RUN    export version=v0.19.0 \
+    && export digest=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c \
+    && wget "https://github.com/krallin/tini/releases/download/${version}/tini" -O /tini \
+    && echo "${digest} /tini" | sha256sum -c - \
+    && chmod +x /tini
 
 COPY kdestroy kinit materialized /usr/local/bin/
 
-ENTRYPOINT ["materialized", "--log-file=stderr"]
+ENTRYPOINT ["/tini", "--", "materialized", "--log-file=stderr" ]

--- a/test/bench/avro-upsert/mzcompose.yml
+++ b/test/bench/avro-upsert/mzcompose.yml
@@ -49,7 +49,6 @@ services:
     mzbuild: materialized
     ports:
       - *materialized
-    init: true
     command:
       - --workers=${MZ_WORKERS:-16}
       - --logical-compaction-window=1ms

--- a/test/chaos/mzcompose.yml
+++ b/test/chaos/mzcompose.yml
@@ -33,7 +33,6 @@ services:
     mzbuild: materialized
     ports:
       - *materialized
-    init: true
     command: -w4 --disable-telemetry
     environment:
       - MZ_DEV=1

--- a/test/performance/perf-kinesis/mzcompose.yml
+++ b/test/performance/perf-kinesis/mzcompose.yml
@@ -29,7 +29,6 @@ services:
     mzbuild: materialized
     ports:
       - *materialized
-    init: true
     command: -w ${MZ_WORKERS:-4} --disable-telemetry
     environment:
       - MZ_DEV=1

--- a/test/performance/perf-upsert/mzcompose.yml
+++ b/test/performance/perf-upsert/mzcompose.yml
@@ -18,7 +18,6 @@ services:
     mzbuild: materialized
     ports:
      - *materialized
-    init: true
     command: --workers ${MZ_WORKERS:-1} --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info

--- a/test/smith/mzcompose.yml
+++ b/test/smith/mzcompose.yml
@@ -13,7 +13,6 @@ services:
     mzbuild: materialized
     ports:
      - 6875
-    init: true
     command: --workers 1 --differential-idle-merge-effort=1000 --disable-telemetry
     environment:
       - MZ_LOG=dataflow=error,info


### PR DESCRIPTION
In production there isn't the equivalent of Docker's `--init` flag so we need to handle this internally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6051)
<!-- Reviewable:end -->
