### PR TITLE
[viz] Aggregate message counts on each edge

### DIFF
--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -229,8 +229,8 @@ function View(props) {
       setOpers(opers);
 
       const chan_table = await query(`
-        SELECT DISTINCT
-          id, source_node, target_node, sent
+        SELECT
+          id, source_node, target_node, sum(sent) as sent
         FROM
           mz_catalog.mz_dataflow_channels AS channels
           LEFT JOIN mz_catalog.mz_message_counts AS counts
@@ -253,7 +253,9 @@ function View(props) {
                       WHERE
                         id = ${props.dataflow_id}
                     )
-            );
+            )
+        GROUP BY id, source_node, target_node
+        ;
       `);
       // {id: [source, target]}.
       const chans = Object.fromEntries(


### PR DESCRIPTION
Messages counts were reported by forming the correct data but then projecting out the `worker` column rather than aggregating across it. This resulted in weirdly low message counts, and apparent inconsistencies. This PR introduces the aggregation, which sorts out the inconsistencies we were observing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6074)
<!-- Reviewable:end -->
