### PR TITLE
Add a facility to check for service dependencies in wait-for-tcp

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -409,11 +409,19 @@ mzworkflows:
     - step: start-services
       services: [kafka, schema-registry]
     - step: wait-for-tcp
-      host: schema-registry
-      port: 8081
-    - step: wait-for-tcp
       host: kafka
       port: 9092
+    - step: wait-for-tcp
+      host: schema-registry
+      port: 8081
+      depencies:
+        # sometimes kafka comes up for awhile and then crashes, which will always cause
+        # schema-registry to fail because there is no kafka cluster
+        - host: kafka
+          port: 9092
+          hint: >-
+            If kafka logs that it has an invalid cluster id ensure that all volumes are
+            destroyed via 'mzcompose down -v'
     - step: start-services
       services: [materialized]
     - step: run
@@ -627,11 +635,20 @@ mzworkflows:
       port: 8083
       timeout_secs: 120
     - step: wait-for-tcp
-      host: schema-registry
-      port: 8081
-    - step: wait-for-tcp
       host: kafka
       port: 9092
+    - step: wait-for-tcp
+      host: schema-registry
+      port: 8081
+      dependencies:
+        # sometimes kafka comes up for awhile and then crashes, which will always cause
+        # schema-registry to fail because there is no kafka cluster
+        - host: kafka
+          port: 9092
+          hint: >-
+            If kafka logs that it has an invalid cluster id ensure that all volumes are
+            destroyed via 'mzcompose down -v'
+
 
   # Brings up everything to run chbench unisolated, i.e. local tests.
   bring-up-source-data-mysql:
@@ -678,11 +695,19 @@ mzworkflows:
       port: 8083
       timeout_secs: 120
     - step: wait-for-tcp
-      host: schema-registry
-      port: 8081
-    - step: wait-for-tcp
       host: kafka
       port: 9092
+    - step: wait-for-tcp
+      host: schema-registry
+      port: 8081
+      dependencies:
+        # sometimes kafka comes up for awhile and then crashes, which will always cause
+        # schema-registry to fail because there is no kafka cluster
+        - host: kafka
+          port: 9092
+          hint: >-
+            If kafka logs that it has an invalid cluster id ensure that all volumes are
+            destroyed via 'mzcompose down -v'
 
   # Brings up everything to run chbench unisolated, i.e. local tests.
   bring-up-source-data-postgres:


### PR DESCRIPTION
We have been having issues with the Kafka directory being persisted across chbench runs, causing
Kafka to crash after it has been up for a bit. This doesn't fix the problem (which I believe would
require breaking the benchmarking code out into its own mzcompose) but it does diagnose and give
instructions for how to recover.

I'm not sure how to cause the kafka failure that we have been seeing, so I tested this by:
* running the ci workflow as-is, which worked
* moving the schema-registry tests to before waiting for Kafka, and it does indeed immediately fail the ci workflow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6261)
<!-- Reviewable:end -->
