### PR TITLE
Drop topics before starting debezium connector

### DIFF
--- a/demo/chbench/mzcompose.yml
+++ b/demo/chbench/mzcompose.yml
@@ -589,9 +589,6 @@ mzworkflows:
       workflow: bring-up-mysql-kafka
     - step: start-services
       services: [prometheus_sql_exporter_mysql_tpcch]
-    - step: drop-kafka-topics
-      kafka-container: chbench_kafka_1
-      topic_pattern: debezium.tpcch.*
     - step: run
       service: chbench
       command: >-
@@ -633,20 +630,23 @@ mzworkflows:
   bring-up-mysql-kafka:
     steps:
     - step: start-services
-      services: [mysql]
+      services: [mysql, kafka]
     - step: wait-for-mysql
       user: root
       password: rootpw
       timeout_secs: 30
+    - step: wait-for-tcp
+      host: kafka
+      port: 9092
+    - step: drop-kafka-topics
+      kafka-container: chbench_kafka_1
+      topic_pattern: debezium.tpcch.*
     - step: start-services
       services: [connector-mysql]
     - step: wait-for-tcp
       host: connect
       port: 8083
       timeout_secs: 120
-    - step: wait-for-tcp
-      host: kafka
-      port: 9092
     - step: wait-for-tcp
       host: schema-registry
       port: 8081
@@ -676,9 +676,6 @@ mzworkflows:
     - step: wait-for-tcp
       host: mysql
       port: 3306
-    - step: drop-kafka-topics
-      kafka-container: chbench_kafka_1
-      topic_pattern: debezium.tpcch.*
     - step: run
       service: chbench
       command: >-
@@ -694,10 +691,13 @@ mzworkflows:
   bring-up-postgres-kafka:
     steps:
     - step: start-services
-      services: [postgres]
+      services: [postgres, kafka]
     - step: wait-for-postgres
       dbname: postgres
       timeout_secs: 30
+    - step: drop-kafka-topics
+      kafka-container: chbench_kafka_1
+      topic_pattern: debezium.tpcch.*
     - step: start-services
       services: [connector-postgres]
     - step: wait-for-tcp
@@ -735,9 +735,6 @@ mzworkflows:
     - step: wait-for-tcp
       host: postgres
       port: 5432
-    - step: drop-kafka-topics
-      kafka-container: chbench_kafka_1
-      topic_pattern: debezium.tpcch.*
     - step: run
       service: chbench
       command: >-


### PR DESCRIPTION
Chbench startup would often timeout because Peeker failed to create
sources due to the Kafka topics missing. This is because we drop the
Kafka topics after creating them in the connector. This then results in
Peeker either succeeding or failing depending on how quickly Debezium
would recreate the topics.

Instead of dropping the topics after starting the connect process,
simply drop them beforehand. That way the topics will be empty and will
exist for both debezium and peeker.

The net result is that Peeker starts without needing to retry any of the source
creation statements:

```
Creating chbench_peeker_run ... done
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var ENV_VAR w/ default val default
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var KAFKA_HOST w/ env var kafka
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var KAFKA_EXTERNAL_PORT w/ env var 9092
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var SR_HOST w/ env var schema-registry
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var OLAP_THREADS w/ env var 1
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var OLAP_THREADS w/ env var 1
[2021-04-09T23:58:05Z INFO  peeker::args] substituting config var OLAP_THREADS w/ env var 1
[2021-04-09T23:58:05Z INFO  peeker] startup 2021-04-09 23:58:05.613953745 UTC
[2021-04-09T23:58:05Z INFO  peeker] Allowing chbench to warm up for 0 seconds at 2021-04-09 23:58:05.616894850 UTC
[2021-04-09T23:58:05Z INFO  peeker] Done warming up at 2021-04-09 23:58:05.616911492 UTC
[2021-04-09T23:58:05Z INFO  peeker] serving prometheus metrics on port 16875
[2021-04-09T23:58:05Z INFO  peeker] installed source customer for topic debezium.tpcch.customer
[2021-04-09T23:58:05Z INFO  peeker] installed source item for topic debezium.tpcch.item
[2021-04-09T23:58:05Z INFO  peeker] installed source nation for topic debezium.tpcch.nation
[2021-04-09T23:58:05Z INFO  peeker] installed source neworder for topic debezium.tpcch.neworder
[2021-04-09T23:58:06Z INFO  peeker] installed source order for topic debezium.tpcch.order
[2021-04-09T23:58:06Z INFO  peeker] installed source orderline for topic debezium.tpcch.orderline
[2021-04-09T23:58:06Z INFO  peeker] installed source stock for topic debezium.tpcch.stock
[2021-04-09T23:58:06Z INFO  peeker] installed source supplier for topic debezium.tpcch.supplier
[2021-04-09T23:58:06Z INFO  peeker] installed source history for topic debezium.tpcch.history
[2021-04-09T23:58:06Z INFO  peeker] installed source district for topic debezium.tpcch.district
[2021-04-09T23:58:06Z INFO  peeker] installed source region for topic debezium.tpcch.region
[2021-04-09T23:58:06Z INFO  peeker] installed source warehouse for topic debezium.tpcch.warehouse
[2021-04-09T23:58:06Z INFO  peeker] installed view q01
[2021-04-09T23:58:06Z INFO  peeker] installed view q02
[2021-04-09T23:58:06Z INFO  peeker] installed view q05
[2021-04-09T23:58:07Z INFO  peeker] installed view q06
[2021-04-09T23:58:07Z INFO  peeker] installed view q08
[2021-04-09T23:58:07Z INFO  peeker] installed view q09
[2021-04-09T23:58:07Z INFO  peeker] installed view q12
[2021-04-09T23:58:07Z INFO  peeker] installed view q14
[2021-04-09T23:58:07Z INFO  peeker] installed view q17
[2021-04-09T23:58:07Z INFO  peeker] installed view q19
```