### PR TITLE
coord,sql: Repurpose the --timestamp-frequency option to specify default timestamp frequency for sources

### DIFF
--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -4,7 +4,7 @@
 `security_protocol` | `text` | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberized-kafka-details), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics.
 `ignore_source_keys` | `boolean` | Default: `false`. If `true`, do not perform optimizations assuming uniqueness of primary keys in schemas.
-`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently timestamps advance in the system. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
+`timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 `topic_metadata_refresh_interval_ms` | `int` | Default: `30000`. Sets the frequency in `ms` at which the system checks for new partitions. Accepts values [0,3600000].
 
 #### SSL `WITH` options

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -12,7 +12,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::bail;
 use chrono::{DateTime, TimeZone, Utc};
@@ -472,6 +472,7 @@ impl Catalog {
                 cache_directory: config.cache_directory.clone(),
                 build_info: config.build_info,
                 num_workers: config.num_workers,
+                timestamp_frequency: config.timestamp_frequency,
             },
         };
         let mut events = vec![];
@@ -779,6 +780,7 @@ impl Catalog {
             cache_directory: None,
             build_info: &DUMMY_BUILD_INFO,
             num_workers: 0,
+            timestamp_frequency: Duration::from_secs(1),
         })?;
         Ok(catalog)
     }

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use build_info::BuildInfo;
 
@@ -28,4 +29,6 @@ pub struct Config<'a> {
     pub build_info: &'static BuildInfo,
     /// The number of workers in use by the server.
     pub num_workers: usize,
+    /// Timestamp frequency to use for CREATE SOURCE
+    pub timestamp_frequency: Duration,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3467,6 +3467,7 @@ pub async fn serve(
         cache_directory: cache_config.map(|c| c.path),
         build_info,
         num_workers: workers,
+        timestamp_frequency,
     })?;
     let cluster_id = catalog.config().cluster_id;
     let session_id = catalog.config().session_id;
@@ -3483,7 +3484,8 @@ pub async fn serve(
     // Spawn timestamper after any fallible operations so that if bootstrap fails we still
     // tell it to shut down.
     let (ts_tx, ts_rx) = std::sync::mpsc::channel();
-    let mut timestamper = Timestamper::new(timestamp_frequency, internal_cmd_tx.clone(), ts_rx);
+    let mut timestamper =
+        Timestamper::new(Duration::from_millis(10), internal_cmd_tx.clone(), ts_rx);
     let executor = TokioHandle::current();
     let timestamper_thread_handle = thread::spawn(move || {
         let _executor_guard = executor.enter();

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -105,9 +105,10 @@ struct Args {
     /// Set to "off" to disable logical compaction.
     #[structopt(long, env = "MZ_LOGICAL_COMPACTION_WINDOW", parse(try_from_str = parse_optional_duration), value_name = "DURATION", default_value = "1ms")]
     logical_compaction_window: OptionalDuration,
-    /// [DEPRECATED] Frequency with which to advance timestamps.
-    #[structopt(long, env = "MZ_TIMESTAMP_FREQUENCY", hidden = true, parse(try_from_str = parse_duration::parse), value_name = "DURATION", default_value = "10ms")]
+    /// Default frequency with which to advance timestamps
+    #[structopt(long, env = "MZ_TIMESTAMP_FREQUENCY", hidden = true, parse(try_from_str = parse_duration::parse), value_name = "DURATION", default_value = "1s")]
     timestamp_frequency: Duration,
+
     /// Maximum number of source records to buffer in memory before flushing to
     /// disk.
     #[structopt(

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -35,7 +35,7 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             data_directory: None,
-            logging_granularity: Some(Duration::from_millis(10)),
+            logging_granularity: Some(Duration::from_secs(1)),
             tls: None,
             experimental_mode: false,
             workers: 1,
@@ -100,7 +100,7 @@ pub fn start_server(config: Config) -> Result<Server, Box<dyn Error>> {
                     granularity,
                     log_logging: false,
                 }),
-            timestamp_frequency: Duration::from_millis(10),
+            timestamp_frequency: Duration::from_secs(1),
             cache: None,
             persistence: None,
             logical_compaction_window: None,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -13,7 +13,7 @@
 
 use std::fmt;
 use std::path::PathBuf;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use std::{error::Error, unimplemented};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
@@ -163,6 +163,8 @@ pub struct CatalogConfig {
     pub build_info: &'static BuildInfo,
     /// The number of worker in use by the server.
     pub num_workers: usize,
+    /// Default timestamp frequency for CREATE SOURCE
+    pub timestamp_frequency: Duration,
 }
 
 /// A database in a [`Catalog`].
@@ -342,6 +344,7 @@ lazy_static! {
         cache_directory: None,
         build_info: &DUMMY_BUILD_INFO,
         num_workers: 0,
+        timestamp_frequency: Duration::from_secs(1)
     };
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -519,7 +519,7 @@ pub fn plan_create_source(
     let mut with_options = normalize::options(with_options);
 
     let mut consistency = Consistency::RealTime;
-    let mut ts_frequency = Duration::from_secs(1);
+    let mut ts_frequency = scx.catalog.config().timestamp_frequency;
 
     let (external_connector, mut encoding) = match connector {
         Connector::Kafka { broker, topic, .. } => {
@@ -537,7 +537,10 @@ pub fn plan_create_source(
                 Some(_) => bail!("group_id_prefix must be a string"),
             };
 
-            ts_frequency = extract_timestamp_frequency_option(&mut with_options)?;
+            ts_frequency = extract_timestamp_frequency_option(
+                scx.catalog.config().timestamp_frequency,
+                &mut with_options,
+            )?;
 
             // THIS IS EXPERIMENTAL - DO NOT DOCUMENT IT
             // until we have had time to think about what the right UX/design is on a non-urgent timeline!
@@ -639,7 +642,10 @@ pub fn plan_create_source(
                 None => Consistency::RealTime,
                 Some(_) => bail!("BYO consistency not supported for file sources"),
             };
-            ts_frequency = extract_timestamp_frequency_option(&mut with_options)?;
+            ts_frequency = extract_timestamp_frequency_option(
+                scx.catalog.config().timestamp_frequency,
+                &mut with_options,
+            )?;
 
             let connector = ExternalSourceConnector::File(FileSourceConnector {
                 path: path.clone().into(),
@@ -764,7 +770,10 @@ pub fn plan_create_source(
                 bail!("BYO consistency only supported for Debezium Avro OCF sources");
             }
 
-            ts_frequency = extract_timestamp_frequency_option(&mut with_options)?;
+            ts_frequency = extract_timestamp_frequency_option(
+                scx.catalog.config().timestamp_frequency,
+                &mut with_options,
+            )?;
 
             let connector = ExternalSourceConnector::AvroOcf(FileSourceConnector {
                 path: path.clone().into(),
@@ -1586,10 +1595,11 @@ pub fn plan_create_type(
 }
 
 fn extract_timestamp_frequency_option(
+    default: Duration,
     with_options: &mut BTreeMap<String, Value>,
 ) -> Result<Duration, anyhow::Error> {
     match with_options.remove("timestamp_frequency_ms") {
-        None => Ok(Duration::from_secs(1)),
+        None => Ok(default),
         Some(Value::Number(n)) => match n.parse::<u64>() {
             Ok(n) => Ok(Duration::from_millis(n)),
             _ => bail!("timestamp_frequency_ms must be an u64"),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -503,7 +503,7 @@ impl Runner {
         let temp_dir = tempfile::tempdir()?;
         let mz_config = materialized::Config {
             logging: None,
-            timestamp_frequency: Duration::from_millis(10),
+            timestamp_frequency: Duration::from_secs(1),
             cache: None,
             persistence: None,
             logical_compaction_window: None,

--- a/test/atp/driver/docker-compose.yml
+++ b/test/atp/driver/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       --workers 1
       --experimental
       --cache-max-pending-records 1
+      --timestamp-frequency 100ms
       --disable-telemetry
     environment:
       AWS_ACCESS_KEY_ID: null

--- a/test/testdrive/mzcompose.yml
+++ b/test/testdrive/mzcompose.yml
@@ -81,6 +81,7 @@ services:
       --data-directory=/share/mzdata
       -w1 --experimental
       --cache-max-pending-records 1
+      --timestamp-frequency 100ms
       --disable-telemetry
     ports:
       - 6875


### PR DESCRIPTION
By default all CREATE SOURCES are created with a timestamp frequency
of 1s. In order to speed up tests, add a hidden materialized option
that allows this to be lowered substantially, resulting in much
snappier tests.

I am not too happy with this change, but it does cause tests to run faster, so please do let me know how this should be done correctly. An option ```timestamp-frequency``` already exists, but it is used for something else and has a different default, so I decided not to use it. As a consequence, I had to wire the new option through one too many different types of ```Config``` objects and finally pass it all the way into ```extract_timestamp_frequency_option```

On a positive note, this removes two instances of integer literals in ```Duration::from_secs()``` from the code with many more remaining.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6199)
<!-- Reviewable:end -->
