### PR TITLE
Make `SourceInfo::get_next_message` a lot simpler

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -365,13 +365,7 @@ fn byo_extract_update_from_bytes(
                     }
                 };
                 let partition = match &consumer.connector {
-                    ByoTimestampConnector::Kinesis(_) => match split[2].parse::<String>() {
-                        Ok(s) => PartitionId::Kinesis(s),
-                        Err(err) => {
-                            error!("incorrect timestamp format {}", err);
-                            continue;
-                        }
-                    },
+                    ByoTimestampConnector::Kinesis(_) => PartitionId::Kinesis,
                     ByoTimestampConnector::Kafka(_) => match split[2].parse::<i32>() {
                         Ok(i) => PartitionId::Kafka(i),
                         Err(err) => {
@@ -491,10 +485,8 @@ fn parse_byo(record: Vec<(String, Value)>) -> (String, i32, PartitionId, u64, Mz
             if let Value::Union { inner: value, .. } = value {
                 if let Value::Int(pid) = *value {
                     partition_id = PartitionId::Kafka(pid);
-                } else if let Value::String(s) = *value {
-                    partition_id = PartitionId::Kinesis(s);
                 } else {
-                    panic!("String or Int expected");
+                    panic!("Int expected");
                 }
             } else {
                 panic!("Union expected");
@@ -554,9 +546,7 @@ fn generate_ts_updates_from_debezium(
                                     ByoTimestampConnector::File(_)
                                     | ByoTimestampConnector::Ocf(_) => PartitionId::File,
                                     ByoTimestampConnector::Kafka(_) => PartitionId::Kafka(0),
-                                    ByoTimestampConnector::Kinesis(_) => {
-                                        PartitionId::Kinesis(String::new())
-                                    }
+                                    ByoTimestampConnector::Kinesis(_) => PartitionId::Kinesis,
                                 },
                                 byo_consumer.last_ts,
                                 byo_consumer.last_offset,

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -17,7 +17,7 @@ use flate2::read::MultiGzDecoder;
 #[cfg(target_os = "linux")]
 use inotify::{Inotify, WatchMask};
 use log::error;
-use timely::scheduling::{Activator, SyncActivator};
+use timely::scheduling::SyncActivator;
 
 use dataflow_types::{
     AvroOcfEncoding, Compression, DataEncoding, ExternalSourceConnector, MzOffset,
@@ -200,11 +200,7 @@ impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
         log::debug!("update_partition_count erroneously called for file sources");
     }
 
-    fn get_next_message(
-        &mut self,
-        _consistency_info: &mut ConsistencyInfo,
-        _activator: &Activator,
-    ) -> Result<NextMessage<Out>, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Out>, anyhow::Error> {
         match self.receiver_stream.try_recv() {
             Ok(Ok(record)) => {
                 self.current_file_offset.offset += 1;

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -47,14 +47,8 @@ const KINESIS_SHARD_REFRESH_RATE: Duration = Duration::from_secs(60);
 
 /// Contains all information necessary to ingest data from Kinesis
 pub struct KinesisSourceInfo {
-    /// Source Name
-    name: String,
-    /// Unique Source Id
-    id: SourceInstanceId,
     /// Kinesis client used to obtain records
     kinesis_client: KinesisClient,
-    /// Timely worker logger for source events
-    logger: Option<Logger>,
     /// The name of the stream
     stream_name: String,
     /// The set of active shards
@@ -93,26 +87,21 @@ impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
         match state {
             Ok((kinesis_client, stream_name, shard_set, shard_queue)) => {
                 if active {
-                    for shard_id in &shard_set {
-                        let kinesis_id = PartitionId::Kinesis(shard_id.clone());
-                        consistency_info.update_partition_metadata(kinesis_id.clone());
-                        consistency_info.partition_metrics.insert(
-                            kinesis_id.clone(),
-                            PartitionMetrics::new(
-                                &source_name,
-                                source_id,
-                                &kinesis_id.to_string(),
-                                logger.clone(),
-                            ),
-                        );
-                    }
+                    let kinesis_id = PartitionId::Kinesis;
+                    consistency_info.update_partition_metadata(kinesis_id.clone());
+                    consistency_info.partition_metrics.insert(
+                        kinesis_id.clone(),
+                        PartitionMetrics::new(
+                            &source_name,
+                            source_id,
+                            &kinesis_id.to_string(),
+                            logger,
+                        ),
+                    );
                 }
 
                 Ok(KinesisSourceInfo {
-                    name: source_name,
-                    id: source_id,
                     kinesis_client,
-                    logger,
                     shard_queue,
                     last_checked_shards: Instant::now(),
                     buffered_messages: VecDeque::new(),
@@ -127,10 +116,7 @@ impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
 }
 
 impl KinesisSourceInfo {
-    async fn update_shard_information(
-        &mut self,
-        consistency_info: &mut ConsistencyInfo,
-    ) -> Result<(), anyhow::Error> {
+    async fn update_shard_information(&mut self) -> Result<(), anyhow::Error> {
         let new_shards: HashSet<String> = get_shard_ids(&self.kinesis_client, &self.stream_name)
             .await?
             .difference(&self.shard_set)
@@ -142,17 +128,6 @@ impl KinesisSourceInfo {
                 shard_id.clone(),
                 get_shard_iterator(&self.kinesis_client, &self.stream_name, &shard_id).await?,
             ));
-            let kinesis_id = PartitionId::Kinesis(shard_id);
-            consistency_info.update_partition_metadata(kinesis_id.clone());
-            consistency_info.partition_metrics.insert(
-                kinesis_id.clone(),
-                PartitionMetrics::new(
-                    &self.name,
-                    self.id,
-                    &kinesis_id.to_string(),
-                    self.logger.clone(),
-                ),
-            );
         }
         Ok(())
     }
@@ -186,14 +161,14 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
 
     fn get_next_message(
         &mut self,
-        consistency_info: &mut ConsistencyInfo,
+        _consistency_info: &mut ConsistencyInfo,
         activator: &Activator,
     ) -> Result<NextMessage<Vec<u8>>, anyhow::Error> {
         assert_eq!(self.shard_queue.len(), self.shard_set.len());
 
         //TODO move to timestamper
         if self.last_checked_shards.elapsed() >= KINESIS_SHARD_REFRESH_RATE {
-            if let Err(e) = block_on(self.update_shard_information(consistency_info)) {
+            if let Err(e) = block_on(self.update_shard_information()) {
                 error!("{:#?}", e);
                 return Err(anyhow::Error::msg(e.to_string()));
             }
@@ -259,7 +234,7 @@ impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
                         let data = record.data.as_ref().to_vec();
                         self.processed_message_count += 1;
                         let source_message = SourceMessage {
-                            partition: PartitionId::Kinesis(shard_id.clone()),
+                            partition: PartitionId::Kinesis,
                             offset: MzOffset {
                                 //TODO: should MzOffset be modified to be a string?
                                 offset: self.processed_message_count,

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -26,7 +26,7 @@ use rusoto_sqs::{
     ChangeMessageVisibilityBatchRequest, ChangeMessageVisibilityBatchRequestEntry,
     DeleteMessageRequest, GetQueueUrlRequest, ReceiveMessageRequest, Sqs,
 };
-use timely::scheduling::{Activator, SyncActivator};
+use timely::scheduling::SyncActivator;
 use tokio::io::AsyncReadExt;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio::time::{self, Duration};
@@ -677,11 +677,7 @@ async fn download_object(
 }
 
 impl SourceInfo<Vec<u8>> for S3SourceInfo {
-    fn get_next_message(
-        &mut self,
-        _consistency_info: &mut ConsistencyInfo,
-        _activator: &Activator,
-    ) -> Result<NextMessage<Out>, anyhow::Error> {
+    fn get_next_message(&mut self) -> Result<NextMessage<Out>, anyhow::Error> {
         match self.receiver_stream.try_recv() {
             Ok(Ok(InternalMessage { record })) => {
                 self.offset += 1;

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -137,7 +137,7 @@ impl fmt::Display for SourceInstanceId {
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum PartitionId {
     Kafka(i32),
-    Kinesis(String),
+    Kinesis,
     File,
     S3,
 }


### PR DESCRIPTION
In particular - make the implementer responsible for deduplicating records, and give them a way to indicate "there was a temporary glitch please check again later"

I think the Kinesis changes in the first commit might be a bit controversial, and I need to look at the Kafka changes in the second commit a lot more carefully to convince myself I didn't screw something up (1-indexed mzoffset strikes again!)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6130)
<!-- Reviewable:end -->
