### PR TITLE
Remove RowPacker from MFP::evaluate

### DIFF
--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -96,7 +96,7 @@ where
                                             datums_local[index] = Datum::Dummy;
                                         }
                                     }
-                                    mfp.evaluate(&mut datums_local, temp_storage, row_packer)
+                                    mfp.evaluate(&mut datums_local, temp_storage)
                                         .transpose()
                                         .map(|x| (x.map_err(DataflowError::from), *r))
                                 } else {

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -403,17 +403,12 @@ where
                                 if let Some(initial_closure) = initial_closure {
                                     let (stream, errs) = update_stream.flat_map_fallible({
                                         let mut datums = DatumVec::new();
-                                        let mut row_packer = RowPacker::new();
                                         move |row| {
                                             let temp_storage = RowArena::new();
                                             let mut datums_local = datums.borrow_with(&row);
                                             // TODO(mcsherry): re-use `row` allocation.
                                             initial_closure
-                                                .apply(
-                                                    &mut datums_local,
-                                                    &temp_storage,
-                                                    &mut row_packer,
-                                                )
+                                                .apply(&mut datums_local, &temp_storage)
                                                 .transpose()
                                         }
                                     });
@@ -482,17 +477,12 @@ where
                                     let (updates, errors) = update_stream.flat_map_fallible({
                                         // Reuseable allocation for unpacking.
                                         let mut datums = DatumVec::new();
-                                        let mut row_packer = repr::RowPacker::new();
                                         move |row| {
                                             let temp_storage = RowArena::new();
                                             let mut datums_local = datums.borrow_with(&row);
                                             // TODO(mcsherry): re-use `row` allocation.
                                             final_closure
-                                                .apply(
-                                                    &mut datums_local,
-                                                    &temp_storage,
-                                                    &mut row_packer,
-                                                )
+                                                .apply(&mut datums_local, &temp_storage)
                                                 .map_err(DataflowError::from)
                                                 .transpose()
                                         }
@@ -580,7 +570,6 @@ where
     use timely::dataflow::operators::OkErr;
 
     let mut datums = DatumVec::new();
-    let mut row_packer = RowPacker::new();
     let (oks, errs2) = dogsdogsdogs::operators::lookup_map(
         &updates,
         trace,
@@ -595,7 +584,7 @@ where
             datums_local.extend(stream_row.iter());
             datums_local.extend(lookup_row.iter());
             (
-                closure.apply(&mut datums_local, &temp_storage, &mut row_packer),
+                closure.apply(&mut datums_local, &temp_storage),
                 diff1 * diff2,
             )
         },

--- a/src/dataflow/src/render/join/mod.rs
+++ b/src/dataflow/src/render/join/mod.rs
@@ -33,7 +33,7 @@ mod linear_join;
 use std::collections::HashMap;
 
 use expr::{MapFilterProject, MirScalarExpr};
-use repr::{Datum, Row, RowArena, RowPacker};
+use repr::{Datum, Row, RowArena};
 
 /// A manual closure implementation of filtering and logic application.
 ///
@@ -54,7 +54,6 @@ impl JoinClosure {
         &'a self,
         datums: &mut Vec<Datum<'a>>,
         temp_storage: &'a RowArena,
-        row_packer: &mut RowPacker,
     ) -> Result<Option<Row>, expr::EvalError> {
         for exprs in self.ready_equivalences.iter() {
             // Each list of expressions should be equal to the same value.
@@ -65,7 +64,7 @@ impl JoinClosure {
                 }
             }
         }
-        self.before.evaluate(datums, &temp_storage, row_packer)
+        self.before.evaluate(datums, &temp_storage)
     }
 
     /// Construct an instance of the closure from available columns.

--- a/src/dataflow/src/render/reduce.rs
+++ b/src/dataflow/src/render/reduce.rs
@@ -587,11 +587,7 @@ where
 
                         // Evaluate the key expressions.
                         row_packer.clear();
-                        let key = match key_mfp.evaluate(
-                            &mut datums_local,
-                            &temp_storage,
-                            &mut row_packer,
-                        ) {
+                        let key = match key_mfp.evaluate(&mut datums_local, &temp_storage) {
                             Err(e) => return Some(Err(DataflowError::from(e))),
                             Ok(key) => key.expect("Row expected as no predicate was used"),
                         };

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -913,7 +913,6 @@ impl PendingPeek {
         let (mut cursor, storage) = self.trace_bundle.oks_mut().cursor();
         // Accumulated `Vec<Datum>` results that we are likely to return.
         let mut results = Vec::new();
-        let mut row_packer = repr::RowPacker::new();
 
         // When set, a bound on the number of records we need to return.
         // The requirements on the records are driven by the finishing's
@@ -941,7 +940,7 @@ impl PendingPeek {
                 let mut datums = row.unpack();
                 if let Some(result) = self
                     .map_filter_project
-                    .evaluate(&mut datums, &arena, &mut row_packer)
+                    .evaluate(&mut datums, &arena)
                     .map_err(|e| e.to_string())?
                 {
                     let mut copies = 0;

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -32,7 +32,7 @@ pub mod strconv;
 
 pub use cache::{CachedRecord, CachedRecordIter};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{datum_size, DatumList, DatumMap, Row, RowArena, RowPacker, RowRef};
+pub use row::{datum_size, datums_size, DatumList, DatumMap, Row, RowArena, RowPacker, RowRef};
 pub use scalar::{Datum, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.


### PR DESCRIPTION
The `MapFilterProject::evaluate` method populates the output `Datum` elements before forming them into a `Row`. Because it does, we are able to determine the appropriate length for the row allocation first, and then populate the contents, rather than copying in to a `RowPacker`, then allocating and copying back.

This was un-blocked by the introduction of methods to directly size and write into `Row` types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6274)
<!-- Reviewable:end -->
