### PR TITLE
demonstrate kafka source hang

### DIFF
--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -13,7 +13,6 @@
 //! scripts. The tests here are simply too complicated to be easily expressed
 //! in testdrive, e.g., because they depend on the current time.
 
-use std::env;
 use std::error::Error;
 use std::io::Write;
 use std::net::TcpListener;
@@ -25,20 +24,12 @@ use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
-use lazy_static::lazy_static;
 use log::info;
 use tempfile::NamedTempFile;
 
-use util::{MzTimestamp, PostgresErrorExt};
+use util::{MzTimestamp, PostgresErrorExt, KAFKA_ADDRS};
 
 pub mod util;
-
-lazy_static! {
-    pub static ref KAFKA_ADDRS: kafka_util::KafkaAddrs = match env::var("KAFKA_ADDRS") {
-        Ok(addr) => addr.parse().expect("unable to parse KAFKA_ADDRS"),
-        _ => "localhost:9092".parse().unwrap(),
-    };
-}
 
 #[test]
 fn test_no_block() -> Result<(), Box<dyn Error>> {

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -8,19 +8,29 @@
 // by the Apache License, Version 2.0.
 
 use std::convert::TryInto;
+use std::env;
 use std::error::Error;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use materialized::TlsMode;
+use lazy_static::lazy_static;
 use postgres::error::DbError;
 use postgres::tls::{MakeTlsConnect, TlsConnect};
 use postgres::types::{FromSql, Type};
 use postgres::Socket;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+
+use materialized::TlsMode;
+
+lazy_static! {
+    pub static ref KAFKA_ADDRS: kafka_util::KafkaAddrs = match env::var("KAFKA_ADDRS") {
+        Ok(addr) => addr.parse().expect("unable to parse KAFKA_ADDRS"),
+        _ => "localhost:9092".parse().unwrap(),
+    };
+}
 
 #[derive(Clone)]
 pub struct Config {


### PR DESCRIPTION
To observe the hang:

```
cargo test -p materialized --test=server -- --nocapture test_shutdown
```