### PR TITLE
sql-parser: golf down an allocation when displaying ASTs

### DIFF
--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -9,12 +9,14 @@
 
 //! Provides convenience functions for working with upstream Postgres sources from the `sql` package.
 
+use std::fmt;
+
 use anyhow::anyhow;
+use tokio_postgres::types::Type as PgType;
+use tokio_postgres::NoTls;
 
 use sql_parser::ast::display::{AstDisplay, AstFormatter};
 use sql_parser::impl_display;
-use tokio_postgres::types::Type as PgType;
-use tokio_postgres::NoTls;
 
 /// The schema of a single column
 pub struct PgColumn {
@@ -25,7 +27,7 @@ pub struct PgColumn {
 }
 
 impl AstDisplay for PgColumn {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(&self.name);
         f.write_str(" ");
         f.write_str(&self.scalar_type);

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -18,6 +18,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
@@ -173,7 +174,7 @@ pub enum Expr<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for Expr<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Expr::Identifier(s) => f.write_node(&display::separated(s, ".")),
             Expr::QualifiedWildcard(q) => {
@@ -546,7 +547,7 @@ pub struct SubscriptPosition<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for SubscriptPosition<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         if let Some(start) = &self.start {
             f.write_node(start);
         }
@@ -567,7 +568,7 @@ pub struct WindowSpec<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for WindowSpec<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         let mut delim = "";
         if !self.partition_by.is_empty() {
             delim = " ";
@@ -623,7 +624,7 @@ pub enum WindowFrameUnits {
 }
 
 impl AstDisplay for WindowFrameUnits {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             WindowFrameUnits::Rows => "ROWS",
             WindowFrameUnits::Range => "RANGE",
@@ -645,7 +646,7 @@ pub enum WindowFrameBound {
 }
 
 impl AstDisplay for WindowFrameBound {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             WindowFrameBound::CurrentRow => f.write_str("CURRENT ROW"),
             WindowFrameBound::Preceding(None) => f.write_str("UNBOUNDED PRECEDING"),
@@ -676,7 +677,7 @@ pub struct Function<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for Function<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.name);
         f.write_str("(");
         if self.distinct {
@@ -708,7 +709,7 @@ pub enum FunctionArgs<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for FunctionArgs<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             FunctionArgs::Star => f.write_str("*"),
             FunctionArgs::Args(args) => f.write_node(&display::comma_separated(&args)),

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -18,6 +18,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::keywords::Keyword;
 
@@ -75,7 +77,7 @@ impl From<&str> for Ident {
 ///
 /// Quotation is forced when printing in Stable mode.
 impl AstDisplay for Ident {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         if self.can_be_printed_bare() && !f.stable() {
             f.write_str(&self.0);
         } else {
@@ -120,14 +122,14 @@ impl UnresolvedObjectName {
 }
 
 impl AstDisplay for UnresolvedObjectName {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         display::separated(&self.0, ".").fmt(f);
     }
 }
 impl_display!(UnresolvedObjectName);
 
 impl AstDisplay for &UnresolvedObjectName {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         display::separated(&self.0, ".").fmt(f);
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -18,6 +18,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
+
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
     AstInfo, ColumnDef, Connector, DataType, Envelope, Expr, Format, Ident, MultiConnector, Query,
@@ -81,7 +83,7 @@ impl<T: AstInfo> Statement<T> {
 }
 
 impl<T: AstInfo> AstDisplay for Statement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Statement::Select(stmt) => f.write_node(stmt),
             Statement::Insert(stmt) => f.write_node(stmt),
@@ -136,7 +138,7 @@ pub struct SelectStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for SelectStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.query);
         if let Some(as_of) = &self.as_of {
             f.write_str(" AS OF ");
@@ -158,7 +160,7 @@ pub struct InsertStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for InsertStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("INSERT INTO ");
         f.write_node(&self.table_name);
         if !self.columns.is_empty() {
@@ -189,7 +191,7 @@ pub enum CopyDirection {
 }
 
 impl AstDisplay for CopyDirection {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             CopyDirection::To => "TO",
             CopyDirection::From => "FROM",
@@ -205,7 +207,7 @@ pub enum CopyTarget {
 }
 
 impl AstDisplay for CopyTarget {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             CopyTarget::Stdin => "STDIN",
             CopyTarget::Stdout => "STDOUT",
@@ -228,7 +230,7 @@ pub struct CopyStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CopyStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("COPY ");
         match &self.relation {
             CopyRelation::Table { name, columns } => {
@@ -275,7 +277,7 @@ pub struct UpdateStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for UpdateStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("UPDATE ");
         f.write_node(&self.table_name);
         if !self.assignments.is_empty() {
@@ -300,7 +302,7 @@ pub struct DeleteStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for DeleteStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DELETE FROM ");
         f.write_node(&self.table_name);
         if let Some(selection) = &self.selection {
@@ -319,7 +321,7 @@ pub struct CreateDatabaseStatement {
 }
 
 impl AstDisplay for CreateDatabaseStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE DATABASE ");
         if self.if_not_exists {
             f.write_str("IF NOT EXISTS ");
@@ -337,7 +339,7 @@ pub struct CreateSchemaStatement {
 }
 
 impl AstDisplay for CreateSchemaStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE SCHEMA ");
         if self.if_not_exists {
             f.write_str("IF NOT EXISTS ");
@@ -361,7 +363,7 @@ pub struct CreateSourceStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE ");
         if self.materialized {
             f.write_str("MATERIALIZED ");
@@ -408,7 +410,7 @@ pub struct CreateSourcesStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourcesStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE ");
         if self.materialized {
             f.write_str("MATERIALIZED ");
@@ -434,7 +436,7 @@ pub struct CreateSinkStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateSinkStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE SINK ");
         if self.if_not_exists {
             f.write_str("IF NOT EXISTS ");
@@ -485,7 +487,7 @@ pub struct CreateViewStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateViewStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE");
         if self.if_exists == IfExistsBehavior::Replace {
             f.write_str(" OR REPLACE");
@@ -538,7 +540,7 @@ pub struct CreateTableStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateTableStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE ");
         if self.temporary {
             f.write_str("TEMPORARY ");
@@ -580,7 +582,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateIndexStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE ");
         if self.key_parts.is_none() {
             f.write_str("DEFAULT ");
@@ -621,7 +623,7 @@ pub struct CreateRoleStatement {
 }
 
 impl AstDisplay for CreateRoleStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE ");
         if self.is_user {
             f.write_str("USER ");
@@ -651,7 +653,7 @@ pub enum CreateRoleOption {
 }
 
 impl AstDisplay for CreateRoleOption {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             CreateRoleOption::SuperUser => f.write_str("SUPERUSER"),
             CreateRoleOption::NoSuperUser => f.write_str("NOSUPERUSER"),
@@ -675,7 +677,7 @@ pub struct CreateTypeStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for CreateTypeStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE TYPE ");
         f.write_node(&self.name);
         f.write_str(" AS ");
@@ -697,7 +699,7 @@ pub enum CreateTypeAs {
 }
 
 impl AstDisplay for CreateTypeAs {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             CreateTypeAs::List => f.write_str("LIST "),
             CreateTypeAs::Map => f.write_str("MAP "),
@@ -716,7 +718,7 @@ pub struct AlterObjectRenameStatement {
 }
 
 impl AstDisplay for AlterObjectRenameStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER ");
         f.write_node(&self.object_type);
         f.write_str(" ");
@@ -745,7 +747,7 @@ pub struct AlterIndexOptionsStatement {
 }
 
 impl AstDisplay for AlterIndexOptionsStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER INDEX ");
         if self.if_exists {
             f.write_str("IF EXISTS ");
@@ -776,7 +778,7 @@ pub struct DiscardStatement {
 }
 
 impl AstDisplay for DiscardStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DISCARD ");
         f.write_node(&self.target);
     }
@@ -792,7 +794,7 @@ pub enum DiscardTarget {
 }
 
 impl AstDisplay for DiscardTarget {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             DiscardTarget::Plans => f.write_str("PLANS"),
             DiscardTarget::Sequences => f.write_str("SEQUENCES"),
@@ -810,7 +812,7 @@ pub struct DropDatabaseStatement {
 }
 
 impl AstDisplay for DropDatabaseStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DROP DATABASE ");
         if self.if_exists {
             f.write_str("IF EXISTS ");
@@ -835,7 +837,7 @@ pub struct DropObjectsStatement {
 }
 
 impl AstDisplay for DropObjectsStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DROP ");
         f.write_node(&self.object_type);
         f.write_str(" ");
@@ -863,7 +865,7 @@ pub struct SetVariableStatement {
 }
 
 impl AstDisplay for SetVariableStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SET ");
         if self.local {
             f.write_str("LOCAL ");
@@ -882,7 +884,7 @@ pub struct ShowVariableStatement {
 }
 
 impl AstDisplay for ShowVariableStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW ");
         f.write_node(&self.variable);
     }
@@ -896,7 +898,7 @@ pub struct ShowDatabasesStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for ShowDatabasesStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW DATABASES");
         if let Some(filter) = &self.filter {
             f.write_str(" ");
@@ -925,7 +927,7 @@ pub struct ShowObjectsStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW");
         if self.extended {
             f.write_str(" EXTENDED");
@@ -969,7 +971,7 @@ pub struct ShowIndexesStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for ShowIndexesStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW ");
         if self.extended {
             f.write_str("EXTENDED ");
@@ -996,7 +998,7 @@ pub struct ShowColumnsStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for ShowColumnsStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW ");
         if self.extended {
             f.write_str("EXTENDED ");
@@ -1021,7 +1023,7 @@ pub struct ShowCreateViewStatement {
 }
 
 impl AstDisplay for ShowCreateViewStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE VIEW ");
         f.write_node(&self.view_name);
     }
@@ -1035,7 +1037,7 @@ pub struct ShowCreateSourceStatement {
 }
 
 impl AstDisplay for ShowCreateSourceStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE SOURCE ");
         f.write_node(&self.source_name);
     }
@@ -1049,7 +1051,7 @@ pub struct ShowCreateTableStatement {
 }
 
 impl AstDisplay for ShowCreateTableStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE TABLE ");
         f.write_node(&self.table_name);
     }
@@ -1063,7 +1065,7 @@ pub struct ShowCreateSinkStatement {
 }
 
 impl AstDisplay for ShowCreateSinkStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE SINK ");
         f.write_node(&self.sink_name);
     }
@@ -1077,7 +1079,7 @@ pub struct ShowCreateIndexStatement {
 }
 
 impl AstDisplay for ShowCreateIndexStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE INDEX ");
         f.write_node(&self.index_name);
     }
@@ -1091,7 +1093,7 @@ pub struct StartTransactionStatement {
 }
 
 impl AstDisplay for StartTransactionStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("START TRANSACTION");
         if !self.modes.is_empty() {
             f.write_str(" ");
@@ -1108,7 +1110,7 @@ pub struct SetTransactionStatement {
 }
 
 impl AstDisplay for SetTransactionStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SET TRANSACTION");
         if !self.modes.is_empty() {
             f.write_str(" ");
@@ -1125,7 +1127,7 @@ pub struct CommitStatement {
 }
 
 impl AstDisplay for CommitStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("COMMIT");
         if self.chain {
             f.write_str(" AND CHAIN");
@@ -1141,7 +1143,7 @@ pub struct RollbackStatement {
 }
 
 impl AstDisplay for RollbackStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ROLLBACK");
         if self.chain {
             f.write_str(" AND CHAIN");
@@ -1159,7 +1161,7 @@ pub struct TailStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for TailStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("TAIL ");
         f.write_node(&self.name);
         if !self.options.is_empty() {
@@ -1184,7 +1186,7 @@ pub struct ExplainStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for ExplainStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("EXPLAIN ");
         if self.options.typed {
             f.write_str("TYPED ");
@@ -1203,7 +1205,7 @@ pub enum InsertSource<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for InsertSource<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             InsertSource::Query(query) => f.write_node(query),
             InsertSource::DefaultValues => f.write_str("DEFAULT VALUES"),
@@ -1226,7 +1228,7 @@ pub enum ObjectType {
 }
 
 impl AstDisplay for ObjectType {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             ObjectType::Schema => "SCHEMA",
             ObjectType::Table => "TABLE",
@@ -1249,7 +1251,7 @@ pub enum ShowStatementFilter<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for ShowStatementFilter<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         use ShowStatementFilter::*;
         match self {
             Like(pattern) => {
@@ -1293,7 +1295,7 @@ impl<T: AstInfo> SqlOption<T> {
 }
 
 impl<T: AstInfo> AstDisplay for SqlOption<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             SqlOption::Value { name, value } => {
                 f.write_node(name);
@@ -1322,7 +1324,7 @@ pub struct WithOption {
 }
 
 impl AstDisplay for WithOption {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.key);
         if let Some(opt) = &self.value {
             f.write_str(" = ");
@@ -1339,7 +1341,7 @@ pub enum WithOptionValue {
 }
 
 impl AstDisplay for WithOptionValue {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             WithOptionValue::Value(value) => f.write_node(value),
             WithOptionValue::ObjectName(name) => f.write_node(name),
@@ -1355,7 +1357,7 @@ pub enum TransactionMode {
 }
 
 impl AstDisplay for TransactionMode {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         use TransactionMode::*;
         match self {
             AccessMode(access_mode) => f.write_node(access_mode),
@@ -1375,7 +1377,7 @@ pub enum TransactionAccessMode {
 }
 
 impl AstDisplay for TransactionAccessMode {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         use TransactionAccessMode::*;
         f.write_str(match self {
             ReadOnly => "READ ONLY",
@@ -1394,7 +1396,7 @@ pub enum TransactionIsolationLevel {
 }
 
 impl AstDisplay for TransactionIsolationLevel {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         use TransactionIsolationLevel::*;
         f.write_str(match self {
             ReadUncommitted => "READ UNCOMMITTED",
@@ -1413,7 +1415,7 @@ pub enum SetVariableValue {
 }
 
 impl AstDisplay for SetVariableValue {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         use SetVariableValue::*;
         match self {
             Ident(ident) => f.write_node(ident),
@@ -1431,7 +1433,7 @@ pub struct Assignment<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for Assignment<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.id);
         f.write_str(" = ");
         f.write_node(&self.value);
@@ -1451,7 +1453,7 @@ pub enum ExplainStage {
 }
 
 impl AstDisplay for ExplainStage {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             ExplainStage::RawPlan => f.write_str("RAW PLAN"),
             ExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
@@ -1473,7 +1475,7 @@ pub struct ExplainOptions {
 }
 
 impl<T: AstInfo> AstDisplay for Explainee<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Explainee::View(name) => {
                 f.write_str("VIEW ");
@@ -1500,7 +1502,7 @@ pub struct DeclareStatement<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for DeclareStatement<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DECLARE ");
         f.write_node(&self.name);
         f.write_str(" CURSOR FOR ");
@@ -1516,7 +1518,7 @@ pub struct CloseStatement {
 }
 
 impl AstDisplay for CloseStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CLOSE ");
         f.write_node(&self.name);
     }
@@ -1532,7 +1534,7 @@ pub struct FetchStatement {
 }
 
 impl AstDisplay for FetchStatement {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("FETCH ");
         if let Some(ref count) = self.count {
             f.write_str(format!("{} ", count));
@@ -1554,7 +1556,7 @@ pub enum FetchDirection {
 }
 
 impl AstDisplay for FetchDirection {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             FetchDirection::ForwardAll => f.write_str("ALL"),
             FetchDirection::ForwardCount(count) => f.write_str(format!("{}", count)),

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -62,7 +62,7 @@ pub enum Value {
 }
 
 impl AstDisplay for Value {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Value::Number(v) => f.write_str(v),
             Value::String(v) => {
@@ -202,7 +202,7 @@ pub enum DataType<T: AstInfo> {
 }
 
 impl<T: AstInfo> AstDisplay for DataType<T> {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             DataType::Array(ty) => {
                 f.write_node(&ty);

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -23,6 +23,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
+use std::fmt;
 use std::iter;
 use std::mem;
 
@@ -80,7 +81,7 @@ pub struct ResolvedObjectName {
 }
 
 impl AstDisplay for ResolvedObjectName {
-    fn fmt(&self, f: &mut AstFormatter) {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         if self.print_id {
             f.write_str(format!("[{} AS ", self.id));
         }


### PR DESCRIPTION
This isn't particularly performance sensitive at the moment, but it just seemed like bad form to allocate a temporary output buffer when there was already one handy.