### PR TITLE
ci/deploy: use stable image to deploy the devsite

### DIFF
--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 steps:
-  - command: bin/ci-builder run nightly ci/deploy/devsite.sh
+  - command: bin/ci-builder run stable ci/deploy/devsite.sh
     branches: main
     timeout_in_minutes: 30
     agents:


### PR DESCRIPTION
Intra-rustdoc links are stable now, so no need to use the nightly image
to build the documentation. This avoids the deploy job failing due to
additional lints that were not present in the PR build's check that the
docs are buildable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6100)
<!-- Reviewable:end -->
