### PR TITLE
Disable column knowledge

### DIFF
--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -29,7 +29,6 @@ use expr::MirRelationExpr;
 use expr::MirScalarExpr;
 use expr::{GlobalId, IdGen};
 
-pub mod column_knowledge;
 pub mod cse;
 pub mod demand;
 pub mod fusion;
@@ -210,7 +209,6 @@ impl Default for Optimizer {
                     Box::new(crate::projection_lifting::ProjectionLifting),
                     Box::new(crate::map_lifting::LiteralLifting),
                     Box::new(crate::nonnull_requirements::NonNullRequirements),
-                    Box::new(crate::column_knowledge::ColumnKnowledge),
                     Box::new(crate::reduction_pushdown::ReductionPushdown),
                     Box::new(crate::redundant_join::RedundantJoin),
                     Box::new(crate::topk_elision::TopKElision),
@@ -231,7 +229,6 @@ impl Default for Optimizer {
                 transforms: vec![
                     Box::new(crate::projection_lifting::ProjectionLifting),
                     Box::new(crate::join_implementation::JoinImplementation),
-                    Box::new(crate::column_knowledge::ColumnKnowledge),
                     Box::new(crate::reduction::FoldConstants),
                     Box::new(crate::fusion::filter::Filter),
                     Box::new(crate::demand::Demand),

--- a/src/transform/tests/testdata/keys
+++ b/src/transform/tests/testdata/keys
@@ -65,7 +65,7 @@ steps format=types
 ====
 No change: Join, InlineLet, FoldConstants, Filter, Map, ProjectionExtraction, Project, Join, FoldConstants, Filter, Map, FoldConstants
 ====
-Applied Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, Demand], limit: 100 }:
+Applied Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ReductionPushdown, RedundantJoin, TopKElision, Demand], limit: 100 }:
 %0 =
 | Get x (u0)
 | | types = (ColumnType { nullable: true, scalar_type: Int32 }, ColumnType { nullable: true, scalar_type: Int64 }, ColumnType { nullable: true, scalar_type: Int32 })
@@ -75,7 +75,7 @@ Applied Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, J
 | | keys = ((#0), (#1))
 
 ====
-No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+No change: FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
 ====
 Final:
 %0 =

--- a/src/transform/tests/testdata/steps
+++ b/src/transform/tests/testdata/steps
@@ -30,7 +30,7 @@ steps
 | Union %0 %1
 
 ====
-No change: Join, InlineLet, FoldConstants, Filter, Map, ProjectionExtraction, Project, Join, FoldConstants, Filter, Map, FoldConstants, Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ColumnKnowledge, ReductionPushdown, RedundantJoin, TopKElision, Demand], limit: 100 }, FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, ColumnKnowledge, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
+No change: Join, InlineLet, FoldConstants, Filter, Map, ProjectionExtraction, Project, Join, FoldConstants, Filter, Map, FoldConstants, Fixpoint { transforms: [NonNullable, FoldConstants, PredicatePushdown, Join, Filter, Project, Map, Union, ReduceElision, InlineLet, UpdateLet, ProjectionExtraction, ProjectionLifting, LiteralLifting, NonNullRequirements, ReductionPushdown, RedundantJoin, TopKElision, Demand], limit: 100 }, FoldConstants, Fixpoint { transforms: [ProjectionLifting, JoinImplementation, FoldConstants, Filter, Demand, LiteralLifting], limit: 100 }, ReductionPushdown, Map, ProjectionLifting, JoinImplementation, Project, FoldConstants
 ====
 Final:
 %0 =

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -377,8 +377,8 @@ ORDER BY revenue DESC, o_entry_d
 | |   delta %1 %2.(#0, #1, #2) %0.(#0, #1, #2) %3.(#2, #1, #0)
 | |   delta %2 %0.(#0, #1, #2) %1.(#0, #1, #2) %3.(#2, #1, #0)
 | |   delta %3 %1.(#0, #1, #2) %2.(#0, #1, #2) %0.(#0, #1, #2)
-| | demand = (#1, #2, #9, #22, #29, #41)
-| Filter "^A.*$" ~(#9), (datetots(#29) > 2007-01-02 00:00:00)
+| | demand = (#0..#2, #9, #22, #29, #41)
+| Filter !(isnull(#0)), "^A.*$" ~(#9), (datetots(#29) > 2007-01-02 00:00:00)
 | Reduce group=(#22, #2, #1, #29)
 | | agg sum(#41)
 | Project (#0..#2, #4, #3)
@@ -493,8 +493,8 @@ ORDER BY revenue DESC
 %7 =
 | Join %0 %1 %2 %3 %4 %5 %6 (= #0 #25) (= #1 #23 #31) (= #2 #24 #32 #41) (= #21 #61 #65) (= #22 #30) (= #34 #40) (= #57 #58) (= #67 #69)
 | | implementation = Differential %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0, #1) %4.(#0, #3) %5.(#0) %6.(#0)
-| | demand = (#26, #38, #66, #70)
-| Filter (#70 = "EUROPE"), (datetots(#26) >= 2007-01-02 00:00:00)
+| | demand = (#0, #21, #26, #38, #66, #70)
+| Filter !(isnull(#0)), !(isnull(#21)), (#70 = "EUROPE"), (datetots(#26) >= 2007-01-02 00:00:00)
 | Reduce group=(#66)
 | | agg sum(#38)
 
@@ -601,8 +601,8 @@ ORDER BY su_nationkey, cust_nation, l_year
 | |   delta %4 %6.(#0) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
 | |   delta %5 %0.(#3) %1.(#17) %2.(#5, #4) %3.(#0, #1, #2) %4.(#0, #1, #2) %6.(#0)
 | |   delta %6 %4.(#21) %3.(#2, #1, #3) %2.(#2, #1, #0) %1.(#0, #1) %0.(#0) %5.(#0)
-| | demand = (#3, #31, #33, #39, #52, #66, #70)
-| Filter (((#66 = "GERMANY") && (#70 = "CAMBODIA")) || ((#66 = "CAMBODIA") && (#70 = "GERMANY"))), (datetots(#31) <= 2012-01-02 00:00:00), (datetots(#31) >= 2007-01-02 00:00:00)
+| | demand = (#3, #7, #8, #31, #33, #38, #39, #52, #64, #66, #70)
+| Filter !(isnull(#7)), !(isnull(#8)), !(isnull(#38)), !(isnull(#64)), (((#66 = "GERMANY") && (#70 = "CAMBODIA")) || ((#66 = "CAMBODIA") && (#70 = "GERMANY"))), (datetots(#31) <= 2012-01-02 00:00:00), (datetots(#31) >= 2007-01-02 00:00:00)
 | Reduce group=(#3, substr(#52, 1, 1), date_part_year_tstz(datetotstz(#39)))
 | | agg sum(#33)
 
@@ -686,8 +686,8 @@ ORDER BY l_year
 | |   delta %6 %8.(#0) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
 | |   delta %7 %1.(#3) %2.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2) %5.(#0, #1, #2) %6.(#0) %8.(#0)
 | |   delta %8 %6.(#2) %5.(#21) %4.(#2, #1, #3) %3.(#2, #1, #0) %2.(#0, #1) %0.(#0) %1.(#0) %7.(#0)
-| | demand = (#0, #4, #38, #44, #75, #79)
-| Filter "^.*b$" ~(#4), (#79 = "EUROPE"), (#0 < 1000), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
+| | demand = (#0, #4, #13, #38, #43, #44, #69, #75, #79)
+| Filter !(isnull(#0)), !(isnull(#13)), !(isnull(#43)), !(isnull(#69)), "^.*b$" ~(#4), (#79 = "EUROPE"), (#0 < 1000), (datetots(#44) <= 2012-01-02 00:00:00), (datetots(#44) >= 2007-01-02 00:00:00)
 | Reduce group=(date_part_year_tstz(datetotstz(#44)))
 | | agg sum(if (#75 = "GERMANY") then {#38} else {0dec})
 | | agg sum(#38)
@@ -750,8 +750,8 @@ ORDER BY n_name, l_year DESC
 | |   delta %3 %4.(#0, #1, #2) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
 | |   delta %4 %3.(#2, #1, #0) %1.(#0, #1) %0.(#0) %2.(#0) %5.(#0)
 | |   delta %5 %2.(#3) %1.(#17) %0.(#0) %3.(#5, #4) %4.(#0, #1, #2)
-| | demand = (#4, #38, #44, #49)
-| Filter "^.*BB$" ~(#4)
+| | demand = (#0, #4, #6, #38, #44, #49)
+| Filter !(isnull(#0)), !(isnull(#6)), "^.*BB$" ~(#4)
 | Reduce group=(#49, date_part_year_tstz(datetotstz(#44)))
 | | agg sum(#38)
 
@@ -800,8 +800,8 @@ ORDER BY revenue DESC
 | |   delta %1 %0.(#0, #1, #2) %3.(#0) %2.(#2, #1, #0)
 | |   delta %2 %1.(#0, #1, #2) %0.(#0, #1, #2) %3.(#0)
 | |   delta %3 %0.(#21) %1.(#2, #1, #3) %2.(#2, #1, #0)
-| | demand = (#0, #5, #8, #11, #26, #36, #38, #41)
-| Filter (#26 <= #36), (datetots(#26) >= 2007-01-02 00:00:00)
+| | demand = (#0, #5, #8, #11, #21, #26, #36, #38, #41)
+| Filter !(isnull(#0)), !(isnull(#21)), (#26 <= #36), (datetots(#26) >= 2007-01-02 00:00:00)
 | Reduce group=(#0, #5, #8, #11, #41)
 | | agg sum(#38)
 | Project (#0, #1, #5, #2..#4)
@@ -957,22 +957,26 @@ ORDER BY custdist DESC, c_count DESC
 | |   delta %0 %1.(#2, #1, #3)
 | |   delta %1 %0.(#0, #1, #2)
 | | demand = (#0..#22, #27)
-| Filter (#27 > 8)
+| Filter !(isnull(#0)), (#27 > 8)
 
 %3 =
+| Get %2 (l0)
+| Project (#0..#22, #1, #2, #0, #26..#29)
+
+%4 =
 | Get %2 (l0)
 | Distinct group=(#0, #1, #2, #3, #4, #5, #6, #7, #8, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #20, #21)
 | Negate
 
-%4 =
+%5 =
 | Get materialize.public.customer (u6)
 
-%5 =
-| Union %3 %4
+%6 =
+| Union %4 %5
 | Map null, null, null, null, null, null, null, null
 
-%6 =
-| Union %2 %5
+%7 =
+| Union %3 %6
 | Reduce group=(#0)
 | | agg count(#22)
 | Reduce group=(#1)
@@ -1005,8 +1009,8 @@ AND ol_delivery_d < TIMESTAMP '2020-01-02 00:00:00.000000'
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#4)
-| | demand = (#6, #8, #14)
-| Filter (datetots(#6) < 2020-01-02 00:00:00), (datetots(#6) >= 2007-01-02 00:00:00)
+| | demand = (#4, #6, #8, #14)
+| Filter !(isnull(#4)), (datetots(#6) < 2020-01-02 00:00:00), (datetots(#6) >= 2007-01-02 00:00:00)
 | Reduce group=()
 | | agg sum(if "^PR.*$" ~(#14) then {#8} else {0dec})
 | | agg sum(#8)
@@ -1079,8 +1083,8 @@ ORDER BY su_suppkey
 | | implementation = DeltaQuery
 | |   delta %1 %2.(#0, #1)
 | |   delta %2 %1.(#5, #4)
-| | demand = (#6, #8, #27)
-| Filter (datetots(#6) >= 2007-01-02 00:00:00)
+| | demand = (#4..#6, #8, #27)
+| Filter !(isnull(#4)), !(isnull(#5)), (datetots(#6) >= 2007-01-02 00:00:00)
 | Reduce group=(#27)
 | | agg sum(#8)
 | ArrangeBy (#0)
@@ -1098,8 +1102,8 @@ ORDER BY su_suppkey
 | | implementation = DeltaQuery
 | |   delta %4 %5.(#0, #1)
 | |   delta %5 %4.(#5, #4)
-| | demand = (#6, #8, #27)
-| Filter (datetots(#6) >= 2007-01-02 00:00:00)
+| | demand = (#4..#6, #8, #27)
+| Filter !(isnull(#4)), !(isnull(#5)), (datetots(#6) >= 2007-01-02 00:00:00)
 | Reduce group=(#27)
 | | agg sum(#8)
 | Reduce group=()
@@ -1111,6 +1115,7 @@ ORDER BY su_suppkey
 | Join %0 %3 %6 (= #0 #7) (= #8 #9)
 | | implementation = Differential %0.(#0) %3.(#0) %6.(#0)
 | | demand = (#0..#2, #4, #8)
+| Filter !(isnull(#8))
 | Project (#0..#2, #4, #8)
 
 Finish order_by=(#0 asc) limit=none offset=0 project=(#0..#4)
@@ -1224,7 +1229,7 @@ AND ol_quantity < t.a
 | |   delta %1 %2.(#4)
 | |   delta %2 %1.(#0)
 | | demand = (#0, #4, #12)
-| Filter "^.*b$" ~(#4)
+| Filter !(isnull(#0)), "^.*b$" ~(#4)
 | Reduce group=(#0)
 | | agg sum(#12)
 | | agg count(#12)
@@ -1236,8 +1241,8 @@ AND ol_quantity < t.a
 | | implementation = DeltaQuery
 | |   delta %0 %3.(#0)
 | |   delta %3 %0.(#4)
-| | demand = (#7, #8, #13)
-| Filter (i32tof64(#7) < #13)
+| | demand = (#4, #7, #8, #13)
+| Filter !(isnull(#4)), (i32tof64(#7) < #13)
 | Reduce group=()
 | | agg sum(#8)
 
@@ -1294,6 +1299,7 @@ ORDER BY sum(ol_amount) DESC, o_entry_d
 | |   delta %1 %0.(#0, #1, #2) %2.(#2, #1, #0)
 | |   delta %2 %1.(#0, #1, #2) %0.(#0, #1, #2)
 | | demand = (#0..#2, #5, #22, #26, #28, #38)
+| Filter !(isnull(#0))
 | Reduce group=(#22, #2, #1, #0, #5, #26, #28)
 | | agg sum(#38)
 | Filter (#7 > 20000dec)
@@ -1344,8 +1350,8 @@ WHERE (
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#4)
-| | demand = (#2, #7, #8, #13, #14)
-| Filter ((("^.*a$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 3))) || ("^.*b$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 4)))) || ("^.*c$" ~(#14) && (((#2 = 1) || (#2 = 5)) || (#2 = 3)))), (#7 <= 10), (#13 <= 40000000dec), (#7 >= 1), (#13 >= 100dec)
+| | demand = (#2, #4, #7, #8, #13, #14)
+| Filter !(isnull(#4)), ((("^.*a$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 3))) || ("^.*b$" ~(#14) && (((#2 = 1) || (#2 = 2)) || (#2 = 4)))) || ("^.*c$" ~(#14) && (((#2 = 1) || (#2 = 5)) || (#2 = 3)))), (#7 <= 10), (#13 <= 40000000dec), (#7 >= 1), (#13 >= 100dec)
 | Reduce group=()
 | | agg sum(#8)
 
@@ -1421,7 +1427,7 @@ ORDER BY su_name
 | Join %3 %4 %5 %6 (= #11 #33 #39)
 | | implementation = Differential %4.(#0) %6.(#0) %5.(#4) %3.()
 | | demand = (#0, #11..#13, #35, #36, #43)
-| Filter "^co.*$" ~(#43), (datetots(#35) > 2010-05-23 12:00:00)
+| Filter !(isnull(#11)), "^co.*$" ~(#43), (datetots(#35) > 2010-05-23 12:00:00)
 | Reduce group=(#0, #11, #12, #13)
 | | agg sum(#36)
 | Filter (i32toi64((2 * #3)) > #4)
@@ -1587,6 +1593,7 @@ ORDER BY substr(c_state, 1, 1)
 | |   delta %4 %5.(#2, #1, #3)
 | |   delta %5 %4.(#0, #1, #2)
 | | demand = (#0..#2)
+| Filter !(isnull(#0))
 | Distinct group=(#0, #1, #2)
 | Negate
 

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -125,6 +125,7 @@ where foo.a = bar.a
 | Join %0 %1 %2 (= #0 #2) (= #3 #4)
 | | implementation = Differential %1 %2.(#0) %0.(#0)
 | | demand = (#0, #5)
+| Filter !(isnull(#0))
 | Project (#0, #5)
 
 EOF


### PR DESCRIPTION
This PR disables the `column_knowledge.rs` transformation, which propagated information "known" to be true about columns, e.g. non-nullability and equality to constant values. Because there are no rules about filter movement, almost all of these rules are unsound: filters might temporarily be before some expression, but then move after them once the expression is simplified. An expression surrounding a join could use the implicit `col1 = col2` filter of the join, but then simplify and be pushed through the join. In each case, expressions like `if <check> then <something scary>` could go from never-erroring to potentially erroring.

This PR is first to check the fallout in plans, and see if any of the good things that we lose are things that we expect to work in the first place, and perhaps why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6141)
<!-- Reviewable:end -->
