### PR TITLE
(Take #3) Partially revert #6113

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -160,23 +160,6 @@ class PreImage:
         return ""
 
 
-class Directory(PreImage):
-    """ A `PreImage` action where all files in a directory are defined as inputs."""
-
-    def __init__(self, rd: RepositoryDetails, path: Path, config: Dict[str, Any]):
-        super().__init__(rd, path)
-
-        self.source = config.pop("source", None)
-
-        if self.source is None:
-            raise ValueError("mzbuild config is missing 'source' argument")
-        else:
-            self.source = self.rd.root / self.source
-
-    def inputs(self) -> Set[str]:
-        return set(self.source / f for f in os.listdir(self.source))
-
-
 class CargoPreImage(PreImage):
     """A `PreImage` action that uses Cargo."""
 
@@ -372,8 +355,6 @@ class Image:
                     self.pre_image = CargoBuild(self.rd, self.path, pre_image)
                 elif typ == "cargo-test":
                     self.pre_image = CargoTest(self.rd, self.path, pre_image)
-                elif typ == "directory":
-                    self.pre_image = Directory(self.rd, self.path, pre_image)
                 else:
                     raise ValueError(
                         f"mzbuild config in {self.path} has unknown pre-image type"

--- a/test/testdrive/mzbuild.yml
+++ b/test/testdrive/mzbuild.yml
@@ -9,7 +9,3 @@
 
 name: testdrive-with-tests
 publish: false
-
-pre-image:
-  type: directory
-  source: test/testdrive


### PR DESCRIPTION
The bulk of #6113 was code that was meant to ensure that changes
made to the local directory cause mzbuild to rebuild the container.

Turns out that this is ensured by another mechanism, so this code
is now removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6133)
<!-- Reviewable:end -->
