### PR TITLE
refactor SourceInfo trait to remove buffer_message 

### DIFF
--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -303,10 +303,6 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
             })
         }
     }
-
-    fn buffer_message(&mut self, message: SourceMessage<Vec<u8>>) {
-        self.buffered_messages.push_front(message);
-    }
 }
 
 /// Creates the necessary data-structures for shard management

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -315,6 +315,7 @@ $ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
 {"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 1}, "timestamp": 2, "offset": 1}
 {"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 2}, "timestamp": 2, "offset": 0}
 {"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 3}, "timestamp": 2, "offset": 1}
+{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 2}, "timestamp": 3, "offset": 1}
 
 $ kafka-ingest partition=3 format=avro topic=data-multi schema=${schema} timestamp=1
 {"a": 3, "b": 1}
@@ -336,7 +337,6 @@ $ kafka-ingest partition=1 format=avro topic=data-multi schema=${schema} timesta
 
 
 $ kafka-ingest format=avro topic=data-consistency2 schema=${consistency}
-{"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 2}, "timestamp": 3, "offset": 1}
 {"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 1}, "timestamp": 3, "offset": 2}
 {"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 3}, "timestamp": 3, "offset": 2}
 {"source": "testdrive-data-multi-${testdrive.seed}", "partition_count": 4 , "partition_id": {"int": 0}, "timestamp": 3, "offset": 2}


### PR DESCRIPTION
This pr tries to refactor the operator returned by `create_source` (or I guess, more precisely, the inner closure returned by that function) to no longer rely on each specific `SourceInfo` implementation to handle message buffering.

I believe that we should reduce the amount of functionality in `SourceInfo` to only cover "reading from upstream sources, and reporting how far we have read" instead of the many different things that trait does currently.

The first commit is purely code movement to extract out the core bit of logic required to handle ingesting a message (the resulting function is a bit of a mess but baby steps) and then the second commit actually removes the per-source info buffering

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6053)
<!-- Reviewable:end -->
