### PR TITLE
Support `ENVELOPE DEBEZIUM UPSERT`

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -35,9 +35,9 @@ use tokio::sync::mpsc;
 use dataflow::source::read_file_task;
 use dataflow::source::FileReadStyle;
 use dataflow_types::{
-    AvroOcfEncoding, Consistency, DataEncoding, ExternalSourceConnector, FileSourceConnector,
-    KafkaSourceConnector, KinesisSourceConnector, MzOffset, S3SourceConnector, SourceConnector,
-    SourceEnvelope, TimestampSourceUpdate,
+    AvroOcfEncoding, Consistency, DataEncoding, DebeziumMode, ExternalSourceConnector,
+    FileSourceConnector, KafkaSourceConnector, KinesisSourceConnector, MzOffset, S3SourceConnector,
+    SourceConnector, SourceEnvelope, TimestampSourceUpdate,
 };
 use expr::{GlobalId, PartitionId};
 use ore::collections::CollectionExt;
@@ -397,7 +397,7 @@ fn parse_debezium(record: Vec<(String, Value)>) -> Option<Vec<(String, i64)>> {
 /// 2) any other file source with a Debezium envelope will expect an Avro consistency source
 /// that follows the TRX_METADATA_SCHEMA Avro spec outlined above
 fn identify_consistency_format(enc: DataEncoding, env: SourceEnvelope) -> ConsistencyFormatting {
-    if let SourceEnvelope::Debezium(_) = env {
+    if let SourceEnvelope::Debezium(_, DebeziumMode::Plain) = env {
         if let DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema: _ }) = enc {
             ConsistencyFormatting::DebeziumOcf
         } else {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -515,7 +515,7 @@ pub struct SinkAsOf {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SourceEnvelope {
     None,
-    Debezium(DebeziumDeduplicationStrategy),
+    Debezium(DebeziumDeduplicationStrategy, DebeziumMode),
     Upsert(DataEncoding),
     CdcV2,
 }
@@ -529,6 +529,13 @@ impl SourceEnvelope {
             SourceEnvelope::CdcV2 => avro::EnvelopeType::CdcV2,
         }
     }
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DebeziumMode {
+    Plain,
+    /// Keep track of keys from upstream and discard retractions for new keys
+    Upsert,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::{any::Any, cell::RefCell, collections::VecDeque, rc::Rc, time::Duration};
 
 use anyhow::anyhow;
@@ -17,20 +19,13 @@ use log::warn;
 use mz_avro::{AvroDeserializer, GeneralDeserializer};
 use repr::RelationDesc;
 use repr::ScalarType;
-use timely::{
-    dataflow::{
-        channels::pact::ParallelizationContract,
-        channels::pushers::buffer::Session,
-        channels::pushers::Counter as PushCounter,
-        channels::pushers::Tee,
-        operators::{map::Map, OkErr, Operator},
-        Scope, Stream,
-    },
-    scheduling::SyncActivator,
-};
+use timely::dataflow::channels::pact::ParallelizationContract;
+use timely::dataflow::operators::{map::Map, OkErr, Operator};
+use timely::dataflow::{Scope, Stream};
+use timely::scheduling::SyncActivator;
 
 use ::mz_avro::{types::Value, Schema};
-use dataflow_types::{DataEncoding, RegexEncoding, SourceEnvelope};
+use dataflow_types::{DataEncoding, DebeziumMode, RegexEncoding, SourceEnvelope};
 use dataflow_types::{DataflowError, LinearOperator};
 use interchange::avro::{extract_row, ConfluentAvroResolver, DebeziumDecodeState};
 use log::error;
@@ -47,6 +42,7 @@ mod csv;
 mod protobuf;
 mod regex;
 
+/// Decode for the special case of Avro OCFs
 pub fn decode_avro_values<G>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Value>>,
     envelope: &SourceEnvelope,
@@ -64,15 +60,18 @@ where
     // so that we can spread the decoding among all the workers.
     // See #2133
     let envelope = envelope.clone();
-    let mut dbz_state = if let SourceEnvelope::Debezium(dedup_strat) = envelope {
-        DebeziumDecodeState::new(
+    let mut dbz_state = match envelope {
+        SourceEnvelope::Debezium(dedup_strat, DebeziumMode::Plain) => DebeziumDecodeState::new(
             &schema,
             debug_name.to_string(),
             stream.scope().index(),
             dedup_strat,
-        )
-    } else {
-        None
+        ),
+        SourceEnvelope::Debezium(_, DebeziumMode::Upsert) => {
+            error!("Upsert doesn't make sense for Avro OCFs because they don't have keys");
+            None
+        }
+        _ => None,
     };
 
     let stream = stream.pass_through("AvroValues").flat_map(
@@ -89,7 +88,7 @@ where
             let top_node = schema.top_node();
             let maybe_row = match envelope {
                 SourceEnvelope::None => extract_row(value, index.map(Datum::from), top_node),
-                SourceEnvelope::Debezium(_) => {
+                SourceEnvelope::Debezium(_, _) => {
                     if let Some(dbz_state) = dbz_state.as_mut() {
                         dbz_state.extract(value, index, upstream_time_millis)
                     } else {
@@ -115,9 +114,6 @@ where
     (stream.as_collection(), None)
 }
 
-pub type PushSession<'a, R> =
-    Session<'a, Timestamp, R, PushCounter<Timestamp, R, Tee<Timestamp, R>>>;
-
 pub trait DecoderState {
     fn decode_key(&mut self, bytes: &[u8]) -> Result<Option<Row>, String>;
     /// Decode the value in the upsert context, which means it might be a None.
@@ -128,14 +124,13 @@ pub trait DecoderState {
         upstream_time_millis: Option<i64>,
     ) -> Result<Option<Row>, String>;
     /// give a session a plain value
-    fn give_value<'a>(
+    fn get_value(
         &mut self,
         bytes: &[u8],
         aux_num: Option<i64>,
         upstream_time_millis: Option<i64>,
-        session: &mut PushSession<'a, (Result<Row, DataflowError>, Timestamp, Diff)>,
-        time: Timestamp,
-    );
+    ) -> Option<Result<Row, DataflowError>>;
+
     /// Register number of success and failures with decoding,
     /// and reset count of pending events if necessary
     fn log_error_count(&mut self);
@@ -189,19 +184,13 @@ where
     }
 
     /// give a session a plain value
-    fn give_value<'a>(
+    fn get_value(
         &mut self,
         bytes: &[u8],
         line_no: Option<i64>,
         _upstream_time_millis: Option<i64>,
-        session: &mut PushSession<'a, (Result<Row, DataflowError>, Timestamp, Diff)>,
-        time: Timestamp,
-    ) {
-        session.give((
-            Ok(pack_with_line_no((self.datum_func)(bytes), line_no)),
-            time,
-            1,
-        ));
+    ) -> Option<Result<Row, DataflowError>> {
+        Some(Ok(pack_with_line_no((self.datum_func)(bytes), line_no)))
     }
 
     fn log_error_count(&mut self) {}
@@ -249,6 +238,7 @@ fn decode_values_inner<G, V, C>(
     mut value_decoder_state: V,
     op_name: &str,
     contract: C,
+    upsert_debezium: bool,
 ) -> (
     Collection<G, Row, Diff>,
     Option<Collection<G, dataflow_types::DataflowError, Diff>>,
@@ -259,24 +249,34 @@ where
     C: ParallelizationContract<Timestamp, SourceOutput<Vec<u8>, Vec<u8>>>,
 {
     let stream = stream.unary(contract, &op_name, move |_, _| {
+        let mut keys = if upsert_debezium {
+            Some(HashMap::new())
+        } else {
+            None
+        };
         move |input, output| {
             input.for_each(|cap, data| {
                 let mut session = output.session(&cap);
                 for SourceOutput {
-                    key: _,
+                    key,
                     value: payload,
                     position: aux_num,
                     upstream_time_millis,
                 } in data.iter()
                 {
                     if !payload.is_empty() {
-                        value_decoder_state.give_value(
-                            payload,
-                            *aux_num,
-                            *upstream_time_millis,
-                            &mut session,
-                            *cap.time(),
-                        );
+                        let val =
+                            value_decoder_state.get_value(payload, *aux_num, *upstream_time_millis);
+
+                        if let Some(val) = val {
+                            let val = if let Some(keys) = keys.as_mut() {
+                                rewrite_for_upsert(val, keys, key)
+                            } else {
+                                val
+                            };
+
+                            session.give((val, *cap.time(), 1))
+                        }
                     }
                 }
             });
@@ -290,6 +290,90 @@ where
     });
 
     (oks.as_collection(), Some(errs.as_collection()))
+}
+
+/// Update row to blank out retractions of rows that we have never seen
+fn rewrite_for_upsert(
+    val: Result<Row, DataflowError>,
+    keys: &mut HashMap<Box<[u8]>, Row>,
+    key: &[u8],
+) -> Result<Row, DataflowError> {
+    if let Ok(row) = val {
+        // TODO: handle parsed keys
+        let entry = keys.entry(key.into());
+
+        let mut rowiter = row.iter();
+        let before = rowiter.next().expect("must have a before list");
+        let after = rowiter.next().expect("must have an after list");
+
+        assert_eq!(
+            rowiter.next(),
+            None,
+            "[customer-data] Debezium data should only have retract/insert lists, got unexpected third: {:?}",
+            row
+        );
+        assert!(
+            matches!(before, Datum::List { .. } | Datum::Null),
+            "[customer-data] Debezium logic should be a List or absent, got {:?}",
+            before
+        );
+
+        match entry {
+            Entry::Vacant(vacant) => {
+                // if the key is new, then we know that we always need to ignore the "before" part,
+                // so zero it out
+                vacant.insert({
+                    let mut packer = RowPacker::new();
+                    packer.push(after);
+                    packer.finish()
+                });
+
+                if before.is_null() {
+                    Ok(row)
+                } else {
+                    let mut packer = RowPacker::new();
+                    packer.push(Datum::Null);
+                    packer.push(after);
+                    Ok(packer.finish())
+                }
+            }
+            Entry::Occupied(mut occupied) => {
+                if occupied.get().iter().next() == Some(before) {
+                    if after.is_null() {
+                        occupied.remove_entry();
+                    } else {
+                        occupied.insert({
+                            let mut packer = RowPacker::new();
+                            packer.push(after);
+                            packer.finish()
+                        });
+                    }
+                    // this matches the modifications we'd make in the next step
+                    Ok(row)
+                } else {
+                    let previous_insert = if after.is_null() {
+                        // We are trying to retract something that doesn't exist, so just assume
+                        // that the key is supposed to be empty at this point
+                        let (_k, v) = occupied.remove_entry();
+                        v
+                    } else {
+                        occupied.insert({
+                            let mut packer = RowPacker::new();
+                            packer.push(after);
+                            packer.finish()
+                        })
+                    };
+
+                    let mut packer = RowPacker::new();
+                    packer.push(previous_insert.iter().next().unwrap());
+                    packer.push(after);
+                    Ok(packer.finish())
+                }
+            }
+        }
+    } else {
+        val
+    }
 }
 
 fn decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
@@ -405,7 +489,7 @@ where
         (_, SourceEnvelope::CdcV2) => {
             unreachable!("Internal error: CDCv2 is not supported yet on non-Avro sources.")
         }
-        (DataEncoding::Avro(enc), SourceEnvelope::Debezium(ds)) => {
+        (DataEncoding::Avro(enc), SourceEnvelope::Debezium(ds, mode)) => {
             let dedup_strat = *ds;
             let fields = match &desc.typ().column_types[0].scalar_type {
                 ScalarType::Record { fields, .. } => fields.clone(),
@@ -438,6 +522,7 @@ where
                     .expect("Failed to create Avro decoder"),
                     &op_name,
                     SourceOutput::<Vec<u8>, Vec<u8>>::key_contract(),
+                    *mode == DebeziumMode::Upsert,
                 ),
                 None,
             )
@@ -459,13 +544,14 @@ where
                 .expect("Failed to create Avro decoder"),
                 &op_name,
                 SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
+                false,
             ),
             None,
         ),
         (DataEncoding::AvroOcf { .. }, _) => {
             unreachable!("Internal error: Cannot decode Avro OCF separately from reading")
         }
-        (_, SourceEnvelope::Debezium(_)) => unreachable!(
+        (_, SourceEnvelope::Debezium(_, _)) => unreachable!(
             "Internal error: A non-Avro Debezium-envelope source should not have been created."
         ),
         (DataEncoding::Regex(RegexEncoding { regex }), SourceEnvelope::None) => {
@@ -477,6 +563,7 @@ where
                 protobuf::ProtobufDecoderState::new(&enc.descriptors, &enc.message_name),
                 &op_name,
                 SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
+                false,
             ),
             None,
         ),
@@ -486,6 +573,7 @@ where
                 OffsetDecoderState::from(bytes_to_datum),
                 &op_name,
                 SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
+                false,
             ),
             None,
         ),
@@ -495,6 +583,7 @@ where
                 OffsetDecoderState::from(text_to_datum),
                 &op_name,
                 SourceOutput::<Vec<u8>, Vec<u8>>::position_value_contract(),
+                false,
             ),
             None,
         ),

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -17,6 +17,7 @@ use std::rc::Rc;
 use anyhow::bail;
 use dec::{Context as DecimalCx, Decimal128, OrderedDecimal};
 use ordered_float::OrderedFloat;
+use uuid::Uuid;
 
 use mz_avro::error::{DecodeError, Error as AvroError};
 use mz_avro::schema::{SchemaNode, SchemaPiece};
@@ -30,7 +31,6 @@ use repr::adt::decimal::Significand;
 use repr::adt::jsonb::JsonbPacker;
 use repr::adt::rdn;
 use repr::{Datum, Row, RowPacker};
-use uuid::Uuid;
 
 use super::{
     is_null, AvroDebeziumDecoder, ConfluentAvroResolver, DebeziumDeduplicationState,

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -84,7 +84,7 @@ impl Decoder {
                 || (envelope != EnvelopeType::Debezium && debezium_dedup.is_none())
         );
         let debezium_dedup =
-            debezium_dedup.map(|strat| DebeziumDeduplicationState::new(strat, key_indices));
+            debezium_dedup.and_then(|strat| DebeziumDeduplicationState::new(strat, key_indices));
         let csr_avro =
             ConfluentAvroResolver::new(reader_schema, schema_registry, confluent_wire_format)?;
 
@@ -118,8 +118,6 @@ impl Decoder {
             let dsr = GeneralDeserializer {
                 schema: resolved_schema.top_node(),
             };
-            // Unwrap is OK: we assert in Decoder::new that this is non-none when envelope == dbz.
-            let dedup = self.debezium_dedup.as_mut().unwrap();
             let (row, coords) = dsr.deserialize(&mut bytes, dec)?;
             if self.reject_non_inserts {
                 if !matches!(row.iter().next(), None | Some(Datum::Null)) {
@@ -130,6 +128,7 @@ impl Decoder {
                     )
                 }
             }
+            let dedupe = self.debezium_dedup.as_mut();
             let should_use = if let Some(source) = coords {
                 let mssql_fsn_buf;
                 // This would have ideally been `Option<&[u8]>`,
@@ -144,16 +143,23 @@ impl Decoder {
                     RowCoordinates::Postgres { .. } => &b""[..],
                     RowCoordinates::Unknown { .. } => &b""[..],
                 };
-                dedup.should_use_record(
-                    file,
-                    source.row,
-                    coord,
-                    upstream_time_millis,
-                    &self.debug_name,
-                    self.worker_index,
-                    source.snapshot,
-                    &row,
-                )
+
+                let debug_name = &self.debug_name;
+                let worker_index = self.worker_index;
+                dedupe
+                    .map(|d| {
+                        d.should_use_record(
+                            file,
+                            source.row,
+                            coord,
+                            upstream_time_millis,
+                            debug_name,
+                            worker_index,
+                            source.snapshot,
+                            &row,
+                        )
+                    })
+                    .unwrap_or(true)
             } else {
                 true
             };

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -144,7 +144,7 @@ pub enum Format<T: AstInfo> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Envelope<T: AstInfo> {
     None,
-    Debezium,
+    Debezium(DbzMode),
     Upsert(Option<Format<T>>),
     CdcV2,
 }
@@ -162,8 +162,9 @@ impl<T: AstInfo> AstDisplay for Envelope<T> {
                 // this is unreachable as long as the default is None, but include it in case we ever change that
                 f.write_str("NONE");
             }
-            Self::Debezium => {
+            Self::Debezium(mode) => {
                 f.write_str("DEBEZIUM");
+                f.write_node(mode);
             }
             Self::Upsert(format) => {
                 f.write_str("UPSERT");
@@ -248,6 +249,30 @@ impl AstDisplay for Compression {
     }
 }
 impl_display!(Compression);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DbzMode {
+    /// `ENVELOPE DEBEZIUM` with no suffix
+    Plain,
+    /// `ENVELOPE DEBEZIUM UPSERT`
+    Upsert,
+}
+
+impl Default for DbzMode {
+    fn default() -> Self {
+        Self::Plain
+    }
+}
+
+impl AstDisplay for DbzMode {
+    fn fmt(&self, f: &mut AstFormatter) {
+        match self {
+            Self::Plain => f.write_str(""),
+            Self::Upsert => f.write_str(" UPSERT"),
+        }
+    }
+}
+impl_display!(DbzMode);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Connector<T: AstInfo> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1584,7 +1584,12 @@ impl<'a> Parser<'a> {
         let envelope = if self.parse_keyword(NONE) {
             Envelope::None
         } else if self.parse_keyword(DEBEZIUM) {
-            Envelope::Debezium
+            let debezium_mode = if self.parse_keyword(UPSERT) {
+                DbzMode::Upsert
+            } else {
+                DbzMode::Plain
+            };
+            Envelope::Debezium(debezium_mode)
         } else if self.parse_keyword(UPSERT) {
             let format = if self.parse_keyword(FORMAT) {
                 Some(self.parse_format()?)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -410,7 +410,7 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'h
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' SEED VALUE SCHEMA 'blah'
@@ -431,7 +431,7 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'h
 ----
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: Debezium, if_not_exists: false, materialized: false })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], format: Some(Avro(CsrUrl { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] })), envelope: Debezium(Plain), if_not_exists: false, materialized: false })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -821,9 +821,13 @@ pub fn plan_create_source(
         sql_parser::ast::Envelope::None => SourceEnvelope::None,
         sql_parser::ast::Envelope::Debezium(mode) => {
             let dedup_strat = match with_options.remove("deduplication") {
-                None => DebeziumDeduplicationStrategy::Ordered,
+                None => match mode {
+                    sql_parser::ast::DbzMode::Plain => DebeziumDeduplicationStrategy::Ordered,
+                    sql_parser::ast::DbzMode::Upsert => DebeziumDeduplicationStrategy::None,
+                },
                 Some(Value::String(s)) => {
                     match s.as_str() {
+                        "none" => DebeziumDeduplicationStrategy::None,
                         "full" => DebeziumDeduplicationStrategy::Full,
                         "ordered" => DebeziumDeduplicationStrategy::Ordered,
                         "full_in_range" => {

--- a/test/testdrive/upsert-kafka-debezium.td
+++ b/test/testdrive/upsert-kafka-debezium.td
@@ -1,0 +1,137 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# must be a subset of the keys in the rows
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "id", "type": "long"}
+    ]
+  }
+
+$ set schema={
+    "type" : "record",
+    "name" : "envelope",
+    "fields" : [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                  "name": "id",
+                  "type": "long"
+              },
+              {
+                "name": "creature",
+                "type": "string"
+              }]
+           },
+           "null"
+         ]
+      },
+      {
+        "name": "after",
+        "type": ["row", "null"]
+      }
+    ]
+  }
+
+$ kafka-create-topic topic=dbzupsert
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
+{"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}}
+{"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}}
+
+
+> CREATE MATERIALIZED SOURCE doin_upsert
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM UPSERT
+
+> SELECT * FROM doin_upsert
+id creature
+-----------
+1  lizard
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 1} {"before": {"row": {"id": 1, "creature": "lizard"}}, "after": {"row": {"id": 1, "creature": "dino"}}}
+
+> SELECT * FROM doin_upsert
+id creature
+-----------
+1  dino
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "archeopteryx"}}}
+{"id": 2} {"before": {"row": {"id": 2, "creature": "archeopteryx"}}, "after": {"row": {"id": 2, "creature": "velociraptor"}}}
+
+> SELECT * FROM doin_upsert ORDER BY creature
+id creature
+------------
+1  dino
+2  velociraptor
+
+# test duplicates
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}}
+{"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}}
+
+> SELECT * FROM doin_upsert WHERE id = 3
+id creature
+-----------
+3  triceratops
+
+# test removal and reinsertion
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 4} {"before": null, "after": {"row": {"id": 4, "creature": "moros"}}}
+
+> SELECT creature FROM doin_upsert WHERE id = 4
+creature
+--------
+moros
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": null}
+
+> SELECT creature FROM doin_upsert WHERE id = 4
+creature
+--------
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": {"row": {"id": 4, "creature": "chicken"}}}
+
+> SELECT creature FROM doin_upsert WHERE id = 4
+creature
+--------
+chicken
+
+> SELECT * FROM doin_upsert WHERE id = 3
+id creature
+-----------
+3  triceratops
+
+# Test that it works with full deduplication
+> CREATE MATERIALIZED SOURCE upsert_full_dedupe
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  WITH (deduplication = 'full')
+  FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM UPSERT
+
+> SELECT creature FROM upsert_full_dedupe
+creature
+----
+dino
+velociraptor
+triceratops
+chicken


### PR DESCRIPTION
This adds upsert semantics support for Debezium sources. Fundamentally that means that we treat
upstream diffs as potentially nonsensical.

To do that, we track keys per-key values per-key, and only retract rows that we know that we have
seen.

There is one todo in the code that will be the immediate next work: with the code as it stands we
treat the keys as raw bytes, not decoding them, but since Avro is not self-describing it is possible
for the same bit pattern to have different values when decoded. We feel like this is unlikely enough
to be an issue for most users (considering especially that we don't really support schema evolution)
that it's probably safe to use as is.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6210)
<!-- Reviewable:end -->
