### PR TITLE
Create end-to-end test for BYO EO Kafka Sinks 

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -215,6 +215,14 @@ steps:
           composition: persistent-tables
           run: persistent-tables
 
+  - id: kafka-exactly-once
+    label: "Test for the Kafka exactly-once sink"
+    depends_on: build
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: kafka-exactly-once
+          run: kafka-exactly-once
+
   - id: mzcompose-self
     label: "mzcompose self test"
     timeout_in_minutes: 10

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -339,7 +339,7 @@ where
 
                 let previously_published = match &connector.consistency {
                     Some(consistency) => match consistency.gate_ts {
-                        Some(ts) => as_of.frontier.less_equal(&ts),
+                        Some(gate_ts) => time <= gate_ts,
                         None => false,
                     },
                     None => false,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1088,6 +1088,16 @@ fn kafka_sink_builder(
         Some(_) => bail!("consistency must be a boolean"),
     };
 
+    let exactly_once = match with_options.remove("exactly_once") {
+        Some(Value::Boolean(b)) => b,
+        None => false,
+        Some(_) => bail!("exactly-once must be a boolean"),
+    };
+
+    if exactly_once && !include_consistency {
+        bail!("exactly-once requires a consistency topic");
+    }
+
     let encoder = Encoder::new(
         key_desc_and_indices
             .as_ref()
@@ -1153,7 +1163,7 @@ fn kafka_sink_builder(
         key_schema,
         key_desc_and_indices,
         value_desc,
-        exactly_once: false,
+        exactly_once,
     }))
 }
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -596,6 +596,7 @@ pub async fn create_state(
         kafka_config.set("bootstrap.servers", &config.kafka_addr);
         kafka_config.set("group.id", "materialize-testdrive");
         kafka_config.set("auto.offset.reset", "earliest");
+        kafka_config.set("isolation.level", "read_committed");
         if let Some(cert_path) = &config.cert_path {
             kafka_config.set("security.protocol", "ssl");
             kafka_config.set("ssl.keystore.location", cert_path);

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -78,6 +78,8 @@ pub struct Config {
     pub ci_output: bool,
     /// Default timeout.
     pub default_timeout: Duration,
+    /// A random number to distinguish each TestDrive run.
+    pub seed: Option<u32>,
 }
 
 pub struct State {
@@ -518,7 +520,12 @@ fn substitute_vars(msg: &str, vars: &HashMap<String, String>) -> Result<String, 
 pub async fn create_state(
     config: &Config,
 ) -> Result<(State, impl Future<Output = Result<(), Error>>), Error> {
-    let seed = rand::thread_rng().gen();
+    let seed = if let Some(s) = config.seed {
+        s
+    } else {
+        rand::thread_rng().gen()
+    };
+
     let temp_dir = tempfile::tempdir().err_ctx("creating temporary directory")?;
 
     let materialized_catalog_path = if let Some(path) = &config.materialized_catalog_path {

--- a/src/testdrive/src/main.rs
+++ b/src/testdrive/src/main.rs
@@ -74,6 +74,10 @@ struct Args {
     #[structopt(long, default_value = "10")]
     default_timeout: f64,
 
+    /// A random number to distinguish each TestDrive run.
+    #[structopt(long)]
+    seed: Option<u32>,
+
     // === Positional arguments. ===
     /// Paths to testdrive scripts to run.
     files: Vec<String>,
@@ -159,6 +163,7 @@ async fn run(args: Args) -> Result<(), Error> {
         reset_materialized: !args.no_reset,
         ci_output: args.ci_output,
         default_timeout,
+        seed: args.seed,
     };
 
     if args.files.is_empty() {

--- a/test/kafka-exactly-once/after-restart.td
+++ b/test/kafka-exactly-once/after-restart.td
@@ -1,0 +1,77 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set consistency={
+     "name": "materialize.byo.consistency",
+     "type": "record",
+     "fields": [
+         {
+           "name": "source",
+           "type": "string"
+         },
+         {
+           "name": "partition_count",
+           "type": "int"
+         },
+         {
+           "name": "partition_id",
+           "type": ["int","string"]
+         },
+         {
+            "name": "timestamp",
+            "type": "long"
+         },
+         {
+           "name": "offset",
+           "type": "long"
+         }
+     ]
+  }
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "long"}
+    ]
+  }
+
+$ kafka-ingest format=avro topic=input-consistency schema=${consistency} timestamp=2
+{"source": "testdrive-input-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 52, "offset": 10}
+
+$ kafka-ingest format=avro topic=input schema=${schema} timestamp=14
+{"a": 4, "b": 1}
+{"a": 5, "b": 2}
+
+> SELECT * FROM input_byo
+a  b
+------
+1   1
+2   1
+3   1
+1   2
+11  11
+22  11
+3   4
+5   6
+4  1
+5  2
+
+$ kafka-verify format=avro sink=materialize.public.output
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "30"}}
+{"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "30"}}
+{"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "40"}}
+{"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "40"}}
+{"before": null, "after": {"row": {"a": 4, "b": 1}}, "transaction": {"id": "52"}}
+{"before": null, "after": {"row": {"a": 5, "b": 2}}, "transaction": {"id": "52"}}

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -1,0 +1,99 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set consistency={
+     "name": "materialize.byo.consistency",
+     "type": "record",
+     "fields": [
+         {
+           "name": "source",
+           "type": "string"
+         },
+         {
+           "name": "partition_count",
+           "type": "int"
+         },
+         {
+           "name": "partition_id",
+           "type": ["int","string"]
+         },
+         {
+            "name": "timestamp",
+            "type": "long"
+         },
+         {
+           "name": "offset",
+           "type": "long"
+         }
+     ]
+  }
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "long"}
+    ]
+  }
+
+$ kafka-create-topic topic=input-consistency
+
+$ kafka-create-topic topic=input
+
+> CREATE MATERIALIZED SOURCE input_byo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+    WITH (consistency = 'testdrive-input-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}'
+
+> CREATE SINK output FROM input_byo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-sink-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-ingest format=avro topic=input-consistency schema=${consistency}
+{"source": "testdrive-input-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 10, "offset": 4}
+{"source": "testdrive-input-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 30, "offset": 6}
+{"source": "testdrive-input-${testdrive.seed}", "partition_count": 1, "partition_id": {"int": 0}, "timestamp": 40, "offset": 8}
+
+$ kafka-ingest format=avro topic=input schema=${schema} timestamp=1
+{"a": 1, "b": 1}
+{"a": 2, "b": 1}
+{"a": 3, "b": 1}
+{"a": 1, "b": 2}
+
+$ kafka-ingest format=avro topic=input schema=${schema} timestamp=3
+{"a": 11, "b": 11}
+{"a": 22, "b": 11}
+
+$ kafka-ingest format=avro topic=input schema=${schema} timestamp=4
+{"a": 3, "b": 4}
+{"a": 5, "b": 6}
+
+$ kafka-verify format=avro sink=materialize.public.output
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 1, "b": 2}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 2, "b": 1}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 3, "b": 1}}, "transaction": {"id": "10"}}
+{"before": null, "after": {"row": {"a": 11, "b": 11}}, "transaction": {"id": "30"}}
+{"before": null, "after": {"row": {"a": 22, "b": 11}}, "transaction": {"id": "30"}}
+{"before": null, "after": {"row": {"a": 3, "b": 4}}, "transaction": {"id": "40"}}
+{"before": null, "after": {"row": {"a": 5, "b": 6}}, "transaction": {"id": "40"}}
+
+> SELECT * FROM input_byo
+a  b
+------
+1   1
+2   1
+3   1
+1   2
+11  11
+22  11
+3   4
+5   6

--- a/test/kafka-exactly-once/mzcompose
+++ b/test/kafka-exactly-once/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/kafka-exactly-once/mzcompose.yml
+++ b/test/kafka-exactly-once/mzcompose.yml
@@ -1,0 +1,108 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  kafka-exactly-once:
+    env:
+      KAFKA_VERSION: latest
+      # when testing this on your local machine update SEED
+      # when running this repeatedly to ensure topics don't clash
+      SEED: ${SEED:-1}
+    steps:
+      - step: workflow
+        workflow: start-deps
+
+      - step: run
+        service: testdrive-svc
+        command: --seed ${SEED} --kafka-option=group.id=group1 before-restart.td
+
+      - step: kill-services
+        services: [materialized]
+
+      - step: start-services
+        services: [materialized]
+
+      - step: wait-for-mz
+        service: materialized
+
+      - step: run
+        service: testdrive-svc
+        command: --seed ${SEED} --no-reset --kafka-option=group.id=group2 after-restart.td
+
+  start-deps:
+    steps:
+      - step: start-services
+        services: [kafka, schema-registry, materialized]
+      - step: wait-for-tcp
+        host: kafka
+        port: 9092
+        timeout_secs: 120
+      - step: wait-for-tcp
+        host: schema-registry
+        port: 8081
+      - step: wait-for-mz
+        service: materialized
+
+services:
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        --kafka-addr=kafka:9092
+        --schema-registry-url=http://schema-registry:8081
+        --materialized-url=postgres://materialize@materialized:6875
+        $$*
+      - bash
+    volumes:
+      - .:/workdir
+      - mzdata:/share/mzdata
+    propagate-uid-gid: true
+    init: true
+
+  materialized:
+    mzbuild: materialized
+    command: >-
+      --data-directory=/share/mzdata
+      -w1
+      --disable-telemetry
+    environment:
+      - MZ_DEV=1
+      - MZ_LOG=${MZ_LOG:-dataflow::sink::kafka=debug,dataflow::source::kafka=debug,coord::timestamp=debug,dataflow::source=debug,info}
+    ports:
+      - 6875
+    volumes:
+      - mzdata:/share/mzdata
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:$KAFKA_VERSION
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+
+  kafka:
+    image: confluentinc/cp-kafka:$KAFKA_VERSION
+    environment:
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:$KAFKA_VERSION
+    environment:
+      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+      - SCHEMA_REGISTRY_HOST_NAME=localhost
+    depends_on: [kafka, zookeeper]
+
+volumes:
+  mzdata:


### PR DESCRIPTION
**Note** This only tests the happy path: we produce some data, verify that the output is correct, shut down materialize, produce some more data and verify the results again. The main thing this tests is that we don't produce output for the first batch of produced records when restarting.

Commits have messages that describe what's going on when necessary.

Potentially controversial things:
 - this changes how the sink determines what data has already been written (@ruchirK, Eli mentioned you reviewed this initially, maybe you could have a look at this?)
 -  I added quite some debug output to the Kafka sink. I don't know our policy on logging, so I'm happy to remove that again but I think it could be quite useful when users run into trouble. Could also reduce it to `trace` level.
 - Not sure I wired the test into CI correctly

This closes #6027.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6055)
<!-- Reviewable:end -->
