### PR TITLE
Include the literal that caused a parser error in the error message

### DIFF
--- a/src/sql-parser/src/lexer.rs
+++ b/src/sql-parser/src/lexer.rs
@@ -85,6 +85,29 @@ impl Token {
             Token::Semicolon => "semicolon",
         }
     }
+
+    pub fn value(&self) -> &str {
+        match self {
+            Token::Keyword(kw) => kw.as_str(),
+            Token::Ident(val) => &*val,
+            Token::String(val) => &*val,
+            Token::HexString(val) => &*val,
+            Token::Number(val) => &*val,
+            Token::Parameter(val) => &*val,
+            Token::Op(val) => &*val,
+            Token::Star => "*",
+            Token::Eq => "=",
+            Token::LParen => "(",
+            Token::RParen => ")",
+            Token::LBracket => "[",
+            Token::RBracket => "]",
+            Token::Dot => ".",
+            Token::Comma => ",",
+            Token::Colon => ":",
+            Token::DoubleColon => "::",
+            Token::Semicolon => ";",
+        }
+    }
 }
 
 macro_rules! bail {

--- a/src/sql-parser/src/lexer.rs
+++ b/src/sql-parser/src/lexer.rs
@@ -86,26 +86,51 @@ impl Token {
         }
     }
 
-    pub fn value(&self) -> &str {
+    pub fn value(&self) -> String {
         match self {
-            Token::Keyword(kw) => kw.as_str(),
-            Token::Ident(val) => &*val,
-            Token::String(val) => &*val,
-            Token::HexString(val) => &*val,
-            Token::Number(val) => &*val,
-            Token::Parameter(val) => &*val,
-            Token::Op(val) => &*val,
-            Token::Star => "*",
-            Token::Eq => "=",
-            Token::LParen => "(",
-            Token::RParen => ")",
-            Token::LBracket => "[",
-            Token::RBracket => "]",
-            Token::Dot => ".",
-            Token::Comma => ",",
-            Token::Colon => ":",
-            Token::DoubleColon => "::",
-            Token::Semicolon => ";",
+            Token::Keyword(kw) => kw.as_str().to_string(),
+            Token::Ident(val) => val.to_string(),
+            Token::String(val) => val.to_string(),
+            Token::HexString(val) => val.to_string(),
+            Token::Number(val) => val.to_string(),
+            Token::Op(val) => val.to_string(),
+            Token::Parameter(val) => val.to_string(),
+            Token::Star => "*".to_string(),
+            Token::Eq => "=".to_string(),
+            Token::LParen => "(".to_string(),
+            Token::RParen => ")".to_string(),
+            Token::LBracket => "[".to_string(),
+            Token::RBracket => "]".to_string(),
+            Token::Dot => ".".to_string(),
+            Token::Comma => ",".to_string(),
+            Token::Colon => ":".to_string(),
+            Token::DoubleColon => "::".to_string(),
+            Token::Semicolon => ";".to_string(),
+        }
+    }
+
+    /// True iff the `value()` function will return more information in our error messages
+    pub fn has_value(&self) -> bool {
+        match self {
+            Token::Ident(_)
+            | Token::String(_)
+            | Token::HexString(_)
+            | Token::Number(_)
+            | Token::Op(_)
+            | Token::Parameter(_) => true,
+            // In our error messages we use literal keywords, which makes the keyword value a duplicate
+            Token::Keyword(_) => false,
+            Token::Star
+            | Token::Eq
+            | Token::LParen
+            | Token::RParen
+            | Token::LBracket
+            | Token::RBracket
+            | Token::Dot
+            | Token::Comma
+            | Token::Colon
+            | Token::DoubleColon
+            | Token::Semicolon => false,
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1248,6 +1248,7 @@ impl<'a> Parser<'a> {
             found.as_ref().map(|t| t.name()).unwrap_or("EOF"),
             found
                 .as_ref()
+                .filter(|t| t.has_value())
                 .map(|t| format!(" '{}'", t.value()))
                 .unwrap_or_else(String::new)
         )

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1243,9 +1243,13 @@ impl<'a> Parser<'a> {
         parser_err!(
             self,
             pos,
-            "Expected {}, found {}",
+            "Expected {}, found {}{}",
             expected,
-            found.as_ref().map(|t| t.name()).unwrap_or("EOF")
+            found.as_ref().map(|t| t.name()).unwrap_or("EOF"),
+            found
+                .as_ref()
+                .map(|t| format!(" '{}'", t.value()))
+                .unwrap_or_else(String::new)
         )
     }
 

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -142,7 +142,7 @@ CreateRole(CreateRoleStatement { is_user: false, name: Ident("usr"), options: [L
 parse-statement
 CREATE ROLE usr WITH badopt
 ----
-error: Expected end of statement, found identifier
+error: Expected end of statement, found identifier 'badopt'
 CREATE ROLE usr WITH badopt
                      ^
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -34,7 +34,7 @@ CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities"
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
 ----
-error: Expected column option, found identifier
+error: Expected column option, found identifier 'garbage'
 CREATE TABLE t (a int NOT NULL GARBAGE)
                                ^
 
@@ -195,7 +195,7 @@ CREATE TABLE t (c time with time zone (0,1,100))
 parse-statement
 CREATE TABLE t (c t(1+1))
 ----
-error: Expected right parenthesis, found operator
+error: Expected right parenthesis, found operator '+'
 CREATE TABLE t (c t(1+1))
                      ^
 
@@ -541,7 +541,7 @@ CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbnam
 parse-statement
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ("public.psychic" (pokedex_id int NOT NULL, evolution int))
 ----
-error: Expected literal string, found identifier
+error: Expected literal string, found identifier 'public.psychic'
 CREATE SOURCES FROM POSTGRES HOST 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red' NAMESPACE 'generation1' TABLES ("public.psychic" (pokedex_id int NOT NULL, evolution int))
                                                                                                                                              ^
 

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -35,7 +35,7 @@ UPDATE t WHERE 1
 parse-statement
 UPDATE t SET a = 1 extrabadstuff
 ----
-error: Expected end of statement, found identifier
+error: Expected end of statement, found identifier 'extrabadstuff'
 UPDATE t SET a = 1 extrabadstuff
                    ^
 
@@ -49,7 +49,7 @@ SELECT ALL DISTINCT name FROM customer
 parse-statement
 INSERT public.customer (id, name, active) VALUES (1, 2, 3)
 ----
-error: Expected INTO, found identifier
+error: Expected INTO, found identifier 'public'
 INSERT public.customer (id, name, active) VALUES (1, 2, 3)
        ^
 
@@ -141,7 +141,7 @@ SEL
 
 ECT
 ----
-error: Expected a keyword at the beginning of a statement, found identifier
+error: Expected a keyword at the beginning of a statement, found identifier 'sel'
 SEL
 ^
 
@@ -150,7 +150,7 @@ SELECT foo
 FROM bar+1 ORDER
 BY
 ----
-error: Expected end of statement, found operator
+error: Expected end of statement, found operator '+'
 FROM bar+1 ORDER
         ^
 
@@ -245,6 +245,6 @@ SELECT LIST[1][1:1, ]
 parse-scalar
 ARRAY[]::int[1 + 1]
 ----
-error: Expected right square bracket, found operator
+error: Expected right square bracket, found operator '+'
 ARRAY[]::int[1 + 1]
                ^

--- a/src/sql-parser/tests/testdata/lexer
+++ b/src/sql-parser/tests/testdata/lexer
@@ -59,7 +59,7 @@ SELECT 'foobarbaz'
 parse-statement roundtrip
 SELECT 'foo'  'bar'
 ----
-error: Expected end of statement, found string literal
+error: Expected end of statement, found string literal 'bar'
 SELECT 'foo'  'bar'
               ^
 
@@ -67,7 +67,7 @@ parse-statement roundtrip
 SELECT e'foo'
 e'bar'
 ----
-error: Expected end of statement, found string literal
+error: Expected end of statement, found string literal 'bar'
 e'bar'
 ^
 
@@ -162,7 +162,7 @@ error: extra token after expression
 parse-statement
 ’hello’
 ----
-error: Expected a keyword at the beginning of a statement, found identifier
+error: Expected a keyword at the beginning of a statement, found identifier '’hello’'
 ’hello’
 ^
 
@@ -170,7 +170,7 @@ error: Expected a keyword at the beginning of a statement, found identifier
 parse-statement
 SELECT '’fancy quotes inside a string are ok’’’’' AS alias ’
 ----
-error: Expected end of statement, found identifier
+error: Expected end of statement, found identifier '’'
 SELECT '’fancy quotes inside a string are ok’’’’' AS alias ’
                                                            ^
 

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -489,7 +489,7 @@ parse-scalar roundtrip
 parse-scalar
 (1.a)
 ----
-error: Expected right parenthesis, found identifier
+error: Expected right parenthesis, found identifier 'a'
 (1.a)
    ^
 

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -242,7 +242,7 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT (1.a)
 ----
-error: Expected right parenthesis, found identifier
+error: Expected right parenthesis, found identifier 'a'
 SELECT (1.a)
           ^
 
@@ -343,7 +343,7 @@ SELECT $q
 parse-statement
 SELECT $1$2
 ----
-error: Expected end of statement, found parameter
+error: Expected end of statement, found parameter '2'
 SELECT $1$2
          ^
 
@@ -935,7 +935,7 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
 ----
-error: Expected one of ROW or ROWS, found identifier
+error: Expected one of ROW or ROWS, found identifier 'percent'
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
                                    ^
 
@@ -1019,7 +1019,7 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
 ----
-error: Expected SELECT, VALUES, or a subquery in the query body, found identifier
+error: Expected SELECT, VALUES, or a subquery in the query body, found identifier 'b'
 SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
                                    ^
 

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -366,7 +366,7 @@ SET
 parse-statement
 SET a b
 ----
-error: Expected equals sign or TO, found identifier
+error: Expected equals sign or TO, found identifier 'b'
 SET a b
       ^
 
@@ -415,6 +415,6 @@ Discard(DiscardStatement { target: Temp })
 parse-statement
 DISCARD BAD
 ----
-error: Expected one of ALL or PLANS or SEQUENCES or TEMP or TEMPORARY, found identifier
+error: Expected one of ALL or PLANS or SEQUENCES or TEMP or TEMPORARY, found identifier 'bad'
 DISCARD BAD
         ^

--- a/src/sql-parser/tests/testdata/txn
+++ b/src/sql-parser/tests/testdata/txn
@@ -99,14 +99,14 @@ StartTransaction(StartTransactionStatement { modes: [IsolationLevel(Serializable
 parse-statement
 START TRANSACTION ISOLATION LEVEL BAD
 ----
-error: Expected isolation level, found identifier
+error: Expected isolation level, found identifier 'bad'
 START TRANSACTION ISOLATION LEVEL BAD
                                   ^
 
 parse-statement
 START TRANSACTION BAD
 ----
-error: Expected end of statement, found identifier
+error: Expected end of statement, found identifier 'bad'
 START TRANSACTION BAD
                   ^
 


### PR DESCRIPTION
For me recently I typoed FORMAT in a CREATE SOURCE statement and got "expected EOF found identifier"
which doesn't help. I think I've been annoyed by this in other places.