### PR TITLE
Switch mz_dataflow_operator_addresses from using a slot/value scheme to lists

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -855,10 +855,11 @@ pub const MZ_ADDRESSES_WITH_UNIT_LENGTHS: BuiltinView = BuiltinView {
     mz_dataflow_operator_addresses.worker
 FROM
     mz_catalog.mz_dataflow_operator_addresses
+WHERE
+    mz_catalog.list_length(mz_dataflow_operator_addresses.address) = 1
 GROUP BY
     mz_dataflow_operator_addresses.id,
-    mz_dataflow_operator_addresses.worker
-HAVING pg_catalog.count(*) = 1",
+    mz_dataflow_operator_addresses.worker",
     id: GlobalId::System(5003),
     needs_logs: true,
 };
@@ -869,7 +870,7 @@ pub const MZ_DATAFLOW_NAMES: BuiltinView = BuiltinView {
     sql: "CREATE VIEW mz_dataflow_names AS SELECT
     mz_dataflow_operator_addresses.id,
     mz_dataflow_operator_addresses.worker,
-    mz_dataflow_operator_addresses.value as local_id,
+    mz_dataflow_operator_addresses.address[1] as local_id,
     mz_dataflow_operators.name
 FROM
     mz_catalog.mz_dataflow_operator_addresses,
@@ -879,8 +880,7 @@ WHERE
     mz_dataflow_operator_addresses.id = mz_dataflow_operators.id AND
     mz_dataflow_operator_addresses.worker = mz_dataflow_operators.worker AND
     mz_dataflow_operator_addresses.id = mz_addresses_with_unit_length.id AND
-    mz_dataflow_operator_addresses.worker = mz_addresses_with_unit_length.worker AND
-    mz_dataflow_operator_addresses.slot = 0",
+    mz_dataflow_operator_addresses.worker = mz_addresses_with_unit_length.worker",
     id: GlobalId::System(5004),
     needs_logs: true,
 };
@@ -901,8 +901,7 @@ FROM
 WHERE
     mz_dataflow_operators.id = mz_dataflow_operator_addresses.id AND
     mz_dataflow_operators.worker = mz_dataflow_operator_addresses.worker AND
-    mz_dataflow_operator_addresses.slot = 0 AND
-    mz_dataflow_names.local_id = mz_dataflow_operator_addresses.value AND
+    mz_dataflow_names.local_id = mz_dataflow_operator_addresses.address[1] AND
     mz_dataflow_names.worker = mz_dataflow_operator_addresses.worker",
     id: GlobalId::System(5005),
     needs_logs: true,

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -108,9 +108,15 @@ impl LogVariant {
             LogVariant::Timely(TimelyLog::Addresses) => RelationDesc::empty()
                 .with_column("id", ScalarType::Int64.nullable(false))
                 .with_column("worker", ScalarType::Int64.nullable(false))
-                .with_column("slot", ScalarType::Int64.nullable(false))
-                .with_column("value", ScalarType::Int64.nullable(false))
-                .with_key(vec![0, 1, 2]),
+                .with_column(
+                    "address",
+                    ScalarType::List {
+                        element_type: Box::new(ScalarType::Int64),
+                        custom_oid: None,
+                    }
+                    .nullable(false),
+                )
+                .with_key(vec![0, 1]),
 
             LogVariant::Timely(TimelyLog::Parks) => RelationDesc::empty()
                 .with_column("worker", ScalarType::Int64.nullable(false))

--- a/src/dataflow/src/logging/timely.rs
+++ b/src/dataflow/src/logging/timely.rs
@@ -25,7 +25,7 @@ use timely::logging::{ParkEvent, TimelyEvent, WorkerIdentifier};
 use super::{LogVariant, TimelyLog};
 use crate::arrangement::KeysValsHandle;
 use dataflow_types::logging::LoggingConfig;
-use repr::{Datum, Row, Timestamp};
+use repr::{datum_list_size, datum_size, Datum, Row, Timestamp};
 
 /// Constructs the logging dataflows and returns a logger and trace handles.
 pub fn construct<A: Allocate>(
@@ -103,18 +103,9 @@ pub fn construct<A: Allocate>(
                                     1,
                                 ));
 
-                                for (addr_slot, addr_value) in event.addr.iter().enumerate() {
-                                    addresses_session.give((
-                                        Row::pack_slice(&[
-                                            Datum::Int64(event.id as i64),
-                                            Datum::Int64(worker as i64),
-                                            Datum::Int64(addr_slot as i64),
-                                            Datum::Int64(*addr_value as i64),
-                                        ]),
-                                        time_ms,
-                                        1,
-                                    ));
-                                }
+                                let address_row =
+                                    create_address_row(event.id as i64, worker as i64, &event.addr);
+                                addresses_session.give((address_row, time_ms, 1));
                             }
                             TimelyEvent::Channels(event) => {
                                 // Record channel information so that we can replay a negated
@@ -137,19 +128,12 @@ pub fn construct<A: Allocate>(
                                     1,
                                 ));
 
-                                // Enumerate the address of the scope containing the channel.
-                                for (addr_slot, addr_value) in event.scope_addr.iter().enumerate() {
-                                    addresses_session.give((
-                                        Row::pack_slice(&[
-                                            Datum::Int64(event.id as i64),
-                                            Datum::Int64(worker as i64),
-                                            Datum::Int64(addr_slot as i64),
-                                            Datum::Int64(*addr_value as i64),
-                                        ]),
-                                        time_ms,
-                                        1,
-                                    ));
-                                }
+                                let address_row = create_address_row(
+                                    event.id as i64,
+                                    worker as i64,
+                                    &event.scope_addr,
+                                );
+                                addresses_session.give((address_row, time_ms, 1));
                             }
                             TimelyEvent::Shutdown(event) => {
                                 // Dropped operators should result in a negative record for
@@ -162,18 +146,13 @@ pub fn construct<A: Allocate>(
                                         -1,
                                     ));
 
-                                    for (addr_slot, addr_value) in event.addr.iter().enumerate() {
-                                        addresses_session.give((
-                                            Row::pack_slice(&[
-                                                Datum::Int64(event.id as i64),
-                                                Datum::Int64(worker as i64),
-                                                Datum::Int64(addr_slot as i64),
-                                                Datum::Int64(*addr_value as i64),
-                                            ]),
-                                            time_ms,
-                                            -1,
-                                        ));
-                                    }
+                                    let address_row = create_address_row(
+                                        event.id as i64,
+                                        worker as i64,
+                                        &event.addr,
+                                    );
+                                    addresses_session.give((address_row, time_ms, -1));
+
                                     // If we are observing a dataflow shutdown, we should also
                                     // issue a deletion for channels in the dataflow.
                                     if event.addr.len() == 1 {
@@ -195,21 +174,12 @@ pub fn construct<A: Allocate>(
                                                     -1,
                                                 ));
 
-                                                // Enumerate the address of the scope containing the channel.
-                                                for (addr_slot, addr_value) in
-                                                    event.scope_addr.iter().enumerate()
-                                                {
-                                                    addresses_session.give((
-                                                        Row::pack_slice(&[
-                                                            Datum::Int64(event.id as i64),
-                                                            Datum::Int64(worker as i64),
-                                                            Datum::Int64(addr_slot as i64),
-                                                            Datum::Int64(*addr_value as i64),
-                                                        ]),
-                                                        time_ms,
-                                                        -1,
-                                                    ));
-                                                }
+                                                let address_row = create_address_row(
+                                                    event.id as i64,
+                                                    worker as i64,
+                                                    &event.scope_addr,
+                                                );
+                                                addresses_session.give((address_row, time_ms, -1));
                                             }
                                         }
                                     }
@@ -475,6 +445,25 @@ pub fn construct<A: Allocate>(
     });
 
     traces
+}
+
+fn create_address_row(id: i64, worker: i64, address: &[usize]) -> Row {
+    let id_datum = Datum::Int64(id);
+    let worker_datum = Datum::Int64(worker);
+    // we're collecting into a Vec because we need to iterate over the Datums
+    // twice: once for determining the size of the row, then again for pushing
+    // them
+    let address_datums: Vec<_> = address.iter().map(|i| Datum::Int64(*i as i64)).collect();
+
+    let row_capacity =
+        datum_size(&id_datum) + datum_size(&worker_datum) + datum_list_size(&address_datums);
+
+    let mut address_row = Row::with_capacity(row_capacity);
+    address_row.push(id_datum);
+    address_row.push(worker_datum);
+    address_row.push_list(address_datums);
+
+    address_row
 }
 
 /// Discard all of the records in `c` that `logic` doesn't care about (return).

--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -166,7 +166,7 @@ function View(props) {
       // caused by multiple workers.
       const addr_table = await query(`
         SELECT DISTINCT
-          id, slot, value
+          id, address
         FROM
           mz_catalog.mz_dataflow_operator_addresses
         WHERE
@@ -177,11 +177,10 @@ function View(props) {
               FROM
                 mz_catalog.mz_dataflow_operator_addresses
               WHERE
-                slot = 0
-                AND value
+                address[1]
                   = (
-                      SELECT
-                        value
+                      SELECT DISTINCT
+                        address[1]
                       FROM
                         mz_catalog.mz_dataflow_operator_addresses
                       WHERE
@@ -191,11 +190,10 @@ function View(props) {
       `);
       // Map from id to address (array). {320: [11], 321: [11, 1]}.
       const addrs = {};
-      addr_table.rows.forEach(([id, slot, value]) => {
+      addr_table.rows.forEach(([id, address]) => {
         if (!addrs[id]) {
-          addrs[id] = [];
+          addrs[id] = address;
         }
-        addrs[id][slot] = value;
       });
       setAddrs(addrs);
 
@@ -212,11 +210,10 @@ function View(props) {
               FROM
                 mz_catalog.mz_dataflow_operator_addresses
               WHERE
-                slot = 0
-                AND value
+                address[1]
                   = (
-                      SELECT
-                        value
+                      SELECT DISTINCT
+                        address[1]
                       FROM
                         mz_catalog.mz_dataflow_operator_addresses
                       WHERE
@@ -243,11 +240,10 @@ function View(props) {
               FROM
                 mz_catalog.mz_dataflow_operator_addresses
               WHERE
-                slot = 0
-                AND value
+                address[1]
                   = (
-                      SELECT
-                        value
+                      SELECT DISTINCT
+                        address[1]
                       FROM
                         mz_catalog.mz_dataflow_operator_addresses
                       WHERE
@@ -288,11 +284,10 @@ function View(props) {
               FROM
                 mz_catalog.mz_dataflow_operator_addresses
               WHERE
-                slot = 0
-                AND value
+                address[1]
                   = (
-                      SELECT
-                        value
+                      SELECT DISTINCT
+                        address[1]
                       FROM
                         mz_catalog.mz_dataflow_operator_addresses
                       WHERE

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -32,7 +32,9 @@ pub mod strconv;
 
 pub use cache::{CachedRecord, CachedRecordIter};
 pub use relation::{ColumnName, ColumnType, RelationDesc, RelationType};
-pub use row::{datum_size, datums_size, DatumList, DatumMap, Row, RowArena, RowRef};
+pub use row::{
+    datum_list_size, datum_size, datums_size, DatumList, DatumMap, Row, RowArena, RowRef,
+};
 pub use scalar::{Datum, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -601,6 +601,18 @@ where
     iter.into_iter().map(|d| datum_size(d.borrow())).sum()
 }
 
+/// Number of bytes required by a list of datums. This computes the size that would be required if
+/// the given datums were packed into a list.
+///
+/// This is used to optimistically pre-allocate buffers for packing rows.
+pub fn datum_list_size<'a, I, D>(iter: I) -> usize
+where
+    I: IntoIterator<Item = D>,
+    D: Borrow<Datum<'a>>,
+{
+    1 + size_of::<usize>() + datums_size(iter)
+}
+
 // --------------------------------------------------------------------------------
 // public api
 


### PR DESCRIPTION
This simplifies the diagnostic queries a bit and will make it easier to implement #6394.

I have one question in there about how I can efficiently pack the list into a Row.

I could add release notes for this but I thought that this is probably to obscure to warrant that. I'm happy to add them, of course.

This closes #6368 