### PR TITLE
Large refactor of SourceInfo trait

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -136,12 +136,11 @@ struct ByoTimestampConsumer {
     /// The name of the source with which this connector is associated
     ///
     /// * For kafka this is the topic
-    /// * For kinesis this is the stream name
     /// * For file types this is the file name
     source_name: String,
     /// The format of the connector
     envelope: ConsistencyFormatting,
-    /// The max assigned timestamp. Should be max(last_partition_ts)
+    /// The max assigned timestamp.
     last_ts: u64,
     /// The max offset for which a timestamp has been assigned
     last_offset: MzOffset,

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -654,8 +654,8 @@ pub struct KafkaOffset {
 /// with Timestamp.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TimestampSourceUpdate {
-    /// Update for an RT source: contains an updated partition count for this source
-    RealTime(i32),
+    /// Update for an RT source: contains a new partition to add to this source.
+    RealTime(PartitionId),
     /// Timestamp update for a BYO source: contains a PartitionID, Timestamp,
     /// MzOffset tuple. This tuple informs workers that messages with Offset on
     /// PartitionId will be timestamped with Timestamp.

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -110,7 +110,7 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
                 PartitionId::File,
                 PartitionMetrics::new(&name, source_id, "", logger),
             );
-            consistency_info.update_partition_metadata(PartitionId::File);
+            consistency_info.update_partition_metadata(&PartitionId::File);
         }
 
         Ok(FileSourceInfo {
@@ -171,7 +171,7 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
                 PartitionId::File,
                 PartitionMetrics::new(&name, source_id, "", logger),
             );
-            consistency_info.update_partition_metadata(PartitionId::File);
+            consistency_info.update_partition_metadata(&PartitionId::File);
         }
 
         Ok(FileSourceInfo {
@@ -183,23 +183,6 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
 }
 
 impl<Out> SourceInfo<Out> for FileSourceInfo<Out> {
-    fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
-        // This function should be a no-op for file sources because they don't have partitions.
-        log::debug!("ensure_has_partition erroneously called for file sources");
-    }
-
-    fn update_partition_count(
-        &mut self,
-        _consistency_info: &mut ConsistencyInfo,
-        partition_count: i32,
-    ) {
-        if partition_count > 1 {
-            error!("Files cannot have multiple partitions");
-        }
-        // This function should be a no-op for file sources because they don't have partitions.
-        log::debug!("update_partition_count erroneously called for file sources");
-    }
-
     fn get_next_message(&mut self) -> Result<NextMessage<Out>, anyhow::Error> {
         match self.receiver_stream.try_recv() {
             Ok(Ok(record)) => {

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -10,12 +10,9 @@
 use std::cmp;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::convert::TryInto;
-use std::fs;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use differential_dataflow::hashable::Hashable;
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::error::KafkaError;
@@ -27,18 +24,15 @@ use timely::scheduling::activate::SyncActivator;
 use dataflow_types::{
     DataEncoding, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector, MzOffset,
 };
-use expr::{GlobalId, PartitionId, SourceInstanceId};
+use expr::{PartitionId, SourceInstanceId};
 use kafka_util::KafkaAddrs;
-use log::{debug, error, info, log_enabled, warn};
-use repr::{CachedRecord, CachedRecordIter, Timestamp};
-use tokio::sync::mpsc;
+use log::{error, info, log_enabled, warn};
 use uuid::Uuid;
 
-use crate::source::cache::{RecordFileMetadata, WorkerCacheData};
+use crate::logging::materialized::Logger;
 use crate::source::{
     ConsistencyInfo, NextMessage, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
 };
-use crate::{logging::materialized::Logger, server::CacheMessage};
 
 /// Contains all information necessary to ingest data from Kafka
 pub struct KafkaSourceInfo {
@@ -56,10 +50,6 @@ pub struct KafkaSourceInfo {
     known_partitions: i32,
     /// Worker ID
     worker_id: i32,
-    /// Worker Count
-    worker_count: i32,
-    /// Files to read on startup
-    cached_files: Vec<PathBuf>,
     /// Map from partition -> most recently read offset
     last_offsets: HashMap<i32, i64>,
     /// Map from partition -> offset to start reading at
@@ -74,7 +64,7 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
         source_id: SourceInstanceId,
         _active: bool,
         worker_id: usize,
-        worker_count: usize,
+        _worker_count: usize,
         logger: Option<Logger>,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
@@ -86,7 +76,6 @@ impl SourceConstructor<Vec<u8>> for KafkaSourceInfo {
                 source_name,
                 source_id,
                 worker_id,
-                worker_count,
                 logger,
                 consumer_activator,
                 kc,
@@ -101,46 +90,28 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
     /// Ensures that a partition queue for `pid` exists.
     /// In Kafka, partitions are assigned contiguously. This function consequently
     /// creates partition queues for every p <= pid
-    fn ensure_has_partition(&mut self, consistency_info: &mut ConsistencyInfo, pid: PartitionId) {
+    fn add_partition(&mut self, pid: PartitionId) -> PartitionMetrics {
         let pid = match pid {
             PartitionId::Kafka(p) => p,
             _ => unreachable!(),
         };
-        for i in self.known_partitions..=pid {
-            if self.has_partition(i) {
-                self.create_partition_queue(i);
-                consistency_info.partition_metrics.insert(
-                    PartitionId::Kafka(i),
-                    PartitionMetrics::new(
-                        &self.topic_name,
-                        self.id,
-                        &i.to_string(),
-                        self.logger.clone(),
-                    ),
-                );
-                consistency_info.update_partition_metadata(PartitionId::Kafka(i));
 
-                // Indicate a last offset of -1 if we have not been instructed to
-                // have a specific start offset for this topic.
-                let start_offset = *self.start_offsets.get(&i).unwrap_or(&-1);
-                let prev = self.last_offsets.insert(i, start_offset);
+        self.create_partition_queue(pid);
+        let metrics = PartitionMetrics::new(
+            &self.topic_name,
+            self.id,
+            &pid.to_string(),
+            self.logger.clone(),
+        );
 
-                assert!(prev.is_none());
-            }
-        }
+        // Indicate a last offset of -1 if we have not been instructed to
+        // have a specific start offset for this topic.
+        let start_offset = *self.start_offsets.get(&pid).unwrap_or(&-1);
+        let prev = self.last_offsets.insert(pid, start_offset);
+
+        assert!(prev.is_none());
         self.known_partitions = cmp::max(self.known_partitions, pid + 1);
-    }
-
-    /// Updates the Kafka source to reflect the new partition count.
-    /// Kafka creates partitions with contiguous IDs, starting from 0.
-    /// as PIDs are contiguous, we ensure that we have created partitions up to PID
-    /// (partition_count-1) as partitions are 0-indexed.
-    fn update_partition_count(
-        &mut self,
-        consistency_info: &mut ConsistencyInfo,
-        partition_count: i32,
-    ) {
-        self.ensure_has_partition(consistency_info, PartitionId::Kafka(partition_count - 1));
+        metrics
     }
 
     /// This function polls from the next consumer for which a message is available. This function polls the set
@@ -251,63 +222,6 @@ impl SourceInfo<Vec<u8>> for KafkaSourceInfo {
 
         Ok(next_message)
     }
-
-    fn next_cached_file(&mut self) -> Option<Vec<(Vec<u8>, Vec<u8>, Timestamp, i64)>> {
-        if let Some(f) = &self.cached_files.pop() {
-            debug!("reading cached data from {}", f.display());
-            let data = fs::read(f).unwrap_or_else(|e| {
-                error!("failed to read source cache file {}: {}", f.display(), e);
-                vec![]
-            });
-
-            Some(
-                CachedRecordIter::new(data)
-                    .map(|r| (r.key, r.value, r.timestamp, r.offset))
-                    .collect(),
-            )
-        } else {
-            None
-        }
-    }
-
-    fn cache_message(
-        &self,
-        caching_tx: &mut Option<mpsc::UnboundedSender<CacheMessage>>,
-        message: &SourceMessage<Vec<u8>>,
-        timestamp: Timestamp,
-        predecessor: Option<MzOffset>,
-    ) {
-        // Send this record to be cached
-        if let Some(caching_tx) = caching_tx {
-            let partition_id = match message.partition {
-                PartitionId::Kafka(p) => p,
-                _ => unreachable!(),
-            };
-
-            // TODO(rkhaitan): let's experiment with wrapping these in a
-            // Arc so we don't have to clone.
-            let key = message.key.clone().unwrap_or_default();
-            let value = message.payload.clone().unwrap_or_default();
-
-            let cache_data = CacheMessage::Data(WorkerCacheData {
-                source_id: self.id.source_id,
-                partition_id,
-                record: CachedRecord {
-                    predecessor: predecessor.map(|p| p.offset),
-                    offset: message.offset.offset,
-                    timestamp,
-                    key,
-                    value,
-                },
-            });
-
-            // TODO(benesch): the lack of backpressure here can result in
-            // unbounded memory usage.
-            caching_tx
-                .send(cache_data)
-                .expect("caching receiver should never drop first");
-        }
-    }
 }
 
 impl KafkaSourceInfo {
@@ -316,7 +230,6 @@ impl KafkaSourceInfo {
         source_name: String,
         source_id: SourceInstanceId,
         worker_id: usize,
-        worker_count: usize,
         logger: Option<Logger>,
         consumer_activator: SyncActivator,
         kc: KafkaSourceConnector,
@@ -331,7 +244,6 @@ impl KafkaSourceInfo {
             ..
         } = kc;
         let worker_id = worker_id.try_into().unwrap();
-        let worker_count = worker_count.try_into().unwrap();
         let kafka_config = create_kafka_config(
             &source_name,
             &addrs,
@@ -342,47 +254,6 @@ impl KafkaSourceInfo {
         let consumer: BaseConsumer<GlueConsumerContext> = kafka_config
             .create_with_context(GlueConsumerContext(consumer_activator))
             .expect("Failed to create Kafka Consumer");
-        let cached_files = kc
-            .cached_files
-            .map(|files| {
-                let mut filtered = files
-                    .iter()
-                    .map(|f| {
-                        let metadata = RecordFileMetadata::from_path(f);
-                        (f, metadata)
-                    })
-                    .filter(|(f, metadata)| {
-                        // We partition the given partitions up amongst workers, so we need to be
-                        // careful not to process a partition that this worker was not allocated (or
-                        // else we would process files multiple times).
-                        match metadata {
-                            Ok(Some(meta)) => {
-                                assert_eq!(source_id.source_id, meta.source_id);
-                                has_partition(
-                                    source_id.source_id,
-                                    worker_id,
-                                    worker_count,
-                                    meta.partition_id,
-                                )
-                            }
-                            _ => {
-                                error!("Failed to parse path: {}", f.display());
-                                false
-                            }
-                        }
-                    })
-                    .collect::<Vec<_>>();
-
-                // Sort the list in reverse order so we can pop items off of it in
-                // order of increasing `start_offset`
-                filtered.sort_by_key(|(_, metadata)| match metadata {
-                    Ok(Some(meta)) => -meta.start_offset,
-                    _ => unreachable!(),
-                });
-
-                filtered.iter().map(|(f, _)| (*f).clone()).collect()
-            })
-            .unwrap_or_default();
 
         let start_offsets = start_offsets
             .iter()
@@ -407,22 +278,10 @@ impl KafkaSourceInfo {
             known_partitions: 0,
             consumer: Arc::new(consumer),
             worker_id,
-            worker_count,
             last_offsets: HashMap::new(),
             start_offsets,
-            cached_files,
             logger,
         }
-    }
-
-    /// Returns true if this worker is responsible for this partition
-    fn has_partition(&self, partition_id: i32) -> bool {
-        has_partition(
-            self.id.source_id,
-            self.worker_id,
-            self.worker_count,
-            partition_id,
-        )
     }
 
     /// Returns a count of total number of consumers for this source
@@ -668,27 +527,4 @@ impl ConsumerContext for GlueConsumerContext {
     fn message_queue_nonempty_callback(&self) {
         self.activate();
     }
-}
-
-// We want to distribute partitions across workers evenly, such that
-// - different partitions for the same source are uniformly distributed across workers
-// - the same partition id across different sources are uniformly distributed across workers
-// - the same partition id across different instances of the same source is sent to
-//   the same worker.
-// We achieve this by taking a hash of the `source_id` (not the source instance id) and using
-// that to offset distributing partitions round robin across workers.
-fn has_partition(
-    source_id: GlobalId,
-    worker_id: i32,
-    worker_count: i32,
-    partition_id: i32,
-) -> bool {
-    assert!(worker_id >= 0);
-    assert!(worker_count > worker_id);
-    assert!(partition_id >= 0);
-
-    // We keep only 32 bits of randomness from `hashed` to prevent 64 bit
-    // overflow.
-    let hash = (source_id.hashed() >> 32) + partition_id as u64;
-    (hash % worker_count as u64) == worker_id as u64
 }

--- a/src/dataflow/src/source/kinesis.rs
+++ b/src/dataflow/src/source/kinesis.rs
@@ -88,7 +88,7 @@ impl SourceConstructor<Vec<u8>> for KinesisSourceInfo {
             Ok((kinesis_client, stream_name, shard_set, shard_queue)) => {
                 if active {
                     let kinesis_id = PartitionId::Kinesis;
-                    consistency_info.update_partition_metadata(kinesis_id.clone());
+                    consistency_info.update_partition_metadata(&kinesis_id);
                     consistency_info.partition_metrics.insert(
                         kinesis_id.clone(),
                         PartitionMetrics::new(
@@ -147,18 +147,6 @@ impl KinesisSourceInfo {
 }
 
 impl SourceInfo<Vec<u8>> for KinesisSourceInfo {
-    fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
-        //TODO(natacha): do nothing for now, as do not currently use timestamper
-    }
-
-    fn update_partition_count(
-        &mut self,
-        _consistency_info: &mut ConsistencyInfo,
-        _partition_count: i32,
-    ) {
-        //TODO(natacha): do nothing for now as do not currently use timestamper
-    }
-
     fn get_next_message(&mut self) -> Result<NextMessage<Vec<u8>>, anyhow::Error> {
         assert_eq!(self.shard_queue.len(), self.shard_set.len());
 

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -15,6 +15,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::{self, Debug};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use timely::dataflow::{
@@ -23,16 +24,16 @@ use timely::dataflow::{
 };
 
 use dataflow_types::{Consistency, DataEncoding, ExternalSourceConnector, MzOffset, SourceError};
-use expr::{PartitionId, SourceInstanceId};
+use expr::{GlobalId, PartitionId, SourceInstanceId};
 use lazy_static::lazy_static;
-use log::{debug, error};
+use log::{debug, error, trace};
 use prometheus::core::{AtomicI64, AtomicU64};
 use prometheus::{
     register_int_counter, register_int_counter_vec, register_int_gauge_vec,
     register_uint_gauge_vec, DeleteOnDropCounter, DeleteOnDropGauge, IntCounter, IntCounterVec,
     IntGaugeVec, UIntGauge, UIntGaugeVec,
 };
-use repr::Timestamp;
+use repr::{CachedRecord, CachedRecordIter, Timestamp};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::Scope;
@@ -44,6 +45,7 @@ use super::source::util::source;
 use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::operator::StreamExt;
 use crate::server::{TimestampDataUpdate, TimestampDataUpdates};
+use crate::source::cache::WorkerCacheData;
 use crate::CacheMessage;
 
 mod file;
@@ -278,48 +280,114 @@ impl MaybeLength for Value {
 /// Each source must implement this trait. Sources will then get created as part of the
 /// [`create_source`] function.
 pub(crate) trait SourceInfo<Out> {
-    // BYO consistency methods
-
     /// Ensures that the partition `pid` exists for this source. Once this function has been
     /// called, the source should be able to receive messages from this partition
-    fn ensure_has_partition(&mut self, consistency_info: &mut ConsistencyInfo, pid: PartitionId);
-
-    // BYO  + RT methods
-
-    /// Informs source that there are now `partition_count` entries for this source
-    // this might be better as BYO-only, but it is actually called in RT timestamping as well
-    fn update_partition_count(
-        &mut self,
-        consistency_info: &mut ConsistencyInfo,
-        partition_count: i32,
-    );
-
-    // source reading
+    fn add_partition(&mut self, _pid: PartitionId) -> PartitionMetrics {
+        panic!("add partiton not supported for source!");
+    }
 
     /// Returns the next message read from the source
     fn get_next_message(&mut self) -> Result<NextMessage<Out>, anyhow::Error>;
+}
 
-    // caching
-
+/// This trait defines the interface to cache incoming messages.
+///
+/// Every output message type must implement this trait.
+pub trait SourceCache {
     /// Cache a message
     fn cache_message(
-        &self,
-        _caching_tx: &mut Option<mpsc::UnboundedSender<CacheMessage>>,
-        _message: &SourceMessage<Out>,
-        _timestamp: Timestamp,
-        _offset: Option<MzOffset>,
-    ) {
-        // Default implementation is to do nothing
-    }
+        message: &SourceMessage<Self>,
+        source_id: SourceInstanceId,
+        caching_tx: &mut Option<mpsc::UnboundedSender<CacheMessage>>,
+        timestamp: Timestamp,
+        offset: Option<MzOffset>,
+    ) where
+        Self: Sized;
 
     /// Read back data from a previously cached file.
     /// Reads messages back from files in offset order, and returns None when there is
     /// no more data left to process
     /// TODO(rkhaitan): clean this up to return a proper type and potentially a iterator.
-    fn next_cached_file(&mut self) -> Option<Vec<(Vec<u8>, Out, Timestamp, i64)>> {
-        // Default implementation is to do nothing.
-        debug!("unimplemented: this source does not support reading cached files");
-        None
+    fn read_file(path: PathBuf) -> Vec<SourceMessage<Self>>
+    where
+        Self: Sized;
+}
+
+impl SourceCache for Vec<u8> {
+    fn cache_message(
+        message: &SourceMessage<Vec<u8>>,
+        source_id: SourceInstanceId,
+        caching_tx: &mut Option<mpsc::UnboundedSender<CacheMessage>>,
+        timestamp: Timestamp,
+        predecessor: Option<MzOffset>,
+    ) {
+        // Send this record to be cached
+        if let Some(caching_tx) = caching_tx {
+            let partition_id = match message.partition {
+                PartitionId::Kafka(p) => p,
+                _ => unreachable!(),
+            };
+
+            // TODO(rkhaitan): let's experiment with wrapping these in a
+            // Arc so we don't have to clone.
+            let key = message.key.clone().unwrap_or_default();
+            let value = message.payload.clone().unwrap_or_default();
+
+            let cache_data = CacheMessage::Data(WorkerCacheData {
+                source_id: source_id.source_id,
+                partition_id,
+                record: CachedRecord {
+                    predecessor: predecessor.map(|p| p.offset),
+                    offset: message.offset.offset,
+                    timestamp,
+                    key,
+                    value,
+                },
+            });
+
+            // TODO(benesch): the lack of backpressure here can result in
+            // unbounded memory usage.
+            caching_tx
+                .send(cache_data)
+                .expect("caching receiver should never drop first");
+        }
+    }
+
+    fn read_file(path: PathBuf) -> Vec<SourceMessage<Vec<u8>>> {
+        debug!("reading cached data from {}", path.display());
+        let data = ::std::fs::read(&path).unwrap_or_else(|e| {
+            error!("failed to read source cache file {}: {}", path.display(), e);
+            vec![]
+        });
+
+        let partition =
+            crate::source::cache::cached_file_partition(&path).expect("partition known to exist");
+        CachedRecordIter::new(data)
+            .map(move |r| SourceMessage {
+                key: Some(r.key),
+                payload: Some(r.value),
+                offset: MzOffset { offset: r.offset },
+                upstream_time_millis: None,
+                partition: partition.clone(),
+            })
+            .collect()
+    }
+}
+
+impl SourceCache for mz_avro::types::Value {
+    fn cache_message(
+        _message: &SourceMessage<Self>,
+        _source_id: SourceInstanceId,
+        _caching_tx: &mut Option<mpsc::UnboundedSender<CacheMessage>>,
+        _timestamp: Timestamp,
+        _offset: Option<MzOffset>,
+    ) {
+        // Just no-op for OCF sources
+        trace!("source caching is not supported for Avro OCF sources");
+    }
+
+    fn read_file(_path: PathBuf) -> Vec<SourceMessage<Self>> {
+        panic!("source caching is not supported for Avro OCF sources");
     }
 }
 
@@ -393,13 +461,23 @@ pub struct ConsistencyInfo {
     source_metrics: SourceMetrics,
     /// Per-partition Prometheus metrics.
     partition_metrics: HashMap<PartitionId, PartitionMetrics>,
+    /// source global id
+    source_global_id: GlobalId,
+    /// True if this worker is the active reader
+    active: bool,
+    /// id of worker
+    worker_id: usize,
+    /// total number of workers
+    worker_count: usize,
 }
 
 impl ConsistencyInfo {
     fn new(
+        active: bool,
         source_name: String,
         source_id: SourceInstanceId,
         worker_id: usize,
+        worker_count: usize,
         consistency: Consistency,
         timestamp_frequency: Duration,
         connector: &ExternalSourceConnector,
@@ -433,25 +511,50 @@ impl ConsistencyInfo {
             // we have never downgraded, so make sure the initial value is outside of our frequency
             time_since_downgrade: Instant::now() - timestamp_frequency - Duration::from_secs(1),
             partition_metrics: Default::default(),
+            source_global_id: source_id.source_id,
+            active,
+            worker_id,
+            worker_count,
+        }
+    }
+
+    /// Returns true if this worker is responsible for handling this partition
+    fn responsible_for(&self, pid: &PartitionId) -> bool {
+        match pid {
+            PartitionId::File | PartitionId::S3 | PartitionId::Kinesis => self.active,
+            PartitionId::Kafka(p) => {
+                // We want to distribute partitions across workers evenly, such that
+                // - different partitions for the same source are uniformly distributed across workers
+                // - the same partition id across different sources are uniformly distributed across workers
+                // - the same partition id across different instances of the same source is sent to
+                //   the same worker.
+                // We achieve this by taking a hash of the `source_id` (not the source instance id) and using
+                // that to offset distributing partitions round robin across workers.
+
+                // We keep only 32 bits of randomness from `hashed` to prevent 64 bit
+                // overflow.
+                let hash = (self.source_global_id.hashed() >> 32) + *p as u64;
+                (hash % self.worker_count as u64) == self.worker_id as u64
+            }
         }
     }
 
     /// Returns true if we currently know of particular partition. We know (and have updated the
     /// metadata for this partition) if there is an entry for it
-    pub fn knows_of(&self, pid: PartitionId) -> bool {
-        self.partition_metadata.contains_key(&pid)
+    pub fn knows_of(&self, pid: &PartitionId) -> bool {
+        self.partition_metadata.contains_key(pid)
     }
 
     /// Updates the underlying partition metadata structure to include the current partition.
     /// New partitions must always be added with a minimum closed offset of (last_closed_ts)
     /// They are guaranteed to only receive timestamp update greater than last_closed_ts (this
     /// is enforced in `coord::timestamp::is_ts_valid`.
-    pub fn update_partition_metadata(&mut self, pid: PartitionId) {
+    pub fn update_partition_metadata(&mut self, pid: &PartitionId) {
         let cons_info = ConsInfo {
             offset: self.get_partition_start_offset(&pid),
             ts: self.last_closed_ts,
         };
-        self.partition_metadata.insert(pid, cons_info);
+        self.partition_metadata.insert(pid.clone(), cons_info);
     }
 
     fn get_partition_start_offset(&self, pid: &PartitionId) -> MzOffset {
@@ -530,7 +633,13 @@ impl ConsistencyInfo {
                     TimestampDataUpdate::BringYourOwn(entries) => {
                         // Iterate over each partition that we know about
                         for (pid, entries) in entries {
-                            source.ensure_has_partition(self, pid.clone());
+                            if !self.knows_of(pid) && self.responsible_for(pid) {
+                                let partition_metrics = source.add_partition(pid.clone());
+                                self.update_partition_metadata(pid);
+                                self.partition_metrics
+                                    .insert(pid.clone(), partition_metrics);
+                            }
+
                             if !self.partition_metadata.contains_key(pid) {
                                 // We need to grab the min closed (max) timestamp from partitions we
                                 // don't own.
@@ -619,8 +728,15 @@ impl ConsistencyInfo {
             // capability
             if let Some(entries) = timestamp_histories.borrow().get(&id.source_id) {
                 match entries {
-                    TimestampDataUpdate::RealTime(partition_count) => {
-                        source.update_partition_count(self, *partition_count)
+                    TimestampDataUpdate::RealTime(partitions) => {
+                        for pid in partitions {
+                            if !self.knows_of(pid) && self.responsible_for(pid) {
+                                let partition_metrics = source.add_partition(pid.clone());
+                                self.update_partition_metadata(pid);
+                                self.partition_metrics
+                                    .insert(pid.clone(), partition_metrics);
+                            }
+                        }
                     }
                     _ => panic!("Unexpected timestamp message. Expected RT update."),
                 }
@@ -857,7 +973,7 @@ pub(crate) fn create_source<G, S: 'static, Out>(
 where
     G: Scope<Timestamp = Timestamp>,
     S: SourceInfo<Out> + SourceConstructor<Out>,
-    Out: Debug + Clone + Send + Default + MaybeLength + 'static,
+    Out: Debug + Clone + Send + Default + MaybeLength + SourceCache + 'static,
 {
     let SourceConfig {
         name,
@@ -880,9 +996,11 @@ where
 
         // Create control plane information (Consistency-related information)
         let mut consistency_info = ConsistencyInfo::new(
+            active,
             name.clone(),
             id,
             worker_id,
+            worker_count,
             consistency,
             timestamp_frequency,
             &source_connector,
@@ -903,7 +1021,13 @@ where
             encoding,
         );
 
-        let mut read_cached_files = false;
+        let cached_files = dataflow_types::cached_files(&source_connector);
+        let mut cached_files = crate::source::cache::cached_files_for_worker(
+            id.source_id,
+            cached_files,
+            &consistency_info,
+        );
+
         let mut predecessor = None;
         // Stash messages we cannot yet timestamp here.
         let mut buffer = None;
@@ -925,33 +1049,32 @@ where
             // Downgrade capability (if possible)
             consistency_info.downgrade_capability(&id, cap, source_info, &timestamp_histories);
 
-            if !read_cached_files {
-                if let Some(msgs) = source_info.next_cached_file() {
-                    // TODO(rkhaitan) change this to properly re-use old timestamps.
-                    // Currently this is hard to do because there can be arbitrary delays between
-                    // different workers being scheduled, and this means that all cached state
-                    // can potentially get pulled into memory without being able to close timestamps
-                    // which causes the system to go out of memory.
-                    // For now, constrain we constrain caching to RT sources, and we re-assign
-                    // timestamps to cached messages on startup.
-                    let ts = consistency_info.find_matching_rt_timestamp();
-                    let ts_cap = cap.delayed(&ts);
-                    for m in msgs {
-                        output.session(&ts_cap).give(Ok(SourceOutput::new(
-                            m.0,
-                            m.1,
-                            Some(m.3),
-                            None, // upstream timestamps are normalized before they are cached
-                        )));
-                    }
+            if let Some(file) = cached_files.pop() {
+                // TODO(rkhaitan) change this to properly re-use old timestamps.
+                // Currently this is hard to do because there can be arbitrary delays between
+                // different workers being scheduled, and this means that all cached state
+                // can potentially get pulled into memory without being able to close timestamps
+                // which causes the system to go out of memory.
+                // For now, constrain we constrain caching to RT sources, and we re-assign
+                // timestamps to cached messages on startup.
+                let ts = consistency_info.find_matching_rt_timestamp();
+                let ts_cap = cap.delayed(&ts);
 
-                    // Yield to give downstream operators time to handle this data.
-                    activator.activate_after(Duration::from_millis(10));
-                    return SourceStatus::Alive;
-                } else {
-                    // We've finished reading all cache data
-                    read_cached_files = true;
+                let messages = SourceCache::read_file(file);
+
+                for message in messages {
+                    let key = message.key.unwrap_or_default();
+                    let out = message.payload.unwrap_or_default();
+                    output.session(&ts_cap).give(Ok(SourceOutput::new(
+                        key,
+                        out,
+                        Some(message.offset.offset),
+                        message.upstream_time_millis,
+                    )));
                 }
+                // Yield to give downstream operators time to handle this data.
+                activator.activate_after(Duration::from_millis(10));
+                return SourceStatus::Alive;
             }
 
             // Bound execution of operator to prevent a single operator from hogging
@@ -978,7 +1101,6 @@ where
                         message,
                         &mut predecessor,
                         &mut consistency_info,
-                        source_info,
                         &id,
                         &timestamp_histories,
                         &mut bytes_read,
@@ -995,7 +1117,6 @@ where
                             message,
                             &mut predecessor,
                             &mut consistency_info,
-                            source_info,
                             &id,
                             &timestamp_histories,
                             &mut bytes_read,
@@ -1076,7 +1197,6 @@ fn handle_message<Out>(
     message: SourceMessage<Out>,
     predecessor: &mut Option<MzOffset>,
     consistency_info: &mut ConsistencyInfo,
-    source_info: &mut dyn SourceInfo<Out>,
     id: &SourceInstanceId,
     timestamp_histories: &TimestampDataUpdates,
     bytes_read: &mut usize,
@@ -1092,7 +1212,7 @@ fn handle_message<Out>(
     buffer: &mut Option<SourceMessage<Out>>,
 ) -> (SourceStatus, MessageProcessing)
 where
-    Out: Debug + Clone + Send + Default + MaybeLength + 'static,
+    Out: Debug + Clone + Send + Default + MaybeLength + SourceCache + 'static,
 {
     let partition = message.partition.clone();
     let offset = message.offset;
@@ -1120,7 +1240,7 @@ where
             (SourceStatus::Alive, MessageProcessing::Yielded)
         }
         Some(ts) => {
-            source_info.cache_message(caching_tx, &message, ts, msg_predecessor);
+            SourceCache::cache_message(&message, *id, caching_tx, ts, msg_predecessor);
             // Note: empty and null payload/keys are currently
             // treated as the same thing.
             let key = message.key.unwrap_or_default();

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -154,7 +154,7 @@ impl SourceConstructor<Vec<u8>> for S3SourceInfo {
                 pid.clone(),
                 PartitionMetrics::new(&source_name, source_id, "s3", logger),
             );
-            consistency_info.update_partition_metadata(pid);
+            consistency_info.update_partition_metadata(&pid);
         }
         Ok(S3SourceInfo {
             source_name,
@@ -701,22 +701,6 @@ impl SourceInfo<Vec<u8>> for S3SourceInfo {
             Err(TryRecvError::Empty) => Ok(NextMessage::Pending),
             Err(TryRecvError::Disconnected) => Ok(NextMessage::Finished),
         }
-    }
-
-    fn ensure_has_partition(&mut self, _consistency_info: &mut ConsistencyInfo, _pid: PartitionId) {
-        panic!("s3 sources do not support BYO consistency: ensure_has_partition")
-    }
-
-    fn update_partition_count(
-        &mut self,
-        _consistency_info: &mut ConsistencyInfo,
-        _partition_count: i32,
-    ) {
-        // We can't do anything with just the number of "partitions" that we
-        // know about, fundamentally we know more than the timestamper about
-        // how many partitions there are.
-        //
-        // https://github.com/MaterializeInc/materialize/issues/5715
     }
 }
 

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-sql-timeout duration=30s
+$ set-sql-timeout duration=60s
 
 $ set schema={
     "type": "record",


### PR DESCRIPTION
basically turn SourceInfo into two methods

get_next_message and add_partition. required

-- pulling all of the caching stuff out of source info and into the top level loop
-- extricating the relationship between sourceinfo and consistencyinfo -- now consistencyinfo drives sourceinfo around instead of both of them shouting at each other
-- change timestamper to report the set of partitions available instead of a partitioncount

pending:

~-- clean up the caching changes~

I'll do these next steps in a subsequent pr
-- rename SourceInfo -> SourceReader, more docs
-- remove extra fields from consistencyinfo
-- separate out each SourceInfo::new and consistencyinfo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6162)
<!-- Reviewable:end -->
