### PR TITLE
dataflow: new interface for handling timestamping information

### DIFF
--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -123,7 +123,8 @@ use repr::{RelationType, Row, RowArena, Timestamp};
 use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::operator::CollectionExt;
 use crate::render::context::{ArrangementFlavor, Context};
-use crate::server::{CacheMessage, LocalInput, TimestampDataUpdates};
+use crate::server::{CacheMessage, LocalInput};
+use crate::source::timestamp::TimestampDataUpdates;
 use crate::source::SourceToken;
 
 mod arrange_by;

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -41,6 +41,7 @@ use repr::{CachedRecord, CachedRecordIter, Diff, Row, Timestamp};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::Scope;
+use timely::progress::Antichain;
 use timely::scheduling::activate::{Activator, SyncActivator};
 use timely::Data;
 use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
@@ -48,8 +49,8 @@ use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
 use super::source::util::source;
 use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::operator::StreamExt;
-use crate::server::{TimestampDataUpdate, TimestampDataUpdates};
 use crate::source::cache::WorkerCacheData;
+use crate::source::timestamp::{TimestampBindingRc, TimestampDataUpdate, TimestampDataUpdates};
 use crate::CacheMessage;
 
 mod file;
@@ -60,6 +61,7 @@ mod s3;
 mod util;
 
 pub mod cache;
+pub mod timestamp;
 
 use differential_dataflow::Hashable;
 pub use file::read_file_task;
@@ -645,8 +647,18 @@ impl ConsistencyInfo {
         cap: &mut Capability<Timestamp>,
         source: &mut dyn SourceReader<Out>,
         timestamp_histories: &TimestampDataUpdates,
+        timestamp_bindings: &mut TimestampBindingRc,
     ) {
-        let mut min: Option<Timestamp> = None;
+        //  We need to determine the maximum timestamp that is fully closed. This corresponds to the minimum of
+        //  * closed timestamps across all partitions we own
+        //  * maximum bound timestamps across all partitions we don't own (the `upper`)
+        let mut upper = Antichain::new();
+        timestamp_bindings.read_upper(&mut upper);
+        let mut min: Option<Timestamp> = if let Some(time) = upper.elements().get(0) {
+            Some(*time)
+        } else {
+            None
+        };
 
         if let Consistency::BringYourOwn(_) = self.source_type {
             // Determine which timestamps have been closed. A timestamp is closed once we have processed
@@ -656,54 +668,33 @@ impl ConsistencyInfo {
             // Per partition, we iterate over the data structure to remove (ts,offset) mappings for which
             // we have seen all records <= offset. We keep track of the last "closed" timestamp in that partition
             // in next_partition_ts
-            if let Some(entries) = timestamp_histories.borrow().get(&id.source_id) {
-                match entries {
-                    TimestampDataUpdate::BringYourOwn(entries) => {
-                        // Iterate over each partition that we know about
-                        for (pid, entries) in entries {
-                            if !self.knows_of(pid) && self.responsible_for(pid) {
-                                source.add_partition(pid.clone());
-                                self.add_partition(pid);
-                            }
 
-                            //  We need to determine the maximum timestamp that is fully closed. This corresponds to the minimum of
-                            //  * closed timestamps across all partitions we own
-                            //  * maximum bound timestamps across all partitions we don't own.
-                            if !self.knows_of(pid) {
-                                // We need to grab the min closed (max) timestamp from partitions we
-                                // don't own.
+            for pid in timestamp_bindings.partitions() {
+                if !self.knows_of(&pid) && self.responsible_for(&pid) {
+                    source.add_partition(pid.clone());
+                    self.add_partition(&pid);
+                }
 
-                                if let Some((timestamp, _)) = entries.back() {
-                                    min = match min.as_mut() {
-                                        Some(min) => Some(std::cmp::min(*timestamp, *min)),
-                                        None => Some(*timestamp),
-                                    };
-                                }
-                            } else {
-                                let closed_ts = self
-                                    .partition_metadata
-                                    .get(pid)
-                                    .expect("partition known to exist")
-                                    .get_closed_timestamp();
-                                let metrics = self
-                                    .source_metrics
-                                    .partition_metrics
-                                    .get_mut(pid)
-                                    .expect("partition known to exist");
+                if self.knows_of(&pid) {
+                    let closed_ts = self
+                        .partition_metadata
+                        .get(&pid)
+                        .expect("partition known to exist")
+                        .get_closed_timestamp();
+                    let metrics = self
+                        .source_metrics
+                        .partition_metrics
+                        .get_mut(&pid)
+                        .expect("partition known to exist");
 
-                                metrics.closed_ts.set(closed_ts);
+                    metrics.closed_ts.set(closed_ts);
 
-                                min = match min.as_mut() {
-                                    Some(min) => Some(std::cmp::min(closed_ts, *min)),
-                                    None => Some(closed_ts),
-                                };
-                            }
-                        }
-                    }
-                    _ => panic!("Unexpected timestamp message format. Expected BYO update."),
+                    min = match min.as_mut() {
+                        Some(min) => Some(std::cmp::min(closed_ts, *min)),
+                        None => Some(closed_ts),
+                    };
                 }
             }
-
             let min = min.unwrap_or(0);
 
             // Downgrade capability to new minimum open timestamp (which corresponds to min + 1).
@@ -711,6 +702,9 @@ impl ConsistencyInfo {
                 self.source_metrics.capability.set(min);
                 cap.downgrade(&(&min + 1));
                 self.last_closed_ts = min;
+
+                let new_compaction_frontier = Antichain::from_elem(min);
+                timestamp_bindings.set_compaction_frontier(new_compaction_frontier.borrow());
             }
         } else {
             // This a RT source. It is always possible to close the timestamp and downgrade the
@@ -752,7 +746,7 @@ impl ConsistencyInfo {
         &mut self,
         partition: &PartitionId,
         offset: MzOffset,
-        timestamp_histories: &TimestampDataUpdates,
+        timestamp_bindings: &TimestampBindingRc,
     ) -> Option<Timestamp> {
         if let Consistency::RealTime = self.source_type {
             // Simply assign to this message the next timestamp that is not closed
@@ -761,31 +755,6 @@ impl ConsistencyInfo {
             // The source is a BYO source. We either can take a fast path, where we simply re-use the currently
             // available timestamp binding, or if one isn't available for `offset` in `partition`, we have to
             // look it up from the set of timestamp histories
-
-            // This is the slow path code - we either don't have a timestamp binding
-            // available or have moved past the one we previously had. In either case,
-            // we need to search through the available timestamp bindings to find the
-            // earliest one that can apply to offset.
-
-            let source_global_id = self.source_id.source_id;
-            let update_cons_info = |cons_info: &mut ConsInfo| {
-                if let Some(TimestampDataUpdate::BringYourOwn(entries)) =
-                    timestamp_histories.borrow().get(&source_global_id)
-                {
-                    if let Some(entries) = entries.get(partition) {
-                        for (ts, max_offset) in entries {
-                            if offset <= *max_offset {
-                                cons_info.update_timestamp(*ts, *max_offset);
-                                cons_info.update_offset(offset);
-
-                                return Some(*ts);
-                            }
-                        }
-                    }
-                }
-
-                return None;
-            };
 
             // We know we will only read from partitions already assigned to this
             // worker.
@@ -800,7 +769,15 @@ impl ConsistencyInfo {
                 cons_info.update_offset(offset);
                 Some(cons_info.current_ts)
             } else {
-                update_cons_info(cons_info)
+                if let Some((timestamp, max_offset)) =
+                    timestamp_bindings.get_binding(partition, offset)
+                {
+                    cons_info.update_timestamp(timestamp, max_offset);
+                    cons_info.update_offset(offset);
+                    Some(timestamp)
+                } else {
+                    None
+                }
             }
         }
     }
@@ -1328,6 +1305,17 @@ where
             &consistency_info,
         );
 
+        let mut timestamp_bindings = if let TimestampDataUpdate::BringYourOwn(history) =
+            timestamp_histories
+                .borrow_mut()
+                .get(&id.source_id)
+                .expect("known to exist")
+        {
+            history.clone()
+        } else {
+            TimestampBindingRc::new()
+        };
+
         let mut predecessor = None;
         // Stash messages we cannot yet timestamp here.
         let mut buffer = None;
@@ -1342,7 +1330,13 @@ where
             };
 
             // Downgrade capability (if possible)
-            consistency_info.downgrade_capability(&id, cap, source_reader, &timestamp_histories);
+            consistency_info.downgrade_capability(
+                &id,
+                cap,
+                source_reader,
+                &timestamp_histories,
+                &mut timestamp_bindings,
+            );
 
             if let Some(file) = cached_files.pop() {
                 // TODO(rkhaitan) change this to properly re-use old timestamps.
@@ -1397,7 +1391,6 @@ where
                         &mut predecessor,
                         &mut consistency_info,
                         &id,
-                        &timestamp_histories,
                         &mut bytes_read,
                         &mut caching_tx,
                         &cap,
@@ -1405,6 +1398,7 @@ where
                         &mut metric_updates,
                         &timer,
                         &mut buffer,
+                        &timestamp_bindings,
                     )
                 } else {
                     match source_reader.get_next_message() {
@@ -1413,7 +1407,6 @@ where
                             &mut predecessor,
                             &mut consistency_info,
                             &id,
-                            &timestamp_histories,
                             &mut bytes_read,
                             &mut caching_tx,
                             &cap,
@@ -1421,6 +1414,7 @@ where
                             &mut metric_updates,
                             &timer,
                             &mut buffer,
+                            &timestamp_bindings,
                         ),
                         Ok(NextMessage::TransientDelay) => {
                             // There was a temporary hiccup in getting messages, check again asap.
@@ -1453,7 +1447,13 @@ where
                 .record_partition_offsets(metric_updates);
 
             // Downgrade capability (if possible) before exiting
-            consistency_info.downgrade_capability(&id, cap, source_reader, &timestamp_histories);
+            consistency_info.downgrade_capability(
+                &id,
+                cap,
+                source_reader,
+                &timestamp_histories,
+                &mut timestamp_bindings,
+            );
 
             let (source_status, processing_status) = source_state;
             // Schedule our next activation
@@ -1489,7 +1489,6 @@ fn handle_message<Out>(
     predecessor: &mut Option<MzOffset>,
     consistency_info: &mut ConsistencyInfo,
     id: &SourceInstanceId,
-    timestamp_histories: &TimestampDataUpdates,
     bytes_read: &mut usize,
     caching_tx: &mut Option<mpsc::UnboundedSender<CacheMessage>>,
     cap: &Capability<Timestamp>,
@@ -1501,6 +1500,7 @@ fn handle_message<Out>(
     metric_updates: &mut HashMap<PartitionId, (MzOffset, Timestamp)>,
     timer: &std::time::Instant,
     buffer: &mut Option<SourceMessage<Out>>,
+    timestamp_bindings: &TimestampBindingRc,
 ) -> (SourceStatus, MessageProcessing)
 where
     Out: Debug + Clone + Send + Default + MaybeLength + SourceCache + 'static,
@@ -1522,7 +1522,7 @@ where
         .set(offset.offset);
 
     // Determine the timestamp to which we need to assign this message
-    let ts = consistency_info.find_matching_timestamp(&partition, offset, &timestamp_histories);
+    let ts = consistency_info.find_matching_timestamp(&partition, offset, timestamp_bindings);
     match ts {
         None => {
             // We have not yet decided on a timestamp for this message,

--- a/src/dataflow/src/source/timestamp.rs
+++ b/src/dataflow/src/source/timestamp.rs
@@ -1,0 +1,259 @@
+// Copyright Materialize, Inc. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Types and methods for managing timestamp assignment and invention in sources
+
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+
+use timely::progress::frontier::{Antichain, AntichainRef, MutableAntichain};
+
+use dataflow_types::MzOffset;
+use expr::{GlobalId, PartitionId};
+use repr::Timestamp;
+
+/// This struct holds per-source timestamp state in a way that can be shared across
+/// different source instances and allow different source instances to indicate
+/// how far they have read up to.
+///
+/// This type is almost never meant to be used directly, and you probably want to
+/// use `TimestampBindingRc` instead.
+pub struct TimestampBindingBox {
+    /// List of timestamp bindings per independent partition. This vector is sorted
+    /// by timestamp and offset and each `(time, offset)` entry indicates that offsets <=
+    /// `offset` should be assigned `time` as their timestamp. Consecutive entries form
+    /// an interval of offsets.
+    partitions: HashMap<PartitionId, Vec<(Timestamp, MzOffset)>>,
+    /// Indicates the lowest timestamp across all partitions that we retain bindings for.
+    /// This frontier can be held back by other entities holding the shared
+    /// `TimestampBindingRc`.
+    compaction_frontier: MutableAntichain<Timestamp>,
+}
+
+impl TimestampBindingBox {
+    fn new() -> Self {
+        Self {
+            partitions: HashMap::new(),
+            compaction_frontier: MutableAntichain::new(),
+        }
+    }
+
+    fn adjust_compaction_frontier(
+        &mut self,
+        remove: AntichainRef<Timestamp>,
+        add: AntichainRef<Timestamp>,
+    ) {
+        self.compaction_frontier
+            .update_iter(remove.iter().map(|t| (*t, -1)));
+        self.compaction_frontier
+            .update_iter(add.iter().map(|t| (*t, 1)));
+    }
+
+    fn compact(&mut self) {
+        let frontier = self.compaction_frontier.frontier();
+
+        // Don't compact up to the empty frontier as it would mean there were no
+        // timestamp bindings available
+        // TODO(rkhaitan): is there a more sensible approach here?
+        if frontier.is_empty() {
+            return;
+        }
+
+        for (_, entries) in self.partitions.iter_mut() {
+            if entries.is_empty() {
+                continue;
+            }
+
+            // First, let's advance all times not in advance of the frontier to the frontier
+            // to the frontier
+            for (time, _) in entries.iter_mut() {
+                if !frontier.less_equal(time) {
+                    *time = *frontier.first().expect("known to exist");
+                }
+            }
+
+            let mut new_entries = Vec::with_capacity(entries.len());
+            // Now let's only keep the largest binding for each offset
+            for i in 0..(entries.len() - 1) {
+                if entries[i].0 != entries[i + 1].0 {
+                    new_entries.push(entries[i]);
+                }
+            }
+
+            // We always keep the last binding around.
+            new_entries.push(*entries.last().expect("known to exist"));
+            *entries = new_entries;
+        }
+    }
+
+    fn add_binding(&mut self, partition: PartitionId, timestamp: Timestamp, offset: MzOffset) {
+        let entry = self.partitions.entry(partition).or_insert_with(Vec::new);
+        let (last_ts, last_offset) = entry.last().unwrap_or(&(0, MzOffset { offset: 0 }));
+        assert!(
+            offset >= *last_offset,
+            "offset should not go backwards, but {} < {}",
+            offset,
+            last_offset
+        );
+        assert!(
+            timestamp > *last_ts,
+            "timestamp should move forwards, but {} <= {}",
+            timestamp,
+            last_ts
+        );
+        entry.push((timestamp, offset));
+    }
+
+    fn get_binding(
+        &self,
+        partition: &PartitionId,
+        offset: MzOffset,
+    ) -> Option<(Timestamp, MzOffset)> {
+        if !self.partitions.contains_key(partition) {
+            return None;
+        }
+
+        let entries = self.partitions.get(partition).expect("known to exist");
+
+        for (ts, max_offset) in entries {
+            if offset <= *max_offset {
+                return Some((*ts, *max_offset));
+            }
+        }
+
+        return None;
+    }
+
+    fn read_upper(&self, target: &mut Antichain<Timestamp>) {
+        target.clear();
+
+        for (_, entries) in self.partitions.iter() {
+            if let Some((timestamp, _)) = entries.last() {
+                target.insert(*timestamp);
+            }
+        }
+    }
+
+    fn partitions(&self) -> Vec<PartitionId> {
+        self.partitions
+            .iter()
+            .map(|(pid, _)| pid)
+            .cloned()
+            .collect()
+    }
+}
+
+/// A wrapper that allows multiple source instances to share a `TimestampBindingBox`
+/// and hold back its compaction.
+pub struct TimestampBindingRc {
+    wrapper: Rc<RefCell<TimestampBindingBox>>,
+    compaction_frontier: Antichain<Timestamp>,
+}
+
+impl TimestampBindingRc {
+    /// Create a new instance of `TimestampBindingRc`.
+    pub fn new() -> Self {
+        let wrapper = Rc::new(RefCell::new(TimestampBindingBox::new()));
+
+        let ret = Self {
+            wrapper: wrapper.clone(),
+            compaction_frontier: wrapper.borrow().compaction_frontier.frontier().to_owned(),
+        };
+
+        ret
+    }
+
+    /// Set the compaction frontier to `new_frontier`.
+    ///
+    /// Note that `new_frontier` must be in advance of the current compaction
+    /// frontier.
+    pub fn set_compaction_frontier(&mut self, new_frontier: AntichainRef<Timestamp>) {
+        self.wrapper
+            .borrow_mut()
+            .adjust_compaction_frontier(self.compaction_frontier.borrow(), new_frontier);
+        self.compaction_frontier = new_frontier.to_owned();
+    }
+
+    /// Compact all timestamp bindings at timestamps less than the current
+    /// compaction frontier.
+    ///
+    /// The source can be correctly replayed from any `as_of` in advance of
+    /// the compaction frontier after this operation.
+    pub fn compact(&self) {
+        self.wrapper.borrow_mut().compact();
+    }
+
+    /// Add a new mapping from `(partition, offset) -> timestamp`.
+    ///
+    /// Note that the `timestamp` greater than the largest previously bound
+    /// timestamp for that partition, and `offset` has to be greater than or equal to
+    /// the largest previously bound offset for that partition.
+    pub fn add_binding(&self, partition: PartitionId, timestamp: Timestamp, offset: MzOffset) {
+        self.wrapper
+            .borrow_mut()
+            .add_binding(partition, timestamp, offset);
+    }
+
+    /// Get the timestamp assignment for `(partition, offset)` if it is known.
+    ///
+    /// This function returns the timestamp and the maximum offset for which it is
+    /// valid.
+    /// TODO: this function does a linear scan through the set of timestamp bindings
+    /// but it should do a binary search.
+    pub fn get_binding(
+        &self,
+        partition: &PartitionId,
+        offset: MzOffset,
+    ) -> Option<(Timestamp, MzOffset)> {
+        self.wrapper.borrow().get_binding(partition, offset)
+    }
+
+    /// Returns the lower bound across every partition's most recent timestamp.
+    ///
+    /// All subsequent updates will either be at or in advance of this frontier.
+    pub fn read_upper(&self, target: &mut Antichain<Timestamp>) {
+        self.wrapper.borrow().read_upper(target)
+    }
+
+    /// Returns the list of partitions this source knows about.
+    ///
+    /// TODO(rkhaitan): this function feels like a hack, both in the API of having
+    /// the source instances ask for the list of known partitions and in allocating
+    /// a vector to answer that question.
+    pub fn partitions(&self) -> Vec<PartitionId> {
+        self.wrapper.borrow().partitions()
+    }
+}
+
+impl Clone for TimestampBindingRc {
+    fn clone(&self) -> Self {
+        // Bump the reference count for the current frontier
+        self.wrapper.borrow_mut().adjust_compaction_frontier(
+            Antichain::new().borrow(),
+            self.compaction_frontier.borrow(),
+        );
+
+        Self {
+            wrapper: self.wrapper.clone(),
+            compaction_frontier: self.compaction_frontier.clone(),
+        }
+    }
+}
+
+/// A type wrapper for a timestamp update
+pub enum TimestampDataUpdate {
+    /// RT sources see the current set of partitions known to the source.
+    RealTime(HashSet<PartitionId>),
+    /// BYO sources see a list of (Timestamp, MzOffset) timestamp updates
+    BringYourOwn(TimestampBindingRc),
+}
+
+/// Map of source ID to timestamp data updates (RT or BYO).
+pub type TimestampDataUpdates = Rc<RefCell<HashMap<GlobalId, TimestampDataUpdate>>>;


### PR DESCRIPTION
This pr is ready for a look!

Here, we:

* Define a new interface for communicating timestamping information between a dataflow worker and the various source instances so that source instances can "place a hold" on timestamp compaction
* Have the dataflow worker communicate updates to the upper frontier of timestamps to the coordinator and have the coordinator tell dataflow workers what timestamps it does not care about.
* Have the coordinator consult source's as_of times when rendering a new dataflow

Not done yet / some of this may be part of another pr

* doing the same for rt sources (definitely part of another pr)
* teaching the coordinator to consult the source's `as_of` time when rendering peeks / tails and other sinks. I can't tell to what extent the change in `ship_dataflow` already did that or if I need more changes in `determine_timestamp` and `determine_frontier`
* the current setup have some perf suboptimalities (linear searching the list of timestamp bindings, some extra allocations) - I'll sort those out tomorrow


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6277)
<!-- Reviewable:end -->
