### PR TITLE
sql: purify Postgres replication sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,6 +4056,7 @@ dependencies = [
  "serde_json",
  "sql-parser",
  "tokio",
+ "tokio-postgres",
  "unicase",
  "url",
  "uuid",

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -207,6 +207,14 @@ steps:
           composition: dbt-materialize
           run: ci
 
+  - id: pg-cdc
+    label: "Postgres CDC test"
+    depends_on: build
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: pg-cdc
+          run: pg-cdc
+
   - id: persistent-tables
     label: "Test for --persistent-tables"
     depends_on: build

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -184,7 +184,7 @@ where
 
                     (collection, capability)
                 } else if let ExternalSourceConnector::Postgres(_pg_connector) = connector {
-                    unimplemented!("Postgres sources are not supported yet");
+                    unreachable!("rendering Postgres source");
                 } else if let ExternalSourceConnector::PubNub(pubnub_connector) = connector {
                     let source = PubNubSourceReader::new(pubnub_connector);
 

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -65,6 +65,20 @@ pub fn parse_expr(sql: &str) -> Result<Expr<Raw>, ParserError> {
     }
 }
 
+/// Parses a SQL string containing zero or more SQL columns.
+pub fn parse_columns(
+    sql: &str,
+) -> Result<(Vec<ColumnDef<Raw>>, Vec<TableConstraint<Raw>>), ParserError> {
+    let tokens = lexer::lex(sql)?;
+    let mut parser = Parser::new(sql, tokens);
+    let columns = parser.parse_columns(Optional)?;
+    if parser.next_token().is_some() {
+        parser_err!(parser, parser.peek_prev_pos(), "extra token after columns")
+    } else {
+        Ok(columns)
+    }
+}
+
 macro_rules! maybe {
     ($e:expr) => {{
         if let Some(v) = $e {
@@ -1720,13 +1734,13 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(TABLE)?;
                 let table = self.parse_literal_string()?;
 
-                let (columns, constraints) = self.parse_columns()?;
+                let (columns, constraints) = self.parse_columns(Optional)?;
 
                 if !constraints.is_empty() {
                     return parser_err!(
                         self,
                         self.peek_prev_pos(),
-                        "Cannot specify constraints in postgres table definition"
+                        "Cannot specify constraints in Postgres table definition"
                     );
                 }
 
@@ -2027,7 +2041,7 @@ impl<'a> Parser<'a> {
         let if_not_exists = self.parse_if_not_exists()?;
         let table_name = self.parse_object_name()?;
         // parse optional column list (schema)
-        let (columns, constraints) = self.parse_columns()?;
+        let (columns, constraints) = self.parse_columns(Mandatory)?;
         let with_options = self.parse_opt_with_sql_options()?;
 
         Ok(Statement::CreateTable(CreateTableStatement {
@@ -2042,10 +2056,22 @@ impl<'a> Parser<'a> {
 
     fn parse_columns(
         &mut self,
+        optional: IsOptional,
     ) -> Result<(Vec<ColumnDef<Raw>>, Vec<TableConstraint<Raw>>), ParserError> {
         let mut columns = vec![];
         let mut constraints = vec![];
-        self.expect_token(&Token::LParen)?;
+
+        if !self.consume_token(&Token::LParen) {
+            if optional == Optional {
+                return Ok((columns, constraints));
+            } else {
+                return self.expected(
+                    self.peek_pos(),
+                    "a list of columns in parentheses",
+                    self.peek_token(),
+                );
+            }
+        }
         if self.consume_token(&Token::RParen) {
             // Tables with zero columns are a PostgreSQL extension.
             return Ok((columns, constraints));

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -48,7 +48,7 @@ CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), col
 parse-statement
 CREATE TABLE t
 ----
-error: Expected left parenthesis, found EOF
+error: Expected a list of columns in parentheses, found EOF
 CREATE TABLE t
               ^
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 sql-parser = { path = "../sql-parser" }
 tokio = { version = "1.4.0", features = ["fs"] }
+tokio-postgres = "0.7.0"
 unicase = "2.6.0"
 url = "2.2.1"
 uuid = { version = "0.8.2", features = ["serde", "v4"] }

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -83,6 +83,7 @@ macro_rules! unsupported {
 }
 
 mod kafka_util;
+mod postgres_util;
 
 pub mod ast;
 pub mod catalog;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -703,14 +703,14 @@ pub fn plan_create_source(
             columns,
         } => {
             scx.require_experimental_mode("Postgres Sources")?;
-            let connector = ExternalSourceConnector::Postgres(PostgresSourceConnector {
+            let _connector = ExternalSourceConnector::Postgres(PostgresSourceConnector {
                 conn: conn.clone(),
                 publication: publication.clone(),
                 namespace: namespace.clone(),
                 table: table.clone(),
             });
 
-            // Build the expecte relation description
+            // Build the expected relation description
             let col_names: Vec<_> = columns
                 .iter()
                 .map(|c| Some(normalize::column_name(c.name.clone())))
@@ -731,6 +731,7 @@ pub fn plan_create_source(
                 let mut nullable = true;
                 for option in &c.options {
                     match &option.option {
+                        ColumnOption::Null => (),
                         ColumnOption::NotNull => nullable = false,
                         other => unsupported!(format!(
                             "CREATE SOURCE FROM POSTGRES with column constraint: {}",
@@ -742,9 +743,10 @@ pub fn plan_create_source(
                 col_types.push(scalar_ty.nullable(nullable));
             }
 
-            let desc = RelationDesc::new(RelationType::new(col_types), col_names);
+            let _desc = RelationDesc::new(RelationType::new(col_types), col_names);
 
-            (connector, DataEncoding::Postgres(desc))
+            // (connector, DataEncoding::Postgres(desc))
+            unsupported!("Postgres sources");
         }
         Connector::PubNub {
             subscribe_key,

--- a/src/sql/src/postgres_util.rs
+++ b/src/sql/src/postgres_util.rs
@@ -1,0 +1,103 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Provides convenience functions for working with upstream Postgres sources from the `sql` package.
+
+use anyhow::anyhow;
+
+use tokio_postgres::types::Type as PgType;
+use tokio_postgres::NoTls;
+
+/// The schema of a single column
+pub struct PgColumn {
+    name: String,
+    scalar_type: PgType,
+    nullable: bool,
+}
+
+/// Fetches column information from an upstream Postgres source, given
+/// a connection string, a namespace, and a target table.
+///
+/// # Errors
+///
+/// - Invalid connection string, user information, or user permissions.
+/// - Upstream table does not exist or contains invalid values.
+pub async fn fetch_columns(
+    conn: &str,
+    namespace: &str,
+    table: &str,
+) -> Result<Vec<PgColumn>, anyhow::Error> {
+    let (client, connection) = tokio_postgres::connect(&conn, NoTls).await?;
+    tokio::spawn(connection);
+
+    let rel_id: u32 = client
+        .query(
+            "SELECT c.oid
+                FROM pg_catalog.pg_class c
+                INNER JOIN pg_catalog.pg_namespace n
+                    ON (c.relnamespace = n.oid)
+                WHERE n.nspname = $1
+                    AND c.relname = $2;",
+            &[&namespace, &table],
+        )
+        .await?
+        .get(0)
+        .ok_or_else(|| anyhow!("table not found in the upstream catalog"))?
+        .get(0);
+
+    // todo@jldlaughlin: fetch all constraints, so we correctly error in `plan_create_source` if they
+    // are present.
+    Ok(client
+        .query(
+            "SELECT a.attname, a.atttypid, a.attnotnull
+                FROM pg_catalog.pg_attribute a
+                WHERE a.attnum > 0::pg_catalog.int2
+                    AND NOT a.attisdropped
+                    AND a.attrelid = $1
+                ORDER BY a.attnum",
+            &[&rel_id],
+        )
+        .await?
+        .into_iter()
+        .map(|row| {
+            let name: String = row.get(0);
+            let oid = row.get(1);
+            let scalar_type =
+                PgType::from_oid(oid).ok_or_else(|| anyhow!("unknown type OID: {}", oid))?;
+            let nullable = !row.get::<_, bool>(2);
+            Ok(PgColumn {
+                name,
+                scalar_type,
+                nullable,
+            })
+        })
+        .collect::<Result<Vec<_>, anyhow::Error>>()?)
+}
+
+/// Stringifies `PgColumn` information to appear as they would have been written in text.
+pub fn format_columns(columns: Vec<PgColumn>) -> String {
+    let nullable = |nullable| {
+        if nullable {
+            "NULL"
+        } else {
+            "NOT NULL"
+        }
+    };
+
+    let mut formatted_columns = Vec::with_capacity(columns.len());
+    for c in columns {
+        formatted_columns.push(format!(
+            "{} {} {}",
+            c.name,
+            c.scalar_type,
+            nullable(c.nullable)
+        ));
+    }
+    format!("({})", formatted_columns.join(","))
+}

--- a/test/pg-cdc/mzcompose
+++ b/test/pg-cdc/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")/../../bin/mzcompose" "$@"

--- a/test/pg-cdc/mzcompose.yml
+++ b/test/pg-cdc/mzcompose.yml
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+version: '3.7'
+
+mzworkflows:
+  pg-cdc:
+    steps:
+      - step: start-services
+        services: [materialized, postgres]
+      - step: wait-for-mz
+      - step: wait-for-postgres
+        dbname: postgres
+      - step: run
+        service: testdrive-svc
+
+services:
+  testdrive-svc:
+    mzbuild: testdrive
+    entrypoint: testdrive --materialized-url=postgres://materialize@materialized:6875 pg-cdc.td
+    volumes:
+      - .:/workdir
+    depends_on: [materialized, postgres]
+
+  materialized:
+    mzbuild: materialized
+    command: --experimental --disable-telemetry
+    ports:
+      - 6875
+    environment:
+    - MZ_DEV=1
+    - MZ_LOG
+
+  postgres:
+    image: postgres:11.4
+    ports:
+      - 5432
+    command: postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -1,0 +1,90 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE numbers_${testdrive.seed} (number int PRIMARY KEY, is_prime bool, name text);
+ALTER TABLE numbers_${testdrive.seed} REPLICA IDENTITY FULL;
+CREATE PUBLICATION mz_source_${testdrive.seed} FOR ALL TABLES;
+INSERT INTO numbers_${testdrive.seed} VALUES (5, true, 'five');
+
+## CREATE with correct information should pass purification and fail afterwards.
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}'
+Postgres sources not yet supported
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' ()
+Postgres sources not yet supported
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' (number int NOT NULL, is_prime bool NULL, name text NULL)
+Postgres sources not yet supported
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}'(number int NOT NULL, is_prime bool, name text)
+Postgres sources not yet supported
+
+## CREATE with incorrect information should fail purification.
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' (number int NOT NULL)
+incorrect column specification: 1 columns were specified, upstream has 3: number, is_prime, name
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' (number int NOT NULL, is_prime bool null, name text, extra numeric NULL)
+incorrect column specification: 4 columns were specified, upstream has 3: number, is_prime, name
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' (number int NOT NULL, is_prime int, name text)
+incorrect column specification: specified column does not match upstream source, specified: is_prime int4 NULL, upstream: is_prime bool NULL
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' (number int NULL, is_prime bool null, name text)
+incorrect column specification: specified column does not match upstream source, specified: number int4 NULL, upstream: number int4 NOT NULL
+
+! CREATE MATERIALIZED SOURCE "numbers"
+  FROM POSTGRES
+    HOST 'host=postgres port=5432 user=postgres password=postgres dbname=postgres'
+    PUBLICATION 'mz_source_${testdrive.seed}'
+    NAMESPACE 'public'
+    TABLE 'numbers_${testdrive.seed}' (number int NOT NULL, is_prime bool, name text NOT NULL)
+incorrect column specification: specified column does not match upstream source, specified: name text NOT NULL, upstream: name text NULL


### PR DESCRIPTION
This PR: 

1. ["Purifies"](https://github.com/MaterializeInc/materialize/blob/49d3aa4ce72b46abb70a8501def08ea2e186ab76/src/sql/src/lib.rs#L14) Postgres CDC sources on creation (`CREATE SOURCE`) by comparing the provided column definitions with column information available upstream in the Postgres instance. We will now fail if incorrect column information is provided.
1. Allows users to `CREATE` Postgres CDC sources without specifying column information at all, like:
   ```
   CREATE MATERIALIZED SOURCE "example"
   FROM POSTGRES
     HOST '...'
     PUBLICATION '...'
     NAMESPACE '...'
     TABLE 'example'
   ```
    If column information is not provided in the `CREATE SOURCE` statement, it will be fetched from upstream.
1. Pulls in the `pg-cdc` changes from this [WIP PR](https://github.com/MaterializeInc/materialize/pull/5806) to test the changes.

Note: Creating a Postgres CDC source will not currently fail if there are unsupported constraints on upstream columns. I've left that as a todo.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6207)
<!-- Reviewable:end -->
