### PR TITLE
dependabot: change to sunday evening alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: /
   schedule:
     interval: weekly
-    day: monday
+    day: sunday
     time: "22:00"
   open-pull-requests-limit: 10
   reviewers:


### PR DESCRIPTION
The intent was always to have these appear on Sunday evenings.
I just got the time zone wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6232)
<!-- Reviewable:end -->
