### PR TITLE
Allow the acks option to be specified for Kafka sinks

### DIFF
--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -128,6 +128,7 @@ pub fn extract_config(
     extract(
         with_options,
         &[
+            Config::string("acks"),
             Config::string("client_id"),
             Config::new(
                 "statistics_interval_ms",


### PR DESCRIPTION
The "acks" option, possibly the most important Kafka producer option ever, could not be specified for Kafka sinks. I need it for multi-broker testing and I presume our customers will also need it.

The list of opitons allowed as listed in the Rust file has diverged from the list in the documentation, so I will open a separate ticket to reconcile the two lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6222)
<!-- Reviewable:end -->
