### PR TITLE
repr,expr,sql: permit jsonb numbers to be i64 or f64

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,13 @@ Wrap your release notes at the 80 character mark.
 - Add the [`jsonb_object_agg`](/sql/functions/jsonb_object_agg) function to
   aggregate rows into a JSON object.
 
+- Permit the [`jsonb`](/sql/types/jsonb) type to store all 64-bit integers
+  {{% gh 5919 %}}.
+  Previously integers in the following ranges were rejected:
+
+    * [-2<sup>64</sup>, -(2^<sup>53</sup>-1)]
+    * [2<sup>53</sup> - 1, 2^<sup>64</sup>-1].
+
 {{% version-header v0.7.1 %}}
 
 - **Breaking change.** Change the default

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -23,6 +23,7 @@ use chrono::{
 use hmac::{Hmac, Mac, NewMac};
 use itertools::Itertools;
 use md5::{Digest, Md5};
+use ordered_float::OrderedFloat;
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 use sha1::Sha1;
@@ -233,19 +234,16 @@ fn cast_float32_to_float64<'a>(a: Datum<'a>) -> Datum<'a> {
     Datum::from(f64::from(a.unwrap_float32()))
 }
 
-fn cast_float32_to_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+fn cast_float32_to_decimal<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
     let f = a.unwrap_float32();
-    let scale = b.unwrap_int32();
-
-    if f > 10_f32.powi(MAX_DECIMAL_PRECISION as i32 - scale) {
+    if f > 10_f32.powi(i32::from(MAX_DECIMAL_PRECISION - scale)) {
         // When we can return error detail:
         // format!("A field with precision {}, \
         //         scale {} must round to an absolute value less than 10^{}.",
         //         MAX_DECIMAL_PRECISION, scale, MAX_DECIMAL_PRECISION - scale)
         return Err(EvalError::NumericFieldOverflow);
     }
-
-    Ok(Datum::from((f * 10_f32.powi(scale)) as i128))
+    Ok(Datum::from((f * 10_f32.powi(i32::from(scale))) as i128))
 }
 
 fn cast_float32_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
@@ -292,19 +290,16 @@ fn cast_float64_to_float32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     }
 }
 
-fn cast_float64_to_decimal<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+fn cast_float64_to_decimal<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
     let f = a.unwrap_float64();
-    let scale = b.unwrap_int32();
-
-    if f > 10_f64.powi(MAX_DECIMAL_PRECISION as i32 - scale) {
+    if f > 10_f64.powi(i32::from(MAX_DECIMAL_PRECISION - scale)) {
         // When we can return error detail:
         // format!("A field with precision {}, \
         //         scale {} must round to an absolute value less than 10^{}.",
         //         MAX_DECIMAL_PRECISION, scale, MAX_DECIMAL_PRECISION - scale)
         return Err(EvalError::NumericFieldOverflow);
     }
-
-    Ok(Datum::from((f * 10_f64.powi(scale)) as i128))
+    Ok(Datum::from((f * 10_f64.powi(i32::from(scale))) as i128))
 }
 
 fn cast_float64_to_string<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
@@ -619,23 +614,87 @@ fn cast_jsonb_or_null_to_jsonb<'a>(a: Datum<'a>) -> Datum<'a> {
     }
 }
 
-fn cast_jsonb_to_float64<'a>(a: Datum<'a>) -> Datum<'a> {
+fn cast_jsonb_to_int32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
-        Datum::Float64(_) => a,
-        Datum::String(s) => match s {
-            "NaN" => std::f64::NAN.into(),
-            "Infinity" => std::f64::INFINITY.into(),
-            "-Infinity" => std::f64::NEG_INFINITY.into(),
-            _ => Datum::Null,
-        },
-        _ => Datum::Null,
+        Datum::Int64(_) => cast_int64_to_int32(a),
+        Datum::Float64(_) => cast_float64_to_int32(a),
+        _ => Err(EvalError::InvalidJsonbCast {
+            from: jsonb_type(a).into(),
+            to: "integer".into(),
+        }),
     }
 }
 
-fn cast_jsonb_to_bool<'a>(a: Datum<'a>) -> Datum<'a> {
+fn cast_jsonb_to_int64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     match a {
-        Datum::True | Datum::False => a,
-        _ => Datum::Null,
+        Datum::Int64(_) => Ok(a),
+        Datum::Float64(_) => cast_float64_to_int64(a),
+        _ => Err(EvalError::InvalidJsonbCast {
+            from: jsonb_type(a).into(),
+            to: "bigint".into(),
+        }),
+    }
+}
+
+fn cast_jsonb_to_float32<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    match a {
+        Datum::Int64(_) => Ok(cast_int64_to_float32(a)),
+        Datum::Float64(_) => cast_float64_to_float32(a),
+        _ => Err(EvalError::InvalidJsonbCast {
+            from: jsonb_type(a).into(),
+            to: "real".into(),
+        }),
+    }
+}
+
+fn cast_jsonb_to_float64<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    match a {
+        Datum::Int64(_) => Ok(cast_int64_to_float64(a)),
+        Datum::Float64(_) => Ok(a),
+        _ => Err(EvalError::InvalidJsonbCast {
+            from: jsonb_type(a).into(),
+            to: "double precision".into(),
+        }),
+    }
+}
+
+fn cast_jsonb_to_decimal<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
+    match a {
+        Datum::Int64(_) => {
+            let a = cast_int64_to_decimal(a);
+            if scale > 0 {
+                Ok(mul_decimal(a, Datum::from(10_i128.pow(u32::from(scale)))))
+            } else {
+                Ok(a)
+            }
+        }
+        Datum::Float64(_) => cast_float64_to_decimal(a, scale),
+        _ => Err(EvalError::InvalidJsonbCast {
+            from: jsonb_type(a).into(),
+            to: "numeric".into(),
+        }),
+    }
+}
+
+fn cast_jsonb_to_bool<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
+    match a {
+        Datum::True | Datum::False => Ok(a),
+        _ => Err(EvalError::InvalidJsonbCast {
+            from: jsonb_type(a).into(),
+            to: "boolean".into(),
+        }),
+    }
+}
+
+fn jsonb_type(d: Datum<'_>) -> &'static str {
+    match d {
+        Datum::JsonNull => "null",
+        Datum::False | Datum::True => "boolean",
+        Datum::String(_) => "string",
+        Datum::Int64(_) | Datum::Float64(_) => "numeric",
+        Datum::List(_) => "array",
+        Datum::Map(_) => "object",
+        _ => unreachable!("jsonb_type called on invalid datum {:?}", d),
     }
 }
 
@@ -1194,7 +1253,7 @@ fn sqrt_dec<'a>(a: Datum<'a>, scale: u8) -> Result<Datum, EvalError> {
     }
     let d_f64 = cast_significand_to_float64(a);
     let d_scaled = d_f64.unwrap_float64() / 10_f64.powi(i32::from(scale));
-    cast_float64_to_decimal(Datum::from(d_scaled.sqrt()), Datum::from(i32::from(scale)))
+    cast_float64_to_decimal(Datum::from(d_scaled.sqrt()), scale)
 }
 
 fn cbrt_float64<'a>(a: Datum<'a>) -> Datum {
@@ -1268,12 +1327,11 @@ fn log_dec<'a, 'b, F: Fn(f64) -> f64>(
     scale: u8,
 ) -> Result<Datum<'a>, EvalError> {
     let significand = cast_significand_to_float64(a);
-    let scale = i32::from(scale);
-    let a = log_guard(significand.unwrap_float64() / 10_f64.powi(scale), name)?;
-    Ok(cast_float64_to_decimal(
-        Datum::from(logic(a)),
-        Datum::from(scale),
-    )?)
+    let a = log_guard(
+        significand.unwrap_float64() / 10_f64.powi(i32::from(scale)),
+        name,
+    )?;
+    Ok(cast_float64_to_decimal(Datum::from(logic(a)), scale)?)
 }
 
 fn log<'a, 'b, F: Fn(f64) -> f64>(
@@ -1291,13 +1349,8 @@ fn exp<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 
 fn exp_dec<'a>(a: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
     let significand = cast_significand_to_float64(a);
-    let scale = i32::from(scale);
-    let a = significand.unwrap_float64() / 10_f64.powi(scale);
-
-    Ok(cast_float64_to_decimal(
-        Datum::from(a.exp()),
-        Datum::from(scale),
-    )?)
+    let a = significand.unwrap_float64() / 10_f64.powi(i32::from(scale));
+    Ok(cast_float64_to_decimal(Datum::from(a.exp()), scale)?)
 }
 
 fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
@@ -1307,10 +1360,9 @@ fn power<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalError> {
 }
 
 fn power_dec<'a>(a: Datum<'a>, b: Datum<'a>, scale: u8) -> Result<Datum<'a>, EvalError> {
-    let scale = i32::from(scale);
-    let a = cast_significand_to_float64(a).unwrap_float64() / 10_f64.powi(scale);
-    let b = cast_significand_to_float64(b).unwrap_float64() / 10_f64.powi(scale);
-    cast_float64_to_decimal(Datum::from(a.powf(b)), Datum::from(scale))
+    let a = cast_significand_to_float64(a).unwrap_float64() / 10_f64.powi(i32::from(scale));
+    let b = cast_significand_to_float64(b).unwrap_float64() / 10_f64.powi(i32::from(scale));
+    cast_float64_to_decimal(Datum::from(a.powf(b)), scale)
 }
 
 fn sleep<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
@@ -1499,6 +1551,9 @@ fn jsonb_contains_jsonb<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
             (Datum::JsonNull, Datum::JsonNull) => true,
             (Datum::False, Datum::False) => true,
             (Datum::True, Datum::True) => true,
+            (Datum::Int64(a), Datum::Int64(b)) => (a == b),
+            (Datum::Int64(a), Datum::Float64(b)) => (OrderedFloat(a as f64) == b),
+            (Datum::Float64(a), Datum::Int64(b)) => (a == OrderedFloat(b as f64)),
             (Datum::Float64(a), Datum::Float64(b)) => (a == b),
             (Datum::String(a), Datum::String(b)) => (a == b),
             (Datum::List(a), Datum::List(b)) => b
@@ -2244,8 +2299,6 @@ pub enum BinaryFunc {
     TimezoneIntervalTimestamp,
     TimezoneIntervalTimestampTz,
     TimezoneIntervalTime,
-    CastFloat32ToDecimal,
-    CastFloat64ToDecimal,
     TextConcat,
     JsonbGetInt64 { stringify: bool },
     JsonbGetString { stringify: bool },
@@ -2393,8 +2446,6 @@ impl BinaryFunc {
             BinaryFunc::TimezoneIntervalTimestamp => eager!(timezone_interval_timestamp),
             BinaryFunc::TimezoneIntervalTimestampTz => eager!(timezone_interval_timestamptz),
             BinaryFunc::TimezoneIntervalTime => eager!(timezone_interval_time),
-            BinaryFunc::CastFloat32ToDecimal => eager!(cast_float32_to_decimal),
-            BinaryFunc::CastFloat64ToDecimal => eager!(cast_float64_to_decimal),
             BinaryFunc::TextConcat => Ok(eager!(text_concat_binary, temp_storage)),
             BinaryFunc::JsonbGetInt64 { stringify } => {
                 Ok(eager!(jsonb_get_int64, temp_storage, *stringify))
@@ -2517,13 +2568,6 @@ impl BinaryFunc {
                 let s = s1 - s2;
                 ScalarType::Decimal(MAX_DECIMAL_PRECISION, s).nullable(true)
             }
-
-            CastFloat32ToDecimal | CastFloat64ToDecimal => match input2_type.scalar_type {
-                ScalarType::Decimal(_, s) => {
-                    ScalarType::Decimal(MAX_DECIMAL_PRECISION, s).nullable(true)
-                }
-                _ => unreachable!(),
-            },
 
             RoundDecimal(scale) => {
                 match input1_type.scalar_type {
@@ -2779,8 +2823,6 @@ impl BinaryFunc {
             | TimezoneIntervalTimestamp
             | TimezoneIntervalTimestampTz
             | TimezoneIntervalTime
-            | CastFloat32ToDecimal
-            | CastFloat64ToDecimal
             | RoundDecimal(_)
             | ConvertFrom
             | Position
@@ -2893,8 +2935,6 @@ impl fmt::Display for BinaryFunc {
             BinaryFunc::TimezoneIntervalTimestamp => f.write_str("timezoneits"),
             BinaryFunc::TimezoneIntervalTimestampTz => f.write_str("timezoneitstz"),
             BinaryFunc::TimezoneIntervalTime => f.write_str("timezoneit"),
-            BinaryFunc::CastFloat32ToDecimal => f.write_str("f32todec"),
-            BinaryFunc::CastFloat64ToDecimal => f.write_str("f64todec"),
             BinaryFunc::TextConcat => f.write_str("||"),
             BinaryFunc::JsonbGetInt64 { .. } => f.write_str("->"),
             BinaryFunc::JsonbGetString { .. } => f.write_str("->"),
@@ -2978,6 +3018,8 @@ pub enum UnaryFunc {
     CastFloat32ToInt64,
     CastFloat32ToFloat64,
     CastFloat32ToString,
+    CastFloat32ToDecimal(u8),
+    CastFloat64ToDecimal(u8),
     CastFloat64ToInt32,
     CastFloat64ToInt64,
     CastFloat64ToFloat32,
@@ -3031,7 +3073,11 @@ pub enum UnaryFunc {
     CastStringToJsonb,
     CastJsonbToString,
     CastJsonbOrNullToJsonb,
+    CastJsonbToInt32,
+    CastJsonbToInt64,
+    CastJsonbToFloat32,
     CastJsonbToFloat64,
+    CastJsonbToDecimal(u8),
     CastJsonbToBool,
     CastUuidToString,
     CastRecordToString {
@@ -3137,6 +3183,8 @@ impl UnaryFunc {
             UnaryFunc::CastBoolToString => Ok(cast_bool_to_string(a)),
             UnaryFunc::CastBoolToStringNonstandard => Ok(cast_bool_to_string_nonstandard(a)),
             UnaryFunc::CastBoolToInt32 => Ok(cast_bool_to_int32(a)),
+            UnaryFunc::CastFloat32ToDecimal(scale) => cast_float32_to_decimal(a, *scale),
+            UnaryFunc::CastFloat64ToDecimal(scale) => cast_float64_to_decimal(a, *scale),
             UnaryFunc::CastInt32ToBool => Ok(cast_int32_to_bool(a)),
             UnaryFunc::CastInt32ToFloat32 => Ok(cast_int32_to_float32(a)),
             UnaryFunc::CastInt32ToFloat64 => Ok(cast_int32_to_float64(a)),
@@ -3204,8 +3252,12 @@ impl UnaryFunc {
             UnaryFunc::CastBytesToString => Ok(cast_bytes_to_string(a, temp_storage)),
             UnaryFunc::CastJsonbOrNullToJsonb => Ok(cast_jsonb_or_null_to_jsonb(a)),
             UnaryFunc::CastJsonbToString => Ok(cast_jsonb_to_string(a, temp_storage)),
-            UnaryFunc::CastJsonbToFloat64 => Ok(cast_jsonb_to_float64(a)),
-            UnaryFunc::CastJsonbToBool => Ok(cast_jsonb_to_bool(a)),
+            UnaryFunc::CastJsonbToInt32 => cast_jsonb_to_int32(a),
+            UnaryFunc::CastJsonbToInt64 => cast_jsonb_to_int64(a),
+            UnaryFunc::CastJsonbToFloat32 => cast_jsonb_to_float32(a),
+            UnaryFunc::CastJsonbToFloat64 => cast_jsonb_to_float64(a),
+            UnaryFunc::CastJsonbToDecimal(scale) => cast_jsonb_to_decimal(a, *scale),
+            UnaryFunc::CastJsonbToBool => cast_jsonb_to_bool(a),
             UnaryFunc::CastUuidToString => Ok(cast_uuid_to_string(a, temp_storage)),
             UnaryFunc::CastRecordToString { ty }
             | UnaryFunc::CastArrayToString { ty }
@@ -3346,6 +3398,10 @@ impl UnaryFunc {
             | CastFloat32ToFloat64
             | CastSignificandToFloat64 => ScalarType::Float64.nullable(in_nullable),
 
+            CastFloat32ToDecimal(s) | CastFloat64ToDecimal(s) => {
+                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *s).nullable(in_nullable)
+            }
+
             CastInt64ToInt32 | CastDecimalToInt32(_) => ScalarType::Int32.nullable(in_nullable),
 
             CastFloat32ToInt32 | CastFloat64ToInt32 => ScalarType::Int32.nullable(true),
@@ -3380,7 +3436,13 @@ impl UnaryFunc {
 
             // can return null for other jsonb types
             CastJsonbToString => ScalarType::String.nullable(true),
-            CastJsonbToFloat64 => ScalarType::Float64.nullable(true),
+            CastJsonbToInt32 => ScalarType::Int32.nullable(false),
+            CastJsonbToInt64 => ScalarType::Int64.nullable(false),
+            CastJsonbToFloat32 => ScalarType::Float32.nullable(false),
+            CastJsonbToFloat64 => ScalarType::Float64.nullable(false),
+            CastJsonbToDecimal(scale) => {
+                ScalarType::Decimal(MAX_DECIMAL_PRECISION, *scale).nullable(false)
+            }
             CastJsonbToBool => ScalarType::Bool.nullable(true),
 
             CastUuidToString => ScalarType::String.nullable(true),
@@ -3516,10 +3578,12 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::CastFloat32ToFloat64 => f.write_str("f32tof64"),
             UnaryFunc::CastFloat32ToString => f.write_str("f32tostr"),
             UnaryFunc::CastFloat32ToInt32 => f.write_str("f32toi32"),
+            UnaryFunc::CastFloat32ToDecimal(_) => f.write_str("f32todec"),
             UnaryFunc::CastFloat64ToInt32 => f.write_str("f64toi32"),
             UnaryFunc::CastFloat64ToInt64 => f.write_str("f64toi64"),
             UnaryFunc::CastFloat64ToFloat32 => f.write_str("f64tof32"),
             UnaryFunc::CastFloat64ToString => f.write_str("f64tostr"),
+            UnaryFunc::CastFloat64ToDecimal(_) => f.write_str("f64todec"),
             UnaryFunc::CastDecimalToInt32(_) => f.write_str("dectoi32"),
             UnaryFunc::CastDecimalToInt64(_) => f.write_str("dectoi64"),
             UnaryFunc::CastDecimalToString(_) => f.write_str("dectostr"),
@@ -3557,8 +3621,12 @@ impl fmt::Display for UnaryFunc {
             UnaryFunc::CastStringToJsonb => f.write_str("strtojsonb"),
             UnaryFunc::CastJsonbOrNullToJsonb => f.write_str("jsonb?tojsonb"),
             UnaryFunc::CastJsonbToString => f.write_str("jsonbtostr"),
+            UnaryFunc::CastJsonbToInt32 => f.write_str("jsonbtoi32"),
+            UnaryFunc::CastJsonbToInt64 => f.write_str("jsonbtoi64"),
+            UnaryFunc::CastJsonbToFloat32 => f.write_str("jsonbtof32"),
             UnaryFunc::CastJsonbToFloat64 => f.write_str("jsonbtof64"),
             UnaryFunc::CastJsonbToBool => f.write_str("jsonbtobool"),
+            UnaryFunc::CastJsonbToDecimal(_) => f.write_str("jsonbtodec"),
             UnaryFunc::CastUuidToString => f.write_str("uuidtostr"),
             UnaryFunc::CastRecordToString { .. } => f.write_str("recordtostr"),
             UnaryFunc::CastArrayToString { .. } => f.write_str("arraytostr"),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -887,6 +887,10 @@ pub enum EvalError {
         byte_sequence: String,
         encoding_name: String,
     },
+    InvalidJsonbCast {
+        from: String,
+        to: String,
+    },
     InvalidRegex(String),
     InvalidRegexFlag(char),
     InvalidParameterValue(String),
@@ -922,6 +926,9 @@ impl fmt::Display for EvalError {
                 c.escape_default()
             ),
             EvalError::InvalidBase64EndSequence => f.write_str("invalid base64 end sequence"),
+            EvalError::InvalidJsonbCast { from, to } => {
+                write!(f, "cannot cast jsonb {} to type {}", from, to)
+            }
             EvalError::InvalidTimezone(tz) => write!(f, "invalid time zone '{}'", tz),
             EvalError::InvalidTimezoneInterval => {
                 f.write_str("timezone interval must not contain months or years")

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -346,6 +346,7 @@ impl<'a> Datum<'a> {
                     Datum::JsonNull
                     | Datum::False
                     | Datum::True
+                    | Datum::Int64(_)
                     | Datum::Float64(_)
                     | Datum::String(_) => true,
                     Datum::List(list) => list

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -103,7 +103,7 @@ SELECT json_agg(1)
 query T
 SELECT jsonb_agg(1)
 ----
-[1.0]
+[1]
 
 # Some aggregate functions are not normalized to NULL when given a NULL
 # argument.
@@ -186,7 +186,7 @@ SELECT json_agg(1) FROM kv
 query T
 SELECT jsonb_agg(1) FROM kv
 ----
-[1.0,1.0,1.0,1.0,1.0,1.0]
+[1,1,1,1,1,1]
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 query I rowsort

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -29,7 +29,24 @@ SELECT '[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[
 query T
 SELECT '{"a": 1, "a": 2, "a": 3}'::jsonb
 ----
-{"a":3.0}
+{"a":3}
+
+# Regression test for #5919, in which 64-bit integers could not be represented
+# in the jsonb type.
+query T
+SELECT '1614259308542846100'::jsonb
+----
+1614259308542846100
+
+query T
+SELECT '9223372036854775807'::jsonb
+----
+9223372036854775807
+
+query error invalid input syntax for type jsonb: 9223372036854775808 is out of range for a jsonb number
+SELECT '9223372036854775808'::jsonb
+----
+9223372036854775808
 
 statement ok
 CREATE TABLE test_jsonb (
@@ -101,27 +118,27 @@ NULL
 query T
 SELECT test_json ->> 6 FROM test_jsonb WHERE json_type = 'array'
 ----
-[1.0,2.0,3.0]
+[1,2,3]
 
 query T
 SELECT test_json ->> 7 FROM test_jsonb WHERE json_type = 'array'
 ----
-{"f1":9.0}
+{"f1":9}
 
 query T
 SELECT test_json ->> 'field4' FROM test_jsonb WHERE json_type = 'object'
 ----
-4.0
+4
 
 query T
 SELECT test_json ->> 'field5' FROM test_jsonb WHERE json_type = 'object'
 ----
-[1.0,2.0,3.0]
+[1,2,3]
 
 query T
 SELECT test_json ->> 'field6' FROM test_jsonb WHERE json_type = 'object'
 ----
-{"f1":9.0}
+{"f1":9}
 
 query T
 SELECT test_json ->> 2 FROM test_jsonb WHERE json_type = 'scalar'
@@ -477,7 +494,7 @@ false
 query T
 SELECT '1'::JSONB
 ----
-1.0
+1
 
 query T
 SELECT pg_typeof('1'::JSONB)
@@ -490,7 +507,7 @@ SELECT '{'::JSONB
 query T
 SELECT '{"a":1}'::JSONB->'a'
 ----
-1.0
+1
 
 query T
 SELECT pg_typeof('{"a":1}'::JSONB->'a')
@@ -500,12 +517,12 @@ jsonb
 query T
 SELECT '{"a":1,"b":2}'::JSONB->'b'
 ----
-2.0
+2
 
 query T
 SELECT '{"a":1,"b":{"c":3}}'::JSONB->'b'->'c'
 ----
-3.0
+3
 
 query TT
 SELECT '{"a":1,"b":2}'::JSONB->'c','{"c":1}'::JSONB->'a'
@@ -520,7 +537,7 @@ NULL NULL
 query T
 SELECT '[1,2,3]'::JSONB->0
 ----
-1.0
+1
 
 query T
 SELECT '[1,2,3]'::JSONB->3
@@ -550,7 +567,7 @@ text
 query T
 SELECT '{"a":1,"b":2}'::JSONB->>'b'
 ----
-2.0
+2
 
 query TT
 SELECT '{"a":1,"b":2}'::JSONB->>'c','{"c":1}'::JSONB->>'a'
@@ -565,7 +582,7 @@ NULL NULL
 query T
 SELECT '[1,2,3]'::JSONB->>0
 ----
-1.0
+1
 
 query T
 SELECT '[1,2,3]'::JSONB->>3
@@ -702,18 +719,18 @@ SELECT '{"a":1}'::JSONB - 'a'
 query T
 SELECT '{"a":1}'::JSONB - 'b'
 ----
-{"a":1.0}
+{"a":1}
 
 # `-` is one of the very few cases that PG errors in a JSON type mismatch with operators.
 query T
 SELECT '[1,2,3]'::JSONB - 0
 ----
-[2.0,3.0]
+[2,3]
 
 query T
 SELECT '[1,2,3]'::JSONB - 1
 ----
-[1.0,3.0]
+[1,3]
 
 query T
 SELECT '3'::JSONB - 'b'
@@ -840,7 +857,7 @@ SELECT '["1","2","3"]'::JSONB - ''
 query T
 SELECT '[1,"1",1.0]'::JSONB - '1'
 ----
-[1.0,1.0]
+[1,1.0]
 
 # query T
 # SELECT '[1,2,3]'::JSONB #- ARRAY['0']
@@ -923,7 +940,7 @@ SELECT a,b FROM json_family ORDER BY a
 ----
 a    b
 0  {}
-1  {"a":123.0,"c":"asdf"}
+1  {"a":123,"c":"asdf"}
 
 statement ok
 DROP TABLE json_family
@@ -968,7 +985,7 @@ null
 query T
 SELECT to_jsonb(123::INT)
 ----
-123.0
+123
 
 query T
 SELECT to_jsonb('\a'::TEXT)
@@ -1070,27 +1087,27 @@ SELECT to_jsonb(1.234::FLOAT)
 query T rowsort
 SELECT * FROM jsonb_array_elements('[1,2,3]')
 ----
-1.0
-2.0
-3.0
+1
+2
+3
 
 query T rowsort
 SELECT * FROM jsonb_array_elements('[1,true,null,"text",-1.234,{"2":3,"4":"5"},[1,2,3]]')
 ----
-1.0
-true
-null
 "text"
 -1.234
-{"2":3.0,"4":"5"}
-[1.0,2.0,3.0]
+1
+[1,2,3]
+null
+true
+{"2":3,"4":"5"}
 
 query T rowsort
 SELECT js.value->>'a' FROM jsonb_array_elements('[{"a":1},{"a":2},{"a":3}]') js
 ----
-1.0
-2.0
-3.0
+1
+2
+3
 
 query T
 SELECT * FROM jsonb_array_elements('[]')
@@ -1105,27 +1122,27 @@ SELECT * FROM jsonb_array_elements('{"1":2}')
 query T rowsort
 SELECT * FROM jsonb_array_elements_text('[1,2,3]')
 ----
-1.0
-2.0
-3.0
+1
+2
+3
 
 query T rowsort
 SELECT * FROM jsonb_array_elements_text('[1,2,3]')
 ----
-1.0
-2.0
-3.0
+1
+2
+3
 
 query T rowsort
 SELECT * FROM jsonb_array_elements_text('[1,true,null,"text",-1.234,{"2":3,"4":"5"},[1,2,3]]')
 ----
-1.0
-true
-NULL
-text
 -1.234
-{"2":3.0,"4":"5"}
-[1.0,2.0,3.0]
+1
+NULL
+[1,2,3]
+text
+true
+{"2":3,"4":"5"}
 
 query T
 SELECT * FROM jsonb_array_elements('[]')
@@ -1188,17 +1205,17 @@ SELECT jsonb_build_object()
 query T
 SELECT jsonb_build_object('a',2,'b',4)
 ----
-{"a":2.0,"b":4.0}
+{"a":2,"b":4}
 
 query T
 SELECT jsonb_build_object(true,'val',1,0,1.3,2,date '2019-02-03' - date '2019-01-01',4)
 ----
-{"1":0.0,"1.3":2.0,"33 days":4.0,"true":"val"}
+{"1":0,"1.3":2,"33 days":4,"true":"val"}
 
 query T
 SELECT jsonb_build_object('a',1,'b',1.2::float,'c',true,'d',null,'e','{"x":3,"y":[1,2,3]}'::JSONB)
 ----
-{"a":1.0,"b":1.2,"c":true,"d":null,"e":{"x":3.0,"y":[1.0,2.0,3.0]}}
+{"a":1,"b":1.2,"c":true,"d":null,"e":{"x":3,"y":[1,2,3]}}
 
 query T
 SELECT jsonb_build_object(
@@ -1206,12 +1223,12 @@ SELECT jsonb_build_object(
        'd',jsonb_build_object('e',jsonb_build_array(9,8,7))
 )
 ----
-{"a":{"b":false,"c":99.0},"d":{"e":[9.0,8.0,7.0]}}
+{"a":{"b":false,"c":99},"d":{"e":[9,8,7]}}
 
 query T
 SELECT jsonb_build_object(a,3) FROM (SELECT 1 AS a,2 AS b) r
 ----
-{"1":3.0}
+{"1":3}
 
 # query T
 # SELECT jsonb_build_object('\a'::TEXT COLLATE "fr_FR",1)
@@ -1221,7 +1238,7 @@ SELECT jsonb_build_object(a,3) FROM (SELECT 1 AS a,2 AS b) r
 query T
 SELECT jsonb_build_object('\a',1)
 ----
-{"\\a":1.0}
+{"\\a":1}
 
 # query T
 # SELECT jsonb_build_object(jsonb_object_keys('{"x":3,"y":4}'::JSONB),2)
@@ -1297,12 +1314,12 @@ SELECT jsonb_build_object(1,2,3)
 query T
 SELECT '[1,2,3]'::JSONB || '[4,5,6]'::JSONB
 ----
-[1.0,2.0,3.0,4.0,5.0,6.0]
+[1,2,3,4,5,6]
 
 query T
 SELECT '{"a":1,"b":2}'::JSONB || '{"b":3,"c":4}'::JSONB
 ----
-{"a":1.0,"b":3.0,"c":4.0}
+{"a":1,"b":3,"c":4}
 
 query T
 SELECT '{"a":1,"b":2}'::JSONB || '"c"'::JSONB
@@ -1314,7 +1331,7 @@ NULL
 query T
 SELECT '[1,2,3]'::jsonb || '[4,5,6]'
 ----
-[1.0,2.0,3.0,4.0,5.0,6.0]
+[1,2,3,4,5,6]
 
 query T
 SELECT jsonb_build_array()
@@ -1459,11 +1476,11 @@ query TT colnames,rowsort
 SELECT * from jsonb_each('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}'::JSONB) q
 ----
 key  value
-f1   [1.0,2.0,3.0]
-f2   {"f3":1.0}
-f4   null
-f5   99.0
-f6   "stringy"
+f1  [1,2,3]
+f2  {"f3":1}
+f4  null
+f5  99
+f6  "stringy"
 
 query TT
 SELECT * FROM jsonb_each('[1]')
@@ -1481,11 +1498,11 @@ query TT colnames,rowsort
 SELECT * from jsonb_each('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}'::JSONB) q
 ----
 key  value
-f1   [1.0,2.0,3.0]
-f2   {"f3":1.0}
-f4   null
-f5   99.0
-f6   "stringy"
+f1  [1,2,3]
+f2  {"f3":1}
+f4  null
+f5  99
+f6  "stringy"
 
 query TT
 SELECT * FROM jsonb_each_text('[1]')
@@ -1507,11 +1524,11 @@ query TT colnames,rowsort
 SELECT * from jsonb_each_text('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}') q
 ----
 key  value
-f1   [1.0,2.0,3.0]
-f2   {"f3":1.0}
-f4   NULL
-f5   99.0
-f6   stringy
+f1  [1,2,3]
+f2  {"f3":1}
+f4  NULL
+f5  99
+f6  stringy
 
 query TT
 SELECT * FROM jsonb_each_text('[1]')
@@ -1533,11 +1550,11 @@ query TT colnames,rowsort
 SELECT * from jsonb_each_text('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}') q
 ----
 key  value
-f1   [1.0,2.0,3.0]
-f2   {"f3":1.0}
-f4   NULL
-f5   99.0
-f6   stringy
+f1  [1,2,3]
+f2  {"f3":1}
+f4  NULL
+f5  99
+f6  stringy
 
 # query T
 # SELECT json_set('{"a":1}','{a}'::STRING[],'2')
@@ -1643,7 +1660,7 @@ NULL
 query T
 SELECT jsonb_strip_nulls('1'::JSONB)
 ----
-1.0
+1
 
 query T
 SELECT jsonb_strip_nulls('"a string"'::JSONB)
@@ -1658,17 +1675,17 @@ null
 query T
 SELECT jsonb_strip_nulls('[1,2,null,3,4]'::JSONB)
 ----
-[1.0,2.0,null,3.0,4.0]
+[1,2,null,3,4]
 
 query T
 SELECT jsonb_strip_nulls('{"a":1,"b":null,"c":[2,null,3],"d":{"e":4,"f":null}}'::JSONB)
 ----
-{"a":1.0,"c":[2.0,null,3.0],"d":{"e":4.0}}
+{"a":1,"c":[2,null,3],"d":{"e":4}}
 
 query T
 SELECT jsonb_strip_nulls('[1,{"a":1,"b":null,"c":2},3]'::JSONB)
 ----
-[1.0,{"a":1.0,"c":2.0},3.0]
+[1,{"a":1,"c":2},3]
 
 query T
 SELECT jsonb_strip_nulls('{"a":{"b":null,"c":null},"d":{}}'::JSONB)
@@ -1683,7 +1700,7 @@ NULL
 query T
 SELECT jsonb_strip_nulls('1'::JSONB)
 ----
-1.0
+1
 
 query T
 SELECT jsonb_strip_nulls('"a string"'::JSONB)
@@ -1698,17 +1715,17 @@ null
 query T
 SELECT jsonb_strip_nulls('[1,2,null,3,4]'::JSONB)
 ----
-[1.0,2.0,null,3.0,4.0]
+[1,2,null,3,4]
 
 query T
 SELECT jsonb_strip_nulls('{"a":1,"b":null,"c":[2,null,3],"d":{"e":4,"f":null}}'::JSONB)
 ----
-{"a":1.0,"c":[2.0,null,3.0],"d":{"e":4.0}}
+{"a":1,"c":[2,null,3],"d":{"e":4}}
 
 query T
 SELECT jsonb_strip_nulls('[1,{"a":1,"b":null,"c":2},3]'::JSONB)
 ----
-[1.0,{"a":1.0,"c":2.0},3.0]
+[1,{"a":1,"c":2},3]
 
 query T
 SELECT jsonb_strip_nulls('{"a":{"b":null,"c":null},"d":{}}'::JSONB)
@@ -1763,32 +1780,22 @@ SELECT ('1'::jsonb)::float;
 ----
 1.000
 
-query T
+query error cannot cast jsonb string to type double precision
 SELECT ('"Infinity"'::jsonb)::float;
-----
-inf
 
-query T
+query error cannot cast jsonb string to type double precision
 SELECT ('"-Infinity"'::jsonb)::float;
-----
--inf
 
-query T
+query error cannot cast jsonb string to type double precision
 SELECT ('"NaN"'::jsonb)::float;
-----
-NaN
 
 # not a number
-query T
+query error cannot cast jsonb array to type double precision
 SELECT ('[1]'::jsonb)::float;
-----
-NULL
 
 # not a number
-query T
+query error cannot cast jsonb string to type double precision
 SELECT ('"1"'::jsonb)::float;
-----
-NULL
 
 query T
 SELECT ('1'::jsonb)::int;
@@ -1800,10 +1807,8 @@ query error 9999999999999999999 is out of range for a jsonb number at line 1
 SELECT ('9999999999999999999'::jsonb)::int;
 
 # not a number
-query T
+query error cannot cast jsonb array to type integer
 SELECT ('[1]'::jsonb)::int;
-----
-NULL
 
 query error CAST does not support casting from jsonb to timestamp
 SELECT ('"1969-06-01 10:10:10.410"'::jsonb)::timestamp;
@@ -1854,7 +1859,7 @@ NULL
 query T
 SELECT jsonb_agg(1)
 ----
-[1.0]
+[1]
 
 statement ok
 CREATE TABLE t1 (a int)
@@ -1865,22 +1870,22 @@ INSERT INTO t1 VALUES (1), (2), (3), (NULL)
 query T
 SELECT jsonb_agg(a) FROM (select a from t1 where a IS NOT NULL)
 ----
-[2.0,3.0,1.0]
+[1,2,3]
 
 query T
 SELECT jsonb_agg(a) FROM t1
 ----
-[null,2.0,3.0,1.0]
+[null,1,2,3]
 
 query T
 SELECT jsonb_agg(a::text::jsonb) FROM t1
 ----
-[null,2.0,3.0,1.0]
+[null,1,2,3]
 
 query T
 SELECT jsonb_agg(a) FILTER (WHERE a IS NOT NULL) FROM t1
 ----
-[2.0,3.0,1.0]
+[1,2,3]
 
 query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT jsonb_agg(1, 2)
@@ -1894,12 +1899,12 @@ INSERT INTO t2 VALUES (1, date '2020-01-01'), (NULL, date '2020-01-02')
 query T
 SELECT jsonb_agg((a, b)) FROM t2
 ----
-[{"f1":null,"f2":"2020-01-02"},{"f1":1.0,"f2":"2020-01-01"}]
+[{"f1":null,"f2":"2020-01-02"},{"f1":1,"f2":"2020-01-01"}]
 
 query TTT
 SELECT jsonb_agg((a, b)), jsonb_agg(a), jsonb_agg(b) FROM t2
 ----
-[{"f1":null,"f2":"2020-01-02"},{"f1":1.0,"f2":"2020-01-01"}] [null,1.0] ["2020-01-01","2020-01-02"]
+[{"f1":null,"f2":"2020-01-02"},{"f1":1,"f2":"2020-01-01"}]  [null,1]  ["2020-01-01","2020-01-02"]
 
 # jsonb_object_agg
 
@@ -1911,32 +1916,32 @@ NULL
 query T
 SELECT jsonb_object_agg('one', 2)
 ----
-{"one":2.0}
+{"one":2}
 
 query T
 SELECT jsonb_object_agg(1, 2)
 ----
-{"1":2.0}
+{"1":2}
 
 query T
 SELECT jsonb_object_agg(k, v) FROM (SELECT a - 1 AS k, a AS v from t1 where a IS NOT NULL)
 ----
-{"0":1.0,"1":2.0,"2":3.0}
+{"0":1,"1":2,"2":3}
 
 query T
 SELECT jsonb_object_agg(column1, column2) FROM (VALUES ('a', null), ('b', 1))
 ----
-{"a":null,"b":1.0}
+{"a":null,"b":1}
 
 query T
 SELECT jsonb_object_agg(column1, column2) FROM (VALUES ('b', 2), ('a', 1))
 ----
-{"a":1.0,"b":2.0}
+{"a":1,"b":2}
 
 query T
 SELECT jsonb_object_agg(column1, column2) FROM (VALUES ('a', 1), ('a', 2))
 ----
-{"a":1.0}
+{"a":1}
 
 query T
 SELECT jsonb_object_agg(null, null)
@@ -1946,4 +1951,4 @@ SELECT jsonb_object_agg(null, null)
 query T
 SELECT jsonb_object_agg(a, a) FILTER (WHERE a IS NOT NULL) FROM t1
 ----
-{"1":1.0,"2":2.0,"3":3.0}
+{"1":1,"2":2,"3":3}

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2035,7 +2035,7 @@ CREATE TYPE jsonb_list_c AS LIST (element_type=jsonb);
 query T
 SELECT '{\{\"1\":2\}}'::jsonb_list_c::text;
 ----
-{"{\"1\":2.0}"}
+{"{\"1\":2}"}
 
 # 🔬🔬 Check custom type name resolution
 

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -563,7 +563,7 @@ CREATE TYPE jsonb_map_c AS MAP (key_type=text, value_type=jsonb);
 query T
 SELECT '{a=>\{\"1\":2\}}'::jsonb_map_c::text;
 ----
-{a=>"{\"1\":2.0}"}
+{a=>"{\"1\":2}"}
 
 # 🔬🔬 Check custom type name resolution
 

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -15,4 +15,4 @@ select (select sum(1) from (select c) group by c) from (select 1 as c)
 query T
 select (select jsonb_agg(1) from (select c) group by c) from (select 1 as c)
 ----
-[1.0]
+[1]

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -308,8 +308,7 @@ SELECT 2::int::bigint;
 query error CAST does not support casting from interval to bigint
 SELECT '1'::interval::bigint
 
-#pginvalid
-query T
+query error cannot cast jsonb object to type bigint
 SELECT '{}'::jsonb::bigint;
 ----
 NULL
@@ -361,16 +360,11 @@ true
 query error CAST does not support casting from interval to boolean
 SELECT '1'::interval::boolean
 
-#pginvalid
-query T
+query error cannot cast jsonb object to type boolean
 SELECT '{}'::jsonb::boolean;
-----
-NULL
 
-query T
+query error cannot cast jsonb numeric to type boolean
 SELECT '1'::jsonb::boolean;
-----
-NULL
 
 query error invalid input syntax for type boolean: "dog"
 SELECT 'dog'::text::boolean
@@ -463,7 +457,7 @@ SELECT 2::int::numeric;
 query error CAST does not support casting from interval to numeric\(38,0\)
 SELECT '1'::interval::numeric
 
-query T
+query error cannot cast jsonb object to type numeric
 SELECT '{}'::jsonb::numeric;
 ----
 NULL
@@ -519,8 +513,7 @@ SELECT 2::int::double;
 query error CAST does not support casting from interval to double precision
 SELECT '1'::interval::double
 
-#pginvalid
-query T
+query error cannot cast jsonb object to type double precision
 SELECT '{}'::jsonb::double;
 ----
 NULL
@@ -576,8 +569,7 @@ SELECT 2::int::real;
 query error CAST does not support casting from interval to real
 SELECT '1'::interval::real
 
-#pginvalid
-query T
+query error cannot cast jsonb object to type float
 SELECT '{}'::jsonb::real;
 ----
 NULL
@@ -630,11 +622,8 @@ SELECT 2::int::integer;
 query error CAST does not support casting from interval to integer
 SELECT '1'::interval::integer
 
-#pginvalid
-query T
+query error cannot cast jsonb object to type integer
 SELECT '{}'::jsonb::integer;
-----
-NULL
 
 query R
 SELECT '1'::jsonb::integer;
@@ -726,7 +715,7 @@ SELECT '{}'::jsonb::jsonb;
 query T
 SELECT '1'::jsonb::jsonb;
 ----
-1.0
+1
 
 query error CAST does not support casting from time to jsonb
 SELECT '01:02:03'::time::jsonb
@@ -785,7 +774,7 @@ SELECT '{}'::jsonb::text;
 query T
 SELECT '1'::jsonb::text;
 ----
-1.0
+1
 
 query T
 SELECT 'dog'::text::text;

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -263,19 +263,19 @@ SELECT pg_catalog.interval '1-2 3 4:5:6.7' DAY
 query T
 SELECT '{"1":2,"3":4}'::jsonb
 ----
-{"1":2.0,"3":4.0}
+{"1":2,"3":4}
 
 query T
 SELECT '{"1":2,"3":4}'::pg_catalog.jsonb
 ----
-{"1":2.0,"3":4.0}
+{"1":2,"3":4}
 
 # 🔬🔬🔬 jsonb aliases
 
 query T
 SELECT '{"1":2,"3":4}'::json
 ----
-{"1":2.0,"3":4.0}
+{"1":2,"3":4}
 
 query error unknown catalog item 'pg_catalog.json'
 SELECT '{"1":2,"3":4}'::pg_catalog.json

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -142,7 +142,7 @@ a  b  json                     c            d             e                   f
 ------------------------------------------------------------------------------------
 1  1  null                     True         False         "(42,86.5,)"        <null>
 2  3  "{\"hello\":\"world\"}"  False        FileNotFound  "(43,,\"(44,-1)\")" (45,-2)
--1  7 "[1.0,2.0,3.0]"          FileNotFound True          <null>              <null>
+-1  7 "[1,2,3]"                FileNotFound True          <null>              <null>
 
 > CREATE MATERIALIZED SOURCE fast_forwarded
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
@@ -153,7 +153,7 @@ a  b  json                     c            d             e                   f
 > SELECT a, b, json, c, d FROM fast_forwarded
 a  b  json            c            d
 ---------------------------------------
--1  7 "[1.0,2.0,3.0]" FileNotFound True
+-1  7 "[1,2,3]"       FileNotFound True
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
@@ -165,8 +165,8 @@ a  b  json                     c            d             e                   f
 ------------------------------------------------------------------------------------
 1  1  null                     True         False         "(42,86.5,)"        <null>
 2  3  "{\"hello\":\"world\"}"  False        FileNotFound  "(43,,\"(44,-1)\")" (45,-2)
--1  7 "[1.0,2.0,3.0]"          FileNotFound True          <null>              <null>
-42 19 "[4.0,5.0,6.0]"          FileNotFound True          <null>              <null>
+-1  7 "[1,2,3]"                FileNotFound True          <null>              <null>
+42 19 "[4,5,6]"                FileNotFound True          <null>              <null>
 
 # Create a source using a file schema. This should fail if the named schema file
 # does not exist.
@@ -195,8 +195,8 @@ a  b  json                     c            d
 --------------------------------------------------------
 1  1  null                     True         False
 2  3  "{\"hello\":\"world\"}"  False        FileNotFound
--1  7 "[1.0,2.0,3.0]"          FileNotFound True
-42 19 "[4.0,5.0,6.0]"          FileNotFound True
+-1  7 "[1,2,3]"                FileNotFound True
+42 19 "[4,5,6]"                FileNotFound True
 
 # Test an Avro source without a Debezium envelope.
 

--- a/test/testdrive/jsonb.td
+++ b/test/testdrive/jsonb.td
@@ -12,10 +12,12 @@
 
 > VALUES
   ('1'::jsonb),
+  ('1.0'::jsonb),
   ('["a", "b"]'::jsonb),
   ('{"c": ["d"]}'::jsonb),
   ('null'::jsonb),
   (NULL::jsonb)
+"1"
 "1.0"
 "[\"a\",\"b\"]"
 "{\"c\":[\"d\"]}"


### PR DESCRIPTION
Previously we rejected JSON numbers that were integers greater than
2^53-1, as we stored JSON numbers as double-precision floats. (Integers
greater than 2^53-1 are not guaranteed to be exactly representable by a
double-precision float, and we didn't want to silently change data.)

Our users, however, expect integers up to at least 2^64-1 to be
supported. This commit facilitates that by allowing numbers in the jsonb
type to be *either* an i64 or an f64.

We're still not quite PostgreSQL compatible, since PostgreSQL allows any
number that will fit in its numeric type, which supports up to 1000
digits of precision. But this commit brings us a good deal closer to
PostgreSQL compatibility, and should be sufficient for most real-world
uses of Materialize.

This commit also cleans up casting *from* jsonb to other types.
Previously if those casts failed they'd return NULL; now they return an
error to match PostgreSQL.

Fix #5919.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6126)
<!-- Reviewable:end -->
