### PR TITLE
repr: remove RowPacker

### DIFF
--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -21,7 +21,7 @@ use timely::logging::WorkerIdentifier;
 use super::{LogVariant, MaterializedLog};
 use crate::arrangement::KeysValsHandle;
 use expr::{GlobalId, SourceInstanceId};
-use repr::{Datum, Timestamp};
+use repr::{Datum, Row, Timestamp};
 
 /// Type alias for logging of materialized events.
 pub type Logger = timely::logging_core::Logger<MaterializedEvent, WorkerIdentifier>;
@@ -139,7 +139,6 @@ pub fn construct<A: Allocate>(
         let mut demux_buffer = Vec::new();
         demux.build(move |_capability| {
             let mut active_dataflows = std::collections::HashMap::new();
-            let mut row_packer = repr::RowPacker::new();
             move |_frontiers| {
                 let mut dataflow = dataflow_out.activate();
                 let mut dependency = dependency_out.activate();
@@ -209,7 +208,7 @@ pub fn construct<A: Allocate>(
                             }
                             MaterializedEvent::Frontier(name, logical, delta) => {
                                 frontier_session.give((
-                                    row_packer.pack(&[
+                                    Row::pack_slice(&[
                                         Datum::String(&name.to_string()),
                                         Datum::Int64(worker as i64),
                                         Datum::Int64(logical as i64),
@@ -278,9 +277,8 @@ pub fn construct<A: Allocate>(
             })
             .as_collection()
             .map({
-                let mut row_packer = repr::RowPacker::new();
                 move |(name, worker)| {
-                    row_packer.pack(&[
+                    Row::pack_slice(&[
                         Datum::String(&name.to_string()),
                         Datum::Int64(worker as i64),
                     ])
@@ -296,9 +294,8 @@ pub fn construct<A: Allocate>(
             })
             .as_collection()
             .map({
-                let mut row_packer = repr::RowPacker::new();
                 move |(dataflow, source, worker)| {
-                    row_packer.pack(&[
+                    Row::pack_slice(&[
                         Datum::String(&dataflow.to_string()),
                         Datum::String(&source.to_string()),
                         Datum::Int64(worker as i64),
@@ -310,9 +307,8 @@ pub fn construct<A: Allocate>(
 
         use differential_dataflow::operators::Count;
         let kafka_consumer_info_current = kafka_consumer_info.as_collection().count().map({
-            let mut row_packer = repr::RowPacker::new();
             move |((consumer_name, source_id, partition_id), diff_vector)| {
-                row_packer.pack(&[
+                Row::pack_slice(&[
                     Datum::String(&consumer_name),
                     Datum::String(&source_id.source_id.to_string()),
                     Datum::Int64(source_id.dataflow_id as i64),
@@ -339,9 +335,8 @@ pub fn construct<A: Allocate>(
             })
             .as_collection()
             .map({
-                let mut row_packer = repr::RowPacker::new();
                 move |(peek, worker)| {
-                    row_packer.pack(&[
+                    Row::pack_slice(&[
                         Datum::String(&format!("{}", peek.conn_id)),
                         Datum::Int64(worker as i64),
                         Datum::String(&peek.id.to_string()),
@@ -351,9 +346,8 @@ pub fn construct<A: Allocate>(
             });
 
         let source_info_current = source_info.as_collection().count().map({
-            let mut row_packer = repr::RowPacker::new();
             move |((name, id, pid), (offset, timestamp))| {
-                row_packer.pack(&[
+                Row::pack_slice(&[
                     Datum::String(&name),
                     Datum::String(&id.source_id.to_string()),
                     Datum::Int64(id.dataflow_id as i64),
@@ -418,9 +412,8 @@ pub fn construct<A: Allocate>(
             .as_collection()
             .count_total()
             .map({
-                let mut row_packer = repr::RowPacker::new();
                 move |((worker, pow), count)| {
-                    row_packer.pack(&[
+                    Row::pack_slice(&[
                         Datum::Int64(worker as i64),
                         Datum::Int64(pow as i64),
                         Datum::Int64(count as i64),
@@ -467,11 +460,11 @@ pub fn construct<A: Allocate>(
                 let key_clone = key.clone();
                 let trace = collection
                     .map({
-                        let mut row_packer = repr::RowPacker::new();
+                        let mut row_packer = Row::default();
                         move |row| {
                             let datums = row.unpack();
-                            let key_row = row_packer.pack(key.iter().map(|k| datums[*k]));
-                            (key_row, row)
+                            row_packer.extend(key.iter().map(|k| datums[*k]));
+                            (row_packer.finish_and_reuse(), row)
                         }
                     })
                     .arrange_by_key()

--- a/src/dataflow/src/render/flat_map.rs
+++ b/src/dataflow/src/render/flat_map.rs
@@ -56,7 +56,7 @@ where
             let (ok_collection, new_err_collection) =
                 ok_collection.explode_fallible({
                     let mut datums = DatumVec::new();
-                    let mut row_packer = repr::RowPacker::new();
+                    let mut row_packer = repr::Row::default();
                     move |input_row| {
                         let temp_storage = RowArena::new();
                         // Unpack datums and capture its length (to rewind MFP eval).
@@ -101,8 +101,8 @@ where
                                         .map(|x| (x.map_err(DataflowError::from), *r))
                                 } else {
                                     Some((
-                                        Ok::<_, DataflowError>(
-                                            row_packer.pack(
+                                        Ok::<_, DataflowError>({
+                                            row_packer.extend(
                                                 datums_local
                                                     .iter()
                                                     .cloned()
@@ -115,8 +115,9 @@ where
                                                             datum
                                                         }
                                                     }),
-                                            ),
-                                        ),
+                                            );
+                                            row_packer.finish_and_reuse()
+                                        }),
                                         *r,
                                     ))
                                 }

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -25,7 +25,7 @@ use timely::dataflow::Scope;
 
 use dataflow_types::DataflowError;
 use expr::{JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr};
-use repr::{Datum, Row, RowArena, RowPacker, Timestamp};
+use repr::{Datum, Row, RowArena, Timestamp};
 
 use super::super::context::{ArrangementFlavor, Context};
 use crate::operator::CollectionExt;
@@ -549,7 +549,7 @@ where
     let (updates, errs) = updates.map_fallible({
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
-        let mut row_packer = RowPacker::new();
+        let mut row_packer = Row::default();
         move |row| {
             let temp_storage = RowArena::new();
             let datums_local = datums.borrow_with(&row);

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -547,10 +547,10 @@ where
                         let ok_collection = ok_collection.map({
                             move |row| {
                                 let datums = row.unpack();
-                                let total_size =
-                                    repr::datums_size(outputs.iter().map(|i| datums[*i]));
+                                let iterator = outputs.iter().map(|i| datums[*i]);
+                                let total_size = repr::datums_size(iterator.clone());
                                 let mut row = Row::with_capacity(total_size);
-                                row.extend(outputs.iter().map(|i| datums[*i]));
+                                row.extend(iterator);
                                 row
                             }
                         });

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -41,7 +41,7 @@ where
                         move |row| {
                             let datums = row.unpack();
                             let iterator = keys2.iter().map(|i| datums[*i]);
-                            let total_size = repr::datums_size(keys2.iter().map(|i| datums[*i]));
+                            let total_size = repr::datums_size(iterator.clone());
                             let mut key_row = Row::with_capacity(total_size);
                             key_row.extend(iterator);
                             (key_row, row)

--- a/src/dataflow/src/render/threshold.rs
+++ b/src/dataflow/src/render/threshold.rs
@@ -38,10 +38,12 @@ where
                 let keys2 = keys.clone();
                 let ok_keyed = ok_built
                     .map({
-                        let mut row_packer = repr::RowPacker::new();
                         move |row| {
                             let datums = row.unpack();
-                            let key_row = row_packer.pack(keys2.iter().map(|i| datums[*i]));
+                            let iterator = keys2.iter().map(|i| datums[*i]);
+                            let total_size = repr::datums_size(keys2.iter().map(|i| datums[*i]));
+                            let mut key_row = Row::with_capacity(total_size);
+                            key_row.extend(iterator);
                             (key_row, row)
                         }
                     })

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -67,11 +67,13 @@ where
             {
                 let group_clone = group_key.to_vec();
                 let mut collection = collection.map({
-                    let mut row_packer = repr::RowPacker::new();
                     move |row| {
                         let row_hash = row.hashed();
                         let datums = row.unpack();
-                        let group_row = row_packer.pack(group_clone.iter().map(|i| datums[*i]));
+                        let iterator = group_clone.iter().map(|i| datums[*i]);
+                        let total_size = repr::datums_size(group_clone.iter().map(|i| datums[*i]));
+                        let mut group_row = Row::with_capacity(total_size);
+                        group_row.extend(iterator);
                         ((group_row, row_hash), row)
                     }
                 });

--- a/src/dataflow/src/render/top_k.rs
+++ b/src/dataflow/src/render/top_k.rs
@@ -71,7 +71,7 @@ where
                         let row_hash = row.hashed();
                         let datums = row.unpack();
                         let iterator = group_clone.iter().map(|i| datums[*i]);
-                        let total_size = repr::datums_size(group_clone.iter().map(|i| datums[*i]));
+                        let total_size = repr::datums_size(iterator.clone());
                         let mut group_row = Row::with_capacity(total_size);
                         group_row.extend(iterator);
                         ((group_row, row_hash), row)

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -139,7 +139,7 @@ where
             let mut current_values = HashMap::new();
 
             let mut vector = Vec::new();
-            let mut row_packer = repr::RowPacker::new();
+            let mut row_packer = repr::Row::default();
 
             move |input, output| {
                 // Digest each input, reduce by presented timestamp.
@@ -319,7 +319,7 @@ fn evaluate(
     datums: &[Datum],
     predicates: &[MirScalarExpr],
     position_or: &[Option<usize>],
-    row_packer: &mut repr::RowPacker,
+    row_packer: &mut repr::Row,
 ) -> Result<Option<Row>, EvalError> {
     let arena = RowArena::new();
     // Each predicate is tested in order.

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -19,7 +19,7 @@ use timely::dataflow::{Scope, Stream};
 use dataflow_types::{SinkAsOf, TailSinkConnector};
 use expr::GlobalId;
 use repr::adt::decimal::Significand;
-use repr::{Datum, Diff, Row, RowPacker, Timestamp};
+use repr::{Datum, Diff, Row, Timestamp};
 
 pub fn tail<G>(
     stream: Stream<G, Rc<OrdValBatch<GlobalId, Row, Timestamp, Diff>>>,
@@ -30,7 +30,7 @@ pub fn tail<G>(
     G: Scope<Timestamp = Timestamp>,
 {
     let mut errored = false;
-    let mut packer = RowPacker::new();
+    let mut packer = Row::default();
     stream.sink(Pipeline, &format!("tail-{}", id), move |input| {
         input.for_each(|_, batches| {
             if errored {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::{scalar::EvalError, MirRelationExpr, MirScalarExpr};
-use repr::{Datum, Row, RowArena, RowPacker};
+use repr::{Datum, Row, RowArena};
 
 /// A compound operator that can be applied row-by-row.
 ///
@@ -260,15 +260,15 @@ impl MapFilterProject {
         if exprs.is_empty() {
             return None;
         }
-        let mut row_packer = RowPacker::new();
+        let mut row = Row::default();
         for expr in exprs {
             if let Some(literal) = self.literal_constraint(expr) {
-                row_packer.push(literal);
+                row.push(literal);
             } else {
                 return None;
             }
         }
-        Some(row_packer.finish_and_reuse())
+        Some(row)
     }
 
     /// Extracts any MapFilterProject at the root of the expression.

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -491,10 +491,9 @@ impl MirRelationExpr {
                 );
             }
         }
-        let mut row_packer = repr::RowPacker::new();
         let rows = Ok(rows
             .into_iter()
-            .map(move |(row, diff)| (row_packer.pack(row), diff))
+            .map(move |(row, diff)| (Row::pack_slice(&row), diff))
             .collect());
         MirRelationExpr::Constant { rows, typ }
     }
@@ -1340,11 +1339,11 @@ impl RowSetFinishing {
                 rows.drain(..offset);
             }
             rows.sort_by(&mut sort_by);
-            let mut row_packer = repr::RowPacker::new();
+            let mut row_packer = Row::default();
             for row in rows {
                 let datums = row.unpack();
-                let new_row = row_packer.pack(self.project.iter().map(|i| &datums[*i]));
-                *row = new_row;
+                row_packer.extend(self.project.iter().map(|i| &datums[*i]));
+                *row = row_packer.finish_and_reuse();
             }
         }
     }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -42,7 +42,7 @@ use repr::adt::interval::Interval;
 use repr::adt::jsonb::JsonbRef;
 use repr::adt::rdn;
 use repr::adt::regex::Regex;
-use repr::{strconv, ColumnName, ColumnType, Datum, RowArena, RowPacker, ScalarType};
+use repr::{strconv, ColumnName, ColumnType, Datum, Row, RowArena, ScalarType};
 
 use crate::scalar::func::format::DateTimeFormat;
 use crate::{like_pattern, EvalError, MirScalarExpr};
@@ -2242,28 +2242,28 @@ fn jsonb_typeof<'a>(a: Datum<'a>) -> Datum<'a> {
 }
 
 fn jsonb_strip_nulls<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
-    fn strip_nulls(a: Datum, packer: &mut RowPacker) {
+    fn strip_nulls(a: Datum, row: &mut Row) {
         match a {
-            Datum::Map(dict) => packer.push_dict_with(|packer| {
+            Datum::Map(dict) => row.push_dict_with(|row| {
                 for (k, v) in dict.iter() {
                     match v {
                         Datum::JsonNull => (),
                         _ => {
-                            packer.push(Datum::String(k));
-                            strip_nulls(v, packer);
+                            row.push(Datum::String(k));
+                            strip_nulls(v, row);
                         }
                     }
                 }
             }),
-            Datum::List(list) => packer.push_list_with(|packer| {
+            Datum::List(list) => row.push_list_with(|row| {
                 for elem in list.iter() {
-                    strip_nulls(elem, packer);
+                    strip_nulls(elem, row);
                 }
             }),
-            _ => packer.push(a),
+            _ => row.push(a),
         }
     }
-    temp_storage.make_datum(|packer| strip_nulls(a, packer))
+    temp_storage.make_datum(|row| strip_nulls(a, row))
 }
 
 fn jsonb_pretty<'a>(a: Datum<'a>, temp_storage: &'a RowArena) -> Datum<'a> {
@@ -3950,15 +3950,15 @@ fn regexp_match_static<'a>(
     temp_storage: &'a RowArena,
     needle: &regex::Regex,
 ) -> Result<Datum<'a>, EvalError> {
-    let mut packer = RowPacker::new();
+    let mut row = Row::default();
     if needle.captures_len() > 1 {
         // The regex contains capture groups, so return an array containing the
         // matched text in each capture group, unless the entire match fails.
         // Individual capture groups may also be null if that group did not
         // participate in the match.
         match needle.captures(haystack.unwrap_str()) {
-            None => packer.push(Datum::Null),
-            Some(captures) => packer.push_array(
+            None => row.push(Datum::Null),
+            Some(captures) => row.push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: captures.len() - 1,
@@ -3974,8 +3974,8 @@ fn regexp_match_static<'a>(
         // The regex contains no capture groups, so return a one-element array
         // containing the match, or null if there is no match.
         match needle.find(haystack.unwrap_str()) {
-            None => packer.push(Datum::Null),
-            Some(mtch) => packer.push_array(
+            None => row.push(Datum::Null),
+            Some(mtch) => row.push_array(
                 &[ArrayDimension {
                     lower_bound: 1,
                     length: 1,
@@ -3984,7 +3984,7 @@ fn regexp_match_static<'a>(
             )?,
         };
     };
-    Ok(temp_storage.push_unary_row(packer.finish()))
+    Ok(temp_storage.push_unary_row(row))
 }
 
 pub fn build_regex(needle: &str, flags: &str) -> Result<regex::Regex, EvalError> {
@@ -4277,20 +4277,20 @@ where
 
 fn list_slice<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a> {
     // Return value indicates whether this level's slices are empty results.
-    fn slice_and_descend(d: Datum, ranges: &[(usize, usize)], packer: &mut RowPacker) -> bool {
+    fn slice_and_descend(d: Datum, ranges: &[(usize, usize)], row: &mut Row) -> bool {
         match ranges {
             [(start, n), ranges @ ..] if !d.is_null() => {
                 let mut iter = d.unwrap_list().iter().skip(*start).take(*n).peekable();
                 if iter.peek().is_none() {
-                    packer.push(Datum::Null);
+                    row.push(Datum::Null);
                     true
                 } else {
                     let mut empty_results = true;
-                    let start = packer.data().len();
-                    packer.push_list_with(|packer| {
+                    let start = row.data().len();
+                    row.push_list_with(|row| {
                         for d in iter {
                             // Determine if all higher-dimension slices produced empty results.
-                            empty_results = slice_and_descend(d, ranges, packer) && empty_results;
+                            empty_results = slice_and_descend(d, ranges, row) && empty_results;
                         }
                     });
 
@@ -4300,19 +4300,19 @@ fn list_slice<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a>
                         // were empty.
 
                         // SAFETY: `start` points to a datum boundary because a)
-                        // it comes from a call to `packer.data().len()` above,
+                        // it comes from a call to `row.data().len()` above,
                         // and b) recursive calls to `slice_and_descend` will
-                        // not shrink the packer. (The recursive calls may write
+                        // not shrink the row. (The recursive calls may write
                         // data and then erase that data, but a recursive call
                         // will never erase data that it did not write itself.)
-                        unsafe { packer.truncate(start) }
-                        packer.push(Datum::Null);
+                        unsafe { row.truncate(start) }
+                        row.push(Datum::Null);
                     }
                     empty_results
                 }
             }
             _ => {
-                packer.push(d);
+                row.push(d);
                 // Slicing a NULL produces an empty result.
                 d.is_null() && ranges.len() > 0
             }
@@ -4343,8 +4343,8 @@ fn list_slice<'a>(datums: &[Datum<'a>], temp_storage: &'a RowArena) -> Datum<'a>
         ranges.push((start as usize - 1, (end - start) as usize + 1));
     }
 
-    temp_storage.make_datum(|packer| {
-        slice_and_descend(datums[0], &ranges, packer);
+    temp_storage.make_datum(|row| {
+        slice_and_descend(datums[0], &ranges, row);
     })
 }
 

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -30,7 +30,7 @@ use mz_avro::{
 use repr::adt::decimal::Significand;
 use repr::adt::jsonb::JsonbPacker;
 use repr::adt::rdn;
-use repr::{Datum, Row, RowPacker};
+use repr::{Datum, Row};
 
 use super::{
     is_null, AvroDebeziumDecoder, ConfluentAvroResolver, DebeziumDeduplicationState,
@@ -46,7 +46,7 @@ pub struct Decoder {
     worker_index: usize,
     buf1: Vec<u8>,
     buf2: Vec<u8>,
-    packer: RowPacker,
+    packer: Row,
     reject_non_inserts: bool,
 }
 
@@ -228,7 +228,7 @@ impl<'a> AvroDecode for AvroStringDecoder<'a> {
 }
 
 pub(super) struct OptionalRecordDecoder<'a> {
-    pub packer: &'a mut RowPacker,
+    pub packer: &'a mut Row,
     pub buf: &'a mut Vec<u8>,
 }
 
@@ -261,7 +261,7 @@ impl<'a> AvroDecode for OptionalRecordDecoder<'a> {
 }
 
 pub(super) struct RowDecoder {
-    state: (Rc<RefCell<RowPacker>>, Rc<RefCell<Vec<u8>>>),
+    state: (Rc<RefCell<Row>>, Rc<RefCell<Vec<u8>>>),
 }
 
 impl AvroDecode for RowDecoder {
@@ -292,9 +292,9 @@ pub(super) struct RowWrapper(pub Row);
 
 impl StatefulAvroDecodable for RowWrapper {
     type Decoder = RowDecoder;
-    // TODO - can we make this some sort of &'a mut (RowPacker, Vec<u8>) without
+    // TODO - can we make this some sort of &'a mut (Row, Vec<u8>) without
     // running into lifetime crap?
-    type State = (Rc<RefCell<RowPacker>>, Rc<RefCell<Vec<u8>>>);
+    type State = (Rc<RefCell<Row>>, Rc<RefCell<Vec<u8>>>);
 
     fn new_decoder(state: Self::State) -> Self::Decoder {
         Self::Decoder { state }
@@ -303,7 +303,7 @@ impl StatefulAvroDecodable for RowWrapper {
 
 #[derive(Debug)]
 pub struct AvroFlatDecoder<'a> {
-    pub packer: &'a mut RowPacker,
+    pub packer: &'a mut Row,
     pub buf: &'a mut Vec<u8>,
     pub is_top: bool,
 }
@@ -316,7 +316,7 @@ impl<'a> AvroDecode for AvroFlatDecoder<'a> {
         a: &mut A,
     ) -> Result<Self::Out, AvroError> {
         let mut str_buf = std::mem::take(self.buf);
-        let mut pack_record = |rp: &mut RowPacker| -> Result<(), AvroError> {
+        let mut pack_record = |rp: &mut Row| -> Result<(), AvroError> {
             let mut expected = 0;
             let mut stash = vec![];
             // The idea here is that if the deserializer gives us fields in the order we're expecting,
@@ -326,8 +326,8 @@ impl<'a> AvroDecode for AvroFlatDecoder<'a> {
             //
             // TODO(btv) - this is pretty bad, as a misordering at the top of the schema graph will
             // cause the _entire_ chunk under it to be decoded in the slow way!
-            // Maybe instead, we should decode to separate sub-RowPackers and then add an API
-            // to RowPacker that just copies in the bytes from another one.
+            // Maybe instead, we should decode to separate sub-Rows and then add an API
+            // to Row that just copies in the bytes from another one.
             while let Some((_name, idx, f)) = a.next_field()? {
                 let dec = AvroFlatDecoder {
                     packer: rp,
@@ -620,7 +620,7 @@ impl<'a> AvroDecode for AvroFlatDecoder<'a> {
         Ok(())
     }
 }
-fn pack_value(v: Value, mut row: RowPacker, n: SchemaNode) -> anyhow::Result<RowPacker> {
+fn pack_value(v: Value, mut row: Row, n: SchemaNode) -> anyhow::Result<Row> {
     match v {
         Value::Null => row.push(Datum::Null),
         Value::Boolean(true) => row.push(Datum::True),
@@ -693,7 +693,7 @@ where
                 fields: schema_fields,
                 ..
             } => {
-                let mut row = RowPacker::new();
+                let mut row = Row::default();
                 for (i, (_, col)) in fields.into_iter().enumerate() {
                     let f_schema = &schema_fields[i].schema;
                     let f_node = n.step(f_schema);
@@ -702,7 +702,7 @@ where
                 for d in extra {
                     row.push(d);
                 }
-                Ok(Some(row.finish()))
+                Ok(Some(row))
             }
             _ => unreachable!("Avro value out of sync with schema"),
         },

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -10,7 +10,7 @@
 //! Logic for the Avro representation of the CDCv2 protocol.
 
 use mz_avro::schema::{FullName, SchemaNode};
-use repr::{ColumnName, ColumnType, Diff, RelationDesc, Row, RowPacker, Timestamp};
+use repr::{ColumnName, ColumnType, Diff, RelationDesc, Row, Timestamp};
 use serde_json::json;
 
 use anyhow::anyhow;
@@ -108,7 +108,7 @@ impl Encoder {
 }
 
 #[derive(AvroDecodable)]
-#[state_type(Rc<RefCell<RowPacker>>, Rc<RefCell<Vec<u8>>>)]
+#[state_type(Rc<RefCell<Row>>, Rc<RefCell<Vec<u8>>>)]
 struct MyUpdate {
     #[state_expr(self._STATE.0.clone(), self._STATE.1.clone())]
     data: RowWrapper,
@@ -148,7 +148,7 @@ impl AvroDecode for Decoder {
     ) -> Result<Self::Out, AvroError> {
         match idx {
             0 => {
-                let packer = Rc::new(RefCell::new(RowPacker::new()));
+                let packer = Rc::new(RefCell::new(Row::default()));
                 let buf = Rc::new(RefCell::new(vec![]));
                 let d = ArrayAsVecDecoder::new(|| {
                     <MyUpdate as StatefulAvroDecodable>::new_decoder((packer.clone(), buf.clone()))

--- a/src/interchange/src/avro/envelope_debezium.rs
+++ b/src/interchange/src/avro/envelope_debezium.rs
@@ -26,7 +26,7 @@ use mz_avro::{
 };
 use mz_avro::{TrivialDecoder, ValueDecoder};
 use ore::str::StrExt;
-use repr::{Datum, Row, RowPacker};
+use repr::{Datum, Row};
 
 use crate::avro::{AvroFlatDecoder, AvroStringDecoder, OptionalRecordDecoder};
 
@@ -37,7 +37,7 @@ pub use deduplication::DebeziumDeduplicationStrategy;
 
 #[derive(Debug)]
 pub struct AvroDebeziumDecoder<'a> {
-    pub packer: &'a mut RowPacker,
+    pub packer: &'a mut Row,
     pub buf: &'a mut Vec<u8>,
     pub file_buf: &'a mut Vec<u8>,
 }
@@ -635,7 +635,7 @@ impl DebeziumDecodeState {
                 if let (Some(before_idx), Some(after_idx)) = (before_idx, after_idx) {
                     let before = &fields[before_idx].1;
                     let after = &fields[after_idx].1;
-                    let mut packer = RowPacker::new();
+                    let mut packer = Row::default();
                     let mut buf = vec![];
                     give_value(
                         AvroFlatDecoder {
@@ -653,7 +653,7 @@ impl DebeziumDecodeState {
                         },
                         after,
                     )?;
-                    Ok(Some(packer.finish()))
+                    Ok(Some(packer))
                 } else {
                     bail!("avro envelope does not contain `before` and `after`");
                 }

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -17,7 +17,7 @@ use anyhow::bail;
 use chrono::format::{DelayedFormat, StrftimeItems};
 use chrono::NaiveDateTime;
 use log::{debug, error, info, warn};
-use repr::{Datum, Row, RowPacker};
+use repr::{Datum, Row};
 use serde::{Deserialize, Serialize};
 
 use super::RowCoordinates;
@@ -147,8 +147,8 @@ struct TrackFull {
     /// The highest-ever seen timestamp, used in logging to let us know how far backwards time might go
     max_seen_time: i64,
     key_indices: Option<Vec<usize>>,
-    /// Optimization to avoid re-allocating the row packer over and over when extracting the key..
-    key_buf: RowPacker,
+    /// Optimization to avoid re-allocating the row over and over when extracting the key.
+    key_buf: Row,
     range: Option<TrackRange>,
     started_padding: bool,
     /// Whether we have started full deduplication mode

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -19,7 +19,7 @@ use differential_dataflow::{
 use differential_dataflow::{AsCollection, Collection};
 use itertools::Itertools;
 use ore::collections::CollectionExt;
-use repr::{ColumnType, Datum, Diff, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use repr::{ColumnType, Datum, Diff, RelationDesc, RelationType, Row, ScalarType};
 use timely::dataflow::{channels::pact::Pipeline, operators::Operator, Scope, Stream};
 
 /// Given a stream of batches, produce a stream of (vectors of) DiffPairs, in timestamp order.
@@ -127,7 +127,7 @@ pub fn dbz_desc(desc: RelationDesc) -> RelationDesc {
     RelationDesc::new(typ, vec![Some("before"), Some("after")])
 }
 
-pub fn dbz_format(rp: &mut RowPacker, dp: DiffPair<Row>) -> Row {
+pub fn dbz_format(rp: &mut Row, dp: DiffPair<Row>) -> Row {
     if let Some(before) = dp.before {
         rp.push_list_with(|rp| rp.extend_by_row(&before));
     } else {

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -23,7 +23,7 @@ use serde_protobuf::value::Value as ProtoValue;
 use serde_value::Value as SerdeValue;
 
 use repr::adt::decimal::Significand;
-use repr::{ColumnType, Datum, DatumList, RelationDesc, RelationType, Row, RowPacker, ScalarType};
+use repr::{ColumnType, Datum, DatumList, RelationDesc, RelationType, Row, ScalarType};
 
 fn proto_message_name(message_name: &str) -> String {
     // Prepend a . (following the serde-protobuf naming scheme to list root paths
@@ -171,7 +171,7 @@ pub fn validate_descriptors(message_name: &str, descriptors: &Descriptors) -> Re
 pub struct Decoder {
     descriptors: Descriptors,
     message_name: String,
-    packer: RowPacker,
+    packer: Row,
 }
 
 impl Decoder {
@@ -184,7 +184,7 @@ impl Decoder {
         Decoder {
             descriptors,
             message_name: proto_message_name(message_name),
-            packer: RowPacker::new(),
+            packer: Row::default(),
         }
     }
 
@@ -220,7 +220,7 @@ fn extract_row_into(
     deserialized_message: SerdeValue,
     descriptors: &Descriptors,
     message_descriptors: &MessageDescriptor,
-    packer: &mut RowPacker,
+    packer: &mut Row,
 ) -> Result<()> {
     let deserialized_message = match deserialized_message {
         SerdeValue::Map(deserialized_message) => deserialized_message,
@@ -360,7 +360,7 @@ fn default_datum_from_field_nested<'a>(
 /// type, all numeric types will be converted to f64s (issue #1476)
 fn json_from_serde_value(
     val: &SerdeValue,
-    packer: &mut RowPacker,
+    packer: &mut Row,
     f: &FieldDescriptor,
     descriptors: &Descriptors,
 ) -> Result<()> {
@@ -399,7 +399,7 @@ fn json_from_serde_value(
 
 fn json_nested_from_serde_value(
     val: &SerdeValue,
-    packer: &mut RowPacker,
+    packer: &mut Row,
     f: &FieldDescriptor,
     descriptors: &Descriptors,
 ) -> Result<()> {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -15,8 +15,8 @@
 //! agree to use this representation at their boundaries.
 //!
 //! * The core value type is the [`Datum`] enum, which represents a literal value.
-//! * [`Row`] extends a `Datum` horizontally, and has features for efficiently doing so,
-//!   and can be built via a [`RowPacker`].
+//! * [`Row`] extends a `Datum` horizontally, and has features for efficiently
+//!   doing so.
 //! * [`RelationDesc`] describes what it takes to extend a `Row` vertically, and
 //!   corresponds most closely to what is returned from querying our dataflows
 
@@ -32,7 +32,7 @@ pub mod strconv;
 
 pub use cache::{CachedRecord, CachedRecordIter};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{datum_size, datums_size, DatumList, DatumMap, Row, RowArena, RowPacker, RowRef};
+pub use row::{datum_size, datums_size, DatumList, DatumMap, Row, RowArena, RowRef};
 pub use scalar::{Datum, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -686,6 +686,11 @@ impl Row {
         self.data.extend(row.data.iter().copied());
     }
 
+    /// Clears the contents of the row without de-allocating its backing memory.
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+
     /// Creates a new row from supplied bytes.
     ///
     /// # Safety

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1016,10 +1016,9 @@ impl HirRelationExpr {
 
     /// Constructs a constant collection from specific rows and schema.
     pub fn constant(rows: Vec<Vec<Datum>>, typ: RelationType) -> Self {
-        let mut row_packer = repr::RowPacker::new();
         let rows = rows
             .into_iter()
-            .map(move |datums| row_packer.pack(datums))
+            .map(move |datums| Row::pack_slice(&datums))
             .collect();
         HirRelationExpr::Constant { rows, typ }
     }
@@ -1136,15 +1135,14 @@ impl HirScalarExpr {
             typ => ScalarType::Array(Box::new(typ)).nullable(false),
         };
 
-        let mut packer = RowPacker::new();
-        packer.push_array(
+        let mut row = Row::default();
+        row.push_array(
             &[ArrayDimension {
                 lower_bound: 1,
                 length: datums.len(),
             }],
             datums,
         )?;
-        let row = packer.finish();
 
         Ok(HirScalarExpr::Literal(row, scalar_type))
     }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 use itertools::Itertools;
 
 use expr::{EvalError, MirRelationExpr, MirScalarExpr, UnaryFunc};
-use repr::Datum;
 use repr::{ColumnType, RelationType, ScalarType};
+use repr::{Datum, Row};
 
 use crate::TransformArgs;
 
@@ -53,11 +53,10 @@ impl ColumnKnowledge {
                 .unwrap_or_else(|| typ.column_types.iter().map(DatumKnowledge::from).collect()),
             MirRelationExpr::Constant { rows, typ } => {
                 if let Ok([(row, _diff)]) = rows.as_deref() {
-                    let mut row_packer = repr::RowPacker::new();
                     row.iter()
                         .zip(typ.column_types.iter())
                         .map(|(datum, typ)| DatumKnowledge {
-                            value: Some((Ok(row_packer.pack(Some(datum.clone()))), typ.clone())),
+                            value: Some((Ok(Row::pack_slice(&[datum.clone()])), typ.clone())),
                             nullable: datum == Datum::Null,
                         })
                         .collect()

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -12,7 +12,7 @@
 use std::collections::{HashMap, HashSet};
 
 use expr::{AggregateExpr, AggregateFunc, Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
-use repr::Datum;
+use repr::{Datum, Row};
 
 use crate::TransformArgs;
 
@@ -100,16 +100,13 @@ impl Demand {
                 }
 
                 // Replace un-read expressions with literals to prevent evaluation.
-                let mut row_packer = repr::RowPacker::new();
                 for (index, scalar) in scalars.iter_mut().enumerate() {
                     if !columns.contains(&(arity + index)) {
                         // Leave literals as they are, to benefit explain.
                         if !scalar.is_literal() {
                             let typ = relation_type.column_types[arity + index].clone();
-                            *scalar = MirScalarExpr::Literal(
-                                Ok(row_packer.pack(Some(Datum::Dummy))),
-                                typ,
-                            );
+                            *scalar =
+                                MirScalarExpr::Literal(Ok(Row::pack_slice(&[Datum::Dummy])), typ);
                         }
                     }
                 }

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -22,9 +22,11 @@
 
 use std::collections::HashMap;
 
-use crate::TransformArgs;
-use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 use itertools::Itertools;
+
+use expr::{Id, JoinInputMapper, MirRelationExpr, MirScalarExpr};
+
+use crate::TransformArgs;
 
 /// Hoist literal values from maps wherever possible.
 #[derive(Debug)]
@@ -97,10 +99,9 @@ impl LiteralLifting {
                         typ.keys.sort();
                         typ.keys.dedup();
 
-                        let mut row_packer = repr::RowPacker::new();
-                        *row = row_packer.pack(row.iter().take(typ.arity()));
+                        row.truncate_datums(typ.arity());
                         for (row, _cnt) in rows.iter_mut() {
-                            *row = row_packer.pack(row.iter().take(typ.arity()));
+                            row.truncate_datums(typ.arity());
                         }
                     }
                     literals

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -122,7 +122,6 @@ impl FoldConstants {
                 }
 
                 if let MirRelationExpr::Constant { rows, .. } = &**input {
-                    let mut row_packer = repr::RowPacker::new();
                     let new_rows = match rows {
                         Ok(rows) => rows
                             .iter()
@@ -133,7 +132,7 @@ impl FoldConstants {
                                 for scalar in scalars.iter() {
                                     unpacked.push(scalar.eval(&unpacked, &temp_storage)?)
                                 }
-                                Ok::<_, EvalError>((row_packer.pack(unpacked), diff))
+                                Ok::<_, EvalError>((Row::pack_slice(&unpacked), diff))
                             })
                             .collect::<Result<_, _>>(),
                         Err(e) => Err(e.clone()),
@@ -200,13 +199,14 @@ impl FoldConstants {
             }
             MirRelationExpr::Project { input, outputs } => {
                 if let MirRelationExpr::Constant { rows, .. } = &**input {
-                    let mut row_packer = repr::RowPacker::new();
+                    let mut row_packer = Row::default();
                     let new_rows = match rows {
                         Ok(rows) => Ok(rows
                             .iter()
                             .map(|(input_row, diff)| {
                                 let datums = input_row.unpack();
-                                (row_packer.pack(outputs.iter().map(|i| &datums[*i])), *diff)
+                                row_packer.extend(outputs.iter().map(|i| &datums[*i]));
+                                (row_packer.finish_and_reuse(), *diff)
                             })
                             .collect()),
                         Err(e) => Err(e.clone()),
@@ -246,15 +246,16 @@ impl FoldConstants {
 
                     // We can fold all constant inputs together, but must apply the constraints to restrict them.
                     // We start with a single 0-ary row.
-                    let mut old_rows = vec![(repr::Row::pack::<_, Datum>(None), 1)];
-                    let mut row_packer = repr::RowPacker::new();
+                    let mut old_rows = vec![(Row::pack::<_, Datum>(None), 1)];
+                    let mut row_packer = Row::default();
                     for input in inputs.iter() {
                         if let MirRelationExpr::Constant { rows: Ok(rows), .. } = input {
                             let mut next_rows = Vec::new();
                             for (old_row, old_count) in old_rows {
                                 for (new_row, new_count) in rows.iter() {
+                                    row_packer.extend(old_row.iter().chain(new_row.iter()));
                                     next_rows.push((
-                                        row_packer.pack(old_row.iter().chain(new_row.iter())),
+                                        row_packer.finish_and_reuse(),
                                         old_count * *new_count,
                                     ));
                                 }
@@ -372,7 +373,7 @@ impl FoldConstants {
         // `aggregates`.
         let mut groups = BTreeMap::new();
         let temp_storage2 = RowArena::new();
-        let mut row_packer = repr::RowPacker::new();
+        let mut row_packer = Row::default();
         for (row, diff) in rows {
             // We currently maintain the invariant that any negative
             // multiplicities will be consolidated away before they
@@ -391,7 +392,8 @@ impl FoldConstants {
             let val = aggregates
                 .iter()
                 .map(|agg| {
-                    Ok::<_, EvalError>(row_packer.pack(&[agg.expr.eval(&datums, &temp_storage)?]))
+                    row_packer.extend(&[agg.expr.eval(&datums, &temp_storage)?]);
+                    Ok::<_, EvalError>(row_packer.finish_and_reuse())
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             let entry = groups.entry(key).or_insert_with(Vec::new);
@@ -408,11 +410,11 @@ impl FoldConstants {
         let new_rows = groups
             .into_iter()
             .map({
-                let mut row_packer = repr::RowPacker::new();
+                let mut row_packer = Row::default();
                 move |(key, vals)| {
                     let temp_storage = RowArena::new();
-                    let row = row_packer.pack(key.into_iter().chain(
-                        aggregates.iter().enumerate().map(|(i, agg)| {
+                    row_packer.extend(key.into_iter().chain(aggregates.iter().enumerate().map(
+                        |(i, agg)| {
                             if agg.distinct {
                                 agg.func.eval(
                                     vals.iter()
@@ -427,9 +429,9 @@ impl FoldConstants {
                                     &temp_storage,
                                 )
                             }
-                        }),
-                    ));
-                    (row, 1)
+                        },
+                    )));
+                    (row_packer.finish_and_reuse(), 1)
                 }
             })
             .collect();
@@ -442,7 +444,7 @@ impl FoldConstants {
         rows: &[(Row, isize)],
     ) -> Result<Vec<(Row, isize)>, EvalError> {
         let mut new_rows = Vec::new();
-        let mut row_packer = repr::RowPacker::new();
+        let mut row_packer = Row::default();
         for (input_row, diff) in rows {
             let datums = input_row.unpack();
             let temp_storage = RowArena::new();
@@ -454,9 +456,8 @@ impl FoldConstants {
                 &temp_storage,
             );
             for (output_row, diff2) in output_rows {
-                let row =
-                    row_packer.pack(input_row.clone().into_iter().chain(output_row.into_iter()));
-                new_rows.push((row, diff2 * *diff))
+                row_packer.extend(input_row.clone().into_iter().chain(output_row.into_iter()));
+                new_rows.push((row_packer.finish_and_reuse(), diff2 * *diff))
             }
         }
         Ok(new_rows)

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -318,7 +318,6 @@ mod tests {
             // (constant [<rows>] [<types>])
             "constant" => {
                 // TODO(justin): ...fix this.
-                let mut row_packer = repr::RowPacker::new();
                 let rows: Vec<(Row, isize)> = try_list(nth(&s, 1)?)?
                     .into_iter()
                     .map(try_list)
@@ -332,8 +331,8 @@ mod tests {
                     .collect::<Result<Vec<Vec<MirScalarExpr>>, Error>>()?
                     .iter()
                     .map(move |exprs| {
-                        Ok(row_packer.pack(
-                            exprs
+                        Ok(Row::pack_slice(
+                            &exprs
                                 .iter()
                                 .map(|e| match e {
                                     MirScalarExpr::Literal(r, _) => {


### PR DESCRIPTION
I burned out on fixing `dataflow/src/render`, but made it through the rest of the codebase. I think this is a large win for clarity!

----

Now that Row can be mutated, there's no need to have a separate builder
type. Move the remaining RowPacker methods to Row, then delete
RowPacker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6276)
<!-- Reviewable:end -->
