### PR TITLE
Propose clear definitions of our log levels

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -20,7 +20,8 @@ Flag | Default | Modifies
 [`--introspection-frequency`](#introspection-sources) | 1s | The frequency at which to update [introspection sources](#introspection-sources).
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
 [`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 1ms | The amount of historical detail to retain in arrangements
-[`--log-filter`](#logging) | `info` | Which log messages to emit.
+[`--log-file`](#log-file) | [`mzdata`](#data-directory)`/materialized.log` | Where to emit log messages
+[`--log-filter`](#log-filter) | `info` | Which log messages to emit
 [`--timely-progress-mode`](#dataflow-tuning) | demand | *Advanced.* Timely progress tracking mode.
 [`--tls-ca`](#tls-encryption) | N/A | Path to TLS certificate authority (CA) {{< version-added v0.7.1 />}}
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
@@ -128,11 +129,26 @@ the compaction window.
 
 ### Logging
 
-{{< version-added 0.7.2 />}}
+#### Log file
 
-The `--log-filter` option specifies which log messages Materialize will emit.
-Its value is a comma-separated list of filter directives. Each filter directive
-has the following format:
+The `--log-file` option specifies the path to a file in which Materialize will
+write its [log messages](/ops/monitoring#logging). The value `stderr` is treated
+specially and specifies the standard error stream.
+
+If the option is unspecified, Materialize writes log messages to the
+`materialized.log` file in the [data directory](#data-directory) and
+additionally forwards any log messages at the `WARN` or `ERROR` levels to the
+standard error stream. Forwarding does not occur if you explicitly specify a log
+file.
+
+#### Log filter
+
+{{< version-added v0.7.2 />}}
+
+The `--log-filter` option specifies which [log
+messages](/ops/monitoring#logging) Materialize will emit. Its value is a
+comma-separated list of filter directives. Each filter directive has the
+following format:
 
 ```
 [module::path=]level
@@ -144,15 +160,21 @@ module, then it implicitly applies to all modules. When directives conflict, the
 last directive wins. Materialize will only emit log messages that match at least
 one filter directive.
 
-The module path of a log message reflects its location in Materialize's source
-code. Specifying module paths in filter directives requires familiarity with
-Materialize's codebase and is intended for advanced users. Note that module
-paths change frequency from release to release and are not considered part of
-Materialize's stable interface.
+Specifying module paths in filter directives requires familiarity with
+Materialize's codebase and is intended for advanced users.
 
-The valid levels for a log message are, in increasing order of severity:
-`trace`, `debug`, `info`, `warn`, and `error`. The special level `off` may be
-used in a directive to suppress all log messages, even errors.
+The valid levels for a log message are documented in the [logging
+section](/ops/monitoring/#levels) of the monitoring documentation and are not
+case sensitive. The special level `off` may be used in a directive to suppress
+all log messages, even those at the `error` level.
+
+As an example, the following filter specifies the `TRACE` level for the `pgwire`
+module, which handles SQL network connections, and the `INFO` level for all
+other modules.
+
+```
+pgwire=trace,info
+```
 
 ### Introspection sources
 

--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -175,3 +175,110 @@ Configuration parameter | Value
 `prometheus_url`        | `http://<materialized host>/metrics`
 `namespace`             | Your choice
 `metrics`               | `[mz*]` to select all metrics, or a list of specific metrics
+
+## Logging
+
+Materialize periodically emits messages to its [log file](/cli/#log-filter).
+These log messages serve several purposes:
+
+  * To alert operators to critical issues
+  * To record system status changes
+  * To provide developers with visibility into the system's execution when
+    troubleshooting issues
+
+We recommend that you monitor for messages at the [`WARN` or `ERROR`
+levels](#levels). Every message at either of these levels indicates an issue
+that must be investigated and resolved.
+
+### Message format
+
+Each log message is a single line with the following format:
+
+```
+<timestamp> <level> <module>: [<tag>]... <body>
+```
+
+For example, Materialize emits the following log message when a table named `t`
+is created:
+
+```
+2021-04-08T04:12:25.927738Z  INFO coord::catalog: create table materialize.public.t (u1)
+```
+
+The timestamp is always in UTC and formatted according to ISO 8601.
+
+The log level is one of the five levels described in the next section,
+formatted with all uppercase letters.
+
+The module path reflects the log message's location in Materialize's source
+code. Module paths change frequently from release to release and are not part of
+Materialize's stable interface.
+
+The tags, if included, further categorize the message. Tags are surrounded by
+square brackets. The currently used tags are:
+
+* `[customer-data]`: the message includes clear-text contents of data in the system
+* `[deprecation]`: a feature in use will be removed or changed in a future release
+
+The body is unstructured text intended for human consumption. It may include
+embedded newlines.
+
+### Levels
+
+Every log message is associated with a level that indicates the severity of the
+message. The levels are, in decreasing order of severity, `ERROR`, `WARN`,
+`INFO`, `DEBUG`, and `TRACE`.
+
+Log levels are used in the [`--log-filter` command-line option](/cli/#log-filter)
+to determine which log messages to emit.
+
+Messages at each level must meet the indicated standard:
+
+* **`ERROR`**: Reports an error that has caused data corruption, data loss, or
+  unavailability. You should page on-call staff immediately about these errors.
+
+  Examples:
+
+  * Authentication with an external system (e.g., Amazon S3) has failed.
+  * A source ingested the deletion of a record that does not exist, causing a
+    "negative multiplicity."
+
+* **`WARN`**: Reports an issue that may lead to data corruption, data loss, or
+  unavailability. It is reasonable to check for `WARN`-level messages once per
+  day during normal business hours.
+
+  Examples:
+
+  * A network request (e.g., downloading an object from Amazon S3) has failed
+    several times, but a retry is in progress.
+
+* **`INFO`**: Reports normal system status changes. Messages at this level may
+  be of interest to operators, but do not typically require attention.
+
+  Examples:
+
+  * A view was created.
+  * A view was dropped.
+
+* **`DEBUG`**: Provides information that may help when troubleshooting issues.
+  Messages at this level are primarily of interest to Materialize engineers.
+
+  Examples:
+
+  * An HTTP request was routed through a proxy specified by the `http_proxy`
+    environment variable.
+  * An S3 object downloaded by an S3 source had an invalid `Content-Encoding`
+    header that was ignored, but the object was nonetheless decoded
+    successfully.
+
+* **`TRACE`**: Like `DEBUG`, but the information meets a lower standard of
+  relevance or importance.
+
+  Enabling `TRACE` logs can generate multiple gigabytes of log messages per
+  hour. We recommend that you only enable this level in development or at the
+  direction of a Materialize engineer.
+
+  Examples:
+
+  * A Kafka source consumed a message.
+  * A SQL client issued a command.


### PR DESCRIPTION
This mostly corresponds to the way that we use log statements currently, but it is also a proposal
for making this understanding normative.

Log levels are always going to be a little bit vague, with unfortunately-broad lines between
different levels. However, logs are a useful line of defense in monitoring, and having clear
standards for how we argue whether something should be logged at a specific level can help ensure
that our on-disk logs are useful, instead of just being noise. Once logs are useful, it is possible to
configure automated systems based upon them, automatically surfacing warning and error logs to 
humans as important.

If we agree that these are good levels, I'll do another audit of our log statements to help ensure
that we do match these levels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6311)
<!-- Reviewable:end -->
