### PR TITLE
sqs validation: increase timeout in another place

### DIFF
--- a/src/testdrive/src/action/s3.rs
+++ b/src/testdrive/src/action/s3.rs
@@ -304,7 +304,7 @@ impl Action for AddBucketNotifications {
         let mut attempts = 0;
         let mut success = false;
         print!(
-            "Verifying SQS notification configuration for up to {:?}",
+            "Verifying SQS notification configuration for up to {:?} ",
             sqs_validation_timeout
         );
         let start = Instant::now();

--- a/test/testdrive/esoteric/s3.td
+++ b/test/testdrive/esoteric/s3.td
@@ -23,7 +23,7 @@ b3
 
 $ set queue-name=materialize-ci-notifications-${testdrive.seed}
 
-$ s3-add-notifications bucket=${bucket} queue=${queue-name}
+$ s3-add-notifications bucket=${bucket} queue=${queue-name} sqs-validation-timeout=5m
 
 > CREATE MATERIALIZED SOURCE s3_all
   FROM S3 OBJECTS FROM SCAN BUCKET '${bucket}'


### PR DESCRIPTION
There isn't any reason that this wasn't using the same timeout as the command lower in the file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6251)
<!-- Reviewable:end -->
