### PR TITLE
Stabilize pubnub sources

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -36,8 +36,9 @@ use dataflow::source::read_file_task;
 use dataflow::source::FileReadStyle;
 use dataflow_types::{
     AvroOcfEncoding, Consistency, DataEncoding, DebeziumMode, ExternalSourceConnector,
-    FileSourceConnector, KafkaSourceConnector, KinesisSourceConnector, MzOffset, S3SourceConnector,
-    SourceConnector, SourceEnvelope, TimestampSourceUpdate,
+    FileSourceConnector, KafkaSourceConnector, KinesisSourceConnector, MzOffset,
+    PubNubSourceConnector, S3SourceConnector, SourceConnector, SourceEnvelope,
+    TimestampSourceUpdate,
 };
 use expr::{GlobalId, PartitionId};
 use ore::collections::CollectionExt;
@@ -113,6 +114,7 @@ enum RtTimestampConnector {
     File(RtFileConnector),
     Ocf(RtFileConnector),
     Kinesis(RtKinesisConnector),
+    PubNub(RtPubNubConnector),
     S3(RtS3Connector),
 }
 
@@ -190,6 +192,9 @@ struct RtKinesisConnector {}
 
 /// Data consumer stub for File source with RT consistency
 struct RtFileConnector {}
+
+/// Data consumer stub for PubNub source with RT consistency
+struct RtPubNubConnector {}
 
 /// Data consumer stub for S3 source with RT consistency
 struct RtS3Connector {}
@@ -613,8 +618,12 @@ impl Timestamper {
                         connector: RtTimestampConnector::S3(connector),
                     })
             }
+            ExternalSourceConnector::PubNub(pubnubc) => self
+                .create_rt_pubnub_connector(id, pubnubc)
+                .map(|connector| RtTimestampConsumer {
+                    connector: RtTimestampConnector::PubNub(connector),
+                }),
             ExternalSourceConnector::Postgres(_) => None,
-            ExternalSourceConnector::PubNub(_) => None,
         }
     }
 
@@ -693,6 +702,14 @@ impl Timestamper {
         _fc: FileSourceConnector,
     ) -> Option<RtFileConnector> {
         Some(RtFileConnector {})
+    }
+
+    fn create_rt_pubnub_connector(
+        &self,
+        _id: GlobalId,
+        _pubnubc: PubNubSourceConnector,
+    ) -> Option<RtPubNubConnector> {
+        Some(RtPubNubConnector {})
     }
 
     fn create_rt_s3_connector(

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -695,6 +695,11 @@ where
                             partitions.insert(PartitionId::S3);
                             Some(TimestampDataUpdate::RealTime(partitions))
                         }
+                        (ExternalSourceConnector::PubNub(_), Consistency::RealTime) => {
+                            let mut partitions = HashSet::new();
+                            partitions.insert(PartitionId::File);
+                            Some(TimestampDataUpdate::RealTime(partitions))
+                        }
                         (ExternalSourceConnector::Kinesis(_), Consistency::BringYourOwn(_)) => {
                             log::error!("BYO timestamping not supported for Kinesis sources");
                             None
@@ -703,15 +708,13 @@ where
                             log::error!("BYO timestamping not supported for S3 sources");
                             None
                         }
+                        (ExternalSourceConnector::PubNub(_), Consistency::BringYourOwn(_)) => {
+                            log::error!("BYO timestamping not supported for PubNub sources");
+                            None
+                        }
                         (ExternalSourceConnector::Postgres(_), _) => {
                             log::debug!(
                                 "Postgres sources do not communicate with the timestamper thread"
-                            );
-                            None
-                        }
-                        (ExternalSourceConnector::PubNub(_), _) => {
-                            log::debug!(
-                                "PubNub sources do not communicate with the timestamper thread"
                             );
                             None
                         }

--- a/src/dataflow/src/source/pubnub.rs
+++ b/src/dataflow/src/source/pubnub.rs
@@ -7,64 +7,105 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use async_trait::async_trait;
+use std::convert::TryInto;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use anyhow::anyhow;
 use futures::StreamExt;
 use pubnub_hyper::core::data::message::Type;
 use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport};
+use tokio::sync::mpsc::{self, Receiver};
 
-use crate::source::{SimpleSource, SourceError, Timestamper};
-use dataflow_types::PubNubSourceConnector;
-use repr::{Datum, RowPacker};
+use crate::source::{
+    DataEncoding, ExternalSourceConnector, Logger, MzOffset, NextMessage, PartitionId,
+    SourceInstanceId, SourceMessage, SourceReader, SyncActivator,
+};
 
 /// Information required to sync data from PubNub
 pub struct PubNubSourceReader {
-    connector: PubNubSourceConnector,
+    receiver: Receiver<SourceMessage<Vec<u8>>>,
+    activator: Arc<SyncActivator>,
 }
 
-impl PubNubSourceReader {
-    /// Constructs a new instance
-    pub fn new(connector: PubNubSourceConnector) -> Self {
-        Self { connector }
-    }
-}
+impl SourceReader<Vec<u8>> for PubNubSourceReader {
+    fn new(
+        _name: String,
+        _source_id: SourceInstanceId,
+        worker_id: usize,
+        consumer_activator: SyncActivator,
+        connector: ExternalSourceConnector,
+        _: DataEncoding,
+        _: Option<Logger>,
+    ) -> Result<(PubNubSourceReader, Option<PartitionId>), anyhow::Error> {
+        let pubnub_conn = match connector {
+            ExternalSourceConnector::PubNub(pubnub_conn) => pubnub_conn,
+            _ => panic!("Unsupported ExternalSourceConnector for PubNubSourceReader"),
+        };
+        log::debug!("creating PubNubSourceReader worker_id={}", worker_id);
 
-#[async_trait]
-impl SimpleSource for PubNubSourceReader {
-    async fn start(mut self, timestamper: &Timestamper) -> Result<(), SourceError> {
+        let (tx, rx) = mpsc::channel(1024);
+
         let transport = DefaultTransport::new()
             // we don't need a publish key for subscribing
             .publish_key("")
-            .subscribe_key(&self.connector.subscribe_key)
+            .subscribe_key(&pubnub_conn.subscribe_key)
             .build()
-            .map_err(SourceError::FileIO)?;
+            .map_err(anyhow::Error::msg)?;
+
+        let channel = pubnub_conn
+            .channel
+            .try_into()
+            .or_else(|c| Err(anyhow!("invalid channel name: {}", c)))?;
 
         let mut pubnub = Builder::new()
             .transport(transport)
             .runtime(DefaultRuntime)
             .build();
 
-        let channel = self.connector.channel.parse().unwrap();
+        tokio::spawn(async move {
+            let stream = pubnub.subscribe(channel).await;
+            tokio::pin!(stream);
 
-        let stream = pubnub.subscribe(channel).await;
-        tokio::pin!(stream);
+            while let Some(msg) = stream.next().await {
+                if msg.message_type == Type::Publish {
+                    let record = msg.json.dump().into_bytes();
+                    let offset = MzOffset {
+                        offset: msg.timetoken.t as i64,
+                    };
 
-        let mut packer = RowPacker::new();
-
-        while let Some(msg) = stream.next().await {
-            if msg.message_type == Type::Publish {
-                let s = msg.json.dump();
-
-                let datum: Datum = (&*s).into();
-                packer.push(datum);
-                let row = packer.finish_and_reuse();
-
-                timestamper
-                    .insert(row)
-                    .await
-                    .map_err(|e| SourceError::FileIO(e.to_string()))?;
+                    let message = SourceMessage {
+                        partition: PartitionId::File,
+                        offset: offset,
+                        upstream_time_millis: None,
+                        key: None,
+                        payload: Some(record),
+                    };
+                    if let Err(_) = tx.send(message).await {
+                        // Source is no longer active
+                        return;
+                    }
+                }
             }
-        }
+        });
 
-        Ok(())
+        Ok((
+            PubNubSourceReader {
+                receiver: rx,
+                activator: Arc::new(consumer_activator),
+            },
+            Some(PartitionId::File),
+        ))
+    }
+
+    fn get_next_message(&mut self) -> Result<NextMessage<Vec<u8>>, anyhow::Error> {
+        let waker = futures::task::waker_ref(&self.activator);
+        let mut context = Context::from_waker(&waker);
+
+        match self.receiver.poll_recv(&mut context) {
+            Poll::Ready(Some(message)) => Ok(NextMessage::Ready(message)),
+            Poll::Ready(None) => Ok(NextMessage::Finished),
+            Poll::Pending => Ok(NextMessage::Pending),
+        }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -759,7 +759,6 @@ pub fn plan_create_source(
             subscribe_key,
             channel,
         } => {
-            scx.require_experimental_mode("PubNub Sources")?;
             let connector = ExternalSourceConnector::PubNub(PubNubSourceConnector {
                 subscribe_key: subscribe_key.clone(),
                 channel: channel.clone(),


### PR DESCRIPTION
This PR switches PubNub sources to use the implement `SourceReader` trait and behave for all intents and purposes similar to a File source and also removes it from the experimental state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6258)
<!-- Reviewable:end -->
