### PR TITLE
bin/doc: reject invalid doc links

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -17,7 +17,7 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-cargo doc "$@"
+RUSTDOCFLAGS="-D warnings" cargo doc "$@"
 
 crates=$(cargo metadata --format-version=1 \
   | jq -r -f misc/doc/crates.jq --arg pwd "$(pwd)")

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -20,5 +20,6 @@ SHLIB_NOT_IN_CI=1
 ci_try bin/lint
 ci_try cargo fmt -- --check
 ci_try bin/check
+ci_try bin/doc
 
 ci_status_report

--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -22,4 +22,7 @@ ci_try bin/xcompile test --locked --doc
 # https://github.com/rust-lang/rust-clippy/issues/3840
 ci_try bin/check
 
+ci_try bin/doc
+ci_try bin/doc --document-private-items
+
 ci_status_report

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -84,7 +84,7 @@ pub struct Response<T> {
 
 pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponse> + Send>>;
 
-/// The response to [`ConnClient::startup`]().
+/// The response to [`ConnClient::startup`](crate::ConnClient::startup).
 #[derive(Debug)]
 pub struct StartupResponse {
     /// An opaque secret associated with this session.

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -46,7 +46,7 @@ pub mod session;
 
 pub use crate::cache::CacheConfig;
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
-pub use crate::command::{Cancelled, ExecuteResponse, StartupMessage};
+pub use crate::command::{Cancelled, ExecuteResponse, StartupMessage, StartupResponse};
 pub use crate::coord::{serve, Config, LoggingConfig};
 pub use crate::error::CoordError;
 pub use crate::persistence::PersistenceConfig;

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -469,7 +469,7 @@ impl ConsistencyInfo {
     /// Updates the underlying partition metadata structure to include the current partition.
     /// New partitions must always be added with a minimum closed offset of (last_closed_ts)
     /// They are guaranteed to only receive timestamp update greater than last_closed_ts (this
-    /// is enforced in [coord::timestamp::is_ts_valid]
+    /// is enforced in `coord::timestamp::is_ts_valid`.
     pub fn update_partition_metadata(&mut self, pid: PartitionId) {
         let cons_info = ConsInfo {
             offset: self.get_partition_start_offset(&pid),
@@ -530,7 +530,7 @@ impl ConsistencyInfo {
     /// This method assumes that timestamps are inserted in increasing order in the hashmap
     /// (even across partitions). This means that once we see a timestamp with ts x, no entry with
     /// ts (x-1) will ever be inserted. Entries with timestamp x might still be inserted in different
-    /// partitions. This is guaranteed by the [coord::timestamp::is_ts_valid] method.
+    /// partitions. This is guaranteed by the `coord::timestamp::is_ts_valid` method.
     ///
     fn downgrade_capability<Out: Send + Clone + 'static>(
         &mut self,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -39,7 +39,7 @@ pub use scalar::func::{BinaryFunc, NullaryFunc, UnaryFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};
 
 /// A [`MirRelationExpr`] that claims to have been optimized, e.g., by an
-/// [`Optimizer`].
+/// `transform::Optimizer`.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct OptimizedMirRelationExpr(pub MirRelationExpr);
 

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -26,9 +26,7 @@ use repr::RelationType;
 /// Methods in this class that take an argument `equivalences` are only
 /// guaranteed to return a correct answer if equivalence classes are in
 /// canonical form.
-/// (See [`canonicalize::canonicalize_equivalences`].)
-///
-/// [`canonicalize::canonicalize_equivalences`]: expr::canonicalize::fuse_dedup_equivalences
+/// (See [`crate::relation::canonicalize::canonicalize_equivalences`].)
 #[derive(Debug)]
 pub struct JoinInputMapper {
     /// The number of columns per input. All other fields in this struct are

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -28,7 +28,7 @@ pub mod join_input_mapper;
 
 /// An abstract syntax tree which defines a collection.
 ///
-/// The AST is meant reflect the capabilities of the [`differential_dataflow::Collection`] type,
+/// The AST is meant reflect the capabilities of the `differential_dataflow::Collection` type,
 /// written generically enough to avoid run-time compilation work.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum MirRelationExpr {
@@ -97,7 +97,7 @@ pub enum MirRelationExpr {
         /// expensive to reproduce, so restricting what we produce
         /// as output can be a substantial win.
         ///
-        /// See [`expr::transform::Demand`] for more details.
+        /// See `transform::Demand` for more details.
         demand: Option<Vec<usize>>,
     },
     /// Keep rows from a dataflow where all the predicates are true
@@ -135,7 +135,7 @@ pub enum MirRelationExpr {
         /// dummy values at the end of its computation, avoiding the maintenance of values
         /// not present in this list (when it is non-None).
         ///
-        /// See [`expr::transform::Demand`] for more details.
+        /// See `transform::Demand` for more details.
         demand: Option<Vec<usize>>,
         /// Join implementation information.
         implementation: JoinImplementation,

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -121,7 +121,7 @@ pub(crate) struct DebeziumDeduplicationState {
     ///
     /// A binlog stream is either a file name (for mysql) or "" for postgres.
     ///
-    /// [`DebeziumDeduplicationstrategy`] determines whether messages that are not ahead
+    /// [`DebeziumDeduplicationStrategy`] determines whether messages that are not ahead
     /// of the last recorded pos/row will be skipped.
     binlog_offsets: HashMap<Vec<u8>, (usize, usize, Option<i64>)>,
     /// Whether or not to track every message we've ever seen

--- a/src/ore/src/iter.rs
+++ b/src/ore/src/iter.rs
@@ -124,7 +124,7 @@ where
     ///
     /// Instead of using `PartialOrd::partial_cmp`, this function uses the given `compare`
     /// function to determine the ordering of two elements. Apart from that, it's equivalent to
-    /// [`is_sorted`]; see its documentation for more information.
+    /// [`Iterator::is_sorted`]; see its documentation for more information.
     ///
     /// **Note:** this is a Materialize forward-port of a forthcoming feature
     /// to the standard library.

--- a/src/protoc/src/lib.rs
+++ b/src/protoc/src/lib.rs
@@ -79,11 +79,11 @@ impl Protoc {
     /// Executes the compilation.
     ///
     /// The generated files are placed into `out_dir` according to the
-    /// conventions of the [`protoc_codegen_pure`]. Rougly speaking, for each
-    /// input file `path/to/file.proto`, this method generates the Rust file
-    /// `OUT_DIR/path/to/file.rs`. The details involve some special rules for
-    /// escaping Rust keywords and special characters, but you will have to
-    /// consult the `protoc_codegen_pure` source code for details.
+    /// conventions of the [`protobuf_codegen_pure`] crate. Roughly speaking, for
+    /// each input file `path/to/file.proto`, this method generates the Rust
+    /// file `OUT_DIR/path/to/file.rs`. The details involve some special rules
+    /// for escaping Rust keywords and special characters, but you will have to
+    /// consult the `protobuf_codegen_pure` source code for details.
     pub fn compile_into(&mut self, out_dir: &Path) -> Result<(), anyhow::Error> {
         if !out_dir.exists() {
             bail!(

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -345,7 +345,7 @@ where
     Nestable::MayNeedEscaping
 }
 
-/// Parses a `DateTime<Utc>` from `s`. See [expr::scalar::func::timezone_timestamp] for timezone anomaly considerations.
+/// Parses a `DateTime<Utc>` from `s`. See `expr::scalar::func::timezone_timestamp` for timezone anomaly considerations.
 pub fn parse_timestamptz(s: &str) -> Result<DateTime<Utc>, ParseError> {
     parse_timestamp_string(s)
         .and_then(|(date, time, timezone)| {

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -17,10 +17,12 @@ use sql_parser::ast::{Ident, UnresolvedObjectName};
 
 /// A fully-qualified name of an item in the catalog.
 ///
-/// Catalog names compare case sensitively. Use [`normalize::object_name`] to
-/// perform proper case folding if converting an [`ObjectName`] to a `FullName`.
+/// Catalog names compare case sensitively. Use
+/// [`normalize::unresolved_object_name`] to
+/// perform proper case folding if converting an [`UnresolvedObjectName`] to a
+/// `FullName`.
 ///
-/// [`normalize::object_name`]: crate::normalize::object_name
+/// [`normalize::unresolved_object_name`]: crate::normalize::unresolved_object_name
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct FullName {
     /// The database name.

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -91,7 +91,7 @@ pub fn option_objects(options: &[SqlOption<Raw>]) -> BTreeMap<String, SqlOption<
 
 /// Unnormalizes an object name.
 ///
-/// This is the inverse of the [`object_name`] function.
+/// This is the inverse of the [`unresolved_object_name`] function.
 pub fn unresolve(name: FullName) -> UnresolvedObjectName {
     let mut out = vec![];
     if let DatabaseSpecifier::Name(n) = name.database {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -51,7 +51,7 @@ pub(crate) mod transform_ast;
 pub(crate) mod transform_expr;
 pub(crate) mod typeconv;
 
-pub use self::expr::HirRelationExpr;
+pub use self::expr::{HirRelationExpr, HirScalarExpr};
 pub use error::PlanError;
 pub use explain::Explanation;
 // This is used by sqllogictest to turn SQL values into `Datum`s.

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -154,7 +154,7 @@ pub enum HirScalarExpr {
     Select(Box<HirRelationExpr>),
 }
 
-/// A `CoercibleScalarExpr` is a [`ScalarExpr`] whose type is not fully
+/// A `CoercibleScalarExpr` is a [`HirScalarExpr`] whose type is not fully
 /// determined. Several SQL expressions can be freely coerced based upon where
 /// in the expression tree they appear. For example, the string literal '42'
 /// will be automatically coerced to the integer 42 if used in a numeric
@@ -1083,9 +1083,9 @@ impl HirScalarExpr {
         }
     }
 
-    // Like [`ScalarExpr::bind_parameters`]`, except that parameters are
-    // replaced with the corresponding expression fragment from `params` rather
-    // than a datum.
+    /// Like [`HirScalarExpr::bind_parameters`], except that parameters are
+    /// replaced with the corresponding expression fragment from `params` rather
+    /// than a datum.
     ///
     /// Specifically, the parameter `$1` will be replaced with `params[0]`, the
     /// parameter `$2` will be replaced with `params[1]`, and so on. Parameters

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -636,7 +636,7 @@ fn plan_hypothetical_cast(
 }
 
 /// Plans a cast between [`ScalarType`]s, specifying which types of casts are
-/// permitted using [`CastTo`].
+/// permitted using [`CastContext`].
 ///
 /// # Errors
 ///

--- a/test/correctness/args.rs
+++ b/test/correctness/args.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! [`Args::from_cli`] parses the command line arguments from the cli and the config file
-
 use std::result::Result as StdResult;
 use std::time::Duration;
 


### PR DESCRIPTION
This tweaks #6077 as promised. By fixing all the broken doc links in one shot, we can avoid introducing a new `check-doc` script, and just let `bin/doc` reject broken links.

----

This commit teaches bin/doc to reject Rust documentation comments with
broken intra-doc links. To facilitate this, all existing broken links
are also fixed in this commit.

To prevent unexpected breakage to the deploy job, CI now verifies that
`bin/doc` and `bin/doc --document-private-items` both succeed on every
PR. The pre-push hook now checks `bin/doc`, but not `bin/doc
--document-private-items`, which seems like a good balance of catching
most errors without adding undue latency to the pre-push hook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6080)
<!-- Reviewable:end -->
