### PR TITLE
Fix race condition in rdkafka statistics

### DIFF
--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -142,7 +142,6 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
         // Read any statistics objects generated via the GlueConsumerContext::stats callback
         while let Ok(statistics) = self.stats_rx.try_recv() {
             if let Some(logger) = self.logger.as_mut() {
-                info!("Client stats: {:#?}", statistics);
                 for mut part in self.partition_consumers.iter_mut() {
                     // If this is the first callback, initialize our consumer name
                     // so that we can later retract this when the source is dropped
@@ -150,12 +149,6 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
                         None => part.previous_stats.consumer_name = Some(statistics.name.clone()),
                         _ => (),
                     }
-
-                    info!(
-                        "Topic: {}, Partition: {}",
-                        self.topic_name.as_str(),
-                        part.pid.to_string()
-                    );
 
                     let topic_stats = match statistics.topics.get(self.topic_name.as_str()) {
                         Some(t) => t,

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -157,8 +157,15 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
                         part.pid.to_string()
                     );
 
-                    let partition_stats =
-                        &statistics.topics[self.topic_name.as_str()].partitions[&part.pid];
+                    let topic_stats = match statistics.topics.get(self.topic_name.as_str()) {
+                        Some(t) => t,
+                        None => continue,
+                    };
+
+                    let partition_stats = match topic_stats.partitions.get(&part.pid) {
+                        Some(p) => p,
+                        None => continue,
+                    };
 
                     logger.log(MaterializedEvent::KafkaConsumerInfo {
                         consumer_name: statistics.name.to_string(),

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -142,6 +142,7 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
         // Read any statistics objects generated via the GlueConsumerContext::stats callback
         while let Ok(statistics) = self.stats_rx.try_recv() {
             if let Some(logger) = self.logger.as_mut() {
+                info!("Client stats: {:#?}", statistics);
                 for mut part in self.partition_consumers.iter_mut() {
                     // If this is the first callback, initialize our consumer name
                     // so that we can later retract this when the source is dropped
@@ -149,6 +150,12 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
                         None => part.previous_stats.consumer_name = Some(statistics.name.clone()),
                         _ => (),
                     }
+
+                    info!(
+                        "Topic: {}, Partition: {}",
+                        self.topic_name.as_str(),
+                        part.pid.to_string()
+                    );
 
                     let partition_stats =
                         &statistics.topics[self.topic_name.as_str()].partitions[&part.pid];

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -299,7 +299,7 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 # Erroneously adds start_offsets for non-existent partitions.
 > CREATE MATERIALIZED SOURCE non_dbz_data_varying_partition_2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
-  WITH (start_offset=[0,1])
+  WITH (start_offset=[0,1], statistics_interval_ms = 1000)
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -335,7 +335,7 @@ a  b
 
 > CREATE MATERIALIZED SOURCE non_dbz_data_varying_partition_3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
-  WITH (start_offset=[1,1])
+  WITH (start_offset=[1,1], statistics_interval_ms = 1000)
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -333,6 +333,12 @@ a  b
 5  6
 9  10
 
+# There should be two partitions per consumer
+> SELECT count(*) FROM mz_kafka_consumer_statistics GROUP BY consumer_name;
+count
+-----
+2
+
 > CREATE MATERIALIZED SOURCE non_dbz_data_varying_partition_3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
   WITH (start_offset=[1,1], statistics_interval_ms = 1000)
@@ -351,6 +357,13 @@ a  b
 -----
 9  10
 11 12
+
+# There should be metrics for 3 partitions per consumer
+> SELECT count(*) FROM mz_kafka_consumer_statistics GROUP BY consumer_name;
+count
+-----
+3
+3
 
 $ set-sql-timeout duration=12.7s
 


### PR DESCRIPTION
There appears to be a race where a partition consumer can be aware of a partition before rdkafka decides to populate the statistics data structure for that partition.

We had two unchecked gets from the statistics data structure. Convert both of those gets to checked versions, where we simply ignore statistics for that topic / partition if it's missing. Add a test case to verify that the metrics are populated eventually.

First noticed when this started failing in CI for #6192.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6206)
<!-- Reviewable:end -->
