### PR TITLE
run existing tds against different kafka versions

### DIFF
--- a/test/kafka-matrix/mzcompose.yml
+++ b/test/kafka-matrix/mzcompose.yml
@@ -68,7 +68,7 @@ mzworkflows:
         workflow: start-deps
       - step: run
         service: testdrive-svc
-        command: kafka-matrix.td
+        command: kafka-matrix.td /tests/avro-sinks.td /tests/avro-sources.td /tests/upsert-kafka.td
       - step: remove-services
         services: [materialized, schema-registry, kafka, zookeeper]
         destroy_volumes: true
@@ -107,6 +107,7 @@ services:
       - .:/workdir
       - mzdata:/share/mzdata
       - tmp:/share/tmp
+      - ../testdrive:/tests
     propagate-uid-gid: true
     init: true
     depends_on: [kafka, zookeeper, schema-registry, materialized]


### PR DESCRIPTION
I was messing around for skunkworks, trying to understand mzcompose a bit better.

@philip-stoev what do you think about this, using your matrix framework to run some of the existing kafka testdrives? That might get us some nice regression coverage for free.

We could do:
```
command: kafka-matrix.td /tests/*.td
```
to blanket rerun all the tests against all supported kafka versions, though I think that'd move our nightly CI run from ~20min to ~1-1.5hr. Which might be fine, it's nightly after all. 🤷‍♂️

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6076)
<!-- Reviewable:end -->
