### PR TITLE
Refactoring: Add a generalized version of `MirScalarExpr::visit_mut`.

### DIFF
--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -27,7 +27,7 @@ pub mod explain;
 pub use relation::canonicalize;
 
 pub use id::{GlobalId, Id, LocalId, PartitionId, SourceInstanceId};
-pub use linear::MapFilterProject;
+pub use linear::{memoize_expr, MapFilterProject};
 pub use relation::func::{AggregateFunc, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -745,46 +745,6 @@ impl MapFilterProject {
         }
         let mut new_expressions = Vec::new();
 
-        // A helper method which memoizes expressions by recursively memoizing their parts.
-        fn memoize_expr(
-            expr: &mut MirScalarExpr,
-            new_scalars: &mut Vec<MirScalarExpr>,
-            projection: &HashMap<usize, usize>,
-            input_arity: usize,
-        ) {
-            match expr {
-                MirScalarExpr::Column(index) => {
-                    // Column references need to be rewritten, but do not need to be memoized.
-                    *index = projection[index];
-                }
-                _ => {
-                    // We should not eagerly memoize `if` branches that might not be taken.
-                    // TODO: Memoize expressions in the intersection of `then` and `els`.
-                    if let MirScalarExpr::If { cond, then, els } = expr {
-                        memoize_expr(cond, new_scalars, projection, input_arity);
-                        // Conditionally evaluated expressions still need to update their
-                        // column references.
-                        then.permute_map(projection);
-                        els.permute_map(projection);
-                    } else {
-                        expr.visit1_mut(|e| memoize_expr(e, new_scalars, projection, input_arity));
-                    }
-                    if let Some(position) = new_scalars.iter().position(|e| e == expr) {
-                        // Any complex expression that already exists as a prior column can
-                        // be replaced by a reference to that column.
-                        *expr = MirScalarExpr::Column(input_arity + position);
-                    } else {
-                        // A complex expression that does not exist should be memoized, and
-                        // replaced by a reference to the column.
-                        new_scalars.push(std::mem::replace(
-                            expr,
-                            MirScalarExpr::Column(input_arity + new_scalars.len()),
-                        ));
-                    }
-                }
-            }
-        }
-
         // We follow the same order as for evaluation, to ensure that all
         // column references exist in time for their evaluation. We could
         // prioritize predicates, but we would need to be careful to chase
@@ -792,10 +752,10 @@ impl MapFilterProject {
         let mut expression = 0;
         for (support, predicate) in self.predicates.iter_mut() {
             while self.input_arity + expression < *support {
+                self.expressions[expression].permute_map(&remaps);
                 memoize_expr(
                     &mut self.expressions[expression],
                     &mut new_expressions,
-                    &remaps,
                     self.input_arity,
                 );
                 remaps.insert(
@@ -805,13 +765,14 @@ impl MapFilterProject {
                 new_expressions.push(self.expressions[expression].clone());
                 expression += 1;
             }
-            memoize_expr(predicate, &mut new_expressions, &remaps, self.input_arity);
+            predicate.permute_map(&remaps);
+            memoize_expr(predicate, &mut new_expressions, self.input_arity);
         }
         while expression < self.expressions.len() {
+            self.expressions[expression].permute_map(&remaps);
             memoize_expr(
                 &mut self.expressions[expression],
                 &mut new_expressions,
-                &remaps,
                 self.input_arity,
             );
             remaps.insert(
@@ -1041,4 +1002,43 @@ impl MapFilterProject {
             }))
             .project(projection.into_iter().map(|c| remap[&c]));
     }
+}
+
+// A helper method which memoizes expressions by recursively memoizing their parts.
+pub fn memoize_expr(
+    expr: &mut MirScalarExpr,
+    new_scalars: &mut Vec<MirScalarExpr>,
+    input_arity: usize,
+) {
+    expr.visit_custom_mut(
+        &mut |e| {
+            // We should not eagerly memoize `if` branches that might not be taken.
+            // TODO: Memoize expressions in the intersection of `then` and `els`.
+            if let MirScalarExpr::If { cond, .. } = e {
+                return Some(vec![cond]);
+            }
+            None
+        },
+        &mut |e| {
+            match e {
+                MirScalarExpr::Column(_) | MirScalarExpr::Literal(_, _) => {
+                    // Literals do not need to be memoized.
+                }
+                _ => {
+                    if let Some(position) = new_scalars.iter().position(|e2| e2 == e) {
+                        // Any complex expression that already exists as a prior column can
+                        // be replaced by a reference to that column.
+                        *e = MirScalarExpr::Column(input_arity + position);
+                    } else {
+                        // A complex expression that does not exist should be memoized, and
+                        // replaced by a reference to the column.
+                        new_scalars.push(std::mem::replace(
+                            e,
+                            MirScalarExpr::Column(input_arity + new_scalars.len()),
+                        ));
+                    }
+                }
+            }
+        },
+    )
 }

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -189,7 +189,7 @@ fn replace_subexpr_and_reduce(
     input_type: &RelationType,
 ) -> bool {
     let mut changed = false;
-    predicate.visit_custom_mut(
+    predicate.visit_mut_pre_post(
         &mut |e| {
             // The `cond` of an if statement is not visited to prevent `then`
             // or `els` from being evaluated before `cond`, resulting in a

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -277,37 +277,6 @@ impl JoinInputMapper {
         None
     }
 
-    /// Try to rewrite an subexpression referencing the larger join so that all the
-    /// column references point to the `index` input taking advantage of equivalences
-    /// in the join, if necessary.
-    /// Takes an expression in the global context and makes rewrites in the
-    /// global context so we can identify using `lookup_inputs` whether if an expression
-    /// was only partially rewritten.
-    fn try_map_to_input_with_bound_expr_sub(
-        &self,
-        expr: &mut MirScalarExpr,
-        index: usize,
-        equivalences: &[Vec<MirScalarExpr>],
-    ) {
-        {
-            let mut inputs = self.lookup_inputs(expr);
-            if let Some(first_input) = inputs.next() {
-                if inputs.next().is_none() && first_input == index {
-                    // there is only one input, and it is equal to index, so we're
-                    // good. do not continue the recursion
-                    return;
-                }
-            }
-        }
-        if let Some(bound_expr) = self.find_bound_expr(expr, &[index], equivalences) {
-            // replace the subexpression with the equivalent one from input `index`
-            *expr = bound_expr;
-        } else {
-            // recurse to see if we can replace subexpressions further down
-            expr.visit1_mut(|e| self.try_map_to_input_with_bound_expr_sub(e, index, equivalences))
-        }
-    }
-
     /// Try to rewrite an expression from the global context so that all the
     /// columns point to the `index` input by replacing subexpressions with their
     /// bound equivalents in the `index`th input if necessary.
@@ -318,8 +287,20 @@ impl JoinInputMapper {
         index: usize,
         equivalences: &[Vec<MirScalarExpr>],
     ) -> Option<MirScalarExpr> {
-        // call the recursive submethod
-        self.try_map_to_input_with_bound_expr_sub(&mut expr, index, equivalences);
+        expr.visit_custom_mut(
+            &mut |e| {
+                if let Some(bound_expr) = self.find_bound_expr(e, &[index], equivalences) {
+                    // Replace the subexpression with the equivalent one from input `index`
+                    *e = bound_expr;
+                    // The entire subexpression has been rewritten, so there is
+                    // no need to visit any child expressions.
+                    Some(vec![])
+                } else {
+                    None
+                }
+            },
+            &mut |_| {},
+        );
         // if the localization attempt is successful, all columns in `expr`
         // should only come from input `index`
         let mut inputs_after_localization = self.lookup_inputs(&expr);

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -292,7 +292,7 @@ impl JoinInputMapper {
         // `e` anyway, so we end up visiting nodes in `e` multiple times
         // here. Alternatively, consider having the future `PredicateKnowledge`
         // take over the responsibilities of this code?
-        expr.visit_custom_mut(
+        expr.visit_mut_pre_post(
             &mut |e| {
                 let mut inputs = self.lookup_inputs(e);
                 if let Some(first_input) = inputs.next() {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -188,7 +188,7 @@ impl MirScalarExpr {
     /// The function `post` runs on child `MirScalarExpr`s first before the
     /// parent. Optionally, `pre` can return which child `MirScalarExpr`s, if
     /// any, should be visited (default is to visit all children).
-    pub fn visit_custom_mut<F1, F2>(&mut self, pre: &mut F1, post: &mut F2)
+    pub fn visit_mut_pre_post<F1, F2>(&mut self, pre: &mut F1, post: &mut F2)
     where
         F1: FnMut(&mut Self) -> Option<Vec<&mut MirScalarExpr>>,
         F2: FnMut(&mut Self),
@@ -196,10 +196,10 @@ impl MirScalarExpr {
         let to_visit = pre(self);
         if let Some(to_visit) = to_visit {
             for e in to_visit {
-                e.visit_custom_mut(pre, post);
+                e.visit_mut_pre_post(pre, post);
             }
         } else {
-            self.visit1_mut(|e| e.visit_custom_mut(pre, post));
+            self.visit1_mut(|e| e.visit_mut_pre_post(pre, post));
         }
         post(self);
     }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -327,73 +327,84 @@ pub fn optimize(
     input_type: &RelationType,
     column_knowledge: &[DatumKnowledge],
 ) -> DatumKnowledge {
-    match expr {
-        MirScalarExpr::Column(index) => {
-            let index = *index;
-            if let Some((datum, typ)) = &column_knowledge[index].value {
-                *expr = MirScalarExpr::Literal(datum.clone(), typ.clone());
-            }
-            column_knowledge[index].clone()
-        }
-        MirScalarExpr::Literal(row, typ) => DatumKnowledge {
-            value: Some((row.clone(), typ.clone())),
-            nullable: match row {
-                Ok(row) => row.unpack_first() == Datum::Null,
-                Err(_) => false,
-            },
-        },
-        MirScalarExpr::CallNullary(_) => DatumKnowledge::default(),
-        MirScalarExpr::CallUnary { func, expr: inner } => {
-            let knowledge = optimize(inner, input_type, column_knowledge);
-            if knowledge.value.is_some() {
-                expr.reduce(input_type);
-                optimize(expr, input_type, column_knowledge)
-            } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
-                *expr = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
-                optimize(expr, input_type, column_knowledge)
-            } else {
-                DatumKnowledge::default()
-            }
-        }
-        MirScalarExpr::CallBinary {
-            func: _,
-            expr1,
-            expr2,
-        } => {
-            let knowledge1 = optimize(expr1, input_type, column_knowledge);
-            let knowledge2 = optimize(expr2, input_type, column_knowledge);
-            if knowledge1.value.is_some() && knowledge2.value.is_some() {
-                expr.reduce(input_type);
-                optimize(expr, input_type, column_knowledge)
-            } else {
-                DatumKnowledge::default()
-            }
-        }
-        MirScalarExpr::CallVariadic { func: _, exprs } => {
-            let mut knows = Vec::new();
-            for expr in exprs.iter_mut() {
-                knows.push(optimize(expr, input_type, column_knowledge));
-            }
+    // Storage for `DatumKnowledge` being propagated up through the
+    // `MirScalarExpr`. When a node is visited, pop off as many `DatumKnowledge`
+    // as the number of children the node has, and then push the
+    // `DatumKnowledge` corresponding to the node back onto the stack.
+    // Post-order traversal means that if a node has `n` children, the top `n`
+    // `DatumKnowledge` in the stack are the `DatumKnowledge` corresponding to
+    // the children.
+    let mut knowledge_stack = Vec::<DatumKnowledge>::new();
 
-            if knows.iter().all(|k| k.value.is_some()) {
-                expr.reduce(input_type);
-                optimize(expr, input_type, column_knowledge)
+    expr.visit_custom_mut(
+        &mut |e| {
+            // We should not eagerly memoize `if` branches that might not be taken.
+            // TODO: Memoize expressions in the intersection of `then` and `els`.
+            if let MirScalarExpr::If { then, els, .. } = e {
+                Some(vec![then, els])
             } else {
-                DatumKnowledge::default()
+                None
             }
-        }
-        MirScalarExpr::If { cond: _, then, els } => {
-            // Leave `cond` un-optimized, as we should not remove the conditional
-            // nature of the evaluation based on column knowledge: the resulting
-            // expression could then move down past a filter or join that provided
-            // the guarantees, and would become wrong.
-            //
-            // Instead, we can optimize each of the branches, and union the states
-            // of their columns.
-            let mut know1 = optimize(then, input_type, column_knowledge);
-            let know2 = optimize(els, input_type, column_knowledge);
-            know1.union(&know2);
-            know1
-        }
-    }
+        },
+        &mut |e| {
+            let result = match e {
+                MirScalarExpr::Column(index) => {
+                    let index = *index;
+                    if let Some((datum, typ)) = &column_knowledge[index].value {
+                        *e = MirScalarExpr::Literal(datum.clone(), typ.clone());
+                    }
+                    column_knowledge[index].clone()
+                }
+                MirScalarExpr::Literal(_, _) | MirScalarExpr::CallNullary(_) => {
+                    DatumKnowledge::from(&*e)
+                }
+                MirScalarExpr::CallUnary { func, expr: _ } => {
+                    let knowledge = knowledge_stack.pop().unwrap();
+                    if knowledge.value.is_some() {
+                        e.reduce(input_type);
+                    } else if func == &UnaryFunc::IsNull && !knowledge.nullable {
+                        *e = MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool);
+                    };
+                    DatumKnowledge::from(&*e)
+                }
+                MirScalarExpr::CallBinary {
+                    func: _,
+                    expr1: _,
+                    expr2: _,
+                } => {
+                    let knowledge2 = knowledge_stack.pop().unwrap();
+                    let knowledge1 = knowledge_stack.pop().unwrap();
+                    if knowledge1.value.is_some() && knowledge2.value.is_some() {
+                        e.reduce(input_type);
+                    }
+                    DatumKnowledge::from(&*e)
+                }
+                MirScalarExpr::CallVariadic { func: _, exprs } => {
+                    if (0..exprs.len()).all(|_| knowledge_stack.pop().unwrap().value.is_some()) {
+                        e.reduce(input_type);
+                    }
+                    DatumKnowledge::from(&*e)
+                }
+                MirScalarExpr::If {
+                    cond: _,
+                    then: _,
+                    els: _,
+                } => {
+                    // `cond` has been left un-optimized, as we should not remove the conditional
+                    // nature of the evaluation based on column knowledge: the resulting
+                    // expression could then move down past a filter or join that provided
+                    // the guarantees, and would become wrong.
+                    //
+                    // Instead, each of the branches have been optimized, and we
+                    // can union the states of their columns.
+                    let know2 = knowledge_stack.pop().unwrap();
+                    let mut know1 = knowledge_stack.pop().unwrap();
+                    know1.union(&know2);
+                    know1
+                }
+            };
+            knowledge_stack.push(result);
+        },
+    );
+    knowledge_stack.pop().unwrap()
 }

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -336,7 +336,7 @@ pub fn optimize(
     // the children.
     let mut knowledge_stack = Vec::<DatumKnowledge>::new();
 
-    expr.visit_custom_mut(
+    expr.visit_mut_pre_post(
         &mut |e| {
             // We should not eagerly memoize `if` branches that might not be taken.
             // TODO: Memoize expressions in the intersection of `then` and `els`.

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -383,11 +383,7 @@ impl PredicatePushdown {
                     }
                     MirRelationExpr::Project { input, outputs } => {
                         let predicates = predicates.drain(..).map(|mut predicate| {
-                            predicate.visit_mut(&mut |e| {
-                                if let MirScalarExpr::Column(i) = e {
-                                    *i = outputs[*i];
-                                }
-                            });
+                            predicate.permute(outputs);
                             predicate
                         });
                         *relation = input


### PR DESCRIPTION
Create a generalized version of `MirScalarExpr::visit_mut` called `MirScalarExpr::visit_custom_mut`. It supports pre- and post-order traversal and skipping particular subtrees. Change places that used to have to implement their own versions of `visit_mut` to call `visit_custom_mut` instead.

Other cleanup:
* The method `memoize_expr` turns out to be repeated in two places in the code. Unified them. 
* Found a couple of places using `expr.visit_mut(...)` when they could just call `permute`. 
* Simplified `JoinInputMapper::try_map_to_input_with_bound_expr`.

Has a tiny conflict with #6339, but I think it's easily resolvable by just copying over lines 758-760 + 769 over to the new `memoize_expr`.