### PR TITLE
Optimization correctness: Predicate pushdown should recursively descend on the base of a union.

### DIFF
--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -440,6 +440,7 @@ impl PredicatePushdown {
                     MirRelationExpr::Union { base, inputs } => {
                         let predicates = std::mem::replace(predicates, Vec::new());
                         *base = Box::new(base.take_dangerous().filter(predicates.clone()));
+                        self.action(base, get_predicates);
                         for input in inputs {
                             *input = input.take_dangerous().filter(predicates.clone());
                             self.action(input, get_predicates);


### PR DESCRIPTION
It turns out that with PredicatePushdown, if we pushed a filter through a union, we only descended on the inputs of a union and not the base. 

The reason we haven't noticed this causing any performance issues is that PredicatePushdown is currently in the Fixpoint, so normally if we didn't descend on the base during this go, we would descend on the base during the next go.

It is only correct to push a filter into the subview with id `LocalId(id)` if the filter is around every instance of `Get(LocalId(id))`. Not descending on the base of a union can have the consequence that an instance of `Get(LocalId(id))` was not visited. Not properly visiting every instance of `Get(LocalId(id))` can have the consequence that filters are pushed into the subview that should not be pushed down, resulting in correctness issues. The only reason we haven't noticed correctness issues is that we currently don't push down predicates in the body of a let if there is no filter around the let. 

Thank you @philip-stoev for the testing against #6058 that led me to uncover this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6072)
<!-- Reviewable:end -->
