### PR TITLE
ci/cleanup: specify us-east-2 region

### DIFF
--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -14,3 +14,5 @@ steps:
     timeout_in_minutes: 10
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.cleanup.aws
     timeout_in_minutes: 10
+    env:
+      AWS_DEFAULT_REGION: us-east-2


### PR DESCRIPTION
Testdrive and perf-kinesis run in us-east-2.