### PR TITLE
Intercept SIGINT/SIGTERM and exit cleanly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,6 +2098,7 @@ dependencies = [
  "backtrace",
  "build-info",
  "bytes",
+ "cc",
  "cfg-if 1.0.0",
  "chrono",
  "clap",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -117,6 +117,7 @@ tokio-postgres = { version = "0.7.1", features = ["with-chrono-0_4"] }
 
 [build-dependencies]
 anyhow = "1.0.40"
+cc = "1.0.0"
 flate2 = "1.0.20"
 hex = "0.4.3"
 hex-literal = "0.3.1"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -299,7 +299,7 @@ fn main() {
 fn run(args: Args) -> Result<(), anyhow::Error> {
     panic::set_hook(Box::new(handle_panic));
     sys::enable_sigbus_sigsegv_backtraces()?;
-    sys::enable_sigint_sigterm_exit()?;
+    sys::enable_termination_signal_cleanup()?;
 
     if args.version > 0 {
         println!("materialized {}", materialized::BUILD_INFO.human_version());

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -299,6 +299,7 @@ fn main() {
 fn run(args: Args) -> Result<(), anyhow::Error> {
     panic::set_hook(Box::new(handle_panic));
     sys::enable_sigbus_sigsegv_backtraces()?;
+    sys::enable_sigint_sigterm_exit()?;
 
     if args.version > 0 {
         println!("materialized {}", materialized::BUILD_INFO.human_version());

--- a/src/materialized/src/bin/materialized/sys.c
+++ b/src/materialized/src/bin/materialized/sys.c
@@ -7,16 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::env;
+// System support functions that need to be written in C.
 
-mod npm;
-
-fn main() -> Result<(), anyhow::Error> {
-    println!("cargo:rustc-env=TARGET_TRIPLE={}", env::var("TARGET")?);
-
-    cc::Build::new()
-        .file("src/bin/materialized/sys.c")
-        .compile("materialized_sys");
-
-    npm::ensure()
+// When LLVM source-code based code coverage is active, it provides a strong
+// version of this symbol that actually writes the code coverage information
+// to disk.
+__attribute__((weak))
+int __llvm_profile_write_file() {
+    return 0;
 }

--- a/src/materialized/src/bin/materialized/sys.rs
+++ b/src/materialized/src/bin/materialized/sys.rs
@@ -10,6 +10,7 @@
 //! System support functions.
 
 use std::alloc::{self, Layout};
+use std::convert::TryInto;
 use std::io::{self, Write};
 use std::process;
 use std::ptr;
@@ -164,23 +165,6 @@ pub fn enable_sigbus_sigsegv_backtraces() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-// Clean exit on SIGTERM/SIGINT so that code coverage is
-// safely written to disk
-pub fn enable_sigint_sigterm_exit() -> Result<(), anyhow::Error> {
-    let action = signal::SigAction::new(
-        signal::SigHandler::Handler(handle_sigint_sigterm),
-        signal::SaFlags::SA_NODEFER | signal::SaFlags::SA_ONSTACK,
-        signal::SigSet::empty(),
-    );
-
-    unsafe { signal::sigaction(signal::SIGTERM, &action) }
-        .context("failed to install SIGTERM handler")?;
-    unsafe { signal::sigaction(signal::SIGINT, &action) }
-        .context("failed to install SIGINT handler")?;
-
-    Ok(())
-}
-
 extern "C" fn handle_sigbus_sigsegv(_: i32) {
     // SAFETY: this is is a signal handler function and technically must be
     // "async-signal safe" [0]. That typically means no memory allocation, which
@@ -212,6 +196,47 @@ extern "C" fn handle_sigbus_sigsegv(_: i32) {
     }
 }
 
-extern "C" fn handle_sigint_sigterm(_: i32) {
-    process::exit(0);
+pub fn enable_termination_signal_cleanup() -> Result<(), anyhow::Error> {
+    let action = signal::SigAction::new(
+        signal::SigHandler::Handler(handle_termination_signal),
+        signal::SaFlags::SA_NODEFER | signal::SaFlags::SA_ONSTACK,
+        signal::SigSet::empty(),
+    );
+
+    for signum in &[
+        signal::SIGHUP,
+        signal::SIGINT,
+        signal::SIGPIPE,
+        signal::SIGALRM,
+        signal::SIGTERM,
+        signal::SIGUSR1,
+        signal::SIGUSR2,
+    ] {
+        unsafe { signal::sigaction(*signum, &action) }
+            .with_context(|| format!("failed to install handler for {}", signum))?;
+    }
+
+    Ok(())
+}
+
+extern "C" {
+    fn __llvm_profile_write_file() -> libc::c_int;
+}
+
+extern "C" fn handle_termination_signal(signum: i32) {
+    let _ = unsafe { __llvm_profile_write_file() };
+
+    let action = signal::SigAction::new(
+        signal::SigHandler::SigDfl,
+        signal::SaFlags::SA_NODEFER | signal::SaFlags::SA_ONSTACK,
+        signal::SigSet::empty(),
+    );
+    unsafe { signal::sigaction(signum.try_into().unwrap(), &action) }
+        .unwrap_or_else(|_| panic!("failed to uninstall handler for {}", signum));
+
+    let ret = unsafe { libc::raise(signum) };
+    if ret == -1 {
+        let errno = errno::from_i32(errno::errno());
+        panic!("failed to re-raise signal {}: {}", signum, errno);
+    }
 }


### PR DESCRIPTION
This is required in order for code coverage to be captured properly.