### PR TITLE
sqllogictest: check expected error for parse failures

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -636,13 +636,24 @@ impl Runner {
         // get statement
         let statements = match sql::parse::parse(sql) {
             Ok(statements) => statements,
-            Err(_) if output.is_err() => return Ok(Outcome::Success),
-            Err(e) => {
-                return Ok(Outcome::ParseFailure {
-                    error: e.into(),
-                    location,
-                })
-            }
+            Err(e) => match output {
+                Ok(_) => {
+                    return Ok(Outcome::ParseFailure {
+                        error: e.into(),
+                        location,
+                    });
+                }
+                Err(expected_error) => {
+                    if Regex::new(expected_error)?.is_match(&format!("{:#}", e)) {
+                        return Ok(Outcome::Success);
+                    } else {
+                        return Ok(Outcome::ParseFailure {
+                            error: e.into(),
+                            location,
+                        });
+                    }
+                }
+            },
         };
         let statement = match &*statements {
             [] => bail!("Got zero statements?"),

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -236,7 +236,7 @@ SELECT * FROM kv GROUP BY v, count(DISTINCT w)
 query error aggregate functions are not allowed in GROUP BY
 SELECT count(DISTINCT w) FROM kv GROUP BY 1
 
-query error aggregate functions are not allowed in RETURNING
+query error Expected end of statement, found identifier
 INSERT INTO kv (k, v) VALUES (99, 100) RETURNING sum(v)
 
 query error LIMIT must be an integer constant
@@ -432,7 +432,7 @@ SELECT 3 FROM kv GROUP BY k HAVING v > 2
 query error does not exist
 SELECT k FROM kv HAVING k > 7
 
-query error syntax error at or near ","
+query error Expected right parenthesis, found comma
 SELECT count(*, 1) FROM kv
 
 query I
@@ -870,8 +870,6 @@ INSERT INTO bools VALUES (false), (false)
 
 query error supported
 SELECT bool_and(b), bool_or(b) FROM bools
-----
-false true
 
 # not supported yet
 # statement OK
@@ -934,7 +932,7 @@ NULL true 0 1 5
 query error FILTER specified but abs\(\) is not an aggregate function
 SELECT k, abs(k) FILTER (WHERE k=1) FROM kv
 
-query error syntax error at or near "filter"
+query error Expected end of statement, found left parenthesis
 SELECT k FILTER (WHERE k=1) FROM kv GROUP BY k
 
 query error aggregate functions are not allowed in FILTER
@@ -1076,10 +1074,6 @@ SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1
 # Regression test for distsql aggregator crash when using hash aggregation.
 query error supported
 SELECT v, array_agg('a') FROM kv GROUP BY v
-----
-2     {a,a,a}
-4     {a,a}
-NULL  {a}
 
 query I
 SELECT 123 FROM kv ORDER BY max(v)
@@ -1130,132 +1124,66 @@ SELECT company_id, string_agg(employee, ',')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           B,B
-3           C,C,C
-4           D,D,D,D
 
 query error supported
 SELECT company_id, string_agg(DISTINCT employee, ',')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           B
-3           C
-4           D
 
-query error supported
+query error unknown catalog item 'b'
 SELECT company_id, string_agg(employee::BYTEA, b',')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           B,B
-3           C,C,C
-4           D,D,D,D
 
 query error supported
 SELECT company_id, string_agg(employee, '')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           BB
-3           CCC
-4           DDDD
 
-query error supported
+query error unknown catalog item 'b'
 SELECT company_id, string_agg(employee::BYTEA, b'')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           BB
-3           CCC
-4           DDDD
 
 query error supported
 SELECT company_id, string_agg(employee, NULL)
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           BB
-3           CCC
-4           DDDD
 
 query error supported
 SELECT company_id, string_agg(employee::BYTEA, NULL)
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           A
-2           BB
-3           CCC
-4           DDDD
 
 query error supported
 SELECT company_id, string_agg(NULL::TEXT, ',')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           NULL
-2           NULL
-3           NULL
-4           NULL
 
 query error supported
 SELECT company_id, string_agg(NULL::BYTEA, ',')
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           NULL
-2           NULL
-3           NULL
-4           NULL
 
 query error supported
 SELECT company_id, string_agg(NULL::TEXT, NULL)
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           NULL
-2           NULL
-3           NULL
-4           NULL
 
 query error supported
 SELECT company_id, string_agg(NULL::BYTEA, NULL)
 FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
-----
-company_id  string_agg
-1           NULL
-2           NULL
-3           NULL
-4           NULL
 
 query error supported
 SELECT company_id, string_agg(NULL, NULL)

--- a/test/sqllogictest/cockroach/limit.slt
+++ b/test/sqllogictest/cockroach/limit.slt
@@ -57,7 +57,7 @@ statement error LIMIT must be an integer constant
 SELECT generate_series FROM generate_series(1, 100) FETCH NEXT 1 + 1 ROWS ONLY;
 
 # TODO(benesch): support this.
-query error LIMIT must be an integer constant
+query error Expected a keyword at the beginning of a statement, found number
 SELECT generate_series FROM generate_series(1, 100) ORDER BY generate_series FETCH FIRST (1 + 1) ROWS ONLY;
 ----
 1
@@ -91,7 +91,7 @@ SELECT k, v FROM t ORDER BY k OFFSET 5
 6  -36
 
 # TODO(benesch): support this.
-query error LIMIT must be an integer constant
+query error Expected end of statement, found number
 SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
 4  -16
@@ -101,7 +101,7 @@ SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 5  25
 
 # TODO(benesch): support this.
-query error LIMIT must be an integer constant
+query error Expected end of statement, found number
 SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
 3  9
@@ -141,28 +141,28 @@ SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 # Use expression for LIMIT/OFFSET value.
 # TODO(benesch): support this.
 
-query error LIMIT must be an integer constant
+query error Expected end of statement, found number
 SELECT k, v FROM t ORDER BY k LIMIT length(pg_typeof(123))
 ----
 1  1
 2  -4
 3  9
 
-query error LIMIT must be an integer constant
+query error Expected end of statement, found number
 SELECT k, v FROM t ORDER BY k LIMIT length(pg_typeof(123)) OFFSET length(pg_typeof(123))-2
 ----
 2  -4
 3  9
 4  -16
 
-query error LIMIT must be an integer constant
+query error Expected end of statement, found number
 SELECT k, v FROM t ORDER BY k OFFSET (SELECT count(*)-3 FROM t)
 ----
 4  -16
 5  25
 6  -36
 
-query error LIMIT must be an integer constant
+query error Expected end of statement, found number
 SELECT k, v FROM t ORDER BY k LIMIT (SELECT count(*)-3 FROM t) OFFSET (SELECT count(*)-5 FROM t)
 ----
 2  -4

--- a/test/sqllogictest/cockroach/tuple.slt
+++ b/test/sqllogictest/cockroach/tuple.slt
@@ -746,5 +746,5 @@ SELECT (1, 2, 3) IS NULL AS r
 ----
 false
 
-query error syntax error
+query error Expected an expression, found right parenthesis
 SELECT () = ()

--- a/test/sqllogictest/float.slt
+++ b/test/sqllogictest/float.slt
@@ -75,8 +75,8 @@ SELECT '-2147483777'::float4::int;
 
 # Invalid type mods
 
-query error precision for type float must be within ([1-53])
+query error precision for type float must be within \(\[1-53\]\)
 SELECT 1::float(0);
 
-query error precision for type float must be within ([1-53])
+query error precision for type float must be within \(\[1-53\]\)
 SELECT 1::float(55);

--- a/test/sqllogictest/jsonb.slt
+++ b/test/sqllogictest/jsonb.slt
@@ -45,8 +45,6 @@ SELECT '9223372036854775807'::jsonb
 
 query error invalid input syntax for type jsonb: 9223372036854775808 is out of range for a jsonb number
 SELECT '9223372036854775808'::jsonb
-----
-9223372036854775808
 
 statement ok
 CREATE TABLE test_jsonb (

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1929,7 +1929,7 @@ SELECT '{{1,2}}'::int4_list_list_c::text;
 {{1,2}}
 
 query error unknown catalog item bool list
-CREATE TYPE nested_list AS LIST (element_type = 'bool list')
+CREATE TYPE nested_list AS LIST (element_type = "bool list")
 
 query error unknown catalog item list
 CREATE TYPE nested_list AS LIST (element_type = list)

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -310,8 +310,6 @@ SELECT '1'::interval::bigint
 
 query error cannot cast jsonb object to type bigint
 SELECT '{}'::jsonb::bigint;
-----
-NULL
 
 query R
 SELECT '1'::jsonb::bigint;
@@ -459,8 +457,6 @@ SELECT '1'::interval::numeric
 
 query error cannot cast jsonb object to type numeric
 SELECT '{}'::jsonb::numeric;
-----
-NULL
 
 query R
 SELECT '1'::jsonb::numeric;
@@ -515,8 +511,6 @@ SELECT '1'::interval::double
 
 query error cannot cast jsonb object to type double precision
 SELECT '{}'::jsonb::double;
-----
-NULL
 
 query T
 SELECT '1'::jsonb::double;
@@ -569,10 +563,8 @@ SELECT 2::int::real;
 query error CAST does not support casting from interval to real
 SELECT '1'::interval::real
 
-query error cannot cast jsonb object to type float
+query error cannot cast jsonb object to type real
 SELECT '{}'::jsonb::real;
-----
-NULL
 
 query R
 SELECT '2'::jsonb::real;

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -335,13 +335,11 @@ SELECT '1'::pg_catalog.regclass
 
 # 🔬🔬 record
 
-query T
-SELECT ROW(1, 2) AS record;
-----
-(1,2)
+query error type "record" does not exist
+SELECT ROW(1, 2)::record;
 
 query error type "pg_catalog.record" does not exist
-SELECT ROW(1, 2) AS pg_catalog.record;
+SELECT ROW(1, 2)::pg_catalog.record;
 
 # 🔬🔬 text
 


### PR DESCRIPTION
The SLT runner was failing to validate the expected error message when a
query failed to parse. This was resulting in some queries that were
spuriously succeeding, and made for a very confusing experience in
development [0].

Fix #5347.

[0]: https://github.com/MaterializeInc/materialize/pull/5343#issuecomment-761595269

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6148)
<!-- Reviewable:end -->
