### PR TITLE
introduce SystemEventTime trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#d9d47c2e32b29eb6aded140ab248d3793d87a861"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#5c3bfb874e533c37d33b56a40c2177da74b917c6"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -984,7 +984,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#d9d47c2e32b29eb6aded140ab248d3793d87a861"
+source = "git+https://github.com/TimelyDataflow/differential-dataflow.git#5c3bfb874e533c37d33b56a40c2177da74b917c6"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#34c0f49fb251e1def8dbcff230726726a5ac768a"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d0d84885672d6369a78cd9aff7beb2048390d3b"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4584,12 +4584,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#34c0f49fb251e1def8dbcff230726726a5ac768a"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d0d84885672d6369a78cd9aff7beb2048390d3b"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#34c0f49fb251e1def8dbcff230726726a5ac768a"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d0d84885672d6369a78cd9aff7beb2048390d3b"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -4605,7 +4605,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#34c0f49fb251e1def8dbcff230726726a5ac768a"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#0d0d84885672d6369a78cd9aff7beb2048390d3b"
 
 [[package]]
 name = "tinytemplate"

--- a/src/dataflow/src/render/join/delta_join.rs
+++ b/src/dataflow/src/render/join/delta_join.rs
@@ -19,18 +19,19 @@
 
 #![allow(clippy::op_ref)]
 use differential_dataflow::lattice::Lattice;
-use dogsdogsdogs::altneu::AltNeu;
 use std::collections::HashSet;
 use timely::dataflow::Scope;
+use timely::progress::{timestamp::Refines, Timestamp};
 
 use dataflow_types::DataflowError;
 use expr::{JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr};
-use repr::{Datum, Row, RowArena, Timestamp};
+use repr::{Row, RowArena};
 
 use super::super::context::{ArrangementFlavor, Context};
 use crate::operator::CollectionExt;
 use crate::render::datum_vec::DatumVec;
 use crate::render::join::{JoinBuildState, JoinClosure};
+use crate::render::SystemEventTime;
 
 /// A delta query is implemented by a set of paths, one for each input.
 ///
@@ -181,25 +182,22 @@ impl DeltaJoinPlan {
     }
 }
 
-impl<G> Context<G, MirRelationExpr, Row, Timestamp>
+impl<G, T> Context<G, MirRelationExpr, Row, T>
 where
-    G: Scope<Timestamp = Timestamp>,
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T> + SystemEventTime,
+    T: Timestamp + Lattice,
 {
     /// Renders `MirRelationExpr:Join` using dogs^3 delta query dataflows.
     ///
     /// The join is followed by the application of `map_filter_project`, whose
     /// implementation will be pushed in to the join pipeline if at all possible.
-    pub fn render_delta_join<F>(
+    pub fn render_delta_join(
         &mut self,
         relation_expr: &MirRelationExpr,
         map_filter_project: MapFilterProject,
         scope: &mut G,
-        worker_index: usize,
-        subtract: F,
-    ) -> (Collection<G, Row>, Collection<G, DataflowError>)
-    where
-        F: Fn(&G::Timestamp) -> G::Timestamp + Clone + 'static,
-    {
+    ) -> (Collection<G, Row>, Collection<G, DataflowError>) {
         if let MirRelationExpr::Join {
             inputs,
             equivalences,
@@ -216,10 +214,6 @@ where
                 map_filter_project,
             );
 
-            for input in inputs.iter() {
-                self.ensure_rendered(input, scope, worker_index);
-            }
-
             // Collects error streams for the ambient scope.
             let mut scope_errs = Vec::new();
 
@@ -230,293 +224,246 @@ where
             // We'll need a new scope, to hold `AltNeu` wrappers, and we'll want
             // to import all traces as alt and neu variants (unless we do a more
             // careful analysis).
-            let results =
-                scope
-                    .clone()
-                    .scoped::<AltNeu<G::Timestamp>, _, _>("delta query", |inner| {
-                        // Our plan is to iterate through each input relation, and attempt
-                        // to find a plan that maximally uses existing keys (better: uses
-                        // existing arrangements, to which we have access).
-                        let mut join_results = Vec::new();
+            let results = scope.clone().region_named("delta query", |inner| {
+                // Our plan is to iterate through each input relation, and attempt
+                // to find a plan that maximally uses existing keys (better: uses
+                // existing arrangements, to which we have access).
+                let mut join_results = Vec::new();
 
-                        // First let's prepare the input arrangements we will need.
-                        // This reduces redundant imports, and simplifies the dataflow structure.
-                        // As the arrangements are all shared, it should not dramatically improve
-                        // the efficiency, but the dataflow simplification is worth doing.
+                // First let's prepare the input arrangements we will need.
+                // This reduces redundant imports, and simplifies the dataflow structure.
+                // As the arrangements are all shared, it should not dramatically improve
+                // the efficiency, but the dataflow simplification is worth doing.
+                //
+                // The arrangements are keyed by input and arrangement key, and by whether
+                // the arrangement is "alt" or "neu", which corresponds to whether the use
+                // of the arrangement is by a relation before or after it in the order, resp.
+                // Because the alt and neu variants have different types, we will maintain
+                // them in different collections.
+                let mut arrangements = std::collections::HashMap::new();
+                for relation in 0..inputs.len() {
+                    let order = &orders[relation];
+                    for (other, lookup_key) in order.iter() {
+                        arrangements
+                            .entry((&inputs[*other], &lookup_key[..]))
+                            .or_insert_with(|| {
+                                match self
+                                    .arrangement(&inputs[*other], &lookup_key[..])
+                                    .unwrap_or_else(|| {
+                                        panic!(
+                                            "Arrangement alarmingly absent!: {}, {:?}",
+                                            inputs[*other].pretty(),
+                                            &lookup_key[..]
+                                        )
+                                    }) {
+                                    ArrangementFlavor::Local(oks, errs) => {
+                                        if local_err_dedup
+                                            .insert((&inputs[*other], &lookup_key[..]))
+                                        {
+                                            scope_errs.push(errs.as_collection(|k, _v| k.clone()));
+                                        }
+                                        Ok(oks.enter(inner))
+                                    }
+                                    ArrangementFlavor::Trace(_gid, oks, errs) => {
+                                        if trace_err_dedup
+                                            .insert((&inputs[*other], &lookup_key[..]))
+                                        {
+                                            scope_errs.push(errs.as_collection(|k, _v| k.clone()));
+                                        }
+                                        Err(oks.enter(inner))
+                                    }
+                                }
+                            });
+                    }
+                }
+
+                // Collects error streams for the inner scope. Concats before leaving.
+                let mut inner_errs = Vec::with_capacity(inputs.len());
+                for path_plan in join_plan.path_plans.into_iter() {
+                    // Deconstruct the stages of the path plan.
+                    let DeltaPathPlan {
+                        source_relation,
+                        initial_closure,
+                        stage_plans,
+                        final_closure,
+                    } = path_plan;
+
+                    // This collection determines changes that result from updates inbound
+                    // from `inputs[relation]` and reflects all strictly prior updates and
+                    // concurrent updates from relations prior to `relation`.
+                    let name = format!("delta path {}", source_relation);
+                    let path_results = inner.clone().region_named(&name, |region| {
+                        // The plan is to move through each relation, starting from `relation` and in the order
+                        // indicated in `orders[relation]`. At each moment, we will have the columns from the
+                        // subset of relations encountered so far, and we will have applied as much as we can
+                        // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
+                        // available columns.
                         //
-                        // The arrangements are keyed by input and arrangement key, and by whether
-                        // the arrangement is "alt" or "neu", which corresponds to whether the use
-                        // of the arrangement is by a relation before or after it in the order, resp.
-                        // Because the alt and neu variants have different types, we will maintain
-                        // them in different collections.
-                        let mut arrangements_alt = std::collections::HashMap::new();
-                        let mut arrangements_neu = std::collections::HashMap::new();
-                        for relation in 0..inputs.len() {
-                            let order = &orders[relation];
-                            for (other, lookup_key) in order.iter() {
-                                let subtract = subtract.clone();
-                                // Alt case
-                                if other > &relation {
-                                    arrangements_alt
-                                        .entry((&inputs[*other], &lookup_key[..]))
-                                        .or_insert_with(|| {
-                                            match self
-                                                .arrangement(&inputs[*other], &lookup_key[..])
-                                                .unwrap_or_else(|| {
-                                                    panic!(
-                                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                                        inputs[*other].pretty(),
-                                                        &lookup_key[..]
-                                                    )
-                                                }) {
-                                                ArrangementFlavor::Local(oks, errs) => {
-                                                    if local_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Ok(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::alt(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                                    if trace_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Err(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::alt(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                            }
-                                        });
-                                } else {
-                                    arrangements_neu
-                                        .entry((&inputs[*other], &lookup_key[..]))
-                                        .or_insert_with(|| {
-                                            match self
-                                                .arrangement(&inputs[*other], &lookup_key[..])
-                                                .unwrap_or_else(|| {
-                                                    panic!(
-                                                        "Arrangement alarmingly absent!: {}, {:?}",
-                                                        inputs[*other].pretty(),
-                                                        &lookup_key[..]
-                                                    )
-                                                }) {
-                                                ArrangementFlavor::Local(oks, errs) => {
-                                                    if local_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Ok(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::neu(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                                ArrangementFlavor::Trace(_gid, oks, errs) => {
-                                                    if trace_err_dedup
-                                                        .insert((&inputs[*other], &lookup_key[..]))
-                                                    {
-                                                        scope_errs.push(
-                                                            errs.as_collection(|k, _v| k.clone()),
-                                                        );
-                                                    }
-                                                    Err(oks.enter_at(
-                                                        inner,
-                                                        |_, _, t| AltNeu::neu(t.clone()),
-                                                        move |t| subtract(&t.time),
-                                                    ))
-                                                }
-                                            }
-                                        });
+                        // As we go, we will track the physical locations of each intended output column, as well
+                        // as the locations of intermediate results from partial application of `map_filter_project`.
+                        //
+                        // Just before we apply the `lookup` function to perform a join, we will first use our
+                        // available information to determine the filtering and logic that we can apply, and
+                        // introduce that in to the `lookup` logic to cause it to happen in that operator.
+
+                        // Collects error streams for the region scope. Concats before leaving.
+                        let mut region_errs = Vec::with_capacity(inputs.len());
+
+                        use differential_dataflow::AsCollection;
+                        use timely::dataflow::operators::Map;
+
+                        // Ensure this input is rendered, and extract its update stream.
+                        let mut update_stream = if let Some((_key, val)) = arrangements
+                            .iter()
+                            .find(|(key, _val)| key.0 == &inputs[source_relation])
+                        {
+                            match val {
+                                Ok(local) => {
+                                    local.as_collection(|_k, v| v.clone()).enter_region(region)
+                                }
+                                Err(trace) => {
+                                    trace.as_collection(|_k, v| v.clone()).enter_region(region)
                                 }
                             }
+                        } else {
+                            self.collection(&inputs[source_relation])
+                                .expect("Failed to render update stream")
+                                .0
+                                .enter(inner)
+                                .enter_region(region)
+                        };
+
+                        // Apply what `closure` we are able to, and record any errors.
+                        if let Some(initial_closure) = initial_closure {
+                            let (stream, errs) = update_stream.flat_map_fallible({
+                                let mut datums = DatumVec::new();
+                                move |row| {
+                                    let temp_storage = RowArena::new();
+                                    let mut datums_local = datums.borrow_with(&row);
+                                    // TODO(mcsherry): re-use `row` allocation.
+                                    initial_closure
+                                        .apply(&mut datums_local, &temp_storage)
+                                        .transpose()
+                                }
+                            });
+                            update_stream = stream;
+                            region_errs.push(errs.map(DataflowError::from));
                         }
 
-                        // Collects error streams for the inner scope. Concats before leaving.
-                        let mut inner_errs = Vec::with_capacity(inputs.len());
-                        for path_plan in join_plan.path_plans.into_iter() {
-                            // Deconstruct the stages of the path plan.
-                            let DeltaPathPlan {
-                                source_relation,
-                                initial_closure,
-                                stage_plans,
-                                final_closure,
-                            } = path_plan;
+                        // Promote `time` to a datum element.
+                        let mut update_stream = update_stream
+                            .inner
+                            .map(|(v, t, d)| ((v, t.clone()), t, d))
+                            .as_collection();
 
-                            // This collection determines changes that result from updates inbound
-                            // from `inputs[relation]` and reflects all strictly prior updates and
-                            // concurrent updates from relations prior to `relation`.
-                            let name = format!("delta path {}", source_relation);
-                            let path_results = inner.clone().region_named(&name, |region| {
-                                // The plan is to move through each relation, starting from `relation` and in the order
-                                // indicated in `orders[relation]`. At each moment, we will have the columns from the
-                                // subset of relations encountered so far, and we will have applied as much as we can
-                                // of the filters in `equivalences` and the logic in `map_filter_project`, based on the
-                                // available columns.
-                                //
-                                // As we go, we will track the physical locations of each intended output column, as well
-                                // as the locations of intermediate results from partial application of `map_filter_project`.
-                                //
-                                // Just before we apply the `lookup` function to perform a join, we will first use our
-                                // available information to determine the filtering and logic that we can apply, and
-                                // introduce that in to the `lookup` logic to cause it to happen in that operator.
+                        // Repeatedly update `update_stream` to reflect joins with more and more
+                        // other relations, in the specified order.
+                        for stage_plan in stage_plans.into_iter() {
+                            let DeltaStagePlan {
+                                lookup_relation,
+                                stream_key,
+                                lookup_key,
+                                closure,
+                            } = stage_plan;
 
-                                // Collects error streams for the region scope. Concats before leaving.
-                                let mut region_errs = Vec::with_capacity(inputs.len());
-
-                                // Ensure this input is rendered, and extract its update stream.
-                                let mut update_stream = if let Some((_key, val)) = arrangements_alt
-                                    .iter()
-                                    .find(|(key, _val)| key.0 == &inputs[source_relation])
-                                {
-                                    match val {
-                                        Ok(local) => local
-                                            .as_collection(|_k, v| v.clone())
-                                            .enter_region(region),
-                                        Err(trace) => trace
-                                            .as_collection(|_k, v| v.clone())
-                                            .enter_region(region),
-                                    }
-                                } else {
-                                    self.collection(&inputs[source_relation])
-                                        .expect("Failed to render update stream")
-                                        .0
-                                        .enter(inner)
-                                        .enter_region(region)
-                                };
-
-                                // Apply what `closure` we are able to, and record any errors.
-                                if let Some(initial_closure) = initial_closure {
-                                    let (stream, errs) = update_stream.flat_map_fallible({
-                                        let mut datums = DatumVec::new();
-                                        move |row| {
-                                            let temp_storage = RowArena::new();
-                                            let mut datums_local = datums.borrow_with(&row);
-                                            // TODO(mcsherry): re-use `row` allocation.
-                                            initial_closure
-                                                .apply(&mut datums_local, &temp_storage)
-                                                .transpose()
-                                        }
-                                    });
-                                    update_stream = stream;
-                                    region_errs.push(errs.map(DataflowError::from));
-                                }
-
-                                // Repeatedly update `update_stream` to reflect joins with more and more
-                                // other relations, in the specified order.
-                                for stage_plan in stage_plans.into_iter() {
-                                    let DeltaStagePlan {
-                                        lookup_relation,
-                                        stream_key,
-                                        lookup_key,
-                                        closure,
-                                    } = stage_plan;
-
-                                    // We require different logic based on the flavor of arrangement.
-                                    // We may need to cache each of these if we want to re-use the same wrapped
-                                    // arrangement, rather than re-wrap each time we use a thing.
-                                    let (oks, errs) = if lookup_relation > source_relation {
-                                        match arrangements_alt
-                                            .get(&(&inputs[lookup_relation], &lookup_key[..]))
-                                            .unwrap()
-                                        {
-                                            Ok(local) => build_lookup(
-                                                update_stream,
-                                                local.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                            Err(trace) => build_lookup(
-                                                update_stream,
-                                                trace.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                        }
+                            // We require different logic based on the flavor of arrangement.
+                            // We may need to cache each of these if we want to re-use the same wrapped
+                            // arrangement, rather than re-wrap each time we use a thing.
+                            let (oks, errs) = match arrangements
+                                .get(&(&inputs[lookup_relation], &lookup_key[..]))
+                                .unwrap()
+                            {
+                                Ok(local) => {
+                                    if lookup_relation > source_relation {
+                                        build_halfjoin(
+                                            update_stream,
+                                            local.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.lt(t2),
+                                            closure,
+                                        )
                                     } else {
-                                        match arrangements_neu
-                                            .get(&(&inputs[lookup_relation], &lookup_key[..]))
-                                            .unwrap()
-                                        {
-                                            Ok(local) => build_lookup(
-                                                update_stream,
-                                                local.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                            Err(trace) => build_lookup(
-                                                update_stream,
-                                                trace.enter_region(region),
-                                                stream_key,
-                                                closure,
-                                            ),
-                                        }
-                                    };
-                                    update_stream = oks;
-                                    region_errs.push(errs);
+                                        build_halfjoin(
+                                            update_stream,
+                                            local.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.le(t2),
+                                            closure,
+                                        )
+                                    }
                                 }
-
-                                // We have completed the join building, but may have work remaining.
-                                // For example, we may have expressions not pushed down (e.g. literals)
-                                // and projections that could not be applied (e.g. column repetition).
-                                if let Some(final_closure) = final_closure {
-                                    let (updates, errors) = update_stream.flat_map_fallible({
-                                        // Reuseable allocation for unpacking.
-                                        let mut datums = DatumVec::new();
-                                        move |row| {
-                                            let temp_storage = RowArena::new();
-                                            let mut datums_local = datums.borrow_with(&row);
-                                            // TODO(mcsherry): re-use `row` allocation.
-                                            final_closure
-                                                .apply(&mut datums_local, &temp_storage)
-                                                .map_err(DataflowError::from)
-                                                .transpose()
-                                        }
-                                    });
-
-                                    update_stream = updates;
-                                    region_errs.push(errors);
+                                Err(trace) => {
+                                    if lookup_relation > source_relation {
+                                        build_halfjoin(
+                                            update_stream,
+                                            trace.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.lt(t2),
+                                            closure,
+                                        )
+                                    } else {
+                                        build_halfjoin(
+                                            update_stream,
+                                            trace.enter_region(region),
+                                            stream_key,
+                                            |t1, t2| t1.le(t2),
+                                            closure,
+                                        )
+                                    }
                                 }
+                            };
+                            update_stream = oks;
+                            region_errs.push(errs);
+                        }
 
-                                inner_errs.push(
-                                    differential_dataflow::collection::concatenate(
-                                        region,
-                                        region_errs,
-                                    )
-                                    .leave(),
-                                );
-                                update_stream.leave()
+                        // Delay updates as appropriate.
+                        let mut update_stream = update_stream
+                            .inner
+                            .map(|((row, time), _, diff)| (row, time, diff))
+                            .as_collection();
+
+                        // We have completed the join building, but may have work remaining.
+                        // For example, we may have expressions not pushed down (e.g. literals)
+                        // and projections that could not be applied (e.g. column repetition).
+                        if let Some(final_closure) = final_closure {
+                            let (updates, errors) = update_stream.flat_map_fallible({
+                                // Reuseable allocation for unpacking.
+                                let mut datums = DatumVec::new();
+                                move |row| {
+                                    let temp_storage = RowArena::new();
+                                    let mut datums_local = datums.borrow_with(&row);
+                                    // TODO(mcsherry): re-use `row` allocation.
+                                    final_closure
+                                        .apply(&mut datums_local, &temp_storage)
+                                        .map_err(DataflowError::from)
+                                        .transpose()
+                                }
                             });
 
-                            join_results.push(path_results);
+                            update_stream = updates;
+                            region_errs.push(errors);
                         }
 
-                        scope_errs.push(
-                            differential_dataflow::collection::concatenate(inner, inner_errs)
+                        inner_errs.push(
+                            differential_dataflow::collection::concatenate(region, region_errs)
                                 .leave(),
                         );
-
-                        // Concatenate the results of each delta query as the accumulated results.
-                        (
-                            differential_dataflow::collection::concatenate(inner, join_results)
-                                .leave(),
-                            differential_dataflow::collection::concatenate(scope, scope_errs),
-                        )
+                        update_stream.leave()
                     });
+
+                    join_results.push(path_results);
+                }
+
+                scope_errs.push(
+                    differential_dataflow::collection::concatenate(inner, inner_errs).leave(),
+                );
+
+                // Concatenate the results of each delta query as the accumulated results.
+                (
+                    differential_dataflow::collection::concatenate(inner, join_results).leave(),
+                    differential_dataflow::collection::concatenate(scope, scope_errs),
+                )
+            });
             results
         } else {
             panic!("render_delta_join invoked on non-delta join implementation");
@@ -530,27 +477,34 @@ use differential_dataflow::trace::Cursor;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::Collection;
 
-/// Constructs a `lookup_map` from supplied arguments.
+/// Constructs a `half_join` from supplied arguments.
 ///
 /// This method exists to factor common logic from four code paths that are generic over the type of trace.
-fn build_lookup<G, Tr>(
-    updates: Collection<G, Row>,
+/// The `comparison` function should either be `le` or `lt` depending on which relation comes first in the
+/// total order on relations (in order to break ties consistently).
+fn build_halfjoin<G, Tr, CF>(
+    updates: Collection<G, (Row, G::Timestamp)>,
     trace: Arranged<G, Tr>,
     prev_key: Vec<MirScalarExpr>,
+    comparison: CF,
     closure: JoinClosure,
-) -> (Collection<G, Row>, Collection<G, DataflowError>)
+) -> (
+    Collection<G, (Row, G::Timestamp)>,
+    Collection<G, DataflowError>,
+)
 where
     G: Scope,
-    G::Timestamp: Lattice,
+    G::Timestamp: Lattice + SystemEventTime,
     Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = isize> + Clone + 'static,
     Tr::Batch: BatchReader<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
     Tr::Cursor: Cursor<Tr::Key, Tr::Val, Tr::Time, Tr::R>,
+    CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
     let (updates, errs) = updates.map_fallible({
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
         let mut row_packer = Row::default();
-        move |row| {
+        move |(row, time)| {
             let temp_storage = RowArena::new();
             let datums_local = datums.borrow_with(&row);
             row_packer.clear();
@@ -562,7 +516,7 @@ where
             let row_key = row_packer.finish_and_reuse();
             // Explicit drop to release borrow on `row` so that it can be returned.
             drop(datums_local);
-            Ok((row, row_key))
+            Ok((row_key, row, time))
         }
     });
 
@@ -570,35 +524,27 @@ where
     use timely::dataflow::operators::OkErr;
 
     let mut datums = DatumVec::new();
-    let (oks, errs2) = dogsdogsdogs::operators::lookup_map(
+    let (oks, errs2) = dogsdogsdogs::operators::half_join(
         &updates,
         trace,
-        move |(_row, row_key), key| {
-            // Prefix key selector must populate `key` with key from prefix `row`.
-            key.clone_from(&row_key);
-        },
-        // TODO(mcsherry): consider `RefOrMut` in `lookup` interface to allow re-use.
-        move |(stream_row, _stream_row_key), diff1, lookup_row, diff2| {
+        |time| time.retreat(),
+        comparison,
+        // TODO(mcsherry): consider `RefOrMut` in `half_join` interface to allow re-use.
+        move |_key, stream_row, lookup_row| {
             let temp_storage = RowArena::new();
             let mut datums_local = datums.borrow();
             datums_local.extend(stream_row.iter());
             datums_local.extend(lookup_row.iter());
-            (
-                closure.apply(&mut datums_local, &temp_storage),
-                diff1 * diff2,
-            )
+            closure.apply(&mut datums_local, &temp_storage)
         },
-        // Three default values, for decoding keys into.
-        Row::pack::<_, Datum>(None),
-        Row::pack::<_, Datum>(None),
-        Row::pack::<_, Datum>(None),
     )
     .inner
     .ok_err(|(x, t, d)| {
         // TODO(mcsherry): consider `ok_err()` for `Collection`.
         match x {
-            Ok(x) => Ok((x, t, d)),
-            Err(x) => Err((DataflowError::from(x), t, d)),
+            (Ok(x), time) => Ok((x.map(|x| (x, time)), t, d)),
+            // TODO(mcsherry): what time should we use here?
+            (Err(x), _time) => Err((DataflowError::from(x), t, d)),
         }
     });
 


### PR DESCRIPTION
This is a WIP PR which introduces the `SystemEventTime` trait in to `render`, in an attempt to remove explicit references to `repr::Timestamp`. The trait looks roughly like so
```rust
/// A trait meant to capture requisite functionality for use as a timestamp.
pub trait SystemEventTime: Timestamp {
    /// A reference to the system time component of the timestamp.
    fn system_time(&mut self) -> &mut repr::Timestamp;
    /// An additive delay to system time.
    fn system_delay(delay: repr::Timestamp) -> <Self as Timestamp>::Summary;
    /// A reference to the event time component of the timestamp.
    fn event_time(&mut self) -> &mut repr::Timestamp;
    /// An additive delay to event time.
    fn event_delay(delay: repr::Timestamp) -> <Self as Timestamp>::Summary;
    /// Move the timestamp backwards one unit. (TODO: further document).
    fn retreat(&self) -> Self;
}
```
and means to capture the aspects of a timestamp we want to have access to in rendering.

The trait allows us to write `delta_join.rs`, `top_k.rs`, and `filter.rs` without requiring that the timestamp type be `repr::Timestamp`. This is mostly for clarity, but it could have future implications for bi-temporal processing or other weird stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6291)
<!-- Reviewable:end -->
