### PR TITLE
dataflow: remove can_close_timestamp

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -131,18 +131,14 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
                         self.logger.clone(),
                     ),
                 );
+                consistency_info.update_partition_metadata(PartitionId::Kafka(i));
             }
-            consistency_info.update_partition_metadata(PartitionId::Kafka(i));
         }
         self.known_partitions = cmp::max(self.known_partitions, pid + 1);
 
         assert_eq!(
             self.get_worker_partition_count(),
             self.get_partition_consumers_count()
-        );
-        assert_eq!(
-            self.known_partitions as usize,
-            consistency_info.partition_metadata.len()
         );
     }
 

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -93,39 +93,6 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
-    /// This function determines whether it is safe to close the current timestamp.
-    /// It is safe to close the current timestamp if
-    /// 1) this worker does not own the current partition
-    /// 2) we will never receive a message with a lower or equal timestamp than offset.
-    /// This is true if we have already timestamped a message >= offset.
-    fn can_close_timestamp(
-        &self,
-        consistency_info: &ConsistencyInfo,
-        pid: &PartitionId,
-        offset: MzOffset,
-    ) -> bool {
-        let kafka_pid = match pid {
-            PartitionId::Kafka(pid) => *pid,
-            // KafkaSourceInfo should only receive PartitionId::Kafka
-            _ => unreachable!(),
-        };
-
-        let last_offset = consistency_info
-            .partition_metadata
-            .get(&pid)
-            .unwrap()
-            .offset;
-
-        // For transactional or compacted topics, the `last_offset` may not correspond to
-        // an accurate representation of how far we have read up to (because subsequent offsets
-        // have been garbage collected). However, `last_offset` still represents the lower bound
-        // for the value of the next offset in this partition.
-        if !self.has_partition(kafka_pid) || last_offset >= offset {
-            true
-        } else {
-            false
-        }
-    }
     /// Returns the number of partitions expected *for this worker*. Partitions are assigned
     /// round-robin in worker id order offset by the hash of the source_id
     fn get_worker_partition_count(&self) -> i32 {

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -92,27 +92,39 @@ impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
             _ => unreachable!(),
         };
 
-        let state = block_on(create_state(
-            kc,
-            &source_name,
-            source_id,
-            consistency_info,
-            logger.clone(),
-        ));
+        let state = block_on(create_state(kc));
         match state {
-            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok(KinesisSourceInfo {
-                name: source_name,
-                id: source_id,
-                is_activated_reader: active,
-                kinesis_client,
-                logger,
-                shard_queue,
-                last_checked_shards: Instant::now(),
-                buffered_messages: VecDeque::new(),
-                shard_set,
-                stream_name,
-                processed_message_count: 0,
-            }),
+            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => {
+                if active {
+                    for shard_id in &shard_set {
+                        let kinesis_id = PartitionId::Kinesis(shard_id.clone());
+                        consistency_info.update_partition_metadata(kinesis_id.clone());
+                        consistency_info.partition_metrics.insert(
+                            kinesis_id.clone(),
+                            PartitionMetrics::new(
+                                &source_name,
+                                source_id,
+                                &kinesis_id.to_string(),
+                                logger.clone(),
+                            ),
+                        );
+                    }
+                }
+
+                Ok(KinesisSourceInfo {
+                    name: source_name,
+                    id: source_id,
+                    is_activated_reader: active,
+                    kinesis_client,
+                    logger,
+                    shard_queue,
+                    last_checked_shards: Instant::now(),
+                    buffered_messages: VecDeque::new(),
+                    shard_set,
+                    stream_name,
+                    processed_message_count: 0,
+                })
+            }
             Err(e) => Err(anyhow!("{}", e)),
         }
     }
@@ -164,25 +176,6 @@ impl KinesisSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
-    fn can_close_timestamp(
-        &self,
-        consistency_info: &ConsistencyInfo,
-        pid: &PartitionId,
-        offset: MzOffset,
-    ) -> bool {
-        if !self.is_activated_reader {
-            true
-        } else {
-            // Guaranteed to exist if we receive a message from this partition
-            let last_offset = consistency_info
-                .partition_metadata
-                .get(&pid)
-                .unwrap()
-                .offset;
-            last_offset >= offset
-        }
-    }
-
     fn get_worker_partition_count(&self) -> i32 {
         if self.is_activated_reader {
             // Kinesis does not support more than i32 partitions
@@ -309,10 +302,6 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
 // todo: Better error handling here! Not all errors mean we're done/can't progress.
 async fn create_state(
     c: KinesisSourceConnector,
-    name: &str,
-    id: SourceInstanceId,
-    consistency_info: &mut ConsistencyInfo,
-    logger: Option<Logger>,
 ) -> Result<
     (
         KinesisClient,
@@ -327,16 +316,10 @@ async fn create_state(
     let shard_set: HashSet<String> = get_shard_ids(&kinesis_client, &c.stream_name).await?;
     let mut shard_queue: VecDeque<(String, Option<String>)> = VecDeque::new();
     for shard_id in &shard_set {
-        let kinesis_id = PartitionId::Kinesis(shard_id.clone());
         shard_queue.push_back((
             shard_id.clone(),
             get_shard_iterator(&kinesis_client, &c.stream_name, shard_id).await?,
         ));
-        consistency_info.update_partition_metadata(kinesis_id.clone());
-        consistency_info.partition_metrics.insert(
-            kinesis_id.clone(),
-            PartitionMetrics::new(name, id, &kinesis_id.to_string(), logger.clone()),
-        );
     }
 
     Ok((

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -280,19 +280,6 @@ impl MaybeLength for Value {
 pub(crate) trait SourceInfo<Out> {
     // BYO consistency methods
 
-    /// This function determines whether it is safe to close the current timestamp.
-    ///
-    /// It is safe to close the current timestamp if:
-    ///
-    /// 1) this worker does not own the current partition
-    /// 2) we will never receive a message with a lower or equal timestamp than offset.
-    fn can_close_timestamp(
-        &self,
-        consistency_info: &ConsistencyInfo,
-        pid: &PartitionId,
-        offset: MzOffset,
-    ) -> bool;
-
     /// Returns the number of partitions expected *for this worker*. Partitions are assigned
     /// round-robin in worker id order
     /// Note: we currently support two types of sources: those which support multithreaded reads
@@ -407,7 +394,9 @@ pub struct ConsistencyInfo {
     /// Frequency at which we should downgrade capability (in milliseconds)
     downgrade_capability_frequency: u64,
     /// Per partition (a partition ID in Kafka is an i32), keep track of the last closed offset
-    /// and the last closed timestamp
+    /// and the last closed timestamp.
+    /// Note that we only keep track of partitions this worker is responsible for in this
+    /// hashmap.
     pub partition_metadata: HashMap<PartitionId, ConsInfo>,
     /// Optional: Materialize Offset from which source should start reading (default is 0)
     start_offsets: HashMap<PartitionId, MzOffset>,
@@ -543,7 +532,8 @@ impl ConsistencyInfo {
 
         if let Consistency::BringYourOwn(_) = self.source_type {
             // Determine which timestamps have been closed. A timestamp is closed once we have processed
-            // all messages that we are going to process for this timestamp across all partitions
+            // all messages that we are going to process for this timestamp across all partitions that the
+            // worker knows about (i.e. the ones the worker has been assigned to read from).
             // In practice, the following happens:
             // Per partition, we iterate over the data structure to remove (ts,offset) mappings for which
             // we have seen all records <= offset. We keep track of the last "closed" timestamp in that partition
@@ -554,6 +544,11 @@ impl ConsistencyInfo {
                         // Iterate over each partition that we know about
                         for (pid, entries) in entries {
                             source.ensure_has_partition(self, pid.clone());
+
+                            if !self.partition_metadata.contains_key(pid) {
+                                // We are not responsible for this partition and can ignore it.
+                                continue;
+                            }
 
                             let existing_ts = self.partition_metadata.get(pid).unwrap().ts;
                             // Check whether timestamps can be closed on this partition
@@ -589,16 +584,11 @@ impl ConsistencyInfo {
                                         .set(self.partition_metadata.get(pid).unwrap().ts);
                                 }
 
-                                if source.can_close_timestamp(&self, pid, *offset) {
-                                    // We have either 1) seen all messages corresponding to this timestamp for this
-                                    // partition 2) do not own this partition 3) the consumer has forwarded past the
-                                    // timestamped offset. Either way, we have the guarantee tha we will never see a message with a < timestamp
-                                    // again
-                                    // We can close the timestamp (on this partition) and remove the associated metadata
-                                    self.partition_metadata.get_mut(&pid).unwrap().ts = *ts;
+                                let cons_info = self.partition_metadata.get_mut(pid).unwrap();
+                                if cons_info.offset >= *offset {
+                                    cons_info.ts = *ts;
                                     changed = true;
                                 } else {
-                                    // Offset isn't at a timestamp boundary, we take no action
                                     break;
                                 }
                             }

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -57,8 +57,6 @@ pub struct S3SourceInfo {
     // differential control
     /// Unique source ID
     id: SourceInstanceId,
-    /// Field is set if this operator is responsible for ingesting data
-    is_activated_reader: bool,
     /// Receiver channel that ingests records
     receiver_stream: Receiver<Result<InternalMessage, Error>>,
     /// Total number of records that this source has read
@@ -147,16 +145,17 @@ impl SourceConstructor<Vec<u8>> for S3SourceInfo {
         };
 
         let pid = PartitionId::S3;
-        consistency_info.partition_metrics.insert(
-            pid.clone(),
-            PartitionMetrics::new(&source_name, source_id, "s3", logger),
-        );
-        consistency_info.update_partition_metadata(pid);
 
+        if active {
+            consistency_info.partition_metrics.insert(
+                pid.clone(),
+                PartitionMetrics::new(&source_name, source_id, "s3", logger),
+            );
+            consistency_info.update_partition_metadata(pid);
+        }
         Ok(S3SourceInfo {
             source_name,
             id: source_id,
-            is_activated_reader: active,
             receiver_stream: receiver,
             offset: S3Offset(0),
         })
@@ -647,26 +646,6 @@ impl SourceInfo<Vec<u8>> for S3SourceInfo {
             }
             Err(TryRecvError::Empty) => Ok(NextMessage::Pending),
             Err(TryRecvError::Disconnected) => Ok(NextMessage::Finished),
-        }
-    }
-
-    fn can_close_timestamp(
-        &self,
-        consistency_info: &ConsistencyInfo,
-        pid: &PartitionId,
-        offset: MzOffset,
-    ) -> bool {
-        if !self.is_activated_reader {
-            true
-        } else {
-            // TODO: when is this ever not true for S3?
-            let last_offset = consistency_info
-                .partition_metadata
-                .get(&pid)
-                // Guaranteed to exist for S3
-                .unwrap()
-                .offset;
-            last_offset >= offset
         }
     }
 


### PR DESCRIPTION
The logic for deciding whether or not a timestamp can be closed is now identical across
source implementations. Broadly:

A worker can close a timestamp t if all of the source partitions it is responsible for
can close t, which happens once we have read at an offset greater than the one
assigned as the final offset bound to t across all of the worker's partitions.

Edit: this change requires that I enforce the invariant that each worker's `consistency_info.partition_metadata` only contains entries for the partitions that worker cares about. I should probably document that more aggressively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6070)
<!-- Reviewable:end -->
