### PR TITLE
[wip] Key upsert

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -537,7 +537,7 @@ pub enum UpsertMode {
     /// Treat the entire upsert value as something to flatten
     Flat,
     /// Just ignore the `before` portion of a if the debezium key is new
-    Debezium,
+    Debezium(DebeziumDeduplicationStrategy),
 }
 
 impl SourceEnvelope {

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -505,6 +505,7 @@ where
 }
 
 fn find_dbz_key_indices(desc: &RelationDesc, key_schema: Option<&str>) -> Option<Vec<usize>> {
+    println!("column types {:?}", desc.typ().column_types);
     let fields = match &desc.typ().column_types[0].scalar_type {
         ScalarType::Record { fields, .. } => fields.clone(),
         typ => unreachable!(

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -269,7 +269,7 @@ where
                                                 session.give((new_value, cap.time().clone(), 1));
                                             }
                                         }
-                                        UpsertMode::Debezium => {
+                                        UpsertMode::Debezium(_) => {
                                             let is_new = current_keys.insert(decoded_key);
                                             if is_new {
                                                 // repack row without the before field

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -34,7 +34,9 @@ use self::envelope_debezium::{AvroDebeziumDecoder, DebeziumDeduplicationState, R
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EnvelopeType {
     None,
+    /// An envelope that contains "before" and "after" fields
     Debezium,
+    /// Same as None, but validates that the top level item is a record
     Upsert,
     CdcV2,
 }

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -101,7 +101,12 @@ impl Decoder {
         })
     }
 
-    /// Decodes Avro-encoded `bytes` into a `DiffPair`.
+    /// Decodes Avro-encoded `bytes` into a [`Row`]
+    ///
+    /// For flat data `Row` is what you expect, but for `Debezium` data you may be surprised to see
+    /// a single row returned here. The `Row` returned by this method for Debezium-format data will
+    /// contain the `before` and `after` fields, which are later unwrapped by some planned SQL
+    /// operations.
     pub async fn decode(
         &mut self,
         bytes: &[u8],

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -50,7 +50,7 @@ use super::RowCoordinates;
 /// instances pointing at the same Kafka topic that mean that the Debezium guarantees do
 /// not hold, in which case we are required to track individual messages, instead of just
 /// the highest-ever-seen message.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum DebeziumDeduplicationStrategy {
     /// We can trust high water mark
     Ordered,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -145,8 +145,14 @@ pub enum Format<T: AstInfo> {
 pub enum Envelope<T: AstInfo> {
     None,
     Debezium,
-    Upsert(Option<Format<T>>),
+    Upsert(Option<Format<T>>, UpsertMode),
     CdcV2,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum UpsertMode {
+    Flat,
+    Debezium,
 }
 
 impl<T: AstInfo> Default for Envelope<T> {
@@ -165,8 +171,12 @@ impl<T: AstInfo> AstDisplay for Envelope<T> {
             Self::Debezium => {
                 f.write_str("DEBEZIUM");
             }
-            Self::Upsert(format) => {
-                f.write_str("UPSERT");
+            Self::Upsert(format, mode) => {
+                match mode {
+                    UpsertMode::Flat => f.write_str("UPSERT"),
+                    UpsertMode::Debezium => f.write_str("DBZUPSERT"),
+                }
+
                 if let Some(format) = format {
                     f.write_str(" FORMAT ");
                     f.write_node(format);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -68,6 +68,7 @@ Database
 Databases
 Day
 Days
+DbzUpsert
 Debezium
 Dec
 Decimal

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1591,7 +1591,14 @@ impl<'a> Parser<'a> {
             } else {
                 None
             };
-            Envelope::Upsert(format)
+            Envelope::Upsert(format, UpsertMode::Flat)
+        } else if self.parse_keyword(DBZUPSERT) {
+            let format = if self.parse_keyword(FORMAT) {
+                Some(self.parse_format()?)
+            } else {
+                None
+            };
+            Envelope::Upsert(format, UpsertMode::Debezium)
         } else if self.parse_keyword(MATERIALIZE) {
             Envelope::CdcV2
         } else {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -105,7 +105,8 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
         }
 
         purify_format(format, connector, col_names, file, &config_options).await?;
-        if let sql_parser::ast::Envelope::Upsert(format) = envelope {
+        // TODO: do we need to do more validation
+        if let sql_parser::ast::Envelope::Upsert(format, _) = envelope {
             purify_format(format, connector, col_names, None, &config_options).await?;
         }
     }

--- a/test/testdrive/upsert-kafka-debezium.td
+++ b/test/testdrive/upsert-kafka-debezium.td
@@ -27,7 +27,7 @@ $ set schema={
             "type": "record",
             "fields": [
               {
-                "name": "animal",
+                "name": "creature",
                 "type": "string"
               }]
            },
@@ -44,7 +44,7 @@ $ set schema={
 $ kafka-create-topic topic=dbzupsert
 
 $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
-{"key": "scale"} {"before": {"row": {"animal": "fish"}}, "after": {"row": {"animal": "lizard"}}}
+{"key": "scale"} {"before": {"row": {"creature": "fish"}}, "after": {"row": {"creature": "lizard"}}}
 
 
 > CREATE MATERIALIZED SOURCE doin_upsert
@@ -53,6 +53,36 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
   ENVELOPE DBZUPSERT FORMAT AVRO USING SCHEMA '${keyschema}'
 
 > SELECT * FROM doin_upsert
-animal
+creature
 ----
 lizard
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"key": "scale"} {"before": {"row": {"creature": "lizard"}}, "after": {"row": {"creature": "dino"}}}
+
+> SELECT * FROM doin_upsert
+creature
+----
+dino
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"key": "feather"} {"before": null, "after": {"row": {"creature": "archeopteryx"}}}
+{"key": "feather"} {"before": {"row": {"creature": "archeopteryx"}}, "after": {"row": {"creature": "velociraptor"}}}
+
+> SELECT * FROM doin_upsert ORDER BY creature
+creature
+----
+dino
+velociraptor
+
+> CREATE MATERIALIZED SOURCE upsert_full_dedupe
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  WITH (deduplication = 'full')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DBZUPSERT FORMAT AVRO USING SCHEMA '${keyschema}'
+
+> SELECT * FROM upsert_no_dedupe ORDER BY creature
+creature
+----
+dino
+velociraptor

--- a/test/testdrive/upsert-kafka-debezium.td
+++ b/test/testdrive/upsert-kafka-debezium.td
@@ -1,0 +1,58 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "row",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+    "type" : "record",
+    "name" : "envelope",
+    "fields" : [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                "name": "animal",
+                "type": "string"
+              }]
+           },
+           "null"
+         ]
+      },
+      {
+        "name": "after",
+        "type": ["row", "null"]
+      }
+    ]
+  }
+
+$ kafka-create-topic topic=dbzupsert
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"key": "scale"} {"before": {"row": {"animal": "fish"}}, "after": {"row": {"animal": "lizard"}}}
+
+
+> CREATE MATERIALIZED SOURCE doin_upsert
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DBZUPSERT FORMAT AVRO USING SCHEMA '${keyschema}'
+
+> SELECT * FROM doin_upsert
+animal
+----
+lizard


### PR DESCRIPTION
Very much WIP:

* the sql interface in particular is fundamentally wrong, we haven't thought about syntax yet so this is a hack to make testdrive testing possible
*  testdrive is failing to decode the kafka key, which surprises me because I didn't touch anything related to that

That said, the overall design here is basically complete, modulo the fact that I haven't been able to test it so I don't know if it will work, and I'm sure there are remaining bugs to work out.

The fundamental points are:

* add some parameter to the envelope logic allowing us to distinguish debezium upsert semantics
* inside of the upsert source either track new keys *or* historic values
* Continue using the debezium unwrapping in plan_source_envelope -- instead of doing something custom in upsert -- with the intention of eventually unifying upsert and other envelopes more thoroughly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6132)
<!-- Reviewable:end -->
