### PR TITLE
Implement `repeat` as a function that repeats strings, rename `repeat`->`repeat_row`

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -70,6 +70,9 @@ Wrap your release notes at the 80 character mark.
 - Add the [`mz_uptime`](/sql/functions#system-information-func)
   function, which reports the duration for which the server has been running.
 
+- Add the [`repeat`](/sql/functions#string-func) function, which repeats a
+  string N times.
+
 - Avoid panicking when planning SQL queries of the form
   `SELECT DISTINCT ... ORDER BY <expr>` where `expr` is not a simple column
   reference {{% gh 6021 %}}.

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -260,6 +260,9 @@
       `needle`, in order. If `flags` is set to the string `i` matches
       case-insensitively.
 
+  - signature: 'repeat(s: str, n: int) -> str'
+    description: Replicate the string `n` times.
+
   - signature: 'replace(s: str, f: str, r: str) -> str'
     description: "`s` with all instances of `f` replaced with `r`"
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -931,7 +931,7 @@ impl fmt::Display for TableFunc {
             TableFunc::CsvExtract(n_cols) => write!(f, "csv_extract({}, _)", n_cols),
             TableFunc::GenerateSeriesInt32 => f.write_str("generate_series"),
             TableFunc::GenerateSeriesInt64 => f.write_str("generate_series"),
-            TableFunc::Repeat => f.write_str("repeat"),
+            TableFunc::Repeat => f.write_str("repeat_row"),
             TableFunc::ReadCachedData { source, .. } => {
                 write!(f, "internal_read_cached_data({})", source)
             }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1571,6 +1571,9 @@ lazy_static! {
                     Ok(lhs.call_binary(rhs, BinaryFunc::PowerDecimal(s)))
                 }), 2169;
             },
+            "repeat" => Scalar {
+                params!(String, Int32) => BinaryFunc::RepeatString, 1622;
+            },
             "regexp_match" => Scalar {
                 params!(String, String) => VariadicFunc::RegexpMatch, 3396;
                 params!(String, String, String) => VariadicFunc::RegexpMatch, 3397;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1989,9 +1989,9 @@ lazy_static! {
                     })
                 }), oid::FUNC_REGEXP_EXTRACT_OID;
             },
-            "repeat" => Table {
+            "repeat_row" => Table {
                 params!(Int64) => Operation::unary(move |ecx, n| {
-                    ecx.require_experimental_mode("repeat")?;
+                    ecx.require_experimental_mode("repeat_row")?;
                     Ok(TableFuncPlan {
                         func: TableFunc::Repeat,
                         exprs: vec![n],

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -1060,3 +1060,18 @@ SELECT right('hello', -2147483647)
 # i64
 query error arguments cannot be implicitly cast to any implementation's parameters
 SELECT right('hello', 2147483648)
+
+query T
+SELECT repeat('hi', 5)
+----
+hihihihihi
+
+query T
+SELECT repeat('a', 0)
+----
+(empty)
+
+query T
+SELECT repeat('a', -1)
+----
+(empty)

--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -297,7 +297,7 @@ EXPLAIN PLAN FOR SELECT * FROM x x1, x x2, generate_series(x1.a, x2.b) AS x3(b) 
 EOF
 
 query I
-SELECT * FROM generate_series(0,3), repeat(generate_series);
+SELECT * FROM generate_series(0,3), repeat_row(generate_series);
 ----
 1
 2
@@ -307,7 +307,7 @@ SELECT * FROM generate_series(0,3), repeat(generate_series);
 3
 
 query I
-SELECT abs(generate_series) FROM generate_series(-1, 2), repeat(generate_series);
+SELECT abs(generate_series) FROM generate_series(-1, 2), repeat_row(generate_series);
 ----
 2
 2


### PR DESCRIPTION
This PR can be reviewed on a commit-by-commit basis:

1. First, we rename our experimental `repeat` function to `repeat_row`; this should be easy because it's undocumented and experimental.
2. Then, we implement `repeat` as the eponymous [postgresql string function](https://www.postgresql.org/docs/9.1/functions-string.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6309)
<!-- Reviewable:end -->
