### PR TITLE
(docs) Route Quickstart link in Docs to Docs>Install

### DIFF
--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -9,7 +9,7 @@
       <li><a href="https://materialize.com/docs/">Docs</a></li>
       <li><a href="https://materialize.com/product/">Product</a></li>
       <li><a href="https://materialize.com/streaming-sql/">Use Cases</a></li>
-      <li><a href="https://materialize.com/quickstart/">Quickstart</a></li>
+      <li><a href="https://materialize.com/docs/install/">Quickstart</a></li>
       <li><a href="https://materialize.com/blog/">Blog</a></li>
       <li><a href="https://materialize.com/about/">Company</a></li>
       <li><a href="https://materialize.com/contact/">Contact</a></li>


### PR DESCRIPTION
The WordPress "Quickstart" page has some bugs and out-of-date instructions. Until we resolve the issues, I changed the global nav link to point to `docs/install/` and need to also change it in Docs for consistency.

Thanks to @whhsu2 for reporting the original issue here: #6047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6054)
<!-- Reviewable:end -->
