### PR TITLE
Rename mz_kafka_consumer_statistics => mz_kafka_consumer_partitions

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -54,7 +54,7 @@ Wrap your release notes at the 80 character mark.
   This behavior was previously available via the undocumented `MZ_LOG`
   environment variable, which will be removed in a future release.
 
-- Record Kafka Consumer metrics in the `mz_kafka_consumer_statistics` system
+- Record Kafka Consumer metrics in the `mz_kafka_consumer_partitions` system
   table. Enabled by default for all Kafka sources.
 
 - Add the [`jsonb_object_agg`](/sql/functions/jsonb_object_agg) function to

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -142,10 +142,10 @@ Field            | Type        | Meaning
 `on_expression`  | [`text`]    | If not `NULL`, specifies a SQL expression that is evaluated to compute the value of this index column. The expression may contain references to any of the columns of the relation.
 `nullable`       | [`boolean`] | Can this column of the index evaluate to `NULL`?
 
-### `mz_kafka_consumer_statistics`
+### `mz_kafka_consumer_partitions`
 
-The `mz_kafka_consumer_statistics` table contains a row for each Kafka
-consumer in the system.
+The `mz_kafka_consumer_partitions` table contains a row for partition being
+read by a Kafka consumer in the system.
 
 Field           | Type       | Meaning
 ----------------|------------|--------

--- a/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/with-options.html
@@ -2,7 +2,7 @@
 `group_id_prefix` | `text` | Use the specified prefix in the consumer group ID. The resulting `group.id` looks like `<group_id_prefix>materialize-X-Y`, where `X` and `Y` are values that allow multiple concurrent Kafka consumers from the same topic.
 `cache` | `boolean` | Cache data from this source to local files. Requires [experimental mode](/cli/#experimental-mode).
 `security_protocol` | `text` | Use [`ssl`](#ssl-with-options) or, for [Kerberos](#kerberized-kafka-details), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
-`statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics. Statistics can be queried using the `mz_kafka_consumer_statistics` system table.
+`statistics_interval_ms` | `int` | `librdkafka` statistics emit interval in `ms`. Accepts values [0, 86400000]. The granularity is 1000ms. A value of 0 disables statistics. Statistics can be queried using the `mz_kafka_consumer_partitions` system table.
 `ignore_source_keys` | `boolean` | Default: `false`. If `true`, do not perform optimizations assuming uniqueness of primary keys in schemas.
 `timestamp_frequency_ms`| `int` | Default: `1000`. Sets the timestamping frequency in `ms`. Reflects how frequently the source advances its timestamp. This measure reflects how stale data in views will be. Lower values result in more-up-to-date views but may reduce throughput.
 `topic_metadata_refresh_interval_ms` | `int` | Default: `30000`. Sets the frequency in `ms` at which the system checks for new partitions. Accepts values [0,3600000].

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -554,8 +554,8 @@ pub const MZ_MESSAGE_COUNTS: BuiltinLog = BuiltinLog {
     index_id: GlobalId::System(3029),
 };
 
-pub const MZ_KAFKA_CONSUMER_STATISTICS: BuiltinLog = BuiltinLog {
-    name: "mz_kafka_consumer_statistics",
+pub const MZ_KAFKA_CONSUMER_PARTITIONS: BuiltinLog = BuiltinLog {
+    name: "mz_kafka_consumer_partitions",
     schema: MZ_CATALOG_SCHEMA,
     variant: LogVariant::Materialized(MaterializedLog::KafkaConsumerInfo),
     id: GlobalId::System(3030),
@@ -1279,7 +1279,7 @@ lazy_static! {
             Builtin::Log(&MZ_PEEK_DURATIONS),
             Builtin::Log(&MZ_SOURCE_INFO),
             Builtin::Log(&MZ_MESSAGE_COUNTS),
-            Builtin::Log(&MZ_KAFKA_CONSUMER_STATISTICS),
+            Builtin::Log(&MZ_KAFKA_CONSUMER_PARTITIONS),
             Builtin::Table(&MZ_VIEW_KEYS),
             Builtin::Table(&MZ_VIEW_FOREIGN_KEYS),
             Builtin::Table(&MZ_KAFKA_SINKS),

--- a/src/dataflow/src/logging/materialized.rs
+++ b/src/dataflow/src/logging/materialized.rs
@@ -40,7 +40,7 @@ pub enum MaterializedEvent {
     },
     /// Tracks statistics for a particular Kafka consumer / partition pair
     /// Reference: https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
-    KafkaConsumerInfo {
+    KafkaConsumerPartition {
         /// Kafka name for the consumer
         consumer_name: String,
         /// Materialize source identifier
@@ -217,7 +217,7 @@ pub fn construct<A: Allocate>(
                                     delta as isize,
                                 ));
                             }
-                            MaterializedEvent::KafkaConsumerInfo {
+                            MaterializedEvent::KafkaConsumerPartition {
                                 consumer_name,
                                 source_id,
                                 partition_id,

--- a/src/dataflow/src/source/kafka.rs
+++ b/src/dataflow/src/source/kafka.rs
@@ -160,7 +160,7 @@ impl SourceReader<Vec<u8>> for KafkaSourceReader {
                         None => continue,
                     };
 
-                    logger.log(MaterializedEvent::KafkaConsumerInfo {
+                    logger.log(MaterializedEvent::KafkaConsumerPartition {
                         consumer_name: statistics.name.to_string(),
                         source_id: self.id,
                         partition_id: partition_stats.partition.to_string(),
@@ -429,7 +429,7 @@ impl Drop for KafkaSourceReader {
         if let Some(logger) = self.logger.as_mut() {
             for part in self.partition_consumers.iter_mut() {
                 if let Some(consumer_name) = part.previous_stats.consumer_name.as_ref() {
-                    logger.log(MaterializedEvent::KafkaConsumerInfo {
+                    logger.log(MaterializedEvent::KafkaConsumerPartition {
                         consumer_name: consumer_name.to_string(),
                         source_id: self.id,
                         partition_id: part.pid.to_string(),

--- a/test/catalog-compat/catcompatck/catcompatck
+++ b/test/catalog-compat/catcompatck/catcompatck
@@ -204,7 +204,7 @@ a  b
 # Kafka metrics for the real_time_src should be enabled now
 # Count should be 2 because there are two materialized views on real_time_src
 # If real_time_src_no_stats were also emitting stats, there would be 3 rows
-> SELECT count(*) FROM mz_kafka_consumer_statistics;
+> SELECT count(*) FROM mz_kafka_consumer_partitions;
 count
 -----
 2

--- a/test/testdrive/avro-sources.td
+++ b/test/testdrive/avro-sources.td
@@ -334,7 +334,7 @@ a  b
 9  10
 
 # There should be two partitions for the last created source / consumer (non_dbz_data_varying_partition_2)
-> SELECT count(*) FROM mz_kafka_consumer_statistics GROUP BY consumer_name;
+> SELECT count(*) FROM mz_kafka_consumer_partitions GROUP BY consumer_name;
 count
 -----
 1
@@ -368,7 +368,7 @@ a  b
 11 12
 
 # There should three partitions for the last three sources / consumers (non_dbz_data_varying_partition_[123])
-> SELECT count(*) FROM mz_kafka_consumer_statistics GROUP BY consumer_name;
+> SELECT count(*) FROM mz_kafka_consumer_partitions GROUP BY consumer_name;
 count
 -----
 1

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -301,7 +301,7 @@ mz_arrangement_sizes
 mz_dataflow_channels
 mz_dataflow_operator_addresses
 mz_dataflow_operators
-mz_kafka_consumer_statistics
+mz_kafka_consumer_partitions
 mz_materialization_dependencies
 mz_materializations
 mz_message_counts
@@ -321,7 +321,7 @@ mz_arrangement_sizes                 system true
 mz_dataflow_channels                 system true
 mz_dataflow_operator_addresses       system true
 mz_dataflow_operators                system true
-mz_kafka_consumer_statistics         system true
+mz_kafka_consumer_partitions         system true
 mz_materialization_dependencies      system true
 mz_materializations                  system true
 mz_message_counts                    system true

--- a/test/testdrive/kafka-stats.td
+++ b/test/testdrive/kafka-stats.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test the creation and removal of entries in mz_kafka_consumer_statistics
+# Test the creation and removal of entries in mz_kafka_consumer_partitions
 
 $ set schema={
     "type": "record",
@@ -43,53 +43,53 @@ b  sum
 1  6
 2  1
 
-# There should only be metrics from a single partition consumer
-> SELECT count(*) FROM mz_kafka_consumer_statistics
+# There should only be metrics from a single consumer / partition
+> SELECT count(*) FROM mz_kafka_consumer_partitions
 1
 
 # We should have read 4 messages
-> SELECT count(*) FROM mz_kafka_consumer_statistics where rx_msgs = 4
+> SELECT count(*) FROM mz_kafka_consumer_partitions where rx_msgs = 4
 1
 
 # and they should have non-zero bytes
-> SELECT count(*) FROM mz_kafka_consumer_statistics where rx_bytes = 0
+> SELECT count(*) FROM mz_kafka_consumer_partitions where rx_bytes = 0
 0
 
 # We have not transmitted anything
-> SELECT count(*) FROM mz_kafka_consumer_statistics where tx_msgs = 0
+> SELECT count(*) FROM mz_kafka_consumer_partitions where tx_msgs = 0
 1
 
-> SELECT count(*) FROM mz_kafka_consumer_statistics where tx_bytes = 0
+> SELECT count(*) FROM mz_kafka_consumer_partitions where tx_bytes = 0
 1
 
 # Lo Offset should not exceed Hi offset
-> SELECT count(*) FROM mz_kafka_consumer_statistics where lo_offset > hi_offset
+> SELECT count(*) FROM mz_kafka_consumer_partitions where lo_offset > hi_offset
 0
 
 # Lo Offset should not exceed Ls offset
-> SELECT count(*) FROM mz_kafka_consumer_statistics where lo_offset > ls_offset
+> SELECT count(*) FROM mz_kafka_consumer_partitions where lo_offset > ls_offset
 0
 
 # Ls Offset should not exceed Hi Offset
-> SELECT count(*) FROM mz_kafka_consumer_statistics where ls_offset > hi_offset
+> SELECT count(*) FROM mz_kafka_consumer_partitions where ls_offset > hi_offset
 0
 
 # We should have read 4 records
-> SELECT count(*) FROM mz_kafka_consumer_statistics where app_offset = 4
+> SELECT count(*) FROM mz_kafka_consumer_partitions where app_offset = 4
 1
 
 # And we should not be lagging
-> SELECT count(*) FROM mz_kafka_consumer_statistics where consumer_lag = 0
+> SELECT count(*) FROM mz_kafka_consumer_partitions where consumer_lag = 0
 1
 
 # If we change the message encoding and/or the broker version, these results may change
-> SELECT partition_id, rx_msgs, rx_bytes, tx_msgs, tx_bytes, lo_offset, hi_offset, ls_offset, app_offset, consumer_lag FROM mz_kafka_consumer_statistics;
+> SELECT partition_id, rx_msgs, rx_bytes, tx_msgs, tx_bytes, lo_offset, hi_offset, ls_offset, app_offset, consumer_lag FROM mz_kafka_consumer_partitions;
 partition_id  rx_msgs  rx_bytes  tx_msgs  tx_bytes  lo_offset  hi_offset  ls_offset  app_offset  consumer_lag
 -------------------------------------------------------------------------------------------------------------
 0  4  28  0  0  0  4  4  4 0
 
 # Verify that we can join against mz_source_info
-> SELECT mz_kafka_consumer_statistics.rx_msgs FROM mz_kafka_consumer_statistics INNER JOIN mz_source_info USING (source_id, dataflow_id, partition_id) WHERE mz_source_info.source_name like 'kafka-%%';
+> SELECT mz_kafka_consumer_partitions.rx_msgs FROM mz_kafka_consumer_partitions INNER JOIN mz_source_info USING (source_id, dataflow_id, partition_id) WHERE mz_source_info.source_name like 'kafka-%%';
 rx_msgs
 -------
 4
@@ -99,5 +99,5 @@ rx_msgs
 
 > DROP SOURCE data
 
-> SELECT count(*) FROM mz_kafka_consumer_statistics
+> SELECT count(*) FROM mz_kafka_consumer_partitions
 0


### PR DESCRIPTION
In #6202, there was a discussion about the name of this system table being confusing.

Instead of calling this consumer statistics, rename this table to make it clear that it's about consumer partition metrics.