### PR TITLE
Remove two more functions from `SourceInfo`

### DIFF
--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -36,8 +36,6 @@ use crate::source::{
 pub struct FileSourceInfo<Out> {
     /// Unique source ID
     id: SourceInstanceId,
-    /// Field is set if this operator is responsible for ingesting data
-    is_activated_reader: bool,
     /// Receiver channel that ingests records
     receiver_stream: Receiver<Result<Out, Error>>,
     /// Current File Offset. This corresponds to the offset of last processed message
@@ -117,7 +115,6 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
 
         Ok(FileSourceInfo {
             id: source_id,
-            is_activated_reader: active,
             receiver_stream: receiver,
             current_file_offset: FileOffset { offset: 0 },
         })
@@ -179,7 +176,6 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
 
         Ok(FileSourceInfo {
             id: source_id,
-            is_activated_reader: active,
             receiver_stream: receiver,
             current_file_offset: FileOffset { offset: 0 },
         })
@@ -187,10 +183,6 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
 }
 
 impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
-    fn has_partition(&self, _: PartitionId) -> bool {
-        self.is_activated_reader
-    }
-
     fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
         // This function should be a no-op for file sources because they don't have partitions.
         log::debug!("ensure_has_partition erroneously called for file sources");

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -187,10 +187,6 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
 }
 
 impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
-    fn get_worker_partition_count(&self) -> i32 {
-        1
-    }
-
     fn has_partition(&self, _: PartitionId) -> bool {
         self.is_activated_reader
     }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -93,14 +93,6 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
-    /// Returns the number of partitions expected *for this worker*. Partitions are assigned
-    /// round-robin in worker id order offset by the hash of the source_id
-    fn get_worker_partition_count(&self) -> i32 {
-        (0..self.known_partitions)
-            .filter(|pid| has_partition(self.id.source_id, self.worker_id, self.worker_count, *pid))
-            .count() as i32
-    }
-
     /// Returns true if this worker is responsible for this partition
     fn has_partition(&self, partition_id: PartitionId) -> bool {
         let pid = match partition_id {
@@ -135,11 +127,6 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
             }
         }
         self.known_partitions = cmp::max(self.known_partitions, pid + 1);
-
-        assert_eq!(
-            self.get_worker_partition_count(),
-            self.get_partition_consumers_count()
-        );
     }
 
     /// Updates the Kafka source to reflect the new partition count.
@@ -262,10 +249,6 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
                 attempts += 1;
             }
         }
-        assert_eq!(
-            self.get_partition_consumers_count(),
-            self.get_worker_partition_count()
-        );
 
         Ok(next_message)
     }

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -93,16 +93,6 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
-    /// Returns true if this worker is responsible for this partition
-    fn has_partition(&self, partition_id: PartitionId) -> bool {
-        let pid = match partition_id {
-            PartitionId::Kafka(pid) => pid,
-            _ => unreachable!(),
-        };
-
-        self.has_partition(pid)
-    }
-
     /// Ensures that a partition queue for `pid` exists.
     /// In Kafka, partitions are assigned contiguously. This function consequently
     /// creates partition queues for every p <= pid

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{HashSet, VecDeque};
-use std::convert::TryInto;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -176,15 +175,6 @@ impl KinesisSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
-    fn get_worker_partition_count(&self) -> i32 {
-        if self.is_activated_reader {
-            // Kinesis does not support more than i32 partitions
-            self.shard_set.len().try_into().unwrap()
-        } else {
-            0
-        }
-    }
-
     fn has_partition(&self, _partition_id: PartitionId) -> bool {
         self.is_activated_reader
     }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -51,8 +51,6 @@ pub struct KinesisSourceInfo {
     name: String,
     /// Unique Source Id
     id: SourceInstanceId,
-    /// Field is set if this operator is responsible for ingesting data
-    is_activated_reader: bool,
     /// Kinesis client used to obtain records
     kinesis_client: KinesisClient,
     /// Timely worker logger for source events
@@ -113,7 +111,6 @@ impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
                 Ok(KinesisSourceInfo {
                     name: source_name,
                     id: source_id,
-                    is_activated_reader: active,
                     kinesis_client,
                     logger,
                     shard_queue,
@@ -175,10 +172,6 @@ impl KinesisSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
-    fn has_partition(&self, _partition_id: PartitionId) -> bool {
-        self.is_activated_reader
-    }
-
     fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
         //TODO(natacha): do nothing for now, as do not currently use timestamper
     }

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -280,10 +280,6 @@ impl MaybeLength for Value {
 pub(crate) trait SourceInfo<Out> {
     // BYO consistency methods
 
-    /// Returns true if this worker is responsible for this partition
-    /// This is dependent on whether the source supports multi-worker reads or not.
-    fn has_partition(&self, partition_id: PartitionId) -> bool;
-
     /// Ensures that the partition `pid` exists for this source. Once this function has been
     /// called, the source should be able to receive messages from this partition
     fn ensure_has_partition(&mut self, consistency_info: &mut ConsistencyInfo, pid: PartitionId);

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -280,12 +280,6 @@ impl MaybeLength for Value {
 pub(crate) trait SourceInfo<Out> {
     // BYO consistency methods
 
-    /// Returns the number of partitions expected *for this worker*. Partitions are assigned
-    /// round-robin in worker id order
-    /// Note: we currently support two types of sources: those which support multithreaded reads
-    /// and those which don't.
-    fn get_worker_partition_count(&self) -> i32;
-
     /// Returns true if this worker is responsible for this partition
     /// This is dependent on whether the source supports multi-worker reads or not.
     fn has_partition(&self, partition_id: PartitionId) -> bool;

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -707,10 +707,6 @@ impl SourceInfo<Vec<u8>> for S3SourceInfo {
         }
     }
 
-    fn get_worker_partition_count(&self) -> i32 {
-        panic!("s3 sources do not support BYO consistency: get_worker_partition_count")
-    }
-
     fn has_partition(&self, _partition_id: PartitionId) -> bool {
         panic!("s3 sources do not support BYO consistency: has_partition")
     }

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -707,10 +707,6 @@ impl SourceInfo<Vec<u8>> for S3SourceInfo {
         }
     }
 
-    fn has_partition(&self, _partition_id: PartitionId) -> bool {
-        panic!("s3 sources do not support BYO consistency: has_partition")
-    }
-
     fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
         panic!("s3 sources do not support BYO consistency: ensure_has_partition")
     }


### PR DESCRIPTION
These functions were basically unused / enforcing an invariant via asserts in Kafka sources only. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6102)
<!-- Reviewable:end -->
