### PR TITLE
dbt-materialize: fix catalog query

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -42,7 +42,7 @@
     from pg_catalog.pg_namespace sch
     join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid
     join (select mz_columns.name as attname, position as attnum, mz_relations.oid as attrelid, FALSE as attisdropped, mz_columns.type as type
-          from mz_columns join mz_relations on mz_columns.id = mz_relations.id join mz_types on mz_columns.type = mz_types.name)
+          from mz_columns join mz_relations on mz_columns.id = mz_relations.id)
           as col on col.attrelid = tbl.oid
     left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)
     left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)


### PR DESCRIPTION
In a very thorough bug report (https://github.com/MaterializeInc/materialize/issues/6063), it was pointed out that the
dbt-materialize adapter's catalog query performs a join between types
in the `mz_columns` and `mz_types` system tables that returns `NULL`s for
aliased types. This faulty join causes columns to be without a type
in the generated dbt docs.

As suggested in the bug report, this change simply removes the join
and uses the type present in `mz_columns`, instead.

I re-ran our Wikipedia demo with this change, and am able to see the
desired column type:
<img width="1086" alt="Screen Shot 2021-03-11 at 4 34 57 PM" src="https://user-images.githubusercontent.com/5766027/110858763-77159b80-8288-11eb-90fa-29a3ddcb0072.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6068)
<!-- Reviewable:end -->
