### PR TITLE
Present nontrivial sources to the Dataflow layer as a source + view

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -551,7 +551,7 @@ impl Catalog {
                     let index_name = format!("{}_primary_idx", log.name);
                     let oid = catalog.allocate_oid()?;
                     let expr = HirRelationExpr::Get {
-                        id: Id::BareSource(log.id),
+                        id: Id::LocalBareSource,
                         typ: log.variant.desc().typ().clone(),
                     }
                     .lower();

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -183,13 +183,14 @@ pub fn build_dataflow<A: Allocate>(
             );
 
             // Import declared sources into the rendering context.
-            for (src_id, src) in dataflow.source_imports.clone() {
+            for (src_id, (src, orig_id)) in dataflow.source_imports.clone() {
                 context.import_source(
                     render_state,
                     region,
                     materialized_logging.clone(),
                     src_id,
                     src,
+                    orig_id,
                 );
             }
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -338,7 +338,6 @@ where
                 self.collections
                     .insert(get.clone(), (collection, err_collection));
 
-                // Do whatever envelope processing is required.
                 let token = Rc::new(capability);
                 self.source_tokens.insert(src_id, token.clone());
 

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -47,6 +47,9 @@ where
         materialized_logging: Option<Logger>,
         src_id: GlobalId,
         mut src: SourceDesc,
+        // The original ID of the source, before it was decomposed into a bare source (which might have its own transient ID)
+        // and a relational transformation (which has the original source ID).
+        orig_id: GlobalId,
     ) {
         // Extract the linear operators, as we will need to manipulate them.
         // extracting them reduces the change we might accidentally communicate
@@ -55,7 +58,7 @@ where
 
         // Blank out trivial linear operators.
         if let Some(operator) = &linear_operators {
-            if operator.is_trivial(src.arity()) {
+            if operator.is_trivial(src.bare_desc.arity()) {
                 linear_operators = None;
             }
         }
@@ -67,49 +70,7 @@ where
         // at the end of `src.optimized_expr`.
         //
         // This has a lot of potential for improvement in the near future.
-        use expr::Id::LocalBareSource;
-        match &mut src.optimized_expr.0 {
-            // If the expression is just the source, no need to do anything special.
-            MirRelationExpr::Get {
-                id: LocalBareSource,
-                ..
-            } => {}
-            // A non-trivial expression should tack on filtering and projection, and
-            // also blank out the operator so that it is not applied any earlier.
-            x => {
-                if let Some(operators) = linear_operators.take() {
-                    // Deconstruct fields, as each will be used independently and will
-                    // each invalidate `operators`.
-                    let predicates = operators.predicates;
-                    let projection = operators.projection;
-                    // Non-empty predicates require a filter.
-                    if !predicates.is_empty() {
-                        *x = x.take_dangerous().filter(predicates);
-                    }
-                    // Non-trivial demand information calls for a map and projection.
-                    let rel_typ = x.typ();
-                    let arity = rel_typ.column_types.len();
-                    if (0..arity).any(|x| !projection.contains(&x)) {
-                        let mut dummies = Vec::new();
-                        let mut demand_projection = Vec::new();
-                        for (column, typ) in rel_typ.column_types.into_iter().enumerate() {
-                            if projection.contains(&column) {
-                                demand_projection.push(column);
-                            } else {
-                                demand_projection.push(arity + dummies.len());
-                                dummies.push(expr::MirScalarExpr::literal_ok(
-                                    Datum::Dummy,
-                                    typ.scalar_type,
-                                ));
-                            }
-                        }
-                        *x = x.take_dangerous().map(dummies).project(demand_projection);
-                    }
-                }
-            }
-        }
-
-        match src.connector {
+        match src.connector.clone() {
             SourceConnector::Local => {
                 let ((handle, capability), stream) = scope.new_unordered_input();
                 render_state
@@ -133,7 +94,7 @@ where
 
                 // This uid must be unique across all different instantiations of a source
                 let uid = SourceInstanceId {
-                    source_id: src_id,
+                    source_id: orig_id,
                     dataflow_id: self.dataflow_id,
                 };
 
@@ -369,7 +330,7 @@ where
                 }
 
                 let get = MirRelationExpr::Get {
-                    id: Id::BareSource(src_id),
+                    id: Id::Global(src_id),
                     typ: src.bare_desc.typ().clone(),
                 };
 
@@ -377,29 +338,7 @@ where
                 self.collections
                     .insert(get.clone(), (collection, err_collection));
 
-                let mut expr = src.optimized_expr.0;
-                expr.visit_mut(&mut |node| {
-                    if let MirRelationExpr::Get {
-                        id: Id::LocalBareSource,
-                        ..
-                    } = node
-                    {
-                        *node = get.clone()
-                    }
-                });
-
                 // Do whatever envelope processing is required.
-                self.ensure_rendered(&expr, scope, scope.index());
-
-                // Using `src.desc.typ()` here instead of `expr.typ()` is a bit of a hack to get around the fact
-                // that the typ might have changed due to the `LinearOperator` logic above,
-                // and so views, which are using the source's typ as described in the catalog, wouldn't be able to find it.
-                //
-                // Everything should still work out fine, since that typ has only changed in non-essential ways
-                // (e.g., nullability flags and primary key information)
-                let new_get = MirRelationExpr::global_get(src_id, src.desc.typ().clone());
-                self.clone_from_to(&expr, &new_get);
-
                 let token = Rc::new(capability);
                 self.source_tokens.insert(src_id, token.clone());
 
@@ -407,7 +346,7 @@ where
                 // on timestamp advancement queries
                 render_state
                     .ts_source_mapping
-                    .entry(uid.source_id)
+                    .entry(orig_id)
                     .or_insert_with(Vec::new)
                     .push(Rc::downgrade(&token));
             }

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -335,8 +335,7 @@ where
                 };
 
                 // Introduce the stream by name, as an unarranged collection.
-                self.collections
-                    .insert(get.clone(), (collection, err_collection));
+                self.collections.insert(get, (collection, err_collection));
 
                 let token = Rc::new(capability);
                 self.source_tokens.insert(src_id, token.clone());

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -323,6 +323,7 @@ pub(crate) trait SourceInfo<Out> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum NextMessage<Out> {
     Ready(SourceMessage<Out>),
     Pending,

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -249,14 +249,6 @@ impl<'a> Explanation<'a> {
                         .unwrap_or_else(|| "?".to_owned()),
                     id,
                 )?,
-                Id::BareSource(id) => writeln!(
-                    f,
-                    "| Get Bare Source for {} ({})",
-                    self.expr_humanizer
-                        .humanize_id(*id)
-                        .unwrap_or_else(|| "?".to_owned()),
-                    id
-                )?,
                 Id::LocalBareSource => writeln!(f, "| Get Bare Source for This Source")?,
             },
             // Lets are annotated on the chain ID that they correspond to.

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -21,9 +21,6 @@ pub enum Id {
     Local(LocalId),
     /// An identifier that refers to a global dataflow.
     Global(GlobalId),
-    /// Bare sources don't (yet?) live in the same namespace as catalog items (including the final, possibly transformed source.)
-    /// This gives us a way to refer to them in relation expressions
-    BareSource(GlobalId),
     /// Used to refer to a bare source within the RelationExpr defining the transformation of that source (before an ID has been
     /// allocated for the bare source).
     LocalBareSource,
@@ -34,7 +31,6 @@ impl fmt::Display for Id {
         match self {
             Id::Local(id) => id.fmt(f),
             Id::Global(id) => id.fmt(f),
-            Id::BareSource(id) => write!(f, "{}(bare)", id),
             Id::LocalBareSource => write!(f, "(bare source for this source)"),
         }
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1186,6 +1186,11 @@ impl MirRelationExpr {
             keys,
         }
     }
+
+    /// Returns whether this collection is just a `Get` wrapping an underlying bare source.
+    pub fn is_trivial_source(&self) -> bool {
+        matches!(self, MirRelationExpr::Get {id: Id::LocalBareSource, ..})
+    }
 }
 
 /// Specification for an ordering by a column.

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -264,14 +264,6 @@ impl<'a> Explanation<'a> {
                         .unwrap_or_else(|| "?".to_owned()),
                     id,
                 )?,
-                Id::BareSource(id) => writeln!(
-                    f,
-                    "| Get Bare Source for {} ({})",
-                    self.expr_humanizer
-                        .humanize_id(*id)
-                        .unwrap_or_else(|| "?".to_owned()),
-                    id,
-                )?,
             },
             Project { outputs, .. } => {
                 writeln!(f, "| Project {}", bracketed("(", ")", Indices(outputs)))?

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3240,8 +3240,8 @@ impl<'a> QueryContext<'a> {
 
                 Ok((expr, scope))
             }
-            Id::BareSource(_) | Id::LocalBareSource => {
-                // These are never introduced except when planning source transformations.
+            Id::LocalBareSource => {
+                // This is never introduced except when planning source transformations.
                 unreachable!()
             }
         }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -204,13 +204,13 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) {
     }
 
     // Push demand information into the SourceDesc.
-    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
+    for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
         if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
                     predicates: Vec::new(),
-                    projection: (0..source_desc.arity()).collect(),
+                    projection: (0..source_desc.bare_desc.arity()).collect(),
                 })
             }
             // Restrict required columns by those identified as demanded.
@@ -243,13 +243,13 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) {
     }
 
     // Push predicate information into the SourceDesc.
-    for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
+    for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
         if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
             // Install no-op predicate information if none exists.
             if source_desc.operators.is_none() {
                 source_desc.operators = Some(LinearOperator {
                     predicates: Vec::new(),
-                    projection: (0..source_desc.arity()).collect(),
+                    projection: (0..source_desc.bare_desc.arity()).collect(),
                 })
             }
             // Add any predicates that can be pushed to the source.
@@ -344,7 +344,7 @@ pub mod monotonic {
     /// Propagates information about monotonic inputs through views.
     pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) {
         let mut monotonic = std::collections::HashSet::new();
-        for (source_id, source_desc) in dataflow.source_imports.iter_mut() {
+        for (source_id, (source_desc, _)) in dataflow.source_imports.iter_mut() {
             if let SourceConnector::External {
                 envelope: SourceEnvelope::None,
                 ..


### PR DESCRIPTION
The dataflow layer wants to do cross-view optimizations, whereas the catalog layer wants the present distinction between "sources" and "views". So, we should create a separate "view" corresponding to the source transformations before handing it off to dataflow, which should let us get rid of all the gross hacks we're using now to maintain optimizations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6127)
<!-- Reviewable:end -->
