### PR TITLE
Testdrive default timeout

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -42,7 +42,6 @@ mod s3;
 mod sleep;
 mod sql;
 
-const DEFAULT_SQL_TIMEOUT: Duration = Duration::from_millis(12700);
 const DEFAULT_REGEX_REPLACEMENT: &str = "<regex_match>";
 
 /// User-settable configuration parameters.
@@ -77,6 +76,8 @@ pub struct Config {
     pub reset_materialized: bool,
     /// Emit Buildkite-specific markup.
     pub ci_output: bool,
+    /// Default timeout.
+    pub default_timeout: Duration,
 }
 
 pub struct State {
@@ -104,6 +105,7 @@ pub struct State {
     s3_buckets_created: BTreeSet<String>,
     sqs_client: SqsClient,
     sqs_queues_created: BTreeSet<String>,
+    default_timeout: Duration,
 }
 
 #[derive(Clone)]
@@ -209,7 +211,7 @@ impl State {
     }
 
     async fn delete_bucket_objects(&self, bucket: String) -> Result<(), Error> {
-        ore::retry::retry_for(Duration::from_secs(5), |_| async {
+        ore::retry::retry_for(self.default_timeout, |_| async {
             // loop until error or response has no continuation token
             let mut continuation_token = None;
             loop {
@@ -248,7 +250,7 @@ impl State {
     }
 
     pub async fn reset_sqs(&self) -> Result<(), Error> {
-        ore::retry::retry_for(Duration::from_secs(5), |_| async {
+        ore::retry::retry_for(self.default_timeout, |_| async {
             for queue_url in &self.sqs_queues_created {
                 self.sqs_client
                     .delete_queue(DeleteQueueRequest {
@@ -297,8 +299,9 @@ where
 pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Error> {
     let mut out = Vec::new();
     let mut vars = HashMap::new();
+
     let mut sql_context = SqlContext {
-        timeout: DEFAULT_SQL_TIMEOUT,
+        timeout: state.default_timeout,
         regex: None,
         regex_replacement: DEFAULT_REGEX_REPLACEMENT.to_string(),
     };
@@ -368,6 +371,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
         "testdrive.materialized-user".into(),
         state.materialized_user.clone(),
     );
+
     for cmd in cmds {
         let pos = cmd.pos;
         let wrap_err = |e| InputError { msg: e, pos };
@@ -431,7 +435,7 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
                     "set-sql-timeout" => {
                         let duration = builtin.args.string("duration").map_err(wrap_err)?;
                         if duration.to_lowercase() == "default" {
-                            sql_context.timeout = DEFAULT_SQL_TIMEOUT;
+                            sql_context.timeout = state.default_timeout;
                         } else {
                             sql_context.timeout = parse_duration::parse(&duration)
                                 .map_err(|e| wrap_err(e.to_string()))?;
@@ -608,7 +612,7 @@ pub async fn create_state(
             &[format!("connection string: {}", config.kafka_addr)],
         )?;
 
-        let admin_opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(5)));
+        let admin_opts = AdminOptions::new().operation_timeout(Some(config.default_timeout));
 
         let producer: FutureProducer = kafka_config.create().err_hint(
             "opening Kafka producer connection",
@@ -677,6 +681,7 @@ pub async fn create_state(
         s3_buckets_created: BTreeSet::new(),
         sqs_client,
         sqs_queues_created: BTreeSet::new(),
+        default_timeout: config.default_timeout,
     };
     Ok((state, pgconn_task))
 }

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -12,7 +12,6 @@ use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::os::unix::ffi::OsStringExt;
 use std::path::{self, PathBuf};
-use std::time::Duration;
 
 use async_trait::async_trait;
 
@@ -147,7 +146,7 @@ impl Action for VerifyAction {
     }
 
     async fn redo(&self, state: &mut State) -> Result<(), String> {
-        let path = retry::retry_for(Duration::from_secs(8), |_| async {
+        let path = retry::retry_for(state.default_timeout, |_| async {
             let row = state
                 .pgclient
                 .query_one(

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -81,7 +81,7 @@ impl Action for AddPartitionsAction {
             return Err(e.to_string());
         }
 
-        retry::retry_for(Duration::from_secs(8), |_| async {
+        retry::retry_for(state.default_timeout, |_| async {
             let metadata = state
                 .kafka_producer
                 .client()

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -127,11 +128,11 @@ impl Action for VerifyAction {
             .map_err(|e| format!("creating kafka consumer: {}", e))?;
         consumer.subscribe(&[&topic]).map_err(|e| e.to_string())?;
 
-        // Wait up to 10 seconds for each message.
+        // Wait up to 15 seconds for each message.
         let message_stream = consumer
             .stream()
             .take(self.expected_messages.len())
-            .timeout(Duration::from_secs(15));
+            .timeout(cmp::max(state.default_timeout, Duration::from_secs(15)));
         pin!(message_stream);
 
         let mut actual_messages = vec![];

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -50,7 +50,12 @@ impl Action for CreateStreamAction {
             .map_err(|e| format!("creating stream: {}", e))?;
         state.kinesis_stream_names.push(stream_name.clone());
 
-        util::kinesis::wait_for_stream_shards(&state.kinesis_client, stream_name, self.shard_count)
-            .await
+        util::kinesis::wait_for_stream_shards(
+            &state.kinesis_client,
+            stream_name,
+            self.shard_count,
+            state.default_timeout,
+        )
+        .await
     }
 }

--- a/src/testdrive/src/action/kinesis/ingest.rs
+++ b/src/testdrive/src/action/kinesis/ingest.rs
@@ -7,8 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::time::Duration;
-
 use async_trait::async_trait;
 use bytes::Bytes;
 use rand::distributions::Alphanumeric;
@@ -68,7 +66,7 @@ impl Action for IngestAction {
 
             // The Kinesis stream might not be immediately available,
             // be prepared to back off.
-            retry::retry_for(Duration::from_secs(8), |_| async {
+            retry::retry_for(state.default_timeout, |_| async {
                 match state.kinesis_client.put_record(put_input.clone()).await {
                     Ok(_output) => Ok(()),
                     Err(RusotoError::Service(PutRecordError::ResourceNotFound(err))) => {

--- a/src/testdrive/src/action/kinesis/update_shards.rs
+++ b/src/testdrive/src/action/kinesis/update_shards.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp;
 use std::convert::TryFrom;
 use std::time::Duration;
 
@@ -58,41 +59,46 @@ impl Action for UpdateShardCountAction {
             .map_err(|e| format!("adding shards to stream {}: {}", &stream_name, e))?;
 
         // Verify the current shard count.
-        retry::retry_for(Duration::from_secs(60), |_| async {
-            // Wait for shards to stop updating.
-            let description = state
-                .kinesis_client
-                .describe_stream(DescribeStreamInput {
-                    exclusive_start_shard_id: None,
-                    limit: None,
-                    stream_name: stream_name.clone(),
-                })
-                .await
-                .map_err(|e| format!("getting current shard count: {}", e))?
-                .stream_description;
-            if description.stream_status != "ACTIVE" {
-                return Err(format!(
-                    "stream {} is not active, is {}",
-                    stream_name, description.stream_status
-                ));
-            }
+        retry::retry_for(
+            cmp::max(state.default_timeout, Duration::from_secs(60)),
+            |_| async {
+                // Wait for shards to stop updating.
+                let description = state
+                    .kinesis_client
+                    .describe_stream(DescribeStreamInput {
+                        exclusive_start_shard_id: None,
+                        limit: None,
+                        stream_name: stream_name.clone(),
+                    })
+                    .await
+                    .map_err(|e| format!("getting current shard count: {}", e))?
+                    .stream_description;
+                if description.stream_status != "ACTIVE" {
+                    return Err(format!(
+                        "stream {} is not active, is {}",
+                        stream_name, description.stream_status
+                    ));
+                }
 
-            let active_shards_len = i64::try_from(
-                description
-                    .shards
-                    .iter()
-                    .filter(|shard| shard.sequence_number_range.ending_sequence_number.is_none())
-                    .count(),
-            )
-            .map_err(|e| format!("converting shard length to i64: {}", e))?;
-            if active_shards_len != self.target_shard_count {
-                return Err(format!(
-                    "Expected {} shards, found {}",
-                    self.target_shard_count, active_shards_len
-                ));
-            }
-            Ok(())
-        })
+                let active_shards_len = i64::try_from(
+                    description
+                        .shards
+                        .iter()
+                        .filter(|shard| {
+                            shard.sequence_number_range.ending_sequence_number.is_none()
+                        })
+                        .count(),
+                )
+                .map_err(|e| format!("converting shard length to i64: {}", e))?;
+                if active_shards_len != self.target_shard_count {
+                    return Err(format!(
+                        "Expected {} shards, found {}",
+                        self.target_shard_count, active_shards_len
+                    ));
+                }
+                Ok(())
+            },
+        )
         .await
     }
 }

--- a/src/testdrive/src/action/kinesis/verify.rs
+++ b/src/testdrive/src/action/kinesis/verify.rs
@@ -19,7 +19,6 @@ use aws_util::kinesis::{get_shard_ids, get_shard_iterator};
 
 use crate::action::{Action, State};
 use crate::parser::BuiltinCommand;
-use crate::util::kinesis::DEFAULT_KINESIS_TIMEOUT;
 
 pub struct VerifyAction {
     stream_prefix: String,
@@ -76,7 +75,7 @@ impl Action for VerifyAction {
                     Some(0) => (),
                     _ => shard_iterators.push_back(output.next_shard_iterator),
                 };
-                if timer.elapsed() > DEFAULT_KINESIS_TIMEOUT {
+                if timer.elapsed() > state.default_timeout {
                     // Unable to read all Kinesis records in the default
                     // time allotted -- fail.
                     return Err(format!(

--- a/src/testdrive/src/util/kinesis.rs
+++ b/src/testdrive/src/util/kinesis.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp;
 use std::convert::TryFrom;
 use std::time::Duration;
 
@@ -14,14 +15,13 @@ use rusoto_kinesis::{DescribeStreamInput, Kinesis, KinesisClient};
 
 use ore::retry;
 
-pub const DEFAULT_KINESIS_TIMEOUT: Duration = Duration::from_millis(12700);
-
 pub async fn wait_for_stream_shards(
     kinesis_client: &KinesisClient,
     stream_name: String,
     target_shard_count: i64,
+    timeout: Duration,
 ) -> Result<(), String> {
-    retry::retry_for(Duration::from_secs(60), |_| async {
+    retry::retry_for(cmp::max(timeout, Duration::from_secs(60)), |_| async {
         let description = kinesis_client
             .describe_stream(DescribeStreamInput {
                 exclusive_start_shard_id: None,


### PR DESCRIPTION
Introduce a ```default-timeout``` option to ```testdrive``` and propagate it to all places that have non-zero and non-1-second timeouts.

If a timeout with a larger value previously exited in the code, the larger value is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6090)
<!-- Reviewable:end -->
