### PR TITLE
Add support for pubnub sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -731,6 +731,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "datadriven"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +804,7 @@ dependencies = [
  "pdqselect",
  "prometheus",
  "prometheus-static-metric",
+ "pubnub-hyper",
  "rand 0.8.3",
  "rdkafka",
  "regex",
@@ -861,6 +897,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +988,12 @@ dependencies = [
  "serde_derive",
  "timely",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "duct"
@@ -1070,6 +1137,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-iter"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09bfe3000e5aaf2904d2c90e8f38de83dff06731c666d588d382f19da6606a9"
+
+[[package]]
 name = "expr"
 version = "0.0.0"
 dependencies = [
@@ -1202,6 +1275,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "fs_extra"
@@ -1377,6 +1456,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b328c01a4d71d2d8173daa93562a73ab0fe85616876f02500f53d82948c504"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1599,6 +1690,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2130,6 +2227,33 @@ checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi",
+]
+
+[[package]]
+name = "mockall"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01458f8a19b10cb28195290942e3149161c75acf67ebc8fbf714ab67a2b943bc"
+dependencies = [
+ "cfg-if 0.1.10",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a673cb441f78cd9af4f5919c28576a3cc325fb6b54e42f7047dacce3c718c17b"
+dependencies = [
+ "cfg-if 0.1.10",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3057,6 +3181,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e0cd97c440c06c0ca7f056a27dee4669a723a0b952e065542958bf3ccc8f1c"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pubnub-core"
+version = "0.1.0"
+source = "git+https://github.com/MaterializeInc/pubnub-rust#d51e28438b8ccc14e7b9d714653f62d98059351f"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "error-iter",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "json",
+ "log",
+ "mockall",
+ "percent-encoding",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
+name = "pubnub-hyper"
+version = "0.1.0"
+source = "git+https://github.com/MaterializeInc/pubnub-rust#d51e28438b8ccc14e7b9d714653f62d98059351f"
+dependencies = [
+ "async-trait",
+ "derive_builder",
+ "error-iter",
+ "futures-util",
+ "getset",
+ "http",
+ "hyper",
+ "hyper-tls",
+ "log",
+ "pubnub-core",
+ "pubnub-util",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "pubnub-util"
+version = "0.1.0"
+source = "git+https://github.com/MaterializeInc/pubnub-rust#d51e28438b8ccc14e7b9d714653f62d98059351f"
+dependencies = [
+ "base64",
+ "hmac",
+ "sha2",
+ "uritemplate-next",
 ]
 
 [[package]]
@@ -3994,6 +4168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
 name = "structopt"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4625,6 +4805,15 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "uritemplate-next"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcde98d1fc3f528255b1ecb22fb688ee0d23deb672a8c57127df10b98b4bd18c"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "url"

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -15,6 +15,14 @@
         composition: smith
         run: ci
 
+- id: pubnub
+  label: "pubnub source"
+  depends_on: build
+  plugins:
+    - ./ci/plugins/mzcompose:
+        composition: pubnub
+        run: pubnub
+
 - id: kafka-matrix
   label: Kafka smoke test against previous Kafka versions
   plugins:

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ skip = [
 
     # Waiting for clap to upgrade to v0.12.
     { name = "ansi_term", version = "0.11.0" },
+    # Waiting for clap to upgrade to v0.10.
+    { name = "strsim", version = "0.8.0" },
 
     # Waiting on:
     #   - Upgrade to rand v0.8.
@@ -47,6 +49,7 @@ private = { ignore = true }
 unknown-git = "deny"
 unknown-registry = "deny"
 allow-git = [
+    "https://github.com/MaterializeInc/pubnub-rust.git",
     "https://github.com/MaterializeInc/rust-prometheus.git",
     "https://github.com/MaterializeInc/serde-protobuf.git",
     "https://github.com/TimelyDataflow/timely-dataflow",

--- a/src/coord/src/coord/metrics.rs
+++ b/src/coord/src/coord/metrics.rs
@@ -29,6 +29,7 @@ lazy_static! {
     static ref SOURCE_COUNT_FILE: UIntGauge = SOURCES.with_label_values(&["file"]);
     static ref SOURCE_COUNT_KAFKA: UIntGauge = SOURCES.with_label_values(&["kafka"]);
     static ref SOURCE_COUNT_KINESIS: UIntGauge = SOURCES.with_label_values(&["kinesis"]);
+    static ref SOURCE_COUNT_PUBNUB: UIntGauge = SOURCES.with_label_values(&["pubnub"]);
     static ref SOURCE_COUNT_POSTGRES: UIntGauge = SOURCES.with_label_values(&["postgres"]);
     static ref SOURCE_COUNT_S3: UIntGauge = SOURCES.with_label_values(&["s3"]);
     static ref SOURCE_COUNT_TABLE: UIntGauge = SOURCES.with_label_values(&["table"]);
@@ -61,6 +62,7 @@ pub(super) fn item_created(id: GlobalId, item: &CatalogItem) {
                 ExternalSourceConnector::Kafka(_) => SOURCE_COUNT_KAFKA.inc(),
                 ExternalSourceConnector::Kinesis(_) => SOURCE_COUNT_KINESIS.inc(),
                 ExternalSourceConnector::Postgres(_) => SOURCE_COUNT_POSTGRES.inc(),
+                ExternalSourceConnector::PubNub(_) => SOURCE_COUNT_PUBNUB.inc(),
                 ExternalSourceConnector::S3(_) => SOURCE_COUNT_S3.inc(),
             },
             SourceConnector::Local => {} // nothing interesting to users here
@@ -91,6 +93,7 @@ pub(super) fn item_dropped(id: GlobalId, item: &CatalogItem) {
                 ExternalSourceConnector::Kafka(_) => SOURCE_COUNT_KAFKA.dec(),
                 ExternalSourceConnector::Kinesis(_) => SOURCE_COUNT_KINESIS.dec(),
                 ExternalSourceConnector::Postgres(_) => SOURCE_COUNT_POSTGRES.dec(),
+                ExternalSourceConnector::PubNub(_) => SOURCE_COUNT_PUBNUB.dec(),
                 ExternalSourceConnector::S3(_) => SOURCE_COUNT_S3.dec(),
             },
             SourceConnector::Local => {} // nothing interesting to users here

--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -614,6 +614,7 @@ impl Timestamper {
                     })
             }
             ExternalSourceConnector::Postgres(_) => None,
+            ExternalSourceConnector::PubNub(_) => None,
         }
     }
 
@@ -769,6 +770,7 @@ impl Timestamper {
             ExternalSourceConnector::Kinesis(_) => None, // BYO is not supported for Kinesis sources
             ExternalSourceConnector::S3(_) => None,   // BYO is not supported for s3 sources
             ExternalSourceConnector::Postgres(_) => None, // BYO is not supported for postgres sources
+            ExternalSourceConnector::PubNub(_) => None,   // BYO is not supported for pubnub sources
         }
     }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -566,6 +566,7 @@ pub enum ExternalSourceConnector {
     AvroOcf(FileSourceConnector),
     S3(S3SourceConnector),
     Postgres(PostgresSourceConnector),
+    PubNub(PubNubSourceConnector),
 }
 
 impl ExternalSourceConnector {
@@ -587,6 +588,7 @@ impl ExternalSourceConnector {
             // TODO: should we include object key and possibly object-internal offset here?
             Self::S3(_) => vec![("mz_record".into(), ScalarType::Int64.nullable(false))],
             Self::Postgres(_) => vec![],
+            Self::PubNub(_) => vec![],
         }
     }
 
@@ -599,6 +601,7 @@ impl ExternalSourceConnector {
             ExternalSourceConnector::AvroOcf(_) => "avro-ocf",
             ExternalSourceConnector::S3(_) => "s3",
             ExternalSourceConnector::Postgres(_) => "postgres",
+            ExternalSourceConnector::PubNub(_) => "pubnub",
         }
     }
 
@@ -706,6 +709,12 @@ pub struct PostgresSourceConnector {
     pub publication: String,
     pub namespace: String,
     pub table: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PubNubSourceConnector {
+    pub subscribe_key: String,
+    pub channel: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.4.0", features = ["fs", "rt", "sync" ] }
-tokio-util = { version = "0.6.5", features = ["codec"] }
+tokio-util = { version = "0.6.4", features = ["codec"] }
+pubnub-hyper = { git = "https://github.com/MaterializeInc/pubnub-rust" }
 url = { version = "2.2.1", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -34,7 +34,8 @@ use crate::render::RenderState;
 use crate::server::LocalInput;
 use crate::source::SourceConfig;
 use crate::source::{
-    self, FileSourceReader, KafkaSourceReader, KinesisSourceReader, S3SourceReader,
+    self, FileSourceReader, KafkaSourceReader, KinesisSourceReader, PubNubSourceReader,
+    S3SourceReader,
 };
 
 impl<'g, G> Context<Child<'g, G, G::Timestamp>, MirRelationExpr, Row, Timestamp>
@@ -184,6 +185,20 @@ where
                     (collection, capability)
                 } else if let ExternalSourceConnector::Postgres(_pg_connector) = connector {
                     unimplemented!("Postgres sources are not supported yet");
+                } else if let ExternalSourceConnector::PubNub(pubnub_connector) = connector {
+                    let source = PubNubSourceReader::new(pubnub_connector);
+
+                    let ((ok_stream, err_stream), capability) =
+                        source::create_source_simple(source_config, source);
+
+                    error_collections.push(
+                        err_stream
+                            .map(DataflowError::SourceError)
+                            .pass_through("source-errors")
+                            .as_collection(),
+                    );
+
+                    (ok_stream.as_collection(), capability)
                 } else {
                     let ((ok_source, err_source), capability) = match connector {
                         ExternalSourceConnector::Kafka(_) => {
@@ -209,6 +224,7 @@ where
                         }
                         ExternalSourceConnector::AvroOcf(_) => unreachable!(),
                         ExternalSourceConnector::Postgres(_) => unreachable!(),
+                        ExternalSourceConnector::PubNub(_) => unreachable!(),
                     };
 
                     // Include any source errors.

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -710,6 +710,12 @@ where
                             );
                             None
                         }
+                        (ExternalSourceConnector::PubNub(_), _) => {
+                            log::debug!(
+                                "PubNub sources do not communicate with the timestamper thread"
+                            );
+                            None
+                        }
                     }
                 } else {
                     log::debug!(

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -55,6 +55,7 @@ use crate::CacheMessage;
 mod file;
 mod kafka;
 mod kinesis;
+mod pubnub;
 mod s3;
 mod util;
 
@@ -66,6 +67,7 @@ pub use file::FileReadStyle;
 pub use file::FileSourceReader;
 pub use kafka::KafkaSourceReader;
 pub use kinesis::KinesisSourceReader;
+pub use pubnub::PubNubSourceReader;
 pub use s3::S3SourceReader;
 
 // Interval after which the source operator will yield control.

--- a/src/dataflow/src/source/pubnub.rs
+++ b/src/dataflow/src/source/pubnub.rs
@@ -1,0 +1,70 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use pubnub_hyper::core::data::message::Type;
+use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport};
+
+use crate::source::{SimpleSource, SourceError, Timestamper};
+use dataflow_types::PubNubSourceConnector;
+use repr::{Datum, RowPacker};
+
+/// Information required to sync data from PubNub
+pub struct PubNubSourceReader {
+    connector: PubNubSourceConnector,
+}
+
+impl PubNubSourceReader {
+    /// Constructs a new instance
+    pub fn new(connector: PubNubSourceConnector) -> Self {
+        Self { connector }
+    }
+}
+
+#[async_trait]
+impl SimpleSource for PubNubSourceReader {
+    async fn start(mut self, timestamper: &Timestamper) -> Result<(), SourceError> {
+        let transport = DefaultTransport::new()
+            // we don't need a publish key for subscribing
+            .publish_key("")
+            .subscribe_key(&self.connector.subscribe_key)
+            .build()
+            .map_err(SourceError::FileIO)?;
+
+        let mut pubnub = Builder::new()
+            .transport(transport)
+            .runtime(DefaultRuntime)
+            .build();
+
+        let channel = self.connector.channel.parse().unwrap();
+
+        let stream = pubnub.subscribe(channel).await;
+        tokio::pin!(stream);
+
+        let mut packer = RowPacker::new();
+
+        while let Some(msg) = stream.next().await {
+            if msg.message_type == Type::Publish {
+                let s = msg.json.dump();
+
+                let datum: Datum = (&*s).into();
+                packer.push(datum);
+                let row = packer.finish_and_reuse();
+
+                timestamper
+                    .insert(row)
+                    .await
+                    .map_err(|e| SourceError::FileIO(e.to_string()))?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -286,6 +286,12 @@ pub enum Connector<T: AstInfo> {
         /// The expected column schema of the synced table
         columns: Vec<ColumnDef<T>>,
     },
+    PubNub {
+        /// PubNub's subscribe key
+        subscribe_key: String,
+        /// The PubNub channel to subscribe to
+        channel: String,
+    },
 }
 
 impl<T: AstInfo> AstDisplay for Connector<T> {
@@ -358,6 +364,16 @@ impl<T: AstInfo> AstDisplay for Connector<T> {
                 f.write_str("' (");
                 f.write_node(&display::comma_separated(columns));
                 f.write_str(")");
+            }
+            Connector::PubNub {
+                subscribe_key,
+                channel,
+            } => {
+                f.write_str("PUBNUB SUBSCRIBE KEY '");
+                f.write_str(&display::escape_single_quote_string(subscribe_key));
+                f.write_str("' CHANNEL '");
+                f.write_str(&display::escape_single_quote_string(channel));
+                f.write_str("'");
             }
         }
     }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -46,6 +46,7 @@ Cascade
 Case
 Cast
 Chain
+Channel
 Char
 Character
 Check
@@ -185,6 +186,7 @@ Precision
 Primary
 Protobuf
 Publication
+Pubnub
 Range
 Raw
 Read
@@ -229,6 +231,7 @@ Start
 Stdin
 Stdout
 String
+Subscribe
 Superuser
 Table
 Tables

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1698,7 +1698,18 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_connector(&mut self) -> Result<Connector<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3, POSTGRES])? {
+        match self.expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
+            PUBNUB => {
+                self.expect_keywords(&[SUBSCRIBE, KEY])?;
+                let subscribe_key = self.parse_literal_string()?;
+                self.expect_keyword(CHANNEL)?;
+                let channel = self.parse_literal_string()?;
+
+                Ok(Connector::PubNub {
+                    subscribe_key,
+                    channel,
+                })
+            }
             POSTGRES => {
                 self.expect_keyword(HOST)?;
                 let conn = self.parse_literal_string()?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -504,6 +504,13 @@ CREATE SOURCE psychic FROM POSTGRES HOST 'host=kanto user=ash password=teamrocke
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", namespace: "generation1", table: "psychic", columns: [ColumnDef { name: Ident("pokedex_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("evolution"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }] }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
 
 parse-statement
+CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel';
+----
+CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel'
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: PubNub { subscribe_key: "subscribe_key", channel: "channel" }, with_options: [], format: None, envelope: None, if_not_exists: false, materialized: false })
+
+parse-statement
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' FORMAT BYTES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -39,8 +39,8 @@ use dataflow_types::{
     AvroEncoding, AvroOcfEncoding, AvroOcfSinkConnectorBuilder, Consistency, CsvEncoding,
     DataEncoding, ExternalSourceConnector, FileSourceConnector, KafkaSinkConnectorBuilder,
     KafkaSourceConnector, KinesisSourceConnector, PostgresSourceConnector, ProtobufEncoding,
-    RegexEncoding, S3SourceConnector, SinkConnectorBuilder, SinkEnvelope, SourceConnector,
-    SourceEnvelope,
+    PubNubSourceConnector, RegexEncoding, S3SourceConnector, SinkConnectorBuilder, SinkEnvelope,
+    SourceConnector, SourceEnvelope,
 };
 use expr::GlobalId;
 use interchange::avro::{self, DebeziumDeduplicationStrategy, Encoder};
@@ -746,6 +746,18 @@ pub fn plan_create_source(
 
             (connector, DataEncoding::Postgres(desc))
         }
+        Connector::PubNub {
+            subscribe_key,
+            channel,
+        } => {
+            scx.require_experimental_mode("PubNub Sources")?;
+            let connector = ExternalSourceConnector::PubNub(PubNubSourceConnector {
+                subscribe_key: subscribe_key.clone(),
+                channel: channel.clone(),
+            });
+
+            (connector, DataEncoding::Text)
+        }
         Connector::AvroOcf { path, .. } => {
             let tail = match with_options.remove("tail") {
                 None => false,
@@ -1280,6 +1292,7 @@ pub fn plan_create_sink(
         Connector::AvroOcf { .. } => None,
         Connector::S3 { .. } => None,
         Connector::Postgres { .. } => None,
+        Connector::PubNub { .. } => None,
     };
 
     let key_desc_and_indices = key_indices.map(|key_indices| {
@@ -1323,6 +1336,7 @@ pub fn plan_create_sink(
         }
         Connector::S3 { .. } => unsupported!("S3 sinks"),
         Connector::Postgres { .. } => unsupported!("Postgres sinks"),
+        Connector::PubNub { .. } => unsupported!("PubNub sinks"),
     };
 
     if !with_options.is_empty() {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -102,6 +102,7 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
                 aws_util::aws::validate_credentials(aws_info, Duration::from_secs(1)).await?;
             }
             Connector::Postgres { .. } => (),
+            Connector::PubNub { .. } => (),
         }
 
         purify_format(format, connector, col_names, file, &config_options).await?;

--- a/test/pubnub/mzcompose
+++ b/test/pubnub/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/pubnub/mzcompose.yml
+++ b/test/pubnub/mzcompose.yml
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  pubnub:
+    steps:
+      - step: start-services
+        services: [materialized]
+
+      - step: wait-for-mz
+        service: materialized
+
+      - step: run
+        service: testdrive-svc
+        command: --materialized-url=postgres://materialize@materialized:6875 test.td
+
+services:
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint:
+      - bash
+      - -c
+      - >-
+        testdrive
+        $$*
+      - bash
+    volumes:
+    - .:/workdir
+    - mzdata:/share/mzdata
+    propagate-uid-gid: true
+    init: true
+
+  materialized:
+    mzbuild: materialized
+    command: >-
+      --data-directory=/share/mzdata
+      --experimental
+      --disable-telemetry
+    environment:
+    - MZ_DEV=1
+    ports:
+      - 6875
+    volumes:
+    - mzdata:/share/mzdata
+
+volumes:
+  mzdata:

--- a/test/pubnub/test.td
+++ b/test/pubnub/test.td
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+# The raw source that brings in data as a single text column containing JSON
+> CREATE SOURCE market_orders_raw
+  FROM PUBNUB
+  SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+  CHANNEL 'pubnub-market-orders';
+
+# Extract a couple JSON fields
+> CREATE VIEW market_orders AS
+  SELECT
+    val->>'symbol' AS symbol,
+    (val->'bid_price')::float AS bid_price
+  FROM (SELECT text::jsonb AS val FROM market_orders_raw);
+
+# Create a materialized aggregation
+> CREATE MATERIALIZED VIEW avg_bid AS
+  SELECT symbol, AVG(bid_price) FROM market_orders GROUP BY symbol;
+
+# See the data change
+> SELECT COUNT(*) > 0 FROM avg_bid;
+true


### PR DESCRIPTION
This PR adds basic support for pubnub sources and also acts as a reference implementation of a source using the recently merged SimpleSource trait.

The syntax for the source creation is: 

```sql
CREATE SOURCE foo FROM PUBNUB SUBSCRIBE KEY 'sub_key' CHANNEL 'channel'
```

This sources allows users to test out materialize using one of the example realtime streams offered by pubnub. The streams are listed here https://www.pubnub.com/developers/realtime-data-streams/

**Caveat**: The wikipedia stream was a bit unreliable in my testing but the other ones work great

Here is an example usage of the market order stream:

```sql
# The raw source that brings in data as a single text column containing JSON
CREATE SOURCE market_orders_raw
FROM PUBNUB
    SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
    CHANNEL 'pubnub-market-orders';

# Extract a couple JSON fields
CREATE VIEW market_orders AS
    SELECT
        val->>'symbol' AS symbol,
        (val->'bid_price')::float AS bid_price
FROM (SELECT text::jsonb AS val FROM market_orders_raw);

# Create a materialized aggregation
CREATE MATERIALIZED VIEW avg_bid AS
    SELECT symbol, AVG(bid_price) FROM market_orders GROUP BY symbol;

# See the data change
SELECT * FROM avg_bid;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6189)
<!-- Reviewable:end -->
