### PR TITLE
allow override of librdkafka enable.auto.commit

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -31,6 +31,7 @@ enum ValType {
     String,
     // Number with range [lower, upper]
     Number(i32, i32),
+    Boolean,
 }
 
 // Describes Kafka cluster configurations users can suppply using `CREATE
@@ -76,6 +77,7 @@ impl Config {
     fn validate_val(&self, val: &Value) -> Result<String, anyhow::Error> {
         let val = match (&self.val_type, val) {
             (ValType::String, Value::String(v)) => v.to_string(),
+            (ValType::Boolean, Value::Boolean(b)) => b.to_string(),
             (ValType::Path, Value::String(v)) => {
                 if std::fs::metadata(&v).is_err() {
                     bail!("file does not exist")
@@ -139,6 +141,7 @@ pub fn extract_config(
                 // https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
                 ValType::Number(0, 3_600_000),
             ),
+            Config::new("enable_auto_commit", ValType::Boolean),
             Config::string("security_protocol"),
             Config::path("sasl_kerberos_keytab"),
             Config::string("sasl_username"),


### PR DESCRIPTION
This allows passthrough of `enable.auto.commit` from a CREATE SOURCE WITH options, ie. you can now do this to disable librdkafka auto commit:

```
  CREATE MATERIALIZED SOURCE fast_forwarded
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
  WITH (enable_auto_commit=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
```

Fixes https://github.com/MaterializeInc/materialize/issues/6022

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6071)
<!-- Reviewable:end -->
