### PR TITLE
Fix Avro schema resolution going haywire when a field is added to the end of a record.

### DIFF
--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -359,6 +359,9 @@ impl<'a> SchemaResolver<'a> {
                         }
                     }
                 }
+                while fields.len() < w_fields.len() {
+                    fields.push(None);
+                }
                 let mut n_present = 0;
                 let fields = fields
                     .into_iter()

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2271,6 +2271,43 @@ mod tests {
     }
 
     #[test]
+    fn new_field_in_middle() {
+        let reader = r#"{
+            "type": "record",
+            "name": "MyRecord",
+            "fields": [{"name": "f1", "type": "int"}, {"name": "f2", "type": "int"}]
+        }"#;
+        let writer = r#"{
+            "type": "record",
+            "name": "MyRecord",
+            "fields": [{"name": "f1", "type": "int"}, {"name": "f_interposed", "type": "int"}, {"name": "f2", "type": "int"}]
+        }"#;
+        let reader = Schema::from_str(reader).unwrap();
+        let writer = Schema::from_str(writer).unwrap();
+
+        let mut record = Record::new(writer.top_node()).unwrap();
+        record.put("f1", 1);
+        record.put("f2", 2);
+        record.put("f_interposed", 42);
+
+        let value = record.avro();
+
+        let mut buf = vec![];
+        crate::encode::encode(&value, &writer, &mut buf);
+
+        let resolved = resolve_schemas(&writer, &reader).unwrap();
+
+        let reader = &mut &buf[..];
+        let reader_value = crate::decode::decode(resolved.top_node(), reader).unwrap();
+        let expected = crate::types::Value::Record(vec![
+            ("f1".to_string(), crate::types::Value::Int(1)),
+            ("f2".to_string(), crate::types::Value::Int(2)),
+        ]);
+        assert_eq!(reader_value, expected);
+        assert!(reader.is_empty()); // all bytes should have been consumed
+    }
+
+    #[test]
     fn new_field_at_end() {
         let reader = r#"{
             "type": "record",

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2075,6 +2075,9 @@ fn field_ordering_position(field: &str) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use types::Record;
+    use types::ToAvro;
+
     use super::*;
 
     fn check_schema(schema: &str, expected: SchemaPiece) {
@@ -2265,6 +2268,40 @@ mod tests {
                 r#"{"type":"int","logicalType":"date"}"#
             );
         }
+    }
+
+    #[test]
+    fn new_field_at_end() {
+        let reader = r#"{
+            "type": "record",
+            "name": "MyRecord",
+            "fields": [{"name": "f1", "type": "int"}]
+        }"#;
+        let writer = r#"{
+            "type": "record",
+            "name": "MyRecord",
+            "fields": [{"name": "f1", "type": "int"}, {"name": "f2", "type": "int"}]
+        }"#;
+        let reader = Schema::from_str(reader).unwrap();
+        let writer = Schema::from_str(writer).unwrap();
+
+        let mut record = Record::new(writer.top_node()).unwrap();
+        record.put("f1", 1);
+        record.put("f2", 2);
+
+        let value = record.avro();
+
+        let mut buf = vec![];
+        crate::encode::encode(&value, &writer, &mut buf);
+
+        let resolved = resolve_schemas(&writer, &reader).unwrap();
+
+        let reader = &mut &buf[..];
+        let reader_value = crate::decode::decode(resolved.top_node(), reader).unwrap();
+        let expected =
+            crate::types::Value::Record(vec![("f1".to_string(), crate::types::Value::Int(1))]);
+        assert_eq!(reader_value, expected);
+        assert!(reader.is_empty()); // all bytes should have been consumed
     }
 
     #[test]


### PR DESCRIPTION
When fields are added to an Avro schema, the resolved schema must have a record of each field in the _writer_ schema, even if it is not present in the _reader_ schema, so that when decoding, the fields can be skipped properly.

We were doing this properly for fields added in the middle of a record, but not for ones added at the end of a record. This PR fixes that defect and adds a test for it.