### PR TITLE
Refuse to set statistics.interval.ms on RT timestamping connector

### DIFF
--- a/src/coord/src/timestamp.rs
+++ b/src/coord/src/timestamp.rs
@@ -936,6 +936,9 @@ fn rt_kafka_metadata_fetch_loop(c: RtKafkaConnector, consumer: BaseConsumer, wai
             }
         }
 
+        // Poll once to clear any extraneous messages on this queue.
+        consumer.poll(Duration::from_secs(0));
+
         if current_partition_count > 0 {
             thread::sleep(wait);
         } else {


### PR DESCRIPTION
Previously, when we asked for statistics on a Kafka source, we were passing through that config option to the RT timestamp consumer as well, causing Kafka to generate messages which were never drained. This was causing about 10 KB in leaked memory per statistics tick interval (default 1s).

Fixes #6313

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6315)
<!-- Reviewable:end -->
