### PR TITLE
testdrive: exclude FETCH from the retry logic

### DIFF
--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -48,3 +48,16 @@ $ set-regex match=u\d+ replacement=UID
 
 ! SELECT * FROM u1234;
 unknown catalog item 'UID'
+
+# Exclude FETCH from the retry logic
+
+> CREATE MATERIALIZED VIEW v1 AS VALUES (1),(2),(3);
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v1 AS OF 18446744073709551615;
+
+> FETCH 4 c WITH (timeout='10s');
+18446744073709551615 1 1
+18446744073709551615 1 2
+18446744073709551615 1 3


### PR DESCRIPTION
The commit message:

> It does not make sense to retry FETCH until a match is found because
> subsequent executions are likely to return an empty result and the
> original result returned from the first execution will thus be lost.

If FETCH is retried , testdrive fails with a bogus error: expected ["abc"], got []". This "[]" is because it came from a retry of  FETCH , and retries are likely to return an empty result.

Ideally we would want to:
- either accumulate all the results of the individual FETCH executions as they arrive until a match is found across all the accumulated results. However, there is no obvious place in the structs where one could stash such an accumulation
- destroy the cursor and fetch again from the start. However, the code does not allow for loops/retries over a DECLARE + FETCH combination 

hence this PR that simply disables the retry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6294)
<!-- Reviewable:end -->
