### PR TITLE
sql: tests for optimizations around primary keys

### DIFF
--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -1,0 +1,124 @@
+# Copyright Materialize, Inc. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test that the knowledge that a given set of fields forms a primary key is used by the optimizer to remove grouping and distinct operations
+#
+
+# Remove both newlines, references to internal table identifiers, and "materialize.public" strings, all with a single regexp
+
+$ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
+
+$ set keyschema-2keys={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key1", "type": "string"},
+        {"name": "key2", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"nokey", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=t1
+
+$ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys} schema=${schema} publish=true
+
+> CREATE MATERIALIZED SOURCE t1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-t1-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE UPSERT;
+
+# Optimization is possible - no distinct is mentioned in the plan
+
+> EXPLAIN SELECT DISTINCT key1, key2 FROM t1;
+"%0 =| Get t1| Project (#0, #1)"
+
+> EXPLAIN SELECT DISTINCT key2, key1 FROM t1;
+"%0 =| Get t1| Project (#1, #0)"
+
+> EXPLAIN SELECT DISTINCT key2, key1, key2 FROM t1;
+"%0 =| Get t1| Project (#1, #0, #1)"
+
+> EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2;
+"%0 =| Get t1| Project (#1, #0)"
+
+> EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2, key2 || 'a';
+"%0 =| Get t1| Project (#1, #0)"
+
+> EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1;
+"%0 =| Get t1"
+
+> EXPLAIN SELECT key1, key2, nokey FROM t1 GROUP BY key1, key2, nokey;
+"%0 =| Get t1"
+
+> EXPLAIN SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
+"%0 =| Get t1| Filter (#0 = \"a\")| Project (#0, #1)"
+
+# Optimization not possible - explicit distinct is present in plan
+
+> EXPLAIN SELECT DISTINCT key1 FROM t1;
+"%0 =| Get t1| Distinct group=(#0)"
+
+> EXPLAIN SELECT DISTINCT key2 FROM t1;
+"%0 =| Get t1| Distinct group=(#1)"
+
+> EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1;
+"%0 =| Get t1| Distinct group=(#0, upper(#1))"
+
+> EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1;
+"%0 =| Get t1| Distinct group=(#0, (#1 || \"a\"))"
+
+> EXPLAIN SELECT key1 FROM t1 GROUP BY key1;
+"%0 =| Get t1| Distinct group=(#0)"
+
+> EXPLAIN SELECT key2 FROM t1 GROUP BY key2;
+"%0 =| Get t1| Distinct group=(#1)"
+
+> EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1;
+"%0 = Let l0 =| Get t1| Reduce group=()| | agg count(distinct #0)%1 =| Get %0 (l0)| Negate| Project ()%2 =| Constant ()%3 =| Union %1 %2| Map 0%4 =| Union %0 %3"
+
+# Make sure that primary key information is inherited from the source
+
+> CREATE VIEW v1 AS SELECT * FROM t1;
+
+> EXPLAIN SELECT DISTINCT key1, key2 FROM v1;
+"%0 =| Get t1| Project (#0, #1)"
+
+> CREATE MATERIALIZED VIEW v2 AS SELECT * FROM t1;
+
+> EXPLAIN SELECT DISTINCT key1, key2 FROM v2;
+"%0 =| Get v2| Project (#0, #1)"
+
+# Make sure that having a DISTINCT or a GROUP BY confers PK semantics on upstream views
+
+> CREATE VIEW distinct_view AS SELECT DISTINCT nokey FROM t1;
+
+> CREATE MATERIALIZED VIEW group_by_view AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1 GROUP BY nokey || 'a', nokey || 'b';
+
+> EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view;
+"%0 =| Get group_by_view"
+
+# Redundant table is eliminated from an inner join using PK infomration
+
+> EXPLAIN SELECT a1.* FROM t1 AS a1, t1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+"%0 =| Get t1"
+
+> EXPLAIN SELECT a1.* FROM v1 AS a1, v1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+"%0 =| Get t1"
+
+> EXPLAIN SELECT a1.* FROM v2 AS a1, v2 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
+"%0 =| Get v2"


### PR DESCRIPTION
If a primary key is specified, the optimizer can use it to remove
certain distinct and grouping operations.

---

It occured to me that this can not be tested in SLT and there were no testdrive tests I could find that were testing it.

@wangandi - if you can think of any other cases that should be optimized by the presence of primary keys, please let me know. Thanks!