### PR TITLE
sql: add pow as an alias to power

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -46,6 +46,11 @@ Use relative links (/path/to/doc), not absolute links
 Wrap your release notes at the 80 character mark.
 {{< /comment >}}
 
+{{% version-header v0.7.3 %}}
+
+- Add the [`pow`](/sql/functions/#numbers-func) function as an alias for the
+  [`power`](/sql/functions/#numbers-func) function.
+
 {{% version-header v0.7.2 %}}
 
 - Introduce the concept of [volatility](/overview/volatility) to describe

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -141,6 +141,12 @@
   - signature: 'mod(x: N, y: N) -> N'
     description: "`x % y`"
 
+  - signature: 'pow(x: double precision, y: double precision) -> double precision'
+    description: "Alias of `power`"
+
+  - signature: 'pow(x: numeric, y: numeric) -> numeric'
+    description: "Alias of `power`"
+
   - signature: 'power(x: double precision, y: double precision) -> double precision'
     description: "`x` raised to the power of `y`"
 

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -224,6 +224,7 @@ impl<'a> FuncRewriter<'a> {
                     let (lhs, rhs) = (args[0].clone(), args[1].clone());
                     match name.item.as_str() {
                         "mod" => lhs.modulo(rhs),
+                        "pow" => Expr::call(vec!["power"], vec![lhs, rhs]),
                         _ => return None,
                     }
                 } else {

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1041,3 +1041,18 @@ query T
 SELECT power(9::decimal(15, 5), 0.5::decimal(15, 5));
 ----
 3
+
+query R
+SELECT pow(382, 5);
+----
+8134236862432
+
+query T
+SELECT pow(9::float, 0.5);
+----
+3.000
+
+query T
+SELECT pow(9::decimal(15, 5), 0.5::decimal(15, 5));
+----
+3


### PR DESCRIPTION
Add support for `pow` as an alias to `power`, as supported by Postgres.