### PR TITLE
Limit magit commit message buffers to 72 chars in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ indent_style = space
 indent_size = 4
 max_line_length = 100
 
+[COMMIT_EDITMSG]
+max_line_length = 72
+
 [*.md]
 max_line_length = 80
 


### PR DESCRIPTION
This is a bit of a hack, but annoying otherwise: Our default line length limit is 100 chars, so anytime you make a commit with magit, it would word-wrap at 100 chars. By setting a rule for COMMIT_EDITMSG, this causes the commit message editor to auto-wrap at the right spot again.

I'm assigning the review to @quodlibetor who I hope can relate to the emacsy plight (: