### PR TITLE
[source orthogonality] Strip Debezium deduplication out of decoding and into its own operator

### DIFF
--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -14,6 +14,7 @@ use std::rc::Rc;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{collection, AsCollection, Collection};
+use log::warn;
 use timely::dataflow::operators::unordered_input::UnorderedInput;
 use timely::dataflow::operators::Map;
 use timely::dataflow::scopes::Child;
@@ -24,6 +25,8 @@ use expr::{GlobalId, Id, MirRelationExpr, SourceInstanceId};
 use mz_avro::types::Value;
 use mz_avro::Schema;
 use ore::cast::CastFrom;
+use repr::RelationDesc;
+use repr::ScalarType;
 use repr::{Datum, Row, Timestamp};
 
 use crate::decode::{decode_avro_values, decode_values, get_decoder};
@@ -149,13 +152,13 @@ where
 
                 // AvroOcf is a special case as its delimiters are discovered in the couse of decoding.
                 // This means that unlike the other sources, there is not a decode step that follows.
-                let (mut collection, capability) = if let ExternalSourceConnector::AvroOcf(_) =
-                    connector
+                let (collection, capability) = if let ExternalSourceConnector::AvroOcf(_) =
+                    &connector
                 {
                     let ((source, err_source), capability) =
                         source::create_source::<_, FileSourceReader<Value>, Value>(
                             source_config,
-                            connector,
+                            &connector,
                         );
 
                     // Include any source errors.
@@ -205,22 +208,22 @@ where
                         ExternalSourceConnector::Kafka(_) => {
                             source::create_source::<_, KafkaSourceReader, _>(
                                 source_config,
-                                connector,
+                                &connector,
                             )
                         }
                         ExternalSourceConnector::Kinesis(_) => {
                             source::create_source::<_, KinesisSourceReader, _>(
                                 source_config,
-                                connector,
+                                &connector,
                             )
                         }
                         ExternalSourceConnector::S3(_) => {
-                            source::create_source::<_, S3SourceReader, _>(source_config, connector)
+                            source::create_source::<_, S3SourceReader, _>(source_config, &connector)
                         }
                         ExternalSourceConnector::File(_) => {
                             source::create_source::<_, FileSourceReader<Vec<u8>>, Vec<u8>>(
                                 source_config,
-                                connector,
+                                &connector,
                             )
                         }
                         ExternalSourceConnector::AvroOcf(_) => unreachable!(),
@@ -237,9 +240,8 @@ where
                     );
 
                     let (stream, errors) = if let SourceEnvelope::Upsert(key_encoding) = &envelope {
-                        let value_decoder = get_decoder(encoding, &self.debug_name, scope.index());
-                        let key_decoder =
-                            get_decoder(key_encoding.clone(), &self.debug_name, scope.index());
+                        let value_decoder = get_decoder(encoding, &self.debug_name);
+                        let key_decoder = get_decoder(key_encoding.clone(), &self.debug_name);
                         super::upsert::decode_stream(
                             &ok_source,
                             self.as_of_frontier.clone(),
@@ -259,7 +261,6 @@ where
                             &envelope,
                             &mut linear_operators,
                             fast_forwarded,
-                            src.bare_desc.clone(),
                             uid,
                         );
                         if let Some(tok) = extra_token {
@@ -276,6 +277,46 @@ where
                     }
 
                     (stream, capability)
+                };
+
+                // render debezium dedupe
+                let mut collection = match &envelope {
+                    SourceEnvelope::Debezium(dedupe_strategy, _) => {
+                        let dbz_key_indices = match &src.connector {
+                            SourceConnector::External {
+                                encoding:
+                                    DataEncoding::Avro(AvroEncoding {
+                                        key_schema: Some(key_schema),
+                                        ..
+                                    }),
+                                ..
+                            } => {
+                                let fields = match &src.bare_desc.typ().column_types[0].scalar_type
+                                {
+                                    ScalarType::Record { fields, .. } => fields.clone(),
+                                    _ => unreachable!(),
+                                };
+                                let row_desc = RelationDesc::from_names_and_types(
+                                    fields.into_iter().map(|(n, t)| (Some(n), t)),
+                                );
+                                interchange::avro::validate_key_schema(key_schema, &row_desc)
+                                    .map(Some)
+                                    .unwrap_or_else(|e| {
+                                        warn!("Not using key due to error: {}", e);
+                                        None
+                                    })
+                            }
+                            _ => None,
+                        };
+                        dedupe_strategy.clone().render(
+                            collection,
+                            self.debug_name.to_string(),
+                            scope.index(),
+                            src.bare_desc.arity() + 2,
+                            dbz_key_indices,
+                        )
+                    }
+                    _ => collection,
                 };
 
                 // Implement source filtering and projection.
@@ -333,7 +374,7 @@ where
                 };
 
                 // Apply `as_of` to each timestamp.
-                match envelope {
+                match &envelope {
                     SourceEnvelope::Upsert(_) => {}
                     _ => {
                         let as_of_frontier1 = self.as_of_frontier.clone();

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -312,6 +312,7 @@ where
                             collection,
                             self.debug_name.to_string(),
                             scope.index(),
+                            // Debezium decoding has produced two extra fields, with the dedupe information and the upstream time in millis
                             src.bare_desc.arity() + 2,
                             dbz_key_indices,
                         )

--- a/src/dataflow/src/source/mod.rs
+++ b/src/dataflow/src/source/mod.rs
@@ -1224,7 +1224,7 @@ where
 /// type of source that should be created
 pub(crate) fn create_source<G, S: 'static, Out>(
     config: SourceConfig<G>,
-    source_connector: ExternalSourceConnector,
+    source_connector: &ExternalSourceConnector,
 ) -> (
     (
         timely::dataflow::Stream<G, SourceOutput<Vec<u8>, Out>>,
@@ -1298,7 +1298,7 @@ where
             }
         };
 
-        let cached_files = dataflow_types::cached_files(&source_connector);
+        let cached_files = dataflow_types::cached_files(source_connector);
         let mut cached_files = crate::source::cache::cached_files_for_worker(
             id.source_id,
             cached_files,

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -12,7 +12,7 @@ use criterion::{black_box, Criterion, Throughput};
 use futures::executor::block_on;
 use mz_avro::types::Value as AvroValue;
 
-use interchange::avro::{parse_schema, DebeziumDeduplicationStrategy, Decoder, EnvelopeType};
+use interchange::avro::{parse_schema, Decoder, EnvelopeType};
 use std::ops::Add;
 
 pub fn bench_avro(c: &mut Criterion) {
@@ -394,9 +394,6 @@ pub fn bench_avro(c: &mut Criterion) {
         None,
         EnvelopeType::Debezium,
         "avro_bench".to_string(),
-        0,
-        Some(DebeziumDeduplicationStrategy::Ordered),
-        None,
         false,
         false,
     )

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -29,7 +29,7 @@ pub use self::schema::{
 
 use self::decode::{AvroFlatDecoder, AvroStringDecoder, OptionalRecordDecoder, RowWrapper};
 use self::encode::build_row_schema_json;
-use self::envelope_debezium::{AvroDebeziumDecoder, DebeziumDeduplicationState, RowCoordinates};
+use self::envelope_debezium::{AvroDebeziumDecoder, RowCoordinates};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EnvelopeType {

--- a/src/interchange/src/avro/decode.rs
+++ b/src/interchange/src/avro/decode.rs
@@ -9,6 +9,7 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::io::Read;
@@ -32,22 +33,19 @@ use repr::adt::jsonb::JsonbPacker;
 use repr::adt::rdn;
 use repr::{Datum, Row};
 
-use super::{
-    is_null, AvroDebeziumDecoder, ConfluentAvroResolver, DebeziumDeduplicationState,
-    DebeziumDeduplicationStrategy, EnvelopeType, RowCoordinates,
-};
+use super::{is_null, AvroDebeziumDecoder, ConfluentAvroResolver, EnvelopeType, RowCoordinates};
 
 /// Manages decoding of Avro-encoded bytes.
 pub struct Decoder {
     csr_avro: ConfluentAvroResolver,
     envelope: EnvelopeType,
-    debezium_dedup: Option<DebeziumDeduplicationState>,
     debug_name: String,
-    worker_index: usize,
     buf1: Vec<u8>,
     buf2: Vec<u8>,
     packer: Row,
     reject_non_inserts: bool,
+    filenames_to_indices: HashMap<Vec<u8>, usize>,
+    warned_on_unknown: bool,
 }
 
 impl fmt::Debug for Decoder {
@@ -73,53 +71,102 @@ impl Decoder {
         schema_registry: Option<ccsr::ClientConfig>,
         envelope: EnvelopeType,
         debug_name: String,
-        worker_index: usize,
-        debezium_dedup: Option<DebeziumDeduplicationStrategy>,
-        key_indices: Option<Vec<usize>>,
         confluent_wire_format: bool,
         reject_non_inserts: bool,
     ) -> anyhow::Result<Decoder> {
-        assert!(
-            (envelope == EnvelopeType::Debezium && debezium_dedup.is_some())
-                || (envelope != EnvelopeType::Debezium && debezium_dedup.is_none()),
-            "Debezium deduplication strategy must be specified iff envelope type is debezium"
-        );
-        let debezium_dedup =
-            debezium_dedup.and_then(|strat| DebeziumDeduplicationState::new(strat, key_indices));
         let csr_avro =
             ConfluentAvroResolver::new(reader_schema, schema_registry, confluent_wire_format)?;
 
         Ok(Decoder {
             csr_avro,
             envelope,
-            debezium_dedup,
             debug_name,
-            worker_index,
             buf1: vec![],
             buf2: vec![],
             packer: Default::default(),
             reject_non_inserts,
+            filenames_to_indices: Default::default(),
+            warned_on_unknown: false,
         })
     }
 
-    /// Decodes Avro-encoded `bytes` into a `DiffPair`.
+    /// Decodes Avro-encoded `bytes` into a `Row`.
     pub async fn decode(
         &mut self,
         bytes: &[u8],
         coord: Option<i64>,
         upstream_time_millis: Option<i64>,
-    ) -> anyhow::Result<Option<Row>> {
+    ) -> anyhow::Result<Row> {
         let (mut bytes, resolved_schema) = self.csr_avro.resolve(bytes).await?;
         let result = if self.envelope == EnvelopeType::Debezium {
             let dec = AvroDebeziumDecoder {
                 packer: &mut self.packer,
                 buf: &mut self.buf1,
                 file_buf: &mut self.buf2,
+                filenames_to_indices: &mut self.filenames_to_indices,
             };
             let dsr = GeneralDeserializer {
                 schema: resolved_schema.top_node(),
             };
-            let (row, coords) = dsr.deserialize(&mut bytes, dec)?;
+            let coords = dsr.deserialize(&mut bytes, dec)?;
+            match coords {
+                Some(coords) => {
+                    if coords.snapshot {
+                        self.packer.push(Datum::Null)
+                    } else {
+                        let coords = match coords.row {
+                            RowCoordinates::MySql { file_idx, pos, row } => {
+                                Some((file_idx, pos, row))
+                            }
+                            RowCoordinates::Postgres { lsn, total_order } => {
+                                Some((0, lsn, total_order.unwrap_or(0)))
+                            }
+                            RowCoordinates::MSSql {
+                                change_lsn,
+                                event_serial_no,
+                            } => {
+                                // Consider everything but the file ID to be the offset within the file.
+                                let offset_in_file = ((change_lsn.log_block_offset as usize) << 16)
+                                    | (change_lsn.slot_num as usize);
+                                Some((
+                                    change_lsn.file_seq_num as usize,
+                                    offset_in_file,
+                                    event_serial_no,
+                                ))
+                            }
+                            RowCoordinates::Unknown => {
+                                if !self.warned_on_unknown {
+                                    self.warned_on_unknown = true;
+                                    log::warn!("Record with unrecognized source coordinates in {}. You might be using an unsupported upstream database.", self.debug_name);
+                                }
+                                None
+                            }
+                        };
+                        match coords {
+                            Some((file, pos, row)) => {
+                                self.packer.push_list_with(|packer| {
+                                    // downstream in the deduplication logic, we pack these into rows,
+                                    // and aren't too careful to avoid cloning them. Thus
+                                    // it's important not to go over the 24-byte
+                                    packer.push(Datum::Int32(file as i32));
+                                    packer.push(Datum::Int64(pos as i64));
+                                    packer.push(Datum::Int64(row as i64));
+                                });
+                            }
+                            None => {
+                                self.packer.push(Datum::Null);
+                            }
+                        }
+                    }
+                }
+                None => self.packer.push(Datum::Null),
+            }
+            let upstream_time_millis = match upstream_time_millis {
+                Some(value) => Datum::Int64(value),
+                None => Datum::Null,
+            };
+            self.packer.push(upstream_time_millis);
+            let row = self.packer.finish_and_reuse();
             if self.reject_non_inserts {
                 if !matches!(row.iter().next(), None | Some(Datum::Null)) {
                     panic!(
@@ -129,46 +176,8 @@ impl Decoder {
                     )
                 }
             }
-            let dedupe = self.debezium_dedup.as_mut();
-            let should_use = if let Some(source) = coords {
-                let mssql_fsn_buf;
-                // This would have ideally been `Option<&[u8]>`,
-                // but that can't be used to lookup in a `HashMap` of `Option<Vec<u8>>` without cloning.
-                // So, just use `""` to represent lack of a filename.
-                let file = match source.row {
-                    RowCoordinates::MySql { .. } => &self.buf2,
-                    RowCoordinates::MSSql { change_lsn, .. } => {
-                        mssql_fsn_buf = change_lsn.file_seq_num.to_ne_bytes();
-                        &mssql_fsn_buf[..]
-                    }
-                    RowCoordinates::Postgres { .. } => &b""[..],
-                    RowCoordinates::Unknown { .. } => &b""[..],
-                };
 
-                let debug_name = &self.debug_name;
-                let worker_index = self.worker_index;
-                dedupe
-                    .map(|d| {
-                        d.should_use_record(
-                            file,
-                            source.row,
-                            coord,
-                            upstream_time_millis,
-                            debug_name,
-                            worker_index,
-                            source.snapshot,
-                            &row,
-                        )
-                    })
-                    .unwrap_or(true)
-            } else {
-                true
-            };
-            if should_use {
-                Some(row)
-            } else {
-                None
-            }
+            row
         } else {
             let dec = AvroFlatDecoder {
                 packer: &mut self.packer,
@@ -179,7 +188,7 @@ impl Decoder {
                 schema: resolved_schema.top_node(),
             };
             dsr.deserialize(&mut bytes, dec)?;
-            Some(self.packer.finish_and_reuse())
+            self.packer.finish_and_reuse()
         };
         log::trace!(
             "[customer-data] Decoded row {:?}{} in {}",

--- a/src/interchange/src/avro/envelope_debezium.rs
+++ b/src/interchange/src/avro/envelope_debezium.rs
@@ -14,7 +14,8 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
+use anyhow::bail;
 use smallvec::SmallVec;
 
 use mz_avro::error::{DecodeError, Error as AvroError};
@@ -32,18 +33,20 @@ use crate::avro::{AvroFlatDecoder, AvroStringDecoder, OptionalRecordDecoder};
 
 mod deduplication;
 
-pub(super) use deduplication::DebeziumDeduplicationState;
 pub use deduplication::DebeziumDeduplicationStrategy;
+
+use self::deduplication::DebeziumDeduplicationState;
 
 #[derive(Debug)]
 pub struct AvroDebeziumDecoder<'a> {
     pub packer: &'a mut Row,
     pub buf: &'a mut Vec<u8>,
     pub file_buf: &'a mut Vec<u8>,
+    pub filenames_to_indices: &'a mut HashMap<Vec<u8>, usize>,
 }
 
 impl<'a> AvroDecode for AvroDebeziumDecoder<'a> {
-    type Out = (Row, Option<DebeziumSourceCoordinates>);
+    type Out = Option<DebeziumSourceCoordinates>;
     fn record<R: AvroRead, A: AvroRecordAccess<R>>(
         self,
         a: &mut A,
@@ -75,6 +78,7 @@ impl<'a> AvroDecode for AvroDebeziumDecoder<'a> {
                 "source" => {
                     let d = DebeziumSourceDecoder {
                         file_buf: self.file_buf,
+                        filenames_to_indices: self.filenames_to_indices,
                     };
                     coords = Some(field.decode_field(d)?);
                 }
@@ -96,7 +100,7 @@ impl<'a> AvroDecode for AvroDebeziumDecoder<'a> {
                 *total_order = Some(transaction.total_order);
             }
         }
-        Ok((self.packer.finish_and_reuse(), coords))
+        Ok(coords)
     }
     define_unexpected! {
         union_branch, array, map, enum_variant, scalar, decimal, numeric, bytes, string, json, uuid, fixed
@@ -107,13 +111,14 @@ impl<'a> AvroDecode for AvroDebeziumDecoder<'a> {
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct MSSqlLsn {
     pub(crate) file_seq_num: u32,
-    log_block_offset: u32,
-    slot_num: u16,
+    pub(crate) log_block_offset: u32,
+    pub(crate) slot_num: u16,
 }
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum RowCoordinates {
     MySql {
+        file_idx: usize,
         pos: usize,
         row: usize,
     },
@@ -128,7 +133,7 @@ pub(crate) enum RowCoordinates {
     Unknown,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct DebeziumSourceCoordinates {
     pub(super) snapshot: bool,
     pub(super) row: RowCoordinates,
@@ -142,6 +147,7 @@ pub struct DebeziumTransactionMetadata {
 
 struct DebeziumSourceDecoder<'a> {
     file_buf: &'a mut Vec<u8>,
+    filenames_to_indices: &'a mut HashMap<Vec<u8>, usize>,
 }
 
 struct DebeziumTransactionDecoder;
@@ -289,7 +295,7 @@ impl<'a> AvroDecode for DebeziumSourceDecoder<'a> {
         let mut change_lsn = None;
         let mut event_serial_no = None;
 
-        let mut has_file = false;
+        let mut file_idx = None;
         while let Some((name, _, field)) = a.next_field()? {
             match name {
                 "snapshot" => {
@@ -320,7 +326,15 @@ impl<'a> AvroDecode for DebeziumSourceDecoder<'a> {
                 "file" => {
                     let d = AvroStringDecoder::with_buf(self.file_buf);
                     field.decode_field(d)?;
-                    has_file = true;
+                    file_idx = Some(match self.filenames_to_indices.get(self.file_buf) {
+                        Some(idx) => *idx,
+                        None => {
+                            let n_files = self.filenames_to_indices.len();
+                            self.filenames_to_indices
+                                .insert(std::mem::take(self.file_buf), n_files);
+                            n_files
+                        }
+                    });
                 }
                 // Postgres
                 "lsn" => {
@@ -385,7 +399,7 @@ impl<'a> AvroDecode for DebeziumSourceDecoder<'a> {
                 }
             }
         }
-        let mysql_any = pos.is_some() || row.is_some() || has_file;
+        let mysql_any = pos.is_some() || row.is_some() || file_idx.is_some();
         let pg_any = lsn.is_some();
         let mssql_any = change_lsn.is_some() || event_serial_no.is_some();
         if (mysql_any as usize) + (pg_any as usize) + (mssql_any as usize) > 1 {
@@ -395,10 +409,10 @@ impl<'a> AvroDecode for DebeziumSourceDecoder<'a> {
         let row = if mysql_any {
             let pos = pos.ok_or_else(|| DecodeError::Custom("no pos".to_string()))? as usize;
             let row = row.ok_or_else(|| DecodeError::Custom("no row".to_string()))? as usize;
-            if !has_file {
-                return Err(DecodeError::Custom("no file".to_string()).into());
-            }
-            RowCoordinates::MySql { pos, row }
+            let file_idx = file_idx
+                .ok_or_else(|| DecodeError::Custom("no binlog filename".to_string()))?
+                as usize;
+            RowCoordinates::MySql { file_idx, pos, row }
         } else if pg_any {
             let lsn = lsn.ok_or_else(|| DecodeError::Custom("no lsn".to_string()))? as usize;
             RowCoordinates::Postgres {
@@ -485,6 +499,9 @@ pub struct DebeziumDecodeState {
     debug_name: String,
     /// Worker we are running on (used for printing debug information)
     worker_idx: usize,
+    /// Map of binlog filenames to a unique index. Used to avoid having to write the full filename
+    /// in the output row.
+    filenames_to_indices: HashMap<Vec<u8>, usize>,
 }
 
 fn field_indices(node: SchemaNode) -> Option<HashMap<String, usize>> {
@@ -545,13 +562,13 @@ impl DebeziumDecodeState {
             binlog_schema_indices,
             debug_name,
             worker_idx,
+            filenames_to_indices: Default::default(),
         })
     }
 
     pub fn extract(
         &mut self,
         v: Value,
-        coord: Option<i64>,
         upstream_time_millis: Option<i64>,
     ) -> anyhow::Result<Option<Row>> {
         fn is_snapshot(v: Value) -> anyhow::Result<Option<bool>> {
@@ -570,7 +587,7 @@ impl DebeziumDecodeState {
 
         match v {
             Value::Record(mut fields) => {
-                if let Some(schema_indices) = self.binlog_schema_indices {
+                let dedup_val = if let Some(schema_indices) = self.binlog_schema_indices {
                     let source_val =
                         take_field_by_index(schema_indices.source_idx, "source", &mut fields)?;
                     let mut source_fields = match source_val {
@@ -591,6 +608,11 @@ impl DebeziumDecodeState {
                         )?
                         .into_string()
                         .ok_or_else(|| anyhow!("\"file\" is not a string"))?;
+                        let n_fnames = self.filenames_to_indices.len();
+                        let file_idx = *self
+                            .filenames_to_indices
+                            .entry(file_val.into_bytes())
+                            .or_insert(n_fnames);
                         let pos_val = take_field_by_index(
                             schema_indices.source_pos_idx,
                             "pos",
@@ -607,29 +629,13 @@ impl DebeziumDecodeState {
                         .ok_or_else(|| anyhow!("\"row\" is not an integer"))?;
                         let pos = usize::try_from(pos_val)?;
                         let row = usize::try_from(row_val)?;
-                        let debug_name = &self.debug_name;
-                        let worker_idx = self.worker_idx;
-                        if !self
-                            .dedup
-                            .as_mut()
-                            .map(|d| {
-                                d.should_use_record(
-                                    file_val.as_bytes(),
-                                    RowCoordinates::MySql { pos, row },
-                                    coord,
-                                    upstream_time_millis,
-                                    debug_name,
-                                    worker_idx,
-                                    false,
-                                    &Row::default(),
-                                )
-                            })
-                            .unwrap_or(true)
-                        {
-                            return Ok(None);
-                        }
+                        Some((file_idx, pos, row))
+                    } else {
+                        None
                     }
-                }
+                } else {
+                    None
+                };
                 let before_idx = fields.iter().position(|(name, _value)| "before" == name);
                 let after_idx = fields.iter().position(|(name, _value)| "after" == name);
                 if let (Some(before_idx), Some(after_idx)) = (before_idx, after_idx) {
@@ -653,6 +659,19 @@ impl DebeziumDecodeState {
                         },
                         after,
                     )?;
+                    if let Some((file_idx, pos, row)) = dedup_val {
+                        packer.push_list_with(|packer| {
+                            packer.push(Datum::Int32(file_idx as i32));
+                            packer.push(Datum::Int64(pos as i64));
+                            packer.push(Datum::Int64(row as i64));
+                        });
+                    } else {
+                        packer.push(Datum::Null);
+                    }
+                    packer.push(match upstream_time_millis {
+                        Some(millis) => Datum::Int64(millis),
+                        None => Datum::Null,
+                    });
                     Ok(Some(packer))
                 } else {
                     bail!("avro envelope does not contain `before` and `after`");

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -9,7 +9,7 @@
 
 //! See [`DebeziumDeduplicationStrategy`] for what this module is meant to do
 
-use std::cmp::max;
+use std::cmp::{max, Ordering};
 use std::collections::{HashMap, HashSet};
 
 use anyhow::bail;
@@ -265,6 +265,10 @@ impl TrackFull {
     }
 }
 
+fn cmp_by_datum(left: &Row, right: &Row) -> Ordering {
+    left.iter().cmp(right.iter())
+}
+
 impl DebeziumDeduplicationState {
     pub(crate) fn new(
         strat: DebeziumDeduplicationStrategy,
@@ -326,7 +330,7 @@ impl DebeziumDeduplicationState {
             None => None,
             Some(position) => match &mut self.last_position_and_offset {
                 Some((old_position, old_offset)) => {
-                    if position > old_position {
+                    if cmp_by_datum(position, old_position) == Ordering::Greater {
                         *old_position = position.clone();
                         None
                     } else {

--- a/src/interchange/src/avro/envelope_debezium/deduplication.rs
+++ b/src/interchange/src/avro/envelope_debezium/deduplication.rs
@@ -424,7 +424,7 @@ impl DebeziumDeduplicationState {
                                 *started = false;
 
                                 if seen_positions.get(&position).is_none() {
-                                    seen_positions.insert(position.clone(), upstream_time_millis);
+                                    seen_positions.insert(position, upstream_time_millis);
                                 }
                                 return should_skip.is_none();
                             }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -883,6 +883,9 @@ pub fn plan_create_source(
                 sql_parser::ast::DbzMode::Plain => DebeziumMode::Plain,
                 sql_parser::ast::DbzMode::Upsert => DebeziumMode::Upsert,
             };
+            if mode == DebeziumMode::Upsert && dedup_strat != DebeziumDeduplicationStrategy::None {
+                bail!("Debezium deduplication does not make sense with upsert sources");
+            }
             SourceEnvelope::Debezium(dedup_strat, mode)
         }
         sql_parser::ast::Envelope::Upsert(key_format) => match connector {

--- a/test/testdrive/upsert-kafka-debezium.td
+++ b/test/testdrive/upsert-kafka-debezium.td
@@ -127,17 +127,11 @@ id creature
 -----------
 3  triceratops
 
-# Test that it works with full deduplication
-> CREATE MATERIALIZED SOURCE upsert_full_dedupe
+# Test that it doesn't work with full deduplication
+! CREATE MATERIALIZED SOURCE upsert_full_dedupe
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   WITH (deduplication = 'full')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 
-> SELECT creature FROM upsert_full_dedupe
-creature
-----
-dino
-velociraptor
-triceratops
-chicken
+Debezium deduplication does not make sense with upsert sources


### PR DESCRIPTION
Before this diff, Debezium deduplication logic ran as part of Avro decoding, which is clearly the wrong separation of concerns.

Now, the decoder pushes two new datums onto the row: the first containing a list of arbitrary deduplication position values, and the second the `upstream_time_millis` value relied on by certain forms of deduplication. We are then able to extract deduplication logic into its own operator that looks at these values and filters rows if necessary.

For now, the "deduplication position" list is always three values, corresponding to the old "file/pos/row" from earlier. However, since we are using arbitrary rows, it could in principle be anything the connector wants to write. We will use this flexibility in the future when the arbitrary source position array that Jessica added to Debezium is released.

It makes the API of the Avro decoder _slightly_ more complex (because the shape of the emitted row now has two extra fields for `ENVELOPE DEBEZIUM`, but not for other envelopes), but IMO this is clearly worth the decrease in complexity in its internals and the more rational separation of concerns. At any rate, this wart will go away in a future refactor.

Performance impact should be minimal, since in all currently existing use cases, the position values fit into the 24 byte `smallvec` in `Row`s. Thus packing and cloning these rows can be done with zero allocations.