### PR TITLE
dbt-materialize: fix versioning bug

### DIFF
--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -23,7 +23,11 @@ with open(os.path.join(this_directory, "README.md")) as f:
     long_description = f.read()
 
 package_name = "dbt-materialize"
-package_version = "0.18.1"
+# This adapter's version, and its required dbt-postgres version, tracks the
+# target dbt version.
+target_package_version = "0.18.1"
+package_version_suffix = ".post1"
+package_version = "{}{}".format(target_package_version, package_version_suffix)
 description = """The Materialize adapter plugin for dbt (data build tool)"""
 
 setup(
@@ -43,5 +47,5 @@ setup(
             "include/materialize/macros/**/*.sql",
         ]
     },
-    install_requires=["dbt-postgres=={}".format(package_version)],
+    install_requires=["dbt-postgres=={}".format(target_package_version)],
 )


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/6120.

After [fixing the `dbt-materialize` bug reported in #6063](https://github.com/MaterializeInc/materialize/pull/6068), I mistakenly
bumped the package's version from v0.18.1 to v0.18.2. By convention,
a dbt adapter's version should match the target dbt version. There is
no dbt version v0.18.2. [Following precedent](https://pypi.org/project/dbt-snowflake/#history), I should have bumped to
~v0.18.1b1~ v0.18.1.post1 instead.

This mistake causes `pip install dbt-materialize` to fail because our
setup.py used the same version string (the incorrect v0.18.2) for
its `dbt-postgres` dependency.

This change updates the version to ~v0.18.1b1~ v0.18.1.post1, which will be uploaded
to PyPI. It reverts the `dbt-postgres` dependency to v0.18.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6128)
<!-- Reviewable:end -->
