### PR TITLE
Port differences to tuples and vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#7bc5338a977fe1d95b96a9ba84ba8cd460e0cdd7"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#d9d47c2e32b29eb6aded140ab248d3793d87a861"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -918,7 +918,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#7bc5338a977fe1d95b96a9ba84ba8cd460e0cdd7"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#d9d47c2e32b29eb6aded140ab248d3793d87a861"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/dataflow/src/logging/differential.rs
+++ b/src/dataflow/src/logging/differential.rs
@@ -46,10 +46,7 @@ pub fn construct<A: Allocate>(
                 let time_ms = ((ts.as_millis() as Timestamp / granularity_ms) + 1) * granularity_ms;
                 match event {
                     DifferentialEvent::Batch(event) => {
-                        let difference = differential_dataflow::difference::DiffVector::new(vec![
-                            event.length as isize,
-                            1,
-                        ]);
+                        let difference = (event.length as isize, 1);
                         Some(((event.operator, worker), time_ms, difference))
                     }
                     DifferentialEvent::Merge(event) => {
@@ -57,20 +54,17 @@ pub fn construct<A: Allocate>(
                             Some((
                                 (event.operator, worker),
                                 time_ms,
-                                differential_dataflow::difference::DiffVector::new(vec![
+                                (
                                     (done as isize) - ((event.length1 + event.length2) as isize),
                                     -1,
-                                ]),
+                                ),
                             ))
                         } else {
                             None
                         }
                     }
                     DifferentialEvent::Drop(event) => {
-                        let difference = differential_dataflow::difference::DiffVector::new(vec![
-                            -(event.length as isize),
-                            -1,
-                        ]);
+                        let difference = (-(event.length as isize), -1);
                         Some(((event.operator, worker), time_ms, difference))
                     }
                     DifferentialEvent::MergeShortfall(_) => None,
@@ -85,8 +79,8 @@ pub fn construct<A: Allocate>(
                     row_packer.pack(&[
                         Datum::Int64(op as i64),
                         Datum::Int64(worker as i64),
-                        Datum::Int64(count[0] as i64),
-                        Datum::Int64(count[1] as i64),
+                        Datum::Int64(count.0 as i64),
+                        Datum::Int64(count.1 as i64),
                     ])
                 }
             });

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -11,7 +11,6 @@
 
 use std::time::Duration;
 
-use differential_dataflow::difference::{DiffPair, DiffVector};
 use differential_dataflow::operators::count::CountTotal;
 use log::error;
 use timely::communication::Allocate;
@@ -236,7 +235,7 @@ pub fn construct<A: Allocate>(
                                 kafka_consumer_info_session.give((
                                     (consumer_name, source_id, partition_id),
                                     time_ms,
-                                    DiffVector::new(vec![
+                                    vec![
                                         rxmsgs,
                                         rxbytes,
                                         txmsgs,
@@ -246,7 +245,7 @@ pub fn construct<A: Allocate>(
                                         ls_offset,
                                         app_offset,
                                         consumer_lag,
-                                    ]),
+                                    ],
                                 ));
                             }
                             MaterializedEvent::Peek(peek, is_install) => {
@@ -262,7 +261,7 @@ pub fn construct<A: Allocate>(
                                 source_info_session.give((
                                     (source_name, source_id, partition_id),
                                     time_ms,
-                                    DiffPair::new(offset, timestamp),
+                                    (offset, timestamp),
                                 ));
                             }
                         }
@@ -353,9 +352,7 @@ pub fn construct<A: Allocate>(
 
         let source_info_current = source_info.as_collection().count().map({
             let mut row_packer = repr::RowPacker::new();
-            move |((name, id, pid), pair)| {
-                let offset = pair.element1;
-                let timestamp = pair.element2;
+            move |((name, id, pid), (offset, timestamp))| {
                 row_packer.pack(&[
                     Datum::String(&name),
                     Datum::String(&id.source_id.to_string()),

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -63,7 +63,6 @@
 use std::collections::BTreeMap;
 
 use differential_dataflow::collection::AsCollection;
-use differential_dataflow::difference::DiffVector;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arrange;
@@ -1039,7 +1038,7 @@ where
                 ));
             }
 
-            (key, time, DiffVector::new(output))
+            (key, time, output)
         })
         .as_collection();
     partial
@@ -1167,7 +1166,7 @@ where
                     diffs[3 * accumulable_index + 1] = agg1;
                     diffs[3 * accumulable_index + 2] = agg2;
                 }
-                Some((key, DiffVector::new(diffs)))
+                Some((key, diffs))
             }
         });
     to_aggregate.push(easy_cases);
@@ -1193,7 +1192,7 @@ where
                     diffs[3 * accumulable_index] = 1i128;
                     diffs[3 * accumulable_index + 1] = agg1;
                     diffs[3 * accumulable_index + 2] = agg2;
-                    Some((key, DiffVector::new(diffs)))
+                    Some((key, diffs))
                 }
             });
         to_aggregate.push(collection);
@@ -1362,8 +1361,6 @@ pub mod monoids {
     // will not have such elements in this case (they would correspond to positive and
     // negative infinity, which we do not represent).
 
-    use std::ops::AddAssign;
-
     use differential_dataflow::difference::Semigroup;
     use serde::{Deserialize, Serialize};
 
@@ -1377,8 +1374,8 @@ pub mod monoids {
         Max(Row),
     }
 
-    impl<'a> AddAssign<&'a Self> for ReductionMonoid {
-        fn add_assign(&mut self, rhs: &'a Self) {
+    impl Semigroup for ReductionMonoid {
+        fn plus_equals(&mut self, rhs: &Self) {
             match (self, rhs) {
                 (ReductionMonoid::Min(lhs), ReductionMonoid::Min(rhs)) => {
                     let swap = {
@@ -1417,9 +1414,7 @@ pub mod monoids {
                 ),
             }
         }
-    }
 
-    impl Semigroup for ReductionMonoid {
         fn is_zero(&self) -> bool {
             false
         }


### PR DESCRIPTION
A recent commit to DD allows us to use tuples and vectors in place of `DiffPair` and `DiffVector`. Those changes were made, as well as a few cases where length two vectors were used where we could have used a pair.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6194)
<!-- Reviewable:end -->
