### PR TITLE
dataflow: structure reduce accumulators

### DIFF
--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -48,3 +48,6 @@ cast_from!(i32, isize);
 cast_from!(i64, isize);
 
 cast_from!(isize, i64);
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+cast_from!(isize, i128);


### PR DESCRIPTION
Introduce a new "Accumulator" enumeration for processing accumulable
reductions. Previously, every aggregate accumulated into three i128
counters, even though only the Any and All aggregates actually
needed all three counters. The Accumulator enum introduced here allows
for different aggregates to use different numbers and types of counters.

This should actually result in space savings. While the enum requires an
additional tag byte, that space is more than made up for by accumulating
into isizes where possible. Unclear if the additional switch statement
in the `plus_equals` assignment has a performance cost, though.

The goal here is to make room for an `Accumulator::Decimal` variant
which accumulates the necessary fields for the new decimal type (#5274).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6217)
<!-- Reviewable:end -->
