### PR TITLE
the final SourceInfo refactor!

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -33,7 +33,9 @@ use crate::render::context::Context;
 use crate::render::RenderState;
 use crate::server::LocalInput;
 use crate::source::SourceConfig;
-use crate::source::{self, FileSourceInfo, KafkaSourceInfo, KinesisSourceInfo, S3SourceInfo};
+use crate::source::{
+    self, FileSourceReader, KafkaSourceReader, KinesisSourceReader, S3SourceReader,
+};
 
 impl<'g, G> Context<Child<'g, G, G::Timestamp>, MirRelationExpr, Row, Timestamp>
 where
@@ -149,7 +151,7 @@ where
                     connector
                 {
                     let ((source, err_source), capability) =
-                        source::create_source::<_, FileSourceInfo<Value>, Value>(
+                        source::create_source::<_, FileSourceReader<Value>, Value>(
                             source_config,
                             connector,
                         );
@@ -185,19 +187,22 @@ where
                 } else {
                     let ((ok_source, err_source), capability) = match connector {
                         ExternalSourceConnector::Kafka(_) => {
-                            source::create_source::<_, KafkaSourceInfo, _>(source_config, connector)
+                            source::create_source::<_, KafkaSourceReader, _>(
+                                source_config,
+                                connector,
+                            )
                         }
                         ExternalSourceConnector::Kinesis(_) => {
-                            source::create_source::<_, KinesisSourceInfo, _>(
+                            source::create_source::<_, KinesisSourceReader, _>(
                                 source_config,
                                 connector,
                             )
                         }
                         ExternalSourceConnector::S3(_) => {
-                            source::create_source::<_, S3SourceInfo, _>(source_config, connector)
+                            source::create_source::<_, S3SourceReader, _>(source_config, connector)
                         }
                         ExternalSourceConnector::File(_) => {
-                            source::create_source::<_, FileSourceInfo<Vec<u8>>, Vec<u8>>(
+                            source::create_source::<_, FileSourceReader<Vec<u8>>, Vec<u8>>(
                                 source_config,
                                 connector,
                             )

--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -26,10 +26,7 @@ use expr::{PartitionId, SourceInstanceId};
 use mz_avro::types::Value;
 use mz_avro::{AvroRead, Schema, Skip};
 
-use crate::logging::materialized::Logger;
-use crate::source::{
-    ConsistencyInfo, NextMessage, PartitionMetrics, SourceConstructor, SourceInfo, SourceMessage,
-};
+use crate::source::{ConsistencyInfo, NextMessage, SourceConstructor, SourceInfo, SourceMessage};
 
 /// Contains all information necessary to ingest data from file sources (either
 /// regular sources, or Avro OCF sources)
@@ -60,12 +57,10 @@ impl From<FileOffset> for MzOffset {
 
 impl SourceConstructor<Value> for FileSourceInfo<Value> {
     fn new(
-        name: String,
+        _name: String,
         source_id: SourceInstanceId,
         active: bool,
         _: usize,
-        _: usize,
-        logger: Option<Logger>,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
@@ -106,11 +101,9 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
         };
 
         if active {
-            consistency_info.partition_metrics.insert(
-                PartitionId::File,
-                PartitionMetrics::new(&name, source_id, "", logger),
-            );
-            consistency_info.update_partition_metadata(&PartitionId::File);
+            let pid = PartitionId::File;
+            consistency_info.source_metrics.add_partition(&pid);
+            consistency_info.update_partition_metadata(&pid);
         }
 
         Ok(FileSourceInfo {
@@ -123,12 +116,10 @@ impl SourceConstructor<Value> for FileSourceInfo<Value> {
 
 impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
     fn new(
-        name: String,
+        _name: String,
         source_id: SourceInstanceId,
         active: bool,
         worker_id: usize,
-        _: usize,
-        logger: Option<Logger>,
         consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
         consistency_info: &mut ConsistencyInfo,
@@ -167,11 +158,9 @@ impl SourceConstructor<Vec<u8>> for FileSourceInfo<Vec<u8>> {
         };
 
         if active {
-            consistency_info.partition_metrics.insert(
-                PartitionId::File,
-                PartitionMetrics::new(&name, source_id, "", logger),
-            );
-            consistency_info.update_partition_metadata(&PartitionId::File);
+            let pid = PartitionId::File;
+            consistency_info.source_metrics.add_partition(&pid);
+            consistency_info.update_partition_metadata(&pid);
         }
 
         Ok(FileSourceInfo {

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -127,7 +127,7 @@ impl fmt::Display for SourceInstanceId {
 
 /// Unique identifier for each part of a whole source.
 ///     Kafka -> partition
-///     Kinesis -> shard
+///     Kinesis -> currently treated as single partition, should be shard.
 ///     File -> only one
 ///     S3 -> https://github.com/MaterializeInc/materialize/issues/5715
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -143,7 +143,8 @@ impl fmt::Display for PartitionId {
         match self {
             PartitionId::Kafka(id) => write!(f, "{}", id.to_string()),
             PartitionId::S3 => write!(f, "s3"),
-            _ => write!(f, "0"),
+            PartitionId::Kinesis => write!(f, "kinesis"),
+            PartitionId::File => write!(f, "0"),
         }
     }
 }


### PR DESCRIPTION
removes all dependency on ConsistencyInfo from Source* traits
combines SourceConstructor and SourceInfo into one trait named SourceReader with 3 hopefully clear methods.

I hope this makes it a lot easier for folks to write new sources / make changes in this area of the code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6171)
<!-- Reviewable:end -->
