### PR TITLE
Optimization correctness fix: expr = expr is not equivalent to isnull(expr).

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -495,14 +495,6 @@ impl MirScalarExpr {
                     if expr2 < expr1 {
                         ::std::mem::swap(expr1, expr2);
                     }
-
-                    // Comparison to self is always true unless the element is `Datum::Null`.
-                    if expr1 == expr2 {
-                        *e = expr1
-                            .clone()
-                            .call_unary(UnaryFunc::IsNull)
-                            .call_unary(UnaryFunc::Not);
-                    }
                 }
             }
             MirScalarExpr::CallVariadic { func, exprs } => {

--- a/test/sqllogictest/degenerate.slt
+++ b/test/sqllogictest/degenerate.slt
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests whether correct results are returned in degenerate edge cases
+# where the expected result is empty, null, or a constant.
+
+statement ok
+CREATE TABLE t1 (f1 INTEGER)
+
+statement ok
+INSERT INTO t1 VALUES (NULL)
+
+query I
+SELECT * FROM t1 WHERE NOT (f1 = f1)
+----


### PR DESCRIPTION
Closes #6151 

If expr is null, isnull(expr) returns false whereas expr = expr returns null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6154)
<!-- Reviewable:end -->
