### PR TITLE
Improve error messages&docs around the GSSAPI default

### DIFF
--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -31,7 +31,7 @@ Field | Value | Description
 `sasl_kerberos_min_time_before_relogin` | `text` | Minimum time in milliseconds between key refresh attempts. Disable automatic key refresh by setting this property to 0.
 `sasl_kerberos_principal` | `text` | Materialize Kerberos principal name. Required for `sasl_plaintext`.
 `sasl_kerberos_service_name` | `text` | Kafka's service name on its host, i.e. the service principal name not including `/hostname@REALM`.
-`sasl_mechanisms` | `text` | The SASL mechanism to use for authentication. Currently, the only supported mechanism is `'GSSAPI'`.
+`sasl_mechanisms` | `text` | The SASL mechanism to use for authentication. Currently, the only supported mechanisms are `'GSSAPI'` (the default) and `'PLAIN'`.
 
 #### Inline schema `WITH` options
 

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -226,9 +226,10 @@ pub async fn test_config(
             not available: \"sasl.kerberos.keytab\""
                     {
                         bail!(
-                            "Can't seem to find local keytab cache. You must \
-                    provide explicit sasl_kerberos_keytab or \
-                    sasl_kerberos_kinit_cmd option."
+                            "Can't seem to find local keytab cache. With \
+                             sasl_mechanisms='GSSAPI', you must provide an \
+                             explicit sasl_kerberos_keytab or \
+                             sasl_kerberos_kinit_cmd option."
                         )
                     } else {
                         // Pass existing error back up.


### PR DESCRIPTION
This fixes #6337, by hopefully making it clearer under what circumstances we require a kerberos keytab file.
