### PR TITLE
Explicitly remove containers between phases of the kafka-matrix test …

### DIFF
--- a/misc/python/materialize/mzcompose.py
+++ b/misc/python/materialize/mzcompose.py
@@ -596,7 +596,7 @@ class RemoveServicesStep(WorkflowStep):
     """
     Params:
       services: List of service names
-      volumes: Boolean to indicate if the volumes should be removed as well
+      destroy_volumes: Boolean to indicate if the volumes should be removed as well
     """
 
     def __init__(

--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -69,6 +69,9 @@ mzworkflows:
       - step: run
         service: testdrive-svc
         command: kafka-matrix.td
+      - step: remove-services
+        services: [materialized, schema-registry, kafka, zookeeper]
+        destroy_volumes: true
 
   start-deps:
     steps:


### PR DESCRIPTION
…#5968

Apparently the default reinitialization of containers that happens between testing successive Kafka versions is not enough on the CI. I suspect that this is because the volumes are left behind. Hence the need for an explicit "remove-services" step with the "destroy volumes" flag set to true.

@benesch how can I trigger a Nightly build on one's own fork without merging in a PR?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6060)
<!-- Reviewable:end -->
