### PR TITLE
change testdrive default kafka replication factor to 1

### DIFF
--- a/src/testdrive/src/action/kafka/create_topic.rs
+++ b/src/testdrive/src/action/kafka/create_topic.rs
@@ -29,7 +29,7 @@ pub struct CreateTopicAction {
 pub fn build_create_topic(mut cmd: BuiltinCommand) -> Result<CreateTopicAction, String> {
     let topic_prefix = format!("testdrive-{}", cmd.args.string("topic")?);
     let partitions = cmd.args.opt_parse("partitions")?.unwrap_or(1);
-    let replication_factor = cmd.args.opt_parse("replication-factor")?.unwrap_or(-1);
+    let replication_factor = cmd.args.opt_parse("replication-factor")?.unwrap_or(1);
     let compression = cmd
         .args
         .opt_string("compression")


### PR DESCRIPTION
Settable replication factors were added to support the kafka multi-partition unit tests. The default of -1 was used to indicate 'broker assigned' - unfortunately this means that testdrive create topic won't work on older versions of Kafka unless the replication factor is explicitly set.

Instead of defaulting to -1, default to 1. Tests that want to exercise replfactor can set it explicitly, and tests that want to test broker assigned replfactors can explicitly set it to -1.