### PR TITLE
sql-parser token rendering improvements and OptionExt::display_or

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,6 +2689,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "crossbeam-utils",
+ "either",
  "fallible-iterator",
  "futures",
  "lazy_static",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1.50"
 bytes = "1.0.1"
+either = "1.5.1"
 fallible-iterator = "0.2.0"
 futures = "0.3.14"
 lazy_static = "1.4.0"

--- a/src/ore/src/option.rs
+++ b/src/ore/src/option.rs
@@ -14,7 +14,10 @@
 
 //! Option utilities.
 
+use std::fmt;
 use std::ops::Deref;
+
+use either::Either;
 
 /// Extension methods for [`std::option::Option`].
 pub trait OptionExt<T> {
@@ -29,6 +32,50 @@ pub trait OptionExt<T> {
     where
         T: Deref,
         T::Target: ToOwned;
+
+    /// Returns a type that displays the option's value if it is present, or
+    /// the provided default otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ore::option::OptionExt;
+    ///
+    /// fn render(number: Option<i32>) -> String {
+    ///     format!("Your lucky number is {}.", number.display_or("unknown"))
+    /// }
+    ///
+    /// assert_eq!(render(Some(42)), "Your lucky number is 42.");
+    /// assert_eq!(render(None), "Your lucky number is unknown.");
+    /// ```
+    fn display_or<D>(self, default: D) -> Either<T, D>
+    where
+        T: fmt::Display,
+        D: fmt::Display;
+
+    /// Like [`OptionExt::display_or`], but the default value is computed
+    /// only if the option is `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ore::option::OptionExt;
+    ///
+    /// fn render(number: Option<i32>, guess: i32) -> String {
+    ///     format!(
+    ///         "Your lucky number is {}.",
+    ///         number.display_or_else(|| format!("unknown (best guess: {})", guess)),
+    ///     )
+    /// }
+    ///
+    /// assert_eq!(render(Some(42), 7), "Your lucky number is 42.");
+    /// assert_eq!(render(None, 7), "Your lucky number is unknown (best guess: 7).");
+    /// ```
+    fn display_or_else<D, R>(self, default: D) -> Either<T, R>
+    where
+        T: fmt::Display,
+        D: FnOnce() -> R,
+        R: fmt::Display;
 }
 
 impl<T> OptionExt<T> for Option<T> {
@@ -38,5 +85,28 @@ impl<T> OptionExt<T> for Option<T> {
         T::Target: ToOwned,
     {
         self.as_ref().map(|x| x.deref().to_owned())
+    }
+
+    fn display_or<D>(self, default: D) -> Either<T, D>
+    where
+        T: fmt::Display,
+        D: fmt::Display,
+    {
+        match self {
+            Some(t) => Either::Left(t),
+            None => Either::Right(default),
+        }
+    }
+
+    fn display_or_else<D, R>(self, default: D) -> Either<T, R>
+    where
+        T: fmt::Display,
+        D: FnOnce() -> R,
+        R: fmt::Display,
+    {
+        match self {
+            Some(t) => Either::Left(t),
+            None => Either::Right(default()),
+        }
     }
 }

--- a/src/sql-parser/src/lexer.rs
+++ b/src/sql-parser/src/lexer.rs
@@ -34,8 +34,10 @@
 
 use std::char;
 use std::convert::TryFrom;
+use std::fmt;
 
 use ore::lex::LexBuf;
+use ore::str::StrExt;
 
 use crate::keywords::Keyword;
 use crate::parser::ParserError;
@@ -62,75 +64,27 @@ pub enum Token {
     Semicolon,
 }
 
-impl Token {
-    pub fn name(&self) -> &str {
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Token::Keyword(kw) => kw.as_str(),
-            Token::Ident(_) => "identifier",
-            Token::String(_) => "string literal",
-            Token::HexString(_) => "hex string literal",
-            Token::Number(_) => "number",
-            Token::Parameter(_) => "parameter",
-            Token::Op(_) => "operator",
-            Token::Star => "star",
-            Token::Eq => "equals sign",
-            Token::LParen => "left parenthesis",
-            Token::RParen => "right parenthesis",
-            Token::LBracket => "left square bracket",
-            Token::RBracket => "right square bracket",
-            Token::Dot => "dot",
-            Token::Comma => "comma",
-            Token::Colon => "colon",
-            Token::DoubleColon => "double colon",
-            Token::Semicolon => "semicolon",
-        }
-    }
-
-    pub fn value(&self) -> String {
-        match self {
-            Token::Keyword(kw) => kw.as_str().to_string(),
-            Token::Ident(val) => val.to_string(),
-            Token::String(val) => val.to_string(),
-            Token::HexString(val) => val.to_string(),
-            Token::Number(val) => val.to_string(),
-            Token::Op(val) => val.to_string(),
-            Token::Parameter(val) => val.to_string(),
-            Token::Star => "*".to_string(),
-            Token::Eq => "=".to_string(),
-            Token::LParen => "(".to_string(),
-            Token::RParen => ")".to_string(),
-            Token::LBracket => "[".to_string(),
-            Token::RBracket => "]".to_string(),
-            Token::Dot => ".".to_string(),
-            Token::Comma => ",".to_string(),
-            Token::Colon => ":".to_string(),
-            Token::DoubleColon => "::".to_string(),
-            Token::Semicolon => ";".to_string(),
-        }
-    }
-
-    /// True iff the `value()` function will return more information in our error messages
-    pub fn has_value(&self) -> bool {
-        match self {
-            Token::Ident(_)
-            | Token::String(_)
-            | Token::HexString(_)
-            | Token::Number(_)
-            | Token::Op(_)
-            | Token::Parameter(_) => true,
-            // In our error messages we use literal keywords, which makes the keyword value a duplicate
-            Token::Keyword(_) => false,
-            Token::Star
-            | Token::Eq
-            | Token::LParen
-            | Token::RParen
-            | Token::LBracket
-            | Token::RBracket
-            | Token::Dot
-            | Token::Comma
-            | Token::Colon
-            | Token::DoubleColon
-            | Token::Semicolon => false,
+            Token::Keyword(kw) => f.write_str(kw.as_str()),
+            Token::Ident(id) => write!(f, "identifier {}", id.quoted()),
+            Token::String(s) => write!(f, "string literal {}", s.quoted()),
+            Token::HexString(s) => write!(f, "hex string literal {}", s.quoted()),
+            Token::Number(n) => write!(f, "number \"{}\"", n),
+            Token::Parameter(n) => write!(f, "parameter \"${}\"", n),
+            Token::Op(op) => write!(f, "operator {}", op.quoted()),
+            Token::Star => f.write_str("star"),
+            Token::Eq => f.write_str("equals sign"),
+            Token::LParen => f.write_str("left parenthesis"),
+            Token::RParen => f.write_str("right parenthesis"),
+            Token::LBracket => f.write_str("left square bracket"),
+            Token::RBracket => f.write_str("right square bracket"),
+            Token::Dot => f.write_str("dot"),
+            Token::Comma => f.write_str("comma"),
+            Token::Colon => f.write_str("colon"),
+            Token::DoubleColon => f.write_str("double colon"),
+            Token::Semicolon => f.write_str("semicolon"),
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -27,6 +27,7 @@ use itertools::Itertools;
 use log::{debug, warn};
 
 use ore::collections::CollectionExt;
+use ore::option::OptionExt;
 use repr::adt::datetime::DateTimeField;
 
 use crate::ast::*;
@@ -1257,14 +1258,9 @@ impl<'a> Parser<'a> {
         parser_err!(
             self,
             pos,
-            "Expected {}, found {}{}",
+            "Expected {}, found {}",
             expected,
-            found.as_ref().map(|t| t.name()).unwrap_or("EOF"),
-            found
-                .as_ref()
-                .filter(|t| t.has_value())
-                .map(|t| format!(" '{}'", t.value()))
-                .unwrap_or_else(String::new)
+            found.display_or("EOF"),
         )
     }
 
@@ -1351,7 +1347,7 @@ impl<'a> Parser<'a> {
         if self.consume_token(expected) {
             Ok(())
         } else {
-            self.expected(self.peek_pos(), expected.name(), self.peek_token())
+            self.expected(self.peek_pos(), expected, self.peek_token())
         }
     }
 
@@ -2339,7 +2335,7 @@ impl<'a> Parser<'a> {
         // there's no value, anything else means we expect a valid value.
         let has_value = !matches!(self.peek_token(), Some(Token::RParen) | Some(Token::Comma));
         if has_value && !has_eq && require_equals {
-            return self.expected(self.peek_pos(), Token::Eq.name(), self.peek_token());
+            return self.expected(self.peek_pos(), Token::Eq, self.peek_token());
         }
         let value = if has_value {
             if let Some(value) = self.maybe_parse(Parser::parse_value) {

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -142,7 +142,7 @@ CreateRole(CreateRoleStatement { is_user: false, name: Ident("usr"), options: [L
 parse-statement
 CREATE ROLE usr WITH badopt
 ----
-error: Expected end of statement, found identifier 'badopt'
+error: Expected end of statement, found identifier "badopt"
 CREATE ROLE usr WITH badopt
                      ^
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -34,7 +34,7 @@ CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("uk_cities"
 parse-statement
 CREATE TABLE t (a int NOT NULL GARBAGE)
 ----
-error: Expected column option, found identifier 'garbage'
+error: Expected column option, found identifier "garbage"
 CREATE TABLE t (a int NOT NULL GARBAGE)
                                ^
 
@@ -202,7 +202,7 @@ CREATE TABLE t (c time with time zone (0,1,100))
 parse-statement
 CREATE TABLE t (c t(1+1))
 ----
-error: Expected right parenthesis, found operator '+'
+error: Expected right parenthesis, found operator "+"
 CREATE TABLE t (c t(1+1))
                      ^
 

--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -35,7 +35,7 @@ UPDATE t WHERE 1
 parse-statement
 UPDATE t SET a = 1 extrabadstuff
 ----
-error: Expected end of statement, found identifier 'extrabadstuff'
+error: Expected end of statement, found identifier "extrabadstuff"
 UPDATE t SET a = 1 extrabadstuff
                    ^
 
@@ -49,7 +49,7 @@ SELECT ALL DISTINCT name FROM customer
 parse-statement
 INSERT public.customer (id, name, active) VALUES (1, 2, 3)
 ----
-error: Expected INTO, found identifier 'public'
+error: Expected INTO, found identifier "public"
 INSERT public.customer (id, name, active) VALUES (1, 2, 3)
        ^
 
@@ -141,7 +141,7 @@ SEL
 
 ECT
 ----
-error: Expected a keyword at the beginning of a statement, found identifier 'sel'
+error: Expected a keyword at the beginning of a statement, found identifier "sel"
 SEL
 ^
 
@@ -150,7 +150,7 @@ SELECT foo
 FROM bar+1 ORDER
 BY
 ----
-error: Expected end of statement, found operator '+'
+error: Expected end of statement, found operator "+"
 FROM bar+1 ORDER
         ^
 
@@ -245,6 +245,6 @@ SELECT LIST[1][1:1, ]
 parse-scalar
 ARRAY[]::int[1 + 1]
 ----
-error: Expected right square bracket, found operator '+'
+error: Expected right square bracket, found operator "+"
 ARRAY[]::int[1 + 1]
                ^

--- a/src/sql-parser/tests/testdata/lexer
+++ b/src/sql-parser/tests/testdata/lexer
@@ -59,7 +59,7 @@ SELECT 'foobarbaz'
 parse-statement roundtrip
 SELECT 'foo'  'bar'
 ----
-error: Expected end of statement, found string literal 'bar'
+error: Expected end of statement, found string literal "bar"
 SELECT 'foo'  'bar'
               ^
 
@@ -67,7 +67,7 @@ parse-statement roundtrip
 SELECT e'foo'
 e'bar'
 ----
-error: Expected end of statement, found string literal 'bar'
+error: Expected end of statement, found string literal "bar"
 e'bar'
 ^
 
@@ -162,7 +162,7 @@ error: extra token after expression
 parse-statement
 ’hello’
 ----
-error: Expected a keyword at the beginning of a statement, found identifier '’hello’'
+error: Expected a keyword at the beginning of a statement, found identifier "’hello’"
 ’hello’
 ^
 
@@ -170,7 +170,7 @@ error: Expected a keyword at the beginning of a statement, found identifier '’
 parse-statement
 SELECT '’fancy quotes inside a string are ok’’’’' AS alias ’
 ----
-error: Expected end of statement, found identifier '’'
+error: Expected end of statement, found identifier "’"
 SELECT '’fancy quotes inside a string are ok’’’’' AS alias ’
                                                            ^
 

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -494,7 +494,7 @@ parse-scalar roundtrip
 parse-scalar
 (1.a)
 ----
-error: Expected right parenthesis, found identifier 'a'
+error: Expected right parenthesis, found identifier "a"
 (1.a)
    ^
 

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -242,7 +242,7 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT (1.a)
 ----
-error: Expected right parenthesis, found identifier 'a'
+error: Expected right parenthesis, found identifier "a"
 SELECT (1.a)
           ^
 
@@ -343,7 +343,7 @@ SELECT $q
 parse-statement
 SELECT $1$2
 ----
-error: Expected end of statement, found parameter '2'
+error: Expected end of statement, found parameter "$2"
 SELECT $1$2
          ^
 
@@ -935,7 +935,7 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
 ----
-error: Expected one of ROW or ROWS, found identifier 'percent'
+error: Expected one of ROW or ROWS, found identifier "percent"
 SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY
                                    ^
 
@@ -1019,7 +1019,7 @@ Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct
 parse-statement
 SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
 ----
-error: Expected SELECT, VALUES, or a subquery in the query body, found identifier 'b'
+error: Expected SELECT, VALUES, or a subquery in the query body, found identifier "b"
 SELECT * FROM a LEFT JOIN LATERAL (b CROSS JOIN c)
                                    ^
 

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -366,7 +366,7 @@ SET
 parse-statement
 SET a b
 ----
-error: Expected equals sign or TO, found identifier 'b'
+error: Expected equals sign or TO, found identifier "b"
 SET a b
       ^
 
@@ -415,6 +415,6 @@ Discard(DiscardStatement { target: Temp })
 parse-statement
 DISCARD BAD
 ----
-error: Expected one of ALL or PLANS or SEQUENCES or TEMP or TEMPORARY, found identifier 'bad'
+error: Expected one of ALL or PLANS or SEQUENCES or TEMP or TEMPORARY, found identifier "bad"
 DISCARD BAD
         ^

--- a/src/sql-parser/tests/testdata/txn
+++ b/src/sql-parser/tests/testdata/txn
@@ -99,14 +99,14 @@ StartTransaction(StartTransactionStatement { modes: [IsolationLevel(Serializable
 parse-statement
 START TRANSACTION ISOLATION LEVEL BAD
 ----
-error: Expected isolation level, found identifier 'bad'
+error: Expected isolation level, found identifier "bad"
 START TRANSACTION ISOLATION LEVEL BAD
                                   ^
 
 parse-statement
 START TRANSACTION BAD
 ----
-error: Expected end of statement, found identifier 'bad'
+error: Expected end of statement, found identifier "bad"
 START TRANSACTION BAD
                   ^
 


### PR DESCRIPTION
Two fairly unrelated but interdependent commits in here. @umanwizard could you review the first and @quodlibetor the second?

----

**ore: add OptionExt::display_or[_else]**

This combinator makes it easy to efficiently display the contents of an
option or a default if the option is `None`. Supersedes #6002.

----

**sql-parser: simplify printing of tokens in error messages**

Simplify the printing of tokens in SQL parser error messages, as
suggested in the review of #6435.