### PR TITLE
Tests around Avro deserialization and schema resolution

### DIFF
--- a/test/testdrive/avro-decode-mismatched-columns.td
+++ b/test/testdrive/avro-decode-mismatched-columns.td
@@ -1,0 +1,72 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that reading an Avro buffer with a schema different from the one that was used
+# when it was written does not cause panics or anything like that.
+#
+
+$ set 1column={"type": "record", "name": "schema_1column", "fields": [ {"name": "f1", "type": "int"} ] }
+$ set 2columns-nodefault={"type": "record", "name": "schema_2columns_nodefault", "fields": [ {"name": "f1", "type": "int"} , {"name": "f2", "type": "int"} ] }
+$ set 2columns-default={"type": "record", "name": "schema_2columns_default", "fields": [ {"name": "f1", "type": "int"} , {"name": "f2", "type": "int", "default": "345"} ] }
+
+#
+# 1 column -> 2 columns with no default
+#
+
+$ kafka-create-topic topic=decode-1to2-nodefault
+
+$ kafka-ingest format=avro topic=decode-1to2-nodefault schema=${1column} timestamp=1
+{"f1": 123}
+
+> CREATE MATERIALIZED SOURCE decode_1to2_nodefault
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-decode-1to2-nodefault-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${2columns-nodefault}'
+  ENVELOPE NONE
+
+! SELECT * FROM decode_1to2_nodefault
+avro deserialization error: IO error: UnexpectedEof
+
+#
+# 1 column -> 2 columns with default
+#
+
+$ kafka-create-topic topic=decode-1to2-default
+
+$ kafka-ingest format=avro topic=decode-1to2-default schema=${1column} timestamp=1
+{"f1": 123}
+
+> CREATE MATERIALIZED SOURCE decode_1to2_default
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-decode-1to2-default-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${2columns-default}'
+  ENVELOPE NONE
+
+! SELECT * FROM decode_1to2_default
+avro deserialization error: IO error: UnexpectedEof
+
+#
+# 2 columns -> 1 column
+#
+
+$ kafka-create-topic topic=decode-2to1
+
+$ kafka-ingest format=avro topic=decode-2to1 schema=${2columns-nodefault} timestamp=1
+{"f1": 123, "f2": 234}
+{"f2": 345, "f1": 456}
+
+> CREATE MATERIALIZED SOURCE decode_2to1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-decode-2to1-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${1column}'
+  ENVELOPE NONE
+
+> SELECT * FROM decode_2to1
+f1
+---
+123
+456

--- a/test/testdrive/avro-decode-mismatched-types.td
+++ b/test/testdrive/avro-decode-mismatched-types.td
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that reading an Avro buffer with a schema different from the one that was used
+# when it was written does not cause panics or anything like that.
+#
+# Note that this test uses inline Avro schemas and not the schema registry, so any
+# protections thus provided are not in force.
+#
+
+$ set null={"type": "record", "name": "field_null", "fields": [ {"name": "f1", "type": "null"} ] }
+$ set boolean={"type": "record", "name": "field_boolean", "fields": [ {"name": "f1", "type": "boolean"} ] }
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+$ set long={"type": "record", "name": "field_long", "fields": [ {"name": "f1", "type": "long"} ] }
+$ set float={"type": "record", "name": "field_float", "fields": [ {"name": "f1", "type": "float"} ] }
+$ set double={"type": "record", "name": "field_double", "fields": [ {"name": "f1", "type": "double"} ] }
+$ set bytes={"type": "record", "name": "field_bytes", "fields": [ {"name": "f1", "type": "bytes"} ] }
+$ set string={"type": "record", "name": "field_string", "fields": [ {"name": "f1", "type": "string"} ] }
+
+#
+# Null -> int
+#
+
+$ kafka-create-topic topic=avro-types-null2int
+
+$ kafka-ingest format=avro topic=avro-types-null2int schema=${null} timestamp=1
+{"f1": null}
+
+> CREATE MATERIALIZED SOURCE avro_types_null2int
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-null2int-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+! SELECT * FROM avro_types_null2int
+avro deserialization error: IO error: UnexpectedEof
+
+#
+# boolean -> int
+#
+
+$ kafka-create-topic topic=avro-types-boolean2int
+
+$ kafka-ingest format=avro topic=avro-types-boolean2int schema=${boolean} timestamp=1
+{"f1": true}
+{"f1": false}
+
+> CREATE MATERIALIZED SOURCE avro_types_boolean2int
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-boolean2int-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+# Bogus result, but at least we do not panic
+> SELECT f1 FROM avro_types_boolean2int
+-1
+0
+
+#
+# int -> long
+#
+
+$ kafka-create-topic topic=avro-types-int2long
+
+$ kafka-ingest format=avro topic=avro-types-int2long schema=${int} timestamp=1
+{"f1": 123}
+
+> CREATE MATERIALIZED SOURCE avro_types_int2long
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-int2long-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${long}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_types_int2long
+123
+
+#
+# int -> float
+#
+
+$ kafka-create-topic topic=avro-types-int2float
+
+$ kafka-ingest format=avro topic=avro-types-int2float schema=${int} timestamp=1
+{"f1": 123}
+
+> CREATE MATERIALIZED SOURCE avro_types_int2float
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-int2float-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${float}'
+  ENVELOPE NONE
+
+! SELECT * FROM avro_types_int2float
+avro deserialization error: IO error: UnexpectedEof
+
+#
+# long -> float
+#
+
+$ kafka-create-topic topic=avro-types-long2float
+
+$ kafka-ingest format=avro topic=avro-types-long2float schema=${long} timestamp=1
+{"f1": 992147483647}
+
+> CREATE MATERIALIZED SOURCE avro_types_long2float
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-long2float-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${float}'
+  ENVELOPE NONE
+
+# Bogus result but at least we do not panic
+> SELECT * FROM avro_types_long2float
+-0.0000000000000000000000000000000048554492
+
+#
+# long -> int
+#
+
+$ kafka-create-topic topic=avro-types-long2int
+
+$ kafka-ingest format=avro topic=avro-types-long2int schema=${long} timestamp=1
+{"f1": 992147483647}
+
+> CREATE MATERIALIZED SOURCE avro_types_long2int
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-long2int-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+! SELECT * FROM avro_types_long2int
+avro deserialization error: Decode error: Decoding error: Expected i32, got: 992147483647
+
+#
+# float -> double
+#
+
+$ kafka-create-topic topic=avro-types-float2double
+
+$ kafka-ingest format=avro topic=avro-types-float2double schema=${float} timestamp=1
+{"f1": 123456789.123456789}
+
+> CREATE MATERIALIZED SOURCE avro_types_float2double
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-float2double-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${double}'
+  ENVELOPE NONE
+
+! SELECT * FROM avro_types_float2double
+avro deserialization error: IO error: UnexpectedEof
+
+#
+# avro-typestion string -> bytes
+#
+
+$ kafka-create-topic topic=avro-types-string2bytes
+
+$ kafka-ingest format=avro topic=avro-types-string2bytes schema=${string} timestamp=1
+{"f1": "abc абц"}
+
+> CREATE MATERIALIZED SOURCE avro_types_string2bytes
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-types-string2bytes-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${bytes}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_types_string2bytes
+"abc \\xd0\\xb0\\xd0\\xb1\\xd1\\x86"

--- a/test/testdrive/avro-decode-multi-record.td
+++ b/test/testdrive/avro-decode-multi-record.td
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Multi-record schemas are rejected
+#
+
+$ set multi-record=[{"type": "record", "name": "f1", "fields": [ {"name": "f1", "type": "int"} ] }, {"type": "record", "name": "f2", "fields": [ {"name": "f2", "type": "int"} ] } ]
+
+$ kafka-create-topic topic=avro-decode-type-multi-record
+
+$ kafka-ingest format=avro topic=avro-decode-type-multi-record schema=${multi-record} timestamp=1
+{"f1": {"f1":123}}
+
+! CREATE MATERIALIZED SOURCE avro_decode_type_multi_record
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-type-multi-record-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${multi-record}'
+  ENVELOPE NONE
+row schemas must be records, got: Union

--- a/test/testdrive/avro-decode-no-record.td
+++ b/test/testdrive/avro-decode-no-record.td
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that attempting to decode something that is not a record results in a proper error
+#
+
+$ set no-record={"type": "map", "values" : "int" }
+
+$ kafka-create-topic topic=avro-decode-no-record
+
+$ kafka-ingest format=avro topic=avro-decode-no-record schema=${no-record} timestamp=1
+{"f1":123}
+
+! CREATE MATERIALIZED SOURCE avro_decode_no_record
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-no-record-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${no-record}'
+  ENVELOPE NONE
+validating avro value schema: row schemas must be records, got: Map(Piece(Int))

--- a/test/testdrive/avro-decode-temporal.td
+++ b/test/testdrive/avro-decode-temporal.td
@@ -1,0 +1,155 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# 'date' is days since the start of the UNiX epoch
+
+$ set date={"type": "record", "name": "date_field", "fields": [ { "name": "f1", "type": { "logicalType": "date", "type": "int" } } ] }
+
+$ kafka-create-topic topic=avro-decode-date
+
+$ kafka-ingest format=avro topic=avro-decode-date schema=${date} timestamp=1
+{"f1": -1}
+{"f1": 0}
+{"f1": 1}
+{"f1": 12345678}
+
+> CREATE MATERIALIZED SOURCE avro_decode_date
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-date-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${date}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_decode_date
+1969-12-31
+1970-01-01
+1970-01-02
++35771-04-27
+
+# Time and time-millis do not appear to be decoded to a temporal data type, see rc/avro/tests/schema.rs
+
+$ set time-millis={"type": "record", "name": "time_millis_field", "fields": [ { "name": "f1", "type": { "logicalType": "time-millis", "type": "int" } } ] }
+
+$ kafka-create-topic topic=avro-decode-time-millis
+
+$ kafka-ingest format=avro topic=avro-decode-time-millis schema=${time-millis} timestamp=1
+{"f1": -10}
+{"f1": 0}
+{"f1": 1}
+{"f1": 12345678}
+
+> CREATE MATERIALIZED SOURCE avro_decode_time_millis
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-date-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${time-millis}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_decode_time_millis
+-1
+0
+1
+12345678
+
+#
+# timestamp-millis
+#
+
+$ set timestamp-millis={"type": "record", "name": "timestamp_millis_field", "fields": [ { "name": "f1", "type": { "logicalType": "timestamp-millis", "type": "long" } } ] }
+
+$ kafka-create-topic topic=avro-decode-timestamp-millis
+
+$ kafka-ingest format=avro topic=avro-decode-timestamp-millis schema=${timestamp-millis} timestamp=1
+{"f1": 0}
+{"f1": 1}
+{"f1": 10}
+{"f1": 100}
+{"f1": 1000}
+{"f1": 10000}
+{"f1": 61000}
+{"f1": 1234567890}
+
+> CREATE MATERIALIZED SOURCE avro_decode_timestamp_millis
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-timestamp-millis-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${timestamp-millis}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_decode_timestamp_millis
+"1970-01-01 00:00:00"
+"1970-01-01 00:00:00.001"
+"1970-01-01 00:00:00.010"
+"1970-01-01 00:00:00.100"
+"1970-01-01 00:00:01"
+"1970-01-01 00:00:10"
+"1970-01-01 00:01:01"
+"1970-01-15 06:56:07.890"
+
+#
+# timestamp-micros
+#
+
+$ set timestamp-micros={"type": "record", "name": "timestamp_micros_field", "fields": [ { "name": "f1", "type": { "logicalType": "timestamp-micros", "type": "long" } } ] }
+
+$ kafka-create-topic topic=avro-decode-timestamp-micros
+
+$ kafka-ingest format=avro topic=avro-decode-timestamp-micros schema=${timestamp-micros} timestamp=1
+{"f1": 0}
+{"f1": 1}
+{"f1": 10}
+{"f1": 100}
+{"f1": 1000}
+{"f1": 10000}
+{"f1": 61000000}
+{"f1": 1234567890}
+
+> CREATE MATERIALIZED SOURCE avro_decode_timestamp_micros
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-timestamp-micros-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${timestamp-micros}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_decode_timestamp_micros
+"1970-01-01 00:00:00"
+"1970-01-01 00:00:00.000001"
+"1970-01-01 00:00:00.000010"
+"1970-01-01 00:00:00.000100"
+"1970-01-01 00:00:00.001"
+"1970-01-01 00:00:00.010"
+"1970-01-01 00:01:01"
+"1970-01-01 00:20:34.567890"
+
+#
+# local-timestamp-millis is not decoded to a temporal type
+#
+
+$ set local-timestamp-millis={"type": "record", "name": "timestamp_millis_field", "fields": [ { "name": "f1", "type": { "logicalType": "local-timestamp-millis", "type": "long" } } ] }
+
+$ kafka-create-topic topic=avro-decode-local-timestamp-millis
+
+$ kafka-ingest format=avro topic=avro-decode-local-timestamp-millis schema=${local-timestamp-millis} timestamp=1
+{"f1": 0}
+{"f1": 1}
+{"f1": 10}
+{"f1": 100}
+{"f1": 1000}
+{"f1": 10000}
+{"f1": 1234567890}
+
+> CREATE MATERIALIZED SOURCE avro_decode_local_timestamp_millis
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-decode-local-timestamp-millis-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${local-timestamp-millis}'
+  ENVELOPE NONE
+
+> SELECT * FROM avro_decode_local_timestamp_millis
+0
+1
+10
+100
+1000
+10000
+1234567890
+
+#
+# duration is not tested because there is no support for "fixed"
+#

--- a/test/testdrive/avro-resolution-enums.td
+++ b/test/testdrive/avro-resolution-enums.td
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that compatible writer and reader enums work
+#
+
+$ set enum-reader={"type": "record", "name": "schema_enum", "fields": [ {"name": "f1", "type": { "type": "enum", "name": "enum1", "symbols" : ["E1", "E2", "E3", "E4", "E_DEFAULT"], "default": "E_DEFAULT" } } ] }
+$ set enum-writer={"type": "record", "name": "schema_enum", "fields": [ {"name": "f1", "type": { "type": "enum", "name": "enum1", "symbols" : ["E2", "E3", "E4", "E5"] } } ] }
+
+$ kafka-create-topic topic=resolution-enums
+
+$ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} publish=true timestamp=1
+{"f1": "E1" }
+
+> CREATE MATERIALIZED SOURCE resolution_enums
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-enums-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+# E5 will be recorded as E_DEFAULT
+$ kafka-ingest format=avro topic=resolution-enums schema=${enum-writer} publish=true timestamp=2
+{"f1": "E5" }
+
+$ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} publish=true timestamp=1
+{"f1": "E1" }
+
+> SHOW COLUMNS FROM resolution_enums
+f1 false text
+
+> SELECT f1 FROM resolution_enums
+E1
+E1
+E_DEFAULT

--- a/test/testdrive/avro-resolution-less-columns.td
+++ b/test/testdrive/avro-resolution-less-columns.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Allow a writer schema that has a smaller number of columns if the reader schema has specified a default
+#
+
+$ set 2columns={"type": "record", "name": "schema_less_columns", "fields": [ {"name": "f1", "type": "string", "default": "default_f1"} , {"name": "f2", "type": "string", "default": "default_f2"}] }
+$ set 1column={"type": "record", "name": "schema_less_columns", "fields": [ {"name": "f1", "type": "string"} ] }
+
+$ kafka-create-topic topic=resolution-2to1
+
+$ kafka-ingest format=avro topic=resolution-2to1 schema=${2columns} publish=true timestamp=1
+{"f1": "val_f1a", "f2": "val_f2a"}
+
+> CREATE MATERIALIZED SOURCE resolution_2to1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-2to1-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-2to1 schema=${1column} publish=true timestamp=2
+{"f1": "val_f1b"}
+
+> SELECT * FROM resolution_2to1
+f1 f2
+---
+val_f1a val_f2a
+val_f1b default_f2

--- a/test/testdrive/avro-resolution-more-columns.td
+++ b/test/testdrive/avro-resolution-more-columns.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test writing more columns in a source that has less columns. The extra columns are ignored
+#
+
+$ set 1column={"type": "record", "name": "schema_more_columns", "fields": [ {"name": "f1", "type": "string"} ] }
+$ set 2columns={"type": "record", "name": "schema_more_columns", "fields": [ {"name": "f1", "type": "string"} , {"name": "f2", "type": "string", "default": "default_f2"}] }
+
+$ kafka-create-topic topic=resolution-1to2
+
+$ kafka-ingest format=avro topic=resolution-1to2 schema=${1column} publish=true timestamp=1
+{"f1": "val_f1b"}
+
+> CREATE MATERIALIZED SOURCE resolution_1to2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-1to2-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-1to2 schema=${2columns} publish=true timestamp=2
+{"f1": "val_f1a", "f2": "val_f2a"}
+
+> SELECT * FROM resolution_1to2
+f1
+---
+val_f1a
+val_f1b

--- a/test/testdrive/avro-resolution-no-publish-reader.td
+++ b/test/testdrive/avro-resolution-no-publish-reader.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test the case where we fail to publish the schema of the reader
+#
+
+$ set int-schema={"type": "record", "name": "schema_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=resolution-no-publish-writer
+
+$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
+{"f1": 123}
+
+> DROP SCHEMA IF EXISTS public CASCADE
+> CREATE SCHEMA public
+
+! CREATE MATERIALIZED SOURCE resolution_no_publish_writer
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-no-publish-writer-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+subject not found

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test the case where we fail to publish the schema of the writer
+#
+
+$ set int-schema={"type": "record", "name": "schema_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=resolution-no-publish-writer
+
+$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} publish=true timestamp=1
+{"f1": 123}
+
+> DROP SCHEMA IF EXISTS public CASCADE
+> CREATE SCHEMA public
+
+> CREATE MATERIALIZED SOURCE resolution_no_publish_writer
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-no-publish-writer-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
+{"f1": 123}
+
+! SELECT * FROM resolution_no_publish_writer;
+Failed to fetch schema

--- a/test/testdrive/avro-resolution-notnull2null.td
+++ b/test/testdrive/avro-resolution-notnull2null.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to introduce NULL values into a source that does not accept nulls - should fail
+#
+
+$ set not-null={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": ["int" ] } ] }
+$ set null={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": ["null", "int" ] } ] }
+
+$ kafka-create-topic topic=resolution-unions
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${not-null} publish=true timestamp=1
+{"f1": {"int": 123 } }
+
+> CREATE MATERIALIZED SOURCE resolution_unions
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-unions-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${null} publish=true timestamp=2
+{"f1": null }
+{"f1": {"int": 123 } }
+
+! SELECT f1 FROM resolution_unions
+Decode error: Text: avro deserialization error: Schema resolution error: Failed to match Null against any variant in the reader

--- a/test/testdrive/avro-resolution-types-array.td
+++ b/test/testdrive/avro-resolution-types-array.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that schema incompatibility issues within arrays are detected and reported
+#
+
+$ set array-double={"type": "record", "name": "schema_array", "fields": [ {"name": "f1", "type": { "type": "array", "items": "double" } } ] }
+$ set array-int={"type": "record", "name": "schema_array", "fields": [ {"name": "f1", "type": { "type": "array", "items": "int" } } ] }
+
+$ kafka-create-topic topic=resolution-arrays
+
+$ kafka-ingest format=avro topic=resolution-arrays schema=${array-int} publish=true timestamp=1
+{"f1": [ 123 ] }
+
+> CREATE MATERIALIZED SOURCE resolution_arrays
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-arrays-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-arrays schema=${array-double} publish=true timestamp=2
+{"f1": [ 234.345 ] }
+
+! SELECT f1[0] FROM resolution_arrays
+Failed to fetch schema

--- a/test/testdrive/avro-resolution-types-map.td
+++ b/test/testdrive/avro-resolution-types-map.td
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that schema incompatibility issues within maps are detected and reported
+#
+
+$ set map-double={"type": "record", "name": "schema_map", "fields": [ {"name": "f1", "type": { "type": "map", "values": "double" } } ] }
+$ set map-int={"type": "record", "name": "schema_map", "fields": [ {"name": "f1", "type": { "type": "map", "values": "int" } } ] }
+
+$ kafka-create-topic topic=resolution-maps
+
+$ kafka-ingest format=avro topic=resolution-maps schema=${map-int} publish=true timestamp=1
+{"f1": { "key1": 123 } }
+
+> CREATE MATERIALIZED SOURCE resolution_maps
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-maps-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-maps schema=${map-double} publish=true timestamp=2
+{"f1": { "key1": 234.345 } }
+
+! SELECT f1 -> 'key1' FROM resolution_maps
+Failed to fetch schema

--- a/test/testdrive/avro-resolution-types-records.td
+++ b/test/testdrive/avro-resolution-types-records.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to push a double value inside a record into a int source. According to the schema registry
+# this is allowed, so it is up to Materialize to reject it.
+#
+
+$ set int-col={"type": "record", "name": "outer", "fields": [ {"name": "f1", "type": {"type": "record", "name": "inner", "fields": [ {"name": "f1", "type": "int" } ] } } ] }
+$ set double-col={"type": "record", "name": "outer", "fields": [ {"name": "f1", "type": {"type": "record", "name": "inner", "fields": [ {"name": "f1", "type": "double" } ] } } ] }
+
+$ kafka-create-topic topic=resolution-records-int2double
+
+$ kafka-ingest format=avro topic=resolution-records-int2double schema=${int-col} publish=true timestamp=1
+{"f1": { "f1": 123 }}
+
+> CREATE MATERIALIZED SOURCE resolution_records_int2double
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-records-int2double-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-records-int2double schema=${double-col} publish=true timestamp=2
+{"f1": { "f1": 123.234 }}
+
+! SELECT * FROM resolution_records_int2double
+Failed to fetch schema

--- a/test/testdrive/avro-resolution-types.td
+++ b/test/testdrive/avro-resolution-types.td
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that we reject changes of basic column types even if the schema registry reports that the two
+# schemas are compatible. It is up to Materialize to reject the value
+#
+
+$ set int-col={"type": "record", "name": "schema_int_double", "fields": [ {"name": "f1", "type": "int"} ] }
+$ set double-col={"type": "record", "name": "schema_int_double", "fields": [ {"name": "f1", "type": "double"} ] }
+
+$ kafka-create-topic topic=resolution-int2double
+
+$ kafka-ingest format=avro topic=resolution-int2double schema=${int-col} publish=true timestamp=1
+{"f1": 123}
+
+> CREATE MATERIALIZED SOURCE resolution_int2double
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-int2double-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-int2double schema=${double-col} publish=true timestamp=2
+{"f1": 234.456}
+
+! SELECT * FROM resolution_int2double
+Failed to fetch schema

--- a/test/testdrive/avro-resolution-union-reader.td
+++ b/test/testdrive/avro-resolution-union-reader.td
@@ -1,0 +1,33 @@
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to write a non-union into a union source
+#
+
+$ set union-int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": [ "int" ] } ] }
+$ set int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": "int" } ] }
+
+$ kafka-create-topic topic=resolution-unions
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=true timestamp=1
+{"f1": {"int": 123 } }
+
+> CREATE MATERIALIZED SOURCE resolution_unions
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-unions-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${int} publish=true timestamp=2
+{"f1": 234 }
+
+> SELECT f1 FROM resolution_unions
+123
+234

--- a/test/testdrive/avro-resolution-union-writer.td
+++ b/test/testdrive/avro-resolution-union-writer.td
@@ -1,0 +1,33 @@
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to write a union into a non-union source
+#
+
+$ set union-int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": [ "int" ] } ] }
+$ set int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": "int" } ] }
+
+$ kafka-create-topic topic=resolution-unions
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${int} publish=true timestamp=1
+{"f1": 234 }
+
+> CREATE MATERIALIZED SOURCE resolution_unions
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-unions-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=true timestamp=2
+{"f1": {"int": 123 } }
+
+> SELECT f1 FROM resolution_unions
+234
+123

--- a/test/testdrive/avro-resolution-unions.td
+++ b/test/testdrive/avro-resolution-unions.td
@@ -1,0 +1,33 @@
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Attempt to introduce a new element in a union - should fail
+#
+
+$ set union-int-string={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": ["int", "string"] } ] }
+$ set union-int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", "type": ["int"] } ] }
+
+$ kafka-create-topic topic=resolution-unions
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=true timestamp=1
+{"f1": {"int": 123 } }
+
+> CREATE MATERIALIZED SOURCE resolution_unions
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-resolution-unions-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int-string} publish=true timestamp=2
+{"f1": {"int": 123 } }
+{"f1": {"string": "abc" } }
+
+! SELECT f1 FROM resolution_unions
+avro deserialization error: Schema resolution error: Failed to match String against any variant in the reader

--- a/test/testdrive/schema-registry-network-errors.td
+++ b/test/testdrive/schema-registry-network-errors.td
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that various network-level errors are handled without panics or other unexpected issues
+# The error messages recored herein are the ones currently returned, even if not very informative.
+#
+
+#
+# Point to invalid host:port
+#
+
+! CREATE MATERIALIZED SOURCE foo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://127.0.0.1:65535'
+  ENVELOPE NONE
+connect error: Connection refused
+
+#
+# Point to invalid URL schema
+#
+
+! CREATE MATERIALIZED SOURCE foo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'ftp://127.0.0.1'
+  ENVELOPE NONE
+URL scheme is not allowed
+
+#
+# Point to a valid HTTP/S URL that is not a registry service
+#
+
+! CREATE MATERIALIZED SOURCE foo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}/no-such-path'
+  ENVELOPE NONE
+fetching latest schema for subject 'foo-value' from registry: subject not found
+
+#
+# HTTP connection to an HTTPS port
+#
+
+! CREATE MATERIALIZED SOURCE foo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://www.materialize.com:443'
+  ENVELOPE NONE
+fetching latest schema for subject 'foo-value' from registry: server error 400: unable to decode error details
+
+
+#
+# HTTPS connection to an HTTP port
+#
+
+! CREATE MATERIALIZED SOURCE foo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://www.materialize.com'
+  ENVELOPE NONE
+fetching latest schema for subject 'foo-value' from registry: server error 301: unable to decode error details


### PR DESCRIPTION
Those are the tests that I was able to produce. They include the following:

- tests for deserializing data using the wrong schema. We expect no panics and such even if the result can not be expected to be correct
- tests for deserializing temporal data from Avro (using the supported logicalType-s)
- tests for schema upgrades where the Schema Registry rejects the writer schema due to compatibility rules
- tests for schema upgrades where the Schema Registry accepts the schema , but MZ rejects it
- tests for the rare cases where a schema upgrade is accepted by all parties
- a test that covers various HTTP and TCP-level errors that can happen with the schema registry

This is all that I could come up at this time. Please let me know if you want anything else tested or I would be moving on to other stuff.

All the errors recorded in those tests, informative or not, is what is currently returned by the server. I have opened a couple of tickets about making specific error messages more helpful. Apart from those tickets , there is also the general tendency of error messages to dump internal MZ data structures and struct names -- those could also be intimidating to users.

Thank you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6167)
<!-- Reviewable:end -->
