### PR TITLE
Validate inputs when creating Kafka exactly-once Sinks

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -297,6 +297,13 @@ impl CatalogItem {
         }
     }
 
+    pub fn source_connector(&self, name: &FullName) -> Result<&SourceConnector, SqlCatalogError> {
+        match &self {
+            CatalogItem::Source(source) => Ok(&source.connector),
+            _ => Err(SqlCatalogError::UnknownSource(name.to_string())),
+        }
+    }
+
     /// Collects the identifiers of the dataflows that this item depends
     /// upon.
     pub fn uses(&self) -> &[GlobalId] {
@@ -405,6 +412,12 @@ impl CatalogEntry {
     /// Returns the [`sql::func::Func`] associated with this `CatalogEntry`.
     pub fn func(&self) -> Result<&'static sql::func::Func, SqlCatalogError> {
         self.item.func(&self.name)
+    }
+
+    /// Returns the [`dataflow_types::SourceConnector`] associated with
+    /// this `CatalogEntry`.
+    pub fn source_connector(&self) -> Result<&SourceConnector, SqlCatalogError> {
+        self.item.source_connector(&self.name)
     }
 
     /// Reports whether this catalog entry is a table.
@@ -2347,6 +2360,10 @@ impl sql::catalog::CatalogItem for CatalogEntry {
 
     fn func(&self) -> Result<&'static sql::func::Func, SqlCatalogError> {
         Ok(self.func()?)
+    }
+
+    fn source_connector(&self) -> Result<&SourceConnector, SqlCatalogError> {
+        Ok(self.source_connector()?)
     }
 
     fn create_sql(&self) -> &str {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -549,6 +549,25 @@ pub enum SourceConnector {
     Local,
 }
 
+impl SourceConnector {
+    /// Returns `true` if this connector yields input data (including
+    /// timestamps) that is stable across restarts. This is important for
+    /// exactly-once Sinks that need to ensure that the same data is written,
+    /// even when failures/restarts happen.
+    pub fn yields_stable_input(&self) -> bool {
+        if let SourceConnector::External {
+            connector: ExternalSourceConnector::Kafka(_),
+            consistency: Consistency::BringYourOwn(_),
+            ..
+        } = self
+        {
+            true
+        } else {
+            false
+        }
+    }
+}
+
 pub fn cached_files(e: &ExternalSourceConnector) -> Vec<PathBuf> {
     match e {
         ExternalSourceConnector::Kafka(KafkaSourceConnector { cached_files, .. }) => {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -17,6 +17,7 @@ use std::time::Instant;
 use std::{error::Error, unimplemented};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
+use dataflow_types::SourceConnector;
 use lazy_static::lazy_static;
 
 use build_info::{BuildInfo, DUMMY_BUILD_INFO};
@@ -218,6 +219,12 @@ pub trait CatalogItem {
     /// anything other than a function), it returns an error.
     fn func(&self) -> Result<&'static Func, CatalogError>;
 
+    /// Returns the resolved source connector.
+    ///
+    /// If the catalog item is not of a type that contains a `SourceConnector`
+    /// (i.e., anything other than sources), it returns an error.
+    fn source_connector(&self) -> Result<&SourceConnector, CatalogError>;
+
     /// Returns the type of the catalog item.
     fn item_type(&self) -> CatalogItemType;
 
@@ -290,6 +297,8 @@ pub enum CatalogError {
     UnknownItem(String),
     /// Unknown function.
     UnknownFunction(String),
+    /// Unknown source.
+    UnknownSource(String),
     /// Invalid attempt to depend on a non-dependable item.
     InvalidDependency {
         /// The invalid item's name.
@@ -304,6 +313,7 @@ impl fmt::Display for CatalogError {
         match self {
             Self::UnknownDatabase(name) => write!(f, "unknown database '{}'", name),
             Self::UnknownFunction(name) => write!(f, "function \"{}\" does not exist", name),
+            Self::UnknownSource(name) => write!(f, "source \"{}\" does not exist", name),
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -46,9 +46,35 @@ $ kafka-create-topic topic=input
 
 > CREATE MATERIALIZED VIEW input_kafka_byo_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_byo;
 
+> CREATE MATERIALIZED VIEW input_kafka_byo_mview_view AS SELECT * FROM input_kafka_byo_mview;
+
 > CREATE VIEW input_kafka_no_byo_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_no_byo;
 
+> CREATE MATERIALIZED VIEW input_kafka_no_byo_mview_view AS SELECT * FROM input_kafka_no_byo_mview;
+
 > CREATE MATERIALIZED VIEW input_table_mview AS SELECT a + 2 AS a , b + 10 AS b from input_table;
+
+> CREATE VIEW input_values_view AS VALUES (1), (2), (3);
+
+> CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
+
+> CREATE VIEW input_kafka_no_byo_join_view AS SELECT * FROM input_kafka_byo, input_kafka_no_byo;
+
+> CREATE MATERIALIZED VIEW input_kafka_no_byo_join_mview AS SELECT * FROM input_kafka_no_byo, input_kafka_byo;
+
+> CREATE MATERIALIZED VIEW input_kafka_no_byo_scalar_subquery AS SELECT (SELECT a FROM input_kafka_no_byo LIMIT 1) FROM input_kafka_byo;
+
+> CREATE MATERIALIZED VIEW input_kafka_no_byo_derived_table AS SELECT * FROM ( SELECT * FROM input_kafka_no_byo ) AS a1;
+
+$ file-append path=static.csv
+city,state,zip
+Rochester,NY,14618
+New York,NY,10004
+"bad,place""",CA,92679
+
+> CREATE SOURCE input_csv
+  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FORMAT CSV WITH 3 COLUMNS
 
 > CREATE SINK output1 FROM input_kafka_byo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
@@ -72,7 +98,18 @@ all inputs of an exactly-once Kafka sink must be sources, materialize.public.inp
   WITH (exactly_once=true, consistency=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
+> CREATE SINK output4_view FROM input_kafka_byo_mview_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
 ! CREATE SINK output5 FROM input_kafka_no_byo_mview
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output5_view FROM input_kafka_no_byo_mview_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
   WITH (exactly_once=true, consistency=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -83,3 +120,45 @@ all input sources of an exactly-once Kafka sink must be replayable, materialize.
   WITH (exactly_once=true, consistency=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not
+
+! CREATE SINK output7 FROM input_values_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_view is not
+
+! CREATE SINK output8 FROM input_values_mview
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_values_mview is not
+
+! CREATE SINK output9 FROM input_kafka_no_byo_join_view
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output9 FROM input_kafka_no_byo_join_mview
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output9 FROM input_kafka_no_byo_scalar_subquery
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output9 FROM input_kafka_no_byo_derived_table
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output9 FROM input_csv
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_csv is not

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -1,0 +1,85 @@
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set schema={
+    "type": "record",
+    "name": "envelope",
+    "fields": [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {"name": "a", "type": "long"},
+              {"name": "b", "type": "long"}
+            ]
+          },
+          "null"
+        ]
+      },
+      { "name": "after", "type": ["row", "null"] }
+    ]
+  }
+
+$ kafka-create-topic topic=input-consistency
+$ kafka-create-topic topic=input
+
+> CREATE MATERIALIZED SOURCE input_kafka_byo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+    WITH (consistency = 'testdrive-input-consistency-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE MATERIALIZED SOURCE input_kafka_no_byo
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+
+> CREATE TABLE input_table (a bigint, b bigint)
+
+> CREATE MATERIALIZED VIEW input_kafka_byo_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_byo;
+
+> CREATE VIEW input_kafka_no_byo_mview AS SELECT a + 2 AS a , b + 10 AS b from input_kafka_no_byo;
+
+> CREATE MATERIALIZED VIEW input_table_mview AS SELECT a + 2 AS a , b + 10 AS b from input_table;
+
+> CREATE SINK output1 FROM input_kafka_byo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+! CREATE SINK output2 FROM input_kafka_no_byo
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output3 FROM input_table
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not
+
+> CREATE SINK output4 FROM input_kafka_byo_mview
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+! CREATE SINK output5 FROM input_kafka_no_byo_mview
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all input sources of an exactly-once Kafka sink must be replayable, materialize.public.input_kafka_no_byo is not
+
+! CREATE SINK output6 FROM input_table_mview
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-view-${testdrive.seed}'
+  WITH (exactly_once=true, consistency=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+all inputs of an exactly-once Kafka sink must be sources, materialize.public.input_table is not


### PR DESCRIPTION
I'm not married to where the check is performed and to the method being on `SourceConnector`. This seemed sensible to me but I'm open to suggestions.

Also, right now we only allow Kafka + BYO consistency as valid input for Kafka EO Sinks. And the test coverage is not exhaustive, I didn't add File sources, Kinesis, and some others.

This closes #6121.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6168)
<!-- Reviewable:end -->
