### PR TITLE
Allow containers built out of cargo artifacts to bundle a separate as…

### DIFF
--- a/src/testdrive/ci/.gitignore
+++ b/src/testdrive/ci/.gitignore
@@ -1,3 +1,4 @@
 /kdestroy
 /kinit
 /testdrive
+/assets_dir

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -20,5 +20,8 @@ WORKDIR /workdir
 RUN mkdir -p /share/tmp && chmod 777 /share/tmp
 RUN mkdir -p /share/mzdata && chmod 777 /share/mzdata
 
+COPY assets_dir /testdrive-tests
+RUN chmod 777 /testdrive-tests
+
 VOLUME /share/tmp
 VOLUME /share/mzdata

--- a/src/testdrive/ci/mzbuild.yml
+++ b/src/testdrive/ci/mzbuild.yml
@@ -15,3 +15,4 @@ pre-image:
     krb5-src:
       - install/bin/kinit
       - install/bin/kdestroy
+  assets_dir: test/testdrive


### PR DESCRIPTION
…sets directory

This is needed so that the testdrive container can include the actual .td tests

I am not sure I did it in the cleanest way possible, however ```mzimage``` expects that there will be only one ```pre-image``` action, so I hacked it inside the ```cargo-build``` action.

Please advise if you would like to see this done in some other way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6089)
<!-- Reviewable:end -->
