### PR TITLE
Record a prometheus metric counting the log messages emitted by level

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -51,6 +51,9 @@ Wrap your release notes at the 80 character mark.
 - Add the [`pow`](/sql/functions/#numbers-func) function as an alias for the
   [`power`](/sql/functions/#numbers-func) function.
 
+- Add a new metric, `mz_log_message_total` that counts the number of log
+  messages emitted per severity.
+
 {{% version-header v0.7.2 %}}
 
 - Introduce the concept of [volatility](/overview/volatility) to describe


### PR DESCRIPTION
This change adds a new metric, "mz_log_message_total", which counts the number of log messages emitted by level. This should make it easier for users of the cloud product (and on-prem users also) to hook up alerting to the log messages: Our recommendation is to page people if an ERROR is logged, so this allows doing just that.

This relates to #6311.