### PR TITLE
coord: don't log creation of system items

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1075,7 +1075,7 @@ impl Catalog {
         name: FullName,
         item: CatalogItem,
     ) -> Event {
-        if !item.is_placeholder() {
+        if !id.is_system() && !item.is_placeholder() {
             info!("create {} {} ({})", item.typ(), name, id);
         }
 


### PR DESCRIPTION
These items are guaranteed to exist, so there isn't much point to
logging their creation during server startup. This makes server startup
*substantially* less noisy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/materialize/6323)
<!-- Reviewable:end -->
