### PR TITLE
Change the design doc template placeholder text into markdown comments

### DIFF
--- a/doc/developer/design/00000000_template.md
+++ b/doc/developer/design/00000000_template.md
@@ -2,29 +2,41 @@
 
 ## Summary
 
+<!--
 // Brief, high-level overview. A few sentences long.
 // Be sure to capture the customer impact - framing this as a release note may be useful.
+-->
 
 ## Goals
 
+<!--
 // Enumerate the concrete goals that are in scope for the project.
+-->
 
 ## Non-Goals
 
+<!--
 // Enumerate potential goals that are explicitly out of scope for the project
 // ie. what could we do or what do we want to do in the future - but are not doing now
+-->
 
 ## Description
 
+<!--
 // Describe the approach in detail. If there is no clear frontrunner, feel free to list all approaches in alternatives.
 // If applicable, be sure to call out any new testing/validation that will be required
+-->
 
 ## Alternatives
 
+<!--
 // Similar to the Description section. List of alternative approaches considered, pros/cons or why they were not chosen
+-->
 
 ## Open questions
 
+<!--
 // Anything currently unanswered that needs specific focus. This section may be expanded during the doc meeting as
 // other unknowns are pointed out.
 // These questions may be technical, product, or anything in-between.
+-->


### PR DESCRIPTION
This allows authors to keep the text around (for referencing it while authoring) in a way that doesn't hurt the readability of the final spec as rendered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6124)
<!-- Reviewable:end -->
