### PR TITLE
sql: reject DISTINCT specifier in non-aggregate functions

### DIFF
--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -236,7 +236,7 @@ SELECT v, mark, count(*) FILTER (WHERE k > 5), count(*), max(k) FILTER (WHERE k 
 4 true 1 3 3
 NULL true 0 1 5
 
-query error FILTER specified but abs\(\) is not an aggregate function
+query error FILTER specified, but abs is not an aggregate function
 SELECT abs(1) FILTER (WHERE false)
 
 query error Expected end of statement, found left parenthesis

--- a/test/sqllogictest/cockroach/aggregate.slt
+++ b/test/sqllogictest/cockroach/aggregate.slt
@@ -931,7 +931,7 @@ SELECT v, mark, count(*) FILTER (WHERE k > 5), count(*), max(k) FILTER (WHERE k 
 4 true 1 3 3
 NULL true 0 1 5
 
-query error FILTER specified but abs\(\) is not an aggregate function
+query error FILTER specified, but abs is not an aggregate function
 SELECT k, abs(k) FILTER (WHERE k=1) FROM kv
 
 query error syntax error at or near "filter"

--- a/test/sqllogictest/cockroach/window.slt
+++ b/test/sqllogictest/cockroach/window.slt
@@ -1917,7 +1917,7 @@ SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
 statement ok
 DELETE FROM kv WHERE k = 12
 
-query error FILTER specified but rank\(\) is not an aggregate function
+query error FILTER specified, but rank is not an aggregate function
 SELECT k, rank() FILTER (WHERE k=1) OVER () FROM kv
 
 # Issue #14606: correctly handle aggregation functions above the windowing level

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -9,6 +9,12 @@
 
 mode cockroach
 
+query error DISTINCT specified, but now is not an aggregate function
+SELECT now(DISTINCT)
+
+query error DISTINCT specified, but round is not an aggregate function
+SELECT round(DISTINCT 1)
+
 # Test date_trunc()
 
 # TODO: PostgreSQL truncates trailing zeros from seconds, we do not.


### PR DESCRIPTION
Also use pattern matching to ensure the compiler's unused variable
warning can help uncover issues like this in the future.

Fix #5854.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6149)
<!-- Reviewable:end -->
