### PR TITLE
Upsert interface: Enable protobuf value + bytes/text key with upsert.

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -395,6 +395,10 @@ impl DataEncoding {
             }) => {
                 let d = decode_descriptors(descriptors)?;
                 validate_descriptors(message_name, &d)?
+                    .into_iter()
+                    .fold(key_desc, |desc, (name, ty)| {
+                        desc.with_column(name.unwrap(), ty)
+                    })
             }
             DataEncoding::Regex(RegexEncoding { regex }) => regex
                 .capture_names()

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -220,6 +220,10 @@ pub(crate) fn get_decoder(
 ) -> Box<dyn DecoderState> {
     let avro_err = "Failed to create Avro decoder";
     match encoding {
+        DataEncoding::Protobuf(enc) => Box::new(protobuf::ProtobufDecoderState::new(
+            &enc.descriptors,
+            &enc.message_name,
+        )),
         DataEncoding::Avro(val_enc) => Box::new(
             avro::AvroDecoderState::new(
                 &val_enc.value_schema,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -878,7 +878,7 @@ pub fn plan_create_source(
             DataEncoding::Avro(AvroEncoding { key_schema, .. }) => {
                 *key_schema = None;
             }
-            DataEncoding::Bytes | DataEncoding::Text => {
+            DataEncoding::Bytes | DataEncoding::Text | DataEncoding::Protobuf(_) => {
                 if let DataEncoding::Avro(_) = &key_encoding {
                     unsupported!("Avro key for this format");
                 }

--- a/test/testdrive/upsert-kafka.td
+++ b/test/testdrive/upsert-kafka.td
@@ -235,6 +235,64 @@ b\xc3\xadrdmore  géese            6
 mammal1          mouse            9
 mammalmore       herd             10
 
+$ kafka-create-topic topic=textproto
+
+> CREATE MATERIALIZED SOURCE textproto
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textproto-${testdrive.seed}'
+      WITH (consistency = 'testdrive-data-consistency2-${testdrive.seed}')
+  FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
+  ENVELOPE UPSERT FORMAT TEXT
+
+> CREATE MATERIALIZED SOURCE bytesproto
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-textproto-${testdrive.seed}'
+        WITH (consistency = 'testdrive-data-consistency2-${testdrive.seed}')
+  FORMAT PROTOBUF MESSAGE '.Struct' USING SCHEMA FILE '${testdrive.protobuf-descriptors-file}'
+  ENVELOPE UPSERT FORMAT BYTES
+
+$ kafka-ingest format=protobuf message=struct topic=textproto key-format=bytes key-terminator=: publish=true
+fish:{"int": 1, "bad_int": 1, "bin": "ONE", "st": "my-string"}
+bìrd1:{"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+birdmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+mammal1: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+bìrd1:
+birdmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "stuff"}
+mämmalmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+bìrd1:{"int": 2, "bad_int": 1, "bin": "ONE", "st": "something-valid"}
+mammal1:
+mammalmore: {"int": 2, "bad_int": 2, "bin": "ONE", "st": "something-valid"}
+
+$ kafka-ingest format=bytes topic=data-consistency2
+testdrive-textproto-${testdrive.seed},1,0,1,3
+
+> SELECT * FROM bytesproto
+fish 1 1 ONE my-string 1
+b\xc3\xacrd1 2 2 ONE something-valid 2
+birdmore 2 2 ONE something-valid 3
+
+> SELECT * FROM textproto
+fish 1 1 ONE my-string 1
+bìrd1 2 2 ONE something-valid 2
+birdmore 2 2 ONE something-valid 3
+
+$ kafka-ingest format=bytes topic=data-consistency2
+testdrive-textproto-${testdrive.seed},1,0,2,10
+
+> SELECT * FROM bytesproto
+fish 1 1 ONE my-string 1
+birdmore 2 2 ONE stuff 6
+m\xc3\xa4mmalmore 2 2 ONE something-valid 7
+b\xc3\xacrd1 2 1 ONE something-valid 8
+mammalmore 2 2 ONE something-valid 10
+
+> SELECT * FROM textproto
+fish 1 1 ONE my-string 1
+birdmore 2 2 ONE stuff 6
+mämmalmore 2 2 ONE something-valid 7
+bìrd1 2 1 ONE something-valid 8
+mammalmore 2 2 ONE something-valid 10
+
 $ kafka-create-topic topic=nullkey
 
 # A null key should result in an error decoding that row but not a panic


### PR DESCRIPTION
Turning on upsert support for protobuf value + bytes/text key is a request from #5429.

In my mind, this is the extent of the code we need to turn the support on. 

Questions:
* Do we want to hide this behind `--experimental` until we have even more extensive text coverage?
* Does putting this in inhibit future source orthogonality in any way?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6125)
<!-- Reviewable:end -->
