### PR TITLE
testdrive: tests for TAIL and FETCH

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -375,6 +375,10 @@ pub fn build(cmds: Vec<PosCommand>, state: &State) -> Result<Vec<PosAction>, Err
         },
     );
     vars.insert(
+        "testdrive.materialized-addr".into(),
+        state.materialized_addr.clone(),
+    );
+    vars.insert(
         "testdrive.materialized-user".into(),
         state.materialized_user.clone(),
     );

--- a/test/testdrive/fetch-concurrent-same-source.td
+++ b/test/testdrive/fetch-concurrent-same-source.td
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that FETCH-ing using multiple cursors from the same source works as expected
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=fetch-concurrent-same-source
+
+> CREATE MATERIALIZED SOURCE fetch_concurrent_same_source
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-fetch-concurrent-same-source-${testdrive.seed}'
+  WITH( timestamp_frequency_ms = 10 )
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=fetch-concurrent-same-source schema=${int} timestamp=1
+{"f1": 123}
+{"f1": 234}
+{"f1": 345}
+
+> SELECT COUNT(*) = 3 FROM fetch_concurrent_same_source;
+true
+
+> BEGIN
+
+> DECLARE c1 CURSOR FOR SELECT * FROM fetch_concurrent_same_source;
+
+> DECLARE c2 CURSOR FOR SELECT * FROM fetch_concurrent_same_source;
+
+> FETCH ALL c1;
+123
+234
+345
+
+> FETCH ALL c2;
+123
+234
+345
+
+> DECLARE c3 CURSOR FOR TAIL fetch_concurrent_same_source;
+> FETCH 3 c3;
+<TIMESTAMP> 1 123
+<TIMESTAMP> 1 234
+<TIMESTAMP> 1 345
+
+> DECLARE c4 CURSOR FOR SELECT * FROM fetch_concurrent_same_source;
+
+> FETCH ALL c4;
+123
+234
+345
+
+> DECLARE c5 CURSOR FOR TAIL fetch_concurrent_same_source;
+> FETCH 3 c5;
+<TIMESTAMP> 1 123
+<TIMESTAMP> 1 234
+<TIMESTAMP> 1 345

--- a/test/testdrive/fetch-concurrent-two-sources.td
+++ b/test/testdrive/fetch-concurrent-two-sources.td
@@ -1,0 +1,74 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that FETCH-ing using multiple cursors from different sources works as expected
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=fetch-concurrent-two-sources
+
+> CREATE MATERIALIZED SOURCE fetch_concurrent_two_sources1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-fetch-concurrent-two-sources-${testdrive.seed}'
+  WITH( timestamp_frequency_ms = 100 )
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+> CREATE MATERIALIZED SOURCE fetch_concurrent_two_sources2
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-fetch-concurrent-two-sources-${testdrive.seed}'
+  WITH( timestamp_frequency_ms = 100 )
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+> CREATE MATERIALIZED VIEW fetch_concurrent_two_sources1_view AS SELECT * FROM fetch_concurrent_two_sources1 ORDER BY f1;
+
+> CREATE MATERIALIZED VIEW fetch_concurrent_two_sources2_view AS SELECT * FROM fetch_concurrent_two_sources2 ORDER BY f1;
+
+
+$ kafka-ingest format=avro topic=fetch-concurrent-two-sources schema=${int} timestamp=1
+{"f1": 12}
+
+$ kafka-ingest format=avro topic=fetch-concurrent-two-sources schema=${int} timestamp=2
+{"f1": 23}
+
+$ kafka-ingest format=avro topic=fetch-concurrent-two-sources schema=${int} timestamp=3
+{"f1": 34}
+
+> SELECT COUNT(*) = 3 FROM fetch_concurrent_two_sources1_view;
+true
+
+> SELECT COUNT(*) = 3 FROM fetch_concurrent_two_sources2_view;
+true
+
+> BEGIN
+
+> DECLARE c1 CURSOR FOR TAIL fetch_concurrent_two_sources1_view;
+
+> DECLARE c2 CURSOR FOR TAIL fetch_concurrent_two_sources2_view;
+
+> FETCH 1 c1;
+<TIMESTAMP> 1 12
+
+> FETCH 1 c2;
+<TIMESTAMP> 1 12
+
+> FETCH 1 c1;
+<TIMESTAMP> 1 23
+
+> FETCH 1 c2;
+<TIMESTAMP> 1 23
+
+> FETCH 1 c1;
+<TIMESTAMP> 1 34
+
+> FETCH 1 c2;
+<TIMESTAMP> 1 34

--- a/test/testdrive/fetch-select-during-ingest.td
+++ b/test/testdrive/fetch-select-during-ingest.td
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that data that was ingested during the lifetime of a SELECT cursor is *NOT* FETCH-ed
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=tail-fetch-during-ingest
+
+> CREATE MATERIALIZED SOURCE fetch_during_ingest
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-fetch-during-ingest-${testdrive.seed}'
+  WITH( timestamp_frequency_ms = 100 )
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=1
+{"f1": 123}
+
+> SELECT * FROM fetch_during_ingest;
+123
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SELECT * FROM fetch_during_ingest;
+
+> FETCH 1 c WITH (timeout='2s');
+123
+
+$ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=2
+{"f1": 234}
+
+# Sleep here to make sure the entire machinery has run. Since we are in a transaction,
+# we have no way of knowing that the source has progressed to '234' outside of the transaction
+
+> SELECT mz_internal.mz_sleep(2);
+<null>
+
+# This will return an empty result - nothing else available for fetching in the current transaction
+> FETCH 1 c WITH (timeout='2s');
+
+> COMMIT;
+
+#
+# The '234' row can now be fetched
+#
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SELECT * FROM fetch_during_ingest;
+
+> FETCH 2 c WITH (timeout='2s');
+123
+234

--- a/test/testdrive/fetch-tail-as-of.td
+++ b/test/testdrive/fetch-tail-as-of.td
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the AS OF is observed for TAIL
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> CREATE TABLE t1 (f1 INTEGER);
+
+> INSERT INTO t1 VALUES (123);
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL t1 AS OF -1;
+
+! FETCH 1 c;
+out of range integral type conversion attempted
+
+> COMMIT
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL t1 AS OF 0;
+
+! FETCH 1 c;
+Timestamp (0) is not valid for all inputs
+
+> COMMIT
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL t1 AS OF NOW();
+
+> FETCH 1 c;
+<TIMESTAMP> 1 123
+
+> COMMIT
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL t1 AS OF 18446744073709551615;
+
+# No rows expected
+> FETCH 1 c WITH (timeout = '1s');

--- a/test/testdrive/fetch-tail-during-ingest.td
+++ b/test/testdrive/fetch-tail-during-ingest.td
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that data that was ingested during the lifetime of a TAIL cursor can be FETCH-ed
+#
+
+$set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=tail-fetch-during-ingest
+
+> CREATE MATERIALIZED SOURCE fetch_during_ingest
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-fetch-during-ingest-${testdrive.seed}'
+  WITH( timestamp_frequency_ms = 100 )
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL fetch_during_ingest;
+
+$ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=1
+{"f1": 123}
+
+> FETCH 1 c WITH (timeout='2s');
+<TIMESTAMP> 1 123
+
+$ kafka-ingest format=avro topic=tail-fetch-during-ingest schema=${int} timestamp=2
+{"f1": 234}
+
+# The row just inserted is ours to fetch
+> FETCH 1 c WITH (timeout='2s');
+<TIMESTAMP> 1 234

--- a/test/testdrive/fetch-tail-large-diff.td
+++ b/test/testdrive/fetch-tail-large-diff.td
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that TAIL/FETCH can handle a case where the diff column has a very large value
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> CREATE TABLE ten (f1 INTEGER);
+
+> INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+
+> CREATE MATERIALIZED VIEW v1 AS SELECT NULL FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7
+
+> SELECT COUNT(*) = 10000000 FROM v1;
+true
+
+> CREATE MATERIALIZED VIEW v2 AS SELECT a1.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7
+
+> SELECT COUNT(*) = 10000000 FROM v2;
+true
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v1;
+
+> FETCH 1 c;
+<TIMESTAMP> 10000000 <null>
+
+> FETCH 1 c WITH (timeout = '1s');
+
+> COMMIT
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v2;
+
+> FETCH 10 c;
+<TIMESTAMP> 1000000 1
+<TIMESTAMP> 1000000 2
+<TIMESTAMP> 1000000 3
+<TIMESTAMP> 1000000 4
+<TIMESTAMP> 1000000 5
+<TIMESTAMP> 1000000 6
+<TIMESTAMP> 1000000 7
+<TIMESTAMP> 1000000 8
+<TIMESTAMP> 1000000 9
+<TIMESTAMP> 1000000 10

--- a/test/testdrive/fetch-tail-retraction.td
+++ b/test/testdrive/fetch-tail-retraction.td
@@ -1,0 +1,52 @@
+
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Observe the retraction of records from a TAIL stream
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> CREATE TABLE inserts (f1 INTEGER);
+
+> INSERT INTO inserts VALUES (123),(123),(NULL);
+
+> CREATE TABLE deletes (f1 INTEGER);
+
+> CREATE MATERIALIZED VIEW v1 AS SELECT * FROM inserts EXCEPT ALL SELECT * FROM deletes;
+
+> SELECT * FROM v1;
+123
+123
+<null>
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v1;
+
+> FETCH 2 c;
+<TIMESTAMP> 2 123
+<TIMESTAMP> 1 <null>
+
+#
+# Force a retraction by performing an update outside of the transaction and making sure
+# that the update has been fully ingested in v1.
+#
+# The value 999 should not cause anything to be retracted, is inserted to check
+# that no erroneous retractions will be issued.
+#
+
+$ postgres-execute connection=postgres://materialize:materialize@${testdrive.materialized-addr}
+INSERT INTO deletes VALUES (123), (123), (NULL), (999);
+SELECT * FROM v1 AS OF NOW();
+
+> FETCH ALL c;
+<TIMESTAMP> -2 123
+<TIMESTAMP> -1 <null>

--- a/test/testdrive/fetch-tail-timestamp-zero.td
+++ b/test/testdrive/fetch-tail-timestamp-zero.td
@@ -1,0 +1,42 @@
+# Copyright Materialize, Inc. All righTIMESTAMP reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that sources for which the timestamp field is zero can be TAIL-ed
+#
+
+> CREATE VIEW v1 AS SELECT 123;
+
+> CREATE VIEW v2 AS VALUES (123);
+
+> SELECT * FROM v1;
+123
+
+> SELECT * FROM v2;
+123
+
+> BEGIN
+
+> DECLARE c1 CURSOR FOR TAIL v1 WITH (PROGRESS = TRUE);
+
+> DECLARE c2 CURSOR FOR TAIL v2 WITH (PROGRESS = TRUE);
+
+> FETCH 2 FROM c1 WITH (timeout = '3s')
+0 false 1 123
+
+> FETCH 2 FROM c2 WITH (timeout = '3s')
+0 false 1 123
+
+> COMMIT;
+
+> BEGIN;
+
+> DECLARE c1 CURSOR FOR TAIL v1 WITH (SNAPSHOT = FALSE);
+
+> FETCH ALL FROM c1 WITH (timeout = '3s')

--- a/test/testdrive/fetch-tail-without-snapshot.td
+++ b/test/testdrive/fetch-tail-without-snapshot.td
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Make sure that the SNAPSHOT=FALSE option is observed
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+$ set int={"type": "record", "name": "field_int", "fields": [ {"name": "f1", "type": "int"} ] }
+
+$ kafka-create-topic topic=tail-without-snapshot
+
+$ kafka-ingest format=avro topic=tail-without-snapshot schema=${int} timestamp=1
+{"f1": 123}
+{"f1": 234}
+{"f1": 345}
+
+> CREATE MATERIALIZED SOURCE tail_without_snapshot
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-without-snapshot-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${int}'
+  ENVELOPE NONE
+
+> SELECT * FROM tail_without_snapshot;
+123
+234
+345
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL tail_without_snapshot WITH (SNAPSHOT = FALSE);
+
+> FETCH 1 FROM c WITH (timeout = '2s')
+
+$ kafka-ingest format=avro topic=tail-without-snapshot schema=${int} timestamp=1
+{"f1": 567}
+
+> FETCH 1 FROM c WITH (timeout = '2s')
+<TIMESTAMP> 1 567

--- a/test/testdrive/fetch-timeout.td
+++ b/test/testdrive/fetch-timeout.td
@@ -1,0 +1,48 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Check that the timeout value is indeed respected and sleeping happens
+# if no rows are available to satify the FETCH immediately
+#
+
+#
+# FETCH + TAIL - sleep happens
+#
+
+> CREATE TABLE t1 (f1 INTEGER);
+
+> CREATE TABLE ts_log (ts TIMESTAMP);
+
+> INSERT INTO ts_log VALUES (NOW());
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL t1;
+
+> FETCH 1 c WITH (timeout='1.1s');
+
+> COMMIT;
+
+> INSERT INTO ts_log VALUES (NOW());
+
+> SELECT MAX(ts) - MIN(ts) > interval '1 second' FROM ts_log;
+true
+
+> DROP TABLE ts_log;
+
+#
+# FETCH + SELECT - timeout not observed, sleep does not happen
+#
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SELECT * FROM t1;
+
+> FETCH 1 c WITH (timeout='1d');

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -76,3 +76,12 @@ $ kafka-verify format=avro sink=materialize.public.sort_messages_sink sort-messa
 {"before": null, "after": {"row": {"a": 1}}}
 {"before": null, "after": {"row": {"a": 2}}}
 {"before": null, "after": {"row": {"a": 3}}}
+
+# Use $ postgresql-execute and ${testdrive.materialize_addr}
+
+$ postgres-execute connection=postgres://materialize:materialize@${testdrive.materialized-addr}
+CREATE TABLE postgres_execute (f1 INTEGER);
+INSERT INTO postgres_execute VALUES (123);
+
+> SELECT * FROM postgres_execute;
+123


### PR DESCRIPTION
Also expose the value passed for --materialized-addr as
${testdrive.materialized-addr} inside .td files.


---

Those are about 1/2 of the tests for FETCH and TAIL that I wrote. The rest fail due to bugs, already filed.