### PR TITLE
coord,dataflow: remove partition_count from BYO API

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -311,7 +311,7 @@ fn generate_ts_updates_from_debezium(
                 // entries in data_collection do not contain server_name
                 // so we discard it before doing the comparison.
                 // We check for both here
-                //TODO(): possible performance issue here?
+                // TODO(): possible performance issue here?
                 let parsed_source_name = byo_consumer.source_name.split('.').skip(1).join(".");
                 if byo_consumer.source_name == topic.trim() || parsed_source_name == topic.trim() {
                     byo_consumer.last_offset.offset += count;
@@ -321,7 +321,6 @@ fn generate_ts_updates_from_debezium(
                         coord::AdvanceSourceTimestamp {
                             id: *id,
                             update: TimestampSourceUpdate::BringYourOwn(
-                                1,
                                 match byo_consumer.connector {
                                     ByoTimestampConnector::Ocf(_) => PartitionId::File,
                                     ByoTimestampConnector::Kafka(_) => PartitionId::Kafka(0),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -656,10 +656,10 @@ pub struct KafkaOffset {
 pub enum TimestampSourceUpdate {
     /// Update for an RT source: contains an updated partition count for this source
     RealTime(i32),
-    ///  Timestamp update for a BYO source: contains an updated partition count for this source,
-    /// combined with a PartitionID, Timestamp, MzOffset tuple. This tuple informs workers that
-    /// messages with Offset on PartitionId will be timestamped with Timestamp.
-    BringYourOwn(i32, PartitionId, u64, MzOffset),
+    /// Timestamp update for a BYO source: contains a PartitionID, Timestamp,
+    /// MzOffset tuple. This tuple informs workers that messages with Offset on
+    /// PartitionId will be timestamped with Timestamp.
+    BringYourOwn(PartitionId, u64, MzOffset),
 }
 
 /// Convert from KafkaOffset to MzOffset (1-indexed)

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -535,7 +535,7 @@ impl ConsistencyInfo {
                                 // We need to grab the min closed (max) timestamp from partitions we
                                 // don't own.
 
-                                if let Some((_, timestamp, _)) = entries.back() {
+                                if let Some((timestamp, _)) = entries.back() {
                                     min_closed_timestamp_unowned_partitions =
                                         match min_closed_timestamp_unowned_partitions.as_mut() {
                                             Some(min) => Some(std::cmp::min(*timestamp, *min)),
@@ -553,7 +553,7 @@ impl ConsistencyInfo {
                             // set of timestamp bindings to find a match every time. This is
                             // clearly suboptimal and can be improved upon with a better
                             // API for sources to interact with timestamp binding information.
-                            for (partition_count, ts, offset) in entries {
+                            for (ts, offset) in entries {
                                 if existing_ts >= *ts {
                                     //skip old records
                                     continue;
@@ -569,10 +569,6 @@ impl ConsistencyInfo {
                                     *ts > 0,
                                     "Internal error! Received a zero-timestamp. Materialize will crash now."
                                 );
-
-                                // This timestamp update was done with the expectation that there were more partitions
-                                // than we know about.
-                                source.update_partition_count(self, *partition_count);
 
                                 if let Some(pmetrics) = self.partition_metrics.get_mut(pid) {
                                     pmetrics
@@ -665,7 +661,7 @@ impl ConsistencyInfo {
                 None => None,
                 Some(TimestampDataUpdate::BringYourOwn(entries)) => match entries.get(partition) {
                     Some(entries) => {
-                        for (_, ts, max_offset) in entries {
+                        for (ts, max_offset) in entries {
                             if offset <= *max_offset {
                                 return Some(ts.clone());
                             }


### PR DESCRIPTION
BYO now only supports Debezium style consistency which only consists of single partition topics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6160)
<!-- Reviewable:end -->
