### PR TITLE
Increase inline allocation size for `Row`

### DIFF
--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,7 +31,7 @@ ryu = "1.0.5"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 serde_regex = "1.1.0"
-smallvec = { version = "1.5.1", features = ["serde"] }
+smallvec = { version = "1.5.1", features = ["serde", "union"] }
 uuid = "0.8.2"
 
 [dev-dependencies]

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -75,7 +75,7 @@ use fmt::Debug;
 /// avoids the allocations involved in `RowPacker::new()`.
 #[derive(Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Row {
-    data: SmallVec<[u8; 23]>,
+    data: SmallVec<[u8; 24]>,
 }
 
 /// These implementations order first by length, and then by slice contents.


### PR DESCRIPTION
Rust 1.49 stabilized something about unions that allows `smallvec`'s `union` feature to be used on stable. This removes an enum tag byte, which gets us back one more byte. This isn't very exciting now, but e.g. if the inline allocation had been 16 bytes then the size of `Row` would drop from 32 to 24 bytes. No preference on that dimension, but seemed like this is worth doing.

There are three uses of `smallvec` across the project (here, `ore`, and `interchange`). They don't all use the same version, so I didn't want to dive in and randomize them too, but I could imagine wanting to thin down the distinct versions and feature sets, in the interest of build times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6079)
<!-- Reviewable:end -->
