### PR TITLE
(Take #2) mzbuild: A container that combines testdrive and the .td tests

### DIFF
--- a/test/testdrive/Dockerfile
+++ b/test/testdrive/Dockerfile
@@ -1,0 +1,12 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM testdrive
+
+COPY . /workdir

--- a/test/testdrive/mzbuild.yml
+++ b/test/testdrive/mzbuild.yml
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: testdrive-with-tests
+publish: false
+
+pre-image:
+  type: directory
+  source: test/testdrive


### PR DESCRIPTION
A new 'testdrive-with-tests' container derives from 'testdrive' and
also includes the .td files from the test/testdrive directory

Extend mzbuild so that all files in a given directory are considered
inputs to the checksum algorithm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6113)
<!-- Reviewable:end -->
