### PR TITLE
expr: make mz_sleep deterministic

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -13,6 +13,7 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::iter;
 use std::str;
+use std::thread;
 
 use ::encoding::label::encoding_from_whatwg_label;
 use ::encoding::DecoderTrap;
@@ -1408,8 +1409,8 @@ fn power_dec<'a>(a: Datum<'a>, b: Datum<'a>, scale: u8) -> Result<Datum<'a>, Eva
 
 fn sleep<'a>(a: Datum<'a>) -> Result<Datum<'a>, EvalError> {
     let duration = std::time::Duration::from_secs_f64(a.unwrap_float64());
-    std::thread::sleep(duration);
-    Ok(Datum::from(Utc::now()))
+    thread::sleep(duration);
+    Ok(Datum::Null)
 }
 
 fn eq<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
@@ -3560,7 +3561,7 @@ impl UnaryFunc {
             Cot => ScalarType::Float64.nullable(in_nullable),
             Log10 | Ln | Exp => ScalarType::Float64.nullable(in_nullable),
             Log10Decimal(_) | LnDecimal(_) | ExpDecimal(_) => input_type,
-            Sleep => ScalarType::TimestampTz.nullable(false),
+            Sleep => ScalarType::TimestampTz.nullable(true),
         }
     }
 

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1084,8 +1084,3 @@ SELECT '"2020!03-17 #?~T~02:36:56#"'::timestamp;
 
 query error invalid input syntax for type timestamp: have unprocessed tokens 56
 select TIMESTAMP '"2020-03-17 ~02:36:~56~"';
-
-query T
-SELECT mz_internal.mz_sleep(0.1) - now() >= '0.1'::interval;
-----
-true


### PR DESCRIPTION
Per Slack discussion. I think @frankmcsherry probably objects to the existence of this function at all, but we might as well improve the situation while we figure out what to do. I think eliminating the nondeterminism solves 95% of the problem?

----

It still has the side effect of sleeping, but at least it is now
deterministic. I think this resolves most of the concerns with it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6257)
<!-- Reviewable:end -->
