### PR TITLE
debezium upsert: Decode Kafka Keys when checking identity

### DIFF
--- a/src/dataflow/src/decode/avro.rs
+++ b/src/dataflow/src/decode/avro.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use anyhow::Context;
 use futures::executor::block_on;
 
 use dataflow_types::{DataflowError, DecodeError};
@@ -18,6 +19,7 @@ use crate::metrics::EVENTS_COUNTER;
 
 pub struct AvroDecoderState {
     decoder: Decoder,
+    key_decoder: Option<Decoder>,
     events_success: i64,
     events_error: i64,
 }
@@ -25,7 +27,8 @@ pub struct AvroDecoderState {
 impl AvroDecoderState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        reader_schema: &str,
+        key_schema: Option<&str>,
+        value_schema: &str,
         schema_registry_config: Option<ccsr::ClientConfig>,
         envelope: EnvelopeType,
         reject_non_inserts: bool,
@@ -35,9 +38,25 @@ impl AvroDecoderState {
         dbz_key_indices: Option<Vec<usize>>,
         confluent_wire_format: bool,
     ) -> Result<Self, anyhow::Error> {
+        let key_decoder = key_schema
+            .map(|key_schema| {
+                Decoder::new(
+                    key_schema,
+                    schema_registry_config.clone(),
+                    EnvelopeType::None,
+                    debug_name.clone(),
+                    worker_index,
+                    None,
+                    dbz_key_indices.clone(),
+                    confluent_wire_format,
+                    reject_non_inserts,
+                )
+            })
+            .transpose()
+            .context("Creating Kafka Avro Key decoder")?;
         Ok(AvroDecoderState {
             decoder: Decoder::new(
-                reader_schema,
+                value_schema,
                 schema_registry_config,
                 envelope,
                 debug_name,
@@ -47,6 +66,7 @@ impl AvroDecoderState {
                 confluent_wire_format,
                 reject_non_inserts,
             )?,
+            key_decoder,
             events_success: 0,
             events_error: 0,
         })
@@ -55,16 +75,19 @@ impl AvroDecoderState {
 
 impl DecoderState for AvroDecoderState {
     fn decode_key(&mut self, bytes: &[u8]) -> Result<Option<Row>, String> {
-        match block_on(self.decoder.decode(bytes, None, None)) {
-            Ok(Some(row)) => {
-                self.events_success += 1;
-                Ok(Some(row))
-            }
-            Ok(None) => Ok(None),
-            Err(err) => {
-                self.events_error += 1;
-                Err(format!("avro deserialization error: {}", err))
-            }
+        match self.key_decoder.as_mut() {
+            Some(key_decoder) => match block_on(key_decoder.decode(bytes, None, None)) {
+                Ok(Some(row)) => {
+                    self.events_success += 1;
+                    Ok(Some(row))
+                }
+                Ok(None) => Ok(None),
+                Err(err) => {
+                    self.events_error += 1;
+                    Err(format!("avro deserialization error: {}", err))
+                }
+            },
+            None => Err(format!("No key decoder configured")),
         }
     }
 

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -27,7 +27,7 @@ use timely::dataflow::{Scope, Stream};
 use timely::scheduling::SyncActivator;
 
 use ::mz_avro::{types::Value, Schema};
-use dataflow_types::{DataEncoding, DebeziumMode, RegexEncoding, SourceEnvelope};
+use dataflow_types::{DataEncoding, DebeziumMode, DecodeError, RegexEncoding, SourceEnvelope};
 use dataflow_types::{DataflowError, LinearOperator};
 use interchange::avro::{extract_row, ConfluentAvroResolver, DebeziumDecodeState};
 use log::error;
@@ -214,17 +214,18 @@ pub(crate) fn get_decoder(
             &enc.descriptors,
             &enc.message_name,
         )),
-        DataEncoding::Avro(val_enc) => Box::new(
+        DataEncoding::Avro(enc) => Box::new(
             avro::AvroDecoderState::new(
-                &val_enc.value_schema,
-                val_enc.schema_registry_config,
+                enc.key_schema.as_deref(),
+                &enc.value_schema,
+                enc.schema_registry_config,
                 interchange::avro::EnvelopeType::Upsert,
                 false,
                 format!("{}-values", debug_name),
                 worker_index,
                 None,
                 None,
-                val_enc.confluent_wire_format,
+                enc.confluent_wire_format,
             )
             .expect(avro_err),
         ),
@@ -236,7 +237,7 @@ pub(crate) fn get_decoder(
 
 fn decode_values_inner<G, V, C>(
     stream: &Stream<G, SourceOutput<Vec<u8>, Vec<u8>>>,
-    mut value_decoder_state: V,
+    mut decoder_state: V,
     op_name: &str,
     source_id: SourceInstanceId,
     contract: C,
@@ -274,11 +275,24 @@ where
                 {
                     if !payload.is_empty() {
                         let val =
-                            value_decoder_state.get_value(payload, *aux_num, *upstream_time_millis);
+                            decoder_state.get_value(payload, *aux_num, *upstream_time_millis);
 
                         if let Some(val) = val {
                             let val = if let Some((keys, metrics)) = trackstate.as_mut() {
-                                rewrite_for_upsert(val, keys, key, metrics)
+                                match decoder_state.decode_key(key) {
+                                    Ok(Some(decoded_key)) => {
+                                        rewrite_for_upsert(val, keys, decoded_key, metrics)
+                                    }
+                                    Ok(None) => Err(DecodeError::Text(format!(
+                                        "[customer-data] All upsert keys should decode to a value: {:?}",
+                                        key
+                                    ))
+                                    .into()),
+                                    Err(e) => {
+                                        Err(DecodeError::Text(format!("Error decoding key: {}", e))
+                                            .into())
+                                    }
+                                }
                             } else {
                                 val
                             };
@@ -288,7 +302,7 @@ where
                     }
                 }
             });
-            value_decoder_state.log_error_count();
+            decoder_state.log_error_count();
         }
     });
 
@@ -303,15 +317,14 @@ where
 /// Update row to blank out retractions of rows that we have never seen
 fn rewrite_for_upsert(
     val: Result<Row, DataflowError>,
-    keys: &mut HashMap<Box<[u8]>, Row>,
-    key: &[u8],
+    keys: &mut HashMap<Row, Row>,
+    key: Row,
     metrics: &mut UIntGauge,
 ) -> Result<Row, DataflowError> {
     if let Ok(row) = val {
         // often off by one, but is only tracked every N seconds so it will always be off
         metrics.set(keys.len() as u64);
 
-        // TODO: handle parsed keys
         let entry = keys.entry(key.into());
 
         let mut rowiter = row.iter();
@@ -504,6 +517,7 @@ where
                 decode_values_inner(
                     stream,
                     avro::AvroDecoderState::new(
+                        enc.key_schema.as_deref(),
                         &enc.value_schema,
                         enc.schema_registry_config,
                         envelope.get_avro_envelope_type(),
@@ -527,6 +541,7 @@ where
             decode_values_inner(
                 stream,
                 avro::AvroDecoderState::new(
+                    enc.key_schema.as_deref(),
                     &enc.value_schema,
                     enc.schema_registry_config,
                     envelope.get_avro_envelope_type(),

--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -205,7 +205,10 @@ where
                             // which would allow us to recover from key decoding errors by a
                             // later retraction of the key (it will never decode correctly, but
                             // we could produce and then remove the error from the output).
-                            match key_decoder_state.decode_key(&key) {
+                            //
+                            // TODO(bwm): migrate upsert to use the same framework for key-value
+                            // decoding as other code, as we build out a design for that.
+                            match key_decoder_state.decode_upsert_value(&key, None, None) {
                                 Ok(Some(decoded_key)) => {
                                     let decoded_value = if data.value.is_empty() {
                                         Ok(None)

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -81,7 +81,8 @@ impl Decoder {
     ) -> anyhow::Result<Decoder> {
         assert!(
             (envelope == EnvelopeType::Debezium && debezium_dedup.is_some())
-                || (envelope != EnvelopeType::Debezium && debezium_dedup.is_none())
+                || (envelope != EnvelopeType::Debezium && debezium_dedup.is_none()),
+            "Debezium deduplication strategy must be specified iff envelope type is debezium"
         );
         let debezium_dedup =
             debezium_dedup.and_then(|strat| DebeziumDeduplicationState::new(strat, key_indices));

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -24,7 +24,8 @@ use repr::strconv;
 use sql_parser::ast::display::AstDisplay;
 use sql_parser::ast::{
     AvroSchema, ColumnDef, ColumnOption, ColumnOptionDef, Connector, CreateSourceStatement,
-    CreateSourcesStatement, CsrSeed, Format, Ident, MultiConnector, Raw, Statement,
+    CreateSourcesStatement, CsrSeed, DbzMode, Envelope, Format, Ident, MultiConnector, Raw,
+    Statement,
 };
 use sql_parser::parser::parse_columns;
 
@@ -115,9 +116,33 @@ pub async fn purify(mut stmt: Statement<Raw>) -> Result<Statement<Raw>, anyhow::
             Connector::PubNub { .. } => (),
         }
 
-        purify_format(format, connector, col_names, file, &config_options).await?;
-        if let sql_parser::ast::Envelope::Upsert(format) = envelope {
-            purify_format(format, connector, col_names, None, &config_options).await?;
+        purify_format(
+            format,
+            connector,
+            &envelope,
+            col_names,
+            file,
+            &config_options,
+        )
+        .await?;
+        if let sql_parser::ast::Envelope::Upsert(_) = envelope {
+            // TODO(bwm): this will be removed with the upcoming upsert rationalization
+            //
+            // The `format` argument is mutated in the call to purify_format, so it must be the
+            // original format from the outer envelope. The envelope is just matched against, and
+            // can be cloned safely.
+            let envelope_dupe = envelope.clone();
+            if let sql_parser::ast::Envelope::Upsert(format) = envelope {
+                purify_format(
+                    format,
+                    connector,
+                    &envelope_dupe,
+                    col_names,
+                    None,
+                    &config_options,
+                )
+                .await?;
+            }
         }
     }
     if let Statement::CreateSources(CreateSourcesStatement { connector }) = &mut stmt {
@@ -199,6 +224,7 @@ async fn purify_postgres_table(
 async fn purify_format(
     format: &mut Option<Format<Raw>>,
     connector: &mut Connector<Raw>,
+    envelope: &Envelope<Raw>,
     col_names: &mut Vec<Ident>,
     file: Option<File>,
     connector_options: &BTreeMap<String, String>,
@@ -231,6 +257,11 @@ async fn purify_format(
                         value_schema,
                         ..
                     } = get_remote_avro_schema(ccsr_config, topic.clone()).await?;
+                    if matches!(envelope, Envelope::Debezium(DbzMode::Upsert))
+                        && key_schema.is_none()
+                    {
+                        bail!("Key schema is required for ENVELOPE DEBEZIUM UPSERT");
+                    }
                     *seed = Some(CsrSeed {
                         key_schema,
                         value_schema,
@@ -241,13 +272,30 @@ async fn purify_format(
                 schema: sql_parser::ast::Schema::File(path),
                 with_options,
             } => {
+                if matches!(envelope, Envelope::Debezium(DbzMode::Upsert)) {
+                    // TODO(bwm): Support key schemas everywhere, something like
+                    // https://github.com/MaterializeInc/materialize/pull/6286
+                    bail!(
+                        "ENVELOPE DEBEZIUM UPSERT can only be used with schemas from \
+                           the confluent schema registry, and requires a key schema"
+                    );
+                }
                 let value_schema = tokio::fs::read_to_string(path).await?;
                 *schema = AvroSchema::Schema {
                     schema: sql_parser::ast::Schema::Inline(value_schema),
                     with_options: with_options.clone(),
                 };
             }
-            _ => {}
+            _ => {
+                if matches!(envelope, Envelope::Debezium(DbzMode::Upsert)) {
+                    // TODO(bwm): Support key schemas everywhere, something like
+                    // https://github.com/MaterializeInc/materialize/pull/6286
+                    bail!(
+                        "ENVELOPE DEBEZIUM UPSERT can only be used with schemas from \
+                           the confluent schema registry, and requires a key schema"
+                    );
+                }
+            }
         },
         Some(Format::Protobuf { schema, .. }) => {
             if let sql_parser::ast::Schema::File(path) = schema {

--- a/test/testdrive/upsert-kafka-debezium.td
+++ b/test/testdrive/upsert-kafka-debezium.td
@@ -54,9 +54,15 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}}
 
 
-> CREATE MATERIALIZED SOURCE doin_upsert
+! CREATE MATERIALIZED SOURCE doin_upsert
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
+  ENVELOPE DEBEZIUM UPSERT
+ENVELOPE DEBEZIUM UPSERT can only be used with schemas from the confluent schema registry, and requires a key schema
+
+> CREATE MATERIALIZED SOURCE doin_upsert
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 
 > SELECT * FROM doin_upsert
@@ -125,7 +131,7 @@ id creature
 > CREATE MATERIALIZED SOURCE upsert_full_dedupe
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   WITH (deduplication = 'full')
-  FORMAT AVRO USING SCHEMA '${schema}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 
 > SELECT creature FROM upsert_full_dedupe


### PR DESCRIPTION
This resolves the potential issue of the same bit pattern possibly meaning different things in the
presence of schema evolution.

This PR does not support inline schemas, requiring the schema registry.  Supporting inline schemas
will work when https://github.com/MaterializeInc/materialize/pull/6286 -- or something like it -- is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6301)
<!-- Reviewable:end -->
