### PR TITLE
Properly clean up timestamper state when we DROP DATABASE

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2229,15 +2229,7 @@ impl Coordinator {
             ObjectType::Schema => unreachable!(),
             ObjectType::Source => ExecuteResponse::DroppedSource,
             ObjectType::View => ExecuteResponse::DroppedView,
-            ObjectType::Table => {
-                for id in items.iter() {
-                    if let Some(tables) = &mut self.persisted_tables {
-                        tables.destroy(*id);
-                    }
-                }
-
-                ExecuteResponse::DroppedTable
-            }
+            ObjectType::Table => ExecuteResponse::DroppedTable,
             ObjectType::Sink => ExecuteResponse::DroppedSink,
             ObjectType::Index => ExecuteResponse::DroppedIndex,
             ObjectType::Type => ExecuteResponse::DroppedType,
@@ -3043,6 +3035,9 @@ impl Coordinator {
                                 -1,
                             )
                             .await;
+                            if let Some(tables) = &mut self.persisted_tables {
+                                tables.destroy(entry.id());
+                            }
                         }
                         CatalogItem::Source(_) => {
                             sources_to_drop.push(entry.id());


### PR DESCRIPTION
Fixes #6094

Previously we were not informing the timestamper about source drops after a DROP DATABASE, which lead to lots of logs complaining about being unable to read from stale consistency topics in testdrive tests

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6098)
<!-- Reviewable:end -->
