### PR TITLE
Propagate inotify related errors in file sources

### DIFF
--- a/src/dataflow/src/source/file.rs
+++ b/src/dataflow/src/source/file.rs
@@ -216,7 +216,8 @@ pub fn read_file_task<Ctor, I, Out, Err>(
     Ctor: FnOnce(Box<dyn AvroRead + Send>) -> Result<I, Err>,
     Err: Into<anyhow::Error>,
 {
-    log::trace!("reading file {}", path.display());
+    let path_display_name = path.display().to_string();
+    log::trace!("reading file {}", path_display_name);
     let file = match std::fs::File::open(&path).with_context(|| {
         format!(
             "file source: unable to open file at path {}",
@@ -225,13 +226,55 @@ pub fn read_file_task<Ctor, I, Out, Err>(
     }) {
         Ok(file) => file,
         Err(err) => {
-            let _ = tx.send(Err(err));
+            if let Err(send_e) = tx.send(Err(err)) {
+                error!("Failed to send error when opening file: {:#}", send_e);
+            }
             return;
         }
     };
 
-    let file: Box<dyn AvroRead + Send> = match read_style {
-        FileReadStyle::ReadOnce => Box::new(file),
+    let file_stream = match open_file_stream(path, file, read_style) {
+        Ok(f) => f,
+        Err(err) => {
+            if let Err(send_e) = tx.send(Err(err)) {
+                error!("Failed to send file initialization error: {:#}", send_e);
+            }
+            return;
+        }
+    };
+
+    let file_stream: Box<dyn AvroRead + Send> = match compression {
+        Compression::Gzip => Box::new(MultiGzDecoder::new(file_stream)),
+        Compression::None => Box::new(file_stream),
+    };
+
+    let iter = iter_ctor(file_stream);
+
+    match iter.map_err(Into::into).with_context(|| {
+        format!(
+            "Failed to obtain records from file at path {}",
+            path_display_name,
+        )
+    }) {
+        Ok(i) => send_records(i, tx, activator),
+        Err(err) => {
+            if let Err(send_e) = tx.send(Err(err)) {
+                error!(
+                    "Failed to send error when reading file records: {:#}",
+                    send_e
+                );
+            }
+        }
+    };
+}
+
+fn open_file_stream(
+    path: PathBuf,
+    file: std::fs::File,
+    read_style: FileReadStyle,
+) -> Result<Box<dyn AvroRead + Send>, anyhow::Error> {
+    match read_style {
+        FileReadStyle::ReadOnce => Ok(Box::new(file)),
         FileReadStyle::TailFollowFd => {
             let (notice_tx, notice_rx) = mpsc::channel();
 
@@ -257,21 +300,11 @@ pub fn read_file_task<Ctor, I, Out, Err>(
 
             #[cfg(target_os = "linux")]
             {
-                let mut inotify = match Inotify::init() {
-                    Ok(w) => w,
-                    Err(err) => {
-                        error!("file source: failed to initialize inotify: {:#}", err,);
-                        return;
-                    }
-                };
-                if let Err(err) = inotify.add_watch(&path, WatchMask::ALL_EVENTS) {
-                    error!(
-                        "file source: failed to add watch for file: {:#} (path: {})",
-                        err,
-                        path.display()
-                    );
-                    return;
-                }
+                let mut inotify = Inotify::init()
+                    .with_context(|| format!("file source: failed to initialize inotify"))?;
+                inotify
+                    .add_watch(&path, WatchMask::ALL_EVENTS)
+                    .with_context(|| format!("failed to add watch for file {}", path.display()))?;
                 let path = path.clone();
                 thread::spawn(move || {
                     // This buffer must be at least `sizeof(struct inotify_event) + NAME_MAX + 1`.
@@ -280,14 +313,28 @@ pub fn read_file_task<Ctor, I, Out, Err>(
                     let mut buf = [0; 1024];
                     loop {
                         if let Err(err) = inotify.read_events_blocking(&mut buf) {
+                            if notice_tx
+                                .send(Err(format!(
+                                    "file source: failed to get events for file: {:#} (path: {})",
+                                    err,
+                                    path.display()
+                                )))
+                                .is_err()
+                            {
+                                // If the notice_tx returns an error, it's because
+                                // the source has been dropped. Just exit the
+                                // thread.
+                                return;
+                            }
+                            // We have no method for recovering from this error
+                            // Close this thread and log an error message (which duplicates the err above)
                             error!(
-                                "file source: failed to get events for file: {:#} (path: {})",
-                                err,
+                                "file source: closing stream due to read errors (path: {})",
                                 path.display()
                             );
                             return;
                         };
-                        if notice_tx.send(()).is_err() {
+                        if notice_tx.send(Ok(())).is_err() {
                             // If the notice_tx returns an error, it's because
                             // the source has been dropped. Just exit the
                             // thread.
@@ -297,31 +344,12 @@ pub fn read_file_task<Ctor, I, Out, Err>(
                 });
             };
 
-            Box::new(ForeverTailedFile {
+            Ok(Box::new(ForeverTailedFile {
                 rx: notice_rx,
                 inner: file,
-            })
+            }))
         }
-    };
-
-    let file: Box<dyn AvroRead + Send> = match compression {
-        Compression::Gzip => Box::new(MultiGzDecoder::new(file)),
-        Compression::None => Box::new(file),
-    };
-
-    let iter = iter_ctor(file);
-
-    match iter.map_err(Into::into).with_context(|| {
-        format!(
-            "Failed to obtain records from file at path {}",
-            path.to_string_lossy(),
-        )
-    }) {
-        Ok(i) => send_records(i, tx, activator),
-        Err(e) => {
-            let _ = tx.send(Err(e));
-        }
-    };
+    }
 }
 
 /// Strategies for streaming content from a file.


### PR DESCRIPTION
Instead of ignoring errors from inotify, raise the errors on the source stream. This will cause views to error out instead of returning empty results.

Fixes #6114

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6218)
<!-- Reviewable:end -->
