### PR TITLE
materialized: push simple sql execution into coord client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1971,7 +1971,6 @@ dependencies = [
  "sha2",
  "shell-words",
  "sql",
- "sql-parser",
  "structopt",
  "sysctl",
  "sysinfo",

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -13,6 +13,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use derivative::Derivative;
+use serde::Serialize;
 use tokio::sync::{mpsc, oneshot};
 
 use dataflow_types::PeekResponse;
@@ -234,6 +235,13 @@ pub enum ExecuteResponse {
     },
     /// The specified number of rows were updated in the requested table.
     Updated(usize),
+}
+
+/// The response to [`SessionClient::simple_execute`](crate::SessionClient::simple_execute).
+#[derive(Debug, Serialize)]
+pub struct SimpleExecuteResponse {
+    pub rows: Vec<Vec<serde_json::Value>>,
+    pub col_names: Vec<Option<String>>,
 }
 
 /// The state of a cancellation request.

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -70,7 +70,6 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 shell-words = "1.0.0"
 sql = { path = "../sql" }
-sql-parser = { path = "../sql-parser" }
 structopt = "0.3.21"
 sysctl = "0.4.0"
 sysinfo = "0.16.4"

--- a/src/materialized/src/http/sql.rs
+++ b/src/materialized/src/http/sql.rs
@@ -11,16 +11,9 @@ use std::collections::HashMap;
 
 use anyhow::bail;
 use hyper::{header, Body, Request, Response, StatusCode};
-use serde::Serialize;
-use serde_json::{Number, Value};
 use url::form_urlencoded;
 
 use crate::http::util;
-use coord::ExecuteResponse;
-use dataflow_types::PeekResponse;
-use ore::collections::CollectionExt;
-use repr::{Datum, ScalarType};
-use sql_parser::parser::parse_statements;
 
 pub async fn handle_sql(
     req: Request<Body>,
@@ -33,7 +26,7 @@ pub async fn handle_sql(
             Some(sql) => sql,
             None => bail!("expected `sql` parameter"),
         };
-        let res = query_sql(coord_client, sql.to_string()).await?;
+        let res = coord_client.simple_execute(sql).await?;
         Ok(Response::builder()
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(serde_json::to_string(&res)?))
@@ -43,110 +36,5 @@ pub async fn handle_sql(
     match res {
         Ok(res) => Ok(res),
         Err(e) => Ok(util::error_response(StatusCode::BAD_REQUEST, e.to_string())),
-    }
-}
-
-/// Executes a single SQL statement as the specified user.
-async fn query_sql(
-    coord_client: &mut coord::SessionClient,
-    sql: String,
-) -> anyhow::Result<SqlResult> {
-    let stmts = parse_statements(&sql)?;
-    if stmts.len() != 1 {
-        bail!("expected exactly 1 statement");
-    }
-    let stmt = stmts.into_element();
-
-    coord_client.session().start_transaction();
-
-    const EMPTY_PORTAL: &str = "";
-    let params = vec![];
-    coord_client
-        .declare(EMPTY_PORTAL.into(), stmt, params)
-        .await?;
-    let desc = coord_client
-        .session()
-        .get_portal(EMPTY_PORTAL)
-        .map(|portal| portal.desc.clone())
-        .expect("unnamed portal should be present");
-    if !desc.param_types.is_empty() {
-        bail!("parameters are not supported");
-    }
-
-    let res = coord_client.execute(EMPTY_PORTAL.into()).await?;
-
-    let rows = match res {
-        ExecuteResponse::SendingRows(rows) => {
-            let response = rows.await;
-            response
-        }
-        _ => bail!("unsupported statement type"),
-    };
-    let rows = match rows {
-        PeekResponse::Rows(rows) => rows,
-        PeekResponse::Error(e) => bail!("{}", e),
-        PeekResponse::Canceled => bail!("execution canceled"),
-    };
-    let mut sql_rows: Vec<Vec<Value>> = vec![];
-    let (col_names, col_types) = match desc.relation_desc {
-        Some(desc) => (
-            desc.iter_names()
-                .map(|name| name.map(|name| name.to_string()))
-                .collect(),
-            desc.typ().column_types.clone(),
-        ),
-        None => (vec![], vec![]),
-    };
-    for row in rows {
-        let datums = row.unpack();
-        sql_rows.push(
-            datums
-                .iter()
-                .enumerate()
-                .map(|(idx, datum)| match datum {
-                    // Convert some common things to a native JSON value. This doesn't need to be
-                    // too exhaustive because the SQL-over-HTTP interface is currently not hooked
-                    // up to arbitrary external user queries.
-                    Datum::Null | Datum::JsonNull => Value::Null,
-                    Datum::False => Value::Bool(false),
-                    Datum::True => Value::Bool(true),
-                    Datum::Int32(n) => Value::Number(Number::from(*n)),
-                    Datum::Int64(n) => Value::Number(Number::from(*n)),
-                    Datum::Float32(n) => float_to_json(n.into_inner() as f64),
-                    Datum::Float64(n) => float_to_json(n.into_inner()),
-                    Datum::String(s) => Value::String(s.to_string()),
-                    Datum::Decimal(d) => Value::String(if col_types.len() > idx {
-                        match col_types[idx].scalar_type {
-                            ScalarType::Decimal(_precision, scale) => {
-                                d.with_scale(scale).to_string()
-                            }
-                            _ => datum.to_string(),
-                        }
-                    } else {
-                        datum.to_string()
-                    }),
-                    _ => Value::String(datum.to_string()),
-                })
-                .collect(),
-        );
-    }
-    Ok(SqlResult {
-        rows: sql_rows,
-        col_names,
-    })
-}
-
-#[derive(Serialize)]
-struct SqlResult {
-    rows: Vec<Vec<Value>>,
-    col_names: Vec<Option<String>>,
-}
-
-// Convert most floats to a JSON Number. JSON Numbers don't support NaN or
-// Infinity, so those will still be rendered as strings.
-fn float_to_json(f: f64) -> Value {
-    match Number::from_f64(f) {
-        Some(n) => Value::Number(n),
-        None => Value::String(f.to_string()),
     }
 }


### PR DESCRIPTION
This will make it possible to use the simple SQL execution interface
outside of the HTTP client. Also I think it's just nice to have it as
part of the coordinator's API.

Pure code movement. No behavior changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6112)
<!-- Reviewable:end -->
