### PR TITLE
Make files flamegraph.pl can understand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ dependencies = [
  "jemalloc-ctl",
  "lazy_static",
  "pprof",
+ "serde",
  "tempfile",
  "tokio",
 ]

--- a/src/materialized/src/http/prof.rs
+++ b/src/materialized/src/http/prof.rs
@@ -293,7 +293,7 @@ mod enabled {
                 Ok(Response::builder()
                     .header(
                         header::CONTENT_DISPOSITION,
-                        "attachement; filename=\"mz.fg\"",
+                        "attachment; filename=\"mz.fg\"",
                     )
                     .body(Body::from(s))
                     .unwrap())

--- a/src/materialized/src/http/prof.rs
+++ b/src/materialized/src/http/prof.rs
@@ -171,11 +171,14 @@ mod disabled {
 
 #[cfg(not(target_os = "macos"))]
 mod enabled {
+    use std::borrow::Cow;
     use std::collections::HashMap;
+    use std::fmt::Write;
     use std::io::{BufReader, Read};
     use std::sync::Arc;
 
     use hyper::{header, Body, Method, Request, Response, StatusCode};
+    use prof::symbolicate;
     use tokio::sync::Mutex;
     use url::form_urlencoded;
 
@@ -255,6 +258,42 @@ mod enabled {
                     .header(
                         header::CONTENT_DISPOSITION,
                         "attachment; filename=\"jeprof.heap\"",
+                    )
+                    .body(Body::from(s))
+                    .unwrap())
+            }
+            "dump_symbolicated_file" => {
+                let mut borrow = prof_ctl.lock().await;
+                let f = borrow.dump()?;
+                let r = BufReader::new(f);
+                let stacks = parse_jeheap(r)?;
+                let syms = symbolicate(&stacks);
+                let mut s = String::new();
+                // Emitting the format expected by Brendan Gregg's flamegraph tool.
+                //
+                // foo;bar;quux 30
+                // foo;bar;asdf 40
+                //
+                // etc.
+                for (stack, _anno) in stacks.iter() {
+                    for (i, addr) in stack.addrs.iter().enumerate() {
+                        let syms = match syms.get(addr) {
+                            Some(syms) => Cow::Borrowed(syms),
+                            None => Cow::Owned(vec!["???".to_string()]),
+                        };
+                        for (j, sym) in syms.iter().enumerate() {
+                            if j != 0 || i != 0 {
+                                s.push_str(";");
+                            }
+                            s.push_str(&*sym);
+                        }
+                    }
+                    writeln!(&mut s, " {}", stack.weight).unwrap();
+                }
+                Ok(Response::builder()
+                    .header(
+                        header::CONTENT_DISPOSITION,
+                        "attachement; filename=\"mz.fg\"",
                     )
                     .body(Body::from(s))
                     .unwrap())

--- a/src/materialized/src/http/templates/prof.html
+++ b/src/materialized/src/http/templates/prof.html
@@ -17,6 +17,7 @@
     <form method="post">
       <button name="action" value="deactivate">Deactivate</button>
       <button name="action" value="dump_file">Download heap profile</button>
+      <button name="action" value="dump_symbolicated_file">Download symbolicated heap profile</button>
       <button name="action" value="mem_fg">Visualize heap profile (flamegraph)</button>
     </form>
   {% when None %}

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -12,6 +12,7 @@ jemalloc-ctl = { version = "0.3.0", features = ["use_std"], optional = true }
 lazy_static = "1.4.0"
 pprof = "0.4.2"
 tempfile = "3.2.0"
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.4.0", features = ["time"] }
 
 [features]


### PR DESCRIPTION
It's really annoying that:

1. We have to ask customers to send us a copy of the `materialized` binary they're using, so that we can symbolicate traces;
2. We have to write some complicated command to do so.

Now, just download the symbolicated profile, and then run `flamegraph.pl < ~/Downloads/mz.fg > out.svg` (where flamegraph.pl comes from [here](https://github.com/brendangregg/FlameGraph) .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6253)
<!-- Reviewable:end -->
