### PR TITLE
pgwire: ignore timeout if FETCH returned the requested number of rows

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1232,9 +1232,11 @@ where
                     total_sent_rows += drain_rows;
                     want_rows -= drain_rows;
                     // If we have sent the number of requested rows, put the remainder of the batch
-                    // back and stop sending.
-                    if want_rows == 0 && !batch_rows.is_empty() {
-                        rows = Box::new(stream::iter(vec![batch_rows]).chain(rows));
+                    // (if any) back and stop sending.
+                    if want_rows == 0 {
+                        if !batch_rows.is_empty() {
+                            rows = Box::new(stream::iter(vec![batch_rows]).chain(rows));
+                        }
                         break;
                     }
                     self.conn.flush().await?;

--- a/test/testdrive/fetch-tail-limit-timeout.td
+++ b/test/testdrive/fetch-tail-limit-timeout.td
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that specifying a limit for FETCH works with timeout
+#
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> CREATE TABLE v1 (f1 INTEGER);
+
+> INSERT INTO v1 VALUES (123);
+
+> SELECT * FROM v1;
+123
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SELECT * FROM v1;
+
+> FETCH 1 c WITH (timeout = '1d');
+123
+
+> COMMIT
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v1;
+
+> FETCH 1 c WITH (timeout = '1d');
+<TIMESTAMP> 1 123
+
+> COMMIT
+
+> INSERT INTO v1 VALUES (234);
+
+> INSERT INTO v1 VALUES (345);
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v1;
+
+> FETCH 3 c WITH (timeout = '1d');
+<TIMESTAMP> 1 123
+<TIMESTAMP> 1 234
+<TIMESTAMP> 1 345
+
+> COMMIT
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SELECT * FROM v1;
+
+> FETCH 3 c WITH (timeout = '1d');
+123
+234
+345


### PR DESCRIPTION
Bug fix. Previously, if FETCH was given a timeout and a number of rows
to return, it would wait the timeout even if the requested number of
rows was immediately available.

Closes #6307