### PR TITLE
materialized: replace MZ_LOG with a new `--log-filter` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -4402,6 +4403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,6 +4532,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 

--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -20,6 +20,7 @@ Flag | Default | Modifies
 [`--introspection-frequency`](#introspection-sources) | 1s | The frequency at which to update [introspection sources](#introspection-sources).
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | Materialize node's host and port
 [`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 1ms | The amount of historical detail to retain in arrangements
+[`--log-filter`](#logging) | `info` | Which log messages to emit.
 [`--timely-progress-mode`](#dataflow-tuning) | demand | *Advanced.* Timely progress tracking mode.
 [`--tls-ca`](#tls-encryption) | N/A | Path to TLS certificate authority (CA) {{< version-added v0.7.1 />}}
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
@@ -123,6 +124,34 @@ time for the configured duration. The default window is 1 millisecond.
 
 See the [Deployment section](/ops/deployment#compaction) for guidance on tuning
 the compaction window.
+
+### Logging
+
+{{< version-added 0.7.2 />}}
+
+The `--log-filter` option specifies which log messages Materialize will emit.
+Its value is a comma-separated list of filter directives. Each filter directive
+has the following format:
+
+```
+[module::path=]level
+```
+
+A filter directive registers interest in log messages from the specified module
+that are at least as severe as the specified level. If a directive omits the
+module, then it implicitly applies to all modules. When directives conflict, the
+last directive wins. Materialize will only emit log messages that match at least
+one filter directive.
+
+The module path of a log message reflects its location in Materialize's source
+code. Specifying module paths in filter directives requires familiarity with
+Materialize's codebase and is intended for advanced users. Note that module
+paths change frequency from release to release and are not considered part of
+Materialize's stable interface.
+
+The valid levels for a log message are, in increasing order of severity:
+`trace`, `debug`, `info`, `warn`, and `error`. The special level `off` may be
+used in a directive to suppress all log messages, even errors.
 
 ### Introspection sources
 

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -48,6 +48,12 @@ Wrap your release notes at the 80 character mark.
 
 {{% version-header v0.7.2 %}}
 
+- Add a [`--log-filter` command-line option](/cli/#logging) and a
+  `MZ_LOG_FILTER` environment variable that control which log messages to emit.
+
+  This behavior was previously available via the undocumented `MZ_LOG`
+  environment variable, which will be removed in a future release.
+
 - Record Kafka Consumer metrics in the `mz_kafka_consumer_statistics` system
   table. Enabled by default for all Kafka sources.
 

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -34,7 +34,7 @@ atty = "0.2.14"
 backtrace = "0.3.56"
 build-info = { path = "../build-info" }
 cfg-if = "1.0.0"
-clap = "2.33.0"
+clap = { version = "2.33.0", features = ["wrap_help"] }
 compile-time-run = "0.2.11"
 coord = { path = "../coord" }
 crossbeam-channel = "0.5.0"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -126,9 +126,37 @@ struct Args {
     differential_idle_merge_effort: Option<isize>,
 
     // === Logging options. ===
-    /// Where materialized will emit log messages.
+    /// Where to emit log messages.
+    ///
+    /// The special value "stderr" will emit messages to the standard error
+    /// stream. All other values are taken as file paths.
     #[structopt(long, env = "MZ_LOG_FILE", value_name = "PATH")]
     log_file: Option<String>,
+    /// Which log messages to emit.
+    ///
+    /// This value is a comma-separated list of filter directives. Each filter
+    /// directive has the following format:
+    ///
+    ///     [module::path=]level
+    ///
+    /// A directive indicates that log messages from the specified module that
+    /// are at least as severe as the specified level should be emitted. If a
+    /// directive omits the module, then it implicitly applies to all modules.
+    /// When directives conflict, the last directive wins. If a log message does
+    /// not match any directive, it is not emitted.
+    ///
+    /// The module path of a log message reflects its location in Materialize's
+    /// source code. Choosing module paths for filter directives requires
+    /// familiarity with Materialize's codebase and is intended for advanced
+    /// users. Note that module paths change frequency from release to release.
+    ///
+    /// The valid levels for a log message are, in increasing order of severity:
+    /// trace, debug, info, warn, and error. The special level "off" may be used
+    /// in a directive to suppress all log messages, even errors.
+    ///
+    /// The default value for this option is "info".
+    #[structopt(long, env = "MZ_LOG_FILTER", value_name = "FILTER")]
+    log_filter: Option<String>,
 
     // == Connection options.
     /// The address on which to listen for connections.
@@ -402,10 +430,18 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
 
         use crate::tracing::FilterLayer;
 
-        let env_filter = EnvFilter::try_from_env("MZ_LOG")
-            .or_else(|_| EnvFilter::try_new("info")) // default log level
-            .unwrap()
-            .add_directive("panic=error".parse().unwrap()); // prevent suppressing logs about panics
+        // TODO(benesch): remove the MZ_LOG fallback and move the default into
+        // structopt when sufficient time has passed (say, June 2021).
+        let directives = args
+            .log_filter
+            .or_else(|| env::var("MZ_LOG").ok())
+            .unwrap_or_else(|| "info".into());
+
+        let env_filter = EnvFilter::try_new(directives)
+            .context("parsing --log-filter option")?
+            // Ensure panics are logged, even if the user has specified
+            // otherwise.
+            .add_directive("panic=error".parse().unwrap());
 
         match args.log_file.as_deref() {
             Some("stderr") => {
@@ -583,21 +619,14 @@ For more details, see https://materialize.com/docs/cli#experimental-mode
         );
     }
 
-    for (key, _val) in env::vars() {
-        // TODO(benesch): remove these hints about deprecated environment
-        // variables once a sufficient amount of time has passed, say, March
-        // 2021.
-        match key.as_str() {
-            "DIFFERENTIAL_EAGER_MERGE" => warn!(
-                "Materialize no longer respects the DIFFERENTIAL_EAGER_MERGE environment variable \
-                 (hint: use the --differential-idle-merge-effort command-line option instead)",
-            ),
-            "DEFAULT_PROGRESS_MODE" => warn!(
-                "Materialize no longer respects the DEFAULT_PROGRESS_MODE environment variable \
-                 (hint: use the --timely-progress-mode command-line option instead)",
-            ),
-            _ => (),
-        }
+    // TODO(benesch): remove this message when sufficient time has passed
+    // (say, June 2021).
+    if env::var_os("MZ_LOG").is_some() {
+        warn!(
+            "The MZ_LOG environment variable is deprecated and will be removed \
+            in a future release. Use the MZ_LOG_FILTER environment variable or \
+            the --log-filter command-line option instead."
+        );
     }
 
     println!(

--- a/src/materialized/src/mux.rs
+++ b/src/materialized/src/mux.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::{Stream, StreamExt};
-use log::error;
+use log::{debug, error};
 use tokio::io::{self, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -103,7 +103,7 @@ async fn handle_connection(handlers: Arc<Handlers>, conn: TcpStream) {
         }
     }
 
-    log::warn!(
+    debug!(
         "dropped connection using unknown protocol (sniffed: 0x{})",
         hex::encode(buf)
     );


### PR DESCRIPTION
The MZ_LOG variable has been an undocumented means of controlling
Materialize's log output. Replace it with a new `--log-filter`
command-line option, whose name makes its purpose much clearer. Per the
usual environment variable naming rules, this flag is controllable via
the new MZ_LOG_FILTER environment variable.

Inspired by #6311.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6317)
<!-- Reviewable:end -->
