### PR TITLE
Allow testdrive tests to contain entire EXPLAIN blocks

### DIFF
--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -458,8 +458,6 @@ cannot drop materialize.public.test1: still depended upon by catalog item 'mater
 > CREATE MATERIALIZED VIEW IF NOT EXISTS test1 AS SELECT 2 as b;
 
 > SELECT * FROM test1;
-?column?
------------
 1
 
 > DROP VIEW test2;

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -154,8 +154,6 @@ b  c
 2  1
 
 > SELECT c+b from test5
-?column?
---------
 4
 3
 
@@ -180,8 +178,6 @@ b  c
 2  1
 
 > SELECT c-b from test5
-?column?
---------
 2
 -1
 
@@ -342,8 +338,6 @@ mat_data user  unknown
 > DROP INDEX mat_data_primary_idx
 
 > SELECT a+b from mat_data
-?column?
---------
 -1
 0
 7

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -43,8 +43,18 @@ row 2
 
 $ set-regex match=u\d+ replacement=UID
 
-> EXPLAIN SELECT * FROM t1;
-"%0 =\n| Get materialize.public.t1 (UID)\n"
+? EXPLAIN SELECT * FROM t1, t1;
+%0 =
+| Get materialize.public.t1 (UID)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t1 (UID)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| | demand = (#0..#5)
 
 ! SELECT * FROM u1234;
 unknown catalog item 'UID'


### PR DESCRIPTION
This change allows for the following testdrive syntax:

```
E EXPLAIN SELECT * FROM mz_sinks, mz_sinks;
%0 =
| Get mz_catalog.mz_sinks (s4023)
| ArrangeBy ()

%1 =
| Get mz_catalog.mz_sinks (s4023)

%2 =
| Join %0 %1
| | implementation = Differential %1 %0.()
| | demand = (#0..#7)
```

Lines that are started with ```E``` will cause the entire expected output to be accumulated in a single-row, single-col ```Result``` which can then directly be compared to the single-row, single-col output from ```EXPLAIN```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6282)
<!-- Reviewable:end -->
